### PR TITLE
Fixing some docker and alembic bugs

### DIFF
--- a/alembic/versions/2022_10_27_2242-f620c4521c80_add_uuid_column_to_database_model.py
+++ b/alembic/versions/2022_10_27_2242-f620c4521c80_add_uuid_column_to_database_model.py
@@ -7,7 +7,6 @@ Create Date: 2022-10-27 22:42:19.160413+00:00
 """
 # pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
 
-from uuid import UUID
 
 import sqlalchemy as sa
 import sqlalchemy_utils
@@ -23,33 +22,11 @@ branch_labels = None
 depends_on = None
 
 
-DJ_DATABASE_ID = 0
-DJ_DATABASE_UUID = UUID("594804bf-47cb-426c-83c4-94a348e95972")
-SQLITE_DATABASE_ID = -1
-SQLITE_DATABASE_UUID = UUID("3619eeba-d628-4ab1-9dd5-65738ab3c02f")
-
-
 def upgrade():
     with op.batch_alter_table("database") as bop:
         bop.add_column(
             sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
         )
-
-    database = table(
-        "database",
-        sa.Column("id", sa.Integer()),
-        sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
-    )
-    op.execute(
-        database.update()
-        .where(database.c.id == DJ_DATABASE_ID)
-        .values({"uuid": DJ_DATABASE_UUID}),
-    )
-    op.execute(
-        database.update()
-        .where(database.c.id == SQLITE_DATABASE_ID)
-        .values({"uuid": SQLITE_DATABASE_UUID}),
-    )
 
 
 def downgrade():

--- a/alembic/versions/2023_01_30_1835-1780b415e2c5_set_uuid_for_dj_database_and_in_memory_.py
+++ b/alembic/versions/2023_01_30_1835-1780b415e2c5_set_uuid_for_dj_database_and_in_memory_.py
@@ -1,0 +1,64 @@
+"""Set uuid for dj database and in-memory database
+
+Revision ID: 1780b415e2c5
+Revises: af60d8073876
+Create Date: 2023-01-30 18:35:49.406002+00:00
+
+"""
+# pylint: disable=invalid-name
+
+from uuid import UUID
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from sqlalchemy import table
+
+from alembic import op
+
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+
+# revision identifiers, used by Alembic.
+revision = "1780b415e2c5"
+down_revision = "af60d8073876"
+branch_labels = None
+depends_on = None
+
+DJ_DATABASE_ID = 0
+DJ_DATABASE_UUID = UUID("594804bf-47cb-426c-83c4-94a348e95972")
+SQLITE_DATABASE_ID = -1
+SQLITE_DATABASE_UUID = UUID("3619eeba-d628-4ab1-9dd5-65738ab3c02f")
+
+
+def upgrade():
+    database = table(
+        "database",
+        sa.Column("id", sa.Integer()),
+        sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
+    )
+    op.execute(
+        database.update()
+        .where(database.c.id == DJ_DATABASE_ID)
+        .values({"uuid": DJ_DATABASE_UUID}),
+    )
+    op.execute(
+        database.update()
+        .where(database.c.id == SQLITE_DATABASE_ID)
+        .values({"uuid": SQLITE_DATABASE_UUID}),
+    )
+
+
+def downgrade():
+    database = table(
+        "database",
+        sa.Column("id", sa.Integer()),
+        sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
+    )
+    op.execute(
+        database.update().where(database.c.id == DJ_DATABASE_ID).values({"uuid": None}),
+    )
+    op.execute(
+        database.update()
+        .where(database.c.id == SQLITE_DATABASE_ID)
+        .values({"uuid": None}),
+    )

--- a/docker-compose.cockroachdb.yml
+++ b/docker-compose.cockroachdb.yml
@@ -36,6 +36,8 @@ services:
 
   cockroachdb_metadata:
     container_name: cockroachdb_metadata
+    networks:
+      - core
     image: cockroachdb/cockroach
     command: start-single-node --insecure
     volumes:
@@ -47,6 +49,8 @@ services:
 
   cockroachdb_examples:
     container_name: cockroachdb_examples
+    networks:
+      - core
     image: cockroachdb/cockroach
     command: start-single-node --insecure --external-io-dir /import-data
     ports:

--- a/docker-compose.druid.yaml
+++ b/docker-compose.druid.yaml
@@ -13,6 +13,8 @@ volumes:
 services:
   druid_postgres:
     container_name: druid_postgres
+    networks:
+      - core
     image: postgres:latest
     volumes:
       - metadata_data:/var/lib/postgresql/data
@@ -24,6 +26,8 @@ services:
   # Need 3.5 or later for container nodes
   druid_zookeeper:
     container_name: druid_zookeeper
+    networks:
+      - core
     image: zookeeper:3.5
     ports:
       - "2181:2181"
@@ -33,6 +37,8 @@ services:
   druid_coordinator:
     image: apache/druid:0.20.0
     container_name: druid_coordinator
+    networks:
+      - core
     volumes:
       - druid_shared:/opt/shared
       - coordinator_var:/opt/druid/var
@@ -49,6 +55,8 @@ services:
   druid_broker:
     image: apache/druid:0.20.0
     container_name: druid_broker
+    networks:
+      - core
     volumes:
       - broker_var:/opt/druid/var
     depends_on:
@@ -65,6 +73,8 @@ services:
   druid_historical:
     image: apache/druid:0.20.0
     container_name: druid_historical
+    networks:
+      - core
     volumes:
       - druid_shared:/opt/shared
       - historical_var:/opt/druid/var
@@ -82,6 +92,8 @@ services:
   druid_middlemanager:
     image: apache/druid:0.20.0
     container_name: druid_middlemanager
+    networks:
+      - core
     volumes:
       - druid_shared:/opt/shared
       - middle_var:/opt/druid/var
@@ -100,6 +112,8 @@ services:
   druid_router:
     image: apache/druid:0.20.0
     container_name: druid_router
+    networks:
+      - core
     volumes:
       - router_var:/opt/druid/var
     depends_on:
@@ -118,6 +132,8 @@ services:
     depends_on:
       - druid_router
     container_name: druid_ingest
+    networks:
+      - core
     volumes:
       - ./examples/docker/druid_init.sh:/druid_init.sh
       - ./examples/docker/druid_spec.json:/druid_spec.json

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -29,6 +29,8 @@ services:
 
   postgres_metadata:
     container_name: postgres_metadata
+    networks:
+      - core
     image: postgres:latest
     volumes:
       - postgres_metadata:/var/lib/postgresql/data


### PR DESCRIPTION
### Summary

I noticed a bug while making sure all of the different docker overrides work properly. It turns out that there's a quirk with alembic and cockroach DB that causes an error when you add a column and try to set values on that column in the same revision. This PR fixes that by moving the portion that sets the UUID values to a separate alembic revision.

One other thing I noticed is that the `core` network was not set on the docker compose overrides which is required to allow them to communicate with the `dj` container in the main docker compose.

### Test Plan

Ran every variation of `docker compose up` with every override file and ensured that the migration works as well as the API.

- [x] PR has an associated issue: #283 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
