### PR TITLE
Add endpoint for posting availability state of materialized nodes

### DIFF
--- a/alembic/versions/2022_04_30_1939-5f31ff8814e7_initial_migration.py
+++ b/alembic/versions/2022_04_30_1939-5f31ff8814e7_initial_migration.py
@@ -102,6 +102,7 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["dimension_id"],
             ["node.id"],
+            name="fk_column_dimension_id",
         ),
         sa.PrimaryKeyConstraint("id"),
     )
@@ -126,10 +127,12 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["child_id"],
             ["node.id"],
+            name="fk_noderelationship_child_id",
         ),
         sa.ForeignKeyConstraint(
             ["parent_id"],
             ["node.id"],
+            name="fk_noderelationship_parent_id",
         ),
         sa.PrimaryKeyConstraint("parent_id", "child_id"),
     )
@@ -165,6 +168,7 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["database_id"],
             ["database.id"],
+            name="fk_query_database_id",
         ),
         sa.PrimaryKeyConstraint("id"),
     )
@@ -203,12 +207,12 @@ def upgrade():
         sa.Column("table", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("cost", sa.Float(), nullable=True),
         sa.ForeignKeyConstraint(
-            ["database_id"],
-            ["database.id"],
+            ["database_id"], ["database.id"], name="fk_table_database_id",
         ),
         sa.ForeignKeyConstraint(
             ["node_id"],
             ["node.id"],
+            name="fk_table_node_id",
         ),
         sa.PrimaryKeyConstraint("id"),
     )
@@ -231,10 +235,12 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["column_id"],
             ["column.id"],
+            name="fk_nodecolumns_column_id",
         ),
         sa.ForeignKeyConstraint(
             ["node_id"],
             ["node.id"],
+            name="fk_nodecolumns_node_id",
         ),
         sa.PrimaryKeyConstraint("node_id", "column_id"),
     )
@@ -257,10 +263,12 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["column_id"],
             ["column.id"],
+            name="fk_tablecolumns_column_id",
         ),
         sa.ForeignKeyConstraint(
             ["table_id"],
             ["table.id"],
+            name="fk_tablecolumns_table_id",
         ),
         sa.PrimaryKeyConstraint("table_id", "column_id"),
     )

--- a/alembic/versions/2022_04_30_1939-5f31ff8814e7_initial_migration.py
+++ b/alembic/versions/2022_04_30_1939-5f31ff8814e7_initial_migration.py
@@ -207,7 +207,9 @@ def upgrade():
         sa.Column("table", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("cost", sa.Float(), nullable=True),
         sa.ForeignKeyConstraint(
-            ["database_id"], ["database.id"], name="fk_table_database_id",
+            ["database_id"],
+            ["database.id"],
+            name="fk_table_database_id",
         ),
         sa.ForeignKeyConstraint(
             ["node_id"],

--- a/alembic/versions/2023_01_14_0405-7caaf4276ea2_add_missing_parents_table_and_node_.py
+++ b/alembic/versions/2023_01_14_0405-7caaf4276ea2_add_missing_parents_table_and_node_.py
@@ -34,10 +34,12 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["missing_parent_id"],
             ["missingparent.id"],
+            name="fk_nodemissingparents_missing_parent_id",
         ),
         sa.ForeignKeyConstraint(
             ["referencing_node_id"],
             ["node.id"],
+            name="fk_nodemissingparents_referencing_node_id",
         ),
         sa.PrimaryKeyConstraint("missing_parent_id", "referencing_node_id"),
     )

--- a/alembic/versions/2023_01_25_1601-84e6a136312d_add_availability_state_table_and_join_.py
+++ b/alembic/versions/2023_01_25_1601-84e6a136312d_add_availability_state_table_and_join_.py
@@ -41,7 +41,9 @@ def upgrade():
             name="fk_nodeavailability_availability_id",
         ),
         sa.ForeignKeyConstraint(
-            ["node_id"], ["node.id"], name="fk_nodeavailability_node_id",
+            ["node_id"],
+            ["node.id"],
+            name="fk_nodeavailability_node_id",
         ),
         sa.PrimaryKeyConstraint("availability_id", "node_id"),
     )

--- a/alembic/versions/2023_01_25_1601-84e6a136312d_add_availability_state_table_and_join_.py
+++ b/alembic/versions/2023_01_25_1601-84e6a136312d_add_availability_state_table_and_join_.py
@@ -1,0 +1,52 @@
+"""Add availability state table and join table
+
+Revision ID: 84e6a136312d
+Revises: 7caaf4276ea2
+Create Date: 2023-01-25 16:01:38.166209+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "84e6a136312d"
+down_revision = "7caaf4276ea2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "availabilitystate",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("catalog", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("schema_", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("table", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("valid_through_ts", sa.Integer(), nullable=False),
+        sa.Column("max_partition", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("min_partition", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "nodeavailabilitystate",
+        sa.Column("availability_id", sa.Integer(), nullable=False),
+        sa.Column("node_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["availability_id"],
+            ["availabilitystate.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["node_id"],
+            ["node.id"],
+        ),
+        sa.PrimaryKeyConstraint("availability_id", "node_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("nodeavailabilitystate")
+    op.drop_table("availabilitystate")

--- a/alembic/versions/2023_01_25_1601-84e6a136312d_add_availability_state_table_and_join_.py
+++ b/alembic/versions/2023_01_25_1601-84e6a136312d_add_availability_state_table_and_join_.py
@@ -38,10 +38,10 @@ def upgrade():
         sa.ForeignKeyConstraint(
             ["availability_id"],
             ["availabilitystate.id"],
+            name="fk_nodeavailability_availability_id",
         ),
         sa.ForeignKeyConstraint(
-            ["node_id"],
-            ["node.id"],
+            ["node_id"], ["node.id"], name="fk_nodeavailability_node_id",
         ),
         sa.PrimaryKeyConstraint("availability_id", "node_id"),
     )

--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -1,0 +1,84 @@
+"""
+Data related APIs.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import NoResultFound
+from sqlmodel import Session, select
+
+from dj.errors import DJException
+from dj.models.node import AvailabilityState, AvailabilityStateBase, Node, NodeType
+from dj.utils import get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post("/data/availability/{node_name}/")
+def add_availability(
+    node_name: str,
+    data: AvailabilityStateBase,
+    *,
+    session: Session = Depends(get_session),
+) -> JSONResponse:
+    """
+    Add an availability state to a node
+    """
+    new_availability = data
+
+    try:
+        statement = select(Node).where(Node.name == node_name)
+        results = session.exec(statement)
+        existing_node = results.one()
+    except NoResultFound as exc:
+        raise DJException(
+            message=f"Cannot add availability state, node `{node_name}` does not exist",
+        ) from exc
+
+    # Source nodes require that any availability states set are for one of the defined tables
+    if existing_node.type == NodeType.SOURCE:
+        matches = False
+        for table in existing_node.tables:
+            if (
+                table.catalog == new_availability.catalog
+                and table.schema_ == new_availability.schema_
+                and table.table == new_availability.table
+            ):
+                matches = True
+        if not matches:
+            raise DJException(
+                message=(
+                    "Cannot set availability state, "
+                    "source nodes require availability "
+                    "states match an existing table: "
+                    f"{new_availability.catalog}."
+                    f"{new_availability.schema_}."
+                    f"{new_availability.table}"
+                ),
+            )
+
+    # Merge the new availability state with the current availability state if one exists
+    if (
+        existing_node.availability
+        and existing_node.availability.catalog == new_availability.catalog
+        and existing_node.availability.schema_ == new_availability.schema_
+        and existing_node.availability.table == new_availability.table
+    ):
+        new_availability.max_partition = max(
+            (existing_node.availability.max_partition, new_availability.max_partition),
+        )
+        new_availability.min_partition = min(
+            (existing_node.availability.min_partition, new_availability.min_partition),
+        )
+
+    db_new_availability = AvailabilityState.from_orm(new_availability)
+    existing_node.availability = db_new_availability
+    session.add(existing_node)
+    session.commit()
+    return JSONResponse(
+        status_code=200,
+        content={"message": "Availability state successfully posted"},
+    )

--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -67,6 +67,8 @@ def add_availability(
         and existing_node.availability.schema_ == new_availability.schema_
         and existing_node.availability.table == new_availability.table
     ):
+        # Currently, we do not consider type information. We should eventually check the type of
+        # the partition values in order to cast them before sorting.
         new_availability.max_partition = max(
             (existing_node.availability.max_partition, new_availability.max_partition),
         )

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from dj import __version__
-from dj.api import databases, metrics, nodes, queries
+from dj.api import data, databases, metrics, nodes, queries
 from dj.api.graphql.main import graphql_app
 from dj.errors import DJException
 from dj.models.column import Column
@@ -40,6 +40,7 @@ app.include_router(databases.router)
 app.include_router(queries.router)
 app.include_router(metrics.router)
 app.include_router(nodes.router)
+app.include_router(data.router)
 app.include_router(graphql_app, prefix="/graphql")
 
 

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from sqlmodel import Session, SQLModel, select
 
 from dj.models.column import ColumnType
-from dj.models.node import Node, NodeType
+from dj.models.node import AvailabilityState, Node, NodeType
 from dj.utils import get_session
 
 _logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ class NodeMetadata(SQLModel):
 
     type: NodeType
     query: Optional[str] = None
-
+    availability: Optional[AvailabilityState] = None
     columns: List[SimpleColumn]
 
 

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from functools import partial
 from typing import Dict, List, Optional, TypedDict, cast
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import JSON, DateTime, String
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy.types import Enum
 from sqlmodel import Field, Relationship, SQLModel
@@ -161,8 +161,8 @@ class AvailabilityStateBase(SQLModel):
     schema_: Optional[str] = Field(default=None)
     table: str
     valid_through_ts: int
-    max_partition: str
-    min_partition: str
+    max_partition: List[str] = Field(sa_column=SqlaColumn(JSON))
+    min_partition: List[str] = Field(sa_column=SqlaColumn(JSON))
 
 
 class AvailabilityState(AvailabilityStateBase, table=True):  # type: ignore

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -171,6 +171,10 @@ class AvailabilityState(AvailabilityStateBase, table=True):  # type: ignore
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
+    updated_at: datetime = Field(
+        sa_column=SqlaColumn(DateTime(timezone=True)),
+        default_factory=partial(datetime.now, timezone.utc),
+    )
 
 
 class NodeAvailabilityState(SQLModel, table=True):  # type: ignore

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -103,7 +103,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             Node.name == "large_revenue_payments_and_business_only",
         )
         large_revenue_payments_and_business_only = session.exec(statement).one()
-        assert large_revenue_payments_and_business_only.availability.dict() == {
+        node_dict = large_revenue_payments_and_business_only.availability.dict()
+        node_dict.pop("updated_at")
+        assert node_dict == {
             "valid_through_ts": 20230125,
             "catalog": "prod",
             "min_partition": ["2022", "01", "01"],
@@ -173,7 +175,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             Node.name == "large_revenue_payments_and_business_only",
         )
         large_revenue_payments_and_business_only = session.exec(statement).one()
-        assert large_revenue_payments_and_business_only.availability.dict() == {
+        node_dict = large_revenue_payments_and_business_only.availability.dict()
+        node_dict.pop("updated_at")
+        assert node_dict == {
             "valid_through_ts": 20230125,
             "catalog": "prod",
             "min_partition": ["2022", "01", "01"],
@@ -182,6 +186,54 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "schema_": "new_accounting",
             "id": 3,
         }
+
+    def test_that_update_at_timestamp_is_being_updated(
+        self,
+        session: Session,
+        client: TestClient,
+    ) -> None:
+        """
+        Test that the `updated_at` attribute is being updated
+        """
+        response = client.post(
+            "/data/availability/large_revenue_payments_and_business_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_partition": ["2023", "01", "25"],
+                "min_partition": ["2022", "01", "01"],
+            },
+        )
+        assert response.status_code == 200
+        statement = select(Node).where(
+            Node.name == "large_revenue_payments_and_business_only",
+        )
+        large_revenue_payments_and_business_only = session.exec(statement).one()
+        updated_at_1 = large_revenue_payments_and_business_only.availability.dict()[
+            "updated_at"
+        ]
+
+        response = client.post(
+            "/data/availability/large_revenue_payments_and_business_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_partition": ["2023", "01", "25"],
+                "min_partition": ["2022", "01", "01"],
+            },
+        )
+        assert response.status_code == 200
+
+        session.refresh(large_revenue_payments_and_business_only)
+        updated_at_2 = large_revenue_payments_and_business_only.availability.dict()[
+            "updated_at"
+        ]
+
+        assert updated_at_2 > updated_at_1
 
     def test_raising_when_node_does_not_exist(
         self,
@@ -257,7 +309,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             Node.name == "large_revenue_payments_only",
         )
         large_revenue_payments_only = session.exec(statement).one()
-        assert large_revenue_payments_only.availability.dict() == {
+        node_dict = large_revenue_payments_only.availability.dict()
+        node_dict.pop("updated_at")
+        assert node_dict == {
             "valid_through_ts": 20230102,
             "catalog": "prod",
             "min_partition": ["2022", "01", "01"],
@@ -314,7 +368,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             Node.name == "large_revenue_payments_only",
         )
         large_revenue_payments_only = session.exec(statement).one()
-        assert large_revenue_payments_only.availability.dict() == {
+        node_dict = large_revenue_payments_only.availability.dict()
+        node_dict.pop("updated_at")
+        assert node_dict == {
             "valid_through_ts": 20230101,
             "catalog": "prod",
             "min_partition": ["2021", "12", "31"],
@@ -371,7 +427,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             Node.name == "large_revenue_payments_only",
         )
         large_revenue_payments_only = session.exec(statement).one()
-        assert large_revenue_payments_only.availability.dict() == {
+        node_dict = large_revenue_payments_only.availability.dict()
+        node_dict.pop("updated_at")
+        assert node_dict == {
             "valid_through_ts": 20221231,
             "catalog": "prod",
             "min_partition": ["2022", "01", "01"],
@@ -409,7 +467,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             Node.name == "revenue_source",
         )
         revenue_source = session.exec(statement).one()
-        assert revenue_source.availability.dict() == {
+        node_dict = revenue_source.availability.dict()
+        node_dict.pop("updated_at")
+        assert node_dict == {
             "valid_through_ts": 20230101,
             "catalog": "test",
             "min_partition": ["2022", "01", "01"],
@@ -419,7 +479,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "id": 1,
         }
 
-    def test_raise_on_setting_invalid_availablity_state_on_a_source_node(
+    def test_raise_on_setting_invalid_availability_state_on_a_source_node(
         self,
         client: TestClient,
     ) -> None:

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -90,8 +90,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
-                "max_partition": "20230125",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "25"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         data = response.json()
@@ -106,9 +106,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert large_revenue_payments_and_business_only.availability.dict() == {
             "valid_through_ts": 20230125,
             "catalog": "prod",
-            "min_partition": "20220101",
+            "min_partition": ["2022", "01", "01"],
             "table": "pmts",
-            "max_partition": "20230125",
+            "max_partition": ["2023", "01", "25"],
             "schema_": "accounting",
             "id": 1,
         }
@@ -128,8 +128,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
-                "max_partition": "20230125",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "25"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         data = response.json()
@@ -144,8 +144,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
-                "max_partition": "20230125",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "25"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         data = response.json()
@@ -160,8 +160,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "new_accounting",
                 "table": "new_payments_table",
                 "valid_through_ts": 20230125,
-                "max_partition": "20230125",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "25"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         data = response.json()
@@ -176,9 +176,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert large_revenue_payments_and_business_only.availability.dict() == {
             "valid_through_ts": 20230125,
             "catalog": "prod",
-            "min_partition": "20220101",
+            "min_partition": ["2022", "01", "01"],
             "table": "new_payments_table",
-            "max_partition": "20230125",
+            "max_partition": ["2023", "01", "25"],
             "schema_": "new_accounting",
             "id": 3,
         }
@@ -197,8 +197,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
-                "max_partition": "20230125",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "25"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         data = response.json()
@@ -225,8 +225,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
-                "max_partition": "20230101",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "01"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         response = client.post(
@@ -236,8 +236,16 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230102,
-                "max_partition": "20230102",  # should be used since it's a higher max_partition
-                "min_partition": "20230102",  # should be ignored since it's a higher min_partition
+                "max_partition": [
+                    "2023",
+                    "01",
+                    "02",
+                ],  # should be used since it's a higher max_partition
+                "min_partition": [
+                    "2023",
+                    "01",
+                    "02",
+                ],  # should be ignored since it's a higher min_partition
             },
         )
         data = response.json()
@@ -252,9 +260,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert large_revenue_payments_only.availability.dict() == {
             "valid_through_ts": 20230102,
             "catalog": "prod",
-            "min_partition": "20220101",
+            "min_partition": ["2022", "01", "01"],
             "table": "large_pmts",
-            "max_partition": "20230102",
+            "max_partition": ["2023", "01", "02"],
             "schema_": "accounting",
             "id": 2,
         }
@@ -274,8 +282,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
-                "max_partition": "20230101",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "01"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         response = client.post(
@@ -285,8 +293,16 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
-                "max_partition": "20211231",  # should be ignored since it's a lower max_partition
-                "min_partition": "20211231",  # should be used since it's a lower min_partition
+                "max_partition": [
+                    "2021",
+                    "12",
+                    "31",
+                ],  # should be ignored since it's a lower max_partition
+                "min_partition": [
+                    "2021",
+                    "12",
+                    "31",
+                ],  # should be used since it's a lower min_partition
             },
         )
         data = response.json()
@@ -301,9 +317,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert large_revenue_payments_only.availability.dict() == {
             "valid_through_ts": 20230101,
             "catalog": "prod",
-            "min_partition": "20211231",
+            "min_partition": ["2021", "12", "31"],
             "table": "large_pmts",
-            "max_partition": "20230101",
+            "max_partition": ["2023", "01", "01"],
             "schema_": "accounting",
             "id": 2,
         }
@@ -323,8 +339,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
-                "max_partition": "20230101",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "01"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         response = client.post(
@@ -334,8 +350,16 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20221231,
-                "max_partition": "20230101",  # should be ignored since it's a lower max_partition
-                "min_partition": "20220101",  # should be used since it's a lower min_partition
+                "max_partition": [
+                    "2023",
+                    "01",
+                    "01",
+                ],  # should be ignored since it's a lower max_partition
+                "min_partition": [
+                    "2022",
+                    "01",
+                    "01",
+                ],  # should be used since it's a lower min_partition
             },
         )
         data = response.json()
@@ -350,9 +374,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert large_revenue_payments_only.availability.dict() == {
             "valid_through_ts": 20221231,
             "catalog": "prod",
-            "min_partition": "20220101",
+            "min_partition": ["2022", "01", "01"],
             "table": "large_pmts",
-            "max_partition": "20230101",
+            "max_partition": ["2023", "01", "01"],
             "schema_": "accounting",
             "id": 2,
         }
@@ -372,8 +396,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "revenue",
                 "valid_through_ts": 20230101,
-                "max_partition": "20230101",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "01"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         data = response.json()
@@ -388,9 +412,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert revenue_source.availability.dict() == {
             "valid_through_ts": 20230101,
             "catalog": "test",
-            "min_partition": "20220101",
+            "min_partition": ["2022", "01", "01"],
             "table": "revenue",
-            "max_partition": "20230101",
+            "max_partition": ["2023", "01", "01"],
             "schema_": "accounting",
             "id": 1,
         }
@@ -409,8 +433,8 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
-                "max_partition": "20230101",
-                "min_partition": "20220101",
+                "max_partition": ["2023", "01", "01"],
+                "min_partition": ["2022", "01", "01"],
             },
         )
         data = response.json()

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -1,0 +1,427 @@
+"""
+Tests for the data API.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from dj.models import Table
+from dj.models.column import Column, ColumnType
+from dj.models.node import Node, NodeType
+
+
+class TestAvailabilityState:  # pylint: disable=too-many-public-methods
+    """
+    Test ``POST /data/availability/{node_name}/``.
+    """
+
+    @pytest.fixture
+    def session(self, session: Session) -> Session:
+        """
+        Add nodes to facilitate testing of availability state updates
+        """
+
+        node1 = Node(
+            name="revenue_source",
+            type=NodeType.SOURCE,
+            columns=[
+                Column(name="payment_id", type=ColumnType.INT),
+                Column(name="payment_amount", type=ColumnType.FLOAT),
+                Column(name="customer_id", type=ColumnType.INT),
+                Column(name="account_type", type=ColumnType.STR),
+            ],
+            tables=[
+                Table(
+                    database_id=1,
+                    catalog="test",
+                    schema="accounting",
+                    table="revenue",
+                ),
+            ],
+        )
+        node2 = Node(
+            name="large_revenue_payments_only",
+            query=(
+                "SELECT payment_id, payment_amount, customer_id, account_type "
+                "FROM revenue_source WHERE payment_amount > 1000000"
+            ),
+            type=NodeType.TRANSFORM,
+            columns=[
+                Column(name="payment_id", type=ColumnType.INT),
+                Column(name="payment_amount", type=ColumnType.FLOAT),
+                Column(name="customer_id", type=ColumnType.INT),
+                Column(name="account_type", type=ColumnType.STR),
+            ],
+        )
+        node3 = Node(
+            name="large_revenue_payments_and_business_only",
+            query=(
+                "SELECT payment_id, payment_amount, customer_id, account_type "
+                "FROM revenue_source WHERE payment_amount > 1000000 "
+                "AND account_type = 'BUSINESS'"
+            ),
+            type=NodeType.TRANSFORM,
+            columns=[
+                Column(name="payment_id", type=ColumnType.INT),
+                Column(name="payment_amount", type=ColumnType.FLOAT),
+                Column(name="customer_id", type=ColumnType.INT),
+                Column(name="account_type", type=ColumnType.STR),
+            ],
+        )
+        session.add(node1)
+        session.add(node2)
+        session.add(node3)
+        session.commit()
+        return session
+
+    def test_setting_availability_state(
+        self,
+        session: Session,
+        client: TestClient,
+    ) -> None:
+        """
+        Test adding an availability state
+        """
+        response = client.post(
+            "/data/availability/large_revenue_payments_and_business_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_partition": "20230125",
+                "min_partition": "20220101",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        statement = select(Node).where(
+            Node.name == "large_revenue_payments_and_business_only",
+        )
+        large_revenue_payments_and_business_only = session.exec(statement).one()
+        assert large_revenue_payments_and_business_only.availability.dict() == {
+            "valid_through_ts": 20230125,
+            "catalog": "prod",
+            "min_partition": "20220101",
+            "table": "pmts",
+            "max_partition": "20230125",
+            "schema_": "accounting",
+            "id": 1,
+        }
+
+    def test_setting_availability_state_multiple_times(
+        self,
+        session: Session,
+        client: TestClient,
+    ) -> None:
+        """
+        Test adding multiple availability states
+        """
+        response = client.post(
+            "/data/availability/large_revenue_payments_and_business_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_partition": "20230125",
+                "min_partition": "20220101",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        response = client.post(
+            "/data/availability/large_revenue_payments_and_business_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_partition": "20230125",
+                "min_partition": "20220101",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        response = client.post(
+            "/data/availability/large_revenue_payments_and_business_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "new_accounting",
+                "table": "new_payments_table",
+                "valid_through_ts": 20230125,
+                "max_partition": "20230125",
+                "min_partition": "20220101",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        statement = select(Node).where(
+            Node.name == "large_revenue_payments_and_business_only",
+        )
+        large_revenue_payments_and_business_only = session.exec(statement).one()
+        assert large_revenue_payments_and_business_only.availability.dict() == {
+            "valid_through_ts": 20230125,
+            "catalog": "prod",
+            "min_partition": "20220101",
+            "table": "new_payments_table",
+            "max_partition": "20230125",
+            "schema_": "new_accounting",
+            "id": 3,
+        }
+
+    def test_raising_when_node_does_not_exist(
+        self,
+        client: TestClient,
+    ) -> None:
+        """
+        Test raising when setting availability state on non-existent node
+        """
+        response = client.post(
+            "/data/availability/nonexistentnode/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_partition": "20230125",
+                "min_partition": "20220101",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 500
+        assert data == {
+            "message": "Cannot add availability state, node `nonexistentnode` does not exist",
+            "errors": [],
+            "warnings": [],
+        }
+
+    def test_merging_in_a_higher_max_partition(
+        self,
+        session: Session,
+        client: TestClient,
+    ) -> None:
+        """
+        Test that the higher max_partition value is used when merging in an availability state
+        """
+        client.post(
+            "/data/availability/large_revenue_payments_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "large_pmts",
+                "valid_through_ts": 20230101,
+                "max_partition": "20230101",
+                "min_partition": "20220101",
+            },
+        )
+        response = client.post(
+            "/data/availability/large_revenue_payments_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "large_pmts",
+                "valid_through_ts": 20230102,
+                "max_partition": "20230102",  # should be used since it's a higher max_partition
+                "min_partition": "20230102",  # should be ignored since it's a higher min_partition
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        statement = select(Node).where(
+            Node.name == "large_revenue_payments_only",
+        )
+        large_revenue_payments_only = session.exec(statement).one()
+        assert large_revenue_payments_only.availability.dict() == {
+            "valid_through_ts": 20230102,
+            "catalog": "prod",
+            "min_partition": "20220101",
+            "table": "large_pmts",
+            "max_partition": "20230102",
+            "schema_": "accounting",
+            "id": 2,
+        }
+
+    def test_merging_in_a_lower_min_partition(
+        self,
+        session: Session,
+        client: TestClient,
+    ) -> None:
+        """
+        Test that the lower min_partition value is used when merging in an availability state
+        """
+        client.post(
+            "/data/availability/large_revenue_payments_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "large_pmts",
+                "valid_through_ts": 20230101,
+                "max_partition": "20230101",
+                "min_partition": "20220101",
+            },
+        )
+        response = client.post(
+            "/data/availability/large_revenue_payments_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "large_pmts",
+                "valid_through_ts": 20230101,
+                "max_partition": "20211231",  # should be ignored since it's a lower max_partition
+                "min_partition": "20211231",  # should be used since it's a lower min_partition
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        statement = select(Node).where(
+            Node.name == "large_revenue_payments_only",
+        )
+        large_revenue_payments_only = session.exec(statement).one()
+        assert large_revenue_payments_only.availability.dict() == {
+            "valid_through_ts": 20230101,
+            "catalog": "prod",
+            "min_partition": "20211231",
+            "table": "large_pmts",
+            "max_partition": "20230101",
+            "schema_": "accounting",
+            "id": 2,
+        }
+
+    def test_moving_back_valid_through_ts(
+        self,
+        session: Session,
+        client: TestClient,
+    ) -> None:
+        """
+        Test that the valid through timestamp can be moved backwards
+        """
+        client.post(
+            "/data/availability/large_revenue_payments_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "large_pmts",
+                "valid_through_ts": 20230101,
+                "max_partition": "20230101",
+                "min_partition": "20220101",
+            },
+        )
+        response = client.post(
+            "/data/availability/large_revenue_payments_only/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "large_pmts",
+                "valid_through_ts": 20221231,
+                "max_partition": "20230101",  # should be ignored since it's a lower max_partition
+                "min_partition": "20220101",  # should be used since it's a lower min_partition
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        statement = select(Node).where(
+            Node.name == "large_revenue_payments_only",
+        )
+        large_revenue_payments_only = session.exec(statement).one()
+        assert large_revenue_payments_only.availability.dict() == {
+            "valid_through_ts": 20221231,
+            "catalog": "prod",
+            "min_partition": "20220101",
+            "table": "large_pmts",
+            "max_partition": "20230101",
+            "schema_": "accounting",
+            "id": 2,
+        }
+
+    def test_setting_availablity_state_on_a_source_node(
+        self,
+        session: Session,
+        client: TestClient,
+    ) -> None:
+        """
+        Test setting the availability state on a source node
+        """
+        response = client.post(
+            "/data/availability/revenue_source/",
+            json={
+                "catalog": "test",
+                "schema_": "accounting",
+                "table": "revenue",
+                "valid_through_ts": 20230101,
+                "max_partition": "20230101",
+                "min_partition": "20220101",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data == {"message": "Availability state successfully posted"}
+
+        statement = select(Node).where(
+            Node.name == "revenue_source",
+        )
+        revenue_source = session.exec(statement).one()
+        assert revenue_source.availability.dict() == {
+            "valid_through_ts": 20230101,
+            "catalog": "test",
+            "min_partition": "20220101",
+            "table": "revenue",
+            "max_partition": "20230101",
+            "schema_": "accounting",
+            "id": 1,
+        }
+
+    def test_raise_on_setting_invalid_availablity_state_on_a_source_node(
+        self,
+        client: TestClient,
+    ) -> None:
+        """
+        Test raising availability state doesn't match existing source node table
+        """
+        response = client.post(
+            "/data/availability/revenue_source/",
+            json={
+                "catalog": "prod",
+                "schema_": "accounting",
+                "table": "large_pmts",
+                "valid_through_ts": 20230101,
+                "max_partition": "20230101",
+                "min_partition": "20220101",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 500
+        assert data == {
+            "message": (
+                "Cannot set availability state, source "
+                "nodes require availability states match "
+                "an existing table: prod.accounting.large_pmts"
+            ),
+            "errors": [],
+            "warnings": [],
+        }

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -25,6 +25,7 @@ http://localhost:8000/metrics/{node_id}/: Return a metric by ID.
 http://localhost:8000/metrics/{node_id}/data/: Return data for a metric.
 http://localhost:8000/metrics/{node_id}/sql/: Return SQL for a metric.
 http://localhost:8000/nodes/: List the available nodes.
+http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/graphql: GraphQL endpoint.
 """
     )


### PR DESCRIPTION
### Summary

This adds a new endpoint `POST "/data/availability/{node_name}/"` that allows an external materialization service to post information about the availability of a node. The tests include many examples but here's an example of a payload that's setting an availability state for a node `revenue`.

_POST /data/availability/revenue_
```py
{
    "catalog": "test",
    "schema_": "accounting",
    "table": "revenue",
    "valid_through_ts": 20230125,
    "max_partition": "20230125",
    "min_partition": "20220101",
}
```

Availability states are merged meaning the `max_partition` value that's currently on a node is only moved forward if an availability state with a higher `max_partition` value is received. For `min_partition` it's only changed when a state with a lower `min_partition` is received. `valid_through_ts` can be moved forward or backward and could potentially be made optional (and default to `now()`). One thing that's challenging here is knowing how to handle different partition types. Here I make an insufficient assumption that the partition is a string and is sortable in a way that makes sense. If a dataset is partitioned by country however, I'm not sure what a sort of `max_partition` or `min_partition` would mean and if those values are even at all useful.

Another requirement enforced in the API endpoint is that source nodes may have availability states set, but they must be for tables pre-configured as source node tables. Since source tables are fundamentally external to DJ (the starting point for all other transformations), I'm not sure what it would mean to allow posting that a source table `prod.db.foo` is available under the name `prod.db.bar`. Therefore I added this restriction so if the source table is `prod.db.foo`, you can post availability states (for example to inform which partitions are available), however it must be for the table named `prod.db.foo`.

### Test Plan

Wrote a number of tests as well as started up the docker compose environment and tried out the following request:

_POST /data/availability/dbt.dimension.customers_
```json
{
  "catalog": "test",
  "schema_": "accounting",
  "table": "customers",
  "valid_through_ts": 20230125,
  "max_partition": "20230125",
  "min_partition": "20230101"
}
```
_response_
```json
{
  "message": "Availability state successfully posted"
}
```
I then checked the `GET "/nodes/"` route to ensure the availability set can be seen for that node.

- [x] PR has an associated issue: #274 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
