### PR TITLE
Add query running functions to the query service client

### DIFF
--- a/dj/errors.py
+++ b/dj/errors.py
@@ -235,3 +235,12 @@ class DJDoesNotExistException(DJException):
 
     dbapi_exception: DBAPIExceptions = "DataError"
     http_status_code: int = 404
+
+
+class DJQueryServiceClientException(DJException):
+    """
+    Exception raised when the query service returns an error
+    """
+
+    dbapi_exception: DBAPIExceptions = "InterfaceError"
+    http_status_code: int = 500

--- a/dj/models/catalog.py
+++ b/dj/models/catalog.py
@@ -13,7 +13,7 @@ from sqlmodel import JSON, Field, Relationship, SQLModel
 
 from dj.models.base import BaseSQLModel
 from dj.models.engine import Engine, EngineInfo
-from dj.utils import UTCDatetime
+from dj.typing import UTCDatetime
 
 if TYPE_CHECKING:
     from dj.models import NodeRevision, Table

--- a/dj/models/cube.py
+++ b/dj/models/cube.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from sqlmodel import SQLModel
 
 from dj.models.node import AvailabilityState, NodeType
-from dj.utils import UTCDatetime
+from dj.typing import UTCDatetime
 
 
 class CubeElementMetadata(SQLModel):

--- a/dj/models/database.py
+++ b/dj/models/database.py
@@ -13,7 +13,7 @@ from sqlalchemy_utils import UUIDType
 from sqlmodel import JSON, Field, Relationship
 
 from dj.models.base import BaseSQLModel
-from dj.utils import UTCDatetime
+from dj.typing import UTCDatetime
 
 if TYPE_CHECKING:
     from dj.models.catalog import Catalog

--- a/dj/models/metric.py
+++ b/dj/models/metric.py
@@ -7,7 +7,7 @@ from sqlmodel import SQLModel
 
 from dj.models.node import Node
 from dj.sql.dag import get_dimensions
-from dj.utils import UTCDatetime
+from dj.typing import UTCDatetime
 
 
 class Metric(SQLModel):

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -26,8 +26,8 @@ from dj.models.engine import Engine, EngineInfo
 # from dj.models.table import Table, TableNodeRevision, TableYAML
 from dj.models.tag import Tag, TagNodeRelationship
 from dj.sql.parse import is_metric
-from dj.typing import ColumnType
-from dj.utils import UTCDatetime, Version
+from dj.typing import ColumnType, UTCDatetime
+from dj.utils import Version
 
 DEFAULT_DRAFT_VERSION = Version(major=0, minor=1)
 DEFAULT_PUBLISHED_VERSION = Version(major=1, minor=0)

--- a/dj/models/query.py
+++ b/dj/models/query.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional
 from uuid import UUID, uuid4
 
 import msgpack
-from pydantic import AnyHttpUrl
+from pydantic import AnyHttpUrl, validator
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy_utils import UUIDType
 from sqlmodel import Field, Relationship
@@ -115,6 +115,27 @@ class QueryWithResults(BaseQuery):
     next: Optional[AnyHttpUrl] = None
     previous: Optional[AnyHttpUrl] = None
     errors: List[str]
+
+    @validator("scheduled", pre=True)
+    def parse_scheduled_date_string(cls, value):  # pylint: disable=no-self-argument
+        """
+        Convert string date values to datetime
+        """
+        return datetime.fromisoformat(value) if isinstance(value, str) else value
+
+    @validator("started", pre=True)
+    def parse_started_date_string(cls, value):  # pylint: disable=no-self-argument
+        """
+        Convert string date values to datetime
+        """
+        return datetime.fromisoformat(value) if isinstance(value, str) else value
+
+    @validator("finished", pre=True)
+    def parse_finisheddate_string(cls, value):  # pylint: disable=no-self-argument
+        """
+        Convert string date values to datetime
+        """
+        return datetime.fromisoformat(value) if isinstance(value, str) else value
 
 
 class QueryExtType(int, Enum):

--- a/dj/service_clients.py
+++ b/dj/service_clients.py
@@ -6,7 +6,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-from dj.errors import DJException
+from dj.errors import DJQueryServiceClientException
 from dj.models.column import Column
 from dj.models.query import QueryWithResults
 from dj.typing import ColumnType
@@ -106,8 +106,8 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
                 "async_": async_,
             },
         )
-        if response.status_code >= 400:
-            raise DJException(
+        if not response.ok:
+            raise DJQueryServiceClientException(
                 message=f"Error response from query service: {response.text}",
             )
         query_info = response.json()
@@ -122,7 +122,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         """
         response = self.requests_session.get(f"/queries/{query_id}/")
         if not response.ok:
-            raise DJException(
+            raise DJQueryServiceClientException(
                 message=f"Error response from query service: {response.text}",
             )
         query_info = response.json()

--- a/dj/service_clients.py
+++ b/dj/service_clients.py
@@ -121,7 +121,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         Get a previously submitted query
         """
         response = self.requests_session.get(f"/queries/{query_id}/")
-        if response.status_code >= 400:
+        if not response.ok:
             raise DJException(
                 message=f"Error response from query service: {response.text}",
             )

--- a/dj/service_clients.py
+++ b/dj/service_clients.py
@@ -1,12 +1,14 @@
 """Clients for various configurable services."""
-from typing import List
+from typing import List, Optional
 from urllib.parse import urljoin
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
+from dj.errors import DJException
 from dj.models.column import Column
+from dj.models.query import QueryWithResults
 from dj.typing import ColumnType
 
 
@@ -82,3 +84,46 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             Column(name=column["name"], type=ColumnType(column["type"]))
             for column in table_columns
         ]
+
+    def submit_query(  # pylint: disable=too-many-arguments
+        self,
+        engine: str,
+        engine_version: str,
+        submitted_query: str,
+        catalog: Optional[str] = "default",
+        async_: Optional[bool] = False,
+    ) -> QueryWithResults:
+        """
+        Submit a query to the query service
+        """
+        response = self.requests_session.post(
+            "/queries/",
+            json={
+                "engine": engine,
+                "engine_version": engine_version,
+                "submitted_query": submitted_query,
+                "catalog_name": catalog,
+                "async_": async_,
+            },
+        )
+        if response.status_code >= 400:
+            raise DJException(
+                message=f"Error response from query service: {response.text}",
+            )
+        query_info = response.json()
+        return QueryWithResults(**query_info)
+
+    def get_query(
+        self,
+        query_id: str,
+    ) -> QueryWithResults:
+        """
+        Get a previously submitted query
+        """
+        response = self.requests_session.get(f"/queries/{query_id}/")
+        if response.status_code >= 400:
+            raise DJException(
+                message=f"Error response from query service: {response.text}",
+            )
+        query_info = response.json()
+        return QueryWithResults(**query_info)

--- a/dj/utils.py
+++ b/dj/utils.py
@@ -1,7 +1,6 @@
 """
 Utility functions.
 """
-import datetime
 import logging
 import os
 import re
@@ -12,7 +11,6 @@ from functools import lru_cache
 from typing import Iterator, List, Optional
 
 from dotenv import load_dotenv
-from pydantic.datetime_parse import parse_datetime
 from rich.logging import RichHandler
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
@@ -100,30 +98,6 @@ def get_issue_url(
     query_arguments = {k: v for k, v in query_arguments.items() if v is not None}
 
     return baseurl % query_arguments
-
-
-class UTCDatetime(datetime.datetime):
-    """
-    A UTC extension of pydantic's normal datetime handling
-    """
-
-    @classmethod
-    def __get_validators__(cls):
-        """
-        Extend the builtin pydantic datetime parser with a custom validate method
-        """
-        yield parse_datetime
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value) -> str:
-        """
-        Convert to UTC
-        """
-        if value.tzinfo is None:
-            return value.replace(tzinfo=datetime.timezone.utc)
-
-        return value.astimezone(datetime.timezone.utc)
 
 
 class VersionUpgrade(str, Enum):

--- a/tests/service_clients_test.py
+++ b/tests/service_clients_test.py
@@ -1,10 +1,13 @@
 """
 Tests for ``dj.service_clients``.
 """
+from unittest.mock import MagicMock
+
 import pytest
 from pytest_mock import MockerFixture
 from requests import Request
 
+from dj.errors import DJException
 from dj.service_clients import QueryServiceClient, RequestsSessionWithEndpoint
 
 
@@ -71,7 +74,10 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
 
     endpoint = "http://queryservice:8001"
 
-    def test_get_columns_for_table(self, mocker: MockerFixture) -> None:
+    def test_query_service_client_get_columns_for_table(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
         """
         Test the query service client.
         """
@@ -85,3 +91,127 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "http://queryservice:8001/table/hive.test.pies/columns/",
             allow_redirects=True,
         )
+
+    def test_query_service_client_submit_query(self, mocker: MockerFixture) -> None:
+        """
+        Test submitting a query to a query service client.
+        """
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "catalog_name": "public",
+            "engine_name": "postgres",
+            "engine_version": "15.2",
+            "id": "ef209eef-c31a-4089-aae6-833259a08e22",
+            "submitted_query": "SELECT 1 as num",
+            "executed_query": "SELECT 1 as num",
+            "scheduled": "2023-01-01T00:00:00.000000",
+            "started": "2023-01-01T00:00:00.000000",
+            "finished": "2023-01-01T00:00:00.000001",
+            "state": "FINISHED",
+            "progress": 1,
+            "results": [
+                {
+                    "sql": "SELECT 1 as num",
+                    "columns": [{"name": "num", "type": "INT"}],
+                    "rows": [[1]],
+                    "row_count": 1,
+                },
+            ],
+            "next": None,
+            "previous": None,
+            "errors": [],
+            "database_id": 1,  # Will be deprecated soon in favor of catalog
+        }
+
+        mock_request = mocker.patch(
+            "dj.service_clients.RequestsSessionWithEndpoint.post",
+            return_value=mock_response,
+        )
+
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        query_service_client.submit_query(
+            engine="postgres",
+            engine_version="15.2",
+            submitted_query="SELECT 1",
+            catalog="public",
+            async_=False,
+        )
+
+        mock_request.assert_called_with(
+            "/queries/",
+            json={
+                "catalog_name": "public",
+                "engine": "postgres",
+                "engine_version": "15.2",
+                "submitted_query": "SELECT 1",
+                "async_": False,
+            },
+        )
+
+    def test_query_service_client_get_query(self, mocker: MockerFixture) -> None:
+        """
+        Test getting a previously submitted query from a query service client.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "catalog_name": "public",
+            "engine_name": "postgres",
+            "engine_version": "15.2",
+            "id": "ef209eef-c31a-4089-aae6-833259a08e22",
+            "submitted_query": "SELECT 1 as num",
+            "executed_query": "SELECT 1 as num",
+            "scheduled": "2023-01-01T00:00:00.000000",
+            "started": "2023-01-01T00:00:00.000000",
+            "finished": "2023-01-01T00:00:00.000001",
+            "state": "FINISHED",
+            "progress": 1,
+            "results": [
+                {
+                    "sql": "SELECT 1 as num",
+                    "columns": [{"name": "num", "type": "INT"}],
+                    "rows": [[1]],
+                    "row_count": 1,
+                },
+            ],
+            "next": None,
+            "previous": None,
+            "errors": [],
+            "database_id": 1,  # Will be deprecated soon in favor of catalog
+        }
+
+        mock_request = mocker.patch(
+            "dj.service_clients.RequestsSessionWithEndpoint.get",
+            return_value=mock_response,
+        )
+
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        query_service_client.get_query("ef209eef-c31a-4089-aae6-833259a08e22")
+
+        mock_request.assert_called_with(
+            "/queries/ef209eef-c31a-4089-aae6-833259a08e22/",
+        )
+
+    def test_query_service_client_raising_error(self) -> None:
+        """
+        Test handling an error response from the query service client
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+
+        with pytest.raises(DJException) as exc_info:
+            query_service_client.get_query("ef209eef-c31a-4089-aae6-833259a08e22")
+        assert "Error response from query service" in str(exc_info.value)
+
+        with pytest.raises(DJException) as exc_info:
+            query_service_client.submit_query(
+                engine="postgres",
+                engine_version="15.2",
+                submitted_query="SELECT 1",
+                catalog="public",
+                async_=False,
+            )
+        assert "Error response from query service" in str(exc_info.value)

--- a/tests/service_clients_test.py
+++ b/tests/service_clients_test.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 from requests import Request
 
-from dj.errors import DJException
+from dj.errors import DJQueryServiceClientException
 from dj.service_clients import QueryServiceClient, RequestsSessionWithEndpoint
 
 
@@ -199,7 +199,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         Test handling an error response from the query service client
         """
         mock_response = MagicMock()
-        mock_response.status_code = 500
+        mock_response.ok = False
 
         mocker.patch(
             "dj.service_clients.RequestsSessionWithEndpoint.get",
@@ -212,11 +212,11 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
 
         query_service_client = QueryServiceClient(uri=self.endpoint)
 
-        with pytest.raises(DJException) as exc_info:
+        with pytest.raises(DJQueryServiceClientException) as exc_info:
             query_service_client.get_query("ef209eef-c31a-4089-aae6-833259a08e22")
         assert "Error response from query service" in str(exc_info.value)
 
-        with pytest.raises(DJException) as exc_info:
+        with pytest.raises(DJQueryServiceClientException) as exc_info:
             query_service_client.submit_query(
                 engine="postgres",
                 engine_version="15.2",

--- a/tests/service_clients_test.py
+++ b/tests/service_clients_test.py
@@ -98,7 +98,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         """
 
         mock_response = MagicMock()
-        mock_response.status_code = 200
+        mock_response.ok = True
         mock_response.json.return_value = {
             "catalog_name": "public",
             "engine_name": "postgres",

--- a/tests/service_clients_test.py
+++ b/tests/service_clients_test.py
@@ -194,12 +194,22 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "/queries/ef209eef-c31a-4089-aae6-833259a08e22/",
         )
 
-    def test_query_service_client_raising_error(self) -> None:
+    def test_query_service_client_raising_error(self, mocker: MockerFixture) -> None:
         """
         Test handling an error response from the query service client
         """
         mock_response = MagicMock()
         mock_response.status_code = 500
+
+        mocker.patch(
+            "dj.service_clients.RequestsSessionWithEndpoint.get",
+            return_value=mock_response,
+        )
+        mocker.patch(
+            "dj.service_clients.RequestsSessionWithEndpoint.post",
+            return_value=mock_response,
+        )
+
         query_service_client = QueryServiceClient(uri=self.endpoint)
 
         with pytest.raises(DJException) as exc_info:


### PR DESCRIPTION
### Summary

This adds functions to the query service client for submitting queries and retrieving them (when running async).

### Test Plan

N/A

- [x] PR has an associated issue: #342 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
