### PR TITLE
Support type parsing for rows with complex types

### DIFF
--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -18,7 +18,7 @@ def test_columntype_bad_complex():
     """tests that an unknown complex type raises"""
     with pytest.raises(ColumnTypeError) as exc:
         ColumnType("list[string]")
-    assert "LIST is not a KNOWN complex type" in str(exc)
+    assert "LIST is not a known complex type." in str(exc)
 
 
 def test_columntype_not_complex():
@@ -32,14 +32,14 @@ def test_columntype_array_wrong_number_generic():
     """tests that complex require specific number of args"""
     with pytest.raises(ColumnTypeError) as exc:
         ColumnType("array[str, str]")
-    assert "ColumnTypeError('STR, STR is not an acceptable type.')" in str(exc)
+    assert "ColumnTypeError('STR, STR is not an acceptable type for ARRAY')" in str(exc)
 
 
 def test_columntype_map_bad_key():
     """tests that map require specific key types"""
     with pytest.raises(ColumnTypeError) as exc:
         ColumnType("map[null, str]")
-    assert "MAP key is not an acceptable type" in str(exc)
+    assert "`NULL` is not an acceptable MAP key type." in str(exc)
 
 
 def test_columntype_map_wrong_number_generic():
@@ -49,9 +49,52 @@ def test_columntype_map_wrong_number_generic():
     assert "MAP expects 2 inner types but got 1" in str(exc)
 
 
+def test_invalid_complex_types():
+    """Tests invalid complex types."""
+    with pytest.raises(ColumnTypeError) as exc:
+        ColumnType("array[map]")
+    assert "Missing type definition for complex type!" in str(exc)
+
+    with pytest.raises(ColumnTypeError) as exc:
+        ColumnType("map[str]]")
+    assert "Unbalanced parentheses" in str(exc)
+
+
 def test_validate_columntype_returns_primitive():
     """tests that direct primitive validation returns"""
     assert ColumnType._validate_type("INT") == "INT"  # pylint: disable=W0212
+
+
+def test_nested_types():
+    """Test various nested types."""
+    assert (
+        ColumnType._validate_type("ARRAY[STR]") == "ARRAY[STR]"  # pylint: disable=W0212
+    )
+    assert (
+        ColumnType._validate_type("ARRAY[MAP[STR, STR]]")  # pylint: disable=W0212
+        == "ARRAY[MAP[STR, STR]]"
+    )
+    assert (
+        ColumnType._validate_type("ARRAY[ROW[STR, STR]]")  # pylint: disable=W0212
+        == "ARRAY[ROW[STR, STR]]"
+    )
+    assert (
+        ColumnType._validate_type(  # pylint: disable=W0212
+            "ROW[ARRAY[STR], MAP[STR, STR], STR, INT, MAP[STR, MAP[FLOAT, STR]]]",
+        )
+        == "ROW[ARRAY[STR], MAP[STR, STR], STR, INT, MAP[STR, MAP[FLOAT, STR]]]"
+    )
+    assert (
+        ColumnType._validate_type(  # pylint: disable=W0212
+            "ROW[MAP[STR, ARRAY[STR]], STR name]",
+        )
+        == "ROW[MAP[STR, ARRAY[STR]], STR]"
+    )
+
+    assert (
+        ColumnType._validate_type("MAP[STR, MAP[STR, STR]]")  # pylint: disable=W0212
+        == "MAP[STR, MAP[STR, STR]]"
+    )
 
 
 def test_serialize_not_fully_defined_complex():


### PR DESCRIPTION
### Summary

Type parsing didn't work for some rows with complex types before, i.e.,
```
ROW[MAP[STR, STR], STR, ARRAY[STR]]
```

This change adds support for these types of arbitrarily nested values in rows by switching from solely using a regex matcher to using a custom function that takes a given type string and parses the nested structure based on the parentheses. For example:
```
>>> from dj.typing import parse_type
>>> parse_type('ROW[MAP[STR, STR], STR, ARRAY[STR]]')
[['ROW', [['MAP', ['STR', 'STR']], 'STR', ['ARRAY', ['STR']]]]]
```

This nested list is then used to construct the `ColumnType` object.

### Test Plan

Added some unit tests.

- [X] PR has an associated issue: Related to #339
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A