### PR TITLE
Use SQLite by default

### DIFF
--- a/.docker-env/.env-postgres
+++ b/.docker-env/.env-postgres
@@ -1,5 +1,5 @@
-NAME="Example DJ server"
-DESCRIPTION="A simple DJ server running in Docker"
+NAME="Example DJ server backed by Postgres"
+DESCRIPTION="A simple DJ server running in Docker backed by Postgres"
 INDEX=postgresql://username:FoolishPassword@postgres_metadata:5432/dj
 REPOSITORY=examples/configs
 REDIS_CACHE=redis://query_broker:6379/0

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ docker-build:
 docker-run:
 	docker compose up
 
+docker-run-with-postgres:
+	docker compose -f docker-compose.yml -f docker-compose.postgres.yml up
+
 docker-run-with-druid:
 	docker compose -f docker-compose.yml -f docker-compose.druid.yml up
 

--- a/docker-compose.cockroachdb.yml
+++ b/docker-compose.cockroachdb.yml
@@ -1,4 +1,4 @@
-# WARNING: this is not a standaonle docker config file. It must be used in addition to the docker-compose.yml.
+# WARNING: this is not a standalone docker config file. It must be used in addition to the docker-compose.yml.
 #          If in doubt please use the Makefile commands to build DJ docker containers.
 version: "2.2"
 

--- a/docker-compose.cockroachdb.yml
+++ b/docker-compose.cockroachdb.yml
@@ -1,3 +1,5 @@
+# WARNING: this is not a standaonle docker config file. It must be used in addition to the docker-compose.yml.
+#          If in doubt please use the Makefile commands to build DJ docker containers.
 version: "2.2"
 
 volumes:

--- a/docker-compose.druid.yaml
+++ b/docker-compose.druid.yaml
@@ -3,25 +3,14 @@
 version: "2.2"
 
 volumes:
+  middle_var: {}
+  historical_var: {}
+  broker_var: {}
+  coordinator_var: {}
+  router_var: {}
   druid_shared: {}
 
 services:
-  dj:
-    container_name: dj
-    environment:
-      - DOTENV_FILE=.env-docker
-    build: .
-    volumes:
-      - .:/code
-    ports:
-      - "8000:8000"
-    depends_on:
-      - db_migration
-      - postgres_metadata
-      - postgres_examples
-      - redis
-      - druid_coordinator
-
   druid_postgres:
     container_name: druid_postgres
     image: postgres:latest

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,40 @@
+# WARNING: this is not a standaonle docker config file. It must be used in addition to the docker-compose.yml.
+#          If in doubt please use the Makefile commands to build DJ docker containers.
+version: "2.2"
+
+volumes:
+  postgres_metadata: {}
+
+services:
+  dj:
+    environment:
+      - DOTENV_FILE=.docker-env/.env-postgres
+    depends_on:
+      - db_migration
+      - postgres_metadata
+      - postgres_examples
+      - redis
+
+  celery:
+    environment:
+      - DOTENV_FILE=.docker-env/.env-postgres
+
+  watchdog:
+    environment:
+      - DOTENV_FILE=.docker-env/.env-postgres
+
+  db_migration:
+    environment:
+      - DOTENV_FILE=.docker-env/.env-postgres
+
+  postgres_metadata:
+    container_name: postgres_metadata
+    image: postgres:latest
+    volumes:
+      - postgres_metadata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=FoolishPassword
+      - POSTGRES_USER=username
+      - POSTGRES_DB=dj
+    ports:
+      - "5434:5432"

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,4 +1,4 @@
-# WARNING: this is not a standaonle docker config file. It must be used in addition to the docker-compose.yml.
+# WARNING: this is not a standalone docker config file. It must be used in addition to the docker-compose.yml.
 #          If in doubt please use the Makefile commands to build DJ docker containers.
 version: "2.2"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,14 @@
 version: "2.2"
 
 volumes:
-  metadata_data: {}
-  middle_var: {}
-  historical_var: {}
-  broker_var: {}
-  coordinator_var: {}
-  router_var: {}
   postgres_data: {}
-  postgres_metadata: {}
   redis_data: {}
 
 services:
   dj:
     container_name: dj
     environment:
-      - DOTENV_FILE=.docker-env/.env-postgres
+      - DOTENV_FILE=.docker-env/.env
     build: .
     volumes:
       - .:/code
@@ -23,14 +16,13 @@ services:
       - "8000:8000"
     depends_on:
       - db_migration
-      - postgres_metadata
       - postgres_examples
       - redis
 
   celery:
     container_name: celery
     environment:
-      - DOTENV_FILE=.docker-env/.env-postgres
+      - DOTENV_FILE=.docker-env/.env
     build: .
     volumes:
       - .:/code
@@ -41,7 +33,7 @@ services:
   watchdog:
     container_name: watchdog
     environment:
-      - DOTENV_FILE=.docker-env/.env-postgres
+      - DOTENV_FILE=.docker-env/.env
     build: .
     volumes:
       - .:/code
@@ -53,12 +45,10 @@ services:
   db_migration:
     container_name: db_migration
     environment:
-      - DOTENV_FILE=.docker-env/.env-postgres
+      - DOTENV_FILE=.docker-env/.env
     build: .
     volumes:
       - .:/code
-    depends_on:
-      - postgres_metadata
     command: alembic upgrade head
     restart: on-failure
 
@@ -70,18 +60,6 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
-
-  postgres_metadata:
-    container_name: postgres_metadata
-    image: postgres:latest
-    volumes:
-      - postgres_metadata:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_PASSWORD=FoolishPassword
-      - POSTGRES_USER=username
-      - POSTGRES_DB=dj
-    ports:
-      - "5434:5432"
 
   postgres_examples:
     container_name: postgres_examples

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -104,14 +104,25 @@ in Postgres. However, DJ leverages SQL Alchemy to enable flexibility when it com
 its own metadata. Variations of the default docker compose environments can be selected using one of the available override
 docker compose files which add, remove, or modify services.
 
-+-------------------+-----------------------------------------------------------------------------------------------------+---------------------------------------------------------+
-| Name              | Command                                                                                             | Description                                             |
-+===================+=====================================================================================================+=========================================================+
-| SQLite            | docker compose up                                                                                   | DJ server backed by SQLite                              |
-| Postgres          | docker compose -f docker-compose.yml -f docker-compose.postgres.yml up                              | DJ server backed by Postgres                            |
-| Postgres + Druid  | docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.druid.yml up  | An extension of the Postgres setup that includes Druid  |
-| CockroachDB       | docker compose -f docker-compose.yml -f docker-compose.cockroachdb.yml up                           | DJ server backed by CockroachDB                         |
-+-------------------+-----------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+.. list-table:: Docker Compose Optional Overrides
+   :widths: 15 10 30
+   :header-rows: 1
+
+   * - Name
+     - Command
+     - Description
+   * - SQLite
+     - docker compose up
+     - DJ server backed by SQLite
+   * - Postgres
+     - docker compose -f docker-compose.yml -f docker-compose.postgres.yml up
+     - DJ server backed by Postgres
+   * - Postgres + Druid
+     - docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.druid.yml up
+     - An extension of the Postgres setup that includes Druid
+   * - CockroachDB
+     - docker compose -f docker-compose.yml -f docker-compose.cockroachdb.yml up
+     - DJ server backed by CockroachDB
 
 Troubleshooting
 ===============

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -104,13 +104,14 @@ in Postgres. However, DJ leverages SQL Alchemy to enable flexibility when it com
 its own metadata. Variations of the default docker compose environments can be selected using one of the available override
 docker compose files which add, remove, or modify services.
 
-+-------------------+----------------------------------------------------------------------------+------------------------------------------------------------------------+
-| Name              | Command                                                                    | Description                                                            |
-+===================+============================================================================+========================================================================+
-| Postgres          | docker compose up                                                          | DJ server backed by Postgres                                           |
-| Postgres + Druid  | docker compose -f docker-compose.yml -f docker-compose.druid.yml up        | An extension of the Postgres setup that includes Druid                 |
-| CockroachDB       | docker compose -f docker-compose.yml -f docker-compose.cockroachdb.yml up  | DJ server backed by CockroachDB                                        |
-+-------------------+----------------------------------------------------------------------------+------------------------------------------------------------------------+
++-------------------+-----------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| Name              | Command                                                                                             | Description                                             |
++===================+=====================================================================================================+=========================================================+
+| SQLite            | docker compose up                                                                                   | DJ server backed by SQLite                              |
+| Postgres          | docker compose -f docker-compose.yml -f docker-compose.postgres.yml up                              | DJ server backed by Postgres                            |
+| Postgres + Druid  | docker compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.druid.yml up  | An extension of the Postgres setup that includes Druid  |
+| CockroachDB       | docker compose -f docker-compose.yml -f docker-compose.cockroachdb.yml up                           | DJ server backed by CockroachDB                         |
++-------------------+-----------------------------------------------------------------------------------------------------+---------------------------------------------------------+
 
 Troubleshooting
 ===============


### PR DESCRIPTION
### Summary

Instead of using Postgres by default, this changes the default `docker compose up` environment to not use any `INDEX` value and not launch any `postgres_metadata` container. DJ will then fall back and use SQLite by default.

Using a postgres container to store the metadata (the old behavior) can still be achieved using an override that adds the `postgres_metadata` container and uses a DJ env file that includes an `INDEX` value that points to the container.

*To use postgres*:
```
docker compose -f docker-compose.yml -f docker-compose.postgres.yml up
```

### Test Plan

Ran `docker compose up` and ran queries through curl as well as the graphql API.

Also ran `docker compose -f docker-compose.yml -f docker-compose.postgres.yml up` and ran the same queries.

- [x] PR has an associated issue: #225 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
