### PR TITLE
Add separate creation endpoints and rewire query-service for source node schema auto-population

### DIFF
--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -22,6 +22,7 @@ from dj.api.helpers import (
     get_engine,
     get_node_by_name,
     propagate_valid_status,
+    raise_if_node_exists,
     resolve_downstream_references,
     validate_node_data,
 )
@@ -458,12 +459,7 @@ def create_source_node(
     Create a source node. If columns are not provided, the source node's schema
     will be inferred using the configured query service.
     """
-    get_node_by_name(
-        session,
-        data.name,
-        raise_if_not_exists=False,
-        raise_if_exists=True,
-    )
+    raise_if_node_exists(session, data.name)
     node = Node(name=data.name, type=NodeType.SOURCE, current_version=0)
     catalog = get_catalog(session=session, name=data.catalog)
 
@@ -525,12 +521,7 @@ def create_node(
     Create a node.
     """
     node_type = NodeType(os.path.basename(os.path.normpath(request.url.path)))
-    get_node_by_name(
-        session,
-        data.name,
-        raise_if_not_exists=False,
-        raise_if_exists=True,
-    )
+    raise_if_node_exists(session, data.name)
     node = Node(name=data.name, type=NodeType(node_type), current_version=0)
     node_revision = create_node_revision(data, node_type, session)
     save_node(session, node_revision, node, data.mode)
@@ -545,12 +536,7 @@ def create_cube_node(
     """
     Create a node.
     """
-    get_node_by_name(
-        session,
-        data.name,
-        raise_if_not_exists=False,
-        raise_if_exists=True,
-    )
+    raise_if_node_exists(session, data.name)
     node = Node(name=data.name, type=NodeType.CUBE, current_version=0)
     node_revision = create_cube_node_revision(session=session, data=data)
     save_node(session, node_revision, node, data.mode)

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -3,6 +3,7 @@ Node related APIs.
 """
 import http.client
 import logging
+import os
 from collections import defaultdict
 from http import HTTPStatus
 from typing import List, Optional, Union
@@ -11,6 +12,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import joinedload
 from sqlmodel import Session, select
+from starlette.requests import Request
 
 from dj.api.helpers import (
     get_attribute_type,
@@ -24,7 +26,7 @@ from dj.api.helpers import (
     validate_node_data,
 )
 from dj.api.tags import get_tag_by_name
-from dj.errors import DJDoesNotExistException, DJException, DJInvalidInputException
+from dj.errors import DJDoesNotExistException, DJException
 from dj.models import ColumnAttribute
 from dj.models.attribute import UniquenessScope
 from dj.models.base import generate_display_name
@@ -52,27 +54,10 @@ from dj.models.node import (
 )
 from dj.service_clients import QueryServiceClient
 from dj.sql.parsing import parse
-from dj.utils import Version, VersionUpgrade, get_session, get_query_service_client
+from dj.utils import Version, VersionUpgrade, get_query_service_client, get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
-
-
-def raise_on_query_not_allowed(
-    data: Union[CreateNode, CreateSourceNode, CreateCubeNode],
-) -> None:
-    """
-    Check if the payload includes a query for a node type that can't have one
-    """
-    if (
-        data.type in (NodeType.SOURCE, NodeType.CUBE)
-        and not isinstance(data, (CreateSourceNode, CreateCubeNode))
-        and data.query
-    ):
-        raise DJException(
-            message=(f"Query not allowed for node of type {data.type}"),
-            http_status_code=http.client.UNPROCESSABLE_ENTITY,
-        )
 
 
 @router.post("/nodes/validate/", response_model=NodeValidation)
@@ -319,6 +304,7 @@ def list_node_revisions(
 
 def create_node_revision(
     data: CreateNode,
+    node_type: NodeType,
     session: Session,
 ) -> NodeRevision:
     """
@@ -330,9 +316,10 @@ def create_node_revision(
         if data.display_name
         else generate_display_name(data.name),
         description=data.description,
-        type=data.type,
+        type=node_type,
         status=NodeStatus.VALID,
         query=data.query,
+        mode=data.mode,
     )
     (
         validated_node,
@@ -353,7 +340,7 @@ def create_node_revision(
         raise DJException(
             f"Cannot create nodes with multi-catalog dependencies: {set(catalog_ids)}",
         )
-    catalog_id = next(iter(catalog_ids), "draft")
+    catalog_id = next(iter(catalog_ids), 0)
     parent_refs = session.exec(
         select(Node).where(
             # pylint: disable=no-member
@@ -382,11 +369,6 @@ def create_cube_node_revision(
     """
     Create a cube node revision.
     """
-    if not data.cube_elements:
-        raise DJException(
-            message=("Cannot create a cube node with no cube elements"),
-            http_status_code=http.client.UNPROCESSABLE_ENTITY,
-        )
     metrics = []
     dimensions = []
     catalogs = []
@@ -428,95 +410,35 @@ def create_cube_node_revision(
     return NodeRevision(
         name=data.name,
         description=data.description,
-        type=data.type,
+        type=NodeType.CUBE,
         cube_elements=metrics + dimensions,
     )
 
 
-@router.post("/nodes/", response_model=NodeOutput, status_code=201)
-def create_node(
-    data: Union[CreateSourceNode, CreateCubeNode, CreateNode],
-    session: Session = Depends(get_session),
-    query_service_client: QueryServiceClient = Depends(get_query_service_client),
-) -> NodeOutput:
+def save_node(
+    session: Session,
+    node_revision: NodeRevision,
+    node: Node,
+    node_mode: NodeMode,
+):
     """
-    Create a node.
+    Links the node and node revision together and saves them
     """
-    node = get_node_by_name(session, data.name, raise_if_not_exists=False)
-    if node:
-        raise DJException(
-            message=f"A node with name `{data.name}` already exists.",
-            http_status_code=HTTPStatus.CONFLICT,
-        )
-
-    node = Node(name=data.name, type=data.type, current_version=0)
-
-    raise_on_query_not_allowed(data)
-
-    if data.type == NodeType.SOURCE:
-        if not data.schema_ or not data.table or not data.catalog:
-            raise DJInvalidInputException(
-                f"Nodes of type `{NodeType.SOURCE}` must have `catalog`, "
-                "`schema_`, and `table` set",
-            )
-        catalog = get_catalog(session=session, name=data.catalog)
-
-        # When no columns are provided, attempt to find actual table columns
-        # if a query service is set
-        columns = [
-            Column(
-                name=column_name,
-                type=ColumnType[column_data["type"]],
-            )
-            for column_name, column_data in data.columns.items()
-        ] if data.columns else None
-        if not columns:
-            if not query_service_client:
-                raise DJException(
-                    message="No table columns were provided and no query "
-                            "service is configured for table columns inference!",
-                )
-            columns = query_service_client.get_columns_for_table(
-                data.catalog,
-                data.schema_,  # type: ignore
-                data.table,
-            )
-
-        node_revision = NodeRevision(
-            name=data.name,
-            display_name=data.display_name
-            if data.display_name
-            else generate_display_name(data.name),
-            description=data.description,
-            type=data.type,
-            status=NodeStatus.VALID,
-            catalog_id=catalog.id,
-            schema_=data.schema_,
-            table=data.table,
-            columns=columns,
-            parents=[],
-        )
-    elif data.type == NodeType.CUBE:
-        node_revision = create_cube_node_revision(session=session, data=data)
-    else:
-        node_revision = create_node_revision(data, session)
-
-    # Point the node to the new node revision.
     node_revision.node = node
     node_revision.version = (
         str(DEFAULT_DRAFT_VERSION)
-        if data.mode == NodeMode.DRAFT
+        if node_mode == NodeMode.DRAFT
         else str(DEFAULT_PUBLISHED_VERSION)
     )
     node.current_version = node_revision.version
-
     node_revision.extra_validation()
 
     session.add(node)
     session.commit()
+
     newly_valid_nodes = resolve_downstream_references(
         session=session,
-        node_revision=node,
+        node_revision=node_revision,
     )
     propagate_valid_status(
         session=session,
@@ -524,6 +446,114 @@ def create_node(
         catalog_id=node.current.catalog_id,  # pylint: disable=no-member
     )
     session.refresh(node.current)
+
+
+@router.post("/nodes/source/", response_model=NodeOutput, status_code=201)
+def create_source_node(
+    data: CreateSourceNode,
+    session: Session = Depends(get_session),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+) -> NodeOutput:
+    """
+    Create a source node. If columns are not provided, the source node's schema
+    will be inferred using the configured query service.
+    """
+    get_node_by_name(
+        session,
+        data.name,
+        raise_if_not_exists=False,
+        raise_if_exists=True,
+    )
+    node = Node(name=data.name, type=NodeType.SOURCE, current_version=0)
+    catalog = get_catalog(session=session, name=data.catalog)
+
+    # When no columns are provided, attempt to find actual table columns
+    # if a query service is set
+    columns = (
+        [
+            Column(
+                name=column_name,
+                type=ColumnType[column_data["type"]],
+            )
+            for column_name, column_data in data.columns.items()
+        ]
+        if data.columns
+        else None
+    )
+    if not columns:
+        if not query_service_client:
+            raise DJException(
+                message="No table columns were provided and no query "
+                "service is configured for table columns inference!",
+            )
+        columns = query_service_client.get_columns_for_table(
+            data.catalog,
+            data.schema_,  # type: ignore
+            data.table,
+        )
+
+    node_revision = NodeRevision(
+        name=data.name,
+        display_name=data.display_name
+        if data.display_name
+        else generate_display_name(data.name),
+        description=data.description,
+        type=NodeType.SOURCE,
+        status=NodeStatus.VALID,
+        catalog_id=catalog.id,
+        schema_=data.schema_,
+        table=data.table,
+        columns=columns,
+        parents=[],
+    )
+
+    # Point the node to the new node revision.
+    save_node(session, node_revision, node, data.mode)
+    return node  # type: ignore
+
+
+@router.post("/nodes/transform/", response_model=NodeOutput, status_code=201)
+@router.post("/nodes/dimension/", response_model=NodeOutput, status_code=201)
+@router.post("/nodes/metric/", response_model=NodeOutput, status_code=201)
+def create_node(
+    data: CreateNode,
+    request: Request,
+    *,
+    session: Session = Depends(get_session),
+) -> NodeOutput:
+    """
+    Create a node.
+    """
+    node_type = NodeType(os.path.basename(os.path.normpath(request.url.path)))
+    get_node_by_name(
+        session,
+        data.name,
+        raise_if_not_exists=False,
+        raise_if_exists=True,
+    )
+    node = Node(name=data.name, type=NodeType(node_type), current_version=0)
+    node_revision = create_node_revision(data, node_type, session)
+    save_node(session, node_revision, node, data.mode)
+    return node  # type: ignore
+
+
+@router.post("/nodes/cube/", response_model=NodeOutput, status_code=201)
+def create_cube_node(
+    data: CreateCubeNode,
+    session: Session = Depends(get_session),
+) -> NodeOutput:
+    """
+    Create a node.
+    """
+    get_node_by_name(
+        session,
+        data.name,
+        raise_if_not_exists=False,
+        raise_if_exists=True,
+    )
+    node = Node(name=data.name, type=NodeType.CUBE, current_version=0)
+    node_revision = create_cube_node_revision(session=session, data=data)
+    save_node(session, node_revision, node, data.mode)
     return node  # type: ignore
 
 

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -26,8 +26,8 @@ from dj.models.engine import Engine, EngineInfo
 # from dj.models.table import Table, TableNodeRevision, TableYAML
 from dj.models.tag import Tag, TagNodeRelationship
 from dj.sql.parse import is_metric
-from dj.typing import ColumnType, UTCDatetime
-from dj.utils import Version
+from dj.typing import ColumnType
+from dj.utils import UTCDatetime, Version
 
 DEFAULT_DRAFT_VERSION = Version(major=0, minor=1)
 DEFAULT_PUBLISHED_VERSION = Version(major=1, minor=0)
@@ -71,8 +71,6 @@ class CubeRelationship(BaseSQLModel, table=True):  # type: ignore
     """
     Join table for many-to-many relationships between cube nodes and metric/dimension nodes.
     """
-
-    __tablename__ = "cube"
 
     cube_id: Optional[int] = Field(
         default=None,
@@ -495,7 +493,7 @@ class SourceNodeFields(BaseSQLModel):
     catalog: Optional[str] = None
     schema_: Optional[str] = None
     table: Optional[str] = None
-    columns: Dict[str, SourceNodeColumnType]
+    columns: Optional[Dict[str, SourceNodeColumnType]]
 
 
 class CubeNodeFields(BaseSQLModel):

--- a/notebooks/Modeling the Roads Example Database.ipynb
+++ b/notebooks/Modeling the Roads Example Database.ipynb
@@ -21,7 +21,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ba3ff960",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import requests\n",
@@ -46,7 +48,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da86a1ec",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(  # Add a catalog named public\n",
@@ -79,11 +83,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4b6e7674",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"repair_order_id\": {\"type\": \"INT\"},\n",
@@ -97,7 +103,6 @@
     "        \"description\": \"Repair orders\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"repair_orders\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"repair_orders\",\n",
@@ -110,11 +115,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "99812125",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"repair_order_id\": {\"type\": \"INT\"},\n",
@@ -126,7 +133,6 @@
     "        \"description\": \"Details on repair orders\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"repair_order_details\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"repair_order_details\",\n",
@@ -139,11 +145,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "122440f9",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"repair_type_id\": {\"type\": \"INT\"},\n",
@@ -153,7 +161,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"repair_type\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"repair_type\",\n",
@@ -166,11 +173,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b4092b42",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"contractor_id\": {\"type\": \"INT\"},\n",
@@ -187,7 +196,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"contractors\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"contractors\",\n",
@@ -200,11 +208,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "05cc34e6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"municipality_id\": {\"type\": \"STR\"},\n",
@@ -213,7 +223,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"municipality_municipality_type\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"municipality_municipality_type\",\n",
@@ -226,11 +235,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9dc5d78b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"municipality_type_id\": {\"type\": \"STR\"},\n",
@@ -239,7 +250,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"municipality_type\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"municipality_type\",\n",
@@ -252,11 +262,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c20728c0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"municipality_id\": {\"type\": \"STR\"},\n",
@@ -269,7 +281,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"municipality\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"municipality\",\n",
@@ -282,11 +293,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b876fc24",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"dispatcher_id\": {\"type\": \"INT\"},\n",
@@ -296,7 +309,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"dispatchers\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"dispatchers\",\n",
@@ -309,11 +321,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1cc47895",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"hard_hat_id\": {\"type\": \"INT\"},\n",
@@ -333,7 +347,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"hard_hats\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"hard_hats\",\n",
@@ -346,11 +359,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "87aeb9b6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"hard_hat_id\": {\"type\": \"INT\"},\n",
@@ -359,7 +374,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"hard_hat_state\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"hard_hat_state\",\n",
@@ -372,11 +386,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "310c9ef4",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"state_id\": {\"type\": \"INT\"},\n",
@@ -387,7 +403,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"us_states\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"us_states\",\n",
@@ -400,11 +415,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b7ce8d9d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
     "    json={\n",
     "        \"columns\": {\n",
     "            \"us_region_id\": {\"type\": \"INT\"},\n",
@@ -413,7 +430,6 @@
     "        \"description\": \"Information on different types of repairs\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"us_region\",\n",
-    "        \"type\": \"source\",\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
     "        \"table\": \"us_region\",\n",
@@ -436,11 +452,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dffcf40a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/transform/\",\n",
     "    json={\n",
     "        \"description\": \"Repair order dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -463,11 +481,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "41d414c3",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
     "    json={\n",
     "        \"description\": \"Repair order dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -480,7 +500,6 @@
     "        \"\"\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"repair_order\",\n",
-    "        \"type\": \"dimension\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -490,11 +509,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4b61a229",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
     "    json={\n",
     "        \"description\": \"Contractor dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -513,7 +534,6 @@
     "        \"\"\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"contractor\",\n",
-    "        \"type\": \"dimension\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -523,11 +543,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9a866d4a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
     "    json={\n",
     "        \"description\": \"Hard hat dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -549,7 +571,6 @@
     "        \"\"\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"hard_hat\",\n",
-    "        \"type\": \"dimension\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -559,11 +580,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d995d032",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
     "    json={\n",
     "        \"description\": \"Hard hat dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -589,7 +612,6 @@
     "        \"\"\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"local_hard_hats\",\n",
-    "        \"type\": \"dimension\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -599,11 +621,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0ebaa645",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
     "    json={\n",
     "        \"description\": \"US state dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -619,7 +643,6 @@
     "        \"\"\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"us_state\",\n",
-    "        \"type\": \"dimension\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -629,11 +652,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d2105f66",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
     "    json={\n",
     "        \"description\": \"Dispatcher dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -645,7 +670,6 @@
     "        \"\"\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"dispatcher\",\n",
-    "        \"type\": \"dimension\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -655,11 +679,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5e5b3210",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
     "    json={\n",
     "        \"description\": \"Municipality dimension\",\n",
     "        \"query\": \"\"\"\n",
@@ -680,7 +706,6 @@
     "        \"\"\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"municipality_dim\",\n",
-    "        \"type\": \"dimension\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -711,17 +736,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f87bc290",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
     "    json={\n",
     "        \"description\": \"Number of repair orders\",\n",
     "        \"query\": \"SELECT count(repair_order_id) as num_repair_orders FROM repair_orders\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"num_repair_orders\",\n",
-    "        \"type\": \"metric\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -731,17 +757,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "be519eac",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
     "    json={\n",
     "        \"description\": \"Average repair price\",\n",
     "        \"query\": \"SELECT avg(price) as avg_repair_price FROM repair_order_details\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"avg_repair_price\",\n",
-    "        \"type\": \"metric\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -751,17 +778,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a8d229c3",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
     "    json={\n",
     "        \"description\": \"Total repair cost\",\n",
     "        \"query\": \"SELECT sum(price) as total_repair_cost FROM repair_order_details\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"total_repair_cost\",\n",
-    "        \"type\": \"metric\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -771,17 +799,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ebaa0482",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
     "    json={\n",
     "        \"description\": \"Average length of employment\",\n",
     "        \"query\": \"SELECT avg(NOW() - hire_date) as avg_length_of_employment FROM hard_hats\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"avg_length_of_employment\",\n",
-    "        \"type\": \"metric\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -791,17 +820,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0144baf7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
     "    json={\n",
     "        \"description\": \"Total repair order discounts\",\n",
     "        \"query\": \"SELECT sum(price * discount) as total_discount FROM repair_order_details\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"total_repair_order_discounts\",\n",
-    "        \"type\": \"metric\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -811,17 +841,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fce8e1f7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
     "    json={\n",
     "        \"description\": \"Total repair order discounts\",\n",
     "        \"query\": \"SELECT avg(price * discount) as avg_repair_order_discount FROM repair_order_details\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"avg_repair_order_discounts\",\n",
-    "        \"type\": \"metric\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -831,17 +862,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cbba1585",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/nodes/\",\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
     "    json={\n",
     "        \"description\": \"Average time to dispatch a repair order\",\n",
     "        \"query\": \"SELECT avg(dispatched_date - order_date) as avg_time_to_dispatch FROM repair_orders\",\n",
     "        \"mode\": \"published\",\n",
     "        \"name\": \"avg_time_to_dispatch\",\n",
-    "        \"type\": \"metric\",\n",
     "    },\n",
     ")\n",
     "response.json()"
@@ -861,7 +893,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2bf208cc",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
@@ -874,7 +908,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e5fe02fe",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
@@ -887,7 +923,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5237f6f3",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
@@ -900,7 +938,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e3370384",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
@@ -913,7 +953,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bb441b50",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
@@ -926,7 +968,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ab3ffde2",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.post(\n",
@@ -949,7 +993,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f3f61edb",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "nodes = requests.get(f\"{DJ_URL}/nodes/\").json()\n",
@@ -971,7 +1017,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ccb90f88",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "for metric in [\n",
@@ -1006,7 +1054,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "22f78085",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.get(\n",
@@ -1019,7 +1069,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "960b072c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.get(\n",
@@ -1032,7 +1084,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "edb60b48",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.get(\n",
@@ -1045,7 +1099,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f8fea581",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.get(\n",
@@ -1074,7 +1130,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0de9f612",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Add an availability for the contractor dimension node\n",
@@ -1104,7 +1162,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c069f3ff",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = requests.get(\n",
@@ -1112,6 +1172,14 @@
     ")\n",
     "print(response.json()[\"sql\"])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d28d942-e41f-4da4-89d7-a6eb62d0d145",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1130,7 +1198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ Fixtures for testing.
 """
 # pylint: disable=redefined-outer-name, invalid-name, W0611
 
-from typing import Iterator
+from typing import Iterator, List
 
 import pytest
 from cachelib.simple import SimpleCache
@@ -15,10 +15,12 @@ from sqlmodel.pool import StaticPool
 
 from dj.api.main import app
 from dj.config import Settings
-from dj.utils import get_session, get_settings
+from dj.models import Column
+from dj.service_clients import QueryServiceClient
+from dj.utils import get_query_service_client, get_session, get_settings
 
 from .construction.fixtures import build_expectation, construction_session
-from .examples import EXAMPLES
+from .examples import COLUMN_MAPPINGS, EXAMPLES
 from .sql.parsing.queries import (
     case_when_null,
     cte_query,
@@ -69,6 +71,29 @@ def session() -> Iterator[Session]:
 
 
 @pytest.fixture
+def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
+    """
+    Custom settings for unit tests.
+    """
+    qs_client = QueryServiceClient(uri="query_service:8001")
+
+    def mock_get_columns_for_table(
+        catalog: str,
+        schema: str,
+        table: str,
+    ) -> List[Column]:
+        return COLUMN_MAPPINGS[f"{catalog}.{schema}.{table}"]
+
+    mocker.patch.object(
+        qs_client,
+        "get_columns_for_table",
+        mock_get_columns_for_table,
+    )
+
+    yield qs_client
+
+
+@pytest.fixture
 def client(  # pylint: disable=too-many-statements
     session: Session,
     settings: Settings,
@@ -109,6 +134,39 @@ def client_with_examples(client: TestClient) -> TestClient:
     for endpoint, json in EXAMPLES:
         post_and_raise_if_error(client=client, endpoint=endpoint, json=json)  # type: ignore
     return client
+
+
+@pytest.fixture
+def client_with_query_service(  # pylint: disable=too-many-statements
+    session: Session,
+    settings: Settings,
+    query_service_client: QueryServiceClient,
+) -> TestClient:
+    """
+    Add a mock query service to the test client.
+    """
+
+    def get_query_service_client_override() -> QueryServiceClient:
+        return query_service_client
+
+    def get_session_override() -> Session:
+        return session
+
+    def get_settings_override() -> Settings:
+        return settings
+
+    app.dependency_overrides[get_session] = get_session_override
+    app.dependency_overrides[get_settings] = get_settings_override
+    app.dependency_overrides[
+        get_query_service_client
+    ] = get_query_service_client_override
+
+    with TestClient(app) as client:
+        for endpoint, json in EXAMPLES:
+            post_and_raise_if_error(client=client, endpoint=endpoint, json=json)  # type: ignore
+        yield client
+
+    app.dependency_overrides.clear()
 
 
 def pytest_addoption(parser):

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,6 +1,8 @@
 """
 Post requests for all example entities
 """
+from dj.models import Column
+from dj.typing import ColumnType
 
 EXAMPLES = (  # type: ignore
     (
@@ -32,7 +34,7 @@ EXAMPLES = (  # type: ignore
         [{"name": "postgres", "version": "15.2"}],
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "repair_order_id": {"type": "INT"},
@@ -46,14 +48,13 @@ EXAMPLES = (  # type: ignore
             "description": "All repair orders",
             "mode": "published",
             "name": "repair_orders",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_orders",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "repair_order_id": {"type": "INT"},
@@ -65,14 +66,13 @@ EXAMPLES = (  # type: ignore
             "description": "Details on repair orders",
             "mode": "published",
             "name": "repair_order_details",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_order_details",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "repair_type_id": {"type": "INT"},
@@ -82,14 +82,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on types of repairs",
             "mode": "published",
             "name": "repair_type",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_type",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "contractor_id": {"type": "INT"},
@@ -106,14 +105,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on contractors",
             "mode": "published",
             "name": "contractors",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "contractors",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "municipality_id": {"type": "STR"},
@@ -122,14 +120,13 @@ EXAMPLES = (  # type: ignore
             "description": "Lookup table for municipality and municipality types",
             "mode": "published",
             "name": "municipality_municipality_type",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality_municipality_type",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "municipality_type_id": {"type": "STR"},
@@ -138,14 +135,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on municipality types",
             "mode": "published",
             "name": "municipality_type",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality_type",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "municipality_id": {"type": "STR"},
@@ -158,14 +154,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on municipalities",
             "mode": "published",
             "name": "municipality",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "dispatcher_id": {"type": "INT"},
@@ -175,14 +170,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on dispatchers",
             "mode": "published",
             "name": "dispatchers",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "dispatchers",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "hard_hat_id": {"type": "INT"},
@@ -202,14 +196,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on employees",
             "mode": "published",
             "name": "hard_hats",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "hard_hats",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "hard_hat_id": {"type": "INT"},
@@ -218,14 +211,13 @@ EXAMPLES = (  # type: ignore
             "description": "Lookup table for employee's current state",
             "mode": "published",
             "name": "hard_hat_state",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "hard_hat_state",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "state_id": {"type": "INT"},
@@ -236,14 +228,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on different types of repairs",
             "mode": "published",
             "name": "us_states",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "us_states",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "us_region_id": {"type": "INT"},
@@ -252,14 +243,13 @@ EXAMPLES = (  # type: ignore
             "description": "Information on US regions",
             "mode": "published",
             "name": "us_region",
-            "type": "source",
             "catalog": "default",
             "schema_": "roads",
             "table": "us_region",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Repair order dimension",
             "query": """
@@ -275,11 +265,10 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "repair_order",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Contractor dimension",
             "query": """
@@ -298,11 +287,10 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "contractor",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Hard hat dimension",
             "query": """
@@ -324,11 +312,10 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "hard_hat",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Hard hat dimension",
             "query": """
@@ -354,11 +341,10 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "local_hard_hats",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "US state dimension",
             "query": """
@@ -374,11 +360,10 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "us_state",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Dispatcher dimension",
             "query": """
@@ -390,11 +375,10 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "dispatcher",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Municipality dimension",
             "query": """
@@ -415,11 +399,10 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "municipality_dim",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Number of repair orders",
             "query": (
@@ -428,31 +411,28 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "num_repair_orders",
-            "type": "metric",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Average repair price",
             "query": "SELECT avg(price) as avg_repair_price FROM repair_order_details",
             "mode": "published",
             "name": "avg_repair_price",
-            "type": "metric",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Total repair cost",
             "query": "SELECT sum(price) as total_repair_cost FROM repair_order_details",
             "mode": "published",
             "name": "total_repair_cost",
-            "type": "metric",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Average length of employment",
             "query": (
@@ -461,11 +441,10 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "avg_length_of_employment",
-            "type": "metric",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Total repair order discounts",
             "query": (
@@ -474,11 +453,10 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "total_repair_order_discounts",
-            "type": "metric",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Total repair order discounts",
             "query": (
@@ -487,11 +465,10 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "avg_repair_order_discounts",
-            "type": "metric",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Average time to dispatch a repair order",
             "query": (
@@ -500,7 +477,6 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "avg_time_to_dispatch",
-            "type": "metric",
         },
     ),
     (
@@ -546,7 +522,7 @@ EXAMPLES = (  # type: ignore
         {},
     ),
     (  # Accounts/Revenue examples begin
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "id": {"type": "INT"},
@@ -557,14 +533,13 @@ EXAMPLES = (  # type: ignore
             "description": "A source table for account type data",
             "mode": "published",
             "name": "account_type_table",
-            "type": "source",
             "catalog": "default",
             "schema_": "accounting",
             "table": "account_type_table",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "id": {"type": "INT"},
@@ -574,14 +549,13 @@ EXAMPLES = (  # type: ignore
             "description": "A source table for different types of payments",
             "mode": "published",
             "name": "payment_type_table",
-            "type": "source",
             "catalog": "default",
             "schema_": "accounting",
             "table": "payment_type_table",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "payment_id": {"type": "INT"},
@@ -593,14 +567,13 @@ EXAMPLES = (  # type: ignore
             "description": "All repair orders",
             "mode": "published",
             "name": "revenue",
-            "type": "source",
             "catalog": "default",
             "schema_": "accounting",
             "table": "revenue",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Payment type dimensions",
             "query": (
@@ -609,11 +582,10 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "payment_type",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Account type dimension",
             "query": (
@@ -623,11 +595,10 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "account_type",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/transform/",
         {
             "query": (
                 "SELECT payment_id, payment_amount, customer_id, account_type "
@@ -636,11 +607,10 @@ EXAMPLES = (  # type: ignore
             "description": "Only large revenue payments",
             "mode": "published",
             "name": "large_revenue_payments_only",
-            "type": "transform",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/transform/",
         {
             "query": (
                 "SELECT payment_id, payment_amount, customer_id, account_type "
@@ -651,25 +621,22 @@ EXAMPLES = (  # type: ignore
             "description": "Only large revenue payments from business accounts",
             "mode": "published",
             "name": "large_revenue_payments_and_business_only",
-            "type": "transform",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Total number of account types",
             "query": "SELECT count(id) as num_accounts FROM account_type",
             "mode": "published",
             "name": "number_of_account_types",
-            "type": "metric",
         },
     ),
     (  # Basic namespace
-        "/nodes/",
+        "/nodes/source/",
         {
             "name": "basic.source.comments",
             "description": "A fact table with comments",
-            "type": "source",
             "columns": {
                 "id": {"type": "INT"},
                 "user_id": {
@@ -689,11 +656,10 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "name": "basic.source.users",
             "description": "A user table",
-            "type": "source",
             "columns": {
                 "id": {"type": "INT"},
                 "full_name": {"type": "STR"},
@@ -712,10 +678,9 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Country dimension",
-            "type": "dimension",
             "query": "SELECT country, COUNT(1) AS user_cnt "
             "FROM basic.source.users GROUP BY country",
             "mode": "published",
@@ -723,10 +688,9 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "User dimension",
-            "type": "dimension",
             "query": (
                 "SELECT id, full_name, age, country, gender, preferred_language, "
                 "secret_number, created_at, post_processing_timestamp "
@@ -737,10 +701,9 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (
-        "/nodes/",
+        "/nodes/transform/",
         {
             "description": "Country level agg table",
-            "type": "transform",
             "query": (
                 "SELECT country, COUNT(DISTINCT id) AS num_users "
                 "FROM basic.source.users GROUP BY 1"
@@ -750,17 +713,16 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Number of comments",
-            "type": "metric",
             "query": ("SELECT COUNT(1) AS cnt " "FROM basic.source.comments"),
             "mode": "published",
             "name": "basic.num_comments",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Number of users.",
             "type": "metric",
@@ -770,11 +732,10 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (  # Event examples
-        "/nodes/",
+        "/nodes/source/",
         {
             "name": "event_source",
             "description": "Events",
-            "type": "source",
             "columns": {
                 "event_id": {"type": "INT"},
                 "event_latency": {"type": "INT"},
@@ -788,49 +749,45 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (
-        "/nodes/",
+        "/nodes/transform/",
         {
             "name": "long_events",
             "description": "High-Latency Events",
-            "type": "transform",
             "query": "SELECT event_id, event_latency, device_id, country "
             "FROM event_source WHERE event_latency > 1000000",
             "mode": "published",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "name": "country_dim",
             "description": "Country Dimension",
-            "type": "dimension",
             "query": "SELECT country, COUNT(DISTINCT event_id) AS events_cnt "
             "FROM event_source GROUP BY country",
             "mode": "published",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "name": "device_ids_count",
             "description": "Number of Distinct Devices",
-            "type": "metric",
             "query": "SELECT COUNT(DISTINCT device_id) " "FROM event_source",
             "mode": "published",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "name": "long_events_distinct_countries",
             "description": "Number of Distinct Countries for Long Events",
-            "type": "metric",
             "query": "SELECT COUNT(DISTINCT country) " "FROM long_events",
             "mode": "published",
         },
     ),
     (  # DBT examples
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "id": {"type": "INT"},
@@ -840,14 +797,13 @@ EXAMPLES = (  # type: ignore
             "description": "Customer table",
             "mode": "published",
             "name": "dbt.source.jaffle_shop.customers",
-            "type": "source",
             "catalog": "public",
             "schema_": "jaffle_shop",
             "table": "customers",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "User dimension",
             "query": (
@@ -856,11 +812,10 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "dbt.dimension.customers",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "id": {"type": "INT"},
@@ -875,14 +830,13 @@ EXAMPLES = (  # type: ignore
             "description": "Orders fact table",
             "mode": "published",
             "name": "dbt.source.jaffle_shop.orders",
-            "type": "source",
             "catalog": "public",
             "schema_": "jaffle_shop",
             "table": "orders",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "id": {"type": "INT"},
@@ -896,14 +850,13 @@ EXAMPLES = (  # type: ignore
             "description": "Payments fact table.",
             "mode": "published",
             "name": "dbt.source.stripe.payments",
-            "type": "source",
             "catalog": "public",
             "schema_": "stripe",
             "table": "payments",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/transform/",
         {
             "query": (
                 'SELECT "dbt.source.jaffle_shop.customers".id, '
@@ -919,11 +872,10 @@ EXAMPLES = (  # type: ignore
             "description": "Country level agg table",
             "mode": "published",
             "name": "dbt.transform.customer_agg",
-            "type": "transform",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/source/",
         {
             "columns": {
                 "id": {"type": "INT"},
@@ -938,37 +890,43 @@ EXAMPLES = (  # type: ignore
             "catalog": "default",
             "schema_": "revenue",
             "table": "sales",
-            "type": "source",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/dimension/",
         {
             "description": "Item dimension",
             "query": ("SELECT item_name " "account_type_classification FROM " "sales"),
             "mode": "published",
             "name": "items",
-            "type": "dimension",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Total units sold",
             "query": "SELECT SUM(sold_count) as num_sold FROM sales",
             "mode": "published",
             "name": "items_sold_count",
-            "type": "metric",
         },
     ),
     (
-        "/nodes/",
+        "/nodes/metric/",
         {
             "description": "Total profit",
             "query": "SELECT SUM(sold_count * price_per_unit) as num_sold FROM sales",
             "mode": "published",
             "name": "total_profit",
-            "type": "metric",
         },
     ),
 )
+
+
+COLUMN_MAPPINGS = {
+    "public.basic.comments": [
+        Column(name="id", type=ColumnType("INT")),
+        Column(name="user_id", type=ColumnType("INT")),
+        Column(name="timestamp", type=ColumnType("TIMESTAMP")),
+        Column(name="text", type=ColumnType("STR")),
+    ],
+}


### PR DESCRIPTION
### Summary

This PR does two main things:

1. Adds separate creation endpoints for each of the different node types. This allows us to be much crisper about the different pydantic models used for creation. These are the new endpoints:
  * `POST /nodes/source/` 
  * `POST /nodes/dimension/`
  * `POST /nodes/transform/`
  * `POST /nodes/metric/`
  * `POST /nodes/cube/`
2. Adds back the query service client used for source node schema auto-population.

### Test Plan

Modified some unit tests to conform to the new endpoints and added an additional test for the query service's schema population.

- [X] PR has an associated issue: #402
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A