### PR TITLE
include uri in EngineInfo, update runbook

### DIFF
--- a/dj/models/engine.py
+++ b/dj/models/engine.py
@@ -27,3 +27,4 @@ class EngineInfo(SQLModel):
 
     name: str
     version: str
+    uri: Optional[str]

--- a/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
+++ b/notebooks/DJ Runbook - Creating and Linking Nodes.ipynb
@@ -391,7 +391,7 @@
    "source": [
     "response = requests.post(\n",
     "    f\"{DJ_URL}/catalogs/\",\n",
-    "    json={\"name\": \"test\"},\n",
+    "    json={\"name\": \"default\"},\n",
     ")\n",
     "response.json()"
    ]
@@ -401,7 +401,7 @@
    "id": "d417fba4",
    "metadata": {},
    "source": [
-    "## Add an engine"
+    "## Add engines"
    ]
   },
   {
@@ -414,6 +414,68 @@
     "response = requests.post(\n",
     "    f\"{DJ_URL}/engines/\",\n",
     "    json={\"name\": \"spark\", \"version\": \"2.4.4\"},\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "079ec8c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/engines/\",\n",
+    "    json={\n",
+    "        \"name\": \"postgres_examples\",\n",
+    "        \"version\": \"\",\n",
+    "        \"uri\": \"postgresql://username:FoolishPassword@postgres_examples:5432/examples\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d979589",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/engines/\",\n",
+    "    json={\n",
+    "        \"name\": \"postgres_roads\",\n",
+    "        \"version\": \"\",\n",
+    "        \"uri\": \"postgresql://dj:dj@postgres_roads:5435/roads\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6afdc974",
+   "metadata": {},
+   "source": [
+    "## Attach engines to catalogs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a353282a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/catalogs/default/engines/\",\n",
+    "    json=[\n",
+    "        {\"name\": \"spark\", \"version\": \"2.4.4\"},\n",
+    "        {\"name\": \"postgres_examples\", \"version\": \"\"},\n",
+    "        {\"name\": \"postgres_roads\", \"version\": \"\"},\n",
+    "    ],\n",
     ")\n",
     "response.json()"
    ]
@@ -437,7 +499,7 @@
     "    f\"{DJ_URL}/nodes/revenue_source/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog_name\": \"test\",\n",
+    "        \"catalog_name\": \"default\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"revenue\",\n",
@@ -464,7 +526,7 @@
     "    f\"{DJ_URL}/nodes/account_type_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog_name\": \"test\",\n",
+    "        \"catalog_name\": \"default\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"account_type\",\n",
@@ -490,7 +552,7 @@
     "    f\"{DJ_URL}/nodes/payment_type_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog_name\": \"test\",\n",
+    "        \"catalog_name\": \"default\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"payment_type\",\n",
@@ -515,7 +577,7 @@
     "    f\"{DJ_URL}/nodes/customers_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog_name\": \"test\",\n",
+    "        \"catalog_name\": \"default\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"customers\",\n",
@@ -540,7 +602,7 @@
     "    f\"{DJ_URL}/nodes/default_payment_account_table/table/\",\n",
     "    json={\n",
     "        \"database_name\": \"postgres\",\n",
-    "        \"catalog_name\": \"test\",\n",
+    "        \"catalog_name\": \"default\",\n",
     "        \"cost\": 1.0,\n",
     "        \"schema\": \"accounting\",\n",
     "        \"table\": \"default_payment_account\",\n",
@@ -696,7 +758,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -710,7 +772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/tests/api/catalog_test.py
+++ b/tests/api/catalog_test.py
@@ -72,16 +72,10 @@ def test_catalog_list(
     assert response.json() == [
         {
             "name": "dev",
-            "engines": [{"name": "spark", "version": "3.3.1"}],
+            "engines": [{"name": "spark", "version": "3.3.1", "uri": None}],
         },
-        {
-            "name": "test",
-            "engines": [],
-        },
-        {
-            "name": "prod",
-            "engines": [],
-        },
+        {"name": "test", "engines": []},
+        {"name": "prod", "engines": []},
     ]
 
 
@@ -119,7 +113,10 @@ def test_catalog_get_catalog(
     )
     assert response.status_code == 200
     data = response.json()
-    assert data == {"name": "dev", "engines": [{"name": "spark", "version": "3.3.1"}]}
+    assert data == {
+        "name": "dev",
+        "engines": [{"name": "spark", "uri": None, "version": "3.3.1"}],
+    }
 
 
 def test_catalog_adding_a_new_catalog_with_engines(
@@ -132,6 +129,7 @@ def test_catalog_adding_a_new_catalog_with_engines(
         "/engines/",
         json={
             "name": "spark",
+            "uri": None,
             "version": "3.3.1",
         },
     )
@@ -157,6 +155,7 @@ def test_catalog_adding_a_new_catalog_with_engines(
         "engines": [
             {
                 "name": "spark",
+                "uri": None,
                 "version": "3.3.1",
             },
         ],
@@ -173,6 +172,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
         "/engines/",
         json={
             "name": "spark",
+            "uri": None,
             "version": "3.3.1",
         },
     )
@@ -204,6 +204,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
         "engines": [
             {
                 "name": "spark",
+                "uri": None,
                 "version": "3.3.1",
             },
         ],
@@ -220,6 +221,7 @@ def test_catalog_adding_without_duplicating(
         "/engines/",
         json={
             "name": "spark",
+            "uri": None,
             "version": "2.4.4",
         },
     )
@@ -297,14 +299,17 @@ def test_catalog_adding_without_duplicating(
         "engines": [
             {
                 "name": "spark",
+                "uri": None,
                 "version": "2.4.4",
             },
             {
                 "name": "spark",
+                "uri": None,
                 "version": "3.3.0",
             },
             {
                 "name": "spark",
+                "uri": None,
                 "version": "3.3.1",
             },
         ],

--- a/tests/api/engine_test.py
+++ b/tests/api/engine_test.py
@@ -20,7 +20,7 @@ def test_engine_adding_a_new_engine(
     )
     data = response.json()
     assert response.status_code == 200
-    assert data == {"name": "spark", "version": "3.3.1"}
+    assert data == {"name": "spark", "uri": None, "version": "3.3.1"}
 
 
 def test_engine_list(
@@ -62,14 +62,17 @@ def test_engine_list(
     assert data == [
         {
             "name": "spark",
+            "uri": None,
             "version": "2.4.4",
         },
         {
             "name": "spark",
+            "uri": None,
             "version": "3.3.0",
         },
         {
             "name": "spark",
+            "uri": None,
             "version": "3.3.1",
         },
     ]
@@ -95,7 +98,7 @@ def test_engine_get_engine(
     )
     assert response.status_code == 200
     data = response.json()
-    assert data == {"name": "spark", "version": "3.3.1"}
+    assert data == {"name": "spark", "uri": None, "version": "3.3.1"}
 
 
 def test_engine_raise_on_engine_already_exists(

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -587,7 +587,10 @@ class TestCreateOrUpdateNodes:
         data = response.json()
         assert data["version"] == "2"
         assert data["materialization_configs"] == [
-            {"config": "blahblah", "engine": {"name": "spark", "version": "2.4.4"}},
+            {
+                "config": "blahblah",
+                "engine": {"name": "spark", "uri": None, "version": "2.4.4"},
+            },
         ]
         assert old_node_data["node_revision_id"] < data["node_revision_id"]
 


### PR DESCRIPTION
### Summary

This is a small PR that include the `Engine.uri` attribute in the engine endpoints as well as adds some examples to the runbook of using it when adding engines.

### Test Plan

Ran the notebook end to end.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
