### PR TITLE
Remove postgres_metadata override in crdb example

### DIFF
--- a/docker-compose.cockroachdb.yml
+++ b/docker-compose.cockroachdb.yml
@@ -30,10 +30,6 @@ services:
     environment:
       - DOTENV_FILE=.docker-env/.env-cockroachdb
 
-  postgres_metadata:
-    profiles:
-      - disabled
-
   postgres_examples:
     profiles:
       - disabled

--- a/examples/cockroachdb/configs/nodes/kaggle/avg_play_time.yaml
+++ b/examples/cockroachdb/configs/nodes/kaggle/avg_play_time.yaml
@@ -1,6 +1,9 @@
 description: Average user playtime
 type: metric
-query: SELECT AVG(amount) FROM kaggle.source.playtime WHERE behavior='play'
+query: |-
+  SELECT AVG(amount)
+  FROM kaggle.source.playtime
+  WHERE behavior='play'
 columns:
   _col0:
     type: FLOAT

--- a/examples/cockroachdb/configs/nodes/kaggle/dimension/games.yaml
+++ b/examples/cockroachdb/configs/nodes/kaggle/dimension/games.yaml
@@ -1,6 +1,8 @@
 description: Game dimension
 type: dimension
-query: SELECT distinct name FROM kaggle.source.games
+query: |-
+  SELECT DISTINCT name
+  FROM kaggle.source.games
 columns:
   name:
     type: STR

--- a/examples/cockroachdb/configs/nodes/kaggle/num_italian_games.yaml
+++ b/examples/cockroachdb/configs/nodes/kaggle/num_italian_games.yaml
@@ -1,6 +1,9 @@
 description: Number of Steam games that include Italian dubs/subs
 type: metric
-query: SELECT COUNT(*) FROM kaggle.source.games WHERE language LIKE '%Italian%'
+query: |-
+  SELECT COUNT(*)
+  FROM kaggle.source.games
+  WHERE LANGUAGE LIKE '%Italian%'
 columns:
   _col0:
     type: INT

--- a/examples/cockroachdb/configs/nodes/kaggle/num_play_events.yaml
+++ b/examples/cockroachdb/configs/nodes/kaggle/num_play_events.yaml
@@ -1,6 +1,9 @@
 description: Number of Steam user play events captured
 type: metric
-query: SELECT COUNT(*) FROM kaggle.source.playtime WHERE behavior='play'
+query: |-
+  SELECT COUNT(*)
+  FROM kaggle.source.playtime
+  WHERE behavior='play'
 columns:
   _col0:
     type: INT

--- a/examples/cockroachdb/configs/nodes/kaggle/num_purchase_events.yaml
+++ b/examples/cockroachdb/configs/nodes/kaggle/num_purchase_events.yaml
@@ -1,6 +1,9 @@
 description: Number of Steam user purchase events captured
 type: metric
-query: SELECT COUNT(*) FROM kaggle.source.playtime WHERE behavior='purchase'
+query: |-
+  SELECT COUNT(*)
+  FROM kaggle.source.playtime
+  WHERE behavior='purchase'
 columns:
   _col0:
     type: INT


### PR DESCRIPTION
### Summary

Fixes the cockroach db docker setup

### Test Plan

Start up the cockroach db docker compose...
```sh
docker compose -f docker-compose.yml -f docker-compose.cockroachdb.yml up
```
...and submitted queries through curl and the graphql UI to confirm that everything works as expected.

- [x] PR has an associated issue: #230
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
