### PR TITLE
Update flake8 to github url instead of gitlab url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
 #   - id: blacken-docs
 #     additional_dependencies: [black]
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
### Summary

The flake8 gitlab repo is gone now so we have to remove it in our pre-commit configuration. This PR switches to the github repo.

### Test Plan

Ran `make check`

- [x] PR has an associated issue: #243 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
