### PR TITLE
Set pydantic response model for downstream endpoint

### DIFF
--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -620,10 +620,10 @@ def node_similarity(
     return JSONResponse(status_code=200, content={"similarity": similarity})
 
 
-@router.get("/nodes/{name}/downstream/")
+@router.get("/nodes/{name}/downstream/", response_model=List[Node])
 def downstream_nodes(
     name: str, *, node_type: NodeType = None, session: Session = Depends(get_session)
-) -> List[NodeMetadata]:
+) -> List[Node]:
     """
     List all nodes that are downstream from the given node, filterable by type.
     """


### PR DESCRIPTION
### Summary

Not sure how the tests in github actions were passing but `make test` on `main` started failing for me locally with this:
```
E               pydantic.error_wrappers.ValidationError: 2 validation errors for NodeMetadata
E               response -> 0 -> current
E                 field required (type=value_error.missing)
E               response -> 1 -> current
E                 field required (type=value_error.missing)
```

@shangyian does this fix look right?

### Test Plan

`make test` and `make check` locally.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
