### PR TITLE
Allow specifying specific dimension_column

### DIFF
--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -56,6 +56,7 @@ def get_column(node: NodeRevision, column_name: str) -> Column:
     for node_column in node.columns:
         if node_column.name == column_name:
             requested_column = node_column
+            break
 
     if not requested_column:
         raise DJException(

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -7,8 +7,8 @@ from typing import Optional
 from sqlmodel import Session, select
 
 from dj.errors import DJException
-from dj.models import Database
-from dj.models.node import Node, NodeType
+from dj.models import Column, Database
+from dj.models.node import Node, NodeRevision, NodeType
 
 
 def get_node_by_name(
@@ -46,3 +46,20 @@ def get_database_by_name(session: Session, name: str) -> Database:
             http_status_code=404,
         )
     return database
+
+
+def get_column(node: NodeRevision, column_name: str) -> Column:
+    """
+    Get a column from a node revision
+    """
+    requested_column = None
+    for node_column in node.columns:
+        if node_column.name == column_name:
+            requested_column = node_column
+
+    if not requested_column:
+        raise DJException(
+            message=f"Column {column_name} does not exist on node {node.name}",
+            http_status_code=404,
+        )
+    return requested_column

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -969,12 +969,27 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert response.status_code == 404
         data = response.json()
         assert data["message"] == (
-            "A column with name `non_existent_column` on node "
-            "`company_revenue` does not exist."
+            "Column non_existent_column does not " "exist on node company_revenue"
         )
 
-        # Check that the proper error is raised when no dimension is provided
-        response = client.post("/nodes/company_revenue/columns/payment_type/")
-        assert response.status_code == 400
+        # Add a dimension including a specific dimension column name
+        response = client.post(
+            "/nodes/company_revenue/columns/payment_type/"
+            "?dimension=payment_type"
+            "&dimension_column=payment_type_name",
+        )
+        assert response.status_code == 200
         data = response.json()
-        assert data["message"] == "A dimension node must be specified"
+        assert data["message"] == (
+            "Dimension node payment_type has been successfully "
+            "linked to column payment_type on node company_revenue"
+        )
+
+        # Check that not including the dimension defaults it to the column name
+        response = client.post("/nodes/company_revenue/columns/payment_type/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == (
+            "Dimension node payment_type has been successfully "
+            "linked to column payment_type on node company_revenue"
+        )

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -969,7 +969,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert response.status_code == 404
         data = response.json()
         assert data["message"] == (
-            "Column non_existent_column does not " "exist on node company_revenue"
+            "Column non_existent_column does not exist on node company_revenue"
         )
 
         # Add a dimension including a specific dimension column name


### PR DESCRIPTION
### Summary

This is a small fast-followup PR to #314. I realized I didn't fully implement the feedback offered by @agorajek [here](https://github.com/DataJunction/dj/pull/314#discussion_r1101074005). When adding a dimension and not specifying a dimension node name, the API will assume the dimension node you're looking to link has the same name as the column.

That also made me realize I didn't provide a way to specify a specific dimension node's column you want to link to (when not specified, there's a system default of `id`). So I also added an optional argument `dimension_column` that can be provided.

Besides those things, I did a little clean up by moving some logic out to a `get_columns` function in `dj/api/helpers.py`.

### Test Plan

Tested out the API, ran the runbook, ran `make check`, ran `make tests`

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A