### PR TITLE
Endpoint for query-based node similarity

### DIFF
--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -36,6 +36,7 @@ http://localhost:8000/nodes/{name}/: Show the active version of the specified no
 http://localhost:8000/nodes/{name}/revisions/: List all revisions for the node.
 http://localhost:8000/nodes/{name}/columns/{column}/: Add information to a node column
 http://localhost:8000/nodes/{name}/table/: Add a table to a node
+http://localhost:8000/nodes/similarity/{node1_name}/{node2_name}: Compare two nodes by how similar their queries are
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/graphql: GraphQL endpoint.
 """


### PR DESCRIPTION
### Summary

This adds an endpoint for the recently merged node similarity logic (#310).

### Test Plan

Wrote tests, ran `docker compose up`, and tested the API endpoint.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
