### PR TITLE
Fix pre-commit error by upgrading isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
 #     ]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 


### PR DESCRIPTION
### Summary

A recent release of isort busted up pre-commit and now the builds are failing. This was then fixed by a [commit](https://github.com/PyCQA/isort/commit/0d219a6e0b49b7f84ef0702b2387d5e14299bb8e) to isort earlier today. Hoping upgrading isort fixes this. 🤞 

### Test Plan

Watch the PR build with my fingers crossed.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A