### PR TITLE
Add endpoint to list all downstream nodes from a given node

### DIFF
--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -1,7 +1,7 @@
 """
 Node related APIs.
 """
-
+import collections
 import logging
 from http import HTTPStatus
 from typing import Dict, List, Optional, Tuple, Union
@@ -546,3 +546,22 @@ def node_similarity(
     node2_ast = parse(node2.current.query)  # type: ignore
     similarity = node1_ast.similarity_score(node2_ast)
     return JSONResponse(status_code=200, content={"similarity": similarity})
+
+
+@router.get("/nodes/{name}/downstream/")
+def downstream_nodes(
+    name: str, *, node_type: NodeType = None, session: Session = Depends(get_session)
+) -> List[NodeMetadata]:
+    """
+    List all nodes that are downstream from the given node, filterable by type.
+    """
+    node = get_node_by_name(session=session, name=name)
+    queue = collections.deque([node])
+    metrics = set()
+    while queue:
+        current = queue.popleft()
+        if current.id != node.id and (node_type is None or current.type == node_type):
+            metrics.add(current)
+        for child in current.children:
+            queue.append(child.node)
+    return metrics  # type: ignore

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -37,6 +37,7 @@ http://localhost:8000/nodes/{name}/revisions/: List all revisions for the node.
 http://localhost:8000/nodes/{name}/columns/{column}/: Add information to a node column
 http://localhost:8000/nodes/{name}/table/: Add a table to a node
 http://localhost:8000/nodes/similarity/{node1_name}/{node2_name}: Compare two nodes by how similar their queries are
+http://localhost:8000/nodes/{name}/downstream/: List all nodes that are downstream from the given node, filterable by type.
 http://localhost:8000/data/availability/{node_name}/: Add an availability state to a node
 http://localhost:8000/health/: Healthcheck for services.
 http://localhost:8000/graphql: GraphQL endpoint.


### PR DESCRIPTION
### Summary

Adds an endpoint to list all nodes that are downstream from the given node, filterable by `node_type`. 

### Test Plan

Added a unit test. Ran a few manual checks.

- [X] PR has an associated issue: #323
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A