### PR TITLE
Add restart rule to db_migration service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     depends_on:
       - postgres_metadata
     command: alembic upgrade head
+    restart: on-failure
 
   redis:
     image: redis:latest


### PR DESCRIPTION
In a fresh docker environment, the metadata takes a while to initialize and the `db_migration` service fails because it can't access the database (even though it depends on that service). Stopping and then starting the docker environment ends up working because the database is already initialized. Since it's idempotent, this adds `restart: on-failure` to the db_migration service so that it can retry after failing.