### PR TITLE
Column typing validation + named inner types

### DIFF
--- a/dj/typing.py
+++ b/dj/typing.py
@@ -95,10 +95,7 @@ def process_row_args(*args: str) -> Tuple["ColumnType", ...]:
     """
     Validate the args of a ROW
     """
-    if len(args) < 1:
-        raise ColumnTypeError(
-            "ROW must have at least one inner type.",
-        )
+
     ret = []
     for arg in args:
         type_, name, *_ = (*arg.split(), None)

--- a/dj/typing.py
+++ b/dj/typing.py
@@ -157,11 +157,12 @@ class ColumnType(str, metaclass=ColumnTypeMeta):
         >>> ColumnType.Map['str', ColumnType.Array[ColumnType.int]].args[1].args[0]
         'INT'
 
-        >>> ColumnType.Row[ColumnType.STR, ColumnType.INT, ColumnType.ARRAY[ColumnType.bytes]]
+        >>> ColumnType.Row[ColumnType.STR, "INT id", ColumnType.ARRAY[ColumnType.bytes]]
         'ROW[STR, INT, ARRAY[BYTES]]'
 
         >>> ColumnType.Row['int "number"'].args[0].name
         'number'
+
     """
 
     # pylint: enable=C0301
@@ -212,7 +213,7 @@ class ColumnType(str, metaclass=ColumnTypeMeta):
         # need to add check if args are acceptable types for the generic
         obj = str.__new__(
             self.__class__,
-            self + "[" + ", ".join(str(arg) for arg in args) + "]",
+            self + "[" + ", ".join(arg for arg in args) + "]",
         )
         obj.args = args
         return obj

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -28,10 +28,24 @@ def test_columntype_not_complex():
     assert "The type INT is not a complex type" in str(exc)
 
 
-def test_columntype_wrong_number_generic():
+def test_columntype_array_wrong_number_generic():
     """tests that complex require specific number of args"""
     with pytest.raises(ColumnTypeError) as exc:
-        ColumnType("Map[string]")
+        ColumnType("array[str, str]")
+    assert "ARRAY expects 1 inner type but got 2" in str(exc)
+
+
+def test_columntype_map_bad_key():
+    """tests that map require specific key types"""
+    with pytest.raises(ColumnTypeError) as exc:
+        ColumnType("map[null, str]")
+    assert "MAP key is not an acceptable type" in str(exc)
+
+
+def test_columntype_map_wrong_number_generic():
+    """tests that map require specific number of args"""
+    with pytest.raises(ColumnTypeError) as exc:
+        ColumnType("map[str]")
     assert "MAP expects 2 inner types but got 1" in str(exc)
 
 

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -32,7 +32,7 @@ def test_columntype_wrong_number_generic():
     """tests that complex require specific number of args"""
     with pytest.raises(ColumnTypeError) as exc:
         ColumnType("Map[string]")
-    assert "MAP expects 2 inner type(s) but got 1" in str(exc)
+    assert "MAP expects 2 inner types but got 1" in str(exc)
 
 
 def test_validate_columntype_returns_primitive():


### PR DESCRIPTION
### Summary

@agorajek suggestions from https://github.com/DataJunction/dj/pull/290

validates map key types and allows named types for row. Row still has full support for any inner types including other nested complex types

```python
>>> ColumnType.Row['int "number"'].args[0].name
'number'
```

### Test Plan
unit tests

- [x] PR has an associated issue: #https://github.com/DataJunction/dj/issues/291
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
