### PR TITLE
Adding display name to node and modify responses for read node endpoints

### DIFF
--- a/alembic/versions/2023_02_07_1723-2bdcec2d24a7_add_display_name_to_nodes.py
+++ b/alembic/versions/2023_02_07_1723-2bdcec2d24a7_add_display_name_to_nodes.py
@@ -23,10 +23,6 @@ def upgrade():
     with op.batch_alter_table("node") as batch_op:
         batch_op.add_column(sa.Column("display_name", sa.String(), nullable=True))
         batch_op.drop_constraint("uniq_node_name", type_="unique")
-        batch_op.create_unique_constraint(
-            op.f("uq_node_display_name"),
-            ["display_name"],
-        )
         batch_op.create_unique_constraint(op.f("uq_node_name"), ["name"])
     with op.batch_alter_table("noderevision") as batch_op:
         batch_op.add_column(sa.Column("display_name", sa.String(), nullable=True))
@@ -44,6 +40,5 @@ def downgrade():
 
     with op.batch_alter_table("node") as batch_op:
         batch_op.drop_constraint(op.f("uq_node_name"), type_="unique")
-        batch_op.drop_constraint(op.f("uq_node_display_name"), type_="unique")
         batch_op.create_unique_constraint("uniq_node_name", ["name"])
         batch_op.drop_column("display_name")

--- a/alembic/versions/2023_02_07_1723-2bdcec2d24a7_add_display_name_to_nodes.py
+++ b/alembic/versions/2023_02_07_1723-2bdcec2d24a7_add_display_name_to_nodes.py
@@ -1,0 +1,49 @@
+"""Add display name to nodes
+
+Revision ID: 2bdcec2d24a7
+Revises: 03aaf20e6ab6
+Create Date: 2023-02-07 17:23:09.239258+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2bdcec2d24a7"
+down_revision = "03aaf20e6ab6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("node") as batch_op:
+        batch_op.add_column(sa.Column("display_name", sa.String(), nullable=True))
+        batch_op.drop_constraint("uniq_node_name", type_="unique")
+        batch_op.create_unique_constraint(
+            op.f("uq_node_display_name"),
+            ["display_name"],
+        )
+        batch_op.create_unique_constraint(op.f("uq_node_name"), ["name"])
+    with op.batch_alter_table("noderevision") as batch_op:
+        batch_op.add_column(sa.Column("display_name", sa.String(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_noderevision_display_name_node",
+            "node",
+            ["display_name"],
+            ["display_name"],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("noderevision") as batch_op:
+        batch_op.drop_column("display_name")
+
+    with op.batch_alter_table("node") as batch_op:
+        batch_op.drop_constraint(op.f("uq_node_name"), type_="unique")
+        batch_op.drop_constraint(op.f("uq_node_display_name"), type_="unique")
+        batch_op.create_unique_constraint("uniq_node_name", ["name"])
+        batch_op.drop_column("display_name")

--- a/dj/api/graphql/metric.py
+++ b/dj/api/graphql/metric.py
@@ -27,6 +27,7 @@ from dj.sql.build import get_query_for_node
     fields=[
         "id",
         "name",
+        "display_name",
         "description",
         "query",
         "dimensions",

--- a/dj/api/metrics.py
+++ b/dj/api/metrics.py
@@ -27,6 +27,7 @@ class Metric(SQLModel):
 
     id: int
     name: str
+    display_name: str
     current_version: str
     description: str = ""
 

--- a/dj/cli/compile.py
+++ b/dj/cli/compile.py
@@ -32,7 +32,7 @@ from dj.constants import (
 )
 from dj.models.column import Column
 from dj.models.database import Database
-from dj.models.node import Node, NodeRevision, NodeType, NodeYAML
+from dj.models.node import Node, NodeRevision, NodeType, NodeYAML, labelize
 from dj.models.query import Query  # pylint: disable=unused-import
 from dj.models.table import Table
 from dj.sql.dag import render_dag
@@ -387,6 +387,9 @@ async def add_node(  # pylint: disable=too-many-locals
 
     config = {
         "name": name,
+        "display_name": data["display_name"]
+        if "display_name" in data
+        else labelize(name),
         "description": data["description"],
         "updated_at": datetime.now(timezone.utc),
         "type": data["type"],

--- a/dj/models/column.py
+++ b/dj/models/column.py
@@ -2,7 +2,7 @@
 Models for columns.
 """
 
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, Optional, Tuple, TypedDict
 
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlmodel import Field, Relationship
@@ -46,6 +46,12 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         return {
             "type": str(self.type),  # pylint: disable=no-member
         }
+
+    def identifier(self) -> Tuple[str, ColumnType]:
+        """
+        Unique identifier for this column.
+        """
+        return self.name, self.type
 
     def __hash__(self) -> int:
         return hash(self.id)

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -155,7 +155,6 @@ class NodeBase(BaseSQLModel):
         sa_column=SqlaColumn(
             "display_name",
             String,
-            unique=True,
             default=generate_display_name("name"),
         ),
         max_length=100,
@@ -175,7 +174,6 @@ class NodeRevisionBase(BaseSQLModel):
         sa_column=SqlaColumn(
             "display_name",
             String,
-            unique=False,
             default=generate_display_name("name"),
         ),
         foreign_key="node.display_name",

--- a/dj/models/table.py
+++ b/dj/models/table.py
@@ -2,7 +2,7 @@
 Models for tables.
 """
 
-from typing import TYPE_CHECKING, List, Optional, TypedDict
+from typing import TYPE_CHECKING, List, Optional, Tuple, TypedDict
 
 from sqlmodel import Field, Relationship
 
@@ -111,6 +111,12 @@ class Table(TableBase, table=True):  # type: ignore
             "table": self.table,
             "cost": self.cost,
         }
+
+    def identifier(self) -> Tuple[Optional[str], Optional[str], str]:
+        """
+        Unique identifier for this table.
+        """
+        return self.catalog, self.schema_, self.table
 
     def __hash__(self):
         return hash(self.id)

--- a/examples/configs/nodes/basic/dimension/countries.yaml
+++ b/examples/configs/nodes/basic/dimension/countries.yaml
@@ -1,4 +1,5 @@
 description: Country dimension
+display_name: 'Basic: Dimension: Countries'
 type: dimension
 query: |-
   SELECT country,

--- a/examples/configs/nodes/basic/dimension/users.yaml
+++ b/examples/configs/nodes/basic/dimension/users.yaml
@@ -1,4 +1,5 @@
 description: User dimension
+display_name: 'Basic: Dimension: Users'
 type: dimension
 query: |-
   SELECT id,

--- a/examples/configs/nodes/basic/num_comments.yaml
+++ b/examples/configs/nodes/basic/num_comments.yaml
@@ -1,4 +1,5 @@
 description: Number of comments
+display_name: 'Basic: Num Comments'
 type: metric
 query: |-
   SELECT COUNT(1) AS cnt

--- a/examples/configs/nodes/basic/num_users.yaml
+++ b/examples/configs/nodes/basic/num_users.yaml
@@ -1,4 +1,5 @@
 description: Number of users.
+display_name: 'Basic: Num Users'
 type: metric
 query: |-
   SELECT SUM(num_users)

--- a/examples/configs/nodes/basic/source/comments.yaml
+++ b/examples/configs/nodes/basic/source/comments.yaml
@@ -1,4 +1,5 @@
 description: A fact table with comments
+display_name: 'Basic: Source: Comments'
 type: source
 columns:
   id:

--- a/examples/configs/nodes/basic/source/users.yaml
+++ b/examples/configs/nodes/basic/source/users.yaml
@@ -1,4 +1,5 @@
 description: A user table
+display_name: 'Basic: Source: Users'
 type: source
 columns:
   id:

--- a/examples/configs/nodes/basic/transform/country_agg.yaml
+++ b/examples/configs/nodes/basic/transform/country_agg.yaml
@@ -1,4 +1,5 @@
 description: Country level agg table
+display_name: 'Basic: Transform: Country Agg'
 type: transform
 query: |-
   SELECT country,

--- a/examples/configs/nodes/dbt/dimension/customers.yaml
+++ b/examples/configs/nodes/dbt/dimension/customers.yaml
@@ -1,4 +1,5 @@
 description: User dimension
+display_name: 'Dbt: Dimension: Customers'
 type: dimension
 query: |-
   SELECT id,

--- a/examples/configs/nodes/dbt/source/jaffle_shop/customers.yaml
+++ b/examples/configs/nodes/dbt/source/jaffle_shop/customers.yaml
@@ -1,4 +1,5 @@
 description: Customer table
+display_name: 'Dbt: Source: Jaffle Shop: Customers'
 type: source
 columns:
   id:

--- a/examples/configs/nodes/dbt/source/jaffle_shop/orders.yaml
+++ b/examples/configs/nodes/dbt/source/jaffle_shop/orders.yaml
@@ -1,4 +1,5 @@
 description: Orders fact table
+display_name: 'Dbt: Source: Jaffle Shop: Orders'
 type: source
 columns:
   id:

--- a/examples/configs/nodes/dbt/source/stripe/payments.yaml
+++ b/examples/configs/nodes/dbt/source/stripe/payments.yaml
@@ -1,4 +1,5 @@
 description: Payments fact table.
+display_name: 'Dbt: Source: Stripe: Payments'
 type: source
 columns:
   id:

--- a/examples/configs/nodes/dbt/transform/customer_agg.yaml
+++ b/examples/configs/nodes/dbt/transform/customer_agg.yaml
@@ -1,4 +1,5 @@
 description: Country level agg table
+display_name: 'Dbt: Transform: Customer Agg'
 type: transform
 query: |-
   SELECT "dbt.source.jaffle_shop.customers".id,

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -28,6 +28,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             current_version="1",
         )
         node_rev1 = NodeRevision(
+            name=node1.name,
             node=node1,
             version="1",
             columns=[
@@ -51,6 +52,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             current_version="1",
         )
         node_rev2 = NodeRevision(
+            name=node2.name,
             node=node2,
             version="1",
             type=NodeType.TRANSFORM,
@@ -67,6 +69,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             current_version="1",
         )
         node_rev3 = NodeRevision(
+            name=node3.name,
             node=node3,
             version="1",
             query=(

--- a/tests/api/graphql/metric_test.py
+++ b/tests/api/graphql/metric_test.py
@@ -18,13 +18,19 @@ def test_read_metrics(session: Session, client: TestClient):
     Test ``read_metrics``.
     """
     node1 = Node(name="not-a-metric", current_version="1")
-    node_rev1 = NodeRevision(node=node1, version="1")
+    node_rev1 = NodeRevision(name=node1.name, node=node1, version="1")
 
     node2 = Node(name="also-not-a-metric", current_version="1")
-    node_rev2 = NodeRevision(node=node2, version="1", query="select 42 as foo")
+    node_rev2 = NodeRevision(
+        name=node2.name,
+        node=node2,
+        version="1",
+        query="select 42 as foo",
+    )
 
     node3 = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
     node_rev3 = NodeRevision(
+        name=node3.name,
         node=node3,
         version="1",
         query="select count(*) from a_table",
@@ -40,13 +46,17 @@ def test_read_metrics(session: Session, client: TestClient):
     {
         readMetrics{
             name
+            displayName
             id
         }
     }
     """
     response = client.post("/graphql", json={"query": query})
-    print("res", response.json())
-    assert response.json() == {"data": {"readMetrics": [{"id": 3, "name": "a-metric"}]}}
+    assert response.json() == {
+        "data": {
+            "readMetrics": [{"id": 3, "name": "a-metric", "displayName": "A-Metric"}],
+        },
+    }
 
 
 def test_read_metric(session: Session, client: TestClient):
@@ -54,13 +64,19 @@ def test_read_metric(session: Session, client: TestClient):
     Test ``read_metric``.
     """
     node1 = Node(name="not-a-metric", current_version="1")
-    node_rev1 = NodeRevision(node=node1, version="1")
+    node_rev1 = NodeRevision(name=node1.name, node=node1, version="1")
 
     node2 = Node(name="also-not-a-metric", current_version="1")
-    node_rev2 = NodeRevision(node=node2, version="1", query="select 42 as foo")
+    node_rev2 = NodeRevision(
+        name=node2.name,
+        node=node2,
+        version="1",
+        query="select 42 as foo",
+    )
 
     node3 = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
     node_rev3 = NodeRevision(
+        name=node3.name,
         node=node3,
         version="1",
         query="select count(*) from a_table",
@@ -76,12 +92,17 @@ def test_read_metric(session: Session, client: TestClient):
     {
         readMetric(nodeName: "a-metric"){
             id,
-            name
+            name,
+            displayName
         }
     }
     """
     response = client.post("/graphql", json={"query": query})
-    assert response.json() == {"data": {"readMetric": {"id": 3, "name": "a-metric"}}}
+    assert response.json() == {
+        "data": {
+            "readMetric": {"id": 3, "name": "a-metric", "displayName": "A-Metric"},
+        },
+    }
 
 
 def test_read_metric_errors(session: Session, client: TestClient) -> None:
@@ -90,7 +111,12 @@ def test_read_metric_errors(session: Session, client: TestClient) -> None:
     """
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", current_version="1")
-    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
+    node_revision = NodeRevision(
+        name=node.name,
+        node=node,
+        version="1",
+        query="SELECT 1 AS col",
+    )
     session.add(database)
     session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
@@ -132,6 +158,7 @@ def test_read_metrics_data(
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
     node_revision = NodeRevision(
+        name=node.name,
         node=node,
         version="1",
         query="SELECT COUNT(*) FROM my_table",
@@ -188,6 +215,7 @@ def test_read_metrics_sql(
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", current_version="1", type=NodeType.METRIC)
     node_revision = NodeRevision(
+        name=node.name,
         node=node,
         version="1",
         query="SELECT COUNT(*) FROM my_table",
@@ -230,7 +258,12 @@ def test_read_metrics_sql_errors(session: Session, client: TestClient):
 
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", current_version="1")
-    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
+    node_revision = NodeRevision(
+        name=node.name,
+        node=node,
+        version="1",
+        query="SELECT 1 AS col",
+    )
     session.add(database)
     session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
@@ -266,7 +299,12 @@ def test_read_metrics_data_errors(session: Session, client: TestClient):
     """
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", current_version="1")
-    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
+    node_revision = NodeRevision(
+        name=node.name,
+        node=node,
+        version="1",
+        query="SELECT 1 AS col",
+    )
     session.add(database)
     session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")

--- a/tests/api/graphql/node_test.py
+++ b/tests/api/graphql/node_test.py
@@ -18,7 +18,7 @@ def test_get_nodes(session: Session, client: TestClient) -> None:
         type=NodeType.SOURCE,
         current_version="1",
     )
-    node_rev1 = NodeRevision(node=node1, version="1")
+    node_rev1 = NodeRevision(name=node1.name, node=node1, version="1")
 
     node2 = Node(
         name="also-not-a-metric",
@@ -26,6 +26,7 @@ def test_get_nodes(session: Session, client: TestClient) -> None:
         current_version="1",
     )
     node_rev2 = NodeRevision(
+        name=node2.name,
         node=node2,
         version="1",
         query="SELECT 42 AS answer",
@@ -35,6 +36,7 @@ def test_get_nodes(session: Session, client: TestClient) -> None:
     )
     node3 = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
     node_rev3 = NodeRevision(
+        name=node3.name,
         node=node3,
         version="1",
         query="SELECT COUNT(*) FROM my_table",

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -25,17 +25,23 @@ def test_read_metrics(session: Session, client: TestClient) -> None:
         type=NodeType.TRANSFORM,
         current_version="1",
     )
-    node_rev1 = NodeRevision(node=node1, version=node1.current_version)
+    node_rev1 = NodeRevision(name=node1.name, node=node1, version=node1.current_version)
 
     node2 = Node(
         name="also-not-a-metric",
         type=NodeType.TRANSFORM,
         current_version="1",
     )
-    node_rev2 = NodeRevision(node=node2, query="SELECT 42", version="1")
+    node_rev2 = NodeRevision(
+        name=node2.name,
+        node=node2,
+        query="SELECT 42",
+        version="1",
+    )
 
     node3 = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
     node_rev3 = NodeRevision(
+        name=node3.name,
         node=node3,
         version="1",
         query="SELECT COUNT(*) FROM my_table",
@@ -59,6 +65,7 @@ def test_read_metric(session: Session, client: TestClient) -> None:
     Test ``GET /metric/{node_id}/``.
     """
     parent_rev = NodeRevision(
+        name="parent",
         version="1",
         tables=[
             Table(
@@ -78,7 +85,7 @@ def test_read_metric(session: Session, client: TestClient) -> None:
         ],
     )
     parent_node = Node(
-        name="parent",
+        name=parent_rev.name,
         type=NodeType.SOURCE,
         current_version="1",
     )
@@ -90,6 +97,7 @@ def test_read_metric(session: Session, client: TestClient) -> None:
         current_version="1",
     )
     child_rev = NodeRevision(
+        name=child_node.name,
         node=child_node,
         version="1",
         query="SELECT COUNT(*) FROM parent",
@@ -118,7 +126,12 @@ def test_read_metrics_errors(session: Session, client: TestClient) -> None:
         type=NodeType.TRANSFORM,
         current_version="1",
     )
-    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
+    node_revision = NodeRevision(
+        name=node.name,
+        node=node,
+        version="1",
+        query="SELECT 1 AS col",
+    )
     session.add(database)
     session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
@@ -144,6 +157,7 @@ def test_read_metrics_data(
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
     node_revision = NodeRevision(
+        name=node.name,
         node=node,
         version="1",
         query="SELECT COUNT(*) FROM my_table",
@@ -186,7 +200,12 @@ def test_read_metrics_data_errors(session: Session, client: TestClient) -> None:
     """
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", current_version="1")
-    node_revision = NodeRevision(node=node, version="1", query="SELECT 1 AS col")
+    node_revision = NodeRevision(
+        name=node.name,
+        node=node,
+        version="1",
+        query="SELECT 1 AS col",
+    )
     session.add(database)
     session.add(node_revision)
     session.execute("CREATE TABLE my_table (one TEXT)")
@@ -212,6 +231,7 @@ def test_read_metrics_sql(
     database = Database(name="test", URI="sqlite://")
     node = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
     node_revision = NodeRevision(
+        name=node.name,
         node=node,
         version="1",
         query="SELECT COUNT(*) FROM my_table",

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -251,6 +251,7 @@ async def test_index_nodes(
     session.add(node)
     session.add(
         NodeRevision(
+            name=node.name,
             node=node,
             version="1",
             description="A Number of comments whose config was deleted",
@@ -277,6 +278,7 @@ async def test_index_nodes(
     assert sorted(configs, key=itemgetter("name")) == [
         {
             "name": "core.comments",
+            "display_name": "Core: Comments",
             "description": "A fact table with comments",
             "mode": "published",
             "type": NodeType.SOURCE,
@@ -289,6 +291,7 @@ async def test_index_nodes(
         },
         {
             "name": "core.dim_users",
+            "display_name": "Core: Dim Users",
             "description": "User dimension",
             "mode": "published",
             "type": NodeType.DIMENSION,
@@ -301,6 +304,7 @@ async def test_index_nodes(
         },
         {
             "name": "core.num_comments",
+            "display_name": "Core: Num Comments",
             "description": "Number of comments",
             "mode": "published",
             "type": NodeType.METRIC,
@@ -313,6 +317,7 @@ async def test_index_nodes(
         },
         {
             "name": "core.users",
+            "display_name": "Core: Users",
             "description": "A user table",
             "mode": "published",
             "type": NodeType.SOURCE,
@@ -561,6 +566,7 @@ async def test_update_node_config_user_attributes(
 
     node = Node(name="C", type=NodeType.SOURCE, current_version="1")
     node_revision = NodeRevision(
+        name=node.name,
         node=node,
         version="1",
         tables=[table_a, table_b],

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -32,7 +32,8 @@ http://localhost:8000/metrics/{name}/data/: Return data for a metric.
 http://localhost:8000/metrics/{name}/sql/: Return SQL for a metric.
 http://localhost:8000/nodes/validate/: Validate a node.
 http://localhost:8000/nodes/: List the available nodes.
-http://localhost:8000/nodes/{name}/: List the specified node and include all revisions.
+http://localhost:8000/nodes/{name}/: Show the active version of the specified node.
+http://localhost:8000/nodes/{name}/revisions/: List all revisions for the node.
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/graphql: GraphQL endpoint.
 """

--- a/tests/sql/build_test.py
+++ b/tests/sql/build_test.py
@@ -33,11 +33,12 @@ async def test_get_query_for_node(mocker: MockerFixture) -> None:
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     parent_ref = Node(name="A", current_version="1")
-    parent = NodeRevision(node=parent_ref, version="1")
+    parent = NodeRevision(name=parent_ref.name, node=parent_ref, version="1")
     parent_ref.current = parent
 
     child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
+        name=child_ref.name,
         node=child_ref,
         version="1",
         tables=[
@@ -72,6 +73,7 @@ async def test_get_query_for_node_with_groupbys(mocker: MockerFixture) -> None:
 
     parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
+        name=parent_ref.name,
         node=parent_ref,
         version="1",
         tables=[
@@ -93,6 +95,7 @@ async def test_get_query_for_node_with_groupbys(mocker: MockerFixture) -> None:
 
     child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
+        name=child_ref.name,
         node=child_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
@@ -125,11 +128,12 @@ async def test_get_query_for_node_specify_database(mocker: MockerFixture) -> Non
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     parent_ref = Node(name="A", current_version="1")
-    parent = NodeRevision(node=parent_ref, version="1")
+    parent = NodeRevision(name=parent_ref.name, node=parent_ref, version="1")
     parent_ref.current = parent
 
     child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
+        name=child_ref.name,
         node=child_ref,
         version="1",
         tables=[
@@ -169,11 +173,12 @@ async def test_get_query_for_node_no_databases(mocker: MockerFixture) -> None:
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     parent_ref = Node(name="A", current_version="1")
-    parent = NodeRevision(node=parent_ref, version="1")
+    parent = NodeRevision(name=parent_ref.name, node=parent_ref, version="1")
     parent_ref.current = parent
 
     child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
+        name=child_ref.name,
         node=child_ref,
         version="1",
         tables=[
@@ -206,11 +211,12 @@ async def test_get_query_for_node_no_active_databases(mocker: MockerFixture) -> 
     database.do_ping = mocker.AsyncMock(return_value=False)
 
     parent_ref = Node(name="A", current_version="1")
-    parent = NodeRevision(node=parent_ref, version="1")
+    parent = NodeRevision(name=parent_ref.name, node=parent_ref, version="1")
     parent_ref.current = parent
 
     child_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
+        name=child_ref.name,
         node=child_ref,
         version="1",
         tables=[
@@ -350,6 +356,7 @@ async def test_get_query_for_node_with_multiple_dimensions(
 
     dimension_1_ref = Node(name="core.users", current_version="1")
     dimension_1 = NodeRevision(
+        name=dimension_1_ref.name,
         node=dimension_1_ref,
         version="1",
         type=NodeType.DIMENSION,
@@ -374,6 +381,7 @@ async def test_get_query_for_node_with_multiple_dimensions(
 
     dimension_2_ref = Node(name="core.bands", current_version="1")
     dimension_2 = NodeRevision(
+        name=dimension_2_ref.name,
         node=dimension_2_ref,
         version="1",
         type=NodeType.DIMENSION,
@@ -398,6 +406,7 @@ async def test_get_query_for_node_with_multiple_dimensions(
 
     parent_ref = Node(name="core.comments", current_version="1")
     parent = NodeRevision(
+        name=parent_ref.name,
         node=parent_ref,
         version="1",
         tables=[
@@ -542,6 +551,7 @@ async def test_get_query_for_sql(mocker: MockerFixture, session: Session) -> Non
 
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -606,6 +616,7 @@ async def test_get_query_for_sql_no_metrics(
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
+        name=dimension_ref.name,
         node=dimension_ref,
         version="1",
         tables=[
@@ -653,6 +664,7 @@ FROM dim_users) AS "core.users"'''
         type=NodeType.DIMENSION,
     )
     other_dimension = NodeRevision(
+        name=other_ref.name,
         node=other_ref,
         version="1",
         columns=[
@@ -707,6 +719,7 @@ async def test_get_query_for_sql_having(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -729,6 +742,7 @@ async def test_get_query_for_sql_having(
 
     node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
@@ -776,6 +790,7 @@ async def test_get_query_for_sql_with_dimensions(  # pylint: disable=too-many-lo
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
+        name=dimension_ref.name,
         node=dimension_ref,
         version="1",
         tables=[
@@ -797,6 +812,7 @@ async def test_get_query_for_sql_with_dimensions(  # pylint: disable=too-many-lo
     )
 
     parent = NodeRevision(
+        name="core.comments",
         version="1",
         tables=[
             Table(
@@ -892,6 +908,7 @@ async def test_get_query_for_sql_with_dimensions_order_by(  # pylint: disable=to
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
+        name=dimension_ref.name,
         node=dimension_ref,
         version="1",
         tables=[
@@ -913,6 +930,7 @@ async def test_get_query_for_sql_with_dimensions_order_by(  # pylint: disable=to
     )
 
     parent = NodeRevision(
+        name="core.comments",
         version="1",
         tables=[
             Table(
@@ -1063,6 +1081,7 @@ async def test_get_query_for_sql_compound_names(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="core.A",
         version="1",
         tables=[
             Table(
@@ -1085,6 +1104,7 @@ async def test_get_query_for_sql_compound_names(
 
     node_b_ref = Node(name="core.B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM core.A",
@@ -1122,6 +1142,7 @@ async def test_get_query_for_sql_multiple_databases(
     database_2 = Database(id=2, name="fast", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -1155,6 +1176,7 @@ async def test_get_query_for_sql_multiple_databases(
 
     node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
@@ -1192,6 +1214,7 @@ async def test_get_query_for_sql_multiple_metrics(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -1218,6 +1241,7 @@ async def test_get_query_for_sql_multiple_metrics(
 
     node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
@@ -1227,6 +1251,7 @@ async def test_get_query_for_sql_multiple_metrics(
 
     node_c_ref = Node(name="C", current_version="1", type=NodeType.METRIC)
     node_c = NodeRevision(
+        name=node_c_ref.name,
         node=node_c_ref,
         version="1",
         query="SELECT MAX(one) AS max_one FROM A",
@@ -1263,6 +1288,7 @@ async def test_get_query_for_sql_non_identifiers(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -1289,6 +1315,7 @@ async def test_get_query_for_sql_non_identifiers(
 
     node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
@@ -1297,6 +1324,7 @@ async def test_get_query_for_sql_non_identifiers(
     session.add(node_b)
     node_c_ref = Node(name="C", current_version="1", type=NodeType.METRIC)
     node_c = NodeRevision(
+        name=node_c_ref.name,
         node=node_c_ref,
         version="1",
         query="SELECT MAX(one) AS max_one FROM A",
@@ -1333,6 +1361,7 @@ async def test_get_query_for_sql_different_parents(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -1348,6 +1377,7 @@ async def test_get_query_for_sql_different_parents(
     node_a_ref = Node(name="A", current_version="1")
     node_a.node = node_a_ref
     node_b = NodeRevision(
+        name="B",
         version="1",
         tables=[
             Table(
@@ -1363,6 +1393,7 @@ async def test_get_query_for_sql_different_parents(
     node_b_ref = Node(name="B", current_version="1")
     node_b.node = node_b_ref
     node_c = NodeRevision(
+        name="C",
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
         parents=[node_a_ref],
@@ -1372,6 +1403,7 @@ async def test_get_query_for_sql_different_parents(
     session.add(node_c)
     node_d_ref = Node(name="D", type=NodeType.METRIC, current_version="1")
     node_d = NodeRevision(
+        name=node_d_ref.name,
         node=node_d_ref,
         version="1",
         query="SELECT MAX(one) AS max_one FROM A",
@@ -1400,6 +1432,7 @@ async def test_get_query_for_sql_not_metric(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -1417,6 +1450,7 @@ async def test_get_query_for_sql_not_metric(
 
     node_b_ref = Node(name="B", current_version="1")
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT one FROM A",
@@ -1443,6 +1477,7 @@ async def test_get_query_for_sql_no_databases(
     get_session().__next__.return_value = session
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[],
     )
@@ -1451,6 +1486,7 @@ async def test_get_query_for_sql_no_databases(
 
     node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
@@ -1476,6 +1512,7 @@ async def test_get_query_for_sql_alias(mocker: MockerFixture, session: Session) 
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     node_a = NodeRevision(
+        name="A",
         version="1",
         tables=[
             Table(
@@ -1498,6 +1535,7 @@ async def test_get_query_for_sql_alias(mocker: MockerFixture, session: Session) 
 
     node_b_ref = Node(name="B", current_version="1", type=NodeType.METRIC)
     node_b = NodeRevision(
+        name=node_b_ref.name,
         node=node_b_ref,
         version="1",
         query="SELECT COUNT(*) AS cnt FROM A",
@@ -1534,6 +1572,7 @@ async def test_get_query_for_sql_where_groupby(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     comments = NodeRevision(
+        name="core.comments",
         version="1",
         tables=[
             Table(
@@ -1560,6 +1599,7 @@ async def test_get_query_for_sql_where_groupby(
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
+        name=num_comments_ref.name,
         node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
@@ -1601,6 +1641,7 @@ async def test_get_query_for_sql_where_groupby_num(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     comments = NodeRevision(
+        name="core.comments",
         version="1",
         tables=[
             Table(
@@ -1627,6 +1668,7 @@ async def test_get_query_for_sql_where_groupby_num(
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
+        name=num_comments_ref.name,
         node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
@@ -1668,6 +1710,7 @@ async def test_get_query_for_sql_date_trunc(
     database = Database(id=1, name="db", URI="sqlite://")
 
     comments = NodeRevision(
+        name="core.comments",
         version="1",
         tables=[
             Table(
@@ -1685,7 +1728,7 @@ async def test_get_query_for_sql_date_trunc(
 
     engine = create_engine(database.URI)
     connection = engine.connect()
-    connection.execute("CREATE TABLE comments (user_id INT, timestamp TIMESTAMP)")
+    connection.execute("CREATE TABLE comments (user_id INT, timestamp DATETIME)")
     mocker.patch("dj.models.database.create_engine", return_value=engine)
 
     num_comments_ref = Node(
@@ -1694,6 +1737,7 @@ async def test_get_query_for_sql_date_trunc(
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
+        name=num_comments_ref.name,
         node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
@@ -1737,6 +1781,7 @@ async def test_get_query_for_sql_invalid_column(
     database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
 
     comments = NodeRevision(
+        name="core.comments",
         version="1",
         tables=[
             Table(
@@ -1763,6 +1808,7 @@ async def test_get_query_for_sql_invalid_column(
         type=NodeType.METRIC,
     )
     num_comments = NodeRevision(
+        name=num_comments_ref.name,
         node=num_comments_ref,
         verison=1,
         query="SELECT COUNT(*) FROM core.comments",
@@ -1984,6 +2030,7 @@ def test_find_on_clause_parent_invalid_reference(mocker: MockerFixture) -> None:
 
     dimension_ref = Node(name="core.users", current_version="1")
     dimension = NodeRevision(
+        name=dimension_ref.name,
         node=dimension_ref,
         version="1",
         type=NodeType.DIMENSION,
@@ -2008,6 +2055,7 @@ def test_find_on_clause_parent_invalid_reference(mocker: MockerFixture) -> None:
 
     parent_ref = Node(name="core.comments", current_version="1")
     parent = NodeRevision(
+        name=parent_ref.name,
         node=parent_ref,
         version="1",
         tables=[
@@ -2033,7 +2081,12 @@ def test_find_on_clause_parent_invalid_reference(mocker: MockerFixture) -> None:
         name="core.num_comments",
         current_version="1",
     )
-    child = NodeRevision(node=child_ref, version="1", parents=[parent_ref])
+    child = NodeRevision(
+        name=child_ref.name,
+        node=child_ref,
+        version="1",
+        parents=[parent_ref],
+    )
     child_ref.current = child
 
     node_select = mocker.MagicMock()
@@ -2059,6 +2112,7 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
         type=NodeType.DIMENSION,
     )
     dimension = NodeRevision(
+        name=dimension_ref.name,
         node=dimension_ref,
         version="1",
         tables=[
@@ -2081,7 +2135,7 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
     dimension_ref.current = dimension
 
     orphan_ref = Node(name="orphan", current_version="1")
-    orphan = NodeRevision(node=orphan_ref, version="1")
+    orphan = NodeRevision(name=orphan_ref.name, node=orphan_ref, version="1")
     orphan_ref.current = orphan
 
     with pytest.raises(Exception) as excinfo:
@@ -2093,6 +2147,7 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
         current_version="1",
     )
     parent_without_columns = NodeRevision(
+        name=parent_without_columns_ref.name,
         node=parent_without_columns_ref,
         version="1",
     )
@@ -2100,6 +2155,7 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
 
     broken_ref = Node(name="broken", current_version="1")
     broken = NodeRevision(
+        name=broken_ref.name,
         node=broken_ref,
         version="1",
         parents=[parent_without_columns_ref],
@@ -2112,6 +2168,7 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
 
     parent_ref = Node(name="parent", current_version="1")
     parent = NodeRevision(
+        name=parent_ref.name,
         node=parent_ref,
         version="1",
         tables=[
@@ -2135,6 +2192,7 @@ def test_get_join_columns() -> None:  # pylint: disable=too-many-locals
 
     child_ref = Node(name="child", current_version="1")
     child = NodeRevision(
+        name=child_ref.name,
         node=child_ref,
         version="1",
         parents=[parent_without_columns_ref, parent_ref],


### PR DESCRIPTION
### Summary

* Add `display_name` to nodes, providing a human-readable version of a node's name. 
* Add an endpoint for listing all revisions for a given node (`GET /nodes/{name}/revisions/`)
* Modify the response model for nodes to return a flattened `NodeRevision` output model along with the node's `created_at` timestamp. It now looks like this without the nesting:
```
{
  "node_revision_id": 3,
  "node_id": 3,
  "type": "source",
  "name": "basic.source.users",
  "display_name": "Users",
  "version": "1",
  "description": "A user table",
  "query": null,
  "availability": null,
  "columns": [
    {
      "name": "id",
      "type": "INT"
    },
    ...
  ],
  "tables": [
    ...
  ],
  "updated_at": "2023-02-08T16:43:28.935144+00:00",
  "created_at": "2023-02-07T17:38:50.343389+00:00"
}
```

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #300
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan
