### PR TITLE
Change all = to - in RST files to avoid pre-commit error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-============
+------------
 DataJunction
-============
+------------
 
 
     A metrics repository
@@ -9,7 +9,7 @@ DataJunction
 DataJunction (DJ) is a repository of **metric definitions**. Metrics are defined using **ANSI SQL** and are **database agnostic**. Metrics can then be computed via a **REST API** or **SQL**.
 
 What does that mean?
-====================
+--------------------
 
 DJ allows users to define metrics once, and reuse them in different databases. This offers a couple benefits:
 
@@ -135,6 +135,6 @@ And if we omit the ``database_id`` DJ will compute the data using the fastest da
 The tables ``dim_users`` and ``dim_fast_users`` can have different columns. For example, ``dim_fast_users`` could have only a subset of the columns in ``dim_users``, the ones that can be quickly populated. DJ will use the fast table if the available columns can satisfy a given query, otherwise it will fallback to the slow table.
 
 Getting started
-===============
+---------------
 
 While all the functionality above currently works, DJ is still not ready for production use. Only a very small number of functions are supported, and we are still working towards a 0.1 release. If you are interested in helping take a look at the `issues marked with the "good first issue" label <https://github.com/DataJunction/dj/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>`_.

--- a/docs/content/0.1.0/docs/dj-concepts/nodes.rst
+++ b/docs/content/0.1.0/docs/dj-concepts/nodes.rst
@@ -4,9 +4,9 @@ weight: 10
 
 .. _functions:
 
-=========
+---------
 Functions
-=========
+---------
 
 Currently, DJ supports only a small subset of SQL functions, limiting the definition of metrics. In order to add new functions to DJ we need to implement two things:
 
@@ -15,7 +15,7 @@ Currently, DJ supports only a small subset of SQL functions, limiting the defini
 2. Translation to SQLAlchemy. In order to run queries, DJ parses the metric definitions (written in ANSI SQL), and converts them to a SQLAlchemy query object, so it can be translated to different dialects (Hive, Trino, Postgres, etc.). Some functions are easier to translate, specially if they are already defined in ``sqlalchemy.sql.functions``. Others, like ``DATE_TRUNC``, are more complex because they are dialect specific.
 
 Supported functions
-===================
+-------------------
 
 ``AVG``
 -------
@@ -97,7 +97,7 @@ Return the sum of a given column:
     12345
 
 Adding new functions
-====================
+--------------------
 
 Let's look at the ``COUNT`` function in DJ:
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,5 +1,5 @@
 Running
-=======
+-------
 
 Run ``docker-compose`` at the project root:
 
@@ -97,7 +97,7 @@ And you should see:
     }
 
 Alternative Docker Compose Setups
-=================================
+---------------------------------
 
 The default docker compose setup includes the minimally required services to run a DJ server and the metadata is persisted
 in Postgres. However, DJ leverages SQL Alchemy to enable flexibility when it comes to reading source databases as well as storing
@@ -125,7 +125,7 @@ docker compose files which add, remove, or modify services.
      - DJ server backed by CockroachDB
 
 Troubleshooting
-===============
+---------------
 
 1. If the Druid data doesn't load, you may need to fix these permissions:
 


### PR DESCRIPTION
### Summary

Small PR to fix a pre-commit error that happens when it thinks the `====` in RST files are merge conflicts.

### Test Plan

Ran make check and make test

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
