### PR TITLE
Explicitly set dj name and core network

### DIFF
--- a/docker-compose.cockroachdb.yml
+++ b/docker-compose.cockroachdb.yml
@@ -1,6 +1,6 @@
 # WARNING: this is not a standalone docker config file. It must be used in addition to the docker-compose.yml.
 #          If in doubt please use the Makefile commands to build DJ docker containers.
-version: "2.2"
+version: "3"
 
 volumes:
   cockroachdb_examples: {}

--- a/docker-compose.druid.yaml
+++ b/docker-compose.druid.yaml
@@ -1,6 +1,6 @@
 # WARNING: this is not a standaonle docker config file. It must be used in addition to the docker-compose.yml.
 #          If in doubt please use the Makefile commands to build DJ docker containers.
-version: "2.2"
+version: "3"
 
 volumes:
   middle_var: {}

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,6 +1,6 @@
 # WARNING: this is not a standalone docker config file. It must be used in addition to the docker-compose.yml.
 #          If in doubt please use the Makefile commands to build DJ docker containers.
-version: "2.2"
+version: "3"
 
 volumes:
   postgres_metadata: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,18 @@
-version: "2.2"
-
+version: "3"
+name: "dj"
 volumes:
   postgres_data: {}
   redis_data: {}
 
+networks:
+  core:
+    driver: bridge
+
 services:
   dj:
     container_name: dj
+    networks:
+      - core
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
@@ -21,6 +27,8 @@ services:
 
   celery:
     container_name: celery
+    networks:
+      - core
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
@@ -32,6 +40,8 @@ services:
 
   watchdog:
     container_name: watchdog
+    networks:
+      - core
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
@@ -44,6 +54,8 @@ services:
 
   db_migration:
     container_name: db_migration
+    networks:
+      - core
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
@@ -55,6 +67,8 @@ services:
   redis:
     image: redis:latest
     container_name: query_broker
+    networks:
+      - core
     restart: unless-stopped
     ports:
       - "6379:6379"
@@ -63,6 +77,8 @@ services:
 
   postgres_examples:
     container_name: postgres_examples
+    networks:
+      - core
     image: postgres:latest
     volumes:
       - ./examples/docker/postgres_init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 version: "3"
-name: "dj"
+name: dj
 volumes:
   postgres_data: {}
   redis_data: {}


### PR DESCRIPTION
### Summary

This explicitly sets a name (`dj`) and a network (`core`) for the docker compose setups. It allows any other docker container to reliably interact with this docker compose setup by joining the `dj_core` network (docker compose prefixes all networks it creates with the project's name).

### Test Plan

Ran `make check` and `make test`. Also ran `docker compose up` and checked that creating a simple standalone docker container connected to the `dj_core` network could ping the `dj` container.

- [x] PR has an associated issue: #251 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
