### PR TITLE
Fix column type parsing to handle named fields in `ROW`

### DIFF
--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -80,20 +80,29 @@ def test_nested_types():
     )
     assert (
         ColumnType._validate_type(  # pylint: disable=W0212
-            "ROW[ARRAY[STR], MAP[STR, STR], STR, INT, MAP[STR, MAP[FLOAT, STR]]]",
+            "ROW[ARRAY[STR] fruits, MAP[STR, STR] vegetables, "
+            "STR grains, INT, MAP[STR, MAP[FLOAT, STR]]]",
         )
-        == "ROW[ARRAY[STR], MAP[STR, STR], STR, INT, MAP[STR, MAP[FLOAT, STR]]]"
+        == "ROW[ARRAY[STR] fruits, MAP[STR, STR] vegetables, "
+        "STR grains, INT, MAP[STR, MAP[FLOAT, STR]]]"
     )
     assert (
         ColumnType._validate_type(  # pylint: disable=W0212
             "ROW[MAP[STR, ARRAY[STR]], STR name]",
         )
-        == "ROW[MAP[STR, ARRAY[STR]], STR]"
+        == "ROW[MAP[STR, ARRAY[STR]], STR name]"
     )
 
     assert (
         ColumnType._validate_type("MAP[STR, MAP[STR, STR]]")  # pylint: disable=W0212
         == "MAP[STR, MAP[STR, STR]]"
+    )
+
+    assert (
+        ColumnType._validate_type(  # pylint: disable=W0212
+            "ROW[STR name, ROW[STR uuid, int id] devices]",
+        )
+        == "ROW[STR name, ROW[STR uuid, INT id] devices]"
     )
 
 


### PR DESCRIPTION
### Summary

Two issues:
1. `ColumnType.ROW` doesn't parse correctly when the `ROW` has a named field with a complex type. For example, with `ROW[STR name, MAP[STR,STR] display, ROW[STR id]]`, it doesn't treat `display` as a field name for the `MAP`.
2. Named fields aren't output in the actual `ColumnType` string. This is needed so that we can store into the columns table for future use (otherwise these names will be lost after parsing it for the first time).

### Test Plan

Added some tests for named fields. Also verified locally with some tables with named struct columns.

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A