### PR TITLE
Add a runbook for basic DJ requests creating nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,3 +94,12 @@ repos:
     language: system
     types: [python]
     exclude: ^templates/
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.6.1
+  hooks:
+    - id: nbstripout
+- repo: https://github.com/tomcatling/black-nb
+  rev: "0.7"
+  hooks:
+    - id: black-nb
+      files: '\.ipynb$'

--- a/notebooks/DJ Runbook - Creating Nodes.ipynb
+++ b/notebooks/DJ Runbook - Creating Nodes.ipynb
@@ -1,0 +1,391 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "db0646c3",
+   "metadata": {},
+   "source": [
+    "# DJ Runbook - Creating Nodes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "618db7b2",
+   "metadata": {},
+   "source": [
+    "This notebook performs a collection of basic requests to a running DJ server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c35d779c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "DJ_PROTOCOL = \"http\"\n",
+    "DJ_HOST = \"localhost\"\n",
+    "DJ_PORT = 8000\n",
+    "DJ_URL = f\"{DJ_PROTOCOL}://{DJ_HOST}:{DJ_PORT}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1abb330",
+   "metadata": {},
+   "source": [
+    "Create some source nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b2bc781",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"payment_id\": {\"type\": \"INT\"},\n",
+    "            \"payment_type\": {\"type\": \"INT\", \"dimension\": \"payment_type\"},\n",
+    "            \"payment_amount\": {\"type\": \"FLOAT\"},\n",
+    "            \"customer_id\": {\"type\": \"INT\", \"dimension\": \"customers\"},\n",
+    "            \"account_type\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"tables\": [\n",
+    "            {\n",
+    "                \"database_name\": \"postgres\",\n",
+    "                \"catalog\": \"test\",\n",
+    "                \"schema\": \"accounting\",\n",
+    "                \"table\": \"revenue\",\n",
+    "            }\n",
+    "        ],\n",
+    "        \"description\": \"A source table for revenue data\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"revenue_source\",\n",
+    "        \"type\": \"source\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "621abdf4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"id\": {\"type\": \"INT\"},\n",
+    "            \"account_type_name\": {\"type\": \"STR\"},\n",
+    "            \"account_type_classification\": {\"type\": \"INT\"},\n",
+    "            \"preferred_payment_method\": {\"type\": \"INT\", \"dimension\": \"payment_type\"},\n",
+    "        },\n",
+    "        \"tables\": [\n",
+    "            {\n",
+    "                \"database_name\": \"postgres\",\n",
+    "                \"catalog\": \"test\",\n",
+    "                \"schema\": \"accounting\",\n",
+    "                \"table\": \"account_type\",\n",
+    "            }\n",
+    "        ],\n",
+    "        \"description\": \"A source table for account type data\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"account_type_table\",\n",
+    "        \"type\": \"source\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75c64ef2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"id\": {\"type\": \"INT\"},\n",
+    "            \"payment_type_name\": {\"type\": \"STR\"},\n",
+    "            \"payment_type_classification\": {\"type\": \"INT\"},\n",
+    "        },\n",
+    "        \"tables\": [\n",
+    "            {\n",
+    "                \"database_name\": \"postgres\",\n",
+    "                \"catalog\": \"test\",\n",
+    "                \"schema\": \"accounting\",\n",
+    "                \"table\": \"payment_type\",\n",
+    "            }\n",
+    "        ],\n",
+    "        \"description\": \"A source table for different types of payments\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"payment_type_table\",\n",
+    "        \"type\": \"source\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6f65511",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"customer_id\": {\"type\": \"INT\"},\n",
+    "            \"first_name\": {\"type\": \"STR\"},\n",
+    "            \"last_name\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"tables\": [\n",
+    "            {\n",
+    "                \"database_name\": \"postgres\",\n",
+    "                \"catalog\": \"test\",\n",
+    "                \"schema\": \"accounting\",\n",
+    "                \"table\": \"customers\",\n",
+    "            }\n",
+    "        ],\n",
+    "        \"description\": \"A source table for customer data\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"customers_table\",\n",
+    "        \"type\": \"source\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bc974af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"customer_id\": {\"type\": \"INT\"},\n",
+    "            \"account_type\": {\"type\": \"STR\", \"dimension\": \"account_type\"},\n",
+    "            \"default_payment_type\": {\"type\": \"INT\", \"dimension\": \"payment_type\"},\n",
+    "        },\n",
+    "        \"tables\": [\n",
+    "            {\n",
+    "                \"database_name\": \"postgres\",\n",
+    "                \"catalog\": \"test\",\n",
+    "                \"schema\": \"accounting\",\n",
+    "                \"table\": \"customers\",\n",
+    "            }\n",
+    "        ],\n",
+    "        \"description\": \"A source table for customer default payment preference\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"default_payment_account_table\",\n",
+    "        \"type\": \"source\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7963fc44",
+   "metadata": {},
+   "source": [
+    "Create some dimension nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0050518a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"description\": \"Payment type dimensions\",\n",
+    "        \"query\": \"SELECT id, payment_type_name, payment_type_classification FROM payment_type_table\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"payment_type\",\n",
+    "        \"type\": \"dimension\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fd3d1f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"description\": \"Customer dimension\",\n",
+    "        \"query\": \"SELECT customer_id, first_name, last_name FROM customers_table\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"customers\",\n",
+    "        \"type\": \"dimension\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8002070d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"description\": \"Account type dimension\",\n",
+    "        \"query\": \"SELECT id, account_type_name, account_type_classification FROM account_type_table\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"account_type\",\n",
+    "        \"type\": \"dimension\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df453f8a",
+   "metadata": {},
+   "source": [
+    "Create some transform nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3aaeda0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"description\": \"Revenue data filtered to large payments only\",\n",
+    "        \"query\": \"SELECT payment_id, payment_amount, customer_id, account_type FROM revenue_source LEFT JOIN payment_type on payment_type = payment_type.id WHERE payment_amount > 1000000\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"large_revenue_payments_only\",\n",
+    "        \"type\": \"transform\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93c7b68c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"description\": \"Revenue data filtered to large business payments only\",\n",
+    "        \"query\": \"SELECT payment_id, payment_amount, customer_id, account_type FROM revenue_source WHERE payment_amount > 1000000 AND account_type = 'BUSINESS'\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"large_revenue_payments_and_business_only\",\n",
+    "        \"type\": \"transform\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68b3fec5",
+   "metadata": {},
+   "source": [
+    "Create some metrics nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e09774e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"description\": \"Total company revenue\",\n",
+    "        \"query\": \"SELECT sum(payment_amount) as total_revenue FROM revenue_source\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"total_revenue\",\n",
+    "        \"type\": \"metric\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c9c6b03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"description\": \"Total number of account types\",\n",
+    "        \"query\": \"SELECT count(id) as num_accounts FROM account_type\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"number_of_account_types\",\n",
+    "        \"type\": \"metric\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/README.rst
+++ b/notebooks/README.rst
@@ -1,0 +1,6 @@
+============
+DJ Tutorials, Demos, and Runbooks
+============
+
+This directory contains a set of notebooks for trying out DJ and running through various scenarios against
+a DJ server.


### PR DESCRIPTION
### Summary

This adds a runbook that walks through API requests to the DJ server to create source, transform, dimension, and metric nodes. I also added `nbstripout` and `black-nb` to the pre-commit config so the notebooks will always have output cleared and the cells auto-formatted.

### Test Plan

Started the DJ server locally with `docker compose up`, started a jupyter notebook server, and ran all cells.

- [x] PR has an associated issue: #305 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
