### PR TITLE
Adding materialization config to nodes + endpoint to create them

### DIFF
--- a/alembic/versions/2023_02_11_1831-f3cbcd8dfac2_add_materialization_config.py
+++ b/alembic/versions/2023_02_11_1831-f3cbcd8dfac2_add_materialization_config.py
@@ -1,0 +1,56 @@
+"""Add materialization config
+
+Revision ID: f3cbcd8dfac2
+Revises: b9f370ef912a
+Create Date: 2023-02-11 18:31:49.245407+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f3cbcd8dfac2"
+down_revision = "6bbaf7974a9d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "materializationconfig",
+        sa.Column("node_revision_id", sa.Integer(), nullable=False),
+        sa.Column("engine_id", sa.Integer(), nullable=False),
+        sa.Column("config", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["engine_id"],
+            ["engine.id"],
+            name=op.f("fk_materializationconfig_engine_id_engine"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["node_revision_id"],
+            ["noderevision.id"],
+            name=op.f("fk_materializationconfig_node_revision_id_noderevision"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "node_revision_id",
+            "engine_id",
+            name=op.f("pk_materializationconfig"),
+        ),
+    )
+
+    with op.batch_alter_table("noderevision") as batch_op:
+        batch_op.create_unique_constraint(
+            op.f("uq_noderevision_version"),
+            ["version", "node_id"],
+        )
+
+
+def downgrade():
+    op.drop_table("materializationconfig")
+
+    with op.batch_alter_table("noderevision") as batch_op:
+        batch_op.drop_constraint("uq_noderevision_version")

--- a/dj/api/engines.py
+++ b/dj/api/engines.py
@@ -6,39 +6,13 @@ from http import HTTPStatus
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.exc import NoResultFound
-from sqlmodel import Session, SQLModel, select
+from sqlmodel import Session, select
 
-from dj.models.engine import Engine
+from dj.api.helpers import get_engine
+from dj.models.engine import Engine, EngineInfo
 from dj.utils import get_session
 
 router = APIRouter()
-
-
-class EngineInfo(SQLModel):
-    """
-    Class for engine creation
-    """
-
-    name: str
-    version: str
-
-
-def get_engine(session: Session, name: str, version: str) -> Engine:
-    """
-    Return an Engine instance given an engine name and version
-    """
-    statement = (
-        select(Engine).where(Engine.name == name).where(Engine.version == version)
-    )
-    try:
-        engine = session.exec(statement).one()
-    except NoResultFound as exc:
-        raise HTTPException(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail=f"Engine not found: `{name}` version `{version}`",
-        ) from exc
-    return engine
 
 
 @router.get("/engines/", response_model=List[EngineInfo])

--- a/dj/models/engine.py
+++ b/dj/models/engine.py
@@ -4,7 +4,7 @@ Models for columns.
 
 from typing import Optional
 
-from sqlmodel import Field
+from sqlmodel import Field, SQLModel
 
 from dj.models.base import BaseSQLModel
 
@@ -18,3 +18,12 @@ class Engine(BaseSQLModel, table=True):  # type: ignore
     name: str
     version: str
     uri: Optional[str]
+
+
+class EngineInfo(SQLModel):
+    """
+    Class for engine creation
+    """
+
+    name: str
+    version: str

--- a/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
+++ b/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "db0646c3",
+   "id": "d7c0ea9f",
    "metadata": {},
    "source": [
     "# DJ Runbook - Creating and Linking Nodes"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "618db7b2",
+   "id": "c8a98151",
    "metadata": {},
    "source": [
     "This notebook performs a collection of basic requests to a running DJ server to create and link nodes."
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c35d779c",
+   "id": "b57d05f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1abb330",
+   "id": "3256a6fa",
    "metadata": {},
    "source": [
     "## Create some source nodes."
@@ -42,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b2bc781",
+   "id": "bd5e86cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "621abdf4",
+   "id": "dcebba68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75c64ef2",
+   "id": "bceed545",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6f65511",
+   "id": "d15c8d3c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bc974af",
+   "id": "ef1d5f2b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7963fc44",
+   "id": "b00c52fc",
    "metadata": {},
    "source": [
     "## Create some dimension nodes."
@@ -173,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0050518a",
+   "id": "775e2183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8fd3d1f3",
+   "id": "3a0d833d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8002070d",
+   "id": "0792cbfa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df453f8a",
+   "id": "eb290e55",
    "metadata": {},
    "source": [
     "## Create some transform nodes."
@@ -241,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3aaeda0a",
+   "id": "df2ac2df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93c7b68c",
+   "id": "434cb711",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68b3fec5",
+   "id": "8f79cb31",
    "metadata": {},
    "source": [
     "## Create some metric nodes."
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e09774e",
+   "id": "fb61d4d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c9c6b03",
+   "id": "4af89d99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41528aac",
+   "id": "25b24304",
    "metadata": {},
    "source": [
     "## Create some cube nodes"
@@ -337,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc32727a",
+   "id": "3ce28c9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8317edb9",
+   "id": "d495b6f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de536045",
+   "id": "bd821e72",
    "metadata": {},
    "source": [
     "## Add a catalog"
@@ -385,7 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28fa3d80",
+   "id": "f623a4be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +398,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3797feff",
+   "id": "d417fba4",
+   "metadata": {},
+   "source": [
+    "## Add an engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3244ab2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/engines/\",\n",
+    "    json={\"name\": \"spark\", \"version\": \"2.4.4\"},\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a1f6dc0",
    "metadata": {},
    "source": [
     "## Add tables to nodes"
@@ -407,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcc79270",
+   "id": "459e36b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0d1b403",
+   "id": "17b08ead",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acf86fc8",
+   "id": "5f4c71ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83700c47",
+   "id": "9df14f34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3f4633f",
+   "id": "c801c99f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +556,44 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b16a302",
+   "id": "980d3b48",
+   "metadata": {},
+   "source": [
+    "## Add Materialization Config to Nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb757716",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/total_revenue_by_customer_payment_type/materialization/\",\n",
+    "    json={\n",
+    "        \"engine_name\": \"spark\",\n",
+    "        \"engine_version\": \"2.4.4\",\n",
+    "        \"config\": '{\"spark.driver.memory\": \"10g\", \"spark.executor.memory\": \"10g\"}',\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ce871a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{DJ_URL}/nodes/total_revenue_by_customer_payment_type/\")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "634d536d",
    "metadata": {},
    "source": [
     "## Label Foreign Keys With Dimension Nodes"
@@ -543,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd673aea",
+   "id": "e36e0ca0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +615,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6fa7ad62",
+   "id": "a382d903",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7c75c17",
+   "id": "7afba17a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6b15a74",
+   "id": "e3da11ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25852a0a",
+   "id": "704d8616",
    "metadata": {},
    "source": [
     "## Generate SQL For Metrics and Dimensions"
@@ -603,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af911957",
+   "id": "51479dae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23558a7b",
+   "id": "f7549394",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,11 +684,19 @@
     ").json()\n",
     "print(response[\"sql\"])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f70695b7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -643,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/tests/api/helpers_test.py
+++ b/tests/api/helpers_test.py
@@ -16,7 +16,7 @@ def test_raise_get_node_when_node_does_not_exist(session: Session):
     with pytest.raises(DJException) as exc_info:
         helpers.get_node_by_name(session=session, name="foo")
 
-    assert "A  node with name `foo` does not exist." in str(exc_info.value)
+    assert "A node with name `foo` does not exist." in str(exc_info.value)
 
 
 def test_raise_get_database_when_database_does_not_exist(session: Session):

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -33,6 +33,7 @@ http://localhost:8000/metrics/{name}/sql/: Return SQL for a metric.
 http://localhost:8000/nodes/validate/: Validate a node.
 http://localhost:8000/nodes/: List the available nodes.
 http://localhost:8000/nodes/{name}/: Show the active version of the specified node.
+http://localhost:8000/nodes/{name}/materialization/: Update materialization config of the specified node.
 http://localhost:8000/nodes/{name}/revisions/: List all revisions for the node.
 http://localhost:8000/nodes/{name}/columns/{column}/: Add information to a node column
 http://localhost:8000/nodes/{name}/table/: Add a table to a node


### PR DESCRIPTION
### Summary

Nodes can be materialized with different engines, some of which require additional configuration for execution. For example, users may want the ability to tune Spark memory parameters or alter the Druid `tuningConfig`. 

This change adds a new `MaterializationConfig` entity that stores these configurations linked up to a node. Source nodes will not have this config, as they don't need to be materialized (i.e., their materialization is not managed as a part of DJ). At some later point we may want to consider adding validation to these configs, although it will be engine-specific so may be difficult to pull off.

I also did some light refactoring to move some CRUD models to their respective model files.

### Test Plan

Wrote some unit tests. Added the scenarios for creating/updating materialization configs and creating an engine to the runbook.

- [X] PR has an associated issue: #312
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A