### PR TITLE
Add .env file for default docker compose

### DIFF
--- a/.docker-env/.env
+++ b/.docker-env/.env
@@ -1,0 +1,5 @@
+NAME="Example DJ server"
+DESCRIPTION="A simple DJ server running in Docker"
+REPOSITORY=examples/configs
+REDIS_CACHE=redis://query_broker:6379/0
+CELERY_BROKER=redis://query_broker:6379/1


### PR DESCRIPTION
### Summary

A follow-up to PR #226. I forgot to add the `.docker-env/.env` file for the standard docker compose up command. This one doesn't include an `INDEX` value to allow DJ to fallback to SQLite.

### Test Plan

Ran `docker compose up` and ran queries using curl and the graphiql UI.

- [x] PR has an associated issue: #228
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
