### PR TITLE
Fix bug by adding updated_at to availabilitystate table

### DIFF
--- a/alembic/versions/2023_01_29_2348-af60d8073876_add_updated_at_for_availability_state.py
+++ b/alembic/versions/2023_01_29_2348-af60d8073876_add_updated_at_for_availability_state.py
@@ -1,0 +1,30 @@
+"""Add updated_at for availability state
+
+Revision ID: af60d8073876
+Revises: 84e6a136312d
+Create Date: 2023-01-29 23:48:45.927434+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "af60d8073876"
+down_revision = "84e6a136312d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "availabilitystate",
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("availabilitystate", "updated_at")


### PR DESCRIPTION
### Summary

After recently merging PR #275, I noticed that I introduced a bug by not adding the `updated_at` field to the alembic upgrade. This PR fixes that.

### Test Plan

Ran docker compose up and checked the metadata database. Also tested out all of the API calls including to the availability state endpoint.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
