### PR TITLE
Move all models to the model module

### DIFF
--- a/dj/api/catalogs.py
+++ b/dj/api/catalogs.py
@@ -7,25 +7,16 @@ from http import HTTPStatus
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlmodel import Session, SQLModel, select
+from sqlmodel import Session, select
 
 from dj.api.engines import EngineInfo, get_engine
 from dj.api.helpers import get_catalog
 from dj.errors import DJException
-from dj.models.catalog import Catalog
+from dj.models.catalog import Catalog, CatalogInfo
 from dj.utils import get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
-
-
-class CatalogInfo(SQLModel):
-    """
-    Class for catalog creation
-    """
-
-    name: str
-    engines: List[EngineInfo] = []
 
 
 @router.get("/catalogs/", response_model=List[CatalogInfo])

--- a/dj/api/cubes.py
+++ b/dj/api/cubes.py
@@ -2,48 +2,17 @@
 Cube related APIs.
 """
 import logging
-from typing import List, Optional
 
 from fastapi import APIRouter, Depends
-from pydantic import Field
-from sqlmodel import Session, SQLModel
+from sqlmodel import Session
 
 from dj.api.helpers import get_node_by_name
-from dj.models.node import AvailabilityState, NodeType
-from dj.utils import UTCDatetime, get_session
+from dj.models.cube import CubeRevisionMetadata
+from dj.models.node import NodeType
+from dj.utils import get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
-
-
-class CubeElementMetadata(SQLModel):
-    """
-    Metadata for an element in a cube
-    """
-
-    id: int
-    current_version: str
-    name: str
-
-
-class CubeRevisionMetadata(SQLModel):
-    """
-    Metadata for a cube node
-    """
-
-    id: int = Field(alias="node_revision_id")
-    node_id: int
-    type: NodeType
-    name: str
-    display_name: str
-    version: str
-    description: str = ""
-    availability: Optional[AvailabilityState] = None
-    cube_elements: List[CubeElementMetadata]
-    updated_at: UTCDatetime
-
-    class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
-        allow_population_by_field_name = True
 
 
 @router.get("/cubes/{name}/", response_model=CubeRevisionMetadata)

--- a/dj/models/base.py
+++ b/dj/models/base.py
@@ -1,7 +1,6 @@
 """
 A base SQLModel class with a default naming convention.
 """
-
 from sqlmodel import SQLModel
 
 NAMING_CONVENTION = {

--- a/dj/models/catalog.py
+++ b/dj/models/catalog.py
@@ -9,10 +9,10 @@ from uuid import UUID, uuid4
 from sqlalchemy import DateTime
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy_utils import UUIDType
-from sqlmodel import JSON, Field, Relationship
+from sqlmodel import JSON, Field, Relationship, SQLModel
 
 from dj.models.base import BaseSQLModel
-from dj.models.engine import Engine
+from dj.models.engine import Engine, EngineInfo
 from dj.utils import UTCDatetime
 
 if TYPE_CHECKING:
@@ -70,3 +70,12 @@ class Catalog(BaseSQLModel, table=True):  # type: ignore
 
     def __hash__(self) -> int:
         return hash(self.id)
+
+
+class CatalogInfo(SQLModel):
+    """
+    Class for catalog creation
+    """
+
+    name: str
+    engines: List[EngineInfo] = []

--- a/dj/models/cube.py
+++ b/dj/models/cube.py
@@ -1,0 +1,41 @@
+"""
+Models for cubes.
+"""
+
+from typing import List, Optional
+
+from pydantic import Field
+from sqlmodel import SQLModel
+
+from dj.models.node import AvailabilityState, NodeType
+from dj.utils import UTCDatetime
+
+
+class CubeElementMetadata(SQLModel):
+    """
+    Metadata for an element in a cube
+    """
+
+    id: int
+    current_version: str
+    name: str
+
+
+class CubeRevisionMetadata(SQLModel):
+    """
+    Metadata for a cube node
+    """
+
+    id: int = Field(alias="node_revision_id")
+    node_id: int
+    type: NodeType
+    name: str
+    display_name: str
+    version: str
+    description: str = ""
+    availability: Optional[AvailabilityState] = None
+    cube_elements: List[CubeElementMetadata]
+    updated_at: UTCDatetime
+
+    class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        allow_population_by_field_name = True

--- a/dj/models/metric.py
+++ b/dj/models/metric.py
@@ -1,0 +1,52 @@
+"""
+Models for metrics.
+"""
+from typing import List
+
+from sqlmodel import SQLModel
+
+from dj.models.node import Node
+from dj.sql.dag import get_dimensions
+from dj.utils import UTCDatetime
+
+
+class Metric(SQLModel):
+    """
+    Class for a metric.
+    """
+
+    id: int
+    name: str
+    display_name: str
+    current_version: str
+    description: str = ""
+
+    created_at: UTCDatetime
+    updated_at: UTCDatetime
+
+    query: str
+
+    dimensions: List[str]
+
+    @classmethod
+    def parse_node(cls, node: Node) -> "Metric":
+        """
+        Parses a node into a metric.
+        """
+
+        return cls(
+            **node.dict(),
+            description=node.current.description,
+            updated_at=node.current.updated_at,
+            query=node.current.query,
+            dimensions=get_dimensions(node),
+        )
+
+
+class TranslatedSQL(SQLModel):
+    """
+    Class for SQL generated from a given metric.
+    """
+
+    database_id: int
+    sql: str

--- a/dj/sql/parsing/backends/sqloxide.py
+++ b/dj/sql/parsing/backends/sqloxide.py
@@ -94,7 +94,6 @@ def parse_cast(parse_tree: dict) -> ast.Cast:
         elif isinstance(data_type, dict) and {
             typ.upper() for typ in data_type.keys()
         }.intersection(PRIMITIVE_TYPES):
-            print(data_type)
             type_ = [
                 ColumnType(typ)
                 for typ in data_type.keys()

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -279,9 +279,9 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         )
         data = response.json()
 
-        assert response.status_code == 500
+        assert response.status_code == 404
         assert data == {
-            "message": "Cannot add availability state, node `nonexistentnode` does not exist",
+            "message": "A node with name `nonexistentnode` does not exist.",
             "errors": [],
             "warnings": [],
         }

--- a/tests/api/graphql/metric_test.py
+++ b/tests/api/graphql/metric_test.py
@@ -130,7 +130,10 @@ def test_read_metric_errors(session: Session, client: TestClient) -> None:
 
     response_json = client.post("/graphql", json={"query": query}).json()
     assert response_json["data"] is None
-    assert response_json["errors"][0]["message"] == "Metric node not found: `foo`"
+    assert (
+        response_json["errors"][0]["message"]
+        == "A node with name `foo` does not exist."
+    )
 
     query = """
     {

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -137,7 +137,8 @@ def test_read_metrics_errors(session: Session, client: TestClient) -> None:
 
     response = client.get("/metrics/foo")
     assert response.status_code == 404
-    assert response.json() == {"detail": "Metric node not found: `foo`"}
+    data = response.json()
+    assert data["message"] == "A node with name `foo` does not exist."
 
     response = client.get("/metrics/a-metric")
     assert response.status_code == 400


### PR DESCRIPTION
### Summary

This change moves all of the models in the `api` module to the `models` module so that we can have some logical separation between the two. I originally had this as a part of the tagging PR but pulled it out for clarity.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A