### PR TITLE
Adjust pre-commit hooks to skip the clients dir.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^docs/'
+exclude: (^docs/|^clients/)
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
### Summary

Maybe not the best approach long term but I think it is ok to unblock the checks on the generate-clients PRs. We probably need to add a separate test suits there depending on the language anyway.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

After this goes in the checks should pass on the generate-clients workflow PR.