### PR TITLE
Adding a reference node to facilitate node versioning

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -8,7 +8,7 @@ from logging.config import fileConfig
 from sqlmodel import SQLModel, create_engine
 
 from alembic import context
-from dj.models import Column, Database, Node, Query, Table
+from dj.models import Column, Database, NodeRevision, Query, Table
 from dj.utils import get_settings
 
 settings = get_settings()

--- a/alembic/versions/2022_04_30_1939-5f31ff8814e7_initial_migration.py
+++ b/alembic/versions/2022_04_30_1939-5f31ff8814e7_initial_migration.py
@@ -65,7 +65,7 @@ def upgrade():
         sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
         sa.Column("expression", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("name"),
+        sa.UniqueConstraint("name", name="uniq_node_name"),
     )
     op.create_index(op.f("ix_node_description"), "node", ["description"], unique=False)
     op.create_index(op.f("ix_node_expression"), "node", ["expression"], unique=False)

--- a/alembic/versions/2023_02_05_1758-06b0bef0a7e3_create_node_histories_table.py
+++ b/alembic/versions/2023_02_05_1758-06b0bef0a7e3_create_node_histories_table.py
@@ -1,0 +1,183 @@
+"""Create node histories table
+
+Revision ID: 06b0bef0a7e3
+Revises: 1780b415e2c5
+Create Date: 2023-02-05 17:58:43.317077+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "06b0bef0a7e3"
+down_revision = "1780b415e2c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "noderevision",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column(
+            "type",
+            sa.Enum("SOURCE", "TRANSFORM", "METRIC", "DIMENSION", name="nodetype"),
+            nullable=True,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("query", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("mode", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("version", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("reference_node_id", sa.Integer(), nullable=True),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["reference_node_id"],
+            ["node.id"],
+            name="referencenode_reference_node_id_fk",
+        ),
+        sa.ForeignKeyConstraint(["name"], ["node.name"], name="referencenode_name_fk"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "tablenoderevision",
+        sa.Column("table_id", sa.Integer(), nullable=False),
+        sa.Column("node_revision_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["node_revision_id"],
+            ["noderevision.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["table_id"],
+            ["table.id"],
+        ),
+        sa.PrimaryKeyConstraint("table_id", "node_revision_id"),
+    )
+
+    with op.batch_alter_table("node") as batch_op:
+        batch_op.drop_column("mode")
+        batch_op.drop_column("query")
+        batch_op.drop_column("status")
+        batch_op.drop_column("description")
+        batch_op.drop_column("updated_at")
+
+        batch_op.add_column(
+            sa.Column(
+                "current_version",
+                sqlmodel.sql.sqltypes.AutoString(),
+                nullable=False,
+            ),
+        )
+
+    with op.batch_alter_table("nodeavailabilitystate") as batch_op:
+        batch_op.drop_constraint("fk_nodeavailability_node_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_nodeavailability_node_id",
+            "noderevision",
+            ["node_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("nodecolumns") as batch_op:
+        batch_op.drop_constraint("fk_nodecolumns_node_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_nodecolumns_node_id",
+            "noderevision",
+            ["node_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("nodemissingparents") as batch_op:
+        batch_op.drop_constraint(
+            "fk_nodemissingparents_referencing_node_id",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_nodemissingparents_referencing_node_id",
+            "noderevision",
+            ["referencing_node_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("noderelationship") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "parent_version",
+                sqlmodel.sql.sqltypes.AutoString(),
+                nullable=True,
+            ),
+        )
+        batch_op.drop_constraint("fk_noderelationship_child_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_noderelationship_child_id",
+            "noderevision",
+            ["child_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("table") as batch_op:
+        batch_op.drop_constraint("fk_table_node_id", type_="foreignkey")
+        batch_op.drop_column("node_id")
+
+
+def downgrade():
+    op.drop_constraint(None, "table", type_="foreignkey")
+    op.create_foreign_key("fk_table_node_id", "table", "node", ["node_id"], ["id"])
+
+    with op.batch_alter_table("noderelationship") as batch_op:
+        batch_op.drop_constraint("fk_noderelationship_child_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_noderelationship_child_id",
+            "node",
+            ["child_id"],
+            ["id"],
+        )
+        batch_op.drop_column("parent_version")
+
+    with op.batch_alter_table("nodemissingparents") as batch_op:
+        batch_op.drop_constraint(
+            "fk_nodemissingparents_referencing_node_id",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_nodemissingparents_referencing_node_id",
+            "node",
+            ["referencing_node_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("nodecolumns") as batch_op:
+        batch_op.drop_constraint("fk_nodecolumns_node_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_nodecolumns_node_id",
+            "node",
+            ["node_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("nodeavailabilitystate") as batch_op:
+        batch_op.drop_constraint("fk_nodeavailability_node_id", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_nodeavailability_node_id",
+            "nodeavailabilitystate",
+            "node",
+            ["node_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("node") as batch_op:
+        batch_op.add_column(sa.Column("updated_at", sa.DATETIME(), nullable=True))
+        batch_op.add_column(sa.Column("description", sa.VARCHAR(), nullable=False))
+        batch_op.add_column(sa.Column("status", sa.VARCHAR(), nullable=False))
+        batch_op.add_column(sa.Column("query", sa.VARCHAR(), nullable=True))
+        batch_op.add_column(sa.Column("mode", sa.VARCHAR(), nullable=False))
+        batch_op.drop_column("current_version")
+
+    op.drop_table("noderevision")
+    op.drop_table("tablenoderevision")

--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -32,14 +32,15 @@ def add_availability(
     try:
         statement = select(Node).where(Node.name == node_name)
         results = session.exec(statement)
-        existing_node = results.one()
+        existing_ref_node = results.one()
     except NoResultFound as exc:
         raise DJException(
             message=f"Cannot add availability state, node `{node_name}` does not exist",
         ) from exc
 
     # Source nodes require that any availability states set are for one of the defined tables
-    if existing_node.type == NodeType.SOURCE:
+    existing_node = existing_ref_node.current
+    if existing_ref_node.type == NodeType.SOURCE:
         matches = False
         for table in existing_node.tables:
             if (

--- a/dj/api/graphql/column.py
+++ b/dj/api/graphql/column.py
@@ -12,7 +12,7 @@ from dj.models.column import Column as Column_
 from dj.typing import ColumnType as ColumnType_
 
 if TYPE_CHECKING:
-    from dj.models.node import Node
+    from dj.models.node import NodeRevision
 
 
 ColumnType = strawberry.scalar(

--- a/dj/api/graphql/table.py
+++ b/dj/api/graphql/table.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 @strawberry.experimental.pydantic.type(
     model=Table_,
-    fields=["id", "node_id", "database_id"],
+    fields=["id", "database_id"],
 )
 class Table:
     """

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -18,7 +18,7 @@ from dj.api.graphql.main import graphql_app
 from dj.errors import DJException
 from dj.models.column import Column
 from dj.models.database import Database
-from dj.models.node import Node
+from dj.models.node import NodeRevision
 from dj.models.query import Query
 from dj.models.table import Table
 from dj.utils import get_settings

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -3,23 +3,31 @@ Node related APIs.
 """
 
 import logging
-from typing import List, Optional, Union
+from http import HTTPStatus
+from typing import Dict, List, Optional, Tuple, Union
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, SQLModel, select
 
 from dj.construction.extract import extract_dependencies_from_node
 from dj.construction.inference import get_type_of_expression
 from dj.errors import DJError, DJException, ErrorCode
+from dj.models import Database, Table
 from dj.models.column import Column, ColumnType
 from dj.models.node import (
     AvailabilityState,
+    CreateNode,
+    CreateSourceNode,
     Node,
     NodeBase,
     NodeMode,
+    NodeRevision,
     NodeStatus,
     NodeType,
+    UpdateNode,
 )
+from dj.models.table import CreateTable
+from dj.sql.parsing import ast
 from dj.utils import UTCDatetime, get_session
 
 _logger = logging.getLogger(__name__)
@@ -35,22 +43,57 @@ class SimpleColumn(SQLModel):
     type: ColumnType
 
 
-class NodeMetadata(SQLModel):
+class TableMetadata(SQLModel):
+    """
+    Output for table information.
+    """
+
+    id: Optional[int]
+    catalog: Optional[str]
+    schema_: Optional[str]
+    table: Optional[str]
+    database: Optional[Database]
+
+
+class NodeRevisionMetadata(SQLModel):
     """
     A node with information about columns and if it is a metric.
     """
 
     id: int
     name: str
+    version: str
+    reference_node_id: Optional[int]
     description: str = ""
 
-    created_at: UTCDatetime
     updated_at: UTCDatetime
 
     type: NodeType
     query: Optional[str] = None
     availability: Optional[AvailabilityState] = None
     columns: List[SimpleColumn]
+    tables: List[TableMetadata]
+
+
+class NodeMetadata(SQLModel):
+    """
+    A reference node that shows the current revision.
+    """
+
+    id: int
+    name: str
+    type: NodeType
+    current_version: str
+    created_at: UTCDatetime
+    current: NodeRevisionMetadata
+
+
+class NodeWithRevisions(NodeMetadata):
+    """
+    Output for a reference node with revision history.
+    """
+
+    revisions: List[NodeRevisionMetadata]
 
 
 class NodeValidation(SQLModel):
@@ -60,23 +103,23 @@ class NodeValidation(SQLModel):
 
     message: str
     status: NodeStatus
-    node: Node
-    dependencies: List[NodeMetadata]
+    ref_node: Node
+    node: NodeRevision
+    dependencies: List[NodeRevisionMetadata]
     columns: List[Column]
 
 
-@router.post("/nodes/validate/", response_model=NodeValidation)
-def validate_node(
-    data: Union[NodeBase],
+def validate(
+    data: Union[NodeBase, NodeRevision],
     session: Session = Depends(get_session),
-) -> NodeValidation:
+) -> Tuple[Node, NodeRevision, Dict[NodeRevision, List[ast.Table]]]:
     """
     Validate a node.
     """
 
-    if data.type == NodeType.SOURCE:
-        raise DJException(message="Source nodes cannot be validated")
-    node = Node.from_orm(data)
+    ref_node = Node(name=data.name, type=data.type)
+    node = NodeRevision.parse_obj(data)
+    node.reference_node = ref_node
 
     # Try to parse the node's query and extract dependencies
     try:
@@ -112,9 +155,26 @@ def validate_node(
     ]
 
     node.status = NodeStatus.VALID
+    return ref_node, node, dependencies_map
+
+
+@router.post("/nodes/validate/", response_model=NodeValidation)
+def validate_node(
+    data: Union[NodeBase, NodeRevision],
+    session: Session = Depends(get_session),
+) -> NodeValidation:
+    """
+    Validate a node.
+    """
+
+    if data.type == NodeType.SOURCE:
+        raise DJException(message="Source nodes cannot be validated")
+
+    ref_node, node, dependencies_map = validate(data, session)
     return NodeValidation(
-        message=f"Node `{node.name}` is valid",
+        message=f"Node `{ref_node.name}` is valid",
         status=NodeStatus.VALID,
+        ref_node=ref_node,
         node=node,
         dependencies=set(dependencies_map.keys()),
         columns=node.columns,
@@ -124,6 +184,263 @@ def validate_node(
 @router.get("/nodes/", response_model=List[NodeMetadata])
 def read_nodes(*, session: Session = Depends(get_session)) -> List[NodeMetadata]:
     """
-    List the available nodes.
+    List the available reference nodes.
     """
-    return session.exec(select(Node)).all()
+    ref_nodes = session.exec(select(Node)).all()
+    return ref_nodes
+
+
+@router.get("/nodes/{name}/", response_model=NodeWithRevisions)
+def read_node(
+    name: str, *, session: Session = Depends(get_session)
+) -> NodeWithRevisions:
+    """
+    List the specified reference node and include all revisions
+    """
+    statement = select(Node).where(Node.name == name)
+    ref_node = session.exec(statement).one_or_none()
+    if not ref_node:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Node not found: `{name}`",
+        )
+    return ref_node  # type: ignore
+
+
+def check_databases_registered(
+    tables: List[CreateTable],
+    session: Session,
+) -> Dict[str, Database]:
+    """
+    Verify that the referenced databases are registered in the system.
+    """
+
+    database_names = {table.database_name for table in tables}
+    query = select(Database).where(
+        # pylint: disable=no-member
+        Database.name.in_(database_names),  # type: ignore
+    )
+    databases = {db.name: db for db in session.exec(query).all()}
+    missing_databases = database_names - databases.keys()
+    if missing_databases:
+        raise DJException(message=f"Database(s) {missing_databases} not supported.")
+    return databases
+
+
+def create_source_node_revision(
+    data: Union[CreateSourceNode],
+    session: Session,
+) -> NodeRevision:
+    """
+    Creates a source node revision.
+    """
+
+    databases = check_databases_registered(data.tables, session)
+
+    node_revision = NodeRevision(
+        name=data.name,
+        description=data.description,
+        type=data.type,
+        columns=[
+            Column(
+                name=column_name,
+                type=ColumnType[column_data["type"]],
+                dimension_column=column_data.get("dimension"),
+            )
+            for column_name, column_data in data.columns.items()
+        ],
+        tables=[
+            Table(
+                catalog=table.catalog,
+                schema_=table.schema_,
+                table=table.table,
+                cost=table.cost,
+                database=databases[table.database_name],
+                columns=[],
+            )
+            for table in data.tables
+        ],
+        parents=[],
+    )
+    return node_revision
+
+
+def create_node_revision(
+    data: Union[CreateNode],
+    session: Session,
+) -> NodeRevision:
+    """
+    Create a non-source node revision.
+    """
+
+    node_revision = NodeRevision.parse_obj(data)
+    _, node, dependencies_map = validate(node_revision, session)
+    new_parents = [node.name for node in dependencies_map]
+    parent_refs = session.exec(
+        select(Node).where(
+            # pylint: disable=no-member
+            Node.name.in_(  # type: ignore
+                new_parents,
+            ),
+        ),
+    ).all()
+    node_revision.parents = parent_refs
+
+    _logger.info(
+        "Parent nodes for %s (v%s): %s",
+        data.name,
+        node_revision.version,
+        [p.name for p in node_revision.parents],
+    )
+    node_revision.columns = node.columns or []
+    return node_revision
+
+
+@router.post("/nodes/", response_model=NodeMetadata)
+def create_node(
+    data: Union[CreateSourceNode, CreateNode],
+    session: Session = Depends(get_session),
+) -> NodeMetadata:
+    """
+    Create a node.
+    """
+    query = select(Node).where(Node.name == data.name)
+    ref_node = session.exec(query).one_or_none()
+    if ref_node:
+        raise DJException(f"A node with name `{data.name}` already exists.")
+
+    ref_node = Node(name=data.name, type=data.type, current_version=0)
+
+    if data.type == NodeType.SOURCE:
+        node_revision = create_source_node_revision(data, session)
+    else:
+        node_revision = create_node_revision(data, session)
+
+    # Point the reference node to the new node revision.
+    node_revision.reference_node = ref_node
+    node_revision.version = str(int(ref_node.current_version) + 1)
+    ref_node.current_version = node_revision.version
+
+    node_revision.extra_validation()
+
+    session.add(ref_node)
+    session.commit()
+    session.refresh(ref_node)
+    return ref_node  # type: ignore
+
+
+@router.patch("/nodes/{name}/", response_model=NodeMetadata)
+def update_node(
+    name: str,
+    data: Union[UpdateNode],
+    *,
+    session: Session = Depends(get_session),
+) -> NodeMetadata:
+    """
+    Update a node.
+    """
+
+    query = (
+        select(Node)
+        .where(Node.name == name)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    ref_node = session.exec(query).one_or_none()
+    if not ref_node:
+        raise DJException(
+            message=f"A node with name `{name}` does not exist.",
+            http_status_code=404,
+        )
+
+    old_revision = ref_node.current
+    old_tables = old_revision.tables
+    new_revision = NodeRevision(
+        name=old_revision.name,
+        description=(
+            old_revision.description if not data.description else data.description
+        ),
+        query=data.query if data.query else old_revision.query,
+        type=old_revision.type,
+        columns=[
+            Column(
+                name=column_name,
+                type=ColumnType[column_data["type"]],
+                dimension_column=column_data.get("dimension"),
+            )
+            for column_name, column_data in data.columns.items()
+        ]
+        if data.columns
+        else old_revision.columns,
+        tables=old_tables,
+        parents=[],
+        mode=data.mode if data.mode else old_revision.mode,
+    )
+
+    # Update tables if they're provided
+    if data.tables:
+        databases = check_databases_registered(data.tables, session)
+        new_revision.tables = [
+            Table(
+                catalog=table.catalog,
+                schema_=table.schema_,
+                table=table.table,
+                cost=table.cost,
+                database=databases[table.database_name],
+                columns=[],
+            )
+            for table in data.tables
+        ]
+
+    # Build the new version and link its parents
+    if new_revision.type != NodeType.SOURCE:
+        _, node, dependencies_map = validate(new_revision, session)
+        new_parents = [n.name for n in dependencies_map]
+        parent_refs = session.exec(
+            select(Node).where(
+                # pylint: disable=no-member
+                Node.name.in_(  # type: ignore
+                    new_parents,
+                ),
+            ),
+        ).all()
+        new_revision.parents = list(parent_refs)
+
+        _logger.info(
+            "Parent nodes for %s (v%s): %s",
+            new_revision.name,
+            new_revision.version,
+            [p.name for p in new_revision.parents],
+        )
+        new_revision.columns = node.columns or []
+
+    # If nothing has changed, do not create the new node revision
+    node_change_check = (
+        old_revision.type != NodeType.SOURCE
+        and old_revision.query == new_revision.query
+        and old_revision.description == new_revision.description
+        and old_revision.mode == new_revision.mode
+    )
+    source_node_change_check = (
+        old_revision.type == NodeType.SOURCE
+        and {table.id for table in old_tables}
+        == {table.id for table in new_revision.tables}
+        and {col.id for col in old_revision.columns}
+        == {col.id for col in new_revision.columns}
+        and old_revision.description == new_revision.description
+        and old_revision.mode == new_revision.mode
+    )
+    if node_change_check or source_node_change_check:
+        return ref_node  # type: ignore
+
+    # Point the reference node to the new node revision.
+    new_revision.reference_node = ref_node
+    new_revision.version = str(int(ref_node.current_version) + 1)
+    ref_node.current_version = new_revision.version
+
+    new_revision.extra_validation()
+
+    session.add(ref_node)
+    session.commit()
+    session.refresh(ref_node)
+    return ref_node  # type: ignore

--- a/dj/construction/extract.py
+++ b/dj/construction/extract.py
@@ -8,7 +8,7 @@ from sqlmodel import Session
 
 from dj.construction.compile import CompoundBuildException, make_name
 from dj.errors import DJException
-from dj.models.node import Node, NodeType
+from dj.models.node import NodeRevision, NodeType
 from dj.sql.parsing import ast
 from dj.sql.parsing.backends.sqloxide import parse
 
@@ -17,13 +17,13 @@ def extract_dependencies_from_query_ast(
     session: Session,
     query: ast.Query,
     raise_: bool = True,
-) -> Tuple[ast.Query, Dict[Node, List[ast.Table]], Dict[str, List[ast.Table]]]:
+) -> Tuple[ast.Query, Dict[NodeRevision, List[ast.Table]], Dict[str, List[ast.Table]]]:
     """Find all dependencies in a compiled query"""
     CompoundBuildException().reset()
     CompoundBuildException().set_raise(False)
 
     query.compile(session)
-    deps: Dict[Node, List[ast.Table]] = {}
+    deps: Dict[NodeRevision, List[ast.Table]] = {}
     danglers: Dict[str, List[ast.Table]] = {}
     for table in query.find_all(ast.Table):
         if node := table.dj_node:
@@ -56,17 +56,17 @@ def extract_dependencies_from_str_query(
     query: str,
     dialect: Optional[str] = None,
     raise_: bool = True,
-) -> Tuple[ast.Query, Dict[Node, List[ast.Table]], Dict[str, List[ast.Table]]]:
+) -> Tuple[ast.Query, Dict[NodeRevision, List[ast.Table]], Dict[str, List[ast.Table]]]:
     """Find all dependencies in the a string query"""
     return extract_dependencies_from_query_ast(session, parse(query, dialect), raise_)
 
 
 def extract_dependencies_from_node(
     session: Session,
-    node: Node,
+    node: NodeRevision,
     dialect: Optional[str] = None,
     raise_: bool = True,
-) -> Tuple[ast.Query, Dict[Node, List[ast.Table]], Dict[str, List[ast.Table]]]:
+) -> Tuple[ast.Query, Dict[NodeRevision, List[ast.Table]], Dict[str, List[ast.Table]]]:
     """Find all immediate dependencies of a Node"""
     if node.query is None:
         raise DJException("Node has no query to extract from.")

--- a/dj/models/__init__.py
+++ b/dj/models/__init__.py
@@ -2,10 +2,10 @@
 All models.
 """
 
-__all__ = ["Column", "Database", "Node", "Query", "Table"]
+__all__ = ["Column", "Database", "NodeRevision", "Query", "Table"]
 
 from dj.models.column import Column
 from dj.models.database import Database
-from dj.models.node import Node
+from dj.models.node import NodeRevision
 from dj.models.query import Query
 from dj.models.table import Table

--- a/dj/models/column.py
+++ b/dj/models/column.py
@@ -10,7 +10,7 @@ from sqlmodel import Field, Relationship, SQLModel
 from dj.typing import ColumnType, ColumnTypeDecorator
 
 if TYPE_CHECKING:
-    from dj.models.node import Node
+    from dj.models.node import Node, NodeRevision
 
 
 class ColumnYAML(TypedDict, total=False):

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -6,16 +6,19 @@ import enum
 from collections import defaultdict
 from datetime import datetime, timezone
 from functools import partial
-from typing import Dict, List, Optional, TypedDict, cast
+from typing import Dict, List, Optional, cast
 
+from pydantic import Extra
 from sqlalchemy import JSON, DateTime, String
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy.types import Enum
 from sqlmodel import Field, Relationship, SQLModel
+from typing_extensions import TypedDict
 
 from dj.models.column import Column, ColumnYAML
-from dj.models.table import Table, TableYAML
+from dj.models.table import CreateTable, Table, TableNodeRevision, TableYAML
 from dj.sql.parse import is_metric
+from dj.typing import ColumnType
 from dj.utils import UTCDatetime
 
 
@@ -29,9 +32,16 @@ class NodeRelationship(SQLModel, table=True):  # type: ignore
         foreign_key="node.id",
         primary_key=True,
     )
+
+    # This will default to `latest`, which points to the current version of the node,
+    # or it can be a specific version.
+    parent_version: Optional[str] = Field(
+        default="latest",
+    )
+
     child_id: Optional[int] = Field(
         default=None,
-        foreign_key="node.id",
+        foreign_key="noderevision.id",
         primary_key=True,
     )
 
@@ -43,7 +53,7 @@ class NodeColumns(SQLModel, table=True):  # type: ignore
 
     node_id: Optional[int] = Field(
         default=None,
-        foreign_key="node.id",
+        foreign_key="noderevision.id",
         primary_key=True,
     )
     column_id: Optional[int] = Field(
@@ -111,14 +121,26 @@ class NodeYAML(TypedDict, total=False):
     tables: Dict[str, List[TableYAML]]
 
 
+class ReferenceNodeBase(SQLModel):
+    """
+    A base reference node.
+    """
+
+    name: str = Field(sa_column=SqlaColumn("name", String, unique=True))
+    type: NodeType = Field(sa_column=SqlaColumn(Enum(NodeType)))
+
+
 class NodeBase(SQLModel):
     """
     A base node.
     """
 
-    name: str = Field(sa_column=SqlaColumn("name", String, unique=True))
-    description: str = ""
+    name: str = Field(
+        sa_column=SqlaColumn("name", String, unique=False),
+        foreign_key="node.name",
+    )
     type: NodeType = Field(sa_column=SqlaColumn(Enum(NodeType)))
+    description: str = ""
     query: Optional[str] = None
     mode: NodeMode = NodeMode.PUBLISHED
 
@@ -148,7 +170,7 @@ class NodeMissingParents(SQLModel, table=True):  # type: ignore
     )
     referencing_node_id: Optional[int] = Field(
         default=None,
-        foreign_key="node.id",
+        foreign_key="noderevision.id",
         primary_key=True,
     )
 
@@ -190,22 +212,58 @@ class NodeAvailabilityState(SQLModel, table=True):  # type: ignore
     )
     node_id: Optional[int] = Field(
         default=None,
-        foreign_key="node.id",
+        foreign_key="noderevision.id",
         primary_key=True,
     )
 
 
-class Node(NodeBase, table=True):  # type: ignore
+class Node(ReferenceNodeBase, table=True):  # type: ignore
+    """
+    Reference node that acts as an umbrella for all node revisions
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    current_version: str = Field(default="1")
+    created_at: UTCDatetime = Field(
+        sa_column=SqlaColumn(DateTime(timezone=True)),
+        default_factory=partial(datetime.now, timezone.utc),
+    )
+
+    revisions: List["NodeRevision"] = Relationship(back_populates="reference_node")
+    current: "NodeRevision" = Relationship(
+        sa_relationship_kwargs={
+            "primaryjoin": "and_(Node.id==NodeRevision.reference_node_id, "
+            "Node.current_version == NodeRevision.version)",
+            "viewonly": True,
+            "uselist": False,
+        },
+    )
+
+    children: List["NodeRevision"] = Relationship(
+        back_populates="parents",
+        link_model=NodeRelationship,
+        sa_relationship_kwargs={
+            "primaryjoin": "Node.id==NodeRelationship.parent_id",
+            "secondaryjoin": "NodeRevision.id==NodeRelationship.child_id",
+        },
+    )
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+
+class NodeRevision(NodeBase, table=True):  # type: ignore
     """
     A node.
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
+    version: Optional[str] = Field(default="1")
+    reference_node_id: Optional[int] = Field(foreign_key="node.id")
+    reference_node: Node = Relationship(back_populates="revisions")
+
     status: NodeStatus = NodeStatus.INVALID
-    created_at: UTCDatetime = Field(
-        sa_column=SqlaColumn(DateTime(timezone=True)),
-        default_factory=partial(datetime.now, timezone.utc),
-    )
     updated_at: UTCDatetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),
         default_factory=partial(datetime.now, timezone.utc),
@@ -213,49 +271,50 @@ class Node(NodeBase, table=True):  # type: ignore
 
     tables: List[Table] = Relationship(
         back_populates="node",
-        sa_relationship_kwargs={"cascade": "all, delete"},
+        link_model=TableNodeRevision,
+        sa_relationship_kwargs={
+            "primaryjoin": "NodeRevision.id==TableNodeRevision.node_revision_id",
+            "secondaryjoin": "Table.id==TableNodeRevision.table_id",
+            "cascade": "all, delete",
+        },
     )
 
     parents: List["Node"] = Relationship(
         back_populates="children",
         link_model=NodeRelationship,
         sa_relationship_kwargs={
-            "primaryjoin": "Node.id==NodeRelationship.child_id",
+            "primaryjoin": "NodeRevision.id==NodeRelationship.child_id",
             "secondaryjoin": "Node.id==NodeRelationship.parent_id",
         },
     )
 
+    parent_links: List[NodeRelationship] = Relationship()
+
     missing_parents: List[MissingParent] = Relationship(
         link_model=NodeMissingParents,
         sa_relationship_kwargs={
-            "primaryjoin": "Node.id==NodeMissingParents.referencing_node_id",
+            "primaryjoin": "NodeRevision.id==NodeMissingParents.referencing_node_id",
             "secondaryjoin": "MissingParent.id==NodeMissingParents.missing_parent_id",
             "cascade": "all, delete",
-        },
-    )
-
-    children: List["Node"] = Relationship(
-        back_populates="parents",
-        link_model=NodeRelationship,
-        sa_relationship_kwargs={
-            "primaryjoin": "Node.id==NodeRelationship.parent_id",
-            "secondaryjoin": "Node.id==NodeRelationship.child_id",
         },
     )
 
     columns: List[Column] = Relationship(
         link_model=NodeColumns,
         sa_relationship_kwargs={
-            "primaryjoin": "Node.id==NodeColumns.node_id",
+            "primaryjoin": "NodeRevision.id==NodeColumns.node_id",
             "secondaryjoin": "Column.id==NodeColumns.column_id",
             "cascade": "all, delete",
         },
     )
 
+    # The availability of materialized data needs to be stored on the NodeRevision
+    # level in order to support pinned versions, where a node owner wants to pin
+    # to a particular upstream node version.
     availability: Optional[AvailabilityState] = Relationship(
         link_model=NodeAvailabilityState,
         sa_relationship_kwargs={
-            "primaryjoin": "Node.id==NodeAvailabilityState.node_id",
+            "primaryjoin": "NodeRevision.id==NodeAvailabilityState.node_id",
             "secondaryjoin": "AvailabilityState.id==NodeAvailabilityState.availability_id",
             "cascade": "all, delete",
             "uselist": False,
@@ -315,3 +374,73 @@ class Node(NodeBase, table=True):  # type: ignore
                     f"Node {self.name} of type metric has an invalid query, "
                     "should have a single aggregation",
                 )
+
+
+class ImmutableNodeFields(SQLModel):
+    """
+    Node fields that cannot be changed
+    """
+
+    name: str
+    type: NodeType
+
+
+class MutableNodeFields(SQLModel):
+    """
+    Node fields that can be changed.
+    """
+
+    description: str
+    query: Optional[str]
+    mode: NodeMode
+
+
+class SourceNodeColumnType(TypedDict, total=False):
+    """
+    Schema of a column for a table defined in a source node
+    """
+
+    type: ColumnType
+    dimension: Optional[str]
+
+
+class SourceNodeFields(SQLModel):
+    """
+    Source node fields that can be changed.
+    """
+
+    columns: Dict[str, SourceNodeColumnType]
+    tables: List[CreateTable]
+
+
+class CreateNode(ImmutableNodeFields, MutableNodeFields):
+    """
+    Create non-source node object.
+    """
+
+
+class CreateSourceNode(ImmutableNodeFields, MutableNodeFields, SourceNodeFields):
+    """
+    A create object for source nodes
+    """
+
+
+class UpdateNode(MutableNodeFields, SourceNodeFields):
+    """
+    Update node object where all fields are optional
+    """
+
+    __annotations__ = {
+        k: Optional[v]
+        for k, v in {
+            **SourceNodeFields.__annotations__,  # pylint: disable=E1101
+            **MutableNodeFields.__annotations__,  # pylint: disable=E1101
+        }.items()
+    }
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """
+        Do not allow fields other than the ones defined here.
+        """
+
+        extra = Extra.forbid

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -26,7 +26,7 @@ from typing import (
 from sqlmodel import Session
 
 from dj.models.database import Database
-from dj.models.node import Node as DJNode
+from dj.models.node import NodeRevision as DJNode
 from dj.models.node import NodeType as DJNodeType
 from dj.sql.parsing.backends.exceptions import DJParseException
 from dj.typing import ColumnType, ColumnTypeError
@@ -1025,7 +1025,8 @@ class Table(Named):
             DJNodeType.DIMENSION,
         ):
             raise DJParseException(
-                f"Expected dj node of TRANSFORM, SOURCE, or DIMENSION but got {dj_node.type}.",
+                f"Expected dj node of TRANSFORM, SOURCE, or DIMENSION "
+                f"but got {dj_node.type}.",
             )
         self._dj_node = dj_node
         return self

--- a/dj/sql/transpile.py
+++ b/dj/sql/transpile.py
@@ -72,7 +72,7 @@ def get_select_for_node(
     """
     # if no columns are specified, require all
     if columns is None:
-        columns = {column.name for column in node.columns}
+        columns = {column.name for column in node.current.columns}
 
     engine = database.engine
 
@@ -80,7 +80,7 @@ def get_select_for_node(
     # has all the requested columns (see #104)
     tables = [
         table
-        for table in node.tables
+        for table in node.current.tables
         if table.database == database
         and columns <= {column.name for column in table.columns}
     ]
@@ -94,8 +94,14 @@ def get_select_for_node(
         )
         return select(materialized_table)
 
-    tree = parse_sql(node.query, dialect="ansi")
-    return get_query(node.query, node.parents, tree, database, engine.dialect.name)
+    tree = parse_sql(node.current.query, dialect="ansi")
+    return get_query(
+        node.current.query,
+        node.current.parents,
+        tree,
+        database,
+        engine.dialect.name,
+    )
 
 
 def get_query(
@@ -458,7 +464,10 @@ def get_value(
     raise NotImplementedError(f"Unable to handle value: {value}")
 
 
-def get_node_from_relation(relation: Relation, parent_map: Dict[str, Node]) -> Node:
+def get_node_from_relation(
+    relation: Relation,
+    parent_map: Dict[str, Node],
+) -> Node:
     """
     Return a node from a relation.
     """

--- a/tests/api/graphql/node_test.py
+++ b/tests/api/graphql/node_test.py
@@ -6,29 +6,41 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from dj.models.column import Column, ColumnType
-from dj.models.node import Node, NodeType
+from dj.models.node import Node, NodeRevision, NodeType
 
 
 def test_get_nodes(session: Session, client: TestClient) -> None:
     """
     Test ``get_nodes``.
     """
-    node1 = Node(name="not-a-metric", type=NodeType.SOURCE)
-    node2 = Node(
+    ref_node1 = Node(
+        name="not-a-metric",
+        type=NodeType.SOURCE,
+        current_version=1,
+    )
+    node1 = NodeRevision(reference_node=ref_node1, version=1)
+
+    ref_node2 = Node(
         name="also-not-a-metric",
-        query="SELECT 42 AS answer",
         type=NodeType.TRANSFORM,
+        current_version=1,
+    )
+    node2 = NodeRevision(
+        reference_node=ref_node2,
+        version=1,
+        query="SELECT 42 AS answer",
         columns=[
             Column(name="answer", type=ColumnType.INT),
         ],
     )
-    node3 = Node(
-        name="a-metric",
+    ref_node3 = Node(name="a-metric", type=NodeType.METRIC, current_version=1)
+    node3 = NodeRevision(
+        reference_node=ref_node3,
+        version=1,
         query="SELECT COUNT(*) FROM my_table",
         columns=[
             Column(name="_col0", type=ColumnType.INT),
         ],
-        type=NodeType.METRIC,
     )
     session.add(node1)
     session.add(node2)
@@ -39,10 +51,14 @@ def test_get_nodes(session: Session, client: TestClient) -> None:
     {
         getNodes{
             name
-            query
-            columns{
-                name
-                type
+            currentVersion
+            current{
+                version
+                query
+                columns{
+                    name
+                    type
+                }
             }
         }
     }
@@ -55,21 +71,27 @@ def test_get_nodes(session: Session, client: TestClient) -> None:
 
     nodes = {node["name"]: node for node in data}
 
-    assert nodes["not-a-metric"]["query"] is None
-    assert not nodes["not-a-metric"]["columns"]
+    assert nodes["not-a-metric"]["currentVersion"] == "1"
+    assert nodes["not-a-metric"]["current"]["query"] is None
+    assert not nodes["not-a-metric"]["current"]["columns"]
+    assert nodes["not-a-metric"]["current"]["version"] == "1"
 
-    assert nodes["also-not-a-metric"]["query"] == "SELECT 42 AS answer"
-    assert nodes["also-not-a-metric"]["columns"] == [
+    assert nodes["also-not-a-metric"]["current"]["query"] == "SELECT 42 AS answer"
+    assert nodes["also-not-a-metric"]["current"]["columns"] == [
         {
             "name": "answer",
             "type": "INT",
         },
     ]
+    assert nodes["also-not-a-metric"]["current"]["version"] == "1"
+    assert nodes["also-not-a-metric"]["currentVersion"] == "1"
 
-    assert nodes["a-metric"]["query"] == "SELECT COUNT(*) FROM my_table"
-    assert nodes["a-metric"]["columns"] == [
+    assert nodes["a-metric"]["current"]["query"] == "SELECT COUNT(*) FROM my_table"
+    assert nodes["a-metric"]["current"]["columns"] == [
         {
             "name": "_col0",
             "type": "INT",
         },
     ]
+    assert nodes["a-metric"]["current"]["version"] == "1"
+    assert nodes["a-metric"]["currentVersion"] == "1"

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -1,34 +1,87 @@
 """
 Tests for the nodes API.
 """
+from typing import Any, Dict
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
+from dj.models import Database, Table
 from dj.models.column import Column, ColumnType
-from dj.models.node import Node, NodeType
+from dj.models.node import Node, NodeRevision, NodeType
+
+
+def test_read_node(session: Session, client: TestClient) -> None:
+    """
+    Test ``GET /nodes/{node_id}``.
+    """
+    ref_node = Node(name="something", type=NodeType.SOURCE, current_version=1)
+    node = NodeRevision(
+        name=ref_node.name,
+        type=ref_node.type,
+        reference_node=ref_node,
+        version=1,
+    )
+    session.add(node)
+    session.commit()
+
+    response = client.get("/nodes/something/")
+    data = response.json()
+
+    assert response.status_code == 200
+
+    assert data["current"]["version"] == "1"
+    assert data["current_version"] == "1"
+    assert len(data["revisions"]) == 1
+
+    response = client.get("/nodes/nothing/")
+    data = response.json()
+
+    assert response.status_code == 404
+    assert data["detail"] == "Node not found: `nothing`"
 
 
 def test_read_nodes(session: Session, client: TestClient) -> None:
     """
     Test ``GET /nodes/``.
     """
-    node1 = Node(name="not-a-metric", type=NodeType.SOURCE)
-    node2 = Node(
+    ref_node1 = Node(
+        name="not-a-metric",
+        type=NodeType.SOURCE,
+        current_version=1,
+    )
+    node1 = NodeRevision(
+        reference_node=ref_node1,
+        version=1,
+        name=ref_node1.name,
+        type=ref_node1.type,
+    )
+    ref_node2 = Node(
         name="also-not-a-metric",
-        query="SELECT 42 AS answer",
         type=NodeType.TRANSFORM,
+        current_version=1,
+    )
+    node2 = NodeRevision(
+        name=ref_node2.name,
+        reference_node=ref_node2,
+        version=1,
+        query="SELECT 42 AS answer",
+        type=ref_node2.type,
         columns=[
             Column(name="answer", type=ColumnType.INT),
         ],
     )
-    node3 = Node(
-        name="a-metric",
+    ref_node3 = Node(name="a-metric", type=NodeType.METRIC, current_version=1)
+    node3 = NodeRevision(
+        name=ref_node3.name,
+        reference_node=ref_node3,
+        version=1,
         query="SELECT COUNT(*) FROM my_table",
         columns=[
             Column(name="_col0", type=ColumnType.INT),
         ],
-        type=NodeType.METRIC,
+        type=ref_node3.type,
     )
     session.add(node1)
     session.add(node2)
@@ -42,25 +95,470 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     assert len(data) == 3
 
     nodes = {node["name"]: node for node in data}
+    assert nodes["not-a-metric"]["current"]["query"] is None
+    assert not nodes["not-a-metric"]["current"]["columns"]
 
-    assert nodes["not-a-metric"]["query"] is None
-    assert not nodes["not-a-metric"]["columns"]
-
-    assert nodes["also-not-a-metric"]["query"] == "SELECT 42 AS answer"
-    assert nodes["also-not-a-metric"]["columns"] == [
+    assert nodes["also-not-a-metric"]["current"]["query"] == "SELECT 42 AS answer"
+    assert nodes["also-not-a-metric"]["current"]["columns"] == [
         {
             "name": "answer",
             "type": "INT",
         },
     ]
 
-    assert nodes["a-metric"]["query"] == "SELECT COUNT(*) FROM my_table"
-    assert nodes["a-metric"]["columns"] == [
+    assert nodes["a-metric"]["current"]["query"] == "SELECT COUNT(*) FROM my_table"
+    assert nodes["a-metric"]["current"]["columns"] == [
         {
             "name": "_col0",
             "type": "INT",
         },
     ]
+
+
+class TestCreateOrUpdateNodes:
+    """
+    Test ``POST /nodes/`` and ``PUT /nodes/{name}``.
+    """
+
+    @pytest.fixture
+    def create_source_node_payload(self) -> Dict[str, Any]:
+        """
+        Payload for creating a source node.
+        """
+
+        return {
+            "name": "comments",
+            "description": "A fact table with comments",
+            "type": "source",
+            "columns": {
+                "id": {"type": "INT"},
+                "user_id": {"type": "INT", "dimension": "basic.dimension.users"},
+                "timestamp": {"type": "DATETIME"},
+                "text": {"type": "STR"},
+            },
+            "mode": "published",
+            "tables": [
+                {
+                    "catalog": None,
+                    "schema_": "basic",
+                    "table": "comments",
+                    "cost": 10.0,
+                    "database_name": "postgres",
+                },
+            ],
+        }
+
+    @pytest.fixture
+    def create_dimension_node_payload(self) -> Dict[str, Any]:
+        """
+        Payload for creating a dimension node.
+        """
+
+        return {
+            "description": "Country dimension",
+            "type": "dimension",
+            "query": "SELECT country, COUNT(1) AS user_cnt "
+            "FROM basic.source.users GROUP BY country",
+            "mode": "published",
+            "name": "countries",
+        }
+
+    @pytest.fixture
+    def create_invalid_transform_node_payload(self) -> Dict[str, Any]:
+        """
+        Payload for creating a transform node.
+        """
+
+        return {
+            "name": "country_agg",
+            "query": "SELECT country, COUNT(DISTINCT id) AS num_users FROM comments",
+            "type": "transform",
+            "mode": "published",
+            "description": "Distinct users per country",
+            "columns": {
+                "country": {"type": "STR"},
+                "num_users": {"type": "INT"},
+            },
+        }
+
+    @pytest.fixture
+    def create_transform_node_payload(self) -> Dict[str, Any]:
+        """
+        Payload for creating a transform node.
+        """
+
+        return {
+            "name": "country_agg",
+            "query": "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users",
+            "type": "transform",
+            "mode": "published",
+            "description": "Distinct users per country",
+            "columns": {
+                "country": {"type": "STR"},
+                "num_users": {"type": "INT"},
+            },
+        }
+
+    @pytest.fixture
+    def database(self, session: Session) -> Database:
+        """
+        A database fixture.
+        """
+
+        database = Database(name="postgres", URI="postgres://")
+        session.add(database)
+        session.commit()
+        return database
+
+    @pytest.fixture
+    def source_node(self, session: Session, database: Database) -> Node:
+        """
+        A source node fixture.
+        """
+
+        table = Table(
+            database=database,
+            table="A",
+            columns=[
+                Column(name="ds", type=ColumnType.STR),
+                Column(name="user_id", type=ColumnType.INT),
+            ],
+        )
+        ref_node = Node(
+            name="basic.source.users",
+            type=NodeType.SOURCE,
+            current_version=1,
+        )
+        node = NodeRevision(
+            reference_node=ref_node,
+            name=ref_node.name,
+            type=ref_node.type,
+            version=1,
+            tables=[table],
+            columns=[
+                Column(name="id", type=ColumnType.INT),
+                Column(name="full_name", type=ColumnType.STR),
+                Column(name="age", type=ColumnType.INT),
+                Column(name="country", type=ColumnType.STR),
+                Column(name="gender", type=ColumnType.STR),
+                Column(name="preferred_language", type=ColumnType.STR),
+            ],
+        )
+        session.add(node)
+        session.commit()
+        return ref_node
+
+    def test_create_update_source_node(
+        self,
+        client: TestClient,
+        database: Database,  # pylint: disable=unused-argument
+        create_source_node_payload: Dict[str, Any],
+    ) -> None:
+        """
+        Test creating and updating a source node
+        """
+
+        response = client.post(
+            "/nodes/",
+            json=create_source_node_payload,
+        )
+        data = response.json()
+
+        assert data["name"] == "comments"
+        assert data["type"] == "source"
+        assert data["current_version"] == "1"
+        assert data["current"]["name"] == "comments"
+        assert data["current"]["version"] == "1"
+        assert data["current"]["reference_node_id"] == 1
+        assert data["current"]["description"] == "A fact table with comments"
+        assert data["current"]["query"] is None
+        assert data["current"]["columns"] == [
+            {"name": "id", "type": "INT"},
+            {"name": "user_id", "type": "INT"},
+            {"name": "timestamp", "type": "DATETIME"},
+            {"name": "text", "type": "STR"},
+        ]
+
+        # Trying to create it again should fail
+        response = client.post(
+            "/nodes/",
+            json=create_source_node_payload,
+        )
+        data = response.json()
+        assert data["message"] == "A node with name `comments` already exists."
+        assert response.status_code == 500
+
+        # Update node with a new description should create a new revision
+        response = client.patch(
+            f"/nodes/{create_source_node_payload['name']}/",
+            json={
+                "description": "New description",
+            },
+        )
+        data = response.json()
+
+        assert data["name"] == "comments"
+        assert data["type"] == "source"
+        assert data["current_version"] == "2"
+        assert data["current"]["name"] == "comments"
+        assert data["current"]["version"] == "2"
+        assert data["current"]["reference_node_id"] == 1
+        assert data["current"]["description"] == "New description"
+
+        # Try to update node with no changes
+        response = client.patch(
+            f"/nodes/{create_source_node_payload['name']}/",
+            json={"description": "New description"},
+        )
+        new_data = response.json()
+        assert data == new_data
+
+        # Update a node with a new table should create a new revision
+        response = client.patch(
+            f"/nodes/{create_source_node_payload['name']}/",
+            json={
+                "tables": [
+                    {
+                        "catalog": None,
+                        "schema_": "basic",
+                        "table": "commentsv2",
+                        "cost": 10.0,
+                        "database_name": "postgres",
+                    },
+                ],
+            },
+        )
+        data = response.json()
+        assert data["current_version"] == "3"
+        assert data["current"]["version"] == "3"
+        assert data["current"]["tables"][0]["table"] == "commentsv2"
+
+        # Try to update a node with a table that has different columns
+        response = client.patch(
+            f"/nodes/{create_source_node_payload['name']}/",
+            json={
+                "columns": {
+                    "id": {"type": "INT"},
+                    "user_id": {"type": "INT", "dimension": "basic.dimension.users"},
+                    "timestamp": {"type": "DATETIME"},
+                    "text_v2": {"type": "STR"},
+                },
+            },
+        )
+        data = response.json()
+        assert data["current_version"] == "4"
+        assert data["current"]["version"] == "4"
+        assert data["current"]["columns"] == [
+            {"name": "id", "type": "INT"},
+            {"name": "user_id", "type": "INT"},
+            {"name": "timestamp", "type": "DATETIME"},
+            {"name": "text_v2", "type": "STR"},
+        ]
+
+    def test_create_source_node_with_unregistered_databases(
+        self,
+        client: TestClient,
+        create_source_node_payload: Dict[str, Any],
+    ) -> None:
+        """
+        Creating a source node with a table in an unregistered database should fail.
+        """
+
+        response = client.post(
+            "/nodes/",
+            json=create_source_node_payload,
+        )
+        data = response.json()
+        assert response.status_code == 500
+        assert data["message"] == "Database(s) {'postgres'} not supported."
+
+    def test_update_nonexistent_node(
+        self,
+        client: TestClient,
+    ) -> None:
+        """
+        Test updating a non-existent node.
+        """
+
+        response = client.patch(
+            "/nodes/something/",
+            json={"description": "new"},
+        )
+        data = response.json()
+        assert response.status_code == 404
+        assert data["message"] == "A node with name `something` does not exist."
+
+    def test_create_invalid_transform_node(
+        self,
+        database: Database,  # pylint: disable=unused-argument
+        source_node: Node,  # pylint: disable=unused-argument
+        client: TestClient,
+        create_invalid_transform_node_payload: Dict[str, Any],
+    ) -> None:
+        """
+        Test creating an invalid transform node in draft and published modes.
+        """
+
+        response = client.post(
+            "/nodes/",
+            json=create_invalid_transform_node_payload,
+        )
+        data = response.json()
+        assert response.status_code == 500
+        assert (
+            data["message"]
+            == "Node definition contains references to nodes that do not exist"
+        )
+
+    def test_create_update_transform_node(
+        self,
+        database: Database,  # pylint: disable=unused-argument
+        source_node: Node,  # pylint: disable=unused-argument
+        client: TestClient,
+        create_transform_node_payload: Dict[str, Any],
+    ) -> None:
+        """
+        Test creating and updating a transform node that references an existing source.
+        """
+
+        response = client.post(
+            "/nodes/",
+            json=create_transform_node_payload,
+        )
+        data = response.json()
+        assert data["name"] == "country_agg"
+        assert data["type"] == "transform"
+        assert data["current"]["description"] == "Distinct users per country"
+        assert (
+            data["current"]["query"]
+            == "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users"
+        )
+        assert data["current"]["columns"] == [
+            {"name": "country", "type": "STR"},
+            {"name": "num_users", "type": "INT"},
+        ]
+        assert data["current"]["tables"] == []
+
+        response = client.patch(
+            "/nodes/country_agg/",
+            json={"description": "Some new description"},
+        )
+        data = response.json()
+        assert data["name"] == "country_agg"
+        assert data["type"] == "transform"
+        assert data["current_version"] == "2"
+        assert data["current"]["version"] == "2"
+        assert data["current"]["description"] == "Some new description"
+        assert (
+            data["current"]["query"]
+            == "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users"
+        )
+        assert data["current"]["tables"] == []
+
+        # Try to update with a new query that references a non-existent source
+        response = client.patch(
+            "/nodes/country_agg/",
+            json={
+                "query": "SELECT country, COUNT(DISTINCT id) AS num_users FROM comments",
+            },
+        )
+        data = response.json()
+        assert (
+            data["message"]
+            == "Node definition contains references to nodes that do not exist"
+        )
+
+        # Try to update with a new query that references an existing source
+        response = client.patch(
+            "/nodes/country_agg/",
+            json={
+                "query": "SELECT country, COUNT(DISTINCT id) AS num_users, "
+                "COUNT(*) AS num_entries FROM basic.source.users",
+            },
+        )
+        data = response.json()
+        assert data["current_version"] == "3"
+        assert data["current"]["version"] == "3"
+        assert (
+            data["current"]["query"]
+            == "SELECT country, COUNT(DISTINCT id) AS num_users, "
+            "COUNT(*) AS num_entries FROM basic.source.users"
+        )
+        assert data["current"]["columns"] == [
+            {"name": "country", "type": "STR"},
+            {"name": "num_users", "type": "INT"},
+            {"name": "num_entries", "type": "INT"},
+        ]
+
+        # Verify that all historical revisions are available for the node
+        response = client.get("/nodes/country_agg/")
+        data = response.json()
+        assert len(data["revisions"]) == 3
+        assert {rev["version"]: rev["query"] for rev in data["revisions"]} == {
+            "1": "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users",
+            "2": "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users",
+            "3": "SELECT country, COUNT(DISTINCT id) AS num_users, COUNT(*) AS num_entries "
+            "FROM basic.source.users",
+        }
+        assert {rev["version"]: rev["columns"] for rev in data["revisions"]} == {
+            "1": [
+                {"name": "country", "type": "STR"},
+                {"name": "num_users", "type": "INT"},
+            ],
+            "2": [
+                {"name": "country", "type": "STR"},
+                {"name": "num_users", "type": "INT"},
+            ],
+            "3": [
+                {"name": "country", "type": "STR"},
+                {"name": "num_users", "type": "INT"},
+                {"name": "num_entries", "type": "INT"},
+            ],
+        }
+
+    def test_create_update_dimension_node(
+        self,
+        database: Database,  # pylint: disable=unused-argument
+        source_node: Node,  # pylint: disable=unused-argument
+        client: TestClient,
+        create_dimension_node_payload: Dict[str, Any],
+    ) -> None:
+        """
+        Test creating and updating a dimension node that references an existing source.
+        """
+
+        response = client.post(
+            "/nodes/",
+            json=create_dimension_node_payload,
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["name"] == "countries"
+        assert data["type"] == "dimension"
+        assert data["current_version"] == "1"
+        assert data["current"]["name"] == "countries"
+        assert data["current"]["description"] == "Country dimension"
+        assert (
+            data["current"]["query"] == "SELECT country, COUNT(1) AS user_cnt "
+            "FROM basic.source.users GROUP BY country"
+        )
+        assert data["current"]["columns"] == [
+            {"name": "country", "type": "STR"},
+            {"name": "user_cnt", "type": "INT"},
+        ]
+
+        # Test updating the dimension node with a new query
+        response = client.patch(
+            "/nodes/countries/",
+            json={"query": "SELECT country FROM basic.source.users GROUP BY country"},
+        )
+        data = response.json()
+        assert data["current_version"] == "2"
+        assert data["current"]["version"] == "2"
+
+        # The columns should have been updated
+        assert data["current"]["columns"] == [{"name": "country", "type": "STR"}]
 
 
 class TestValidateNodes:  # pylint: disable=too-many-public-methods
@@ -74,9 +572,16 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         Add nodes to facilitate testing of the validation route
         """
 
-        node1 = Node(
+        ref_node1 = Node(
             name="revenue_source",
             type=NodeType.SOURCE,
+            current_version=1,
+        )
+        node1 = NodeRevision(
+            name=ref_node1.name,
+            type=ref_node1.type,
+            reference_node=ref_node1,
+            version=1,
             columns=[
                 Column(name="payment_id", type=ColumnType.INT),
                 Column(name="payment_amount", type=ColumnType.FLOAT),
@@ -84,13 +589,20 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 Column(name="account_type", type=ColumnType.STR),
             ],
         )
-        node2 = Node(
+        ref_node2 = Node(
             name="large_revenue_payments_only",
+            type=NodeType.TRANSFORM,
+            current_version=1,
+        )
+        node2 = NodeRevision(
+            reference_node=ref_node2,
+            name=ref_node2.name,
+            type=ref_node2.type,
+            version=1,
             query=(
                 "SELECT payment_id, payment_amount, customer_id, account_type "
                 "FROM revenue_source WHERE payment_amount > 1000000"
             ),
-            type=NodeType.TRANSFORM,
             columns=[
                 Column(name="payment_id", type=ColumnType.INT),
                 Column(name="payment_amount", type=ColumnType.FLOAT),
@@ -98,14 +610,22 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 Column(name="account_type", type=ColumnType.STR),
             ],
         )
-        node3 = Node(
+
+        ref_node3 = Node(
             name="large_revenue_payments_and_business_only",
+            type=NodeType.TRANSFORM,
+            current_version=1,
+        )
+        node3 = NodeRevision(
+            reference_node=ref_node3,
+            name=ref_node3.name,
+            type=ref_node3.type,
+            version=1,
             query=(
                 "SELECT payment_id, payment_amount, customer_id, account_type "
                 "FROM revenue_source WHERE payment_amount > 1000000 "
                 "AND account_type = 'BUSINESS'"
             ),
-            type=NodeType.TRANSFORM,
             columns=[
                 Column(name="payment_id", type=ColumnType.INT),
                 Column(name="payment_amount", type=ColumnType.FLOAT),
@@ -136,7 +656,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         data = response.json()
 
         assert response.status_code == 200
-        assert len(data) == 5
+        assert len(data) == 6
         assert data["columns"] == [
             {
                 "dimension_column": None,
@@ -157,7 +677,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             data["node"]["query"]
             == "SELECT payment_id FROM large_revenue_payments_only"
         )
-        assert data["node"]["type"] == "transform"
+        assert data["ref_node"]["type"] == "transform"
 
     def test_validating_an_invalid_node(self, client: TestClient) -> None:
         """
@@ -256,7 +776,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert response.status_code == 200
         assert data["message"] == "Node `foo` is valid"
         assert data["status"] == "valid"
-        assert data["node"]["name"] == "foo"
+        assert data["ref_node"]["name"] == "foo"
         assert data["node"]["mode"] == "draft"
         assert data["node"]["status"] == "valid"
         assert data["columns"] == [

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -14,6 +14,7 @@ def test_run(capsys: CaptureFixture) -> None:
     run("http://localhost:8000")
 
     captured = capsys.readouterr()
+    print(captured.out)
     assert (
         captured.out
         == """http://localhost:8000/docs: Documentation.
@@ -25,7 +26,8 @@ http://localhost:8000/metrics/{name}/: Return a metric by name.
 http://localhost:8000/metrics/{name}/data/: Return data for a metric.
 http://localhost:8000/metrics/{name}/sql/: Return SQL for a metric.
 http://localhost:8000/nodes/validate/: Validate a node.
-http://localhost:8000/nodes/: List the available nodes.
+http://localhost:8000/nodes/: List the available reference nodes.
+http://localhost:8000/nodes/{name}/: List the specified reference node and include all revisions
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/graphql: GraphQL endpoint.
 """

--- a/tests/construction/build_planning_test.py
+++ b/tests/construction/build_planning_test.py
@@ -5,20 +5,20 @@ import pytest
 from sqlalchemy import select
 
 from dj.construction.build_planning import generate_build_plan_from_node
-from dj.models import Node
+from dj.models.node import Node
 
 
 def test_build_planning_source_fails(construction_session):
     """
     Test build planning source fails
     """
-    node = next(
+    ref_node = next(
         construction_session.exec(
             select(Node).filter(Node.name == "basic.source.users"),
         ),
     )[0]
     with pytest.raises(Exception) as exc:
-        generate_build_plan_from_node(construction_session, node)
+        generate_build_plan_from_node(construction_session, ref_node.current)
 
     assert "Node has no query. Cannot generate a build plan without a query." in str(
         exc,

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -8,8 +8,8 @@ from sqlmodel import Session
 
 from dj.construction.build import amenable_name, build_node_for_database
 from dj.errors import DJException
-from dj.models import Column, Database, Node, Table
-from dj.models.node import NodeType
+from dj.models import Column, Database, NodeRevision, Table
+from dj.models.node import Node, NodeType
 from dj.typing import ColumnType
 
 from ..sql.utils import compare_query_strings
@@ -29,20 +29,28 @@ async def test_build_node_for_database(node_name: str, db_id: int, mocker, reque
         Dict[Optional[int], Tuple[bool, str]],
     ] = request.getfixturevalue("build_expectation")
     succeeds, expected = build_expectation[node_name][db_id]
-    node = next(construction_session.exec(select(Node).filter(Node.name == node_name)))[
-        0
-    ]
+    node = next(
+        construction_session.exec(
+            select(Node).filter(Node.name == node_name),
+        ),
+    )[0]
+    print("NOO", node)
 
     if succeeds:
+        print("NOO curr", node.current)
         ast, _ = await build_node_for_database(
             construction_session,
-            node,
+            node.current,
             database_id=db_id,
         )
         assert compare_query_strings(str(ast), expected)
     else:
         with pytest.raises(Exception) as exc:
-            await build_node_for_database(construction_session, node, database_id=db_id)
+            await build_node_for_database(
+                construction_session,
+                node.current,
+                database_id=db_id,
+            )
             assert expected in str(exc)
 
 
@@ -61,7 +69,7 @@ async def test_build_metric_with_dimensions_aggs(mocker, request):
     )[0]
     query, _ = await build_node_for_database(
         construction_session,
-        num_comments_mtc,
+        num_comments_mtc.current,
         aggs=["basic.dimension.users.country", "basic.dimension.users.gender"],
     )
 
@@ -95,22 +103,35 @@ async def test_raise_on_build_without_required_dimension_column(mocker, request)
     construction_session: Session = request.getfixturevalue("construction_session")
     country_dim: Node = next(
         construction_session.exec(
-            select(Node).filter(Node.name == "basic.dimension.countries"),
+            select(Node).filter(
+                Node.name == "basic.dimension.countries",
+            ),
         ),
     )[0]
-    node_foo = Node(
-        name="foo",
-        type=NodeType.TRANSFORM,
+    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version=1)
+    node_foo = NodeRevision(
+        name=node_foo_ref.name,
+        type=node_foo_ref.type,
+        reference_node=node_foo_ref,
+        version=1,
         query="""SELECT num_users FROM basic.transform.country_agg""",
         columns=[
-            Column(name="num_users", type=ColumnType.INT, dimension=country_dim),
+            Column(
+                name="num_users",
+                type=ColumnType.INT,
+                dimension=country_dim,
+            ),
         ],
     )
     construction_session.add(node_foo)
     construction_session.flush()
-    node_bar = Node(
-        name="bar",
-        type=NodeType.TRANSFORM,
+
+    node_bar_ref = Node(name="bar", type=NodeType.TRANSFORM, current_version=1)
+    node_bar = NodeRevision(
+        name=node_bar_ref.name,
+        type=node_bar_ref.type,
+        reference_node=node_bar_ref,
+        version=1,
         query="""SELECT num_users FROM foo GROUP BY basic.dimension.countries.country""",
         columns=[
             Column(name="num_users", type=ColumnType.STR),
@@ -144,7 +165,7 @@ async def test_build_metric_with_dimensions_filters(mocker, request):
     )[0]
     query, _ = await build_node_for_database(
         construction_session,
-        num_comments_mtc,
+        num_comments_mtc.current,
         filters=["basic.dimension.users.age>=25", "basic.dimension.users.age<50"],
     )
 
@@ -176,9 +197,10 @@ async def test_build_metric_with_database_id_specified(mocker, request):
     mocker.patch("dj.models.database.Database.do_ping", return_value=True)
 
     construction_session: Session = request.getfixturevalue("construction_session")
-    node_foo = Node(
-        name="foo",
-        type=NodeType.TRANSFORM,
+    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version=1)
+    node_foo = NodeRevision(
+        reference_node=node_foo_ref,
+        version=1,
         query="""SELECT num_users FROM basic.transform.country_agg""",
         columns=[
             Column(name="num_users", type=ColumnType.STR),
@@ -223,9 +245,10 @@ async def test_build_node_for_database_with_unnamed_column(mocker, request):
     mocker.patch("dj.models.database.Database.do_ping", return_value=True)
 
     construction_session: Session = request.getfixturevalue("construction_session")
-    node_foo = Node(
-        name="foo",
-        type=NodeType.TRANSFORM,
+    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version=1)
+    node_foo = NodeRevision(
+        reference_node=node_foo_ref,
+        version=1,
         query="""SELECT 1 FROM basic.dimension.countries""",
         columns=[
             Column(name="_col1", type=ColumnType.INT),

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlmodel import Session
 
 from dj.construction.inference import get_type_of_expression
-from dj.models import Node
+from dj.models.node import Node
 from dj.sql.parsing import ast
 from dj.sql.parsing.ast import BinaryOpKind
 from dj.sql.parsing.backends.exceptions import DJParseException
@@ -18,12 +18,14 @@ def test_infer_column_with_table(construction_session: Session):
     """
     Test getting the type of a column that has a table
     """
-    node = next(
+    ref_node = next(
         construction_session.exec(
-            select(Node).filter(Node.name == "dbt.source.jaffle_shop.orders"),
+            select(Node).filter(
+                Node.name == "dbt.source.jaffle_shop.orders",
+            ),
         ),
     )[0]
-    table = ast.Table(ast.Name("orders"), _dj_node=node)
+    table = ast.Table(ast.Name("orders"), _dj_node=ref_node.current)
     assert (
         get_type_of_expression(ast.Column(ast.Name("id"), _table=table))
         == ColumnType.INT
@@ -73,12 +75,14 @@ def test_infer_column_with_an_aliased_table(construction_session: Session):
     """
     Test getting the type of a column that has an aliased table
     """
-    node = next(
+    ref_node = next(
         construction_session.exec(
-            select(Node).filter(Node.name == "dbt.source.jaffle_shop.orders"),
+            select(Node).filter(
+                Node.name == "dbt.source.jaffle_shop.orders",
+            ),
         ),
     )[0]
-    table = ast.Table(ast.Name("orders"), _dj_node=node)
+    table = ast.Table(ast.Name("orders"), _dj_node=ref_node.current)
     alias = ast.Alias(
         ast.Name("foo"),
         ast.Namespace([ast.Name("a"), ast.Name("b"), ast.Name("c")]),

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -7,48 +7,84 @@ Tests for ``dj.models.node``.
 import pytest
 from sqlmodel import Session
 
-from dj.models.node import Node, NodeType
+from dj.models.node import Node, NodeRevision, NodeType
 
 
 def test_node_relationship(session: Session) -> None:
     """
     Test the n:n self-referential relationships.
     """
-    node_a = Node(name="A")
-    node_b = Node(name="B")
-    node_c = Node(name="C", parents=[node_a, node_b])
+    node_a_ref = Node(name="A", current_version=1)
+    node_a = NodeRevision(name="A", version=1, reference_node=node_a_ref)
+
+    node_b_ref = Node(name="B", current_version=1)
+    node_b = NodeRevision(name="B", version=1, reference_node=node_b_ref)
+
+    node_c_ref = Node(name="C", current_version=1)
+    node_c = NodeRevision(
+        name="C",
+        version=1,
+        reference_node=node_c_ref,
+        parents=[node_a_ref, node_b_ref],
+    )
 
     session.add(node_c)
 
-    assert node_a.children == [node_c]
-    assert node_b.children == [node_c]
-    assert node_c.children == []
+    assert node_a_ref.children == [node_c]
+    assert node_b_ref.children == [node_c]
+    assert node_c_ref.children == []
 
     assert node_a.parents == []
     assert node_b.parents == []
-    assert node_c.parents == [node_a, node_b]
+    assert node_c.parents == [node_a_ref, node_b_ref]
 
 
 def test_extra_validation() -> None:
     """
     Test ``extra_validation``.
     """
-    node = Node(name="A", type=NodeType.SOURCE)
+    ref_node = Node(name="A", type=NodeType.SOURCE, current_version=1)
+    node = NodeRevision(
+        name=ref_node.name,
+        type=ref_node.type,
+        reference_node=ref_node,
+        version=1,
+    )
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
     assert str(excinfo.value) == "Node A of type source needs at least one table"
 
-    node = Node(name="A", type=NodeType.SOURCE, query="SELECT * FROM B")
+    ref_node = Node(name="A", type=NodeType.SOURCE, current_version=1)
+    node = NodeRevision(
+        name=ref_node.name,
+        type=ref_node.type,
+        reference_node=ref_node,
+        version=1,
+        query="SELECT * FROM B",
+    )
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
     assert str(excinfo.value) == "Node A of type source should not have a query"
 
-    node = Node(name="A", type=NodeType.METRIC)
+    ref_node = Node(name="A", type=NodeType.METRIC, current_version=1)
+    node = NodeRevision(
+        name=ref_node.name,
+        type=ref_node.type,
+        reference_node=ref_node,
+        version=1,
+    )
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
     assert str(excinfo.value) == "Node A of type metric needs a query"
 
-    node = Node(name="A", type=NodeType.METRIC, query="SELECT 42")
+    ref_node = Node(name="A", type=NodeType.METRIC, current_version=1)
+    node = NodeRevision(
+        name=ref_node.name,
+        type=ref_node.type,
+        reference_node=ref_node,
+        version=1,
+        query="SELECT 42",
+    )
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
     assert str(excinfo.value) == (
@@ -56,10 +92,23 @@ def test_extra_validation() -> None:
         "should have a single aggregation"
     )
 
-    node = Node(name="A", type=NodeType.TRANSFORM, query="SELECT * FROM B")
+    ref_node = Node(name="A", type=NodeType.TRANSFORM, current_version=1)
+    node = NodeRevision(
+        name=ref_node.name,
+        type=ref_node.type,
+        reference_node=ref_node,
+        version=1,
+        query="SELECT * FROM B",
+    )
     node.extra_validation()
 
-    node = Node(name="A", type=NodeType.TRANSFORM)
+    ref_node = Node(name="A", type=NodeType.TRANSFORM, current_version=1)
+    node = NodeRevision(
+        name=ref_node.name,
+        type=ref_node.type,
+        reference_node=ref_node,
+        version=1,
+    )
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
     assert str(excinfo.value) == "Node A of type transform needs a query"

--- a/tests/sql/parsing/test_ast.py
+++ b/tests/sql/parsing/test_ast.py
@@ -367,10 +367,12 @@ def test_adding_bad_node_to_table(construction_session):
     """
     table = Table(Name("a"))
     node = next(
-        construction_session.exec(select(Node).filter(Node.type == NodeType.METRIC)),
+        construction_session.exec(
+            select(Node).filter(Node.type == NodeType.METRIC),
+        ),
     )[0]
     with pytest.raises(DJParseException) as exc:
-        table.add_dj_node(node)
+        table.add_dj_node(node.current)
     assert "Expected dj node of TRANSFORM, SOURCE, or DIMENSION" in str(exc)
 
 


### PR DESCRIPTION
### Summary

**Note:** This isn't completely ready, but I figured it was better to get it out there for feedback first.

In order to facilitate node versioning, this PR adds a `ReferenceNode`, which acts as a reference to all historical node versions, along with a reference to the current node version. 

All columns in the reference node are immutable (i.e., `name`, `type` etc), whereas those in the node itself can be modified and version tracked (i.e., `description`, `query` etc). In this approach, we continue to store links between node versions in the adjacency list tables, which allows us to have multiple "active" versions of a ReferenceNode.

This also adds the following endpoints:

* `POST /nodes/`: Create node
* `PUT /nodes/{name}/` Update an existing node, which may create a new node revision if there are changes

### Test Plan

<!-- How did you test your change? -->

I ran `docker compose up` and verified:
* The yaml configs continue to load 
* Some manual testing of creating and updating different node types (source, transform etc)

Also added some unit tests for the create/update endpoints

- [X] PR has an associated issue: #262  #255 
- [X] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
