### PR TITLE
Unnammed select columns bugfix

### DIFF
--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -1220,7 +1220,7 @@ class Select(Expression):  # pylint: disable=R0902
         Add an alias to any unnamed columns in the projection (`_col<n>`)
         """
         for i, expression in enumerate(self.projection):
-            if not isinstance(expression, Named):
+            if not isinstance(expression, (Column, Alias)):
                 name = f"_col{i}"
                 aliased = Alias(Name(name), child=expression)
                 # only replace those that are identical in memory

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -1221,7 +1221,7 @@ class Select(Expression):  # pylint: disable=R0902
         """
         for i, expression in enumerate(self.projection):
             if not isinstance(expression, (Column, Alias)):
-                name = f"_col{i}"
+                name = f"col{i}"
                 aliased = Alias(Name(name), child=expression)
                 # only replace those that are identical in memory
                 self.replace(expression, aliased, lambda a, b: id(a) == id(b))

--- a/examples/configs/nodes/basic/num_users.yaml
+++ b/examples/configs/nodes/basic/num_users.yaml
@@ -5,5 +5,5 @@ query: |-
   SELECT SUM(num_users)
   FROM basic.transform.country_agg
 columns:
-  unnamed_col0:
+  col0:
     type: INT

--- a/examples/configs/nodes/basic/num_users.yaml
+++ b/examples/configs/nodes/basic/num_users.yaml
@@ -5,5 +5,5 @@ query: |-
   SELECT SUM(num_users)
   FROM basic.transform.country_agg
 columns:
-  _col0:
+  unnamed_col0:
     type: INT

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -835,7 +835,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert data["columns"] == [
             {
                 "id": None,
-                "name": "_col0",
+                "name": "col0",
                 "type": "INT",
                 "dimension_id": None,
                 "dimension_column": None,

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -263,7 +263,7 @@ async def test_build_metric_with_database_id_specified(mocker, request):
 @pytest.mark.asyncio
 async def test_build_node_for_database_with_unnamed_column(mocker, request):
     """
-    Test building a node that has an unnamed column (so defaults to _col<n>)
+    Test building a node that has an unnamed column (so defaults to col<n>)
     """
     mocker.patch("dj.models.database.Database.do_ping", return_value=True)
 
@@ -274,7 +274,7 @@ async def test_build_node_for_database_with_unnamed_column(mocker, request):
         version="1",
         query="""SELECT 1 FROM basic.dimension.countries""",
         columns=[
-            Column(name="_col1", type=ColumnType.INT),
+            Column(name="col1", type=ColumnType.INT),
         ],
     )
     await build_node_for_database(

--- a/tests/construction/fixtures.py
+++ b/tests/construction/fixtures.py
@@ -245,7 +245,7 @@ def build_expectation() -> Dict[str, Dict[Optional[int], Tuple[bool, str]]]:
         """basic.num_users""": {
             None: (
                 True,
-                """SELECT  SUM(basic_DOT_transform_DOT_country_agg.num_users)
+                """SELECT  SUM(basic_DOT_transform_DOT_country_agg.num_users) AS col0
  FROM (SELECT  basic.comments.country,
     COUNT(DISTINCT basic.comments.id) AS num_users
  FROM basic.comments
@@ -254,7 +254,7 @@ def build_expectation() -> Dict[str, Dict[Optional[int], Tuple[bool, str]]]:
             ),
             1: (
                 True,
-                """SELECT  SUM(basic_DOT_transform_DOT_country_agg.num_users)
+                """SELECT  SUM(basic_DOT_transform_DOT_country_agg.num_users) AS col0
  FROM (SELECT  basic.comments.country,
     COUNT(DISTINCT basic.comments.id) AS num_users
  FROM basic.comments
@@ -263,7 +263,7 @@ def build_expectation() -> Dict[str, Dict[Optional[int], Tuple[bool, str]]]:
             ),
             2: (
                 True,
-                """SELECT  SUM(basic_DOT_transform_DOT_country_agg.num_users)
+                """SELECT  SUM(basic_DOT_transform_DOT_country_agg.num_users) AS col0
  FROM (SELECT  comments.country,
     COUNT(DISTINCT comments.id) AS num_users
  FROM comments
@@ -547,7 +547,7 @@ def construction_session(  # pylint: disable=too-many-locals
         node=num_users_mtc_ref,
         version="1",
         query="""
-        SELECT SUM(num_users)
+        SELECT SUM(num_users) AS col0
         FROM basic.transform.country_agg
         """,
         columns=[


### PR DESCRIPTION
### Summary

In the select projection, we standardize by naming unnamed columns to `_col{i}` where `i` is the index in the projection. There is a bug where we only check if the item is `Named` but in reality we want to alias anything that is not a `Column` or an `Alias` because the rest are all sorts of other expressions including functions which are named but not in a usable way.

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
