### PR TITLE
Update watchfiles to 0.18.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ accept-types==0.4.1
     # via dj
 amqp==5.1.1
     # via kombu
-anyio==3.6.1
+anyio==3.6.2
     # via
     #   starlette
     #   watchfiles
@@ -43,15 +43,13 @@ click-repl==0.2.0
     # via celery
 commonmark==0.9.1
     # via rich
-deprecated==1.2.13
-    # via redis
 docopt==0.6.2
     # via dj
 fastapi==0.70.1
     # via dj
 graphql-core==3.2.3
     # via strawberry-graphql
-greenlet==1.1.3
+greenlet==2.0.1
     # via sqlalchemy
 idna==3.4
     # via
@@ -66,7 +64,7 @@ multidict==6.0.2
     # via yarl
 packaging==21.3
     # via redis
-prompt-toolkit==3.0.31
+prompt-toolkit==3.0.33
     # via click-repl
 pydantic==1.10.2
     # via
@@ -80,11 +78,11 @@ python-dateutil==2.8.2
     # via strawberry-graphql
 python-dotenv==0.19.2
     # via dj
-pytz==2022.4
+pytz==2022.6
     # via celery
 pyyaml==6.0
     # via dj
-redis==4.3.4
+redis==4.3.5
     # via dj
 requests==2.28.1
     # via dj
@@ -103,7 +101,7 @@ sqlalchemy==1.4.35
     #   sqlmodel
 sqlalchemy-utils==0.38.3
     # via dj
-sqlalchemy2-stubs==0.0.2a28
+sqlalchemy2-stubs==0.0.2a29
     # via sqlmodel
 sqlmodel==0.0.8
     # via dj
@@ -118,20 +116,19 @@ strawberry-graphql==0.133.5
 typing-extensions==4.4.0
     # via
     #   pydantic
+    #   rich
     #   sqlalchemy2-stubs
     #   strawberry-graphql
-urllib3==1.26.12
+urllib3==1.26.13
     # via requests
 vine==5.0.0
     # via
     #   amqp
     #   celery
     #   kombu
-watchfiles==0.12
+watchfiles==0.18.1
     # via dj
 wcwidth==0.2.5
     # via prompt-toolkit
-wrapt==1.14.1
-    # via deprecated
 yarl==1.8.1
     # via dj

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -8,17 +8,17 @@
 #
 -r test.txt
     # via -r requirements/test.in
-apsw==3.39.3.0
+apsw==3.39.4.0
     # via shillelagh
 asgiref==3.5.2
     # via uvicorn
 cachetools==5.2.0
     # via google-auth
-google-auth==2.12.0
+google-auth==2.14.1
     # via shillelagh
 h11==0.14.0
     # via uvicorn
-psycopg2-binary==2.9.4
+psycopg2-binary==2.9.5
     # via -r requirements/docker.in
 pyasn1==0.4.8
     # via
@@ -28,7 +28,7 @@ pyasn1-modules==0.2.8
     # via google-auth
 rsa==4.9
     # via google-auth
-shillelagh[gsheetsapi]==1.1.0
+shillelagh[gsheetsapi]==1.1.3
     # via -r requirements/docker.in
 sqlalchemy-cockroachdb==1.4.4
     # via -r requirements/docker.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,13 +13,13 @@ alembic==1.8.1
     # via dj
 amqp==5.1.1
     # via kombu
-anyio==3.6.1
+anyio==3.6.2
     # via
     #   starlette
     #   watchfiles
 asciidag==0.2.0
     # via dj
-astroid==2.12.10
+astroid==2.12.13
     # via pylint
 async-timeout==4.0.2
     # via redis
@@ -27,7 +27,7 @@ attrs==22.1.0
     # via pytest
 billiard==3.6.4.0
     # via celery
-build==0.8.0
+build==0.9.0
     # via pip-tools
 cachelib==0.9.0
     # via dj
@@ -52,20 +52,20 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-codespell==2.2.1
+codespell==2.2.2
     # via dj
 commonmark==0.9.1
     # via rich
 coverage[toml]==6.5.0
     # via pytest-cov
-deprecated==1.2.13
-    # via redis
-dill==0.3.5.1
+dill==0.3.6
     # via pylint
 distlib==0.3.6
     # via virtualenv
 docopt==0.6.2
     # via dj
+exceptiongroup==1.0.4
+    # via pytest
 fastapi==0.70.1
     # via dj
 filelock==3.8.0
@@ -74,24 +74,28 @@ freezegun==1.2.2
     # via dj
 graphql-core==3.2.3
     # via strawberry-graphql
-greenlet==1.1.3
+greenlet==2.0.1
     # via sqlalchemy
-identify==2.5.6
+identify==2.5.9
     # via pre-commit
 idna==3.4
     # via
     #   anyio
     #   requests
     #   yarl
+importlib-metadata==5.1.0
+    # via alembic
+importlib-resources==5.10.0
+    # via alembic
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
 kombu==5.2.4
     # via celery
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.8.0
     # via astroid
-mako==1.2.3
+mako==1.2.4
     # via alembic
 markupsafe==2.1.1
     # via mako
@@ -110,9 +114,9 @@ packaging==21.3
     #   redis
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via dj
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via
     #   pylint
     #   virtualenv
@@ -120,25 +124,23 @@ pluggy==1.0.0
     # via pytest
 pre-commit==2.20.0
     # via dj
-prompt-toolkit==3.0.31
+prompt-toolkit==3.0.33
     # via click-repl
-py==1.11.0
-    # via pytest
 pydantic==1.10.2
     # via
     #   fastapi
     #   sqlmodel
-pydruid==0.6.4
+pydruid==0.6.5
     # via dj
-pyfakefs==4.7.0
+pyfakefs==5.0.0
     # via dj
 pygments==2.13.0
     # via rich
-pylint==2.15.3
+pylint==2.15.6
     # via dj
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.3
+pytest==7.2.0
     # via
     #   dj
     #   pytest-asyncio
@@ -158,13 +160,13 @@ python-dateutil==2.8.2
     #   strawberry-graphql
 python-dotenv==0.19.2
     # via dj
-pytz==2022.4
+pytz==2022.6
     # via celery
 pyyaml==6.0
     # via
     #   dj
     #   pre-commit
-redis==4.3.4
+redis==4.3.5
     # via dj
 requests==2.28.1
     # via
@@ -190,7 +192,7 @@ sqlalchemy==1.4.35
     #   sqlmodel
 sqlalchemy-utils==0.38.3
     # via dj
-sqlalchemy2-stubs==0.0.2a28
+sqlalchemy2-stubs==0.0.2a29
     # via sqlmodel
 sqlmodel==0.0.8
     # via dj
@@ -211,7 +213,7 @@ tomli==2.0.1
     #   pep517
     #   pylint
     #   pytest
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via pylint
 typing-extensions==4.4.0
     # via
@@ -219,29 +221,32 @@ typing-extensions==4.4.0
     #   dj
     #   pydantic
     #   pylint
+    #   rich
     #   sqlalchemy2-stubs
     #   strawberry-graphql
-urllib3==1.26.12
+urllib3==1.26.13
     # via requests
 vine==5.0.0
     # via
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.16.5
+virtualenv==20.16.7
     # via pre-commit
-watchfiles==0.12
+watchfiles==0.18.1
     # via dj
 wcwidth==0.2.5
     # via prompt-toolkit
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 wrapt==1.14.1
-    # via
-    #   astroid
-    #   deprecated
+    # via astroid
 yarl==1.8.1
     # via dj
+zipp==3.10.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     sqlmodel==0.0.8
     sqloxide==0.1.15
     sqlparse>=0.3.0
-    watchfiles==0.12
+    watchfiles==0.18.1
     yarl>=1.7.2
     strawberry-graphql==0.133.5
 


### PR DESCRIPTION
### Summary

This updates watchfiles from `0.12` -> `0.18.1`. This fixes the issues that prevent watchfiles from working on M1 macs that come with some new filesystem APIs. After updating it in setup.cfg I ran `pip-compile-multi`.

### Test Plan

Ran `make check && make test` locally.

- [x] PR has an associated issue: #249 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
