### PR TITLE
Cube nodes and cube endpoints

### DIFF
--- a/alembic/versions/2023_02_10_1923-6bbaf7974a9d_add_attributes_for_cube_nodes.py
+++ b/alembic/versions/2023_02_10_1923-6bbaf7974a9d_add_attributes_for_cube_nodes.py
@@ -1,0 +1,46 @@
+"""Add attributes for cube nodes
+
+Revision ID: 6bbaf7974a9d
+Revises: b9f370ef912a
+Create Date: 2023-02-10 19:23:44.130919+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6bbaf7974a9d"
+down_revision = "b9f370ef912a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "cuberelationship",
+        sa.Column("cube_id", sa.Integer(), nullable=False),
+        sa.Column("cube_element_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["cube_element_id"],
+            ["node.id"],
+            name=op.f("fk_cuberelationship_cube_element_id_node"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["cube_id"],
+            ["noderevision.id"],
+            name=op.f("fk_cuberelationship_cube_id_noderevision"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "cube_id",
+            "cube_element_id",
+            name=op.f("pk_cuberelationship"),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("cuberelationship")

--- a/dj/api/cubes.py
+++ b/dj/api/cubes.py
@@ -1,0 +1,57 @@
+"""
+Cube related APIs.
+"""
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import Field
+from sqlmodel import Session, SQLModel
+
+from dj.api.helpers import get_node_by_name
+from dj.models.node import AvailabilityState, NodeType
+from dj.utils import UTCDatetime, get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class CubeElementMetadata(SQLModel):
+    """
+    Metadata for an element in a cube
+    """
+
+    id: int
+    current_version: str
+    name: str
+
+
+class CubeRevisionMetadata(SQLModel):
+    """
+    Metadata for a cube node
+    """
+
+    id: int = Field(alias="node_revision_id")
+    node_id: int
+    type: NodeType
+    name: str
+    display_name: str
+    version: str
+    description: str = ""
+    availability: Optional[AvailabilityState] = None
+    cube_elements: List[CubeElementMetadata]
+    updated_at: UTCDatetime
+
+    class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        allow_population_by_field_name = True
+
+
+@router.get("/cubes/{name}/", response_model=CubeRevisionMetadata)
+def read_cube(
+    name: str, *, session: Session = Depends(get_session)
+) -> CubeRevisionMetadata:
+    """
+    Get information on a cube
+    """
+    node = get_node_by_name(session=session, name=name, node_type=NodeType.CUBE)
+    return node.current

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -13,7 +13,17 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from dj import __version__
-from dj.api import catalogs, data, databases, engines, health, metrics, nodes, queries
+from dj.api import (
+    catalogs,
+    cubes,
+    data,
+    databases,
+    engines,
+    health,
+    metrics,
+    nodes,
+    queries,
+)
 from dj.api.graphql.main import graphql_app
 from dj.errors import DJException
 from dj.models.catalog import Catalog
@@ -46,6 +56,7 @@ app.include_router(metrics.router)
 app.include_router(nodes.router)
 app.include_router(data.router)
 app.include_router(health.router)
+app.include_router(cubes.router)
 app.include_router(graphql_app, prefix="/graphql")
 
 

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -1,7 +1,7 @@
 """
 Node related APIs.
 """
-
+import http.client
 import logging
 from http import HTTPStatus
 from typing import Dict, List, Optional, Tuple, Union
@@ -21,10 +21,11 @@ from dj.api.helpers import (
 from dj.construction.extract import extract_dependencies_from_node
 from dj.construction.inference import get_type_of_expression
 from dj.errors import DJError, DJException, ErrorCode
-from dj.models import Database, Table
+from dj.models import Catalog, Database, Table
 from dj.models.column import Column, ColumnType
 from dj.models.node import (
     AvailabilityState,
+    CreateCubeNode,
     CreateNode,
     CreateSourceNode,
     Node,
@@ -59,7 +60,7 @@ class TableMetadata(SQLModel):
     """
 
     id: Optional[int]
-    catalog: Optional[str]
+    catalog: Optional[Catalog]
     schema_: Optional[str]
     table: Optional[str]
     database: Optional[Database]
@@ -135,6 +136,23 @@ class NodeValidation(SQLModel):
     node_revision: NodeRevision
     dependencies: List[NodeRevisionMetadata]
     columns: List[Column]
+
+
+def raise_on_query_not_allowed(
+    data: Union[CreateNode, CreateSourceNode, CreateCubeNode],
+) -> None:
+    """
+    Check if the payload includes a query for a node type that can't have one
+    """
+    if (
+        data.type in (NodeType.SOURCE, NodeType.CUBE)
+        and not isinstance(data, (CreateSourceNode, CreateCubeNode))
+        and data.query
+    ):
+        raise DJException(
+            message=(f"Query not allowed for node of type {data.type}"),
+            http_status_code=http.client.UNPROCESSABLE_ENTITY,
+        )
 
 
 def validate(
@@ -214,7 +232,7 @@ def read_nodes(*, session: Session = Depends(get_session)) -> List[NodeMetadata]
     """
     List the available nodes.
     """
-    nodes = session.exec(select(Node).options(joinedload(Node.current))).all()
+    nodes = session.exec(select(Node).options(joinedload(Node.current))).unique().all()
     return nodes
 
 
@@ -224,7 +242,7 @@ def read_node(name: str, *, session: Session = Depends(get_session)) -> NodeMeta
     Show the active version of the specified node.
     """
     statement = select(Node).where(Node.name == name).options(joinedload(Node.current))
-    node = session.exec(statement).one_or_none()
+    node = session.exec(statement).unique().one_or_none()
     if not node:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
@@ -283,9 +301,55 @@ def create_node_revision(
     return node_revision
 
 
+def create_cube_node_revision(
+    session: Session,
+    data: Union[CreateCubeNode],
+) -> NodeRevision:
+    """
+    Create a cube node revision.
+    """
+    if not data.cube_elements:
+        raise DJException(
+            message=("Cannot create a cube node with no cube elements"),
+            http_status_code=http.client.UNPROCESSABLE_ENTITY,
+        )
+    metrics = []
+    dimensions = []
+    for node_name in data.cube_elements:
+        cube_element = get_node_by_name(session=session, name=node_name)
+        if cube_element.type == NodeType.METRIC:
+            metrics.append(cube_element)
+        elif cube_element.type == NodeType.DIMENSION:
+            dimensions.append(cube_element)
+        else:
+            raise DJException(
+                message=(
+                    f"Node {cube_element.name} of type {cube_element.type} "
+                    "cannot be added to a cube"
+                ),
+                http_status_code=http.client.UNPROCESSABLE_ENTITY,
+            )
+    if not metrics:
+        raise DJException(
+            message=("At least one metric is required to create a cube node"),
+            http_status_code=http.client.UNPROCESSABLE_ENTITY,
+        )
+    if not dimensions:
+        raise DJException(
+            message=("At least one dimension is required to create a cube node"),
+            http_status_code=http.client.UNPROCESSABLE_ENTITY,
+        )
+    return NodeRevision(
+        name=data.name,
+        description=data.description,
+        type=data.type,
+        cube_elements=metrics + dimensions,
+    )
+
+
 @router.post("/nodes/", response_model=NodeMetadata)
 def create_node(
-    data: Union[CreateSourceNode, CreateNode],
+    data: Union[CreateSourceNode, CreateCubeNode, CreateNode],
     session: Session = Depends(get_session),
 ) -> NodeMetadata:
     """
@@ -294,9 +358,14 @@ def create_node(
     query = select(Node).where(Node.name == data.name)
     node = session.exec(query).one_or_none()
     if node:
-        raise DJException(f"A node with name `{data.name}` already exists.")
+        raise DJException(
+            message=f"A node with name `{data.name}` already exists.",
+            http_status_code=HTTPStatus.CONFLICT,
+        )
 
     node = Node(name=data.name, type=data.type, current_version=0)
+
+    raise_on_query_not_allowed(data)
 
     if data.type == NodeType.SOURCE:
         node_revision = NodeRevision(
@@ -312,6 +381,8 @@ def create_node(
             ],
             parents=[],
         )
+    elif data.type == NodeType.CUBE:
+        node_revision = create_cube_node_revision(session=session, data=data)
     else:
         node_revision = create_node_revision(data, session)
 

--- a/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
+++ b/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
@@ -5,7 +5,7 @@
    "id": "db0646c3",
    "metadata": {},
    "source": [
-    "# DJ Runbook - Creating Nodes"
+    "# DJ Runbook - Creating and Linking Nodes"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "618db7b2",
    "metadata": {},
    "source": [
-    "This notebook performs a collection of basic requests to a running DJ server."
+    "This notebook performs a collection of basic requests to a running DJ server to create and link nodes."
    ]
   },
   {
@@ -328,6 +328,54 @@
   },
   {
    "cell_type": "markdown",
+   "id": "41528aac",
+   "metadata": {},
+   "source": [
+    "## Create some cube nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc32727a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"cube_elements\": [\"total_revenue\", \"payment_type\", \"customers\"],\n",
+    "        \"description\": \"A cube of Total Revenue grouped by customer and payment type\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"total_revenue_by_customer_payment_type\",\n",
+    "        \"type\": \"cube\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8317edb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/\",\n",
+    "    json={\n",
+    "        \"cube_elements\": [\"number_of_account_types\", \"account_type\"],\n",
+    "        \"description\": \"A cube of number of accounts grouped by account type\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"number_of_accounts_by_account_type\",\n",
+    "        \"type\": \"cube\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "de536045",
    "metadata": {},
    "source": [
@@ -543,6 +591,14 @@
     ")\n",
     "response.json()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af911957",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -1,0 +1,189 @@
+"""
+Tests for the cubes API.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_read_cube(client: TestClient) -> None:
+    """
+    Test ``GET /cubes/{name}``.
+    """
+    response = client.post(
+        "/nodes/",
+        json={
+            "columns": {
+                "id": {"type": "INT"},
+                "account_type_name": {"type": "STR"},
+                "account_type_classification": {"type": "INT"},
+                "preferred_payment_method": {"type": "INT"},
+            },
+            "description": "A source table for account type data",
+            "mode": "published",
+            "name": "account_type_table",
+            "type": "source",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/nodes/",
+        json={
+            "description": "Account type dimension",
+            "query": (
+                "SELECT id, account_type_name, "
+                "account_type_classification FROM "
+                "account_type_table"
+            ),
+            "mode": "published",
+            "name": "account_type",
+            "type": "dimension",
+        },
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        "/nodes/",
+        json={
+            "description": "Total number of account types",
+            "query": "SELECT count(id) as num_accounts FROM account_type",
+            "mode": "published",
+            "name": "number_of_account_types",
+            "type": "metric",
+        },
+    )
+    assert response.status_code == 200
+
+    # Create a cube
+    response = client.post(
+        "/nodes/",
+        json={
+            "cube_elements": ["number_of_account_types", "account_type"],
+            "description": "A cube of number of accounts grouped by account type",
+            "mode": "published",
+            "name": "number_of_accounts_by_account_type",
+            "type": "cube",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["node_id"] == 4
+    assert data["version"] == "1"
+    assert data["node_revision_id"] == 4
+    assert data["type"] == "cube"
+    assert data["name"] == "number_of_accounts_by_account_type"
+    assert data["display_name"] == "Number Of Accounts By Account Type"
+    assert data["query"] is None
+
+    # Read the cube
+    response = client.get("/cubes/number_of_accounts_by_account_type")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["node_revision_id"] == 4
+    assert data["node_id"] == 4
+    assert data["type"] == "cube"
+    assert data["name"] == "number_of_accounts_by_account_type"
+    assert data["display_name"] == "Number Of Accounts By Account Type"
+    assert data["version"] == "1"
+    assert data["description"] == "A cube of number of accounts grouped by account type"
+    assert {"id": 2, "current_version": "1", "name": "account_type"} in data[
+        "cube_elements"
+    ]
+    assert {"id": 3, "current_version": "1", "name": "number_of_account_types"} in data[
+        "cube_elements"
+    ]
+
+    # Check that creating a cube with a query fails appropriately
+    response = client.post(
+        "/nodes/",
+        json={
+            "description": "A cube of number of accounts grouped by account type",
+            "mode": "published",
+            "query": "SELECT 1",
+            "name": "cubes_shouldnt_have_queries",
+            "type": "cube",
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data == {
+        "message": "Query not allowed for node of type cube",
+        "errors": [],
+        "warnings": [],
+    }
+
+    # Check that creating a cube with no cube elements fails appropriately
+    response = client.post(
+        "/nodes/",
+        json={
+            "cube_elements": [],
+            "description": "A cube of number of accounts grouped by account type",
+            "mode": "published",
+            "name": "cubes_must_have_elements",
+            "type": "cube",
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data == {
+        "message": "Cannot create a cube node with no cube elements",
+        "errors": [],
+        "warnings": [],
+    }
+
+    # Check that creating a cube with incompatible nodes fails appropriately
+    response = client.post(
+        "/nodes/",
+        json={
+            "cube_elements": ["number_of_account_types", "account_type_table"],
+            "description": "",
+            "mode": "published",
+            "name": "cubes_cant_use_source_nodes",
+            "type": "cube",
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data == {
+        "message": "Node account_type_table of type source cannot be added to a cube",
+        "errors": [],
+        "warnings": [],
+    }
+
+    # Check that creating a cube with no metric nodes fails appropriately
+    response = client.post(
+        "/nodes/",
+        json={
+            "cube_elements": ["account_type"],
+            "description": "",
+            "mode": "published",
+            "name": "cubes_must_have_metrics",
+            "type": "cube",
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data == {
+        "message": "At least one metric is required to create a cube node",
+        "errors": [],
+        "warnings": [],
+    }
+
+    # Check that creating a cube with no dimension nodes fails appropriately
+    response = client.post(
+        "/nodes/",
+        json={
+            "cube_elements": ["number_of_account_types"],
+            "description": "A cube of number of accounts grouped by account type",
+            "mode": "published",
+            "name": "cubes_must_have_dimensions",
+            "type": "cube",
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data == {
+        "message": "At least one dimension is required to create a cube node",
+        "errors": [],
+        "warnings": [],
+    }

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -281,7 +281,7 @@ class TestCreateOrUpdateNodes:
         )
         data = response.json()
         assert data["message"] == "A node with name `comments` already exists."
-        assert response.status_code == 500
+        assert response.status_code == 409
 
         # Update node with a new description should create a new revision
         response = client.patch(

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -39,6 +39,7 @@ http://localhost:8000/nodes/{name}/table/: Add a table to a node
 http://localhost:8000/nodes/similarity/{node1_name}/{node2_name}: Compare two nodes by how similar their queries are
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/health/: Healthcheck for services.
+http://localhost:8000/cubes/{name}/: Get information on a cube
 http://localhost:8000/graphql: GraphQL endpoint.
 """
     )

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -101,3 +101,9 @@ def test_extra_validation() -> None:
     with pytest.raises(Exception) as excinfo:
         node_revision.extra_validation()
     assert str(excinfo.value) == "Node A of type transform needs a query"
+
+    node = Node(name="A", type=NodeType.CUBE, current_version="1")
+    node_revision = NodeRevision(name=node.name, type=node.type, node=node, version="1")
+    with pytest.raises(Exception) as excinfo:
+        node_revision.extra_validation()
+    assert str(excinfo.value) == "Node A of type cube node needs cube elements"


### PR DESCRIPTION
### Summary

This adds the cube node type and endpoints for viewing cube information given a cube name. I've updated the runbook with examples of creating cubes.
```py
response = requests.post(
    f"{DJ_URL}/nodes/",
    json={
        "cube_elements": ["total_revenue", "payment_type", "customers"],
        "description": "A cube of Total Revenue grouped by customer and payment type",
        "mode": "published",
        "name": "total_revenue_by_customer_payment_type",
        "type": "cube",
    },
)
response.json()
```

Although the relations are all here, the validation of cube elements only checks that:

- All elements are either metric nodes or dimension nodes (no source, transform, or other cube nodes)
- At least one metric node and one dimension node is included in the list of `cube_elements`

This doesn't actually check if the metrics and dimensions being added to a cube are joinable. Once #321 is addressed, that logic can also be used here as part of the validation step as well as while managing the status of cube nodes (valid/invalid). We can also add additional attributes here where it makes sense to support #272.

### Test Plan

Wrote some tests, added some working examples to the runbook, ran `docker compose up` and tested out the new endpoints.

- [x] PR has an associated issue: #320 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
