### PR TITLE
Add separate endpoints for adding tables and dimension labels

### DIFF
--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -1,0 +1,48 @@
+"""
+Helpers for API endpoints
+"""
+
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from dj.errors import DJException
+from dj.models import Database
+from dj.models.node import Node, NodeType
+
+
+def get_node_by_name(
+    session: Session,
+    name: str,
+    node_type: Optional[NodeType] = None,
+) -> Node:
+    """
+    Get a node by name
+    """
+    statement = select(Node).where(Node.name == name)
+    if node_type:
+        statement.where(Node.type == node_type)
+    node = session.exec(statement).one_or_none()
+    if not node:
+        raise DJException(
+            message=(
+                f"A {'' if not node_type else node_type} "
+                f"node with name `{name}` does not exist."
+            ),
+            http_status_code=404,
+        )
+    return node
+
+
+def get_database_by_name(session: Session, name: str) -> Database:
+    """
+    Get a database by name
+    """
+    statement = select(Database).where(Database.name == name)
+    database = session.exec(statement).one_or_none()
+    if not database:
+        raise DJException(
+            message=f"Database with name `{name}` does not exist.",
+            http_status_code=404,
+        )
+    return database

--- a/dj/cli/compile.py
+++ b/dj/cli/compile.py
@@ -326,26 +326,7 @@ async def index_nodes(  # pylint: disable=too-many-locals
                 nodes_to_delete.remove(node.name)
             finished.add(node.name)
 
-    # remove existing nodes that were not found when indexing current configs
-    if nodes_to_delete:
-        await asyncio.wait(
-            {remove_node(session, existing_nodes[name]) for name in nodes_to_delete},
-            return_when=asyncio.ALL_COMPLETED,
-        )
-
     return list(nodes.values())
-
-
-async def remove_node(session: Session, node: Node):
-    """
-    Remove a node.
-    """
-    _logger.info(
-        "Removing %s node %s",
-        node.type,
-        node.name,
-    )
-    session.delete(node)
 
 
 async def add_node(  # pylint: disable=too-many-locals

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -18,7 +18,7 @@ from typing_extensions import TypedDict
 
 from dj.models.base import BaseSQLModel
 from dj.models.column import Column, ColumnYAML
-from dj.models.table import CreateTable, Table, TableNodeRevision, TableYAML
+from dj.models.table import Table, TableNodeRevision, TableYAML
 from dj.sql.parse import is_metric
 from dj.typing import ColumnType
 from dj.utils import UTCDatetime
@@ -397,10 +397,6 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
                 raise Exception(
                     f"Node {self.name} of type source should not have a query",
                 )
-            if not self.tables:
-                raise Exception(
-                    f"Node {self.name} of type source needs at least one table",
-                )
 
         if self.type in {NodeType.TRANSFORM, NodeType.METRIC, NodeType.DIMENSION}:
             if not self.query:
@@ -451,7 +447,6 @@ class SourceNodeFields(BaseSQLModel):
     """
 
     columns: Dict[str, SourceNodeColumnType]
-    tables: List[CreateTable]
 
 
 class CreateNode(ImmutableNodeFields, MutableNodeFields):

--- a/dj/models/table.py
+++ b/dj/models/table.py
@@ -75,7 +75,7 @@ class Table(TableBase, table=True):  # type: ignore
     """
     A table with data.
 
-    Nodes can data in multiple tables, in different databases.
+    Nodes can have data in multiple tables, in different databases.
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -122,9 +122,19 @@ class Table(TableBase, table=True):  # type: ignore
         return hash(self.id)
 
 
+class CreateColumn(BaseSQLModel):
+    """
+    A column creation request
+    """
+
+    name: str
+    type: str
+
+
 class CreateTable(TableBase):
     """
     Create table input
     """
 
     database_name: str
+    columns: List[CreateColumn]

--- a/notebooks/DJ Runbook - Creating Nodes.ipynb
+++ b/notebooks/DJ Runbook - Creating Nodes.ipynb
@@ -36,7 +36,7 @@
    "id": "a1abb330",
    "metadata": {},
    "source": [
-    "Create some source nodes."
+    "## Create some source nodes."
    ]
   },
   {
@@ -51,19 +51,11 @@
     "    json={\n",
     "        \"columns\": {\n",
     "            \"payment_id\": {\"type\": \"INT\"},\n",
-    "            \"payment_type\": {\"type\": \"INT\", \"dimension\": \"payment_type\"},\n",
+    "            \"payment_type\": {\"type\": \"INT\"},\n",
     "            \"payment_amount\": {\"type\": \"FLOAT\"},\n",
-    "            \"customer_id\": {\"type\": \"INT\", \"dimension\": \"customers\"},\n",
+    "            \"customer_id\": {\"type\": \"INT\"},\n",
     "            \"account_type\": {\"type\": \"STR\"},\n",
     "        },\n",
-    "        \"tables\": [\n",
-    "            {\n",
-    "                \"database_name\": \"postgres\",\n",
-    "                \"catalog\": \"test\",\n",
-    "                \"schema\": \"accounting\",\n",
-    "                \"table\": \"revenue\",\n",
-    "            }\n",
-    "        ],\n",
     "        \"description\": \"A source table for revenue data\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"revenue_source\",\n",
@@ -87,16 +79,8 @@
     "            \"id\": {\"type\": \"INT\"},\n",
     "            \"account_type_name\": {\"type\": \"STR\"},\n",
     "            \"account_type_classification\": {\"type\": \"INT\"},\n",
-    "            \"preferred_payment_method\": {\"type\": \"INT\", \"dimension\": \"payment_type\"},\n",
+    "            \"preferred_payment_method\": {\"type\": \"INT\"},\n",
     "        },\n",
-    "        \"tables\": [\n",
-    "            {\n",
-    "                \"database_name\": \"postgres\",\n",
-    "                \"catalog\": \"test\",\n",
-    "                \"schema\": \"accounting\",\n",
-    "                \"table\": \"account_type\",\n",
-    "            }\n",
-    "        ],\n",
     "        \"description\": \"A source table for account type data\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"account_type_table\",\n",
@@ -121,14 +105,6 @@
     "            \"payment_type_name\": {\"type\": \"STR\"},\n",
     "            \"payment_type_classification\": {\"type\": \"INT\"},\n",
     "        },\n",
-    "        \"tables\": [\n",
-    "            {\n",
-    "                \"database_name\": \"postgres\",\n",
-    "                \"catalog\": \"test\",\n",
-    "                \"schema\": \"accounting\",\n",
-    "                \"table\": \"payment_type\",\n",
-    "            }\n",
-    "        ],\n",
     "        \"description\": \"A source table for different types of payments\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"payment_type_table\",\n",
@@ -153,14 +129,6 @@
     "            \"first_name\": {\"type\": \"STR\"},\n",
     "            \"last_name\": {\"type\": \"STR\"},\n",
     "        },\n",
-    "        \"tables\": [\n",
-    "            {\n",
-    "                \"database_name\": \"postgres\",\n",
-    "                \"catalog\": \"test\",\n",
-    "                \"schema\": \"accounting\",\n",
-    "                \"table\": \"customers\",\n",
-    "            }\n",
-    "        ],\n",
     "        \"description\": \"A source table for customer data\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"customers_table\",\n",
@@ -182,17 +150,9 @@
     "    json={\n",
     "        \"columns\": {\n",
     "            \"customer_id\": {\"type\": \"INT\"},\n",
-    "            \"account_type\": {\"type\": \"STR\", \"dimension\": \"account_type\"},\n",
-    "            \"default_payment_type\": {\"type\": \"INT\", \"dimension\": \"payment_type\"},\n",
+    "            \"account_type\": {\"type\": \"STR\"},\n",
+    "            \"default_payment_type\": {\"type\": \"INT\"},\n",
     "        },\n",
-    "        \"tables\": [\n",
-    "            {\n",
-    "                \"database_name\": \"postgres\",\n",
-    "                \"catalog\": \"test\",\n",
-    "                \"schema\": \"accounting\",\n",
-    "                \"table\": \"customers\",\n",
-    "            }\n",
-    "        ],\n",
     "        \"description\": \"A source table for customer default payment preference\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"default_payment_account_table\",\n",
@@ -207,7 +167,7 @@
    "id": "7963fc44",
    "metadata": {},
    "source": [
-    "Create some dimension nodes."
+    "## Create some dimension nodes."
    ]
   },
   {
@@ -275,7 +235,7 @@
    "id": "df453f8a",
    "metadata": {},
    "source": [
-    "Create some transform nodes."
+    "## Create some transform nodes."
    ]
   },
   {
@@ -323,7 +283,7 @@
    "id": "68b3fec5",
    "metadata": {},
    "source": [
-    "Create some metrics nodes."
+    "## Create some metric nodes."
    ]
   },
   {
@@ -362,6 +322,202 @@
     "        \"name\": \"number_of_account_types\",\n",
     "        \"type\": \"metric\",\n",
     "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3797feff",
+   "metadata": {},
+   "source": [
+    "## Add tables to nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcc79270",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/revenue_source/table/\",\n",
+    "    json={\n",
+    "        \"database_name\": \"postgres\",\n",
+    "        \"catalog\": \"test\",\n",
+    "        \"cost\": 1.0,\n",
+    "        \"schema\": \"accounting\",\n",
+    "        \"table\": \"revenue\",\n",
+    "        \"columns\": [\n",
+    "            {\"name\": \"payment_id\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"payment_type\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"payment_amount\", \"type\": \"FLOAT\"},\n",
+    "            {\"name\": \"customer_id\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"account_type\", \"type\": \"STR\"},\n",
+    "        ],\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0d1b403",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/account_type_table/table/\",\n",
+    "    json={\n",
+    "        \"database_name\": \"postgres\",\n",
+    "        \"catalog\": \"test\",\n",
+    "        \"cost\": 1.0,\n",
+    "        \"schema\": \"accounting\",\n",
+    "        \"table\": \"account_type\",\n",
+    "        \"columns\": [\n",
+    "            {\"name\": \"id\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"account_type_name\", \"type\": \"STR\"},\n",
+    "            {\"name\": \"account_type_classification\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"preferred_payment_method\", \"type\": \"INT\"},\n",
+    "        ],\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acf86fc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/payment_type_table/table/\",\n",
+    "    json={\n",
+    "        \"database_name\": \"postgres\",\n",
+    "        \"catalog\": \"test\",\n",
+    "        \"cost\": 1.0,\n",
+    "        \"schema\": \"accounting\",\n",
+    "        \"table\": \"payment_type\",\n",
+    "        \"columns\": [\n",
+    "            {\"name\": \"id\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"payment_type_name\", \"type\": \"STR\"},\n",
+    "            {\"name\": \"payment_type_classification\", \"type\": \"INT\"},\n",
+    "        ],\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83700c47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/customers_table/table/\",\n",
+    "    json={\n",
+    "        \"database_name\": \"postgres\",\n",
+    "        \"catalog\": \"test\",\n",
+    "        \"cost\": 1.0,\n",
+    "        \"schema\": \"accounting\",\n",
+    "        \"table\": \"customers\",\n",
+    "        \"columns\": [\n",
+    "            {\"name\": \"customer_id\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"first_name\", \"type\": \"STR\"},\n",
+    "            {\"name\": \"last_name\", \"type\": \"STR\"},\n",
+    "        ],\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3f4633f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/default_payment_account_table/table/\",\n",
+    "    json={\n",
+    "        \"database_name\": \"postgres\",\n",
+    "        \"catalog\": \"test\",\n",
+    "        \"cost\": 1.0,\n",
+    "        \"schema\": \"accounting\",\n",
+    "        \"table\": \"default_payment_account\",\n",
+    "        \"columns\": [\n",
+    "            {\"name\": \"customer_id\", \"type\": \"INT\"},\n",
+    "            {\"name\": \"account_type\", \"type\": \"STR\"},\n",
+    "            {\"name\": \"default_payment_type\", \"type\": \"INT\"},\n",
+    "        ],\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b16a302",
+   "metadata": {},
+   "source": [
+    "## Label Foreign Keys With Dimension Nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd673aea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/revenue_source/columns/payment_type?dimension=payment_type\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fa7ad62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/revenue_source/columns/customer_id?dimension=customers\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7c75c17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/default_payment_account_table/columns/account_type?dimension=account_type\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6b15a74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/default_payment_account_table/columns/default_payment_type?dimension=payment_type\"\n",
     ")\n",
     "response.json()"
    ]

--- a/tests/api/helpers_test.py
+++ b/tests/api/helpers_test.py
@@ -1,0 +1,29 @@
+"""
+Tests for API helpers.
+"""
+
+import pytest
+from sqlmodel import Session
+
+from dj.api import helpers
+from dj.errors import DJException
+
+
+def test_raise_get_node_when_node_does_not_exist(session: Session):
+    """
+    Test raising when a node doesn't exist
+    """
+    with pytest.raises(DJException) as exc_info:
+        helpers.get_node_by_name(session=session, name="foo")
+
+    assert "A  node with name `foo` does not exist." in str(exc_info.value)
+
+
+def test_raise_get_database_when_database_does_not_exist(session: Session):
+    """
+    Test raising when a database doesn't exist
+    """
+    with pytest.raises(DJException) as exc_info:
+        helpers.get_database_by_name(session=session, name="foo")
+
+    assert "Database with name `foo` does not exist." in str(exc_info.value)

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -952,7 +952,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
 
         # Attach the payment_type dimension to the payment_type column on the company_revenue node
         response = client.post(
-            "/nodes/company_revenue/columns/payment_type?dimension=payment_type",
+            "/nodes/company_revenue/columns/payment_type/?dimension=payment_type",
         )
         data = response.json()
         assert data == {
@@ -964,7 +964,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
 
         # Check that the proper error is raised when the column doesn't exist
         response = client.post(
-            "/nodes/company_revenue/columns/non_existent_column?dimension=payment_type",
+            "/nodes/company_revenue/columns/non_existent_column/?dimension=payment_type",
         )
         assert response.status_code == 404
         data = response.json()
@@ -974,7 +974,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         )
 
         # Check that the proper error is raised when no dimension is provided
-        response = client.post("/nodes/company_revenue/columns/payment_type")
+        response = client.post("/nodes/company_revenue/columns/payment_type/")
         assert response.status_code == 400
         data = response.json()
         assert data["message"] == "A dimension node must be specified"

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -34,6 +34,8 @@ http://localhost:8000/nodes/validate/: Validate a node.
 http://localhost:8000/nodes/: List the available nodes.
 http://localhost:8000/nodes/{name}/: Show the active version of the specified node.
 http://localhost:8000/nodes/{name}/revisions/: List all revisions for the node.
+http://localhost:8000/nodes/{name}/columns/{column}/: Add information to a node column
+http://localhost:8000/nodes/{name}/table/: Add a table to a node
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/graphql: GraphQL endpoint.
 """

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -49,17 +49,6 @@ def test_extra_validation() -> None:
         type=node.type,
         node=node,
         version="1",
-    )
-    with pytest.raises(Exception) as excinfo:
-        node_revision.extra_validation()
-    assert str(excinfo.value) == "Node A of type source needs at least one table"
-
-    node = Node(name="A", type=NodeType.SOURCE, current_version="1")
-    node_revision = NodeRevision(
-        name=node.name,
-        type=node.type,
-        node=node,
-        version="1",
         query="SELECT * FROM B",
     )
     with pytest.raises(Exception) as excinfo:


### PR DESCRIPTION
### Summary

This adds two new endpoints:
```
http://localhost:8000/nodes/{name}/{column}/dimension/{dimension}/: Add a dimension to a column on a node
http://localhost:8000/nodes/{name}/table/: Add a table to a node
```

The sequence through the API can be seen in the updated [runbook](https://github.com/DataJunction/dj/blob/bb7be38f73fc75a9d9fbb4f2f392190bce40f6d8/notebooks/DJ%20Runbook%20-%20Creating%20Nodes.ipynb). The existing endpoint for creating nodes now purely focuses on creating nodes and doesn't incorporate tables or dimension labels. After creating nodes, tables and dimension labels are added in follow-up requests.

Another thing to consider here is that these linkages are not versioned and adding links happens only on the current version of the node. (Looking to follow-up with delete endpoints for these). We can always update this later to version these which would just be a small change to create a new `NodeRevision` each time, but I think there's something to the idea of these links being light and very easy to aggressively set and unset. There's always the requirement of "knowing what happened" but maybe activity logging could be something we consider as an alternative to always bumping the version.

### Test Plan

Ran `make check` and `make test`. Also ran `docker compose up` and tested that the endpoints work as expected.

- [x] PR has an associated issue: #308 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
