### PR TITLE
Fix installation issues after the renames.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ zip_safe = False
 packages = find_namespace:
 include_package_data = True
 package_dir =
-    =dj
+    =.
 
 # Require a min/specific Python version (comma-separated conditions)
 python_requires = >=3.8
@@ -69,7 +69,7 @@ install_requires =
     strawberry-graphql==0.133.5
 
 [options.packages.find]
-where = dj
+where = .
 exclude =
     tests
 


### PR DESCRIPTION
1. One down. `pip install .` and `dj` cli work ok now.
2. Still another issue left:
```
dj                 |   File "/usr/local/lib/python3.10/site-packages/uvicorn/supervisors/watchfilesreload.py", line 75, in __init__
dj                 |     self.watcher = watch(
dj                 | TypeError: watch() got an unexpected keyword argument 'yield_on_timeout'
```