### PR TITLE
generate an HTML coverage report when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ docker-run-with-cockroachdb:
 	docker compose -f docker-compose.yml -f docker-compose.cockroachdb.yml up
 
 test: pyenv
-	pytest --cov=dj -vv tests/ --doctest-modules dj --without-integration --without-slow-integration ${PYTEST_ARGS}
+	pytest --cov=dj --cov-report=html -vv tests/ --doctest-modules dj --without-integration --without-slow-integration ${PYTEST_ARGS}
 
 integration: pyenv
 	pytest --cov=dj -vv tests/ --doctest-modules dj --with-integration --with-slow-integration


### PR DESCRIPTION
### Summary

One-line change to add the `--cov-report=html` to the `make test` command. It created an `htmlcov` directory in the root of the project every time the tests run which can be launched with any kind of local server, i.e. live server in VSCode. I find it super helpful when you need to investigate a bit more deeply to identify missing coverage.

### Test Plan

Ran `make test` and made sure the `htmlcov` directory was created.

- [x] PR has an associated issue: #277 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
