### PR TITLE
Test for alembic migrations

### DIFF
--- a/alembic/versions/2023_02_10_1621-b9f370ef912a_initial_migration.py
+++ b/alembic/versions/2023_02_10_1621-b9f370ef912a_initial_migration.py
@@ -118,7 +118,7 @@ def upgrade():
         sa.Column(
             "type",
             sa.String(),
-            nullable=True,
+            nullable=False,
         ),
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),

--- a/tests/migrations_test.py
+++ b/tests/migrations_test.py
@@ -1,0 +1,55 @@
+"""Verify alembic migrations."""
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine.base import Connection
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel
+
+from alembic.autogenerate import compare_metadata
+from alembic.config import Config
+from alembic.runtime.environment import EnvironmentContext
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+
+
+@pytest.fixture(scope="function", name="connection")
+def connection_fixture() -> Connection:
+    """
+    Create an in-memory SQLite connection for verifying models.
+    """
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with engine.connect() as conn:
+        transaction = conn.begin()
+        yield conn
+        transaction.rollback()
+
+
+def test_migrations_are_current(connection):
+    """
+    Verify that the alembic migrations are in line with the models.
+    """
+    target_metadata = SQLModel.metadata
+
+    config = Config("alembic.ini")
+    config.set_main_option("script_location", "alembic")
+    script = ScriptDirectory.from_config(config)
+
+    context = EnvironmentContext(
+        config,
+        script,
+        fn=lambda rev, _: script._upgrade_revs("head", rev),  # pylint: disable=W0212
+    )
+    context.configure(connection=connection)
+    context.run_migrations()
+
+    # Don't use compare_type due to false positives.
+    migrations_state = MigrationContext.configure(
+        connection,
+        opts={"compare_type": False},
+    )
+    diff = compare_metadata(migrations_state, target_metadata)
+    assert diff == [], "The alembic migrations do not match the models."


### PR DESCRIPTION
### Summary

This change adds a test to verify that alembic migrations always match models.

### Test Plan

Ran `make test`.

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A