### PR TITLE
Delete removed metrics

### DIFF
--- a/dj/cli/compile.py
+++ b/dj/cli/compile.py
@@ -313,7 +313,7 @@ async def index_nodes(  # pylint: disable=too-many-locals
         for future in done:
             node = future.result()
             nodes[node.name] = node
-            if node.name in existing_metrics:
+            if node.type == NodeType.METRIC and node.name in existing_metrics:
                 existing_metrics.pop(node.name)
             finished.add(node.name)
 

--- a/dj/cli/compile.py
+++ b/dj/cli/compile.py
@@ -318,7 +318,7 @@ async def index_nodes(  # pylint: disable=too-many-locals
                 nodes_to_delete.remove(node.name)
             finished.add(node.name)
 
-    # remove existing metrics that were not found when indexing current configs
+    # remove existing nodes that were not found when indexing current configs
     if nodes_to_delete:
         await asyncio.wait(
             {remove_node(session, existing_nodes[name]) for name in nodes_to_delete},

--- a/dj/cli/compile.py
+++ b/dj/cli/compile.py
@@ -318,10 +318,11 @@ async def index_nodes(  # pylint: disable=too-many-locals
             finished.add(node.name)
 
     # remove existing metrics that were not found when indexing current configs
-    await asyncio.wait(
-        {remove_node(session, node) for node in existing_metrics.values()},
-        return_when=asyncio.ALL_COMPLETED,
-    )
+    if existing_metrics:
+        await asyncio.wait(
+            {remove_node(session, node) for node in existing_metrics.values()},
+            return_when=asyncio.ALL_COMPLETED,
+        )
 
     return list(nodes.values())
 

--- a/dj/cli/compile.py
+++ b/dj/cli/compile.py
@@ -331,7 +331,7 @@ async def remove_node(session: Session, node: Node):
     """
     Remove a node.
     """
-    _logger.info(f"Removing {node.type} node {node.name}")
+    _logger.info("Removing %s node %s", node.type, node.name)
     session.delete(node)
 
 

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -342,7 +342,7 @@ async def test_index_nodes_removed_existing(
             created_at=datetime(2020, 1, 2, 0, 0),
             updated_at=datetime(2020, 1, 2, 0, 0),
             query="SELECT COUNT(*) FROM core.comments",
-        )
+        ),
     )
 
     session.flush()

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -347,74 +347,14 @@ async def test_index_nodes_removed_existing(
 
     session.flush()
 
-    with freeze_time("2021-01-01T00:00:00Z"):
-        Path("/path/to/repository/nodes/core/comments.yaml").touch()
-        Path("/path/to/repository/nodes/core/users.yaml").touch()
+    nodes = await index_nodes(repository, session)
 
-    with freeze_time("2021-01-02T00:00:00Z"):
-        nodes = await index_nodes(repository, session)
-
-    configs = [node.dict(exclude={"id": True}) for node in nodes]
-    assert sorted(configs, key=itemgetter("name")) == [
-        {
-            "name": "core.comments",
-            "description": "A fact table with comments",
-            "type": NodeType.SOURCE,
-            "created_at": datetime(2021, 1, 2, 0, 0),
-            "updated_at": datetime(2021, 1, 2, 0, 0),
-            "query": None,
-        },
-        {
-            "name": "core.dim_users",
-            "description": "User dimension",
-            "type": NodeType.DIMENSION,
-            "created_at": datetime(2021, 1, 2, 0, 0),
-            "updated_at": datetime(2021, 1, 2, 0, 0),
-            "query": "SELECT * FROM core.users",
-        },
-        {
-            "name": "core.num_comments",
-            "description": "Number of comments",
-            "type": NodeType.METRIC,
-            "created_at": datetime(2021, 1, 2, 0, 0),
-            "updated_at": datetime(2021, 1, 2, 0, 0),
-            "query": "SELECT COUNT(*) FROM core.comments",
-        },
-        {
-            "name": "core.users",
-            "description": "A user table",
-            "type": NodeType.SOURCE,
-            "created_at": datetime(2021, 1, 2, 0, 0),
-            "updated_at": datetime(2021, 1, 2, 0, 0),
-            "query": None,
-        },
-    ]
-
-    # update one of the nodes and reindex
-    with freeze_time("2021-01-03T00:00:00Z"):
-        Path("/path/to/repository/nodes/core/users.yaml").touch()
-        nodes = await index_nodes(repository, session)
-    nodes = sorted(nodes, key=lambda node: node.name)
-
-    assert [(node.name, node.updated_at) for node in nodes] == [
-        ("core.comments", datetime(2021, 1, 2, 0, 0)),
-        ("core.dim_users", datetime(2021, 1, 3, 0, 0)),
-        ("core.num_comments", datetime(2021, 1, 3, 0, 0)),
-        ("core.users", datetime(2021, 1, 3, 0, 0)),
-    ]
-
-    # test that a missing timezone is treated as UTC
-    nodes[0].updated_at = nodes[0].updated_at.replace(tzinfo=None)
-    with freeze_time("2021-01-03T00:00:00Z"):
-        nodes = await index_nodes(repository, session)
-    nodes = sorted(nodes, key=lambda node: node.name)
-
-    assert [(node.name, node.updated_at) for node in nodes] == [
-        ("core.comments", datetime(2021, 1, 2, 0, 0)),
-        ("core.dim_users", datetime(2021, 1, 3, 0, 0)),
-        ("core.num_comments", datetime(2021, 1, 3, 0, 0)),
-        ("core.users", datetime(2021, 1, 3, 0, 0)),
-    ]
+    assert {node.name for node in nodes} == {
+        "core.comments",
+        "core.dim_users",
+        "core.num_comments",
+        "core.users",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -237,6 +237,16 @@ async def test_index_nodes(
         ),
     )
     session.add(Database(name="gsheets", URI="gsheets://"))
+    session.add(
+        Node(
+            name="core.old_num_comments",
+            description="A Number of comments whose config was deleted",
+            type=NodeType.METRIC,
+            created_at=datetime(2020, 1, 2, 0, 0),
+            updated_at=datetime(2020, 1, 2, 0, 0),
+            query="SELECT COUNT(*) FROM core.comments",
+        ),
+    )
     session.flush()
 
     with freeze_time("2021-01-01T00:00:00Z"):
@@ -309,52 +319,52 @@ async def test_index_nodes(
     ]
 
 
-@pytest.mark.asyncio
-async def test_index_nodes_removed_existing(
-    mocker: MockerFixture,
-    repository: Path,
-    session: Session,
-) -> None:
-    """
-    Test ``index_nodes``.
-    """
-    mocker.patch(
-        "dj.cli.compile.get_table_columns",
-        return_value=[],
-    )
-    mocker.patch("dj.cli.compile.update_node_config")
+# @pytest.mark.asyncio
+# async def test_index_nodes_removed_existing(
+#     mocker: MockerFixture,
+#     repository: Path,
+#     session: Session,
+# ) -> None:
+#     """
+#     Test ``index_nodes`` and ``remove_nodes``.
+#     """
+#     mocker.patch(
+#         "dj.cli.compile.get_table_columns",
+#         return_value=[],
+#     )
+#     mocker.patch("dj.cli.compile.update_node_config")
 
-    session.add(
-        Database(name="druid", URI="druid://druid_broker:8082/druid/v2/sql/"),
-    )
-    session.add(
-        Database(
-            name="postgres",
-            URI="postgresql://username:FoolishPassword@postgres_examples:5432/examples",
-        ),
-    )
-    session.add(Database(name="gsheets", URI="gsheets://"))
-    session.add(
-        Node(
-            name="core.old_num_comments",
-            description="A Number of comments whose config was deleted",
-            type=NodeType.METRIC,
-            created_at=datetime(2020, 1, 2, 0, 0),
-            updated_at=datetime(2020, 1, 2, 0, 0),
-            query="SELECT COUNT(*) FROM core.comments",
-        ),
-    )
+#     session.add(
+#         Database(name="druid", URI="druid://druid_broker:8082/druid/v2/sql/"),
+#     )
+#     session.add(
+#         Database(
+#             name="postgres",
+#             URI="postgresql://username:FoolishPassword@postgres_examples:5432/examples",
+#         ),
+#     )
+#     session.add(Database(name="gsheets", URI="gsheets://"))
+#     session.add(
+#         Node(
+#             name="core.old_num_comments",
+#             description="A Number of comments whose config was deleted",
+#             type=NodeType.METRIC,
+#             created_at=datetime(2020, 1, 2, 0, 0),
+#             updated_at=datetime(2020, 1, 2, 0, 0),
+#             query="SELECT COUNT(*) FROM core.comments",
+#         ),
+#     )
 
-    session.flush()
+#     session.flush()
 
-    nodes = await index_nodes(repository, session)
+#     nodes = await index_nodes(repository, session)
 
-    assert {node.name for node in nodes} == {
-        "core.comments",
-        "core.dim_users",
-        "core.num_comments",
-        "core.users",
-    }
+#     assert {node.name for node in nodes} == {
+#         "core.comments",
+#         "core.dim_users",
+#         "core.num_comments",
+#         "core.users",
+#     }
 
 
 @pytest.mark.asyncio

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -319,54 +319,6 @@ async def test_index_nodes(
     ]
 
 
-# @pytest.mark.asyncio
-# async def test_index_nodes_removed_existing(
-#     mocker: MockerFixture,
-#     repository: Path,
-#     session: Session,
-# ) -> None:
-#     """
-#     Test ``index_nodes`` and ``remove_nodes``.
-#     """
-#     mocker.patch(
-#         "dj.cli.compile.get_table_columns",
-#         return_value=[],
-#     )
-#     mocker.patch("dj.cli.compile.update_node_config")
-
-#     session.add(
-#         Database(name="druid", URI="druid://druid_broker:8082/druid/v2/sql/"),
-#     )
-#     session.add(
-#         Database(
-#             name="postgres",
-#             URI="postgresql://username:FoolishPassword@postgres_examples:5432/examples",
-#         ),
-#     )
-#     session.add(Database(name="gsheets", URI="gsheets://"))
-#     session.add(
-#         Node(
-#             name="core.old_num_comments",
-#             description="A Number of comments whose config was deleted",
-#             type=NodeType.METRIC,
-#             created_at=datetime(2020, 1, 2, 0, 0),
-#             updated_at=datetime(2020, 1, 2, 0, 0),
-#             query="SELECT COUNT(*) FROM core.comments",
-#         ),
-#     )
-
-#     session.flush()
-
-#     nodes = await index_nodes(repository, session)
-
-#     assert {node.name for node in nodes} == {
-#         "core.comments",
-#         "core.dim_users",
-#         "core.num_comments",
-#         "core.users",
-#     }
-
-
 @pytest.mark.asyncio
 async def test_add_node_force(
     mocker: MockerFixture,


### PR DESCRIPTION
### Summary

Checking for metric nodes that no longer have a config. `dj compile` will remove them

### Test Plan

Add a metric node to `test_index_nodes` and see if it exists at the end of the test.

- [x] PR has an associated issue: https://github.com/DataJunction/dj/issues/195
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

