### PR TITLE
Endpoint for creating a node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ ENV/
 
 # VS Code
 .vscode
+
+# Intellij
+.idea

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,9 @@
 # https://github.com/samuelcolvin/pydantic/issues/1961#issuecomment-759522422
 extension-pkg-whitelist=pydantic
 ignore=templates,docs
+
+[BASIC]
+good-names=
+    e,
+    ex,
+    i,

--- a/alembic/versions/2022_12_16_2349-07cbd423efcd_add_an_environment_attribute_to_nodes.py
+++ b/alembic/versions/2022_12_16_2349-07cbd423efcd_add_an_environment_attribute_to_nodes.py
@@ -1,0 +1,27 @@
+"""Add an environment attribute to nodes
+
+Revision ID: 07cbd423efcd
+Revises: f620c4521c80
+Create Date: 2022-12-16 23:49:44.715585+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "07cbd423efcd"
+down_revision = "f620c4521c80"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("node", sa.Column("environment", sa.String))
+
+
+def downgrade():
+    op.drop_column("node", "environment")

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -4,17 +4,35 @@ Node related APIs.
 
 import logging
 from datetime import datetime
-from typing import List, Optional
+from http import HTTPStatus
+from typing import List, Optional, Union
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, SQLModel, select
 
-from dj.models.column import ColumnType
-from dj.models.node import Node, NodeType
+from dj.models.column import Column, ColumnType
+from dj.models.node import Node, NodeBase, NodeEnvironment, NodeType
+from dj.models.source import ExistingSourceNode, SourceNodeCreator
+from dj.sql.inference import infer_columns
+from dj.sql.parse import get_dependencies
 from dj.utils import get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+class NodeCreator(NodeBase):
+    """
+    A create object for adding a new node
+    """
+
+
+class ExistingNode(NodeBase):
+    """
+    A node read from the DJ system
+    """
+
+    id: int
 
 
 class SimpleColumn(SQLModel):
@@ -50,3 +68,83 @@ def read_nodes(*, session: Session = Depends(get_session)) -> List[NodeMetadata]
     List the available nodes.
     """
     return session.exec(select(Node)).all()
+
+
+@router.post("/nodes/", response_model=Union[ExistingSourceNode, ExistingNode])
+def create_node(
+    data: Union[SourceNodeCreator, NodeCreator],
+    session: Session = Depends(get_session),
+) -> Union[ExistingSourceNode, ExistingNode]:
+    """
+    Create a node
+    """
+    # Check if the node already exists
+    query = select(Node).where(Node.name == data.name)
+    node = session.exec(query).one_or_none()
+    if node:
+        raise HTTPException(
+            status_code=HTTPStatus.CONFLICT,
+            detail=f"Node already exists: {data.name}",
+        )
+
+    if data.type == NodeType.SOURCE:
+        return create_source_node(
+            session=session,
+            data=data,
+        )  # Source nodes can't be created with Node.from_orm
+    new_node = Node.from_orm(data)
+    new_nodes_parents = get_dependencies(new_node.query) if new_node.query else set()
+
+    # Lookup the parent nodes for the new node
+    new_node.parents = session.exec(
+        select(Node).where(Node.name.in_(new_nodes_parents)),  # type: ignore  # pylint: disable=no-member
+    ).all()
+    _logger.info("Found parent nodes for %s: %s", new_node.name, new_node.parents)
+
+    # Infer the node's column names and column types by inspecting the parent nodes
+    try:
+        new_node.columns = infer_columns(new_node.query, parents=new_node.parents)
+    except Exception as e:  # pylint: disable=broad-except
+        error_message = f"Cannot infer columns for {new_node.name}: {str(e)}"
+        _logger.error(error_message)
+        if new_node.environment == NodeEnvironment.PRODUCTION:
+            raise HTTPException(
+                status_code=HTTPStatus.PRECONDITION_FAILED,
+                detail=error_message,
+            ) from e
+
+    new_node.extra_validation()
+
+    session.add(new_node)
+    session.commit()
+    session.refresh(new_node)
+
+    return new_node  # type: ignore
+
+
+def create_source_node(session: Session, data: SourceNodeCreator) -> Node:
+    """
+    Create a source node
+    """
+
+    config = {
+        "name": data.name,
+        "description": data.description,
+        "type": data.type,
+        "environment": data.environment,
+        "columns": [
+            Column(
+                name=column_name,
+                type=ColumnType[column_data["type"]],
+            )
+            for column_name, column_data in data.columns.items()
+        ],
+        "parents": [],
+    }
+
+    new_source_node = Node(**config)
+    session.add(new_source_node)
+    session.commit()
+    session.refresh(new_source_node)
+
+    return new_source_node

--- a/dj/models/source.py
+++ b/dj/models/source.py
@@ -1,0 +1,33 @@
+"""
+Models for source node CRUD operations.
+"""
+from typing import Dict, List, Optional
+
+from typing_extensions import TypedDict
+
+from dj.models import Column, Table
+from dj.models.node import NodeBase
+from dj.typing import ColumnType
+
+
+class SourceNodeColumnType(TypedDict, total=False):
+    """
+    Schema of a column for a table defined in a source node
+    """
+
+    type: ColumnType
+    dimension: Optional[str]
+
+
+class SourceNodeCreator(NodeBase):
+    """A create object for adding a new source node"""
+
+    columns: Dict[str, SourceNodeColumnType]
+
+
+class ExistingSourceNode(NodeBase):
+    """A source read from the DJ system"""
+
+    id: int
+    columns: List[Column]
+    tables: List[Table]

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -5,8 +5,9 @@ Tests for the nodes API.
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
+from dj.api.nodes import NodeCreator
 from dj.models.column import Column, ColumnType
-from dj.models.node import Node, NodeType
+from dj.models.node import Node, NodeEnvironment, NodeType
 
 
 def test_read_nodes(session: Session, client: TestClient) -> None:
@@ -61,3 +62,212 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
             "type": "INT",
         },
     ]
+
+
+def test_create_nodes(client: TestClient) -> None:
+    """
+    Test ``POST /nodes/``.
+    """
+    # Create a source node
+    source_create = {
+        "name": "revenue",
+        "description": "This is a source table containing revenue data about the product",
+        "type": "source",
+        "tables": {
+            "postgres": [{"catalog": None, "schema_": "product", "table": "revenue"}],
+        },
+        "columns": {"country": {"type": "STR"}, "revenue": {"type": "FLOAT"}},
+    }
+    response = client.post("/nodes/", json=source_create)
+    data = response.json()
+
+    # Check the response after creating the source node
+    assert response.status_code == 200
+    assert len(data) == 8
+    assert data["id"] == 1
+    assert data["name"] == "revenue"
+    assert (
+        data["description"]
+        == "This is a source table containing revenue data about the product"
+    )
+    assert data["type"] == "source"
+    assert data["environment"] == "production"
+
+    # Create a dimension node
+    transform_create = NodeCreator(
+        name="country_dim",
+        description="This creates a country dimension node by pulling all distinct country names",
+        type=NodeType.DIMENSION,
+        query=(
+            "SELECT DISTINCT country as id, SUM(revenue) as total_revenue FROM revenue GROUP BY id"
+        ),
+    )
+    response = client.post("/nodes/", json=transform_create.dict())
+    data = response.json()
+
+    # Check the response after creating the dimension node
+    assert response.status_code == 200
+    assert len(data) == 8
+    assert data["id"] == 2
+    assert data["name"] == "country_dim"
+    assert (
+        data["description"]
+        == "This creates a country dimension node by pulling all distinct country names"
+    )
+    assert data["type"] == "dimension"
+    assert data["columns"] == [
+        {
+            "id": 1,
+            "dimension_id": None,
+            "dimension_column": None,
+            "name": "country",
+            "type": "STR",
+        },
+        {
+            "id": 3,
+            "dimension_id": None,
+            "dimension_column": None,
+            "name": "total_revenue",
+            "type": "FLOAT",
+        },
+    ]
+
+    # Create a transform node
+    transform_create = NodeCreator(
+        name="purchases_over_a_grand",
+        description="This filters the revenue source node to only include purchases over $1,000",
+        type=NodeType.TRANSFORM,
+        query="SELECT country, revenue FROM revenue WHERE revenue > 1000.00",
+    )
+    response = client.post("/nodes/", json=transform_create.dict())
+    data = response.json()
+
+    # Check the response after creating the transform node
+    assert response.status_code == 200
+    assert len(data) == 8
+    assert data["id"] == 3
+    assert data["name"] == "purchases_over_a_grand"
+    assert (
+        data["description"]
+        == "This filters the revenue source node to only include purchases over $1,000"
+    )
+    assert data["type"] == "transform"
+    assert data["columns"] == [
+        {
+            "id": 1,
+            "dimension_id": None,
+            "dimension_column": None,
+            "name": "country",
+            "type": "STR",
+        },
+        {
+            "id": 2,
+            "dimension_id": None,
+            "dimension_column": None,
+            "name": "revenue",
+            "type": "FLOAT",
+        },
+    ]
+
+    # Create a metric node
+    metric_create = NodeCreator(
+        name="total_revenue_from_purchases_over_a_grand",
+        description="A total of product revenue where only purchases over $1,000 are included",
+        type=NodeType.METRIC,
+        query="SELECT SUM(revenue) as total_revenue FROM purchases_over_a_grand",
+    )
+    response = client.post("/nodes/", json=metric_create.dict())
+    data = response.json()
+
+    # Check the response after creating the metric node
+    assert response.status_code == 200
+    assert len(data) == 8
+    assert data["id"] == 4
+    assert data["name"] == "total_revenue_from_purchases_over_a_grand"
+    assert (
+        data["description"]
+        == "A total of product revenue where only purchases over $1,000 are included"
+    )
+    assert data["type"] == "metric"
+    assert (
+        data["query"]
+        == "SELECT SUM(revenue) as total_revenue FROM purchases_over_a_grand"
+    )
+    assert data["columns"] == [
+        {
+            "id": 4,
+            "dimension_id": None,
+            "dimension_column": None,
+            "name": "total_revenue",
+            "type": "FLOAT",
+        },
+    ]
+
+
+def test_raise_on_duplicate_node(client: TestClient) -> None:
+    """
+    Test that an error is raised when trying to add a node that already exists
+    """
+    # Create a source node
+    node_create = {
+        "name": "revenue",
+        "description": "This is a source table containing revenue data about the product",
+        "type": "source",
+        "tables": {
+            "postgres": [{"catalog": None, "schema_": "product", "table": "revenue"}],
+        },
+        "columns": {"country": {"type": "STR"}, "revenue": {"type": "FLOAT"}},
+    }
+    client.post("/nodes/", json=node_create)
+    response = client.post(
+        "/nodes/",
+        json=node_create,
+    )  # Try to add the same source node again
+    data = response.json()
+
+    assert response.status_code == 409
+    assert data == {"detail": "Node already exists: revenue"}
+
+
+def test_raise_when_columns_cannot_be_inferred(client: TestClient) -> None:
+    """
+    Test that an error is raised when the columns of a node cannot be inferred
+    """
+    # Create a transform node referencing a non-existent source node
+    transform_create = NodeCreator(
+        name="purchases_over_a_grand",
+        description="This filters the revenue source node to only include purchases over $1,000",
+        type=NodeType.TRANSFORM,
+        query="SELECT country, revenue FROM revenue WHERE revenue > 1000.00",
+    )
+    response = client.post("/nodes/", json=transform_create.dict())
+    data = response.json()
+
+    assert response.status_code == 412
+    assert data == {
+        "detail": (
+            "Cannot infer columns for purchases_over_a_grand: "
+            'Unable to determine origin of column "country"'
+        ),
+    }
+
+
+def test_not_raising_when_columns_cannot_be_inferred_in_staging(
+    client: TestClient,
+) -> None:
+    """
+    Test that an error is not raised in staging when the columns of a node cannot be inferred
+    """
+    # Create a transform node referencing a non-existent source node
+    transform_create = NodeCreator(
+        name="purchases_over_a_grand",
+        description="This filters the revenue source node to only include purchases over $1,000",
+        type=NodeType.TRANSFORM,
+        environment=NodeEnvironment.STAGING,
+        query="SELECT country, revenue FROM revenue WHERE revenue > 1000.00",
+    )
+    response = client.post("/nodes/", json=transform_create.dict())
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["name"] == "purchases_over_a_grand"

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -266,6 +266,7 @@ async def test_index_nodes(
         {
             "name": "core.comments",
             "description": "A fact table with comments",
+            "environment": "production",
             "type": NodeType.SOURCE,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
@@ -274,6 +275,7 @@ async def test_index_nodes(
         {
             "name": "core.dim_users",
             "description": "User dimension",
+            "environment": "production",
             "type": NodeType.DIMENSION,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
@@ -282,6 +284,7 @@ async def test_index_nodes(
         {
             "name": "core.num_comments",
             "description": "Number of comments",
+            "environment": "production",
             "type": NodeType.METRIC,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
@@ -290,6 +293,7 @@ async def test_index_nodes(
         {
             "name": "core.users",
             "description": "A user table",
+            "environment": "production",
             "type": NodeType.SOURCE,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
@@ -352,6 +356,7 @@ async def test_add_node_force(
         "name": "test",
         "path": Path("/path/to/repository/nodes/test.yaml"),
         "description": "",
+        "environment": "production",
         "type": "transform",
     }
 


### PR DESCRIPTION
### Summary

This adds a POST `/nodes/` endpoint that allows for creating a node through the API. The functionality here aims to be the same as what runs through the compile step that processes the yaml files (with the plan being to eventually replace the compile command with calls to the REST API.

I've removed the flags above and switched to the idea of having an environment attribute on the node to signal if it's in a staging environment or a production environment. The node data model now has an "environment" attribute with an enum value of "staging" or "production". I've summarized behaviors for the different validations below:

### Inferring Column Types
- `"environment": "published"` - The request will fail if it can't properly infer the columns.
- `"environment": "draft"` - The server will try to infer the columns and if it can't, it will still allow adding the node.

### Unknown Dimension Tag
I've left this out entirely so right now you can't add dimension tags when creating a node. I started to feel unsure about how this would play with the automatic inferring of column types. If it's ok with everyone, I think it'd be better to tackle this in a follow-up PR to focus in on this. Right now I'm leaning towards having a separate API call that adds a dimension tag to a column in an existing node and we can include this validation logic in that route.

### Auto Discover Source Node Columns
I've removed the ability to add tables when creating a source node (thanks @betodealmeida for highlighting to me that those are optional!). If everyone agrees I think it'd be great to keep it as a separate API call to attach a source node to a table since that feels more involved than the generic "node creation" that the `POST '/nodes/'` route should handle.

### Test Plan

- Ran `docker-compose up`
- Went to the swagger UI at [http:localhost:8000/docs](http:localhost:8000/docs)
- Submitted the following payloads to the `POST /nodes/` route

_request_
```json
{
   "name":"revenue",
   "description":"This is a source table containing revenue data about the product",
   "type":"source",
   "tables":{
      "postgres":[
         {
            "catalog":null,
            "schema_":"product",
            "table":"revenue"
         }
      ]
   },
   "columns":{
      "country":{
         "type":"STR"
      },
      "revenue": {
         "type": "FLOAT"
      }
   }
}
```
_response_
```json
{
  "name": "revenue",
  "description": "This is a source table containing revenue data about the product",
  "type": "source",
  "query": null,
  "id": 13
}
```
_request_
```json
{
   "name":"purchases_over_a_grand",
   "description":"This filters the revenue source node to only include purchases over $1,000",
   "type":"transform",
   "query": "SELECT country, revenue FROM revenue WHERE revenue > 1000.00"
}
```
_response_
```json
{
  "name": "purchases_over_a_grand",
  "description": "This filters the revenue source node to only include purchases over $1,000",
  "type": "transform",
  "query": "SELECT country, revenue FROM revenue WHERE revenue > 1000.00",
  "id": 14,
  "columns": [
    {
      "id": 68,
      "dimension_id": null,
      "dimension_column": null,
      "name": "country",
      "type": "STR"
    },
    {
      "id": 69,
      "dimension_id": null,
      "dimension_column": null,
      "name": "revenue",
      "type": "FLOAT"
    }
  ],
  "tables": []
}
```
_request_
```json
{
   "name":"total_revenue_from_purchases_over_a_grand",
   "description":"A total of product revenue where only purchases over $1,000 are included",
   "type":"metric",
   "query": "SELECT SUM(revenue) as total_revenue FROM purchases_over_a_grand"
}
```
_response_
```json
{
  "name": "total_revenue_from_purchases_over_a_grand",
  "description": "A total of product revenue where only purchases over $1,000 are included",
  "type": "metric",
  "query": "SELECT SUM(revenue) as total_revenue FROM purchases_over_a_grand",
  "id": 15,
  "columns": [
    {
      "id": 70,
      "dimension_id": null,
      "dimension_column": null,
      "name": "total_revenue",
      "type": "FLOAT"
    }
  ],
  "tables": []
}
```
- [x] PR has an associated issue: #255
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
