### PR TITLE
Ignore openapi.json when running end-of-file-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
   - id: debug-statements
     exclude: ^templates/
   - id: end-of-file-fixer
+    exclude: openapi.json
   - id: requirements-txt-fixer
     exclude: ^templates/
   - id: mixed-line-ending


### PR DESCRIPTION
### Summary

The tests are failing because the generated openapi spec file doesn't have a new line at the end, which trips up the end-of-file-fixer. I think it's ok to just ignore configure the linter to ignore the file since it's auto-generated.

### Test Plan

Ran the `make check` and `make test` locally and confirmed that a new line in openapi.json is not picked up by the end-of-file-fixer linter.

- [x] PR has an associated issue: #247
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
