### PR TITLE
Extend pydantic datetime parser with a UTCDatetime parser

### DIFF
--- a/dj/api/graphql/database.py
+++ b/dj/api/graphql/database.py
@@ -4,6 +4,7 @@ GQL Database Models and related APIs.
 
 # pylint: disable=too-few-public-methods, no-member
 
+import datetime
 from typing import TYPE_CHECKING, List
 
 import strawberry
@@ -29,8 +30,6 @@ if TYPE_CHECKING:
         "read_only",
         "async_",
         "cost",
-        "created_at",
-        "updated_at",
     ],
 )
 class Database:  # pylint: disable=too-few-public-methods
@@ -41,6 +40,8 @@ class Database:  # pylint: disable=too-few-public-methods
     extra_params: JSON
     tables: List[Annotated["Table", strawberry.lazy("dj.api.graphql.table")]]
     queries: List[Annotated["Query", strawberry.lazy("dj.api.graphql.query")]]
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
 
 
 def get_databases(info: Info) -> List[Database]:

--- a/dj/api/graphql/metric.py
+++ b/dj/api/graphql/metric.py
@@ -4,6 +4,7 @@ GQL Metric models and related APIs.
 
 # pylint: disable=too-few-public-methods, no-member
 
+import datetime
 from typing import List, Optional
 
 import strawberry
@@ -22,11 +23,23 @@ from dj.sql.build import get_query_for_node
 from dj.sql.dag import get_dimensions
 
 
-@strawberry.experimental.pydantic.type(model=Metric_, all_fields=True)
+@strawberry.experimental.pydantic.type(
+    model=Metric_,
+    fields=[
+        "id",
+        "name",
+        "description",
+        "query",
+        "dimensions",
+    ],
+)
 class Metric:
     """
     Class for a metric.
     """
+
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
 
 
 @strawberry.experimental.pydantic.type(model=TranslatedSQL_, all_fields=True)

--- a/dj/api/graphql/node.py
+++ b/dj/api/graphql/node.py
@@ -1,9 +1,9 @@
 """
 GQL Node models and related APIs.
 """
-
 # pylint: disable=too-few-public-methods, no-member
 
+import datetime
 from typing import TYPE_CHECKING, List
 
 import strawberry
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 @strawberry.experimental.pydantic.type(
     model=Node_,
-    fields=["id", "name", "description", "created_at", "updated_at", "query"],
+    fields=["id", "name", "description", "query"],
 )
 class Node:  # type: ignore
     """
@@ -52,6 +52,8 @@ class Node:  # type: ignore
     parents: List[Annotated["Node", strawberry.lazy("dj.api.graphql.node")]]
     children: List[Annotated["Node", strawberry.lazy("dj.api.graphql.node")]]
     columns: List[Annotated["Column", strawberry.lazy("dj.api.graphql.column")]]
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
 
 
 def get_nodes(info: Info) -> List[Node]:

--- a/dj/api/metrics.py
+++ b/dj/api/metrics.py
@@ -2,7 +2,6 @@
 Metric related APIs.
 """
 
-from datetime import datetime
 from http import HTTPStatus
 from typing import List, Optional
 
@@ -15,7 +14,7 @@ from dj.models.node import Node, NodeType
 from dj.models.query import QueryWithResults
 from dj.sql.build import get_query_for_node
 from dj.sql.dag import get_dimensions
-from dj.utils import get_session, get_settings
+from dj.utils import UTCDatetime, get_session, get_settings
 
 router = APIRouter()
 
@@ -29,8 +28,8 @@ class Metric(SQLModel):
     name: str
     description: str = ""
 
-    created_at: datetime
-    updated_at: datetime
+    created_at: UTCDatetime
+    updated_at: UTCDatetime
 
     query: str
 

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -3,7 +3,6 @@ Node related APIs.
 """
 
 import logging
-from datetime import datetime
 from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends
@@ -21,7 +20,7 @@ from dj.models.node import (
     NodeStatus,
     NodeType,
 )
-from dj.utils import get_session
+from dj.utils import UTCDatetime, get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -45,8 +44,8 @@ class NodeMetadata(SQLModel):
     name: str
     description: str = ""
 
-    created_at: datetime
-    updated_at: datetime
+    created_at: UTCDatetime
+    updated_at: UTCDatetime
 
     type: NodeType
     query: Optional[str] = None

--- a/dj/models/database.py
+++ b/dj/models/database.py
@@ -13,6 +13,8 @@ from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy_utils import UUIDType
 from sqlmodel import JSON, Field, Relationship, SQLModel, create_engine
 
+from dj.utils import UTCDatetime
+
 if TYPE_CHECKING:
     from dj.models.query import Query
     from dj.models.table import Table
@@ -52,11 +54,11 @@ class Database(SQLModel, table=True):  # type: ignore
     async_: bool = Field(default=False, sa_column_kwargs={"name": "async"})
     cost: float = 1.0
 
-    created_at: datetime = Field(
+    created_at: UTCDatetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),
         default_factory=partial(datetime.now, timezone.utc),
     )
-    updated_at: datetime = Field(
+    updated_at: UTCDatetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),
         default_factory=partial(datetime.now, timezone.utc),
     )

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -16,6 +16,7 @@ from sqlmodel import Field, Relationship, SQLModel
 from dj.models.column import Column, ColumnYAML
 from dj.models.table import Table, TableYAML
 from dj.sql.parse import is_metric
+from dj.utils import UTCDatetime
 
 
 class NodeRelationship(SQLModel, table=True):  # type: ignore
@@ -129,7 +130,7 @@ class MissingParent(SQLModel, table=True):  # type: ignore
 
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(sa_column=SqlaColumn("name", String))
-    created_at: datetime = Field(
+    created_at: UTCDatetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),
         default_factory=partial(datetime.now, timezone.utc),
     )
@@ -171,7 +172,7 @@ class AvailabilityState(AvailabilityStateBase, table=True):  # type: ignore
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    updated_at: datetime = Field(
+    updated_at: UTCDatetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),
         default_factory=partial(datetime.now, timezone.utc),
     )
@@ -201,11 +202,11 @@ class Node(NodeBase, table=True):  # type: ignore
 
     id: Optional[int] = Field(default=None, primary_key=True)
     status: NodeStatus = NodeStatus.INVALID
-    created_at: datetime = Field(
+    created_at: UTCDatetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),
         default_factory=partial(datetime.now, timezone.utc),
     )
-    updated_at: datetime = Field(
+    updated_at: UTCDatetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),
         default_factory=partial(datetime.now, timezone.utc),
     )

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -132,7 +132,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
     ]
 
     # test that a missing timezone is treated as UTC
-    databases[0].updated_at = databases[0].updated_at.replace(tzinfo=None)
+    databases[0].updated_at = databases[0].updated_at.replace(tzinfo=None)  # type: ignore
     with freeze_time("2021-01-03T00:00:00Z"):
         databases = await index_databases(repository, session)
     databases = sorted(databases, key=lambda database: database.name)
@@ -319,7 +319,7 @@ async def test_index_nodes(
     ]
 
     # test that a missing timezone is treated as UTC
-    nodes[0].updated_at = nodes[0].updated_at.replace(tzinfo=None)
+    nodes[0].updated_at = nodes[0].updated_at.replace(tzinfo=None)  # type: ignore
     with freeze_time("2021-01-03T00:00:00Z"):
         nodes = await index_nodes(repository, session)
     nodes = sorted(nodes, key=lambda node: node.name)


### PR DESCRIPTION
### Summary

This is a fix for #286 which adds a `UTCDatetime` class that extends `datetime.datetime`. It then can be used as a drop-in replacement for `datetime.datetime` type hints and is usable by pydantic.

### Test Plan

I launched the server with `docker compose up` and queried it with generated Java and Go clients. I also ran curl commands against the server to make sure the date strings are returned as proper UTC ISO timestamps. I also ran queries against the graphql API at `/graphql` to confirm the date strings are showing up properly there as well.

- [x] PR has an associated issue: #286 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A