### PR TITLE
Add query service interface and allow for column inference when one is set

### DIFF
--- a/.docker-env/.env
+++ b/.docker-env/.env
@@ -3,3 +3,4 @@ DESCRIPTION="A simple DJ server running in Docker"
 REPOSITORY=examples/configs
 REDIS_CACHE=redis://query_broker:6379/0
 CELERY_BROKER=redis://query_broker:6379/1
+QUERY_SERVICE=http://host.docker.internal:8001

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -43,8 +43,9 @@ from dj.models.node import (
     UpsertMaterializationConfig,
 )
 from dj.models.table import CreateTable
+from dj.service_clients import QueryServiceClient
 from dj.sql.parsing.backends.sqloxide import parse
-from dj.utils import Version, VersionUpgrade, get_session
+from dj.utils import Version, VersionUpgrade, get_query_service_client, get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -376,7 +377,11 @@ def add_dimension_to_node(
 
 @router.post("/nodes/{name}/table/")
 def add_table_to_node(
-    name: str, data: CreateTable, *, session: Session = Depends(get_session)
+    name: str,
+    data: CreateTable,
+    *,
+    session: Session = Depends(get_session),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
 ) -> JSONResponse:
     """
     Add a table to a node
@@ -397,21 +402,38 @@ def add_table_to_node(
                 ),
                 http_status_code=HTTPStatus.CONFLICT,
             )
+
+    # When no columns are provided, attempt to find actual table columns
+    # if a query service is set
+    columns = [
+        Column(name=column.name, type=ColumnType(column.type))
+        for column in data.columns
+    ]
+    if not columns:
+        if not query_service_client:
+            raise DJException(
+                message="No table columns were provided and no query "
+                "service is configured for table columns inference!",
+            )
+        columns = query_service_client.get_columns_for_table(
+            data.catalog_name,
+            data.schema_,  # type: ignore
+            data.table,
+        )
+
     table = Table(
         catalog_id=catalog.id,
         schema=data.schema_,
         table=data.table,
         database_id=database.id,
         cost=data.cost,
-        columns=[
-            Column(name=column.name, type=ColumnType(column.type))
-            for column in data.columns
-        ],
+        columns=columns,
     )
 
     session.add(table)
     session.commit()
     session.refresh(table)
+    node.current.columns = columns
     node.current.tables.append(table)
     session.add(node)
     session.commit()

--- a/dj/config.py
+++ b/dj/config.py
@@ -45,6 +45,9 @@ class Settings(
     # How long to wait when pinging databases to find out the fastest online database.
     do_ping_timeout: timedelta = timedelta(seconds=5)
 
+    # Query service
+    query_service: Optional[str] = None
+
     @property
     def celery(self) -> Celery:
         """

--- a/dj/service_clients.py
+++ b/dj/service_clients.py
@@ -1,0 +1,84 @@
+"""Clients for various configurable services."""
+from typing import List
+from urllib.parse import urljoin
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+from dj.models.column import Column
+from dj.typing import ColumnType
+
+
+class RequestsSessionWithEndpoint(requests.Session):
+    """
+    Creates a requests session that comes with an endpoint that all
+    subsequent requests will use as a prefix.
+    """
+
+    def __init__(self, endpoint: str = None, retry_strategy: Retry = None):
+        super().__init__()
+        self.endpoint = endpoint
+        self.mount("http://", HTTPAdapter(max_retries=retry_strategy))
+        self.mount("https://", HTTPAdapter(max_retries=retry_strategy))
+
+    def request(self, method, url, *args, **kwargs):
+        """
+        Make the request with the full URL.
+        """
+        url = self.construct_url(url)
+        return super().request(method, url, *args, **kwargs)
+
+    def prepare_request(self, request, *args, **kwargs):
+        """
+        Prepare the request with the full URL.
+        """
+        request.url = self.construct_url(request.url)
+        return super().prepare_request(
+            request,
+            *args,
+            **kwargs,
+        )
+
+    def construct_url(self, url):
+        """
+        Construct full URL based off the endpoint.
+        """
+        return urljoin(self.endpoint, url)
+
+
+class QueryServiceClient:  # pylint: disable=too-few-public-methods
+    """
+    Client for the query service.
+    """
+
+    def __init__(self, uri: str, retries: int = 2):
+        self.uri = uri
+        retry_strategy = Retry(
+            total=retries,
+            backoff_factor=1.5,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET", "POST", "PUT", "PATCH"],
+        )
+        self.requests_session = RequestsSessionWithEndpoint(
+            endpoint=self.uri,
+            retry_strategy=retry_strategy,
+        )
+
+    def get_columns_for_table(
+        self,
+        catalog: str,
+        schema: str,
+        table: str,
+    ) -> List[Column]:
+        """
+        Retrieves columns for a table.
+        """
+        response = self.requests_session.get(
+            f"/table/{catalog}.{schema}.{table}/columns/",
+        )
+        table_columns = response.json()["columns"]
+        return [
+            Column(name=column["name"], type=ColumnType(column["type"]))
+            for column in table_columns
+        ]

--- a/dj/utils.py
+++ b/dj/utils.py
@@ -23,6 +23,7 @@ from yarl import URL
 
 from dj.config import Settings
 from dj.errors import DJException
+from dj.service_clients import QueryServiceClient
 from dj.typing import ColumnType
 
 
@@ -81,6 +82,16 @@ def get_session() -> Iterator[Session]:
 
     with Session(engine, autoflush=False) as session:  # pragma: no cover
         yield session
+
+
+def get_query_service_client() -> Optional[QueryServiceClient]:
+    """
+    Return query service client
+    """
+    settings = get_settings()
+    if not settings.query_service:
+        return None
+    return QueryServiceClient(settings.query_service)
 
 
 def get_name_from_path(repository: Path, path: Path) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - db_migration
       - postgres_examples
       - redis
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   celery:
     container_name: celery

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def settings(mocker: MockerFixture) -> Iterator[Settings]:
         results_backend=SimpleCache(default_timeout=0),
         celery_broker=None,
         redis_cache=None,
+        query_service=None,
     )
 
     mocker.patch(

--- a/tests/service_clients_test.py
+++ b/tests/service_clients_test.py
@@ -1,0 +1,87 @@
+"""
+Tests for ``dj.service_clients``.
+"""
+import pytest
+from pytest_mock import MockerFixture
+from requests import Request
+
+from dj.service_clients import QueryServiceClient, RequestsSessionWithEndpoint
+
+
+class TestRequestsSessionWithEndpoint:
+    """
+    Test using requests session with endpoint.
+    """
+
+    example_endpoint = "http://pieservice:7020"
+
+    @pytest.fixture
+    def requests_session(self) -> RequestsSessionWithEndpoint:
+        """
+        Create a requests session.
+        """
+        return RequestsSessionWithEndpoint(endpoint=self.example_endpoint)
+
+    def test_prepare_request(
+        self,
+        requests_session: RequestsSessionWithEndpoint,
+    ) -> None:
+        """
+        Test preparing request
+        """
+        req = Request(
+            "GET",
+            f"{self.example_endpoint}/pies/?flavor=blueberry",
+            data=None,
+            headers=None,
+        )
+        prepped = requests_session.prepare_request(req)
+        assert prepped.headers["Connection"] == "keep-alive"
+
+    def test_make_requests(
+        self,
+        mocker: MockerFixture,
+        requests_session: RequestsSessionWithEndpoint,
+    ):
+        """
+        Test making requests.
+        """
+        mock_request = mocker.patch("requests.Session.request")
+
+        requests_session.get("/pies/")
+        mock_request.assert_called_with(
+            "GET",
+            f"{self.example_endpoint}/pies/",
+            allow_redirects=True,
+        )
+
+        requests_session.post("/pies/", json={"flavor": "blueberry", "diameter": 10})
+        mock_request.assert_called_with(
+            "POST",
+            f"{self.example_endpoint}/pies/",
+            data=None,
+            json={"flavor": "blueberry", "diameter": 10},
+        )
+
+
+class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
+    """
+    Test using the query service client.
+    """
+
+    endpoint = "http://queryservice:8001"
+
+    def test_get_columns_for_table(self, mocker: MockerFixture) -> None:
+        """
+        Test the query service client.
+        """
+
+        mock_request = mocker.patch("requests.Session.request")
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        query_service_client.get_columns_for_table("hive", "test", "pies")
+
+        mock_request.assert_called_with(
+            "GET",
+            "http://queryservice:8001/table/hive.test.pies/columns/",
+            allow_redirects=True,
+        )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -19,6 +19,7 @@ from dj.utils import (
     get_issue_url,
     get_more_specific_type,
     get_name_from_path,
+    get_query_service_client,
     get_session,
     get_settings,
     setup_logging,
@@ -155,6 +156,16 @@ def test_get_engine(mocker: MockerFixture, settings: Settings) -> None:
     mocker.patch("dj.utils.get_settings", return_value=settings)
     engine = get_engine()
     assert engine.url == make_url("sqlite://")
+
+
+def test_get_query_service_client(mocker: MockerFixture, settings: Settings) -> None:
+    """
+    Test ``get_query_service_client``.
+    """
+    settings.query_service = "http://query_service:8001"
+    mocker.patch("dj.utils.get_settings", return_value=settings)
+    query_service_client = get_query_service_client()
+    assert query_service_client.uri == "http://query_service:8001"  # type: ignore
 
 
 def test_version_parse() -> None:


### PR DESCRIPTION
### Summary

**Query Service Interface**

This change sets up the interface between a query service and DJ through the `QueryServiceClient` class. The client class will serve as a common interface for any custom query services, including the one that [comes default with DJ](https://github.com/DataJunction/djqs). 

(As an addendum to this PR, we'll need to modify [djqs](https://github.com/DataJunction/djqs) to have the same `/table/<name>/columns` API endpoint, and indeed all the endpoints that are supported through this client.)

**Column Interface**

This also modifies the "add table to node" endpoint to allow for column inference when the user passes in empty columns and. valid query service is configured. This makes adding tables very easy, as users don't need to translate from the source table schema to DJ column types and can rely on the configured query service to do so.

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #342
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
