### PR TITLE
Manually dispatched workflow to commit openapi spec

### DIFF
--- a/.github/workflows/commit-openapi-spec.yaml
+++ b/.github/workflows/commit-openapi-spec.yaml
@@ -1,0 +1,26 @@
+name: Update and Commit OpenAPI Spec
+on: [workflow_dispatch]
+jobs:
+  update-openapi-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install DJ
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Generate OpenAPI Spec
+        run: ./scripts/generate-openapi.py -o openapi.json
+
+      - name: Commit Updated OpenAPI Spec
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update OpenAPI Spec
+          file_pattern: 'openapi.json'

--- a/scripts/generate-openapi.py
+++ b/scripts/generate-openapi.py
@@ -4,7 +4,7 @@
 import argparse
 import json
 
-from dj.api.query.engine import app
+from dj.api.main import app
 
 
 def save_openapi_spec(f: str):

--- a/scripts/generate-openapi.py
+++ b/scripts/generate-openapi.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# pylint: skip-file
+
+import argparse
+import json
+
+from dj.api.query.engine import app
+
+
+def save_openapi_spec(f: str):
+    spec = app.openapi()
+    with open(f, "w") as outfile:
+        outfile.write(json.dumps(spec, indent=4))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate a file containing the OpenAPI spec for a DJ server",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        dest="filename",
+        required=True,
+        metavar="FILE",
+    )
+    args = vars(parser.parse_args())
+    save_openapi_spec(f=args["filename"])


### PR DESCRIPTION
### Summary

This PR adds a workflow that imports the DJ app and outputs the OpenAPI spec (which is retrieved by calling `app.openapi()`) to a file called  `openapi.json` that's then committed to the root of the repository. The workflow does not run automatically and for now, I think it's ok that we just manually run it whenever we update any of the API routes.

### Test Plan

I added the workflow to a personal repo and ran it a few times.

- [x] PR has an associated issue: #234 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

The workflow will only run when triggered manually.
