### PR TITLE
add agg and filter columns from api to projections

### DIFF
--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -5,6 +5,7 @@ import re
 
 # pylint: disable=R0401,C0302
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass, field, fields
 from enum import Enum
 from itertools import chain, zip_longest
@@ -140,6 +141,12 @@ class Node(ABC):
         for child in flatten(value):
             if isinstance(child, Node) and not key.startswith("_"):
                 child.set_parent(self, key)
+
+    def copy(self: TNode) -> TNode:
+        """
+        Create a deep copy of the `self`
+        """
+        return deepcopy(self)
 
     def get_nearest_parent_of_type(
         self: "Node",
@@ -951,6 +958,7 @@ class Column(Named):
     _table: Optional["TableExpression"] = field(repr=False, default=None)
     _type: Optional["ColumnType"] = field(repr=False, default=None)
     _expression: Optional[Expression] = field(repr=False, default=None)
+    _api_column: bool = False
 
     def add_type(self, type_: ColumnType) -> "Column":
         """
@@ -971,6 +979,20 @@ class Column(Named):
         Add a referenced expression
         """
         self._expression = expression
+        return self
+
+    @property
+    def is_api_column(self) -> bool:
+        """
+        Is the column added from the api?
+        """
+        return self._api_column
+
+    def set_api_column(self, api_column: bool = False) -> "Column":
+        """
+        Set the api column flag
+        """
+        self._api_column = api_column
         return self
 
     @property

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -73,8 +73,11 @@ async def test_build_metric_with_dimensions_aggs(mocker, request):
         aggs=["basic.dimension.users.country", "basic.dimension.users.gender"],
     )
 
-    expected = """
-    SELECT  COUNT(1) AS cnt
+    expecteds = (
+        """
+    SELECT  COUNT(1) AS cnt,
+    basic_DOT_dimension_DOT_users.gender,
+    basic_DOT_dimension_DOT_users.country
     FROM basic.comments
     LEFT JOIN (SELECT  basic.comments.id,
         basic.comments.full_name,
@@ -88,9 +91,28 @@ async def test_build_metric_with_dimensions_aggs(mocker, request):
     ) AS basic_DOT_dimension_DOT_users
             ON basic.comments.user_id = basic_DOT_dimension_DOT_users.id
     GROUP BY  basic_DOT_dimension_DOT_users.country, basic_DOT_dimension_DOT_users.gender
-    """
+    """,
+        """
+    SELECT  COUNT(1) AS cnt,
+    basic_DOT_dimension_DOT_users.country,
+    basic_DOT_dimension_DOT_users.gender
+    FROM basic.comments
+    LEFT JOIN (SELECT  basic.comments.id,
+        basic.comments.full_name,
+        basic.comments.age,
+        basic.comments.country,
+        basic.comments.gender,
+        basic.comments.preferred_language,
+        basic.comments.secret_number
+    FROM basic.comments
 
-    assert compare_query_strings(str(query), expected)
+    ) AS basic_DOT_dimension_DOT_users
+            ON basic.comments.user_id = basic_DOT_dimension_DOT_users.id
+    GROUP BY  basic_DOT_dimension_DOT_users.country, basic_DOT_dimension_DOT_users.gender
+    """,
+    )
+    str_query = str(query)
+    assert any(compare_query_strings(str_query, expected) for expected in expecteds)
 
 
 @pytest.mark.asyncio
@@ -170,7 +192,8 @@ async def test_build_metric_with_dimensions_filters(mocker, request):
     )
 
     expected = """
-    SELECT  COUNT(1) AS cnt
+    SELECT  COUNT(1) AS cnt,
+    basic_DOT_dimension_DOT_users.age
     FROM basic.comments
     LEFT JOIN (SELECT  basic.comments.id,
         basic.comments.full_name,


### PR DESCRIPTION
### Summary
In the existing build, when aggs and filter dimensions are requested for a metric (or any node) we add them to the ast in the appropriate sections (group by, where) but do not add them to the projection. This implements that along with some parts of the compile refactored to facilitate this.

### Test Plan

Unit tests 
- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan
