### PR TITLE
create-node-save-query

### DIFF
--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -236,4 +236,5 @@ def validate_node_data(
     ]
 
     node_revision.status = NodeStatus.VALID
+    node_revision.query = str(query_ast)
     return node, node_revision, dependencies_map

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -728,7 +728,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert data["node_revision"]["name"] == "foo"
         assert (
             data["node_revision"]["query"]
-            == "SELECT large_revenue_payments_only.payment_id FROM large_revenue_payments_only"
+            == "SELECT  large_revenue_payments_only.payment_id FROM large_revenue_payments_only"
         )
         assert data["node"]["type"] == "transform"
 

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -728,7 +728,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert data["node_revision"]["name"] == "foo"
         assert (
             data["node_revision"]["query"]
-            == "SELECT payment_id FROM large_revenue_payments_only"
+            == "SELECT large_revenue_payments_only.payment_id FROM large_revenue_payments_only"
         )
         assert data["node"]["type"] == "transform"
 


### PR DESCRIPTION
### Summary

Save validated queries so that there are not conflicts downstream. The compile process which is part of validation adds important information that avoids downstream complexities of building derived nodes. One example is namespacing columns which helps to avoid collisions which validation would then complain about.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
