### PR TITLE
unnammed-select-columns-bugfix

### DIFF
--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -1220,7 +1220,7 @@ class Select(Expression):  # pylint: disable=R0902
         Add an alias to any unnamed columns in the projection (`_col<n>`)
         """
         for i, expression in enumerate(self.projection):
-            if not isinstance(expression, Named):
+            if not isinstance(expression, (Column, Alias)):
                 name = f"_col{i}"
                 aliased = Alias(Name(name), child=expression)
                 # only replace those that are identical in memory

--- a/examples/configs/nodes/basic/num_users.yaml
+++ b/examples/configs/nodes/basic/num_users.yaml
@@ -5,5 +5,5 @@ query: |-
   SELECT SUM(num_users)
   FROM basic.transform.country_agg
 columns:
-  _col0:
+  unnamed_col0:
     type: INT


### PR DESCRIPTION
### Summary

In the select projection, we standardize by naming unnamed columns to `_col{i}` where `i` is the index in the projection. There is a bug where we only check if the item is `Named` but in reality we want to alias anything that is not a `Column` or an `Alias` because the rest are all sorts of other expressions including functions which are named but not in a usable way.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
