### PR TITLE
Add __str__ for Catalog model

### DIFF
--- a/dj/models/catalog.py
+++ b/dj/models/catalog.py
@@ -64,3 +64,6 @@ class Catalog(BaseSQLModel, table=True):  # type: ignore
         default_factory=partial(datetime.now, timezone.utc),
     )
     extra_params: Dict = Field(default={}, sa_column=SqlaColumn(JSON))
+
+    def __str__(self):
+        return self.name

--- a/tests/models/catalog_test.py
+++ b/tests/models/catalog_test.py
@@ -1,0 +1,17 @@
+"""
+Tests for ``dj.models.catalog``.
+"""
+
+from dj.models.catalog import Catalog
+
+
+def test_catalog_str_repr():
+    """
+    Test that a catalog instance renders appropriately to a string
+    """
+    spark = Catalog(name="spark")
+    assert str(spark) == "spark"
+    trino = Catalog(name="trino")
+    assert str(trino) == "trino"
+    druid = Catalog(name="druid")
+    assert str(druid) == "druid"


### PR DESCRIPTION
### Summary

My recent PR that changed catalog from `str` to a `Catalog` instance introduced some bugs in the build where it's being used as a string to construct the table reference. This adds a `Catalog.__str__` method to fix this.

### Test Plan

`make test` and `make check`. Also ran a few query builds to make sure the tables in the FROM clauses are being rendered correctly.

- [ ] PR has an associated issue: #298 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
