### PR TITLE
Add models and routes for catalogs and engines

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -8,7 +8,7 @@ from logging.config import fileConfig
 from sqlmodel import SQLModel, create_engine
 
 from alembic import context
-from dj.models import Column, Database, NodeRevision, Query, Table
+from dj.models import Catalog, Column, Database, Engine, NodeRevision, Query, Table
 from dj.utils import get_settings
 
 settings = get_settings()

--- a/alembic/versions/2023_02_04_2130-e6430f249401_add_tables_for_catalog_and_engine_models.py
+++ b/alembic/versions/2023_02_04_2130-e6430f249401_add_tables_for_catalog_and_engine_models.py
@@ -1,0 +1,55 @@
+"""Add tables for Catalog and Engine models
+
+Revision ID: e6430f249401
+Revises: 1780b415e2c5
+Create Date: 2023-02-04 21:30:50.113075+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e6430f249401"
+down_revision = "1780b415e2c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "catalog",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "engine",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("version", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "catalogengines",
+        sa.Column("catalog_id", sa.Integer(), nullable=False),
+        sa.Column("engine_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["catalog_id"],
+            ["catalog.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["engine_id"],
+            ["engine.id"],
+        ),
+        sa.PrimaryKeyConstraint("catalog_id", "engine_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("catalogengines")
+    op.drop_table("engine")
+    op.drop_table("catalog")

--- a/dj/api/catalogs.py
+++ b/dj/api/catalogs.py
@@ -79,7 +79,7 @@ def add_catalog(
 
     catalog = Catalog.from_orm(data)
     catalog.engines.extend(
-        filter_to_new_engines(
+        list_new_engines(
             session=session,
             catalog=catalog,
             create_engines=data.engines,
@@ -104,7 +104,7 @@ def add_engines_to_catalog(
     """
     catalog = get_catalog(session, name)
     catalog.engines.extend(
-        filter_to_new_engines(session=session, catalog=catalog, create_engines=data),
+        list_new_engines(session=session, catalog=catalog, create_engines=data),
     )
     session.add(catalog)
     session.commit()
@@ -112,7 +112,7 @@ def add_engines_to_catalog(
     return catalog
 
 
-def filter_to_new_engines(
+def list_new_engines(
     session: Session,
     catalog: Catalog,
     create_engines: List[EngineInfo],

--- a/dj/api/catalogs.py
+++ b/dj/api/catalogs.py
@@ -1,0 +1,132 @@
+"""
+Catalog related APIs.
+"""
+
+import logging
+from http import HTTPStatus
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import NoResultFound
+from sqlmodel import Session, SQLModel, select
+
+from dj.api.engines import EngineInfo, get_engine
+from dj.models.catalog import Catalog
+from dj.utils import get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class CatalogInfo(SQLModel):
+    """
+    Class for catalog creation
+    """
+
+    name: str
+    engines: List[EngineInfo] = []
+
+
+def get_catalog(session: Session, name: str) -> Catalog:
+    """
+    Return a Catalog instance given a catalog name
+    """
+    statement = select(Catalog).where(Catalog.name == name)
+    try:
+        catalog = session.exec(statement).one()
+    except NoResultFound as exc:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Catalog not found: `{name}`",
+        ) from exc
+    return catalog
+
+
+@router.get("/catalogs/", response_model=List[CatalogInfo])
+def list_catalogs(*, session: Session = Depends(get_session)) -> List[CatalogInfo]:
+    """
+    List all available catalogs
+    """
+    return list(session.exec(select(Catalog)))
+
+
+@router.get("/catalogs/{name}/", response_model=CatalogInfo)
+def read_catalog(name: str, *, session: Session = Depends(get_session)) -> CatalogInfo:
+    """
+    Return a catalog by name
+    """
+    return get_catalog(session, name)
+
+
+@router.post("/catalogs/", response_model=CatalogInfo)
+def add_catalog(
+    data: CatalogInfo,
+    *,
+    session: Session = Depends(get_session),
+) -> CatalogInfo:
+    """
+    Add a Catalog
+    """
+    try:
+        get_catalog(session, data.name)
+    except HTTPException:
+        pass
+    else:
+        raise HTTPException(
+            status_code=HTTPStatus.CONFLICT,
+            detail=f"Catalog already exists: `{data.name}`",
+        )
+
+    catalog = Catalog.from_orm(data)
+    catalog.engines.extend(
+        filter_to_new_engines(
+            session=session,
+            catalog=catalog,
+            create_engines=data.engines,
+        ),
+    )
+    session.add(catalog)
+    session.commit()
+    session.refresh(catalog)
+
+    return catalog
+
+
+@router.post("/catalogs/{name}/engines/", response_model=CatalogInfo)
+def add_engines_to_catalog(
+    name: str,
+    data: List[EngineInfo],
+    *,
+    session: Session = Depends(get_session),
+) -> CatalogInfo:
+    """
+    Attach one or more engines to a catalog
+    """
+    catalog = get_catalog(session, name)
+    catalog.engines.extend(
+        filter_to_new_engines(session=session, catalog=catalog, create_engines=data),
+    )
+    session.add(catalog)
+    session.commit()
+    session.refresh(catalog)
+    return catalog
+
+
+def filter_to_new_engines(
+    session: Session,
+    catalog: Catalog,
+    create_engines: List[EngineInfo],
+) -> List[EngineInfo]:
+    """
+    Filter to engines that are not already set on a catalog
+    """
+    new_engines = []
+    for engine_ref in create_engines:
+        already_set = False
+        engine = get_engine(session, engine_ref.name, engine_ref.version)
+        for set_engine in catalog.engines:
+            if engine.name == set_engine.name and engine.version == set_engine.version:
+                already_set = True
+        if not already_set:
+            new_engines.append(engine)
+    return new_engines

--- a/dj/api/engines.py
+++ b/dj/api/engines.py
@@ -1,0 +1,86 @@
+"""
+Engine related APIs.
+"""
+
+from http import HTTPStatus
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import NoResultFound
+from sqlmodel import Session, SQLModel, select
+
+from dj.models.engine import Engine
+from dj.utils import get_session
+
+router = APIRouter()
+
+
+class EngineInfo(SQLModel):
+    """
+    Class for engine creation
+    """
+
+    name: str
+    version: str
+
+
+def get_engine(session: Session, name: str, version: str) -> Engine:
+    """
+    Return an Engine instance given an engine name and version
+    """
+    statement = (
+        select(Engine).where(Engine.name == name).where(Engine.version == version)
+    )
+    try:
+        engine = session.exec(statement).one()
+    except NoResultFound as exc:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Engine not found: `{name}` version `{version}`",
+        ) from exc
+    return engine
+
+
+@router.get("/engines/", response_model=List[EngineInfo])
+def list_engines(*, session: Session = Depends(get_session)) -> List[EngineInfo]:
+    """
+    List all available engines
+    """
+    return list(session.exec(select(Engine)))
+
+
+@router.get("/engines/{name}/{version}/", response_model=EngineInfo)
+def list_engine(
+    name: str, version: str, *, session: Session = Depends(get_session)
+) -> EngineInfo:
+    """
+    Return an engine by name and version
+    """
+    return get_engine(session, name, version)
+
+
+@router.post("/engines/", response_model=EngineInfo)
+def add_engine(
+    data: EngineInfo,
+    *,
+    session: Session = Depends(get_session),
+) -> EngineInfo:
+    """
+    Add an Engine
+    """
+    try:
+        get_engine(session, data.name, data.version)
+    except HTTPException:
+        pass
+    else:
+        raise HTTPException(
+            status_code=HTTPStatus.CONFLICT,
+            detail=f"Engine already exists: `{data.name}` version `{data.version}`",
+        )
+
+    engine = Engine.from_orm(data)
+    session.add(engine)
+    session.commit()
+    session.refresh(engine)
+
+    return engine

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -13,11 +13,13 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from dj import __version__
-from dj.api import data, databases, metrics, nodes, queries
+from dj.api import catalogs, data, databases, engines, metrics, nodes, queries
 from dj.api.graphql.main import graphql_app
 from dj.errors import DJException
+from dj.models.catalog import Catalog
 from dj.models.column import Column
 from dj.models.database import Database
+from dj.models.engine import Engine
 from dj.models.node import NodeRevision
 from dj.models.query import Query
 from dj.models.table import Table
@@ -36,7 +38,9 @@ app = FastAPI(
         "url": "https://mit-license.org/",
     },
 )
+app.include_router(catalogs.router)
 app.include_router(databases.router)
+app.include_router(engines.router)
 app.include_router(queries.router)
 app.include_router(metrics.router)
 app.include_router(nodes.router)

--- a/dj/models/__init__.py
+++ b/dj/models/__init__.py
@@ -2,10 +2,12 @@
 All models.
 """
 
-__all__ = ["Column", "Database", "NodeRevision", "Query", "Table"]
+__all__ = ["Catalog", "Column", "Database", "Engine", "NodeRevision", "Query", "Table"]
 
+from dj.models.catalog import Catalog
 from dj.models.column import Column
 from dj.models.database import Database
+from dj.models.engine import Engine
 from dj.models.node import NodeRevision
 from dj.models.query import Query
 from dj.models.table import Table

--- a/dj/models/catalog.py
+++ b/dj/models/catalog.py
@@ -1,0 +1,42 @@
+"""
+Models for columns.
+"""
+
+from typing import List, Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+from dj.models.engine import Engine
+
+
+class CatalogEngines(SQLModel, table=True):  # type: ignore
+    """
+    Join table for catalogs and engines.
+    """
+
+    catalog_id: Optional[int] = Field(
+        default=None,
+        foreign_key="catalog.id",
+        primary_key=True,
+    )
+    engine_id: Optional[int] = Field(
+        default=None,
+        foreign_key="engine.id",
+        primary_key=True,
+    )
+
+
+class Catalog(SQLModel, table=True):  # type: ignore
+    """
+    A catalog.
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    engines: List[Engine] = Relationship(
+        link_model=CatalogEngines,
+        sa_relationship_kwargs={
+            "primaryjoin": "Catalog.id==CatalogEngines.catalog_id",
+            "secondaryjoin": "Engine.id==CatalogEngines.engine_id",
+        },
+    )

--- a/dj/models/database.py
+++ b/dj/models/database.py
@@ -16,6 +16,7 @@ from sqlmodel import JSON, Field, Relationship, SQLModel, create_engine
 from dj.utils import UTCDatetime
 
 if TYPE_CHECKING:
+    from dj.models.catalog import Catalog
     from dj.models.query import Query
     from dj.models.table import Table
 

--- a/dj/models/engine.py
+++ b/dj/models/engine.py
@@ -1,0 +1,17 @@
+"""
+Models for columns.
+"""
+
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Engine(SQLModel, table=True):  # type: ignore
+    """
+    A query engine.
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    version: str

--- a/dj/models/table.py
+++ b/dj/models/table.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List, Optional, TypedDict
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
+    from dj.models.catalog import Catalog
     from dj.models.column import Column
     from dj.models.database import Database
     from dj.models.node import NodeRevision

--- a/tests/api/catalog_test.py
+++ b/tests/api/catalog_test.py
@@ -1,0 +1,359 @@
+"""
+Tests for the catalog API.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_catalog_adding_a_new_catalog(
+    client: TestClient,
+) -> None:
+    """
+    Test adding a catalog
+    """
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data == {"name": "dev", "engines": []}
+
+
+def test_catalog_list(
+    client: TestClient,
+) -> None:
+    """
+    Test listing catalogs
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+            "engines": [
+                {
+                    "name": "spark",
+                    "version": "3.3.1",
+                },
+            ],
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "test",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "prod",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.get("/catalogs/")
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "name": "dev",
+            "engines": [{"name": "spark", "version": "3.3.1"}],
+        },
+        {
+            "name": "test",
+            "engines": [],
+        },
+        {
+            "name": "prod",
+            "engines": [],
+        },
+    ]
+
+
+def test_catalog_get_catalog(
+    client: TestClient,
+) -> None:
+    """
+    Test getting a catalog
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+            "engines": [
+                {
+                    "name": "spark",
+                    "version": "3.3.1",
+                },
+            ],
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.get(
+        "/catalogs/dev",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"name": "dev", "engines": [{"name": "spark", "version": "3.3.1"}]}
+
+
+def test_catalog_adding_a_new_catalog_with_engines(
+    client: TestClient,
+) -> None:
+    """
+    Test adding a catalog with engines
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+            "engines": [
+                {
+                    "name": "spark",
+                    "version": "3.3.1",
+                },
+            ],
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data == {
+        "name": "dev",
+        "engines": [
+            {
+                "name": "spark",
+                "version": "3.3.1",
+            },
+        ],
+    }
+
+
+def test_catalog_adding_a_new_catalog_then_attaching_engines(
+    client: TestClient,
+) -> None:
+    """
+    Test adding a catalog then attaching a catalog
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/dev/engines/",
+        json=[
+            {
+                "name": "spark",
+                "version": "3.3.1",
+            },
+        ],
+    )
+
+    response = client.get("/catalogs/dev/")
+    data = response.json()
+    assert data == {
+        "name": "dev",
+        "engines": [
+            {
+                "name": "spark",
+                "version": "3.3.1",
+            },
+        ],
+    }
+
+
+def test_catalog_adding_without_duplicating(
+    client: TestClient,
+) -> None:
+    """
+    Test adding a catalog and having existing catalogs not re-added
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "2.4.4",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.0",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/dev/engines/",
+        json=[
+            {
+                "name": "spark",
+                "version": "2.4.4",
+            },
+            {
+                "name": "spark",
+                "version": "3.3.0",
+            },
+            {
+                "name": "spark",
+                "version": "3.3.1",
+            },
+        ],
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/dev/engines/",
+        json=[
+            {
+                "name": "spark",
+                "version": "2.4.4",
+            },
+            {
+                "name": "spark",
+                "version": "3.3.0",
+            },
+            {
+                "name": "spark",
+                "version": "3.3.1",
+            },
+        ],
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "name": "dev",
+        "engines": [
+            {
+                "name": "spark",
+                "version": "2.4.4",
+            },
+            {
+                "name": "spark",
+                "version": "3.3.0",
+            },
+            {
+                "name": "spark",
+                "version": "3.3.1",
+            },
+        ],
+    }
+
+
+def test_catalog_raise_on_adding_a_new_catalog_with_nonexistent_engines(
+    client: TestClient,
+) -> None:
+    """
+    Test raising an error when adding a catalog with engines that do not exist
+    """
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+            "engines": [
+                {
+                    "name": "spark",
+                    "version": "4.0.0",
+                },
+            ],
+        },
+    )
+    data = response.json()
+    assert response.status_code == 404
+    assert data == {"detail": "Engine not found: `spark` version `4.0.0`"}
+
+
+def test_catalog_raise_on_catalog_already_exists(
+    client: TestClient,
+) -> None:
+    """
+    Test raise on catalog already exists
+    """
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/catalogs/",
+        json={
+            "name": "dev",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 409
+    assert data == {"detail": "Catalog already exists: `dev`"}

--- a/tests/api/engine_test.py
+++ b/tests/api/engine_test.py
@@ -1,0 +1,125 @@
+"""
+Tests for the engine API.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_engine_adding_a_new_engine(
+    client: TestClient,
+) -> None:
+    """
+    Test adding an engine
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data == {"name": "spark", "version": "3.3.1"}
+
+
+def test_engine_list(
+    client: TestClient,
+) -> None:
+    """
+    Test listing engines
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "2.4.4",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.0",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.get("/engines/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == [
+        {
+            "name": "spark",
+            "version": "2.4.4",
+        },
+        {
+            "name": "spark",
+            "version": "3.3.0",
+        },
+        {
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    ]
+
+
+def test_engine_get_engine(
+    client: TestClient,
+) -> None:
+    """
+    Test getting an engine
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.get(
+        "/engines/spark/3.3.1",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"name": "spark", "version": "3.3.1"}
+
+
+def test_engine_raise_on_engine_already_exists(
+    client: TestClient,
+) -> None:
+    """
+    Test raise on engine already exists
+    """
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "3.3.1",
+        },
+    )
+    assert response.status_code == 409
+    data = response.json()
+    assert data == {"detail": "Engine already exists: `spark` version `3.3.1`"}

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -18,7 +18,12 @@ def test_run(capsys: CaptureFixture) -> None:
     assert (
         captured.out
         == """http://localhost:8000/docs: Documentation.
+http://localhost:8000/catalogs/: List all available catalogs
+http://localhost:8000/catalogs/{name}/: Return a catalog by name
+http://localhost:8000/catalogs/{name}/engines/: Attach one or more engines to a catalog
 http://localhost:8000/databases/: List the available databases.
+http://localhost:8000/engines/: List all available engines
+http://localhost:8000/engines/{name}/{version}/: Return an engine by name and version
 http://localhost:8000/queries/: Run or schedule a query.
 http://localhost:8000/queries/{query_id}/: Fetch information about a query.
 http://localhost:8000/metrics/: List all available metrics.


### PR DESCRIPTION
### Summary

This adds models for catalogs and engines as well as API endpoints to list and create them. Catalogs have just a name and an `engines: List[Engine]` attribute. The `Engine` class is very simple with an `id`, `name`, and `version` attribute.

I guess we could follow up by making a `Schema` model which could carry a `catalog_id` attribute. Then for a `Table` we would only need to know the `schema_id` which can then be used to find the catalog and then the available engines that can be used to query that catalog/schema/table.

<img width="1268" alt="Screen Shot 2023-02-05 at 7 40 33 PM" src="https://user-images.githubusercontent.com/43911210/216857133-6bc9a97c-9507-4d58-aef8-0c3860ce36eb.png">

### Test Plan

Wrote tests, ran `make test`, launched the API using `docker compose up` and confirmed that requests/responses behaved as expected.

- [x] PR has an associated issue: #298 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
