### PR TITLE
feat: dj urls command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@
 
 <!-- How did you test your change? -->
 
-[ ] PR has an associated issue: #
-[ ] `make check` passes
-[ ] `make test` shows 100% unit test coverage
+- [ ] PR has an associated issue: #
+- [ ] `make check` passes
+- [ ] `make test` shows 100% unit test coverage
 
 ### Deployment Plan
 

--- a/dj/api/graphql/main.py
+++ b/dj/api/graphql/main.py
@@ -57,3 +57,4 @@ class Mutation:
 schema = strawberry.Schema(query=Query, mutation=Mutation)
 
 graphql_app = GraphQLRouter(schema, context_getter=get_context)
+graphql_app.description = "GraphQL endpoint"

--- a/dj/api/queries.py
+++ b/dj/api/queries.py
@@ -213,7 +213,7 @@ def load_query_results(
     return query_results
 
 
-@router.get("/queries/{query_id}", response_model=QueryWithResults)
+@router.get("/queries/{query_id}/", response_model=QueryWithResults)
 def read_query(
     query_id: uuid.UUID,
     limit: int = 0,

--- a/dj/cli/urls.py
+++ b/dj/cli/urls.py
@@ -17,7 +17,7 @@ def run(url: str) -> None:
     """
     base_url = URL(url)
 
-    sys.stdout.write(f"{base_url / 'docs'}: documentation\n")
+    sys.stdout.write(f"{base_url / 'docs'}: Documentation.\n")
 
     seen = set()
     for route in app.routes:

--- a/dj/cli/urls.py
+++ b/dj/cli/urls.py
@@ -1,0 +1,32 @@
+"""
+Print URLs for documentation and APIs.
+"""
+
+import sys
+import urllib.parse
+
+from fastapi.routing import APIRoute
+from yarl import URL
+
+from dj.api.main import app
+
+
+def run(url: str) -> None:
+    """
+    Print URLs for documentation and APIs.
+    """
+    base_url = URL(url)
+
+    sys.stdout.write(f"{base_url / 'docs'}: documentation\n")
+
+    seen = set()
+    for route in app.routes:
+        if isinstance(route, APIRoute) and route.path not in seen:
+            description = (
+                "GraphQL endpoint."
+                if route.path == "/graphql"
+                else route.description.split("\n")[0]
+            )
+            resource_url = urllib.parse.unquote(str(base_url / route.path[1:]))
+            sys.stdout.write(f"{resource_url}: {description}\n")
+            seen.add(route.path)

--- a/tests/api/queries_test.py
+++ b/tests/api/queries_test.py
@@ -701,7 +701,7 @@ def test_pagination(
     # first request should load data into cache
     response = client.get(f"/queries/{query.id}?limit=2")
     data = response.json()
-    assert data["next"] == f"http://testserver/queries/{query.id}?limit=2&offset=2"
+    assert data["next"] == f"http://testserver/queries/{query.id}/?limit=2&offset=2"
     assert data["previous"] is None
     cache.add.assert_called()
 
@@ -754,4 +754,4 @@ def test_pagination_last_page(
     response = client.get(f"/queries/{query.id}?offset=4&limit=2")
     data = response.json()
     assert data["next"] is None
-    assert data["previous"] == f"http://testserver/queries/{query.id}?limit=2&offset=2"
+    assert data["previous"] == f"http://testserver/queries/{query.id}/?limit=2&offset=2"

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -16,7 +16,7 @@ def test_run(capsys: CaptureFixture) -> None:
     captured = capsys.readouterr()
     assert (
         captured.out
-        == """http://localhost:8000/docs: documentation
+        == """http://localhost:8000/docs: Documentation.
 http://localhost:8000/databases/: List the available databases.
 http://localhost:8000/queries/: Run or schedule a query.
 http://localhost:8000/queries/{query_id}/: Fetch information about a query.

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -1,0 +1,30 @@
+"""
+Tests for ``dj.urls``.
+"""
+
+from pytest import CaptureFixture
+
+from dj.cli.urls import run
+
+
+def test_run(capsys: CaptureFixture) -> None:
+    """
+    Test ``run``.
+    """
+    run("http://localhost:8000")
+
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == """http://localhost:8000/docs: documentation
+http://localhost:8000/databases/: List the available databases.
+http://localhost:8000/queries/: Run or schedule a query.
+http://localhost:8000/queries/{query_id}/: Fetch information about a query.
+http://localhost:8000/metrics/: List all available metrics.
+http://localhost:8000/metrics/{node_id}/: Return a metric by ID.
+http://localhost:8000/metrics/{node_id}/data/: Return data for a metric.
+http://localhost:8000/metrics/{node_id}/sql/: Return SQL for a metric.
+http://localhost:8000/nodes/: List the available nodes.
+http://localhost:8000/graphql: GraphQL endpoint.
+"""
+    )

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -285,3 +285,27 @@ async def test_main_add_database_raise_already_exists(
     await console.main()
     await console.main()  # Run a second time to log an already exists exception
     _logger.error.assert_called_with(exc)
+
+
+@pytest.mark.asyncio
+async def test_main_urls(mocker: MockerFixture) -> None:
+    """
+    Test ``main`` with the "urls" action.
+    """
+    urls = mocker.patch("dj.console.urls")
+    urls.run = mocker.AsyncMock()
+
+    mocker.patch(
+        "dj.console.docopt",
+        return_value={
+            "--loglevel": "debug",
+            "urls": True,
+        },
+    )
+    mocker.patch(
+        "dj.console.get_settings",
+        return_value=Settings(url="http://localhost:8000/"),
+    )
+
+    await console.main()
+    urls.run.assert_called_with("http://localhost:8000/")


### PR DESCRIPTION
### Summary

Add a command `dj urls`:

```bash
$ dj urls
http://localhost:8000/docs: documentation
http://localhost:8000/databases/: List the available databases.
http://localhost:8000/queries/: Run or schedule a query.
http://localhost:8000/queries/{query_id}/: Fetch information about a query.
http://localhost:8000/metrics/: List all available metrics.
http://localhost:8000/metrics/{node_id}/: Return a metric by ID.
http://localhost:8000/metrics/{node_id}/data/: Return data for a metric.
http://localhost:8000/metrics/{node_id}/sql/: Return SQL for a metric.
http://localhost:8000/nodes/: List the available nodes.
http://localhost:8000/graphql: GraphQL endpoint.
```

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #167
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
N/A