### PR TITLE
Adds column attribute for to identify pre-joined dimension attributes on sources/transforms

### DIFF
--- a/dj/api/attributes.py
+++ b/dj/api/attributes.py
@@ -97,6 +97,13 @@ def default_attribute_types(session: Session = Depends(get_session)):
             uniqueness_scope=["node", "column_type"],
             allowed_node_types=[NodeType.DIMENSION],
         ),
+        AttributeType(
+            namespace=RESERVED_ATTRIBUTE_NAMESPACE,
+            name="dimension",
+            description="Points to a dimension attribute column",
+            uniqueness_scope=[],
+            allowed_node_types=[NodeType.SOURCE, NodeType.TRANSFORM],
+        ),
     ]
     default_attribute_type_names = {type_.name: type_ for type_ in defaults}
 

--- a/tests/api/attributes_test.py
+++ b/tests/api/attributes_test.py
@@ -114,4 +114,11 @@ def test_list_attributes(
             "given fact related node. Used to facilitate proper joins with "
             "dimension node to match the desired effect.",
         },
+        "dimension": {
+            "namespace": "system",
+            "uniqueness_scope": [],
+            "allowed_node_types": ["source", "transform"],
+            "name": "dimension",
+            "description": "Points to a dimension attribute column",
+        },
     }


### PR DESCRIPTION
### Summary

This change will add another default column attribute that helps identify pre-joined dimension attributes on source and transform nodes. I noticed that this was missing from the set of default attributes that DJ loads. 

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #386
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
