### PR TITLE
Renaming reference nodes + adding naming conventions

### DIFF
--- a/alembic/versions/2023_02_07_1640-03aaf20e6ab6_remove_reference_node_usage.py
+++ b/alembic/versions/2023_02_07_1640-03aaf20e6ab6_remove_reference_node_usage.py
@@ -1,0 +1,53 @@
+"""Remove reference node usage
+
+Revision ID: 03aaf20e6ab6
+Revises: 06b0bef0a7e3
+Create Date: 2023-02-07 16:40:22.905524+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "03aaf20e6ab6"
+down_revision = "06b0bef0a7e3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("noderevision") as batch_op:
+        batch_op.add_column(sa.Column("node_id", sa.Integer(), nullable=True))
+        batch_op.drop_constraint(
+            "referencenode_reference_node_id_fk",
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint("referencenode_name_fk", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_noderevision_node_id_node",
+            "node",
+            ["node_id"],
+            ["id"],
+        )
+        batch_op.drop_column("reference_node_id")
+
+
+def downgrade():
+    with op.batch_alter_table("noderevision") as batch_op:
+        batch_op.add_column(sa.Column("reference_node_id", sa.INTEGER(), nullable=True))
+        batch_op.drop_constraint(
+            op.f("fk_noderevision_node_id_node"),
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key("referencenode_name_fk", "node", ["name"], ["name"])
+        batch_op.create_foreign_key(
+            "referencenode_reference_node_id_fk",
+            "node",
+            ["reference_node_id"],
+            ["id"],
+        )
+        batch_op.drop_column("noderevision", "node_id")

--- a/dj/api/graphql/metric.py
+++ b/dj/api/graphql/metric.py
@@ -55,9 +55,9 @@ def read_metrics(info: Info) -> List[Metric]:
     session = info.context["session"]
     return [
         Metric.from_pydantic(  # type: ignore
-            Metric_.parse_reference_node(ref_node),
+            Metric_.parse_node(node),
         )
-        for ref_node in session.exec(
+        for node in session.exec(
             select(Node_).where(Node_.type == Node_Type.METRIC),
         )
     ]
@@ -68,12 +68,12 @@ def read_metric(node_name: str, info: Info) -> Metric:
     Return a metric by name.
     """
     try:
-        ref_node = get_metric(info.context["session"], node_name)
+        node = get_metric(info.context["session"], node_name)
     except HTTPException as exc:
         raise Exception(exc.detail) from exc
 
     return Metric.from_pydantic(  # type: ignore
-        Metric_.parse_reference_node(ref_node),
+        Metric_.parse_node(node),
     )
 
 

--- a/dj/api/graphql/node.py
+++ b/dj/api/graphql/node.py
@@ -76,5 +76,5 @@ def get_nodes(info: Info) -> List[Node]:
     """
     List the available nodes.
     """
-    ref_nodes = info.context["session"].exec(select(Node_)).all()
-    return [Node.from_pydantic(ref_node) for ref_node in ref_nodes]  # type: ignore
+    nodes = info.context["session"].exec(select(Node_)).all()
+    return [Node.from_pydantic(node) for node in nodes]  # type: ignore

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -68,16 +68,16 @@ def _build_dimensions_on_select(
                             dim_col.name == "id" for dim_col in dim_node.columns
                         ):
                             raise DJException(
-                                f"Node {table_node.reference_node.name} specifiying dimension "
-                                f"{dim_node.reference_node.name} on column {col.name} does not"
-                                f" specify a dimension column, but {dim_node.reference_node.name} "
+                                f"Node {table_node.node.name} specifiying dimension "
+                                f"{dim_node.node.name} on column {col.name} does not"
+                                f" specify a dimension column, but {dim_node.node.name} "
                                 f"does not have the default key `id`.",
                             )
                         join_dim_cols.append(col)
 
                 join_info[table_node] = join_dim_cols
             if build_plan_depth > 0:  # continue following build plan
-                alias = amenable_name(dim_node.reference_node.name)
+                alias = amenable_name(dim_node.node.name)
 
                 _, dim_build_plan = build_plan_lookup[dim_node]
                 dim_ast = dim_build_plan[0]
@@ -159,7 +159,7 @@ def _build_tables_on_select(
     for node, tbls in tables.items():
 
         if (
-            node.reference_node.type != NodeType.SOURCE and build_plan_depth > 0
+            node.node.type != NodeType.SOURCE and build_plan_depth > 0
         ):  # continue following build plan
             _, node_build_plan = build_plan_lookup[node]
             node_ast = node_build_plan[0]
@@ -170,7 +170,7 @@ def _build_tables_on_select(
                 database,
                 dialect,
             )
-            alias = amenable_name(node.reference_node.name)
+            alias = amenable_name(node.node.name)
             node_select = node_ast.select
             node_ast = ast.Alias(ast.Name(alias), child=node_select)  # type: ignore
             for tbl in tbls:

--- a/dj/construction/build_planning.py
+++ b/dj/construction/build_planning.py
@@ -55,7 +55,7 @@ def generate_build_plan_from_query(
 
         node_mat_dbs = get_materialized_databases_for_node(node, columns)
         build_plan = None
-        if node.reference_node.type != NodeType.SOURCE:
+        if node.node.type != NodeType.SOURCE:
             build_plan = generate_build_plan_from_node(session, node, dialect)
         databases[node] = (node_mat_dbs, build_plan)
 
@@ -117,7 +117,7 @@ def _level_database(
     levels[level].append(dbi)
 
     for node, (sub_build_dbs, sub_sub_build_plan) in sub_build_plan.items():
-        if node.reference_node.type == NodeType.SOURCE:
+        if node.node.type == NodeType.SOURCE:
             source_dbs.update(sub_build_dbs)
         if sub_sub_build_plan:
             _level_database(sub_sub_build_plan, levels, level + 1)

--- a/dj/construction/compile.py
+++ b/dj/construction/compile.py
@@ -405,7 +405,7 @@ def compile_node(
     """
     if node.query is None:
         raise DJException(
-            f"Cannot compile node `{node.reference_node.name}` with no query.",
+            f"Cannot compile node `{node.node.name}` with no query.",
         )
     query = parse(node.query, dialect)
     query.compile(session)

--- a/dj/models/base.py
+++ b/dj/models/base.py
@@ -1,0 +1,23 @@
+"""
+A base SQLModel class with a default naming convention.
+"""
+
+from sqlmodel import SQLModel
+
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(auto_constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class BaseSQLModel(SQLModel):
+    """
+    Base model object with naming convention for constraints. This forces alembic's
+    autogenerate functionality to generate constraints with explicit names.
+    """
+
+    metadata = SQLModel.metadata
+    metadata.naming_convention = NAMING_CONVENTION

--- a/dj/models/catalog.py
+++ b/dj/models/catalog.py
@@ -4,12 +4,13 @@ Models for columns.
 
 from typing import List, Optional
 
-from sqlmodel import Field, Relationship, SQLModel
+from sqlmodel import Field, Relationship
 
+from dj.models.base import BaseSQLModel
 from dj.models.engine import Engine
 
 
-class CatalogEngines(SQLModel, table=True):  # type: ignore
+class CatalogEngines(BaseSQLModel, table=True):  # type: ignore
     """
     Join table for catalogs and engines.
     """
@@ -26,7 +27,7 @@ class CatalogEngines(SQLModel, table=True):  # type: ignore
     )
 
 
-class Catalog(SQLModel, table=True):  # type: ignore
+class Catalog(BaseSQLModel, table=True):  # type: ignore
     """
     A catalog.
     """

--- a/dj/models/column.py
+++ b/dj/models/column.py
@@ -5,8 +5,9 @@ Models for columns.
 from typing import TYPE_CHECKING, Optional, TypedDict
 
 from sqlalchemy.sql.schema import Column as SqlaColumn
-from sqlmodel import Field, Relationship, SQLModel
+from sqlmodel import Field, Relationship
 
+from dj.models.base import BaseSQLModel
 from dj.typing import ColumnType, ColumnTypeDecorator
 
 if TYPE_CHECKING:
@@ -22,7 +23,7 @@ class ColumnYAML(TypedDict, total=False):
     dimension: str
 
 
-class Column(SQLModel, table=True):  # type: ignore
+class Column(BaseSQLModel, table=True):  # type: ignore
     """
     A column.
 

--- a/dj/models/database.py
+++ b/dj/models/database.py
@@ -11,8 +11,9 @@ from sqlalchemy import DateTime, String
 from sqlalchemy.engine import Engine
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy_utils import UUIDType
-from sqlmodel import JSON, Field, Relationship, SQLModel, create_engine
+from sqlmodel import JSON, Field, Relationship, create_engine
 
+from dj.models.base import BaseSQLModel
 from dj.utils import UTCDatetime
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ DatabaseYAML = TypedDict(
 )
 
 
-class Database(SQLModel, table=True):  # type: ignore
+class Database(BaseSQLModel, table=True):  # type: ignore
     """
     A database.
 

--- a/dj/models/engine.py
+++ b/dj/models/engine.py
@@ -4,10 +4,12 @@ Models for columns.
 
 from typing import Optional
 
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field
+
+from dj.models.base import BaseSQLModel
 
 
-class Engine(SQLModel, table=True):  # type: ignore
+class Engine(BaseSQLModel, table=True):  # type: ignore
     """
     A query engine.
     """

--- a/dj/models/query.py
+++ b/dj/models/query.py
@@ -12,13 +12,14 @@ import msgpack
 from pydantic import AnyHttpUrl
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy_utils import UUIDType
-from sqlmodel import Field, Relationship, SQLModel
+from sqlmodel import Field, Relationship
 
+from dj.models.base import BaseSQLModel
 from dj.models.database import Database
 from dj.typing import QueryState, Row
 
 
-class BaseQuery(SQLModel):
+class BaseQuery(BaseSQLModel):
     """
     Base class for query models.
     """
@@ -61,7 +62,7 @@ class QueryCreate(BaseQuery):
     submitted_query: str
 
 
-class ColumnMetadata(SQLModel):
+class ColumnMetadata(BaseSQLModel):
     """
     A simple model for column metadata.
     """
@@ -70,7 +71,7 @@ class ColumnMetadata(SQLModel):
     type: str
 
 
-class StatementResults(SQLModel):
+class StatementResults(BaseSQLModel):
     """
     Results for a given statement.
 
@@ -85,7 +86,7 @@ class StatementResults(SQLModel):
     row_count: int = 0
 
 
-class QueryResults(SQLModel):
+class QueryResults(BaseSQLModel):
     """
     Results for a given query.
     """

--- a/dj/models/table.py
+++ b/dj/models/table.py
@@ -4,7 +4,9 @@ Models for tables.
 
 from typing import TYPE_CHECKING, List, Optional, TypedDict
 
-from sqlmodel import Field, Relationship, SQLModel
+from sqlmodel import Field, Relationship
+
+from dj.models.base import BaseSQLModel
 
 if TYPE_CHECKING:
     from dj.models.catalog import Catalog
@@ -24,7 +26,7 @@ class TableYAML(TypedDict, total=False):
     cost: float
 
 
-class TableColumns(SQLModel, table=True):  # type: ignore
+class TableColumns(BaseSQLModel, table=True):  # type: ignore
     """
     Join table for table columns.
     """
@@ -41,7 +43,7 @@ class TableColumns(SQLModel, table=True):  # type: ignore
     )
 
 
-class TableBase(SQLModel):
+class TableBase(BaseSQLModel):
     """
     A base table.
     """
@@ -52,7 +54,7 @@ class TableBase(SQLModel):
     cost: float = 1.0
 
 
-class TableNodeRevision(SQLModel, table=True):  # type: ignore
+class TableNodeRevision(BaseSQLModel, table=True):  # type: ignore
     """
     Link between a table and a node revision.
     """

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -22,14 +22,14 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Add nodes to facilitate testing of availability state updates
         """
 
-        ref_node1 = Node(
+        node1 = Node(
             name="revenue_source",
             type=NodeType.SOURCE,
-            current_version=1,
+            current_version="1",
         )
-        node1 = NodeRevision(
-            reference_node=ref_node1,
-            version=1,
+        node_rev1 = NodeRevision(
+            node=node1,
+            version="1",
             columns=[
                 Column(name="payment_id", type=ColumnType.INT),
                 Column(name="payment_amount", type=ColumnType.FLOAT),
@@ -45,14 +45,14 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 ),
             ],
         )
-        ref_node2 = Node(
+        node2 = Node(
             name="large_revenue_payments_only",
             type=NodeType.TRANSFORM,
-            current_version=1,
+            current_version="1",
         )
-        node2 = NodeRevision(
-            reference_node=ref_node2,
-            version=1,
+        node_rev2 = NodeRevision(
+            node=node2,
+            version="1",
             type=NodeType.TRANSFORM,
             columns=[
                 Column(name="payment_id", type=ColumnType.INT),
@@ -61,14 +61,14 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 Column(name="account_type", type=ColumnType.STR),
             ],
         )
-        ref_node3 = Node(
+        node3 = Node(
             name="large_revenue_payments_and_business_only",
             type=NodeType.TRANSFORM,
-            current_version=1,
+            current_version="1",
         )
-        node3 = NodeRevision(
-            reference_node=ref_node3,
-            version=1,
+        node_rev3 = NodeRevision(
+            node=node3,
+            version="1",
             query=(
                 "SELECT payment_id, payment_amount, customer_id, account_type "
                 "FROM revenue_source WHERE payment_amount > 1000000 "
@@ -82,9 +82,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 Column(name="account_type", type=ColumnType.STR),
             ],
         )
-        session.add(node1)
-        session.add(node2)
-        session.add(node3)
+        session.add(node_rev1)
+        session.add(node_rev2)
+        session.add(node_rev3)
         session.commit()
         return session
 

--- a/tests/api/graphql/metric_test.py
+++ b/tests/api/graphql/metric_test.py
@@ -17,23 +17,23 @@ def test_read_metrics(session: Session, client: TestClient):
     """
     Test ``read_metrics``.
     """
-    ref_node1 = Node(name="not-a-metric", current_version=1)
-    node1 = NodeRevision(reference_node=ref_node1, version=1)
+    node1 = Node(name="not-a-metric", current_version="1")
+    node_rev1 = NodeRevision(node=node1, version="1")
 
-    ref_node2 = Node(name="also-not-a-metric", current_version=1)
-    node2 = NodeRevision(reference_node=ref_node2, version=1, query="select 42 as foo")
+    node2 = Node(name="also-not-a-metric", current_version="1")
+    node_rev2 = NodeRevision(node=node2, version="1", query="select 42 as foo")
 
-    ref_node3 = Node(name="a-metric", current_version=1, type=NodeType.METRIC)
-    node3 = NodeRevision(
-        reference_node=ref_node3,
-        version=1,
+    node3 = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
+    node_rev3 = NodeRevision(
+        node=node3,
+        version="1",
         query="select count(*) from a_table",
         type=NodeType.METRIC,
     )
 
-    session.add(node1)
-    session.add(node2)
-    session.add(node3)
+    session.add(node_rev1)
+    session.add(node_rev2)
+    session.add(node_rev3)
     session.commit()
 
     query = """
@@ -53,23 +53,23 @@ def test_read_metric(session: Session, client: TestClient):
     """
     Test ``read_metric``.
     """
-    ref_node1 = Node(name="not-a-metric", current_version=1)
-    node1 = NodeRevision(reference_node=ref_node1, version=1)
+    node1 = Node(name="not-a-metric", current_version="1")
+    node_rev1 = NodeRevision(node=node1, version="1")
 
-    ref_node2 = Node(name="also-not-a-metric", current_version=1)
-    node2 = NodeRevision(reference_node=ref_node2, version=1, query="select 42 as foo")
+    node2 = Node(name="also-not-a-metric", current_version="1")
+    node_rev2 = NodeRevision(node=node2, version="1", query="select 42 as foo")
 
-    ref_node3 = Node(name="a-metric", current_version=1, type=NodeType.METRIC)
-    node3 = NodeRevision(
-        reference_node=ref_node3,
-        version=1,
+    node3 = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
+    node_rev3 = NodeRevision(
+        node=node3,
+        version="1",
         query="select count(*) from a_table",
         type=NodeType.METRIC,
     )
 
-    session.add(node1)
-    session.add(node2)
-    session.add(node3)
+    session.add(node_rev1)
+    session.add(node_rev2)
+    session.add(node_rev3)
     session.commit()
 
     query = """
@@ -89,10 +89,10 @@ def test_read_metric_errors(session: Session, client: TestClient) -> None:
     Test error response in ``read_metric``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", current_version=1)
-    node = NodeRevision(reference_node=ref_node, version=1, query="SELECT 1 AS col")
+    node = Node(name="a-metric", current_version="1")
+    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
@@ -130,14 +130,14 @@ def test_read_metrics_data(
     Test ``read_metrics_data``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", current_version=1, type=NodeType.METRIC)
-    node = NodeRevision(
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
+    node_revision = NodeRevision(
+        node=node,
+        version="1",
         query="SELECT COUNT(*) FROM my_table",
     )
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
@@ -186,14 +186,14 @@ def test_read_metrics_sql(
     Test ``read_metrics_sql``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", current_version=1, type=NodeType.METRIC)
-    node = NodeRevision(
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
+    node_revision = NodeRevision(
+        node=node,
+        version="1",
         query="SELECT COUNT(*) FROM my_table",
     )
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
@@ -229,10 +229,10 @@ def test_read_metrics_sql_errors(session: Session, client: TestClient):
     """
 
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", current_version=1)
-    node = NodeRevision(reference_node=ref_node, version=1, query="SELECT 1 AS col")
+    node = Node(name="a-metric", current_version="1")
+    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
@@ -265,10 +265,10 @@ def test_read_metrics_data_errors(session: Session, client: TestClient):
     Test error response in ``read_metrics_data``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", current_version=1)
-    node = NodeRevision(reference_node=ref_node, version=1, query="SELECT 1 AS col")
+    node = Node(name="a-metric", current_version="1")
+    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 

--- a/tests/api/graphql/node_test.py
+++ b/tests/api/graphql/node_test.py
@@ -13,38 +13,38 @@ def test_get_nodes(session: Session, client: TestClient) -> None:
     """
     Test ``get_nodes``.
     """
-    ref_node1 = Node(
+    node1 = Node(
         name="not-a-metric",
         type=NodeType.SOURCE,
-        current_version=1,
+        current_version="1",
     )
-    node1 = NodeRevision(reference_node=ref_node1, version=1)
+    node_rev1 = NodeRevision(node=node1, version="1")
 
-    ref_node2 = Node(
+    node2 = Node(
         name="also-not-a-metric",
         type=NodeType.TRANSFORM,
-        current_version=1,
+        current_version="1",
     )
-    node2 = NodeRevision(
-        reference_node=ref_node2,
-        version=1,
+    node_rev2 = NodeRevision(
+        node=node2,
+        version="1",
         query="SELECT 42 AS answer",
         columns=[
             Column(name="answer", type=ColumnType.INT),
         ],
     )
-    ref_node3 = Node(name="a-metric", type=NodeType.METRIC, current_version=1)
-    node3 = NodeRevision(
-        reference_node=ref_node3,
-        version=1,
+    node3 = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
+    node_rev3 = NodeRevision(
+        node=node3,
+        version="1",
         query="SELECT COUNT(*) FROM my_table",
         columns=[
             Column(name="_col0", type=ColumnType.INT),
         ],
     )
-    session.add(node1)
-    session.add(node2)
-    session.add(node3)
+    session.add(node_rev1)
+    session.add(node_rev2)
+    session.add(node_rev3)
     session.commit()
 
     query = """

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -20,29 +20,29 @@ def test_read_metrics(session: Session, client: TestClient) -> None:
     """
     Test ``GET /metrics/``.
     """
-    ref_node1 = Node(
+    node1 = Node(
         name="not-a-metric",
         type=NodeType.TRANSFORM,
-        current_version=1,
+        current_version="1",
     )
-    node1 = NodeRevision(reference_node=ref_node1, version=ref_node1.current_version)
+    node_rev1 = NodeRevision(node=node1, version=node1.current_version)
 
-    ref_node2 = Node(
+    node2 = Node(
         name="also-not-a-metric",
         type=NodeType.TRANSFORM,
-        current_version=1,
+        current_version="1",
     )
-    node2 = NodeRevision(reference_node=ref_node2, query="SELECT 42", version=1)
+    node_rev2 = NodeRevision(node=node2, query="SELECT 42", version="1")
 
-    ref_node3 = Node(name="a-metric", type=NodeType.METRIC, current_version=1)
-    node3 = NodeRevision(
-        reference_node=ref_node3,
-        version=1,
+    node3 = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
+    node_rev3 = NodeRevision(
+        node=node3,
+        version="1",
         query="SELECT COUNT(*) FROM my_table",
     )
-    session.add(node1)
-    session.add(node2)
-    session.add(node3)
+    session.add(node_rev1)
+    session.add(node_rev2)
+    session.add(node_rev3)
     session.commit()
 
     response = client.get("/metrics/")
@@ -58,8 +58,8 @@ def test_read_metric(session: Session, client: TestClient) -> None:
     """
     Test ``GET /metric/{node_id}/``.
     """
-    parent = NodeRevision(
-        version=1,
+    parent_rev = NodeRevision(
+        version="1",
         tables=[
             Table(
                 database=Database(name="test", URI="sqlite://"),
@@ -77,26 +77,26 @@ def test_read_metric(session: Session, client: TestClient) -> None:
             Column(name="foo", type=ColumnType.FLOAT),
         ],
     )
-    parent_ref_node = Node(
+    parent_node = Node(
         name="parent",
         type=NodeType.SOURCE,
-        current_version=1,
+        current_version="1",
     )
-    parent.reference_node = parent_ref_node
+    parent_rev.node = parent_node
 
-    child_ref_node = Node(
+    child_node = Node(
         name="child",
         type=NodeType.METRIC,
-        current_version=1,
+        current_version="1",
     )
-    child = NodeRevision(
-        reference_node=child_ref_node,
-        version=1,
+    child_rev = NodeRevision(
+        node=child_node,
+        version="1",
         query="SELECT COUNT(*) FROM parent",
-        parents=[parent_ref_node],
+        parents=[parent_node],
     )
 
-    session.add(child)
+    session.add(child_rev)
     session.commit()
 
     response = client.get("/metrics/child/")
@@ -113,14 +113,14 @@ def test_read_metrics_errors(session: Session, client: TestClient) -> None:
     Test errors on ``GET /metrics/{node_id}/``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(
+    node = Node(
         name="a-metric",
         type=NodeType.TRANSFORM,
-        current_version=1,
+        current_version="1",
     )
-    node = NodeRevision(reference_node=ref_node, version=1, query="SELECT 1 AS col")
+    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
@@ -142,14 +142,14 @@ def test_read_metrics_data(
     Test ``GET /metrics/{node_id}/data/``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", type=NodeType.METRIC, current_version=1)
-    node = NodeRevision(
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        node=node,
+        version="1",
         query="SELECT COUNT(*) FROM my_table",
     )
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
@@ -185,10 +185,10 @@ def test_read_metrics_data_errors(session: Session, client: TestClient) -> None:
     Test errors on ``GET /metrics/{node_id}/data/``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", current_version=1)
-    node = NodeRevision(reference_node=ref_node, version=1, query="SELECT 1 AS col")
+    node = Node(name="a-metric", current_version="1")
+    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 
@@ -210,15 +210,15 @@ def test_read_metrics_sql(
     Test ``GET /metrics/{node_id}/sql/``.
     """
     database = Database(name="test", URI="sqlite://")
-    ref_node = Node(name="a-metric", type=NodeType.METRIC, current_version=1)
-    node = NodeRevision(
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        node=node,
+        version="1",
         query="SELECT COUNT(*) FROM my_table",
         type=NodeType.METRIC,
     )
     session.add(database)
-    session.add(node)
+    session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
     session.commit()
 

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -16,14 +16,14 @@ def test_read_node(session: Session, client: TestClient) -> None:
     """
     Test ``GET /nodes/{node_id}``.
     """
-    ref_node = Node(name="something", type=NodeType.SOURCE, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="something", type=NodeType.SOURCE, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
     )
-    session.add(node)
+    session.add(node_revision)
     session.commit()
 
     response = client.get("/nodes/something/")
@@ -46,46 +46,46 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     """
     Test ``GET /nodes/``.
     """
-    ref_node1 = Node(
+    node1 = Node(
         name="not-a-metric",
         type=NodeType.SOURCE,
-        current_version=1,
+        current_version="1",
     )
-    node1 = NodeRevision(
-        reference_node=ref_node1,
-        version=1,
-        name=ref_node1.name,
-        type=ref_node1.type,
+    node_rev1 = NodeRevision(
+        node=node1,
+        version="1",
+        name=node1.name,
+        type=node1.type,
     )
-    ref_node2 = Node(
+    node2 = Node(
         name="also-not-a-metric",
         type=NodeType.TRANSFORM,
-        current_version=1,
+        current_version="1",
     )
-    node2 = NodeRevision(
-        name=ref_node2.name,
-        reference_node=ref_node2,
-        version=1,
+    node_rev2 = NodeRevision(
+        name=node2.name,
+        node=node2,
+        version="1",
         query="SELECT 42 AS answer",
-        type=ref_node2.type,
+        type=node2.type,
         columns=[
             Column(name="answer", type=ColumnType.INT),
         ],
     )
-    ref_node3 = Node(name="a-metric", type=NodeType.METRIC, current_version=1)
-    node3 = NodeRevision(
-        name=ref_node3.name,
-        reference_node=ref_node3,
-        version=1,
+    node3 = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
+    node_rev3 = NodeRevision(
+        name=node3.name,
+        node=node3,
+        version="1",
         query="SELECT COUNT(*) FROM my_table",
         columns=[
             Column(name="_col0", type=ColumnType.INT),
         ],
-        type=ref_node3.type,
+        type=node3.type,
     )
-    session.add(node1)
-    session.add(node2)
-    session.add(node3)
+    session.add(node_rev1)
+    session.add(node_rev2)
+    session.add(node_rev3)
     session.commit()
 
     response = client.get("/nodes/")
@@ -224,16 +224,16 @@ class TestCreateOrUpdateNodes:
                 Column(name="user_id", type=ColumnType.INT),
             ],
         )
-        ref_node = Node(
+        node = Node(
             name="basic.source.users",
             type=NodeType.SOURCE,
-            current_version=1,
+            current_version="1",
         )
-        node = NodeRevision(
-            reference_node=ref_node,
-            name=ref_node.name,
-            type=ref_node.type,
-            version=1,
+        node_revision = NodeRevision(
+            node=node,
+            name=node.name,
+            type=node.type,
+            version="1",
             tables=[table],
             columns=[
                 Column(name="id", type=ColumnType.INT),
@@ -244,9 +244,9 @@ class TestCreateOrUpdateNodes:
                 Column(name="preferred_language", type=ColumnType.STR),
             ],
         )
-        session.add(node)
+        session.add(node_revision)
         session.commit()
-        return ref_node
+        return node
 
     def test_create_update_source_node(
         self,
@@ -269,7 +269,7 @@ class TestCreateOrUpdateNodes:
         assert data["current_version"] == "1"
         assert data["current"]["name"] == "comments"
         assert data["current"]["version"] == "1"
-        assert data["current"]["reference_node_id"] == 1
+        assert data["current"]["node_id"] == 1
         assert data["current"]["description"] == "A fact table with comments"
         assert data["current"]["query"] is None
         assert data["current"]["columns"] == [
@@ -302,7 +302,7 @@ class TestCreateOrUpdateNodes:
         assert data["current_version"] == "2"
         assert data["current"]["name"] == "comments"
         assert data["current"]["version"] == "2"
-        assert data["current"]["reference_node_id"] == 1
+        assert data["current"]["node_id"] == 1
         assert data["current"]["description"] == "New description"
 
         # Try to update node with no changes
@@ -572,16 +572,16 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         Add nodes to facilitate testing of the validation route
         """
 
-        ref_node1 = Node(
+        node1 = Node(
             name="revenue_source",
             type=NodeType.SOURCE,
-            current_version=1,
+            current_version="1",
         )
-        node1 = NodeRevision(
-            name=ref_node1.name,
-            type=ref_node1.type,
-            reference_node=ref_node1,
-            version=1,
+        node_rev1 = NodeRevision(
+            name=node1.name,
+            type=node1.type,
+            node=node1,
+            version="1",
             columns=[
                 Column(name="payment_id", type=ColumnType.INT),
                 Column(name="payment_amount", type=ColumnType.FLOAT),
@@ -589,16 +589,16 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 Column(name="account_type", type=ColumnType.STR),
             ],
         )
-        ref_node2 = Node(
+        node2 = Node(
             name="large_revenue_payments_only",
             type=NodeType.TRANSFORM,
-            current_version=1,
+            current_version="1",
         )
-        node2 = NodeRevision(
-            reference_node=ref_node2,
-            name=ref_node2.name,
-            type=ref_node2.type,
-            version=1,
+        node_rev2 = NodeRevision(
+            node=node2,
+            name=node2.name,
+            type=node2.type,
+            version="1",
             query=(
                 "SELECT payment_id, payment_amount, customer_id, account_type "
                 "FROM revenue_source WHERE payment_amount > 1000000"
@@ -611,16 +611,16 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             ],
         )
 
-        ref_node3 = Node(
+        node3 = Node(
             name="large_revenue_payments_and_business_only",
             type=NodeType.TRANSFORM,
-            current_version=1,
+            current_version="1",
         )
-        node3 = NodeRevision(
-            reference_node=ref_node3,
-            name=ref_node3.name,
-            type=ref_node3.type,
-            version=1,
+        node_rev3 = NodeRevision(
+            node=node3,
+            name=node3.name,
+            type=node3.type,
+            version="1",
             query=(
                 "SELECT payment_id, payment_amount, customer_id, account_type "
                 "FROM revenue_source WHERE payment_amount > 1000000 "
@@ -633,9 +633,9 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 Column(name="account_type", type=ColumnType.STR),
             ],
         )
-        session.add(node1)
-        session.add(node2)
-        session.add(node3)
+        session.add(node_rev1)
+        session.add(node_rev2)
+        session.add(node_rev3)
         session.commit()
         return session
 
@@ -667,17 +667,17 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
         assert data["status"] == "valid"
-        assert data["node"]["status"] == "valid"
+        assert data["node_revision"]["status"] == "valid"
         assert data["dependencies"][0]["name"] == "large_revenue_payments_only"
         assert data["message"] == "Node `foo` is valid"
-        assert data["node"]["id"] is None
-        assert data["node"]["mode"] == "published"
-        assert data["node"]["name"] == "foo"
+        assert data["node_revision"]["id"] is None
+        assert data["node_revision"]["mode"] == "published"
+        assert data["node_revision"]["name"] == "foo"
         assert (
-            data["node"]["query"]
+            data["node_revision"]["query"]
             == "SELECT payment_id FROM large_revenue_payments_only"
         )
-        assert data["ref_node"]["type"] == "transform"
+        assert data["node"]["type"] == "transform"
 
     def test_validating_an_invalid_node(self, client: TestClient) -> None:
         """
@@ -776,9 +776,9 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert response.status_code == 200
         assert data["message"] == "Node `foo` is valid"
         assert data["status"] == "valid"
-        assert data["ref_node"]["name"] == "foo"
-        assert data["node"]["mode"] == "draft"
-        assert data["node"]["status"] == "valid"
+        assert data["node"]["name"] == "foo"
+        assert data["node_revision"]["mode"] == "draft"
+        assert data["node_revision"]["status"] == "valid"
         assert data["columns"] == [
             {
                 "id": None,

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -242,16 +242,16 @@ async def test_index_nodes(
         ),
     )
     session.add(Database(name="gsheets", URI="gsheets://"))
-    ref_node = Node(
+    node = Node(
         name="core.old_num_comments",
         type=NodeType.METRIC,
         current_version="1",
         created_at=datetime(2020, 1, 2, 0, 0),
     )
-    session.add(ref_node)
+    session.add(node)
     session.add(
         NodeRevision(
-            reference_node=ref_node,
+            node=node,
             version="1",
             description="A Number of comments whose config was deleted",
             updated_at=datetime(2020, 1, 2, 0, 0),
@@ -270,7 +270,7 @@ async def test_index_nodes(
     configs = [
         {
             **node.dict(exclude={"id": True}),
-            **node.current.dict(exclude={"id": True, "reference_node_id": True}),
+            **node.current.dict(exclude={"id": True, "node_id": True}),
         }
         for node in nodes
     ]
@@ -486,12 +486,12 @@ async def test_update_node_config(mocker: MockerFixture, fs: FakeFilesystem) -> 
         columns=[Column(name="ds", type=ColumnType.DATETIME)],
     )
 
-    ref_node = Node(name="C", type=NodeType.SOURCE, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="C", type=NodeType.SOURCE, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
         tables=[table_a, table_b],
         columns=[
             Column(name="ds", type=ColumnType.DATETIME),
@@ -504,7 +504,7 @@ async def test_update_node_config(mocker: MockerFixture, fs: FakeFilesystem) -> 
         contents=yaml.safe_dump({}),
     )
 
-    await update_node_config(node, path)
+    await update_node_config(node_revision, path)
 
     with open(path, encoding="utf-8") as input_:
         assert yaml.safe_load(input_) == {
@@ -525,7 +525,7 @@ async def test_update_node_config(mocker: MockerFixture, fs: FakeFilesystem) -> 
         "C",
     )
 
-    await update_node_config(node, path)
+    await update_node_config(node_revision, path)
     _logger.info.assert_called_with(
         "Node %s is up-do-date, skipping",
         "C",
@@ -559,10 +559,10 @@ async def test_update_node_config_user_attributes(
         columns=[Column(name="ds", type=ColumnType.DATETIME)],
     )
 
-    ref_node = Node(name="C", type=NodeType.SOURCE, current_version=1)
-    node = NodeRevision(
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="C", type=NodeType.SOURCE, current_version="1")
+    node_revision = NodeRevision(
+        node=node,
+        version="1",
         tables=[table_a, table_b],
         columns=[
             Column(name="ds", type=ColumnType.DATETIME),
@@ -583,7 +583,7 @@ async def test_update_node_config_user_attributes(
         ),
     )
 
-    await update_node_config(node, path)
+    await update_node_config(node_revision, path)
 
     with open(path, encoding="utf-8") as input_:
         assert yaml.safe_load(input_) == {
@@ -604,7 +604,7 @@ async def test_update_node_config_user_attributes(
         "C",
     )
 
-    await update_node_config(node, path)
+    await update_node_config(node_revision, path)
     _logger.info.assert_called_with(
         "Node %s is up-do-date, skipping",
         "C",
@@ -625,12 +625,12 @@ async def test_update_node_config_sql_query(
     path = Path("/path/to/repository/configs/nodes/T.yaml")
     test_query = "SELECT foo FROM bar WHERE baz"
     fs.create_file(path, contents=yaml.safe_dump({"query": test_query}))
-    ref_node = Node(name="T", type=NodeType.TRANSFORM, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="T", type=NodeType.TRANSFORM, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
         query=test_query,
         columns=[
             Column(name="ds", type=ColumnType.DATETIME),
@@ -638,7 +638,7 @@ async def test_update_node_config_sql_query(
         ],
     )
 
-    await update_node_config(node, path)
+    await update_node_config(node_revision, path)
 
     with open(path, encoding="utf-8") as input_:
         assert yaml.safe_load(input_) == {
@@ -685,14 +685,14 @@ def test_add_dimensions_to_columns(mocker: MockerFixture, repository: Path) -> N
     session = mocker.MagicMock()
     dimension_ref = Node(
         name="users",
-        current_version=1,
+        current_version="1",
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
         name=dimension_ref.name,
         type=dimension_ref.type,
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         columns=[
             Column(name="id", type=ColumnType.INT),
             Column(name="uuid", type=ColumnType.INT),

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -31,8 +31,8 @@ http://localhost:8000/metrics/{name}/: Return a metric by name.
 http://localhost:8000/metrics/{name}/data/: Return data for a metric.
 http://localhost:8000/metrics/{name}/sql/: Return SQL for a metric.
 http://localhost:8000/nodes/validate/: Validate a node.
-http://localhost:8000/nodes/: List the available reference nodes.
-http://localhost:8000/nodes/{name}/: List the specified reference node and include all revisions
+http://localhost:8000/nodes/: List the available nodes.
+http://localhost:8000/nodes/{name}/: List the specified node and include all revisions.
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/graphql: GraphQL endpoint.
 """

--- a/tests/construction/build_planning_test.py
+++ b/tests/construction/build_planning_test.py
@@ -12,13 +12,13 @@ def test_build_planning_source_fails(construction_session):
     """
     Test build planning source fails
     """
-    ref_node = next(
+    node = next(
         construction_session.exec(
             select(Node).filter(Node.name == "basic.source.users"),
         ),
     )[0]
     with pytest.raises(Exception) as exc:
-        generate_build_plan_from_node(construction_session, ref_node.current)
+        generate_build_plan_from_node(construction_session, node.current)
 
     assert "Node has no query. Cannot generate a build plan without a query." in str(
         exc,

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -108,12 +108,12 @@ async def test_raise_on_build_without_required_dimension_column(mocker, request)
             ),
         ),
     )[0]
-    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version=1)
+    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version="1")
     node_foo = NodeRevision(
         name=node_foo_ref.name,
         type=node_foo_ref.type,
-        reference_node=node_foo_ref,
-        version=1,
+        node=node_foo_ref,
+        version="1",
         query="""SELECT num_users FROM basic.transform.country_agg""",
         columns=[
             Column(
@@ -126,12 +126,12 @@ async def test_raise_on_build_without_required_dimension_column(mocker, request)
     construction_session.add(node_foo)
     construction_session.flush()
 
-    node_bar_ref = Node(name="bar", type=NodeType.TRANSFORM, current_version=1)
+    node_bar_ref = Node(name="bar", type=NodeType.TRANSFORM, current_version="1")
     node_bar = NodeRevision(
         name=node_bar_ref.name,
         type=node_bar_ref.type,
-        reference_node=node_bar_ref,
-        version=1,
+        node=node_bar_ref,
+        version="1",
         query="""SELECT num_users FROM foo GROUP BY basic.dimension.countries.country""",
         columns=[
             Column(name="num_users", type=ColumnType.STR),
@@ -197,10 +197,10 @@ async def test_build_metric_with_database_id_specified(mocker, request):
     mocker.patch("dj.models.database.Database.do_ping", return_value=True)
 
     construction_session: Session = request.getfixturevalue("construction_session")
-    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version=1)
+    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version="1")
     node_foo = NodeRevision(
-        reference_node=node_foo_ref,
-        version=1,
+        node=node_foo_ref,
+        version="1",
         query="""SELECT num_users FROM basic.transform.country_agg""",
         columns=[
             Column(name="num_users", type=ColumnType.STR),
@@ -245,10 +245,10 @@ async def test_build_node_for_database_with_unnamed_column(mocker, request):
     mocker.patch("dj.models.database.Database.do_ping", return_value=True)
 
     construction_session: Session = request.getfixturevalue("construction_session")
-    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version=1)
+    node_foo_ref = Node(name="foo", type=NodeType.TRANSFORM, current_version="1")
     node_foo = NodeRevision(
-        reference_node=node_foo_ref,
-        version=1,
+        node=node_foo_ref,
+        version="1",
         query="""SELECT 1 FROM basic.dimension.countries""",
         columns=[
             Column(name="_col1", type=ColumnType.INT),

--- a/tests/construction/compile_test.py
+++ b/tests/construction/compile_test.py
@@ -159,24 +159,24 @@ def test_compile_node(construction_session: Session):
     """
     Test compiling a node
     """
-    ref_node_a = Node(name="A", current_version=1)
-    node_a = NodeRevision(
-        reference_node=ref_node_a,
-        version=1,
+    node_a = Node(name="A", current_version="1")
+    node_a_rev = NodeRevision(
+        node=node_a,
+        version="1",
         query="SELECT country FROM basic.transform.country_agg",
     )
-    compile_node(session=construction_session, node=node_a)
+    compile_node(session=construction_session, node=node_a_rev)
 
 
 def test_raise_on_compile_node_with_no_query(construction_session: Session):
     """
     Test raising when compiling a node that has no query
     """
-    ref_node_a = Node(name="A", current_version=1)
-    node_a = NodeRevision(reference_node=ref_node_a, version=1)
+    node_a = Node(name="A", current_version="1")
+    node_a_rev = NodeRevision(node=node_a, version="1")
 
     with pytest.raises(DJException) as exc_info:
-        compile_node(session=construction_session, node=node_a)
+        compile_node(session=construction_session, node=node_a_rev)
 
     assert "Cannot compile node `A` with no query" in str(exc_info.value)
 
@@ -185,10 +185,10 @@ def test_raise_on_unjoinable_automatic_dimension_groupby(construction_session: S
     """
     Test raising where a dimension node is automatically detected but unjoinable
     """
-    ref_node_a = Node(name="A", current_version=1)
-    node_a = NodeRevision(
-        reference_node=ref_node_a,
-        version=1,
+    node_a = Node(name="A", current_version="1")
+    node_a_rev = NodeRevision(
+        node=node_a,
+        version="1",
         query=(
             "SELECT country FROM basic.transform.country_agg "
             "GROUP BY basic.dimension.countries.country"
@@ -196,7 +196,7 @@ def test_raise_on_unjoinable_automatic_dimension_groupby(construction_session: S
     )
 
     with pytest.raises(DJException) as exc_info:
-        compile_node(session=construction_session, node=node_a)
+        compile_node(session=construction_session, node=node_a_rev)
 
     assert "Dimension `basic.dimension.countries` is not joinable" in str(
         exc_info.value,
@@ -207,17 +207,17 @@ def test_raise_on_having_without_a_groupby(construction_session: Session):
     """
     Test raising when using a having without a groupby
     """
-    ref_node_a = Node(name="A", current_version=1)
-    node_a = NodeRevision(
-        reference_node=ref_node_a,
-        version=1,
+    node_a = Node(name="A", current_version="1")
+    node_a_rev = NodeRevision(
+        node=node_a,
+        version="1",
         query=(
             "SELECT country FROM basic.transform.country_agg " "HAVING country='US'"
         ),
     )
 
     with pytest.raises(DJException) as exc_info:
-        compile_node(session=construction_session, node=node_a)
+        compile_node(session=construction_session, node=node_a_rev)
 
     assert "HAVING without a GROUP BY is not allowed" in str(exc_info.value)
 
@@ -226,14 +226,14 @@ def test_having(construction_session: Session):
     """
     Test using having
     """
-    ref_node_a = Node(name="A", current_version=1)
-    node_a = NodeRevision(
-        reference_node=ref_node_a,
-        version=1,
+    node_a = Node(name="A", current_version="1")
+    node_a_rev = NodeRevision(
+        node=node_a,
+        version="1",
         query=(
             "SELECT order_date, status FROM dbt.source.jaffle_shop.orders "
             "GROUP BY dbt.dimension.customers.id "
             "HAVING dbt.dimension.customers.id=1"
         ),
     )
-    compile_node(session=construction_session, node=node_a)
+    compile_node(session=construction_session, node=node_a_rev)

--- a/tests/construction/fixtures.py
+++ b/tests/construction/fixtures.py
@@ -314,13 +314,13 @@ def construction_session(  # pylint: disable=too-many-locals
     countries_dim_ref = Node(
         name="basic.dimension.countries",
         type=NodeType.DIMENSION,
-        current_version=1,
+        current_version="1",
     )
     countries_dim = NodeRevision(
         name=countries_dim_ref.name,
         type=countries_dim_ref.type,
-        reference_node=countries_dim_ref,
-        version=1,
+        node=countries_dim_ref,
+        version="1",
         query="""
           SELECT country,
                  COUNT(1) AS user_cnt
@@ -336,13 +336,13 @@ def construction_session(  # pylint: disable=too-many-locals
     user_dim_ref = Node(
         name="basic.dimension.users",
         type=NodeType.DIMENSION,
-        current_version=1,
+        current_version="1",
     )
     user_dim = NodeRevision(
         name=user_dim_ref.name,
         type=user_dim_ref.type,
-        reference_node=user_dim_ref,
-        version=1,
+        node=user_dim_ref,
+        version="1",
         query="""
           SELECT id,
                  full_name,
@@ -367,13 +367,13 @@ def construction_session(  # pylint: disable=too-many-locals
     country_agg_tfm_ref = Node(
         name="basic.transform.country_agg",
         type=NodeType.TRANSFORM,
-        current_version=1,
+        current_version="1",
     )
     country_agg_tfm = NodeRevision(
         name=country_agg_tfm_ref.name,
         type=country_agg_tfm_ref.type,
-        reference_node=country_agg_tfm_ref,
-        version=1,
+        node=country_agg_tfm_ref,
+        version="1",
         query="""
         SELECT country,
                 COUNT(DISTINCT id) AS num_users
@@ -389,13 +389,13 @@ def construction_session(  # pylint: disable=too-many-locals
     users_src_ref = Node(
         name="basic.source.users",
         type=NodeType.SOURCE,
-        current_version=1,
+        current_version="1",
     )
     users_src = NodeRevision(
         name=users_src_ref.name,
         type=users_src_ref.type,
-        reference_node=users_src_ref,
-        version=1,
+        node=users_src_ref,
+        version="1",
         columns=[
             Column(name="id", type=ColumnType.INT),
             Column(name="full_name", type=ColumnType.STR),
@@ -445,13 +445,13 @@ def construction_session(  # pylint: disable=too-many-locals
     comments_src_ref = Node(
         name="basic.source.comments",
         type=NodeType.SOURCE,
-        current_version=1,
+        current_version="1",
     )
     comments_src = NodeRevision(
         name=comments_src_ref.name,
         type=comments_src_ref.type,
-        reference_node=comments_src_ref,
-        version=1,
+        node=comments_src_ref,
+        version="1",
         columns=[
             Column(name="id", type=ColumnType.INT),
             Column(
@@ -496,13 +496,13 @@ def construction_session(  # pylint: disable=too-many-locals
     num_comments_mtc_ref = Node(
         name="basic.num_comments",
         type=NodeType.METRIC,
-        current_version=1,
+        current_version="1",
     )
     num_comments_mtc = NodeRevision(
         name=num_comments_mtc_ref.name,
         type=num_comments_mtc_ref.type,
-        reference_node=num_comments_mtc_ref,
-        version=1,
+        node=num_comments_mtc_ref,
+        version="1",
         query="""
         SELECT COUNT(1) AS cnt
         FROM basic.source.comments
@@ -515,13 +515,13 @@ def construction_session(  # pylint: disable=too-many-locals
     num_users_mtc_ref = Node(
         name="basic.num_users",
         type=NodeType.METRIC,
-        current_version=1,
+        current_version="1",
     )
     num_users_mtc = NodeRevision(
         name=num_users_mtc_ref.name,
         type=num_users_mtc_ref.type,
-        reference_node=num_users_mtc_ref,
-        version=1,
+        node=num_users_mtc_ref,
+        version="1",
         query="""
         SELECT SUM(num_users)
         FROM basic.transform.country_agg
@@ -534,13 +534,13 @@ def construction_session(  # pylint: disable=too-many-locals
     customers_dim_ref = Node(
         name="dbt.dimension.customers",
         type=NodeType.DIMENSION,
-        current_version=1,
+        current_version="1",
     )
     customers_dim = NodeRevision(
         name=customers_dim_ref.name,
         type=customers_dim_ref.type,
-        reference_node=customers_dim_ref,
-        version=1,
+        node=customers_dim_ref,
+        version="1",
         query="""
           SELECT id,
              first_name,
@@ -557,13 +557,13 @@ def construction_session(  # pylint: disable=too-many-locals
     customers_agg_tfm_ref = Node(
         name="dbt.transform.customer_agg",
         type=NodeType.TRANSFORM,
-        current_version=1,
+        current_version="1",
     )
     customers_agg_tfm = NodeRevision(
         name=customers_agg_tfm_ref.name,
         type=customers_agg_tfm_ref.type,
-        reference_node=customers_agg_tfm_ref,
-        version=1,
+        node=customers_agg_tfm_ref,
+        version="1",
         query="""
           SELECT c.id,
                  c.first_name,
@@ -586,13 +586,13 @@ def construction_session(  # pylint: disable=too-many-locals
     orders_src_ref = Node(
         name="dbt.source.jaffle_shop.orders",
         type=NodeType.SOURCE,
-        current_version=1,
+        current_version="1",
     )
     orders_src = NodeRevision(
         name=orders_src_ref.name,
         type=orders_src_ref.type,
-        reference_node=orders_src_ref,
-        version=1,
+        node=orders_src_ref,
+        version="1",
         columns=[
             Column(name="id", type=ColumnType.INT),
             Column(
@@ -627,13 +627,13 @@ def construction_session(  # pylint: disable=too-many-locals
     customers_src_ref = Node(
         name="dbt.source.jaffle_shop.customers",
         type=NodeType.SOURCE,
-        current_version=1,
+        current_version="1",
     )
     customers_src = NodeRevision(
         name=customers_src_ref.name,
         type=customers_src_ref.type,
-        reference_node=customers_src_ref,
-        version=1,
+        node=customers_src_ref,
+        version="1",
         columns=[
             Column(name="id", type=ColumnType.INT),
             Column(name="first_name", type=ColumnType.STR),

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -18,14 +18,14 @@ def test_infer_column_with_table(construction_session: Session):
     """
     Test getting the type of a column that has a table
     """
-    ref_node = next(
+    node = next(
         construction_session.exec(
             select(Node).filter(
                 Node.name == "dbt.source.jaffle_shop.orders",
             ),
         ),
     )[0]
-    table = ast.Table(ast.Name("orders"), _dj_node=ref_node.current)
+    table = ast.Table(ast.Name("orders"), _dj_node=node.current)
     assert (
         get_type_of_expression(ast.Column(ast.Name("id"), _table=table))
         == ColumnType.INT
@@ -75,14 +75,14 @@ def test_infer_column_with_an_aliased_table(construction_session: Session):
     """
     Test getting the type of a column that has an aliased table
     """
-    ref_node = next(
+    node = next(
         construction_session.exec(
             select(Node).filter(
                 Node.name == "dbt.source.jaffle_shop.orders",
             ),
         ),
     )[0]
-    table = ast.Table(ast.Name("orders"), _dj_node=ref_node.current)
+    table = ast.Table(ast.Name("orders"), _dj_node=node.current)
     alias = ast.Alias(
         ast.Name("foo"),
         ast.Namespace([ast.Name("a"), ast.Name("b"), ast.Name("c")]),

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -14,101 +14,101 @@ def test_node_relationship(session: Session) -> None:
     """
     Test the n:n self-referential relationships.
     """
-    node_a_ref = Node(name="A", current_version=1)
-    node_a = NodeRevision(name="A", version=1, reference_node=node_a_ref)
+    node_a = Node(name="A", current_version="1")
+    node_a_rev = NodeRevision(name="A", version="1", node=node_a)
 
-    node_b_ref = Node(name="B", current_version=1)
-    node_b = NodeRevision(name="B", version=1, reference_node=node_b_ref)
+    node_b = Node(name="B", current_version="1")
+    node_a_rev = NodeRevision(name="B", version="1", node=node_b)
 
-    node_c_ref = Node(name="C", current_version=1)
-    node_c = NodeRevision(
+    node_c = Node(name="C", current_version="1")
+    node_c_rev = NodeRevision(
         name="C",
-        version=1,
-        reference_node=node_c_ref,
-        parents=[node_a_ref, node_b_ref],
+        version="1",
+        node=node_c,
+        parents=[node_a, node_b],
     )
 
-    session.add(node_c)
+    session.add(node_c_rev)
 
-    assert node_a_ref.children == [node_c]
-    assert node_b_ref.children == [node_c]
-    assert node_c_ref.children == []
+    assert node_a.children == [node_c_rev]
+    assert node_b.children == [node_c_rev]
+    assert node_c.children == []
 
-    assert node_a.parents == []
-    assert node_b.parents == []
-    assert node_c.parents == [node_a_ref, node_b_ref]
+    assert node_a_rev.parents == []
+    assert node_a_rev.parents == []
+    assert node_c_rev.parents == [node_a, node_b]
 
 
 def test_extra_validation() -> None:
     """
     Test ``extra_validation``.
     """
-    ref_node = Node(name="A", type=NodeType.SOURCE, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="A", type=NodeType.SOURCE, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
     )
     with pytest.raises(Exception) as excinfo:
-        node.extra_validation()
+        node_revision.extra_validation()
     assert str(excinfo.value) == "Node A of type source needs at least one table"
 
-    ref_node = Node(name="A", type=NodeType.SOURCE, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="A", type=NodeType.SOURCE, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
         query="SELECT * FROM B",
     )
     with pytest.raises(Exception) as excinfo:
-        node.extra_validation()
+        node_revision.extra_validation()
     assert str(excinfo.value) == "Node A of type source should not have a query"
 
-    ref_node = Node(name="A", type=NodeType.METRIC, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="A", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
     )
     with pytest.raises(Exception) as excinfo:
-        node.extra_validation()
+        node_revision.extra_validation()
     assert str(excinfo.value) == "Node A of type metric needs a query"
 
-    ref_node = Node(name="A", type=NodeType.METRIC, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="A", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
         query="SELECT 42",
     )
     with pytest.raises(Exception) as excinfo:
-        node.extra_validation()
+        node_revision.extra_validation()
     assert str(excinfo.value) == (
         "Node A of type metric has an invalid query, "
         "should have a single aggregation"
     )
 
-    ref_node = Node(name="A", type=NodeType.TRANSFORM, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="A", type=NodeType.TRANSFORM, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
         query="SELECT * FROM B",
     )
-    node.extra_validation()
+    node_revision.extra_validation()
 
-    ref_node = Node(name="A", type=NodeType.TRANSFORM, current_version=1)
-    node = NodeRevision(
-        name=ref_node.name,
-        type=ref_node.type,
-        reference_node=ref_node,
-        version=1,
+    node = Node(name="A", type=NodeType.TRANSFORM, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
     )
     with pytest.raises(Exception) as excinfo:
-        node.extra_validation()
+        node_revision.extra_validation()
     assert str(excinfo.value) == "Node A of type transform needs a query"

--- a/tests/sql/build_test.py
+++ b/tests/sql/build_test.py
@@ -32,14 +32,14 @@ async def test_get_query_for_node(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
-    parent = NodeRevision(reference_node=parent_ref, version=1)
+    parent_ref = Node(name="A", current_version="1")
+    parent = NodeRevision(node=parent_ref, version="1")
     parent_ref.current = parent
 
-    child_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -70,10 +70,10 @@ async def test_get_query_for_node_with_groupbys(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -91,10 +91,10 @@ async def test_get_query_for_node_with_groupbys(mocker: MockerFixture) -> None:
     )
     parent_ref.current = parent
 
-    child_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent_ref],
     )
@@ -124,14 +124,14 @@ async def test_get_query_for_node_specify_database(mocker: MockerFixture) -> Non
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
-    parent = NodeRevision(reference_node=parent_ref, version=1)
+    parent_ref = Node(name="A", current_version="1")
+    parent = NodeRevision(node=parent_ref, version="1")
     parent_ref.current = parent
 
-    child_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -168,14 +168,14 @@ async def test_get_query_for_node_no_databases(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
-    parent = NodeRevision(reference_node=parent_ref, version=1)
+    parent_ref = Node(name="A", current_version="1")
+    parent = NodeRevision(node=parent_ref, version="1")
     parent_ref.current = parent
 
-    child_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -205,14 +205,14 @@ async def test_get_query_for_node_no_active_databases(mocker: MockerFixture) -> 
     database = mocker.MagicMock()
     database.do_ping = mocker.AsyncMock(return_value=False)
 
-    parent_ref = Node(name="A", current_version=1)
-    parent = NodeRevision(reference_node=parent_ref, version=1)
+    parent_ref = Node(name="A", current_version="1")
+    parent = NodeRevision(node=parent_ref, version="1")
     parent_ref.current = parent
 
-    child_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -241,11 +241,11 @@ async def test_get_query_for_node_with_dimensions(mocker: MockerFixture) -> None
     """
     database = Database(id=1, name="one", URI="sqlite://")
 
-    dimension_ref = Node(name="core.users", current_version=1)
+    dimension_ref = Node(name="core.users", current_version="1")
     dimension = NodeRevision(
         name=dimension_ref.name,
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         type=NodeType.DIMENSION,
         tables=[
             Table(
@@ -266,11 +266,11 @@ async def test_get_query_for_node_with_dimensions(mocker: MockerFixture) -> None
     )
     dimension_ref.current = dimension
 
-    parent_ref = Node(name="core.comments", current_version=1)
+    parent_ref = Node(name="core.comments", current_version="1")
     parent = NodeRevision(
         name=parent_ref.name,
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -292,14 +292,14 @@ async def test_get_query_for_node_with_dimensions(mocker: MockerFixture) -> None
 
     child_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     child = NodeRevision(
         name=child_ref.name,
         type=child_ref.type,
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT COUNT(*) FROM core.comments",
         parents=[parent_ref],
     )
@@ -348,10 +348,10 @@ async def test_get_query_for_node_with_multiple_dimensions(
     """
     database = Database(id=1, name="one", URI="sqlite://")
 
-    dimension_1_ref = Node(name="core.users", current_version=1)
+    dimension_1_ref = Node(name="core.users", current_version="1")
     dimension_1 = NodeRevision(
-        reference_node=dimension_1_ref,
-        version=1,
+        node=dimension_1_ref,
+        version="1",
         type=NodeType.DIMENSION,
         tables=[
             Table(
@@ -372,10 +372,10 @@ async def test_get_query_for_node_with_multiple_dimensions(
     )
     dimension_1_ref.current = dimension_1
 
-    dimension_2_ref = Node(name="core.bands", current_version=1)
+    dimension_2_ref = Node(name="core.bands", current_version="1")
     dimension_2 = NodeRevision(
-        reference_node=dimension_2_ref,
-        version=1,
+        node=dimension_2_ref,
+        version="1",
         type=NodeType.DIMENSION,
         tables=[
             Table(
@@ -396,10 +396,10 @@ async def test_get_query_for_node_with_multiple_dimensions(
     )
     dimension_2_ref.current = dimension_2
 
-    parent_ref = Node(name="core.comments", current_version=1)
+    parent_ref = Node(name="core.comments", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -428,13 +428,13 @@ async def test_get_query_for_node_with_multiple_dimensions(
 
     child_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     child = NodeRevision(
         name=child_ref.name,
         type=child_ref.type,
-        reference_node=child_ref,
+        node=child_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
         parents=[parent_ref],
@@ -542,7 +542,7 @@ async def test_get_query_for_sql(mocker: MockerFixture, session: Session) -> Non
 
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -554,18 +554,18 @@ async def test_get_query_for_sql(mocker: MockerFixture, session: Session) -> Non
             ),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    node_b_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         name="B",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
@@ -602,12 +602,12 @@ async def test_get_query_for_sql_no_metrics(
 
     dimension_ref = Node(
         name="core.users",
-        current_version=1,
+        current_version="1",
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -649,12 +649,12 @@ FROM dim_users) AS "core.users"'''
 
     other_ref = Node(
         name="core.other_dim",
-        current_version=1,
+        current_version="1",
         type=NodeType.DIMENSION,
     )
     other_dimension = NodeRevision(
-        reference_node=other_ref,
-        version=1,
+        node=other_ref,
+        version="1",
         columns=[
             Column(name="full_name", type=ColumnType.STR),
         ],
@@ -707,7 +707,7 @@ async def test_get_query_for_sql_having(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -719,18 +719,18 @@ async def test_get_query_for_sql_having(
             ),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    node_b_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
     )
@@ -772,12 +772,12 @@ async def test_get_query_for_sql_with_dimensions(  # pylint: disable=too-many-lo
 
     dimension_ref = Node(
         name="core.users",
-        current_version=1,
+        current_version="1",
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -797,7 +797,7 @@ async def test_get_query_for_sql_with_dimensions(  # pylint: disable=too-many-lo
     )
 
     parent = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -815,18 +815,18 @@ async def test_get_query_for_sql_with_dimensions(  # pylint: disable=too-many-lo
             Column(name="text", type=ColumnType.STR),
         ],
     )
-    parent_ref = Node(name="core.comments", current_version=1)
-    parent.reference_node = parent_ref
+    parent_ref = Node(name="core.comments", current_version="1")
+    parent.node = parent_ref
 
     child_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     child = NodeRevision(
         name=child_ref.name,
         type=child_ref.type,
-        reference_node=child_ref,
+        node=child_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
         parents=[parent_ref],
@@ -888,12 +888,12 @@ async def test_get_query_for_sql_with_dimensions_order_by(  # pylint: disable=to
 
     dimension_ref = Node(
         name="core.users",
-        current_version=1,
+        current_version="1",
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -913,7 +913,7 @@ async def test_get_query_for_sql_with_dimensions_order_by(  # pylint: disable=to
     )
 
     parent = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -931,18 +931,18 @@ async def test_get_query_for_sql_with_dimensions_order_by(  # pylint: disable=to
             Column(name="text", type=ColumnType.STR),
         ],
     )
-    parent_ref = Node(name="core.comments", current_version=1)
-    parent.reference_node = parent_ref
+    parent_ref = Node(name="core.comments", current_version="1")
+    parent.node = parent_ref
 
     child_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     child = NodeRevision(
         name=child_ref.name,
         type=child_ref.type,
-        reference_node=child_ref,
+        node=child_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
         parents=[parent_ref],
@@ -1063,7 +1063,7 @@ async def test_get_query_for_sql_compound_names(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1075,18 +1075,18 @@ async def test_get_query_for_sql_compound_names(
             ),
         ],
     )
-    node_a_ref = Node(name="core.A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="core.A", current_version="1")
+    node_a.node = node_a_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    node_b_ref = Node(name="core.B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="core.B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM core.A",
         parents=[node_a_ref],
     )
@@ -1122,7 +1122,7 @@ async def test_get_query_for_sql_multiple_databases(
     database_2 = Database(id=2, name="fast", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database_1,
@@ -1145,18 +1145,18 @@ async def test_get_query_for_sql_multiple_databases(
             Column(name="two", type=ColumnType.STR),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
     engine = create_engine(database_1.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    node_b_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
     )
@@ -1192,7 +1192,7 @@ async def test_get_query_for_sql_multiple_metrics(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1208,27 +1208,27 @@ async def test_get_query_for_sql_multiple_metrics(
             Column(name="two", type=ColumnType.STR),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    node_b_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
     )
     session.add(node_b)
 
-    node_c_ref = Node(name="C", current_version=1, type=NodeType.METRIC)
+    node_c_ref = Node(name="C", current_version="1", type=NodeType.METRIC)
     node_c = NodeRevision(
-        reference_node=node_c_ref,
-        version=1,
+        node=node_c_ref,
+        version="1",
         query="SELECT MAX(one) AS max_one FROM A",
         parents=[node_a_ref],
     )
@@ -1263,7 +1263,7 @@ async def test_get_query_for_sql_non_identifiers(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1279,26 +1279,26 @@ async def test_get_query_for_sql_non_identifiers(
             Column(name="two", type=ColumnType.STR),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    node_b_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
     )
     session.add(node_b)
-    node_c_ref = Node(name="C", current_version=1, type=NodeType.METRIC)
+    node_c_ref = Node(name="C", current_version="1", type=NodeType.METRIC)
     node_c = NodeRevision(
-        reference_node=node_c_ref,
-        version=1,
+        node=node_c_ref,
+        version="1",
         query="SELECT MAX(one) AS max_one FROM A",
         parents=[node_a_ref],
     )
@@ -1333,7 +1333,7 @@ async def test_get_query_for_sql_different_parents(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1345,10 +1345,10 @@ async def test_get_query_for_sql_different_parents(
             ),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
     node_b = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1360,20 +1360,20 @@ async def test_get_query_for_sql_different_parents(
             ),
         ],
     )
-    node_b_ref = Node(name="B", current_version=1)
-    node_b.reference_node = node_b_ref
+    node_b_ref = Node(name="B", current_version="1")
+    node_b.node = node_b_ref
     node_c = NodeRevision(
-        version=1,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
     )
-    node_c_ref = Node(name="C", current_version=1, type=NodeType.METRIC)
-    node_c.reference_node = node_c_ref
+    node_c_ref = Node(name="C", current_version="1", type=NodeType.METRIC)
+    node_c.node = node_c_ref
     session.add(node_c)
-    node_d_ref = Node(name="D", type=NodeType.METRIC, current_version=1)
+    node_d_ref = Node(name="D", type=NodeType.METRIC, current_version="1")
     node_d = NodeRevision(
-        reference_node=node_d_ref,
-        version=1,
+        node=node_d_ref,
+        version="1",
         query="SELECT MAX(one) AS max_one FROM A",
         parents=[node_b_ref],
     )
@@ -1400,7 +1400,7 @@ async def test_get_query_for_sql_not_metric(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1412,13 +1412,13 @@ async def test_get_query_for_sql_not_metric(
             ),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
-    node_b_ref = Node(name="B", current_version=1)
+    node_b_ref = Node(name="B", current_version="1")
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT one FROM A",
         parents=[node_a_ref],
     )
@@ -1443,16 +1443,16 @@ async def test_get_query_for_sql_no_databases(
     get_session().__next__.return_value = session
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
-    node_b_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
     )
@@ -1476,7 +1476,7 @@ async def test_get_query_for_sql_alias(mocker: MockerFixture, session: Session) 
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1488,18 +1488,18 @@ async def test_get_query_for_sql_alias(mocker: MockerFixture, session: Session) 
             ),
         ],
     )
-    node_a_ref = Node(name="A", current_version=1)
-    node_a.reference_node = node_a_ref
+    node_a_ref = Node(name="A", current_version="1")
+    node_a.node = node_a_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    node_b_ref = Node(name="B", current_version=1, type=NodeType.METRIC)
+    node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
     )
@@ -1534,7 +1534,7 @@ async def test_get_query_for_sql_where_groupby(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     comments = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1546,8 +1546,8 @@ async def test_get_query_for_sql_where_groupby(
             ),
         ],
     )
-    comments_ref = Node(name="core.comments", current_version=1)
-    comments.reference_node = comments_ref
+    comments_ref = Node(name="core.comments", current_version="1")
+    comments.node = comments_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
@@ -1556,11 +1556,11 @@ async def test_get_query_for_sql_where_groupby(
 
     num_comments_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
-        reference_node=num_comments_ref,
+        node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
         parents=[comments_ref],
@@ -1601,7 +1601,7 @@ async def test_get_query_for_sql_where_groupby_num(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     comments = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1613,8 +1613,8 @@ async def test_get_query_for_sql_where_groupby_num(
             ),
         ],
     )
-    comments_ref = Node(name="core.comments", current_version=1)
-    comments.reference_node = comments_ref
+    comments_ref = Node(name="core.comments", current_version="1")
+    comments.node = comments_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
@@ -1623,11 +1623,11 @@ async def test_get_query_for_sql_where_groupby_num(
 
     num_comments_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
-        reference_node=num_comments_ref,
+        node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
         parents=[comments_ref],
@@ -1668,7 +1668,7 @@ async def test_get_query_for_sql_date_trunc(
     database = Database(id=1, name="db", URI="sqlite://")
 
     comments = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1680,8 +1680,8 @@ async def test_get_query_for_sql_date_trunc(
             ),
         ],
     )
-    comments_ref = Node(name="core.comments", current_version=1)
-    comments.reference_node = comments_ref
+    comments_ref = Node(name="core.comments", current_version="1")
+    comments.node = comments_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
@@ -1690,11 +1690,11 @@ async def test_get_query_for_sql_date_trunc(
 
     num_comments_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
-        reference_node=num_comments_ref,
+        node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
         parents=[comments_ref],
@@ -1737,7 +1737,7 @@ async def test_get_query_for_sql_invalid_column(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     comments = NodeRevision(
-        version=1,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1749,8 +1749,8 @@ async def test_get_query_for_sql_invalid_column(
             ),
         ],
     )
-    comments_ref = Node(name="core.comments", current_version=1)
-    comments.reference_node = comments_ref
+    comments_ref = Node(name="core.comments", current_version="1")
+    comments.node = comments_ref
 
     engine = create_engine(database.URI)
     connection = engine.connect()
@@ -1759,11 +1759,11 @@ async def test_get_query_for_sql_invalid_column(
 
     num_comments_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
-        reference_node=num_comments_ref,
+        node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
         parents=[comments_ref],
@@ -1802,11 +1802,11 @@ def test_find_on_clause(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="one", URI="sqlite://")
 
-    dimension_ref = Node(name="core.users", current_version=1)
+    dimension_ref = Node(name="core.users", current_version="1")
     dimension = NodeRevision(
         name=dimension_ref.name,
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         type=NodeType.DIMENSION,
         tables=[
             Table(
@@ -1827,11 +1827,11 @@ def test_find_on_clause(mocker: MockerFixture) -> None:
     )
     dimension_ref.current = dimension
 
-    parent_ref = Node(name="core.comments", current_version=1)
+    parent_ref = Node(name="core.comments", current_version="1")
     parent = NodeRevision(
         name=parent_ref.name,
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1855,11 +1855,11 @@ def test_find_on_clause(mocker: MockerFixture) -> None:
     )
     parent_ref.current = parent
 
-    child_ref = Node(name="core.num_comments", current_version=1)
+    child_ref = Node(name="core.num_comments", current_version="1")
     child = NodeRevision(
         name=child_ref.name,
         type=child_ref.type,
-        reference_node=child_ref,
+        node=child_ref,
         verison=1,
         parents=[parent_ref],
     )
@@ -1884,13 +1884,13 @@ def test_find_on_clause_parent_no_columns(mocker: MockerFixture) -> None:
 
     dimension_ref = Node(
         name="core.users",
-        current_version=1,
+        current_version="1",
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
         name=dimension_ref.name,
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         type=NodeType.DIMENSION,
         tables=[
             Table(
@@ -1911,12 +1911,12 @@ def test_find_on_clause_parent_no_columns(mocker: MockerFixture) -> None:
     )
     dimension_ref.current = dimension
 
-    parent_1_ref = Node(name="core.comments", current_version=1)
+    parent_1_ref = Node(name="core.comments", current_version="1")
     parent_1 = NodeRevision(
         name=parent_1_ref.name,
         type=parent_1_ref.type,
-        reference_node=parent_1_ref,
-        version=1,
+        node=parent_1_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1940,12 +1940,12 @@ def test_find_on_clause_parent_no_columns(mocker: MockerFixture) -> None:
     )
     parent_1_ref.current = parent_1
 
-    parent_2_ref = Node(name="a_weird_node", current_version=1)
+    parent_2_ref = Node(name="a_weird_node", current_version="1")
     parent_2 = NodeRevision(
         name=parent_1_ref.name,
         type=parent_1_ref.type,
-        reference_node=parent_2_ref,
-        version=1,
+        node=parent_2_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -1957,12 +1957,12 @@ def test_find_on_clause_parent_no_columns(mocker: MockerFixture) -> None:
     )
     parent_2_ref.current = parent_2
 
-    child_ref = Node(name="core.num_comments", current_version=1)
+    child_ref = Node(name="core.num_comments", current_version="1")
     child = NodeRevision(
         name=parent_1_ref.name,
         type=parent_1_ref.type,
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         parents=[parent_2_ref, parent_1_ref],
     )
     child_ref.current = child
@@ -1982,10 +1982,10 @@ def test_find_on_clause_parent_invalid_reference(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="one", URI="sqlite://")
 
-    dimension_ref = Node(name="core.users", current_version=1)
+    dimension_ref = Node(name="core.users", current_version="1")
     dimension = NodeRevision(
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         type=NodeType.DIMENSION,
         tables=[
             Table(
@@ -2006,10 +2006,10 @@ def test_find_on_clause_parent_invalid_reference(mocker: MockerFixture) -> None:
     )
     dimension_ref.current = dimension
 
-    parent_ref = Node(name="core.comments", current_version=1)
+    parent_ref = Node(name="core.comments", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -2031,9 +2031,9 @@ def test_find_on_clause_parent_invalid_reference(mocker: MockerFixture) -> None:
 
     child_ref = Node(
         name="core.num_comments",
-        current_version=1,
+        current_version="1",
     )
-    child = NodeRevision(reference_node=child_ref, version=1, parents=[parent_ref])
+    child = NodeRevision(node=child_ref, version="1", parents=[parent_ref])
     child_ref.current = child
 
     node_select = mocker.MagicMock()
@@ -2055,12 +2055,12 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
 
     dimension_ref = Node(
         name="core.users",
-        current_version=1,
+        current_version="1",
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -2080,8 +2080,8 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
     )
     dimension_ref.current = dimension
 
-    orphan_ref = Node(name="orphan", current_version=1)
-    orphan = NodeRevision(reference_node=orphan_ref, version=1)
+    orphan_ref = Node(name="orphan", current_version="1")
+    orphan = NodeRevision(node=orphan_ref, version="1")
     orphan_ref.current = orphan
 
     with pytest.raises(Exception) as excinfo:
@@ -2090,18 +2090,18 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
 
     parent_without_columns_ref = Node(
         name="parent_without_columns",
-        current_version=1,
+        current_version="1",
     )
     parent_without_columns = NodeRevision(
-        reference_node=parent_without_columns_ref,
-        version=1,
+        node=parent_without_columns_ref,
+        version="1",
     )
     parent_without_columns_ref.current = parent_without_columns
 
-    broken_ref = Node(name="broken", current_version=1)
+    broken_ref = Node(name="broken", current_version="1")
     broken = NodeRevision(
-        reference_node=broken_ref,
-        version=1,
+        node=broken_ref,
+        version="1",
         parents=[parent_without_columns_ref],
     )
     broken_ref.current = broken
@@ -2110,10 +2110,10 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
         get_join_columns(broken_ref, dimension_ref)
     assert str(excinfo.value) == "Node broken has no columns with dimension core.users"
 
-    parent_ref = Node(name="parent", current_version=1)
+    parent_ref = Node(name="parent", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -2133,10 +2133,10 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
     )
     parent_ref.current = parent
 
-    child_ref = Node(name="child", current_version=1)
+    child_ref = Node(name="child", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         parents=[parent_without_columns_ref, parent_ref],
     )
     child_ref.current = child

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -30,10 +30,10 @@ def test_get_computable_databases() -> None:
     database_2 = Database(id=2, name="not shared", URI="sqlite://", cost=2.0)
     database_3 = Database(id=3, name="fast", URI="sqlite://", cost=0.1)
 
-    parent_a_ref = Node(name="A", current_version=1)
+    parent_a_ref = Node(name="A", current_version="1")
     parent_a = NodeRevision(
-        reference_node=parent_a_ref,
-        version=1,
+        node=parent_a_ref,
+        version="1",
         tables=[
             Table(database=database_1, table="A"),
             Table(database=database_2, table="A"),
@@ -41,18 +41,18 @@ def test_get_computable_databases() -> None:
     )
     parent_a_ref.current = parent_a
 
-    parent_b_ref = Node(name="B", current_version=1)
+    parent_b_ref = Node(name="B", current_version="1")
     parent_b = NodeRevision(
-        reference_node=parent_b_ref,
-        version=1,
+        node=parent_b_ref,
+        version="1",
         tables=[Table(database=database_1, table="B")],
     )
     parent_b_ref.current = parent_b
 
-    child_ref = Node(name="C", current_version=1)
+    child_ref = Node(name="C", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         tables=[Table(database=database_3, table="C")],
         parents=[parent_a_ref, parent_b_ref],
     )
@@ -78,10 +78,10 @@ def test_get_computable_databases_heterogeneous_columns() -> None:
     database_1 = Database(id=1, name="one", URI="sqlite://", cost=1.0)
     database_2 = Database(id=2, name="two", URI="sqlite://", cost=2.0)
 
-    parent_ref = Node(name="core.A", current_version=1)
+    parent_ref = Node(name="core.A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database_1,
@@ -106,10 +106,10 @@ def test_get_computable_databases_heterogeneous_columns() -> None:
     )
     parent_ref.current = parent
 
-    child_1_ref = Node(name="core.B", current_version=1)
+    child_1_ref = Node(name="core.B", current_version="1")
     child_1 = NodeRevision(
-        reference_node=child_1_ref,
-        version=1,
+        node=child_1_ref,
+        version="1",
         query="SELECT COUNT(core.A.user_id) FROM core.A",
         parents=[parent_ref],
     )
@@ -118,10 +118,10 @@ def test_get_computable_databases_heterogeneous_columns() -> None:
     assert {database.name for database in get_computable_databases(child_1)} == {
         "one",
     }
-    child_2_ref = Node(name="core.C", current_version=1)
+    child_2_ref = Node(name="core.C", current_version="1")
     child_2 = NodeRevision(
-        reference_node=child_2_ref,
-        version=1,
+        node=child_2_ref,
+        version="1",
         query="SELECT COUNT(user_id) FROM core.A",
         parents=[parent_ref],
     )
@@ -137,10 +137,10 @@ def test_get_referenced_columns_from_sql() -> None:
     Test ``get_referenced_columns_from_sql``.
     """
     database = Database(id=1, name="one", URI="sqlite://", cost=1.0)
-    parent_1_ref = Node(name="core.A", current_version=1)
+    parent_1_ref = Node(name="core.A", current_version="1")
     parent_1 = NodeRevision(
-        reference_node=parent_1_ref,
-        version=1,
+        node=parent_1_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -157,10 +157,10 @@ def test_get_referenced_columns_from_sql() -> None:
         ],
     )
     parent_1_ref.current = parent_1
-    parent_2_ref = Node(name="core.B", current_version=1)
+    parent_2_ref = Node(name="core.B", current_version="1")
     parent_2 = NodeRevision(
-        reference_node=parent_2_ref,
-        version=1,
+        node=parent_2_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -225,10 +225,10 @@ def test_get_dimensions() -> None:
     """
     database = Database(id=1, name="one", URI="sqlite://")
 
-    dimension_ref = Node(name="B", type=NodeType.DIMENSION, current_version=1)
+    dimension_ref = Node(name="B", type=NodeType.DIMENSION, current_version="1")
     dimension = NodeRevision(
-        reference_node=dimension_ref,
-        version=1,
+        node=dimension_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -246,10 +246,10 @@ def test_get_dimensions() -> None:
     )
     dimension_ref.current = dimension
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -267,10 +267,10 @@ def test_get_dimensions() -> None:
     )
     parent_ref.current = parent
 
-    child_ref = Node(name="C", current_version=1)
+    child_ref = Node(name="C", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT COUNT(*) FROM A",
         parents=[parent_ref],
     )
@@ -291,10 +291,10 @@ async def test_get_database_for_nodes(mocker: MockerFixture) -> None:
     session = next(get_session())
     session.exec().all.return_value = [database_1, database_2]
 
-    parent_ref = Node(name="parent", current_version=1)
+    parent_ref = Node(name="parent", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database_2,

--- a/tests/sql/inference_test.py
+++ b/tests/sql/inference_test.py
@@ -44,10 +44,10 @@ def test_evaluate_expression() -> None:
     assert evaluate_expression([], get_expression("SELECT 1.1")) == 1.1
     assert evaluate_expression([], get_expression("SELECT 'test'")) == "test"
 
-    node_a_ref = Node(name="A", current_version=1)
+    node_a_ref = Node(name="A", current_version="1")
     node_a = NodeRevision(
-        reference_node=node_a_ref,
-        version=1,
+        node=node_a_ref,
+        version="1",
         tables=[
             Table(
                 database=Database(name="test", URI="sqlite://"),
@@ -103,10 +103,10 @@ def test_evaluate_expression_ambiguous() -> None:
     In this test we select a column without using the fully qualified notation, and it
     exists in multiple parents.
     """
-    node_a_ref = Node(name="A", current_version=1)
+    node_a_ref = Node(name="A", current_version="1")
     node_a = NodeRevision(
-        reference_node=node_a_ref,
-        version=1,
+        node=node_a_ref,
+        version="1",
         tables=[
             Table(
                 database=Database(name="test", URI="sqlite://"),
@@ -126,10 +126,10 @@ def test_evaluate_expression_ambiguous() -> None:
     )
     node_a_ref.current = node_a
 
-    node_b_ref = Node(name="B", current_version=1)
+    node_b_ref = Node(name="B", current_version="1")
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         tables=[
             Table(
                 database=Database(name="test", URI="sqlite://"),
@@ -175,10 +175,10 @@ def test_evaluate_expression_parent_no_columns() -> None:
 
     Test for when one of the parents has no columns. This should never happen.
     """
-    node_a_ref = Node(name="A", current_version=1)
+    node_a_ref = Node(name="A", current_version="1")
     node_a = NodeRevision(
-        reference_node=node_a_ref,
-        version=1,
+        node=node_a_ref,
+        version="1",
         tables=[
             Table(
                 database=Database(name="test", URI="sqlite://"),
@@ -189,10 +189,10 @@ def test_evaluate_expression_parent_no_columns() -> None:
     )
     node_a_ref.current = node_a
 
-    node_b_ref = Node(name="B", current_version=1)
+    node_b_ref = Node(name="B", current_version="1")
     node_b = NodeRevision(
-        reference_node=node_b_ref,
-        version=1,
+        node=node_b_ref,
+        version="1",
         tables=[
             Table(
                 database=Database(name="test", URI="sqlite://"),
@@ -247,10 +247,10 @@ def test_infer_columns() -> None:
     """
     Test ``infer_columns``.
     """
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=Database(name="test", URI="sqlite://"),

--- a/tests/sql/transpile_test.py
+++ b/tests/sql/transpile_test.py
@@ -35,14 +35,14 @@ def test_get_select_for_node_materialized(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
-    parent = NodeRevision(name="A", reference_node=parent_ref, version=1)
+    parent_ref = Node(name="A", current_version="1")
+    parent = NodeRevision(name="A", node=parent_ref, version="1")
     parent_ref.current = parent
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -72,10 +72,10 @@ def test_get_select_for_node_not_materialized(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="db", URI="sqlite://")
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -102,10 +102,10 @@ def test_get_select_for_node_not_materialized(mocker: MockerFixture) -> None:
     connection.execute("CREATE TABLE A_fast (one TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent_ref],
     )
@@ -137,10 +137,10 @@ def test_get_select_for_node_choose_slow(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="db", URI="sqlite://")
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -171,10 +171,10 @@ def test_get_select_for_node_choose_slow(mocker: MockerFixture) -> None:
     connection.execute("CREATE TABLE A_fast (one TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT COUNT(*) AS cnt FROM A WHERE two = 'test'",
         parents=[parent_ref],
     )
@@ -197,10 +197,10 @@ def test_get_select_for_node_projection(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -223,10 +223,10 @@ def test_get_select_for_node_projection(mocker: MockerFixture) -> None:
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT one, MAX(two), 3, 4.0, 'five' FROM A",
         parents=[parent_ref],
     )
@@ -248,10 +248,10 @@ def test_get_select_for_node_where(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -274,10 +274,10 @@ def test_get_select_for_node_where(mocker: MockerFixture) -> None:
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT one, MAX(two), 3, 4.0, 'five' FROM A WHERE one > 10",
         parents=[parent_ref],
     )
@@ -300,10 +300,10 @@ def test_get_select_for_node_groupby(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -326,10 +326,10 @@ def test_get_select_for_node_groupby(mocker: MockerFixture) -> None:
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT one, MAX(two) FROM A GROUP BY one",
         parents=[parent_ref],
     )
@@ -351,10 +351,10 @@ def test_get_select_for_node_limit(mocker: MockerFixture) -> None:
     """
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
-    parent_ref = Node(name="A", current_version=1)
+    parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
-        reference_node=parent_ref,
-        version=1,
+        node=parent_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -377,10 +377,10 @@ def test_get_select_for_node_limit(mocker: MockerFixture) -> None:
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT one, MAX(two) FROM A LIMIT 10",
         parents=[parent_ref],
     )
@@ -442,10 +442,10 @@ def test_get_select_for_node_with_join(mocker: MockerFixture) -> None:
     Test ``get_select_for_node`` when the node query has a join.
     """
     database = Database(id=1, name="db", URI="sqlite://")
-    parent_1_ref = Node(name="A", current_version=1)
+    parent_1_ref = Node(name="A", current_version="1")
     parent_1 = NodeRevision(
-        reference_node=parent_1_ref,
-        version=1,
+        node=parent_1_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -462,10 +462,10 @@ def test_get_select_for_node_with_join(mocker: MockerFixture) -> None:
         ],
     )
     parent_1_ref.current = parent_1
-    parent_2_ref = Node(name="B", current_version=1)
+    parent_2_ref = Node(name="B", current_version="1")
     parent_2 = NodeRevision(
-        reference_node=parent_2_ref,
-        version=1,
+        node=parent_2_ref,
+        version="1",
         tables=[
             Table(
                 database=database,
@@ -489,10 +489,10 @@ def test_get_select_for_node_with_join(mocker: MockerFixture) -> None:
     connection.execute("CREATE TABLE B (two TEXT, three TEXT)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
-    child_ref = Node(name="B", current_version=1)
+    child_ref = Node(name="B", current_version="1")
     child = NodeRevision(
-        reference_node=child_ref,
-        version=1,
+        node=child_ref,
+        version="1",
         query="SELECT COUNT(*) FROM A JOIN B ON A.two = B.two WHERE B.three > 1",
         parents=[parent_1_ref, parent_2_ref],
     )


### PR DESCRIPTION
### Summary

I noticed that there are still instances of 'reference node' lingering in the code. This PR renames all instances of reference node to node, and node to node revision. 

It also adds naming conventions for constraints in alembic migrations with `BaseSQLModel`. This means that using alembic's autogenerate tool will generate constraints with names that follow the defined convention by default.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A