### PR TITLE
Add `MissingParent` class and `missing_parents` node attribute

### DIFF
--- a/alembic/versions/2023_01_14_0405-7caaf4276ea2_add_missing_parents_table_and_node_.py
+++ b/alembic/versions/2023_01_14_0405-7caaf4276ea2_add_missing_parents_table_and_node_.py
@@ -1,0 +1,48 @@
+"""Add missing parents table and node attribute
+
+Revision ID: 7caaf4276ea2
+Revises: 20321580ea8a
+Create Date: 2023-01-14 04:05:31.283222+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7caaf4276ea2"
+down_revision = "20321580ea8a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "missingparent",
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "nodemissingparents",
+        sa.Column("missing_parent_id", sa.Integer(), nullable=False),
+        sa.Column("referencing_node_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["missing_parent_id"],
+            ["missingparent.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["referencing_node_id"],
+            ["node.id"],
+        ),
+        sa.PrimaryKeyConstraint("missing_parent_id", "referencing_node_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("nodemissingparents")
+    op.drop_table("missingparent")

--- a/dj/errors.py
+++ b/dj/errors.py
@@ -34,6 +34,7 @@ class ErrorCode(int, Enum):
 
     # SQL Build Error
     COMPOUND_BUILD_EXCEPTION = 300
+    MISSING_PARENT = 201
 
 
 class DebugType(TypedDict, total=False):


### PR DESCRIPTION
### Summary

This adds a `MissingParent` metadata object and a `missing_parents: List[MissingParent]` attribute to the `Node` class.

Missing parents are stored in a separate table, with each missing parent having a unique ID and a join key to an existing node ID. It also has a name field that is a simple non-unique string field. If multiple invalid existing nodes have references to the same missing parent node name, each reference shows up in the table as an individual record with a unique ID.

Also, I've used `"cascade": "all, delete"` for the relationship so that when a node is deleted, all of that node's entries to the missing parents table is also cleaned up. (looking for a good review there from anyone more familiar with sqlalchemy's behavior).

### Test Plan

Ran `make check` and `make test`. Launched the API locally and did some light testing to confirm there are no obvious side-effects.

- [x] PR has an associated issue: #268 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
