### PR TITLE
Add support for GROUP BY using positions

### DIFF
--- a/examples/configs/nodes/basic/transform/country_agg.yaml
+++ b/examples/configs/nodes/basic/transform/country_agg.yaml
@@ -4,7 +4,7 @@ query: |-
   SELECT country,
          COUNT(DISTINCT id) AS num_users
   FROM basic.source.users
-  GROUP BY country
+  GROUP BY 1
 columns:
   country:
     type: STR


### PR DESCRIPTION
### Summary

This adds support for using positions in a `GROUP BY` clause. For example:

```sql
  SELECT country,
         COUNT(DISTINCT id) AS num_users
  FROM basic.source.users
  GROUP BY 1
```

### Test Plan

I added a test `test_get_query_for_sql_where_groupby_num` and updated the `country_agg.yaml` example node to use
`GROUP BY 1` instead of `GROUP BY country`, then confirmed that the same behavior remains.

- [x] PR has an associated issue: #124 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
