### PR TITLE
Use names in API routes instead of IDs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ DataJunction
     A metrics repository
 
 
-DataJunction (DJ) is a **metrics layer** that stores and calculates metrics. Metrics are defined using **ANSI SQL** and are **database agnostic**. Metrics can then be computed via a **REST API** or **SQL**.
+DataJunction (DJ) is a **metrics platform** to store and manage metric definitions. Metrics are defined using **ANSI SQL**, are **database agnostic** and can be computed via a **REST API** or **SQL** interface.
 
 What does that mean?
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ DataJunction
     A metrics repository
 
 
-DataJunction (DJ) is a repository of **metric definitions**. Metrics are defined using **ANSI SQL** and are **database agnostic**. Metrics can then be computed via a **REST API** or **SQL**.
+DataJunction (DJ) is a **metrics layer** that stores and calculates metrics. Metrics are defined using **ANSI SQL** and are **database agnostic**. Metrics can then be computed via a **REST API** or **SQL**.
 
 What does that mean?
 --------------------
@@ -76,29 +76,42 @@ Now, if we want to compute the metric in our Hive warehouse we can build a pipel
 
 .. code-block:: bash
 
-    % curl "http://localhost:8000/metrics/2/sql/?database_id=1"
+    curl "http://localhost:8000/metrics/basic.num_comments/sql/?database_name=postgres" | jq
+
+.. code-block:: bash
+
     {
-      "database_id": 1,
-      "sql": "SELECT count('*') AS count_1 \nFROM (SELECT default.fact_comments.id AS id, default.fact_comments.user_id AS user_id, default.fact_comments.timestamp AS timestamp, default.fact_comments.text AS text \nFROM default.fact_comments) AS \"comments\""
+      "database_id": 3,
+      "sql": "SELECT count(1) AS cnt \nFROM (SELECT basic.comments.id AS id, basic.comments.user_id AS user_id, basic.comments.timestamp AS timestamp, basic.comments.text AS text \nFROM basic.comments) AS \"basic.source.comments\""
     }
 
 We can also filter and group our metric by any of its dimensions:
 
 .. code-block:: bash
 
-    % curl http://localhost:8000/metrics/2/
+    curl "http://localhost:8000/metrics/basic.num_comments/" | jq
+
+.. code-block:: bash
+
     {
-      "id": 2,
-      "name": "num_comments",
-      "description": "A fact table with comments",
-      "created_at": "2022-01-17T19:06:09.215689",
-      "updated_at": "2022-04-04T16:27:53.374001",
-      "query": "SELECT COUNT(*) FROM comments",
+      "id": 12,
+      "name": "basic.num_comments",
+      "description": "Number of comments",
+      "created_at": "2023-01-31T04:32:01.091728",
+      "updated_at": "2023-01-31T04:32:01.091755",
+      "query": "SELECT COUNT(1) AS cnt\nFROM basic.source.comments",
       "dimensions": [
-        "comments.id",
-        "comments.user_id",
-        "comments.timestamp",
-        "comments.text"
+        "basic.dimension.users.age",
+        "basic.dimension.users.country",
+        "basic.dimension.users.full_name",
+        "basic.dimension.users.gender",
+        "basic.dimension.users.id",
+        "basic.dimension.users.preferred_language",
+        "basic.dimension.users.secret_number",
+        "basic.source.comments.id",
+        "basic.source.comments.text",
+        "basic.source.comments.timestamp",
+        "basic.source.comments.user_id"
       ]
     }
 
@@ -106,15 +119,15 @@ For example, if we want to group the metric by the user ID, to see how many comm
 
 .. code-block:: bash
 
-    % curl "http://localhost:8000/metrics/2/sql/?database_id=1&d=comments.user_id&f=comments.user_id>0"
+    curl "http://localhost:8000/metrics/basic.num_comments/sql/?database_name=postgres&d=basic.source.comments.user_id&f=basic.source.comments.user_id>0" | jq
 
 If instead we want the actual data, instead of the SQL:
 
 .. code-block:: bash
 
-    % curl "http://localhost:8000/metrics/2/data/?database_id=1&d=comments.user_id&f=comments.user_id>0"
+    curl "http://localhost:8000/metrics/basic.num_comments/data/?database_name=postgres&d=basic.source.comments.user_id&f=basic.source.comments.user_id>0" | jq
 
-And if we omit the ``database_id`` DJ will compute the data using the fastest database (ie, the one with lowest ``cost``). It's also possible to specify tables with different costs:
+And if we omit the ``database_name`` DJ will compute the data using the fastest database (ie, the one with lowest ``cost``). It's also possible to specify tables with different costs:
 
 .. code-block:: YAML
 

--- a/dj/api/metrics.py
+++ b/dj/api/metrics.py
@@ -49,7 +49,7 @@ class TranslatedSQL(SQLModel):
 
 def get_metric(session: Session, name: str) -> Node:
     """
-    Return a metric node given a node ID.
+    Return a metric node given a node name.
     """
     statement = select(Node).where(Node.name == name)
     try:

--- a/dj/api/metrics.py
+++ b/dj/api/metrics.py
@@ -81,7 +81,7 @@ def read_metrics(*, session: Session = Depends(get_session)) -> List[Metric]:
 @router.get("/metrics/{name}/", response_model=Metric)
 def read_metric(name: str, *, session: Session = Depends(get_session)) -> Metric:
     """
-    Return a metric by ID.
+    Return a metric by name.
     """
     node = get_metric(session, name)
     return Metric(**node.dict(), dimensions=get_dimensions(node))

--- a/dj/sql/build.py
+++ b/dj/sql/build.py
@@ -111,7 +111,7 @@ async def get_query_for_node(  # pylint: disable=too-many-locals
     node: Node,
     groupbys: List[str],
     filters: List[str],
-    database_id: Optional[int] = None,
+    database_name: Optional[str] = None,
 ) -> QueryCreate:
     """
     Return a DJ QueryCreate object from a given node.
@@ -146,7 +146,7 @@ async def get_query_for_node(  # pylint: disable=too-many-locals
         session,
         nodes,
         referenced_columns,
-        database_id,
+        database_name,
     )
 
     # base query

--- a/dj/sql/dag.py
+++ b/dj/sql/dag.py
@@ -103,7 +103,7 @@ async def get_database_for_nodes(
     session: Session,
     nodes: List[Node],
     node_columns: Dict[str, Set[str]],
-    database_id: Optional[int] = None,
+    database_name: Optional[str] = None,
 ) -> Database:
     """
     Given a list of nodes, return the best database to compute metric.
@@ -123,11 +123,11 @@ async def get_database_for_nodes(
         raise Exception("No valid database was found")
 
     # if a specific database was requested, return it if it's online
-    if database_id is not None:
+    if database_name is not None:
         for database in databases:
-            if database.id == database_id and await database.do_ping():
+            if database.name == database_name and await database.do_ping():
                 return database
-        raise Exception(f"Database ID {database_id} is not valid")
+        raise Exception(f"Unknown database `{database_name}`")
 
     return await get_cheapest_online_database(databases)
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -10,71 +10,111 @@ Run ``docker-compose`` at the project root:
 
 This will run the DJ server with Redis for async queries, as well as a Druid cluster and a Postgres database. On startup the repository from ``examples/configs/`` will be compiled.
 
-You can then see the available databases with:
+You can then list the available databases.
 
 .. code-block:: bash
 
-    $ curl http://localhost:8000/databases/ | jq
-
-You should see:
+    curl http://localhost:8000/databases/ | jq
 
 .. code-block:: json
 
     [
       {
-        "id": 1,
-        "created_at": "2022-01-02T23:07:04.228888",
-        "updated_at": "2022-01-02T23:07:04.228895",
-        "description": "An Apache Druid database",
+        "id": -1,
+        "uuid": "3619eeba-d628-4ab1-9dd5-65738ab3c02f",
+        "description": "An in memory SQLite database for tableless queries",
+        "extra_params": {},
         "read_only": true,
         "async_": false,
+        "cost": 0,
+        "created_at": "2023-01-31T04:31:53.699835",
+        "updated_at": "2023-01-31T04:31:53.699863",
+        "name": "in-memory",
+        "URI": "sqlite://"
+      },
+      {
+        "id": 0,
+        "uuid": "594804bf-47cb-426c-83c4-94a348e95972",
+        "description": "The DJ meta database",
+        "extra_params": {},
+        "read_only": true,
+        "async_": false,
+        "cost": 1,
+        "created_at": "2023-01-31T04:31:53.690792",
+        "updated_at": "2023-01-31T04:31:53.690858",
+        "name": "dj",
+        "URI": "dj://localhost:8000/0"
+      },
+      {
+        "id": 1,
+        "uuid": "48765763-4c1d-48a1-bf6c-fab9e4fad9b6",
+        "description": "An Apache Druid database",
+        "extra_params": {},
+        "read_only": true,
+        "async_": false,
+        "cost": 1,
+        "created_at": "2023-01-31T04:31:53.793496",
+        "updated_at": "2023-01-31T04:31:53.795213",
         "name": "druid",
-        "URI": "druid://host.docker.internal:8082/druid/v2/sql/"
+        "URI": "druid://druid_broker:8082/druid/v2/sql/"
       },
       {
         "id": 2,
-        "created_at": "2022-01-02T23:07:04.270360",
-        "updated_at": "2022-01-02T23:07:04.270371",
+        "uuid": "136d16ba-b953-4a3b-9a3d-037a059c91db",
         "description": "A Google Sheets connector",
+        "extra_params": {
+          "catalog": {
+            "comments": "https://docs.google.com/spreadsheets/d/1SkEZOipqjXQnxHLMr2kZ7Tbn7OiHSgO99gOCS5jTQJs/edit#gid=1811447072",
+            "users": "https://docs.google.com/spreadsheets/d/1SkEZOipqjXQnxHLMr2kZ7Tbn7OiHSgO99gOCS5jTQJs/edit#gid=0"
+          }
+        },
         "read_only": true,
         "async_": false,
+        "cost": 100,
+        "created_at": "2023-01-31T04:31:53.906079",
+        "updated_at": "2023-01-31T04:31:53.909173",
         "name": "gsheets",
         "URI": "gsheets://"
       },
       {
         "id": 3,
-        "created_at": "2022-01-02T23:07:04.281625",
-        "updated_at": "2022-01-02T23:07:04.281634",
+        "uuid": "b87e4ded-e6fc-496d-a171-70b396b129ff",
         "description": "A Postgres database",
+        "extra_params": {
+          "connect_args": {
+            "sslmode": "prefer"
+          }
+        },
         "read_only": false,
         "async_": false,
+        "cost": 10,
+        "created_at": "2023-01-31T04:31:53.967998",
+        "updated_at": "2023-01-31T04:31:53.969566",
         "name": "postgres",
-        "URI": "postgresql://username:FoolishPassword@host.docker.internal:5433/examples"
+        "URI": "postgresql://username:FoolishPassword@postgres_examples:5432/examples"
       }
     ]
 
-To run a query:
+You can also run queries.
 
 .. code-block:: bash
 
-    $ curl -H "Content-Type: application/json" \
-    > -d '{"database_id":2,"submitted_query":"SELECT 1 AS foo"}' \
-    > http://127.0.0.1:8000/queries/ | jq
-
-And you should see:
+    curl -H "Content-Type: application/json" \
+    -d '{"database_id": 2, "submitted_query": "SELECT 1 AS foo"}' \
+    http://localhost:8000/queries/ | jq
 
 .. code-block:: json
 
     {
-      "database_id": 3,
+      "database_id": 2,
       "catalog": null,
-      "schema_": null,
-      "id": "db6c5ef8-bb8c-4972-ad08-9052eaa0c288",
+      "schema": null,
+      "id": "3a6f013e-a2f2-47f1-9fd8-c3b6d7f2094e",
       "submitted_query": "SELECT 1 AS foo",
       "executed_query": "SELECT 1 AS foo",
-      "scheduled": "2022-01-03T01:09:15.164400",
-      "started": "2022-01-03T01:09:15.164467",
-      "finished": "2022-01-03T01:09:15.217595",
+      "scheduled": "2023-01-31T05:21:19.206699",
+      "started": "2023-01-31T05:21:19.206929",
+      "finished": "2023-01-31T05:21:21.576516",
       "state": "FINISHED",
       "progress": 1,
       "results": [
@@ -83,16 +123,19 @@ And you should see:
           "columns": [
             {
               "name": "foo",
-              "type": "NUMBER"
+              "type": "BYTES"
             }
           ],
           "rows": [
             [
               1
             ]
-          ]
+          ],
+          "row_count": 1
         }
       ],
+      "next": null,
+      "previous": null,
       "errors": []
     }
 

--- a/examples/cockroachdb/configs/nodes/kaggle/avg_engagement.yaml
+++ b/examples/cockroachdb/configs/nodes/kaggle/avg_engagement.yaml
@@ -1,0 +1,8 @@
+description: Average user engagement
+type: metric
+query: |-
+  SELECT AVG(amount)
+  FROM kaggle.source.playtime
+columns:
+  _col0:
+    type: FLOAT

--- a/tests/api/graphql/metric_test.py
+++ b/tests/api/graphql/metric_test.py
@@ -61,7 +61,7 @@ def test_read_metric(session: Session, client: TestClient):
 
     query = """
     {
-        readMetric(nodeId: 3){
+        readMetric(nodeName: "a-metric"){
             id,
             name
         }
@@ -84,7 +84,7 @@ def test_read_metric_errors(session: Session, client: TestClient) -> None:
 
     query = """
     {
-        readMetric(nodeId: 2){
+        readMetric(nodeName: "foo"){
             id
         }
     }
@@ -92,10 +92,11 @@ def test_read_metric_errors(session: Session, client: TestClient) -> None:
 
     response_json = client.post("/graphql", json={"query": query}).json()
     assert response_json["data"] is None
-    assert response_json["errors"][0]["message"] == "Metric node not found"
+    assert response_json["errors"][0]["message"] == "Metric node not found: `foo`"
+
     query = """
     {
-        readMetric(nodeId: 1){
+        readMetric(nodeName: "a-metric"){
             id
         }
     }
@@ -103,7 +104,7 @@ def test_read_metric_errors(session: Session, client: TestClient) -> None:
 
     response_json = client.post("/graphql", json={"query": query}).json()
     assert response_json["data"] is None
-    assert response_json["errors"][0]["message"] == "Not a metric node"
+    assert response_json["errors"][0]["message"] == "Not a metric node: `a-metric`"
 
 
 def test_read_metrics_data(
@@ -147,7 +148,7 @@ def test_read_metrics_data(
 
     query = """
     {
-        readMetricsData(nodeId: 1){
+        readMetricsData(nodeName: "a-metric"){
             id
             submittedQuery
         }
@@ -191,7 +192,7 @@ def test_read_metrics_sql(
 
     query = """
     {
-        readMetricsSql(nodeId: 1){
+        readMetricsSql(nodeName: "a-metric"){
             databaseId
             sql
         }
@@ -220,7 +221,7 @@ def test_read_metrics_sql_errors(session: Session, client: TestClient):
 
     query = """
     {
-        readMetricsSql(nodeId: 2){
+        readMetricsSql(nodeName: "a-metric"){
             sql
         }
     }
@@ -228,10 +229,10 @@ def test_read_metrics_sql_errors(session: Session, client: TestClient):
 
     response_json = client.post("/graphql", json={"query": query}).json()
     assert response_json["data"] is None
-    assert response_json["errors"][0]["message"] == "Metric node not found"
+    assert response_json["errors"][0]["message"] == "Not a metric node: `a-metric`"
     query = """
     {
-        readMetricsSql(nodeId: 1){
+        readMetricsSql(nodeName: "a-metric"){
             sql
         }
     }
@@ -239,7 +240,7 @@ def test_read_metrics_sql_errors(session: Session, client: TestClient):
 
     response_json = client.post("/graphql", json={"query": query}).json()
     assert response_json["data"] is None
-    assert response_json["errors"][0]["message"] == "Not a metric node"
+    assert response_json["errors"][0]["message"] == "Not a metric node: `a-metric`"
 
 
 def test_read_metrics_data_errors(session: Session, client: TestClient):
@@ -255,7 +256,7 @@ def test_read_metrics_data_errors(session: Session, client: TestClient):
 
     query = """
     {
-        readMetricsData(nodeId: 2){
+        readMetricsData(nodeName: "a-metric"){
             id
         }
     }
@@ -263,10 +264,10 @@ def test_read_metrics_data_errors(session: Session, client: TestClient):
 
     response_json = client.post("/graphql", json={"query": query}).json()
     assert response_json["data"] is None
-    assert response_json["errors"][0]["message"] == "Metric node not found"
+    assert response_json["errors"][0]["message"] == "Not a metric node: `a-metric`"
     query = """
     {
-        readMetricsData(nodeId: 1){
+        readMetricsData(nodeName: "a-metric"){
             id
         }
     }
@@ -274,4 +275,4 @@ def test_read_metrics_data_errors(session: Session, client: TestClient):
 
     response_json = client.post("/graphql", json={"query": query}).json()
     assert response_json["data"] is None
-    assert response_json["errors"][0]["message"] == "Not a metric node"
+    assert response_json["errors"][0]["message"] == "Not a metric node: `a-metric`"

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -75,7 +75,7 @@ def test_read_metric(session: Session, client: TestClient) -> None:
     session.add(child)
     session.commit()
 
-    response = client.get("/metrics/1/")
+    response = client.get("/metrics/child/")
     data = response.json()
 
     assert response.status_code == 200
@@ -95,13 +95,13 @@ def test_read_metrics_errors(session: Session, client: TestClient) -> None:
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
-    response = client.get("/metrics/2")
+    response = client.get("/metrics/foo")
     assert response.status_code == 404
-    assert response.json() == {"detail": "Metric node not found"}
+    assert response.json() == {"detail": "Metric node not found: `foo`"}
 
-    response = client.get("/metrics/1")
+    response = client.get("/metrics/a-metric")
     assert response.status_code == 400
-    assert response.json() == {"detail": "Not a metric node"}
+    assert response.json() == {"detail": "Not a metric node: `a-metric`"}
 
 
 def test_read_metrics_data(
@@ -144,7 +144,7 @@ def test_read_metrics_data(
     )
 
     with freeze_time("2021-01-01T00:00:00Z"):
-        client.get("/metrics/1/data/")
+        client.get("/metrics/a-metric/data/")
 
     save_query_and_run.assert_called()
     assert save_query_and_run.mock_calls[0].args[0] == create_query
@@ -163,11 +163,11 @@ def test_read_metrics_data_errors(session: Session, client: TestClient) -> None:
 
     response = client.get("/metrics/2/data/")
     assert response.status_code == 404
-    assert response.json() == {"detail": "Metric node not found"}
+    assert response.json() == {"detail": "Metric node not found: `2`"}
 
-    response = client.get("/metrics/1/data/")
+    response = client.get("/metrics/a-metric/data/")
     assert response.status_code == 400
-    assert response.json() == {"detail": "Not a metric node"}
+    assert response.json() == {"detail": "Not a metric node: `a-metric`"}
 
 
 def test_read_metrics_sql(
@@ -198,5 +198,5 @@ def test_read_metrics_sql(
         return_value=create_query,
     )
 
-    response = client.get("/metrics/1/sql/")
+    response = client.get("/metrics/a-metric/sql/")
     assert response.json() == {"database_id": 1, "sql": "SELECT COUNT(*) FROM my_table"}

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -21,9 +21,9 @@ http://localhost:8000/databases/: List the available databases.
 http://localhost:8000/queries/: Run or schedule a query.
 http://localhost:8000/queries/{query_id}/: Fetch information about a query.
 http://localhost:8000/metrics/: List all available metrics.
-http://localhost:8000/metrics/{node_id}/: Return a metric by ID.
-http://localhost:8000/metrics/{node_id}/data/: Return data for a metric.
-http://localhost:8000/metrics/{node_id}/sql/: Return SQL for a metric.
+http://localhost:8000/metrics/{name}/: Return a metric by ID.
+http://localhost:8000/metrics/{name}/data/: Return data for a metric.
+http://localhost:8000/metrics/{name}/sql/: Return SQL for a metric.
 http://localhost:8000/nodes/validate/: Validate a node.
 http://localhost:8000/nodes/: List the available nodes.
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -21,7 +21,7 @@ http://localhost:8000/databases/: List the available databases.
 http://localhost:8000/queries/: Run or schedule a query.
 http://localhost:8000/queries/{query_id}/: Fetch information about a query.
 http://localhost:8000/metrics/: List all available metrics.
-http://localhost:8000/metrics/{name}/: Return a metric by ID.
+http://localhost:8000/metrics/{name}/: Return a metric by name.
 http://localhost:8000/metrics/{name}/data/: Return data for a metric.
 http://localhost:8000/metrics/{name}/sql/: Return SQL for a metric.
 http://localhost:8000/nodes/validate/: Validate a node.

--- a/tests/sql/build_test.py
+++ b/tests/sql/build_test.py
@@ -139,13 +139,13 @@ async def test_get_query_for_node_specify_database(mocker: MockerFixture) -> Non
     session = mocker.MagicMock()
     session.exec().one.return_value = database
 
-    create_query = await get_query_for_node(session, child, [], [], 1)
+    create_query = await get_query_for_node(session, child, [], [], "slow")
     assert create_query.database_id == 1
     assert create_query.submitted_query == 'SELECT "B".cnt \nFROM "B"'
 
     with pytest.raises(Exception) as excinfo:
-        await get_query_for_node(session, child, [], [], 2)
-    assert str(excinfo.value) == "Database ID 2 is not valid"
+        await get_query_for_node(session, child, [], [], "foo")
+    assert str(excinfo.value) == "Unknown database `foo`"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Since we've settled on the requirement that node names cannot be changed, this makes the API a bit more user-friendly by utilizing node and database **names** instead of IDs in all API endpoints. I also updated all of the examples in the `README.md` and `examples/README.md` files to use names. While I was doing some housekeeping on the readme, I also changed the opening sentence from `repository of **metric definitions**.` to `**metrics layer** that stores and calculates metrics`. I feel it's much clearer as we move towards an API-first design (while still supporting source controlled YAML files in a repo as one option, of course). Let me know if that's ok with everyone or if anyone would like to suggest a different opening line.

### Test Plan

Tested all API routes (including graphql) as well as all curl commands in the `README.md` and `examples/README.md` files.

- [x] PR has an associated issue: #261 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
