### PR TITLE
Change catalog attribute on table to Catalog instance

### DIFF
--- a/alembic/versions/2023_02_10_0345-e19b5daa77a7_catalog_and_table_relationships.py
+++ b/alembic/versions/2023_02_10_0345-e19b5daa77a7_catalog_and_table_relationships.py
@@ -1,0 +1,68 @@
+"""catalog and table relationships
+
+Revision ID: e19b5daa77a7
+Revises: 2bdcec2d24a7
+Create Date: 2023-02-10 03:45:17.696922+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e19b5daa77a7"
+down_revision = "2bdcec2d24a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("catalog") as batch_op:
+        batch_op.add_column(
+            sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        batch_op.add_column(sa.Column("extra_params", sa.JSON(), nullable=True))
+
+    with op.batch_alter_table("engine") as batch_op:
+        batch_op.add_column(
+            sa.Column("uri", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        )
+
+    with op.batch_alter_table("table") as batch_op:
+        batch_op.add_column(sa.Column("catalog_id", sa.Integer(), nullable=True))
+        batch_op.drop_column("catalog")
+        batch_op.create_foreign_key(
+            op.f("fk_table_catalog_id_catalog"),
+            "catalog",
+            ["catalog_id"],
+            ["id"],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("catalog") as batch_op:
+        batch_op.drop_column("extra_params")
+        batch_op.drop_column("updated_at")
+        batch_op.drop_column("created_at")
+        batch_op.drop_column("uuid")
+
+    with op.batch_alter_table("engine") as batch_op:
+        batch_op.drop_column("uri")
+
+    with op.batch_alter_table("table") as batch_op:
+        batch_op.add_column(sa.Column("catalog", sa.VARCHAR(), nullable=True))
+        batch_op.drop_column("catalog_id")
+        batch_op.drop_constraint(
+            op.f("fk_table_catalog_id_catalog"),
+            type_="foreignkey",
+        )

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -7,7 +7,7 @@ from typing import Optional
 from sqlmodel import Session, select
 
 from dj.errors import DJException
-from dj.models import Column, Database
+from dj.models import Catalog, Column, Database
 from dj.models.node import Node, NodeRevision, NodeType
 
 
@@ -64,3 +64,17 @@ def get_column(node: NodeRevision, column_name: str) -> Column:
             http_status_code=404,
         )
     return requested_column
+
+
+def get_catalog(session: Session, name: str) -> Catalog:
+    """
+    Get a catalog by name
+    """
+    statement = select(Catalog).where(Catalog.name == name)
+    catalog = session.exec(statement).one_or_none()
+    if not catalog:
+        raise DJException(
+            message=f"Catalog with name `{name}` does not exist.",
+            http_status_code=404,
+        )
+    return catalog

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -12,7 +12,12 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import joinedload
 from sqlmodel import Session, SQLModel, select
 
-from dj.api.helpers import get_column, get_database_by_name, get_node_by_name
+from dj.api.helpers import (
+    get_catalog,
+    get_column,
+    get_database_by_name,
+    get_node_by_name,
+)
 from dj.construction.extract import extract_dependencies_from_node
 from dj.construction.inference import get_type_of_expression
 from dj.errors import DJError, DJException, ErrorCode
@@ -374,11 +379,14 @@ def add_table_to_node(
     """
     node = get_node_by_name(session=session, name=name)
     database = get_database_by_name(session=session, name=data.database_name)
+    catalog = get_catalog(session=session, name=data.catalog_name)
     table = Table(
-        catalog=data.catalog,
+        catalog_id=catalog.id,
+        catalog=catalog,
         schema=data.schema_,
         table=data.table,
         database_id=database.id,
+        database=database,
         cost=data.cost,
         columns=[
             Column(name=column.name, type=ColumnType(column.type))

--- a/dj/models/catalog.py
+++ b/dj/models/catalog.py
@@ -1,13 +1,22 @@
 """
 Models for columns.
 """
+from datetime import datetime, timezone
+from functools import partial
+from typing import TYPE_CHECKING, Dict, List, Optional
+from uuid import UUID, uuid4
 
-from typing import List, Optional
-
-from sqlmodel import Field, Relationship
+from sqlalchemy import DateTime
+from sqlalchemy.sql.schema import Column as SqlaColumn
+from sqlalchemy_utils import UUIDType
+from sqlmodel import JSON, Field, Relationship
 
 from dj.models.base import BaseSQLModel
 from dj.models.engine import Engine
+from dj.utils import UTCDatetime
+
+if TYPE_CHECKING:
+    from dj.models import Table
 
 
 class CatalogEngines(BaseSQLModel, table=True):  # type: ignore
@@ -33,6 +42,7 @@ class Catalog(BaseSQLModel, table=True):  # type: ignore
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
+    uuid: UUID = Field(default_factory=uuid4, sa_column=SqlaColumn(UUIDType()))
     name: str
     engines: List[Engine] = Relationship(
         link_model=CatalogEngines,
@@ -41,3 +51,16 @@ class Catalog(BaseSQLModel, table=True):  # type: ignore
             "secondaryjoin": "Engine.id==CatalogEngines.engine_id",
         },
     )
+    tables: List["Table"] = Relationship(
+        back_populates="catalog",
+        sa_relationship_kwargs={"cascade": "all, delete"},
+    )
+    created_at: UTCDatetime = Field(
+        sa_column=SqlaColumn(DateTime(timezone=True)),
+        default_factory=partial(datetime.now, timezone.utc),
+    )
+    updated_at: UTCDatetime = Field(
+        sa_column=SqlaColumn(DateTime(timezone=True)),
+        default_factory=partial(datetime.now, timezone.utc),
+    )
+    extra_params: Dict = Field(default={}, sa_column=SqlaColumn(JSON))

--- a/dj/models/engine.py
+++ b/dj/models/engine.py
@@ -17,3 +17,4 @@ class Engine(BaseSQLModel, table=True):  # type: ignore
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
     version: str
+    uri: Optional[str]

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -219,7 +219,7 @@ class AvailabilityStateBase(BaseSQLModel):
     An availability state base
     """
 
-    catalog: Optional[str] = None
+    catalog: str
     schema_: Optional[str] = Field(default=None)
     table: str
     valid_through_ts: int

--- a/dj/models/table.py
+++ b/dj/models/table.py
@@ -48,7 +48,6 @@ class TableBase(BaseSQLModel):
     A base table.
     """
 
-    catalog: Optional[str] = None
     schema_: Optional[str] = Field(default=None, alias="schema")
     table: str
     cost: float = 1.0
@@ -89,6 +88,9 @@ class Table(TableBase, table=True):  # type: ignore
         },
     )
 
+    catalog_id: Optional[int] = Field(default=None, foreign_key="catalog.id")
+    catalog: Optional["Catalog"] = Relationship(back_populates="tables")
+
     database_id: int = Field(foreign_key="database.id")
     database: "Database" = Relationship(back_populates="tables")
 
@@ -116,7 +118,12 @@ class Table(TableBase, table=True):  # type: ignore
         """
         Unique identifier for this table.
         """
-        return self.catalog, self.schema_, self.table
+        # Catalogs will soon be required and this return can be simplified
+        return (
+            self.catalog.name if self.catalog else None,  # pylint: disable=no-member
+            self.schema_,
+            self.table,
+        )
 
     def __hash__(self):
         return hash(self.id)
@@ -137,4 +144,5 @@ class CreateTable(TableBase):
     """
 
     database_name: str
+    catalog_name: str
     columns: List[CreateColumn]

--- a/dj/models/table.py
+++ b/dj/models/table.py
@@ -88,7 +88,7 @@ class Table(TableBase, table=True):  # type: ignore
         },
     )
 
-    catalog_id: Optional[int] = Field(default=None, foreign_key="catalog.id")
+    catalog_id: Optional[int] = Field(foreign_key="catalog.id")
     catalog: Optional["Catalog"] = Relationship(back_populates="tables")
 
     database_id: int = Field(foreign_key="database.id")
@@ -114,7 +114,9 @@ class Table(TableBase, table=True):  # type: ignore
             "cost": self.cost,
         }
 
-    def identifier(self) -> Tuple[Optional[str], Optional[str], str]:
+    def identifier(
+        self,
+    ) -> Tuple[Optional[str], Optional[str], str]:  # pragma: no cover
         """
         Unique identifier for this table.
         """

--- a/notebooks/DJ Runbook - Creating Nodes.ipynb
+++ b/notebooks/DJ Runbook - Creating Nodes.ipynb
@@ -328,6 +328,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "de536045",
+   "metadata": {},
+   "source": [
+    "## Add a catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28fa3d80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/catalogs/\",\n",
+    "    json={\"name\": \"test\"},\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3797feff",
    "metadata": {},
    "source": [
@@ -345,7 +367,7 @@
     "    f\"{DJ_URL}/nodes/revenue_source/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog\": \"test\",\n",
+    "        \"catalog_name\": \"test\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"revenue\",\n",
@@ -372,7 +394,7 @@
     "    f\"{DJ_URL}/nodes/account_type_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog\": \"test\",\n",
+    "        \"catalog_name\": \"test\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"account_type\",\n",
@@ -398,7 +420,7 @@
     "    f\"{DJ_URL}/nodes/payment_type_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog\": \"test\",\n",
+    "        \"catalog_name\": \"test\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"payment_type\",\n",
@@ -423,7 +445,7 @@
     "    f\"{DJ_URL}/nodes/customers_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog\": \"test\",\n",
+    "        \"catalog_name\": \"test\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"customers\",\n",
@@ -448,7 +470,7 @@
     "    f\"{DJ_URL}/nodes/default_payment_account_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog\": \"test\",\n",
+    "        \"catalog_name\": \"test\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"default_payment_account\",\n",
@@ -478,7 +500,7 @@
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/revenue_source/columns/payment_type?dimension=payment_type\"\n",
+    "    f\"{DJ_URL}/nodes/revenue_source/columns/payment_type/?dimension=payment_type\"\n",
     ")\n",
     "response.json()"
    ]
@@ -491,7 +513,7 @@
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/revenue_source/columns/customer_id?dimension=customers\"\n",
+    "    f\"{DJ_URL}/nodes/revenue_source/columns/customer_id/?dimension=customers\"\n",
     ")\n",
     "response.json()"
    ]
@@ -504,7 +526,7 @@
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/default_payment_account_table/columns/account_type?dimension=account_type\"\n",
+    "    f\"{DJ_URL}/nodes/default_payment_account_table/columns/account_type/?dimension=account_type\"\n",
     ")\n",
     "response.json()"
    ]
@@ -517,7 +539,7 @@
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/default_payment_account_table/columns/default_payment_type?dimension=payment_type\"\n",
+    "    f\"{DJ_URL}/nodes/default_payment_account_table/columns/default_payment_type/?dimension=payment_type\"\n",
     ")\n",
     "response.json()"
    ]

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from dj.models import Table
+from dj.models import Catalog, Table
 from dj.models.column import Column, ColumnType
 from dj.models.node import Node, NodeRevision, NodeType
 
@@ -21,6 +21,10 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         """
         Add nodes to facilitate testing of availability state updates
         """
+        catalog = Catalog(name="test")
+        session.add(catalog)
+        session.commit()
+        session.refresh(catalog)
 
         node1 = Node(
             name="revenue_source",
@@ -40,7 +44,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             tables=[
                 Table(
                     database_id=1,
-                    catalog="test",
+                    catalog_id=catalog.id,
                     schema="accounting",
                     table="revenue",
                 ),
@@ -102,7 +106,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_and_business_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
@@ -123,7 +127,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         node_dict.pop("updated_at")
         assert node_dict == {
             "valid_through_ts": 20230125,
-            "catalog": "prod",
+            "catalog": "test",
             "min_partition": ["2022", "01", "01"],
             "table": "pmts",
             "max_partition": ["2023", "01", "25"],
@@ -142,7 +146,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_and_business_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
@@ -158,7 +162,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_and_business_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
@@ -174,7 +178,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_and_business_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "new_accounting",
                 "table": "new_payments_table",
                 "valid_through_ts": 20230125,
@@ -195,7 +199,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         node_dict.pop("updated_at")
         assert node_dict == {
             "valid_through_ts": 20230125,
-            "catalog": "prod",
+            "catalog": "test",
             "min_partition": ["2022", "01", "01"],
             "table": "new_payments_table",
             "max_partition": ["2023", "01", "25"],
@@ -214,7 +218,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_and_business_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
@@ -236,7 +240,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_and_business_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
@@ -265,7 +269,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/nonexistentnode/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "pmts",
                 "valid_through_ts": 20230125,
@@ -293,7 +297,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         client.post(
             "/data/availability/large_revenue_payments_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
@@ -304,7 +308,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230102,
@@ -333,7 +337,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         node_dict.pop("updated_at")
         assert node_dict == {
             "valid_through_ts": 20230102,
-            "catalog": "prod",
+            "catalog": "test",
             "min_partition": ["2022", "01", "01"],
             "table": "large_pmts",
             "max_partition": ["2023", "01", "02"],
@@ -352,7 +356,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         client.post(
             "/data/availability/large_revenue_payments_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
@@ -363,7 +367,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
@@ -392,7 +396,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         node_dict.pop("updated_at")
         assert node_dict == {
             "valid_through_ts": 20230101,
-            "catalog": "prod",
+            "catalog": "test",
             "min_partition": ["2021", "12", "31"],
             "table": "large_pmts",
             "max_partition": ["2023", "01", "01"],
@@ -411,7 +415,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         client.post(
             "/data/availability/large_revenue_payments_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
@@ -422,7 +426,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/large_revenue_payments_only/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20221231,
@@ -451,7 +455,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         node_dict.pop("updated_at")
         assert node_dict == {
             "valid_through_ts": 20221231,
-            "catalog": "prod",
+            "catalog": "test",
             "min_partition": ["2022", "01", "01"],
             "table": "large_pmts",
             "max_partition": ["2023", "01", "01"],
@@ -509,7 +513,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         response = client.post(
             "/data/availability/revenue_source/",
             json={
-                "catalog": "prod",
+                "catalog": "test",
                 "schema_": "accounting",
                 "table": "large_pmts",
                 "valid_through_ts": 20230101,
@@ -524,7 +528,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "message": (
                 "Cannot set availability state, source "
                 "nodes require availability states match "
-                "an existing table: prod.accounting.large_pmts"
+                "an existing table: test.accounting.large_pmts"
             ),
             "errors": [],
             "warnings": [],

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
-from dj.models import Database, Table
+from dj.models import Catalog, Database, Table
 from dj.models.column import Column, ColumnType
 from dj.models.node import Node, NodeRevision, NodeType
 
@@ -795,6 +795,10 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         """
         Test adding tables to existing nodes
         """
+        catalog = Catalog(name="test")
+        session.add(catalog)
+        session.commit()
+
         database = Database(name="postgres", URI="postgres://")
         session.add(database)
         session.commit()
@@ -821,7 +825,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "/nodes/third_party_revenue/table/",
             json={
                 "database_name": "postgres",
-                "catalog": "test",
+                "catalog_name": "test",
                 "cost": 1.0,
                 "schema": "accounting",
                 "table": "revenue",
@@ -845,7 +849,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "/nodes/third_party_revenue/table/",
             json={
                 "database_name": "postgres",
-                "catalog": "test",
+                "catalog_name": "test",
                 "cost": 1.0,
                 "schema": "accounting",
                 "table": "third_party_revenue",
@@ -872,7 +876,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "/nodes/third_party_revenue/table/",
             json={
                 "database_name": "postgres",
-                "catalog": "test",
+                "catalog_name": "test",
                 "cost": 1.0,
                 "schema": "accounting",
                 "table": "revenue",

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -893,8 +893,8 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data == {
             "message": (
-                "Table ('test', 'accounting', 'revenue') already "
-                "exists for node third_party_revenue"
+                "Table revenue in database postgres in catalog test already exists "
+                "for node third_party_revenue"
             ),
             "errors": [],
             "warnings": [],


### PR DESCRIPTION
### Summary

This is a continuation of the refactoring towards a catalog and engine design to replace the database entity that currently exists. Specifically, this PR changes the catalog attribute on tables from a `str` to a `Catalog` instance. I've left it optional for now so that it can co-exist with the database based logic that exists now as we migrate. I've also added a `uri` attribute to the `Engine` class--we can use that to facilitate continued support for the sqlalchemy mechanism that currently works.

The API endpoint for adding tables is more strict in that it requires a catalog. Catalogs are not required to have engines and you can see in the updated runbook that it's very easy to create one.
```py
response = requests.post(
    f"{DJ_URL}/catalogs/",
    json={"name": "test"},
)
response.json()
```

I think we should eventually have a `default` catalog that's automatically created when a DJ server is initialized, and then we can make it optional to provide a catalog to the API when creating a table, using `default` when `catalog_name == None`.

For the SQL AST build plan (cc: @CircArgs), instead of looking for `Table` instances on nodes, then finding a common shared `Database` defined, we will need a slight change in that logic to find a common shared `Catalog`. We could either flat out not support cross-catalog joins and return an error when that's the only option, or we can be softer there by generating the SQL anyway and including some metadata in the response that implies it's a multi-catalog query (system clients can check for this metadata and make a decision on what to do). I'm not yet sure what's the best option there.

### Test Plan

Updated tests, ran `docker compose up` and tested the API. Also updated and ran the runbook.

- [x] PR has an associated issue: #298
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
