### PR TITLE
feat: add UUID column to databases

### DIFF
--- a/alembic/versions/2022_10_27_2242-f620c4521c80_add_uuid_column_to_database_model.py
+++ b/alembic/versions/2022_10_27_2242-f620c4521c80_add_uuid_column_to_database_model.py
@@ -1,0 +1,57 @@
+"""Add UUID column to database model
+
+Revision ID: f620c4521c80
+Revises: 71b291295ae1
+Create Date: 2022-10-27 22:42:19.160413+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+from uuid import UUID
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+import sqlmodel
+from sqlalchemy.sql import table
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f620c4521c80"
+down_revision = "71b291295ae1"
+branch_labels = None
+depends_on = None
+
+
+DJ_DATABASE_ID = 0
+DJ_DATABASE_UUID = UUID("594804bf-47cb-426c-83c4-94a348e95972")
+SQLITE_DATABASE_ID = -1
+SQLITE_DATABASE_UUID = UUID("3619eeba-d628-4ab1-9dd5-65738ab3c02f")
+
+
+def upgrade():
+    with op.batch_alter_table("database") as bop:
+        bop.add_column(
+            sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
+        )
+
+    database = table(
+        "database",
+        sa.Column("id", sa.Integer()),
+        sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
+    )
+    op.execute(
+        database.update()
+        .where(database.c.id == DJ_DATABASE_ID)
+        .values({"uuid": DJ_DATABASE_UUID}),
+    )
+    op.execute(
+        database.update()
+        .where(database.c.id == SQLITE_DATABASE_ID)
+        .values({"uuid": SQLITE_DATABASE_UUID}),
+    )
+
+
+def downgrade():
+    with op.batch_alter_table("database") as bop:
+        bop.drop_column("uuid")

--- a/dj/cli/compile.py
+++ b/dj/cli/compile.py
@@ -23,7 +23,13 @@ from sqlalchemy.engine.url import URL
 from sqlmodel import Session, create_engine, select
 from watchfiles import Change, awatch
 
-from dj.constants import DEFAULT_DIMENSION_COLUMN, DJ_DATABASE_ID, SQLITE_DATABASE_ID
+from dj.constants import (
+    DEFAULT_DIMENSION_COLUMN,
+    DJ_DATABASE_ID,
+    DJ_DATABASE_UUID,
+    SQLITE_DATABASE_ID,
+    SQLITE_DATABASE_UUID,
+)
 from dj.models.column import Column
 from dj.models.database import Database
 from dj.models.node import Node, NodeType, NodeYAML
@@ -112,6 +118,7 @@ async def add_special_databases(session: Session) -> None:
                     ),
                 ),
                 read_only=True,
+                uuid=DJ_DATABASE_UUID,
             ),
         )
 
@@ -124,6 +131,7 @@ async def add_special_databases(session: Session) -> None:
                 URI="sqlite://",
                 read_only=True,
                 cost=0,
+                uuid=SQLITE_DATABASE_UUID,
             ),
         )
 

--- a/dj/constants.py
+++ b/dj/constants.py
@@ -3,9 +3,12 @@ Useful constants.
 """
 
 from datetime import timedelta
+from uuid import UUID
 
 DJ_DATABASE_ID = 0
+DJ_DATABASE_UUID = UUID("594804bf-47cb-426c-83c4-94a348e95972")
 SQLITE_DATABASE_ID = -1
+SQLITE_DATABASE_UUID = UUID("3619eeba-d628-4ab1-9dd5-65738ab3c02f")
 
 DEFAULT_DIMENSION_COLUMN = "id"
 

--- a/dj/models/database.py
+++ b/dj/models/database.py
@@ -5,10 +5,12 @@ Models for databases.
 from datetime import datetime, timezone
 from functools import partial
 from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict
+from uuid import UUID, uuid4
 
 from sqlalchemy import DateTime, String
 from sqlalchemy.engine import Engine
 from sqlalchemy.sql.schema import Column as SqlaColumn
+from sqlalchemy_utils import UUIDType
 from sqlmodel import JSON, Field, Relationship, SQLModel, create_engine
 
 if TYPE_CHECKING:
@@ -40,6 +42,8 @@ class Database(SQLModel, table=True):  # type: ignore
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
+    uuid: UUID = Field(default_factory=uuid4, sa_column=SqlaColumn(UUIDType()))
+
     name: str = Field(sa_column=SqlaColumn("name", String, unique=True))
     description: str = ""
     URI: str

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -65,7 +65,9 @@ async def test_index_databases(repository: Path, session: Session) -> None:
         databases = await index_databases(repository, session)
 
     configs = [database.dict(exclude={"id": True}) for database in databases]
-    assert sorted(configs, key=itemgetter("name")) == [
+    configs = sorted(configs, key=itemgetter("name"))
+    uuids = [config["uuid"] for config in configs]
+    assert configs == [
         {
             "async_": False,
             "cost": 1.0,
@@ -76,6 +78,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
             "URI": "druid://druid_broker:8082/druid/v2/sql/",
             "read_only": True,
             "extra_params": {},
+            "uuid": uuids[0],
         },
         {
             "async_": False,
@@ -100,6 +103,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
                     ),
                 },
             },
+            "uuid": uuids[1],
         },
         {
             "async_": False,
@@ -111,6 +115,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
             "URI": "postgresql://username:FoolishPassword@postgres_examples:5432/examples",
             "read_only": False,
             "extra_params": {"connect_args": {"sslmode": "prefer"}},
+            "uuid": uuids[2],
         },
     ]
 


### PR DESCRIPTION
### Summary

<!-- What's this change about? -->

Add a `uuid` column to databases and set a specific UUID for the special databases (DJ and SQLite).

In a next PR, the uuid will be used in the API, replacing the id in requests, so we can get rid of ids -1 and 0 for the databases.

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #193 
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
