### PR TITLE
Disable check_same_thread when using SQLite

### DIFF
--- a/dj/config.py
+++ b/dj/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):  # pylint: disable=too-few-public-methods
     url: str = "http://localhost:8000/"
 
     # SQLAlchemy URI for the metadata database.
-    index: str = "sqlite:///dj.db"
+    index: str = "sqlite:///dj.db?check_same_thread=False"
 
     # Directory where the repository lives. This should have 2 subdirectories, "nodes" and
     # "databases".


### PR DESCRIPTION
### Summary

This disables the check by SQLite that objects aren't used across threads mainly because the errors are noisy in the logs. I don't think this effects anything since all of the write operations to the metadata db are serialized. (read more [here](https://docs.python.org/3/library/sqlite3.html#sqlite3.connect))

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #253 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
