### PR TITLE
Move metric endpoints logic to use AST

### DIFF
--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -2,13 +2,15 @@
 Helpers for API endpoints
 """
 
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from sqlmodel import Session, select
 
+from dj.construction.build import build_node_for_database
 from dj.errors import DJException
 from dj.models import Catalog, Column, Database
 from dj.models.node import Node, NodeRevision, NodeType
+from dj.sql.parsing import ast
 
 
 def get_node_by_name(
@@ -78,3 +80,29 @@ def get_catalog(session: Session, name: str) -> Catalog:
             http_status_code=404,
         )
     return catalog
+
+
+async def get_query(
+    session: Session,
+    metric: str,
+    dimensions: List[str],
+    filters: List[str],
+    database_name: Optional[str] = None,
+) -> Tuple[ast.Query, Database]:
+    """
+    Get a query for a metric, dimensions, and filters
+    """
+    metric = get_node_by_name(session=session, name=metric, node_type=NodeType.METRIC)
+    database_id = (
+        get_database_by_name(session=session, name=database_name).id
+        if database_name
+        else None
+    )
+    query_ast, optimal_database = await build_node_for_database(
+        session=session,
+        node=metric.current,
+        database_id=database_id,
+        dimensions=dimensions,
+        filters=filters,
+    )
+    return query_ast, optimal_database

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -237,10 +237,10 @@ def add_filters_and_aggs_to_query_ast(
     query: ast.Query,
     dialect: Optional[str] = None,
     filters: Optional[List[str]] = None,
-    aggs: Optional[List[str]] = None,
+    dimensions: Optional[List[str]] = None,
 ):
     """
-    Add filters and aggs to a query ast
+    Add filters and dimensions to a query ast
     """
     projection_addition = []
     if filters:
@@ -264,8 +264,8 @@ def add_filters_and_aggs_to_query_ast(
             filter_asts,
         )
 
-    if aggs:
-        for agg in aggs:
+    if dimensions:
+        for agg in dimensions:
             temp_select = parse(
                 f"select * group by {agg}",
                 dialect,
@@ -283,7 +283,7 @@ async def build_node_for_database(  # pylint: disable=too-many-arguments
     dialect: Optional[str] = None,
     database_id: Optional[int] = None,
     filters: Optional[List[str]] = None,
-    aggs: Optional[List[str]] = None,
+    dimensions: Optional[List[str]] = None,
 ) -> Tuple[ast.Query, Database]:
     """
     Determines the optimal database to run the query in and builds the query AST appropriately
@@ -294,8 +294,8 @@ async def build_node_for_database(  # pylint: disable=too-many-arguments
         )
     query = parse(node.query, dialect)
     top_dbs: Set[Database] = set()
-    if filters or aggs:
-        add_filters_and_aggs_to_query_ast(query, dialect, filters, aggs)
+    if filters or dimensions:
+        add_filters_and_aggs_to_query_ast(query, dialect, filters, dimensions)
     else:
         top_dbs = {table.database for table in node.tables}
     build_plan = generate_build_plan_from_query(session, query, dialect)

--- a/dj/construction/compile.py
+++ b/dj/construction/compile.py
@@ -268,15 +268,14 @@ def _validate_columns(
                 if dim is not None:  # pragma: no cover
                     if col.name.name not in {c.name for c in dim.columns}:
                         CompoundBuildException().append(
-                            error=DJError(
+                            DJError(
                                 code=ErrorCode.MISSING_COLUMNS,
                                 message=(
                                     f"Dimension `{dim.name}` has no column "
-                                    "`{col.name.name}`.",
+                                    "`{col.name.name}`."
                                 ),
                                 context=str(col.parent),
                             ),
-                            message="Cannot extract dependencies from SELECT",
                         )
                     else:
                         dim_table = ast.Table(

--- a/dj/models/catalog.py
+++ b/dj/models/catalog.py
@@ -65,5 +65,8 @@ class Catalog(BaseSQLModel, table=True):  # type: ignore
     )
     extra_params: Dict = Field(default={}, sa_column=SqlaColumn(JSON))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
+
+    def __hash__(self) -> int:
+        return hash(self.id)

--- a/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
+++ b/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
@@ -593,12 +593,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "25852a0a",
+   "metadata": {},
+   "source": [
+    "## Generate SQL For Metrics and Dimensions"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "af911957",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/metrics/total_revenue/sql/?dimensions=payment_type.id\"\n",
+    ").json()\n",
+    "print(response[\"sql\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23558a7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/metrics/basic.num_users/sql/?dimensions=basic.transform.country_agg.country\"\n",
+    ").json()\n",
+    "print(response[\"sql\"])"
+   ]
   }
  ],
  "metadata": {

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -70,7 +70,7 @@ async def test_build_metric_with_dimensions_aggs(mocker, request):
     query, _ = await build_node_for_database(
         construction_session,
         num_comments_mtc.current,
-        aggs=["basic.dimension.users.country", "basic.dimension.users.gender"],
+        dimensions=["basic.dimension.users.country", "basic.dimension.users.gender"],
     )
 
     expecteds = (

--- a/tests/models/catalog_test.py
+++ b/tests/models/catalog_test.py
@@ -5,13 +5,16 @@ Tests for ``dj.models.catalog``.
 from dj.models.catalog import Catalog
 
 
-def test_catalog_str_repr():
+def test_catalog_str_and_hash():
     """
-    Test that a catalog instance renders appropriately to a string
+    Test that a catalog instance works properly with str and hash
     """
-    spark = Catalog(name="spark")
+    spark = Catalog(id=1, name="spark")
     assert str(spark) == "spark"
-    trino = Catalog(name="trino")
+    assert hash(spark) == 1
+    trino = Catalog(id=2, name="trino")
     assert str(trino) == "trino"
-    druid = Catalog(name="druid")
+    assert hash(trino) == 2
+    druid = Catalog(id=3, name="druid")
     assert str(druid) == "druid"
+    assert hash(druid) == 3


### PR DESCRIPTION
### Summary

This PR updates the `GET "/metrics/{name}/sql/"` and `GET "/metrics/{name}/data/"` endpoints to use the DJ SQL AST logic (thanks a ton @CircArgs for all the work on that!).

### Test Plan

`docker compose up`, tested out the endpoints, added working examples to the runbook

- [x] PR has an associated issue: #259 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
