### PR TITLE
Endpoint for getting common dimensions for a set of metrics

### DIFF
--- a/notebooks/Modeling the Roads Example Database.ipynb
+++ b/notebooks/Modeling the Roads Example Database.ipynb
@@ -594,94 +594,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d44493cc",
-   "metadata": {},
-   "source": [
-    "# Link Columns to Dimension Nodes\n",
-    "\n",
-    "Dimensions are discovered through labels on node columns throughout the DJ DAG. These labels link these columns to the primary key(s) of the dimension node. Create links to all columns in the DJ DAG to their corresponding dimension nodes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e3ab8667",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/repair_order_details/columns/repair_order_id/?dimension=repair_order&dimension_column=repair_order_id\"\n",
-    ")\n",
-    "response.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c7c4c9c3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/repair_orders/columns/municipality_id/?dimension=municipality_dim&dimension_column=municipality_id\"\n",
-    ")\n",
-    "response.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7aa2d18c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/repair_type/columns/contractor_id/?dimension=contractor&dimension_column=contractor_id\"\n",
-    ")\n",
-    "response.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "49f61713",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/repair_orders/columns/hard_hat_id/?dimension=hard_hat&dimension_column=hard_hat_id\"\n",
-    ")\n",
-    "response.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dd24d3cb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/repair_orders/columns/dispatcher_id/?dimension=dispatcher&dimension_column=dispatcher_id\"\n",
-    ")\n",
-    "response.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4f705582",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/local_hard_hats/columns/state_id/?dimension=us_state&dimension_column=state_id\"\n",
-    ")\n",
-    "response.json()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "d405291d",
    "metadata": {},
    "source": [
@@ -1211,6 +1123,94 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a2edbf18",
+   "metadata": {},
+   "source": [
+    "# Link Columns to Dimension Nodes\n",
+    "\n",
+    "Dimensions are discovered through labels on node columns throughout the DJ DAG. These labels link these columns to the primary key(s) of the dimension node. Create links to all columns in the DJ DAG to their corresponding dimension nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bf208cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_order_details/columns/repair_order_id/?dimension=repair_order&dimension_column=repair_order_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5fe02fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_orders/columns/municipality_id/?dimension=municipality_dim&dimension_column=municipality_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5237f6f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_type/columns/contractor_id/?dimension=contractor&dimension_column=contractor_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3370384",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_orders/columns/hard_hat_id/?dimension=hard_hat&dimension_column=hard_hat_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb441b50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_orders/columns/dispatcher_id/?dimension=dispatcher&dimension_column=dispatcher_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab3ffde2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/local_hard_hats/columns/state_id/?dimension=us_state&dimension_column=state_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c7c11045",
    "metadata": {},
    "source": [
@@ -1327,13 +1327,21 @@
     ")\n",
     "print(response.json()[\"sql\"])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1ff6d8c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (XP Env)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "xp-env-python"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1345,7 +1353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/tests/api/catalog_test.py
+++ b/tests/api/catalog_test.py
@@ -71,6 +71,10 @@ def test_catalog_list(
     assert response.status_code == 200
     assert response.json() == [
         {
+            "name": "public",
+            "engines": [{"name": "spark", "version": "3.1.1", "uri": None}],
+        },
+        {
             "name": "dev",
             "engines": [{"name": "spark", "version": "3.3.1", "uri": None}],
         },

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -67,9 +67,9 @@ def test_read_cube(client: TestClient) -> None:
     )
     assert response.status_code == 201
     data = response.json()
-    assert data["node_id"] == 4
+    assert data["node_id"] == 30
     assert data["version"] == "v1.0"
-    assert data["node_revision_id"] == 4
+    assert data["node_revision_id"] == 30
     assert data["type"] == "cube"
     assert data["name"] == "number_of_accounts_by_account_type"
     assert data["display_name"] == "Number Of Accounts By Account Type"
@@ -79,18 +79,18 @@ def test_read_cube(client: TestClient) -> None:
     response = client.get("/cubes/number_of_accounts_by_account_type")
     assert response.status_code == 200
     data = response.json()
-    assert data["node_revision_id"] == 4
-    assert data["node_id"] == 4
+    assert data["node_revision_id"] == 30
+    assert data["node_id"] == 30
     assert data["type"] == "cube"
     assert data["name"] == "number_of_accounts_by_account_type"
     assert data["display_name"] == "Number Of Accounts By Account Type"
     assert data["version"] == "v1.0"
     assert data["description"] == "A cube of number of accounts grouped by account type"
-    assert {"id": 2, "current_version": "v1.0", "name": "account_type"} in data[
+    assert {"id": 28, "current_version": "v1.0", "name": "account_type"} in data[
         "cube_elements"
     ]
     assert {
-        "id": 3,
+        "id": 29,
         "current_version": "v1.0",
         "name": "number_of_account_types",
     } in data["cube_elements"]

--- a/tests/api/engine_test.py
+++ b/tests/api/engine_test.py
@@ -63,6 +63,11 @@ def test_engine_list(
         {
             "name": "spark",
             "uri": None,
+            "version": "3.1.1",
+        },
+        {
+            "name": "spark",
+            "uri": None,
             "version": "2.4.4",
         },
         {

--- a/tests/api/graphql/metric_test.py
+++ b/tests/api/graphql/metric_test.py
@@ -52,7 +52,44 @@ def test_read_metrics(session: Session, client: TestClient):
     response = client.post("/graphql", json={"query": query})
     assert response.json() == {
         "data": {
-            "readMetrics": [{"id": 3, "name": "a-metric", "displayName": "A-Metric"}],
+            "readMetrics": [
+                {
+                    "name": "num_repair_orders",
+                    "displayName": "Num Repair Orders",
+                    "id": 20,
+                },
+                {
+                    "name": "avg_repair_price",
+                    "displayName": "Avg Repair Price",
+                    "id": 21,
+                },
+                {
+                    "name": "total_repair_cost",
+                    "displayName": "Total Repair Cost",
+                    "id": 22,
+                },
+                {
+                    "name": "avg_length_of_employment",
+                    "displayName": "Avg Length Of Employment",
+                    "id": 23,
+                },
+                {
+                    "name": "total_repair_order_discounts",
+                    "displayName": "Total Repair Order Discounts",
+                    "id": 24,
+                },
+                {
+                    "name": "avg_repair_order_discounts",
+                    "displayName": "Avg Repair Order Discounts",
+                    "id": 25,
+                },
+                {
+                    "name": "avg_time_to_dispatch",
+                    "displayName": "Avg Time To Dispatch",
+                    "id": 26,
+                },
+                {"name": "a-metric", "displayName": "A-Metric", "id": 29},
+            ],
         },
     }
 
@@ -98,7 +135,7 @@ def test_read_metric(session: Session, client: TestClient):
     response = client.post("/graphql", json={"query": query})
     assert response.json() == {
         "data": {
-            "readMetric": {"id": 3, "name": "a-metric", "displayName": "A-Metric"},
+            "readMetric": {"id": 29, "name": "a-metric", "displayName": "A-Metric"},
         },
     }
 

--- a/tests/api/graphql/node_test.py
+++ b/tests/api/graphql/node_test.py
@@ -69,7 +69,7 @@ def test_get_nodes(session: Session, client: TestClient) -> None:
     response = client.post("/graphql", json={"query": query})
     data = response.json()["data"]["getNodes"]
 
-    assert len(data) == 3
+    assert len(data) == 29
 
     nodes = {node["name"]: node for node in data}
 

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -36,8 +36,8 @@ def test_read_node(session: Session, client: TestClient) -> None:
 
     assert response.status_code == 200
     assert data["version"] == "1"
-    assert data["node_id"] == 1
-    assert data["node_revision_id"] == 1
+    assert data["node_id"] == 27
+    assert data["node_revision_id"] == 27
     assert data["type"] == "source"
 
     response = client.get("/nodes/nothing/")
@@ -97,7 +97,7 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 200
-    assert len(data) == 3
+    assert len(data) == 29
 
     nodes = {node["name"]: node for node in data}
     assert nodes["not-a-metric"]["query"] is None
@@ -268,7 +268,7 @@ class TestCreateOrUpdateNodes:
         assert data["type"] == "source"
         assert data["display_name"] == "Comments"
         assert data["version"] == "v1.0"
-        assert data["node_id"] == 1
+        assert data["node_id"] == 27
         assert data["description"] == "A fact table with comments"
         assert data["query"] is None
         assert data["columns"] == [
@@ -301,7 +301,7 @@ class TestCreateOrUpdateNodes:
         assert data["display_name"] == "Comments facts"
         assert data["type"] == "source"
         assert data["version"] == "v1.1"
-        assert data["node_id"] == 1
+        assert data["node_id"] == 27
         assert data["description"] == "New description"
 
         # Try to update node with no changes
@@ -546,7 +546,7 @@ class TestCreateOrUpdateNodes:
         )
         data = response.json()
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert data["name"] == "countries"
         assert data["display_name"] == "Countries"
         assert data["type"] == "dimension"
@@ -1480,7 +1480,7 @@ def test_resolving_downstream_status(
             "/nodes/",
             json=node,
         )
-        assert response.status_code == 200
+        assert response.status_code == 201
         data = response.json()
         assert data["name"] == node["name"]
         assert data["mode"] == node["mode"]
@@ -1504,7 +1504,7 @@ def test_resolving_downstream_status(
         "/nodes/",
         json=missing_parent_node,
     )
-    assert response.status_code == 200
+    assert response.status_code == 201
     data = response.json()
     assert data["name"] == missing_parent_node["name"]
     assert data["mode"] == missing_parent_node["mode"]

--- a/tests/cli/urls_test.py
+++ b/tests/cli/urls_test.py
@@ -27,6 +27,7 @@ http://localhost:8000/engines/{name}/{version}/: Return an engine by name and ve
 http://localhost:8000/metrics/: List all available metrics.
 http://localhost:8000/metrics/{name}/: Return a metric by name.
 http://localhost:8000/metrics/{name}/sql/: Return SQL for a metric.
+http://localhost:8000/metrics/common/dimensions/: Return common dimensions for a set of metrics.
 http://localhost:8000/query/validate: Return SQL for a DJ Query.
 http://localhost:8000/nodes/validate/: Validate a node.
 http://localhost:8000/nodes/: List the available nodes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,10 @@ def session() -> Iterator[Session]:
 
 
 @pytest.fixture()
-def client(session: Session, settings: Settings) -> Iterator[TestClient]:
+def client(  # pylint: disable=too-many-statements
+    session: Session,
+    settings: Settings,
+) -> Iterator[TestClient]:
     """
     Create a client for testing APIs.
     """
@@ -100,6 +103,684 @@ def client(session: Session, settings: Settings) -> Iterator[TestClient]:
     app.dependency_overrides[get_settings] = get_settings_override
 
     with TestClient(app) as client:
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "repair_order_id": {"type": "INT"},
+                    "municipality_id": {"type": "STR"},
+                    "hard_hat_id": {"type": "INT"},
+                    "order_date": {"type": "DATETIME"},
+                    "required_date": {"type": "DATETIME"},
+                    "dispatched_date": {"type": "DATETIME"},
+                    "dispatcher_id": {"type": "INT"},
+                },
+                "description": "Repair orders",
+                "mode": "published",
+                "name": "repair_orders",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "repair_order_id": {"type": "INT"},
+                    "repair_type_id": {"type": "INT"},
+                    "price": {"type": "FLOAT"},
+                    "quantity": {"type": "INT"},
+                    "discount": {"type": "FLOAT"},
+                },
+                "description": "Details on repair orders",
+                "mode": "published",
+                "name": "repair_order_details",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "repair_type_id": {"type": "INT"},
+                    "repair_type_name": {"type": "STR"},
+                    "contractor_id": {"type": "INT"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "repair_type",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "contractor_id": {"type": "INT"},
+                    "company_name": {"type": "STR"},
+                    "contact_name": {"type": "STR"},
+                    "contact_title": {"type": "STR"},
+                    "address": {"type": "STR"},
+                    "city": {"type": "STR"},
+                    "state": {"type": "STR"},
+                    "postal_code": {"type": "STR"},
+                    "country": {"type": "STR"},
+                    "phone": {"type": "STR"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "contractors",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "municipality_id": {"type": "STR"},
+                    "municipality_type_id": {"type": "STR"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "municipality_municipality_type",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "municipality_type_id": {"type": "STR"},
+                    "municipality_type_desc": {"type": "STR"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "municipality_type",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "municipality_id": {"type": "STR"},
+                    "contact_name": {"type": "STR"},
+                    "contact_title": {"type": "STR"},
+                    "local_region": {"type": "STR"},
+                    "phone": {"type": "STR"},
+                    "state_id": {"type": "INT"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "municipality",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "dispatcher_id": {"type": "INT"},
+                    "company_name": {"type": "STR"},
+                    "phone": {"type": "STR"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "dispatchers",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "hard_hat_id": {"type": "INT"},
+                    "last_name": {"type": "STR"},
+                    "first_name": {"type": "STR"},
+                    "title": {"type": "STR"},
+                    "birth_date": {"type": "DATETIME"},
+                    "hire_date": {"type": "DATETIME"},
+                    "address": {"type": "STR"},
+                    "city": {"type": "STR"},
+                    "state": {"type": "STR"},
+                    "postal_code": {"type": "STR"},
+                    "country": {"type": "STR"},
+                    "manager": {"type": "INT"},
+                    "contractor_id": {"type": "INT"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "hard_hats",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "hard_hat_id": {"type": "INT"},
+                    "state_id": {"type": "STR"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "hard_hat_state",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "state_id": {"type": "INT"},
+                    "state_name": {"type": "STR"},
+                    "state_abbr": {"type": "STR"},
+                    "state_region": {"type": "INT"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "us_states",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "columns": {
+                    "us_region_id": {"type": "INT"},
+                    "us_region_description": {"type": "STR"},
+                },
+                "description": "Information on different types of repairs",
+                "mode": "published",
+                "name": "us_region",
+                "type": "source",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Repair order dimension",
+                "query": """
+                    SELECT
+                    repair_order_id,
+                    municipality_id,
+                    hard_hat_id,
+                    order_date,
+                    required_date,
+                    dispatched_date,
+                    dispatcher_id
+                    FROM repair_orders
+                """,
+                "mode": "published",
+                "name": "repair_order",
+                "type": "dimension",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Contractor dimension",
+                "query": """
+                    SELECT
+                    contractor_id,
+                    company_name,
+                    contact_name,
+                    contact_title,
+                    address,
+                    city,
+                    state,
+                    postal_code,
+                    country,
+                    phone
+                    FROM contractors
+                """,
+                "mode": "published",
+                "name": "contractor",
+                "type": "dimension",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Hard hat dimension",
+                "query": """
+                    SELECT
+                    hard_hat_id,
+                    last_name,
+                    first_name,
+                    title,
+                    birth_date,
+                    hire_date,
+                    address,
+                    city,
+                    state,
+                    postal_code,
+                    country,
+                    manager,
+                    contractor_id
+                    FROM hard_hats
+                """,
+                "mode": "published",
+                "name": "hard_hat",
+                "type": "dimension",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Hard hat dimension",
+                "query": """
+                    SELECT
+                    hh.hard_hat_id,
+                    last_name,
+                    first_name,
+                    title,
+                    birth_date,
+                    hire_date,
+                    address,
+                    city,
+                    state,
+                    postal_code,
+                    country,
+                    manager,
+                    contractor_id,
+                    hhs.state_id AS state_id
+                    FROM hard_hats hh
+                    LEFT JOIN hard_hat_state hhs
+                    ON hh.hard_hat_id = hhs.hard_hat_id
+                    WHERE hh.state_id = 'NY'
+                """,
+                "mode": "published",
+                "name": "local_hard_hats",
+                "type": "dimension",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "US state dimension",
+                "query": """
+                    SELECT
+                    state_id,
+                    state_name,
+                    state_abbr,
+                    state_region,
+                    r.us_region_description AS state_region_description
+                    FROM us_states s
+                    LEFT JOIN us_region r
+                    ON s.state_region = r.us_region_id
+                """,
+                "mode": "published",
+                "name": "us_state",
+                "type": "dimension",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Dispatcher dimension",
+                "query": """
+                    SELECT
+                    dispatcher_id,
+                    company_name,
+                    phone
+                    FROM dispatchers
+                """,
+                "mode": "published",
+                "name": "dispatcher",
+                "type": "dimension",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Municipality dimension",
+                "query": """
+                    SELECT
+                    m.municipality_id,
+                    contact_name,
+                    contact_title,
+                    local_region,
+                    phone,
+                    state_id,
+                    mmt.municipality_type_id,
+                    mt.municipality_type_desc
+                    FROM municipality AS m
+                    LEFT JOIN municipality_municipality_type AS mmt
+                    ON m.municipality_id = mmt.municipality_id
+                    LEFT JOIN municipality_type AS mt
+                    ON mmt.municipality_type_id = mt.municipality_type_desc
+                """,
+                "mode": "published",
+                "name": "municipality_dim",
+                "type": "dimension",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Number of repair orders",
+                "query": "SELECT count(repair_order_id) as num_repair_orders FROM repair_orders",
+                "mode": "published",
+                "name": "num_repair_orders",
+                "type": "metric",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Average repair price",
+                "query": "SELECT avg(price) as avg_repair_price FROM repair_order_details",
+                "mode": "published",
+                "name": "avg_repair_price",
+                "type": "metric",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Total repair cost",
+                "query": "SELECT sum(price) as total_repair_cost FROM repair_order_details",
+                "mode": "published",
+                "name": "total_repair_cost",
+                "type": "metric",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Average length of employment",
+                "query": "SELECT avg(NOW() - hire_date) as avg_length_of_employment FROM hard_hats",
+                "mode": "published",
+                "name": "avg_length_of_employment",
+                "type": "metric",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Total repair order discounts",
+                "query": "SELECT sum(price * discount) as total_discount FROM repair_order_details",
+                "mode": "published",
+                "name": "total_repair_order_discounts",
+                "type": "metric",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Total repair order discounts",
+                "query": (
+                    "SELECT avg(price * discount) as avg_repair_order_discount "
+                    "FROM repair_order_details"
+                ),
+                "mode": "published",
+                "name": "avg_repair_order_discounts",
+                "type": "metric",
+            },
+        )
+        client.post(
+            "/nodes/",
+            json={
+                "description": "Average time to dispatch a repair order",
+                "query": (
+                    "SELECT avg(dispatched_date - order_date) as avg_time_to_dispatch "
+                    "FROM repair_orders"
+                ),
+                "mode": "published",
+                "name": "avg_time_to_dispatch",
+                "type": "metric",
+            },
+        )
+        client.post(  # Add a catalog named public
+            "/catalogs/",
+            json={"name": "public"},
+        )
+        client.post(  # Add spark as an engine
+            "/engines/",
+            json={"name": "spark", "version": "3.1.1"},
+        )
+        client.post(  # Attach the spark engine to the public catalog
+            "/catalogs/public/engines/",
+            json=[{"name": "spark", "version": "3.1.1"}],
+        )
+        client.post(
+            "/nodes/repair_orders/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "repair_orders",
+                "columns": [
+                    {"name": "repair_order_id", "type": "INT"},
+                    {"name": "municipality_id", "type": "STR"},
+                    {"name": "hard_hat_id", "type": "INT"},
+                    {"name": "order_date", "type": "DATETIME"},
+                    {"name": "required_date", "type": "DATETIME"},
+                    {"name": "dispatched_date", "type": "DATETIME"},
+                    {"name": "dispatcher_id", "type": "INT"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/repair_order_details/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "repair_order_details",
+                "columns": [
+                    {"name": "repair_order_id", "type": "INT"},
+                    {"name": "repair_type_id", "type": "INT"},
+                    {"name": "price", "type": "FLOAT"},
+                    {"name": "quantity", "type": "INT"},
+                    {"name": "discount", "type": "FLOAT"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/repair_type/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "repair_type",
+                "columns": [
+                    {"name": "repair_type_id", "type": "INT"},
+                    {"name": "repair_type_name", "type": "STR"},
+                    {"name": "contractor_id", "type": "INT"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/municipality/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "municipality",
+                "columns": [
+                    {"name": "municipality_id", "type": "STR"},
+                    {"name": "contact_name", "type": "STR"},
+                    {"name": "contact_title", "type": "STR"},
+                    {"name": "local_region", "type": "STR"},
+                    {"name": "phone", "type": "STR"},
+                    {"name": "state_id", "type": "INT"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/municipality_municipality_type/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "municipality_municipality_type",
+                "columns": [
+                    {"name": "municipality_id", "type": "STR"},
+                    {"name": "municipality_type_id", "type": "STR"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/municipality_type/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "municipality_type",
+                "columns": [
+                    {"name": "municipality_type_id", "type": "STR"},
+                    {"name": "municipality_type_desc", "type": "STR"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/dispatchers/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "dispatchers",
+                "columns": [
+                    {"name": "dispatcher_id", "type": "INT"},
+                    {"name": "company_name", "type": "STR"},
+                    {"name": "phone", "type": "STR"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/us_region/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "us_region",
+                "columns": [
+                    {"name": "us_region_id", "type": "INT"},
+                    {"name": "us_region_description", "type": "STR"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/us_states/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "us_states",
+                "columns": [
+                    {"name": "state_id", "type": "INT"},
+                    {"name": "state_name", "type": "STR"},
+                    {"name": "state_abbr", "type": "STR"},
+                    {"name": "state_region", "type": "INT"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/hard_hat_state/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "hard_hat_state",
+                "columns": [
+                    {"name": "hard_hat_id", "type": "INT"},
+                    {"name": "state_id", "type": "STR"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/hard_hats/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "hard_hats",
+                "columns": [
+                    {"name": "hard_hat_id", "type": "INT"},
+                    {"name": "last_name", "type": "STR"},
+                    {"name": "first_name", "type": "STR"},
+                    {"name": "title", "type": "STR"},
+                    {"name": "birth_date", "type": "DATETIME"},
+                    {"name": "hire_date", "type": "DATETIME"},
+                    {"name": "address", "type": "STR"},
+                    {"name": "city", "type": "STR"},
+                    {"name": "state", "type": "STR"},
+                    {"name": "postal_code", "type": "STR"},
+                    {"name": "country", "type": "STR"},
+                    {"name": "manager", "type": "INT"},
+                    {"name": "contractor_id", "type": "INT"},
+                ],
+            },
+        )
+        client.post(
+            "/nodes/contractors/table/",
+            json={
+                "database_name": "roads",
+                "catalog_name": "public",
+                "cost": 0.1,
+                "schema": "roads",
+                "table": "contractors",
+                "columns": [
+                    {"name": "contractor_id", "type": "INT"},
+                    {"name": "company_name", "type": "STR"},
+                    {"name": "contact_name", "type": "STR"},
+                    {"name": "contact_title", "type": "STR"},
+                    {"name": "address", "type": "STR"},
+                    {"name": "city", "type": "STR"},
+                    {"name": "state", "type": "STR"},
+                    {"name": "postal_code", "type": "STR"},
+                    {"name": "country", "type": "STR"},
+                    {"name": "phone", "type": "STR"},
+                ],
+            },
+        )
+        client.post(
+            (
+                "/nodes/repair_order_details/columns/repair_order_id/"
+                "?dimension=repair_order&dimension_column=repair_order_id"
+            ),
+        )
+        client.post(
+            (
+                "/nodes/repair_orders/columns/municipality_id/"
+                "?dimension=municipality_dim&dimension_column=municipality_id"
+            ),
+        )
+        client.post(
+            (
+                "/nodes/repair_type/columns/contractor_id/"
+                "?dimension=contractor&dimension_column=contractor_id"
+            ),
+        )
+        client.post(
+            (
+                "/nodes/repair_orders/columns/hard_hat_id/"
+                "?dimension=hard_hat&dimension_column=hard_hat_id"
+            ),
+        )
+        client.post(
+            (
+                "/nodes/repair_orders/columns/dispatcher_id/"
+                "?dimension=dispatcher&dimension_column=dispatcher_id"
+            ),
+        )
+        client.post(
+            (
+                "/nodes/local_hard_hats/columns/state_id/"
+                "?dimension=us_state&dimension_column=state_id"
+            ),
+        )
         yield client
 
     app.dependency_overrides.clear()


### PR DESCRIPTION
### Summary

This adds a `GET /metrics/common/dimensions/` endpoint to find the common dimensions that are shared by a set of metrics. In this PR I also added nodes from the roads example to the test client fixture. We can consolidate the various node creation through the tests to instead create it as part of the fixture so we have them all in one place, available to all tests.

For an example of finding common dimensions for a set of metrics, try the following request.

```sh
curl -X 'GET' \
  'http://localhost:8000/metrics/common/dimensions/?metric=total_repair_order_discounts&metric=total_repair_cost' \
  -H 'accept: application/json'
```
_response_
```json
[
  "repair_order_details.quantity",
  "repair_order.repair_order_id",
  "repair_order.dispatched_date",
  "repair_order.dispatcher_id",
  "repair_order.required_date",
  "repair_order_details.repair_order_id",
  "repair_order.order_date",
  "repair_order_details.price",
  "repair_order_details.repair_type_id",
  "repair_order_details.discount",
  "repair_order.hard_hat_id",
  "repair_order.municipality_id"
]
```
### Test Plan

Wrote tests, ran curl requests

- [x] PR has an associated issue: #321 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
