### PR TITLE
Remove example from name

### DIFF
--- a/.docker-env/.env
+++ b/.docker-env/.env
@@ -1,4 +1,4 @@
-NAME="Example DJ server"
+NAME="DJ server"
 DESCRIPTION="A simple DJ server running in Docker"
 REPOSITORY=examples/configs
 REDIS_CACHE=redis://query_broker:6379/0

--- a/.docker-env/.env-cockroachdb
+++ b/.docker-env/.env-cockroachdb
@@ -1,4 +1,4 @@
-NAME="Example DJ server backed by CockroachDB"
+NAME="DJ server backed by CockroachDB"
 DESCRIPTION="A simple DJ server running in Docker backed by CockroachDB"
 INDEX=cockroachdb://root:@cockroachdb_metadata:26257/dj?sslmode=disable
 REPOSITORY=examples/cockroachdb/configs

--- a/.docker-env/.env-postgres
+++ b/.docker-env/.env-postgres
@@ -1,4 +1,4 @@
-NAME="Example DJ server backed by Postgres"
+NAME="DJ server backed by Postgres"
 DESCRIPTION="A simple DJ server running in Docker backed by Postgres"
 INDEX=postgresql://username:FoolishPassword@postgres_metadata:5432/dj
 REPOSITORY=examples/configs


### PR DESCRIPTION
### Summary

The name in the settings is used as the browser title. I'm removing the "Example" in the name so that "DJ" is more prominent. This way it will be more visually obvious when you have both a DJ and a DJQS swagger page up.

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
