### PR TITLE
Add a POST /nodes/validate/ route

### DIFF
--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -4,13 +4,23 @@ Node related APIs.
 
 import logging
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends
 from sqlmodel import Session, SQLModel, select
 
-from dj.models.column import ColumnType
-from dj.models.node import AvailabilityState, Node, NodeType
+from dj.construction.extract import extract_dependencies_from_node
+from dj.construction.inference import get_type_of_expression
+from dj.errors import DJError, DJException, ErrorCode
+from dj.models.column import Column, ColumnType
+from dj.models.node import (
+    AvailabilityState,
+    Node,
+    NodeBase,
+    NodeMode,
+    NodeStatus,
+    NodeType,
+)
 from dj.utils import get_session
 
 _logger = logging.getLogger(__name__)
@@ -42,6 +52,74 @@ class NodeMetadata(SQLModel):
     query: Optional[str] = None
     availability: Optional[AvailabilityState] = None
     columns: List[SimpleColumn]
+
+
+class NodeValidation(SQLModel):
+    """
+    A validation of a provided node definition
+    """
+
+    message: str
+    status: NodeStatus
+    node: Node
+    dependencies: List[NodeMetadata]
+    columns: List[Column]
+
+
+@router.post("/nodes/validate/", response_model=NodeValidation)
+def validate_node(
+    data: Union[NodeBase],
+    session: Session = Depends(get_session),
+) -> NodeValidation:
+    """
+    Validate a node.
+    """
+
+    if data.type == NodeType.SOURCE:
+        raise DJException(message="Source nodes cannot be validated")
+    node = Node.from_orm(data)
+
+    # Try to parse the node's query and extract dependencies
+    try:
+        (
+            query_ast,
+            dependencies_map,
+            missing_parents_map,
+        ) = extract_dependencies_from_node(
+            session=session,
+            node=node,
+            raise_=False,
+        )
+    except ValueError as exc:
+        raise DJException(message=str(exc)) from exc
+
+    # Only raise on missing parents if the node mode is set to published
+    if missing_parents_map and node.mode == NodeMode.PUBLISHED:
+        raise DJException(
+            errors=[
+                DJError(
+                    code=ErrorCode.MISSING_PARENT,
+                    message="Node definition contains references to nodes that do not exist",
+                    debug={"missing_parents": list(missing_parents_map.keys())},
+                ),
+            ],
+        )
+
+    # Add aliases for any unnamed columns and confirm that all column types can be inferred
+    query_ast.select.add_aliases_to_unnamed_columns()
+    node.columns = [
+        Column(name=col.name.name, type=get_type_of_expression(col))  # type: ignore
+        for col in query_ast.select.projection
+    ]
+
+    node.status = NodeStatus.VALID
+    return NodeValidation(
+        message=f"Node `{node.name}` is valid",
+        status=NodeStatus.VALID,
+        node=node,
+        dependencies=set(dependencies_map.keys()),
+        columns=node.columns,
+    )
 
 
 @router.get("/nodes/", response_model=List[NodeMetadata])

--- a/dj/construction/exceptions.py
+++ b/dj/construction/exceptions.py
@@ -37,7 +37,7 @@ class CompoundBuildException:
         """
         self._raise = raise_
 
-    def append(self, error: DJError, message: Optional[str]):
+    def append(self, error: DJError, message: Optional[str] = None):
         """
         Accumulate DJ exceptions
         """

--- a/dj/sql/parsing/backends/exceptions.py
+++ b/dj/sql/parsing/backends/exceptions.py
@@ -1,7 +1,8 @@
 """
 defines exceptions used for backend parsing
 """
+from dj.errors import DJException
 
 
-class DJParseException(Exception):
+class DJParseException(DJException):
     """Exception type raised upon problem creating a DJ sql ast"""

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -1,7 +1,7 @@
 """
 Tests for the nodes API.
 """
-
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
@@ -61,3 +61,249 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
             "type": "INT",
         },
     ]
+
+
+class TestValidateNodes:  # pylint: disable=too-many-public-methods
+    """
+    Test ``POST /nodes/validate/``.
+    """
+
+    @pytest.fixture
+    def session(self, session: Session) -> Session:
+        """
+        Add nodes to facilitate testing of the validation route
+        """
+
+        node1 = Node(
+            name="revenue_source",
+            type=NodeType.SOURCE,
+            columns=[
+                Column(name="payment_id", type=ColumnType.INT),
+                Column(name="payment_amount", type=ColumnType.FLOAT),
+                Column(name="customer_id", type=ColumnType.INT),
+                Column(name="account_type", type=ColumnType.STR),
+            ],
+        )
+        node2 = Node(
+            name="large_revenue_payments_only",
+            query=(
+                "SELECT payment_id, payment_amount, customer_id, account_type "
+                "FROM revenue_source WHERE payment_amount > 1000000"
+            ),
+            type=NodeType.TRANSFORM,
+            columns=[
+                Column(name="payment_id", type=ColumnType.INT),
+                Column(name="payment_amount", type=ColumnType.FLOAT),
+                Column(name="customer_id", type=ColumnType.INT),
+                Column(name="account_type", type=ColumnType.STR),
+            ],
+        )
+        node3 = Node(
+            name="large_revenue_payments_and_business_only",
+            query=(
+                "SELECT payment_id, payment_amount, customer_id, account_type "
+                "FROM revenue_source WHERE payment_amount > 1000000 "
+                "AND account_type = 'BUSINESS'"
+            ),
+            type=NodeType.TRANSFORM,
+            columns=[
+                Column(name="payment_id", type=ColumnType.INT),
+                Column(name="payment_amount", type=ColumnType.FLOAT),
+                Column(name="customer_id", type=ColumnType.INT),
+                Column(name="account_type", type=ColumnType.STR),
+            ],
+        )
+        session.add(node1)
+        session.add(node2)
+        session.add(node3)
+        session.commit()
+        return session
+
+    def test_validating_a_valid_node(self, client: TestClient) -> None:
+        """
+        Test validating a valid node
+        """
+
+        response = client.post(
+            "/nodes/validate/",
+            json={
+                "name": "foo",
+                "description": "This is my foo transform node!",
+                "query": "SELECT payment_id FROM large_revenue_payments_only",
+                "type": "transform",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert len(data) == 5
+        assert data["columns"] == [
+            {
+                "dimension_column": None,
+                "dimension_id": None,
+                "id": None,
+                "name": "payment_id",
+                "type": "INT",
+            },
+        ]
+        assert data["status"] == "valid"
+        assert data["node"]["status"] == "valid"
+        assert data["dependencies"][0]["name"] == "large_revenue_payments_only"
+        assert data["message"] == "Node `foo` is valid"
+        assert data["node"]["id"] is None
+        assert data["node"]["mode"] == "published"
+        assert data["node"]["name"] == "foo"
+        assert (
+            data["node"]["query"]
+            == "SELECT payment_id FROM large_revenue_payments_only"
+        )
+        assert data["node"]["type"] == "transform"
+
+    def test_validating_an_invalid_node(self, client: TestClient) -> None:
+        """
+        Test validating an invalid node
+        """
+
+        response = client.post(
+            "/nodes/validate/",
+            json={
+                "name": "foo",
+                "description": "This is my foo transform node!",
+                "query": "SELECT bar FROM large_revenue_payments_only",
+                "type": "transform",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 500
+        assert data == {
+            "message": "Cannot resolve type of column bar.",
+            "errors": [],
+            "warnings": [],
+        }
+
+    def test_validating_invalid_sql(self, client: TestClient) -> None:
+        """
+        Test validating an invalid node with invalid SQL
+        """
+
+        response = client.post(
+            "/nodes/validate/",
+            json={
+                "name": "foo",
+                "description": "This is my foo transform node!",
+                "query": "SUPER invalid SQL query",
+                "type": "transform",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 500
+        assert data == {
+            "errors": [],
+            "message": "Query parsing failed.\n"
+            "\tsql parser error: Expected an SQL statement, found: SUPER",
+            "warnings": [],
+        }
+
+    def test_validating_with_missing_parents(self, client: TestClient) -> None:
+        """
+        Test validating a node with a query that has missing parents
+        """
+
+        response = client.post(
+            "/nodes/validate/",
+            json={
+                "name": "foo",
+                "description": "This is my foo transform node!",
+                "query": "SELECT 1 FROM node_that_does_not_exist",
+                "type": "transform",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 500
+        assert data == {
+            "message": "Node definition contains references to nodes that do not exist",
+            "errors": [
+                {
+                    "code": 201,
+                    "message": "Node definition contains references to nodes that do not exist",
+                    "debug": {"missing_parents": ["node_that_does_not_exist"]},
+                    "context": "",
+                },
+            ],
+            "warnings": [],
+        }
+
+    def test_allowing_missing_parents_for_draft_nodes(self, client: TestClient) -> None:
+        """
+        Test validating a draft node that's allowed to have missing parents
+        """
+
+        response = client.post(
+            "/nodes/validate/",
+            json={
+                "name": "foo",
+                "description": "This is my foo transform node!",
+                "query": "SELECT 1 FROM node_that_does_not_exist",
+                "type": "transform",
+                "mode": "draft",
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["message"] == "Node `foo` is valid"
+        assert data["status"] == "valid"
+        assert data["node"]["name"] == "foo"
+        assert data["node"]["mode"] == "draft"
+        assert data["node"]["status"] == "valid"
+        assert data["columns"] == [
+            {
+                "id": None,
+                "name": "_col0",
+                "type": "INT",
+                "dimension_id": None,
+                "dimension_column": None,
+            },
+        ]
+
+    def test_raise_when_trying_to_validate_a_source_node(
+        self,
+        client: TestClient,
+    ) -> None:
+        """
+        Test validating a source node which is not possible
+        """
+
+        response = client.post(
+            "/nodes/validate/",
+            json={
+                "name": "foo",
+                "description": "This is my foo source node!",
+                "type": "source",
+                "columns": [
+                    {"name": "payment_id", "type": "INT"},
+                    {"name": "payment_amount", "type": "FLOAT"},
+                    {"name": "customer_id", "type": "INT"},
+                    {"name": "account_type", "type": "INT"},
+                ],
+                "tables": [
+                    {
+                        "database_id": 1,
+                        "catalog": "test",
+                        "schema": "accounting",
+                        "table": "revenue",
+                    },
+                ],
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 500
+        assert data == {
+            "message": "Source nodes cannot be validated",
+            "errors": [],
+            "warnings": [],
+        }

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -24,6 +24,7 @@ http://localhost:8000/metrics/: List all available metrics.
 http://localhost:8000/metrics/{node_id}/: Return a metric by ID.
 http://localhost:8000/metrics/{node_id}/data/: Return data for a metric.
 http://localhost:8000/metrics/{node_id}/sql/: Return SQL for a metric.
+http://localhost:8000/nodes/validate/: Validate a node.
 http://localhost:8000/nodes/: List the available nodes.
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/graphql: GraphQL endpoint.


### PR DESCRIPTION
### Summary

This adds a `POST /nodes/validate/` route that allows validating a given node definition. The route checks the following:
- The node's query can be parsed.
- The node is either in `published` mode and all upstream dependencies can be determined or is in `draft` mode.
- All column types can be inferred.

This function for this validation route will be reusable as part of the create/update routes. When those routes are added, they should start by running this function to ensure that the API has a consistent response (at least for invalid nodes) when someone is creating, updating, or just validating a node definition.

### Test Plan

Added tests to confirm the expected behaviors as well as ran `docker compose up` and submitted a number of requests to the `POST /nodes/validate` route.

- [x] PR has an associated issue: #255 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A