### PR TITLE
Adding endpoints for retrieving data and SQL for a node

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,113 +25,31 @@ The SQLModel documentation is a good start, since it covers the basics of SQLAlc
 Running the examples
 ====================
 
-The repository comes with a small set of examples in the ``examples/configs/`` directory, with some basic nodes built from 3 databases (Postgres, Druid, Google Sheets) and another example based on DBT tutorial (WIP).
+The repository should be run in conjunction with [`djqs`](https://github.com/DataJunction/djqs), which will load a
+`postgres-roads` database with example data. In order to get this up and running:
+* ``docker compose up`` from DJ to get the DJ metrics service up (defaults to run on port 8000)
+* ``docker compose up`` in DJQS to get the DJ query service up (defaults to run on port 8001)
 
-Running ``docker compose up`` will start a Druid cluster, a Postgres database, and the DJ service (together with Celery workers for running async queries and Redis for caching and storing results).
+Once both are up, you can fire up `juypter notebook` to run the `Modeling the Roads Example Database.ipynb`,
+which will create all of the relevant nodes and provide some examples of API interactions.
 
-You can check that everything is working by querying the list of available databasesi (install `jq <https://stedolan.github.io/jq/>`_ if you don't have it):
+You can check that everything is working by querying the list of available catalogs (install `jq <https://stedolan.github.io/jq/>`_ if you don't have it):
 
 .. code-block:: bash
 
-    % curl http://localhost:8000/databases/ | jq
+    % curl http://localhost:8000/catalogs/ | jq
     [
       {
-        "id": 0,
-        "description": "The DJ meta database",
-        "read_only": true,
-        "async_": false,
-        "cost": 1,
-        "created_at": "2022-04-10T20:22:58.274082",
-        "updated_at": "2022-04-10T20:22:58.274092",
-        "name": "dj",
-        "URI": "dj://localhost:8000/0"
-      },
-      {
-        "id": 1,
-        "description": "An in memory SQLite database for tableless queries",
-        "read_only": true,
-        "async_": false,
-        "cost": 0,
-        "created_at": "2022-04-10T20:22:58.275177",
-        "updated_at": "2022-04-10T20:22:58.275183",
-        "name": "in-memory",
-        "URI": "sqlite://"
-      },
-      {
-        "id": 2,
-        "description": "An Apache Druid database",
-        "read_only": true,
-        "async_": false,
-        "cost": 1,
-        "created_at": "2022-04-10T20:22:58.285035",
-        "updated_at": "2022-04-10T20:22:58.291059",
-        "name": "druid",
-        "URI": "druid://host.docker.internal:8082/druid/v2/sql/"
-      },
-      {
-        "id": 3,
-        "description": "A Postgres database",
-        "read_only": false,
-        "async_": false,
-        "cost": 10,
-        "created_at": "2022-04-10T20:22:58.298188",
-        "updated_at": "2022-04-10T20:22:58.305128",
-        "name": "postgres",
-        "URI": "postgresql://username:FoolishPassword@host.docker.internal:5433/examples"
-      },
-      {
-        "id": 4,
-        "description": "A Google Sheets connector",
-        "read_only": true,
-        "async_": false,
-        "cost": 100,
-        "created_at": "2022-04-10T20:22:58.310020",
-        "updated_at": "2022-04-10T20:22:58.317108",
-        "name": "gsheets",
-        "URI": "gsheets://"
+        "name": "default",
+        "engines": [
+          {
+            "name": "postgres",
+            "version": "",
+            "uri": "postgresql://dj:dj@postgres-roads:5432/djdb"
+          }
+        ]
       }
     ]
-
-You can run queries against any of these databases:
-
-.. code-block:: bash
-
-    $ curl -H "Content-Type: application/json" \
-    > -d '{"database_id":1,"submitted_query":"SELECT 1 AS foo"}' \
-    > http://127.0.0.1:8000/queries/ | jq
-    {
-      "database_id": 1,
-      "catalog": null,
-      "schema_": null,
-      "id": "5cc9cc71-02c2-4c73-a0d9-f9c752f0762b",
-      "submitted_query": "SELECT 1 AS foo",
-      "executed_query": "SELECT 1 AS foo",
-      "scheduled": "2022-04-11T01:02:56.221241",
-      "started": "2022-04-11T01:02:56.221289",
-      "finished": "2022-04-11T01:02:56.222603",
-      "state": "FINISHED",
-      "progress": 1,
-      "results": [
-        {
-          "sql": "SELECT 1 AS foo",
-          "columns": [
-            {
-              "name": "foo",
-              "type": "STR"
-            }
-          ],
-          "rows": [
-            [
-              1
-            ]
-          ],
-          "row_count": 1
-        }
-      ],
-      "next": null,
-      "previous": null,
-      "errors": []
-    }
 
 To see the list of available nodes:
 
@@ -140,58 +58,68 @@ To see the list of available nodes:
     $ curl http://localhost:8000/nodes/ | jq
     [
       {
-        "id": 1,
-        "name": "dbt.jaffle_shop.orders",
-        "description": "Orders fact table",
-        "created_at": "2022-09-30T03:51:26.269672+00:00",
-        "updated_at": "2022-09-30T03:51:26.269685+00:00",
+        "node_revision_id": 1,
+        "node_id": 1,
         "type": "source",
+        "name": "repair_orders",
+        "display_name": "Repair Orders",
+        "version": "v1.0",
+        "status": "valid",
+        "mode": "published",
+        "catalog": {
+          "id": 1,
+          "uuid": "c2363d4d-ce0c-4eb2-9b1e-28743970f859",
+          "created_at": "2023-03-17T15:45:15.012784+00:00",
+          "updated_at": "2023-03-17T15:45:15.012795+00:00",
+          "extra_params": {},
+          "name": "default"
+        },
+        "schema_": "roads",
+        "table": "repair_orders",
+        "description": "Repair orders",
         "query": null,
+        "availability": null,
         "columns": [
           {
-            "name": "id",
-            "type": "INT"
+            "name": "repair_order_id",
+            "type": "INT",
+            "attributes": []
           },
           {
-            "name": "user_id",
-            "type": "INT"
+            "name": "municipality_id",
+            "type": "STR",
+            "attributes": []
+          },
+          {
+            "name": "hard_hat_id",
+            "type": "INT",
+            "attributes": []
           },
           {
             "name": "order_date",
-            "type": "DATE"
+            "type": "TIMESTAMP",
+            "attributes": []
           },
           {
-            "name": "status",
-            "type": "STR"
+            "name": "required_date",
+            "type": "TIMESTAMP",
+            "attributes": []
           },
           {
-            "name": "_etl_loaded_at",
-            "type": "TIMESTAMP"
+            "name": "dispatched_date",
+            "type": "TIMESTAMP",
+            "attributes": []
+          },
+          {
+            "name": "dispatcher_id",
+            "type": "INT",
+            "attributes": []
           }
-        ]
-      },
-      {
-        "id": 2,
-        "name": "dbt.jaffle_shop.customers",
-        "description": "Customer table",
-        "created_at": "2022-09-30T03:51:26.363081+00:00",
-        "updated_at": "2022-09-30T03:51:26.363096+00:00",
-        "type": "source",
-        "query": null,
-        "columns": [
-          {
-            "name": "id",
-            "type": "INT"
-          },
-          {
-            "name": "first_name",
-            "type": "STR"
-          },
-          {
-            "name": "last_name",
-            "type": "STR"
-          }
-        ]
+        ],
+        "updated_at": "2023-03-17T15:45:18.456072+00:00",
+        "materialization_configs": [],
+        "created_at": "2023-03-17T15:45:18.448321+00:00",
+        "tags": []
       },
       ...
     ]
@@ -203,38 +131,70 @@ And metrics:
     $ curl http://localhost:8000/metrics/ | jq
     [
       {
-        "id": 8,
-        "name": "basic.num_users",
-        "description": "Number of users.",
-        "created_at": "2022-09-30T03:51:29.193090+00:00",
-        "updated_at": "2022-09-30T03:51:29.193124+00:00",
-        "query": "SELECT SUM(num_users) FROM basic.transform.country_agg",
+        "id": 21,
+        "name": "num_repair_orders",
+        "display_name": "Num Repair Orders",
+        "current_version": "v1.0",
+        "description": "Number of repair orders",
+        "created_at": "2023-03-17T15:45:27.589799+00:00",
+        "updated_at": "2023-03-17T15:45:27.590304+00:00",
+        "query": "SELECT count(repair_order_id) as num_repair_orders FROM repair_orders",
         "dimensions": [
-          "basic.transform.country_agg.country",
-          "basic.transform.country_agg.num_users"
+          "dispatcher.company_name",
+          "dispatcher.dispatcher_id",
+          "dispatcher.phone",
+          "hard_hat.address",
+          "hard_hat.birth_date",
+          "hard_hat.city",
+          "hard_hat.contractor_id",
+          "hard_hat.country",
+          "hard_hat.first_name",
+          "hard_hat.hard_hat_id",
+          "hard_hat.hire_date",
+          "hard_hat.last_name",
+          "hard_hat.manager",
+          "hard_hat.postal_code",
+          "hard_hat.state",
+          "hard_hat.title",
+          "municipality_dim.contact_name",
+          "municipality_dim.contact_title",
+          "municipality_dim.local_region",
+          "municipality_dim.municipality_id",
+          "municipality_dim.municipality_type_desc",
+          "municipality_dim.municipality_type_id",
+          "municipality_dim.phone",
+          "municipality_dim.state_id",
+          "repair_orders.dispatched_date",
+          "repair_orders.dispatcher_id",
+          "repair_orders.hard_hat_id",
+          "repair_orders.municipality_id",
+          "repair_orders.order_date",
+          "repair_orders.repair_order_id",
+          "repair_orders.required_date"
         ]
       },
       {
-        "id": 10,
-        "name": "basic.num_comments",
-        "description": "Number of comments",
-        "created_at": "2022-09-30T03:51:30.376928+00:00",
-        "updated_at": "2022-09-30T03:51:30.376937+00:00",
-        "query": "SELECT COUNT(1) FROM basic.source.comments",
+        "id": 22,
+        "name": "avg_repair_price",
+        "display_name": "Avg Repair Price",
+        "current_version": "v1.0",
+        "description": "Average repair price",
+        "created_at": "2023-03-17T15:45:28.121435+00:00",
+        "updated_at": "2023-03-17T15:45:28.121836+00:00",
+        "query": "SELECT avg(price) as avg_repair_price FROM repair_order_details",
         "dimensions": [
-          "basic.dimension.users.age",
-          "basic.dimension.users.country",
-          "basic.dimension.users.full_name",
-          "basic.dimension.users.gender",
-          "basic.dimension.users.id",
-          "basic.dimension.users.preferred_language",
-          "basic.dimension.users.secret_number",
-          "basic.source.comments.id",
-          "basic.source.comments.text",
-          "basic.source.comments.timestamp",
-          "basic.source.comments.user_id"
+          "repair_order.dispatcher_id",
+          "repair_order.hard_hat_id",
+          "repair_order.municipality_id",
+          "repair_order.repair_order_id",
+          "repair_order_details.discount",
+          "repair_order_details.price",
+          "repair_order_details.quantity",
+          "repair_order_details.repair_order_id",
+          "repair_order_details.repair_type_id"
         ]
-      }
+      },
+      ...
     ]
 
 
@@ -242,23 +202,22 @@ To get data for a given metric:
 
 .. code-block:: bash
 
-    $ curl http://localhost:8000/metrics/8/data/ | jq
+    $ curl http://localhost:8000/data/avg_repair_price/ | jq
 
-You can also pass query parameters to group by a dimension (``d``) or filter (``f``):
+You can also pass query parameters to group by a dimension or filter:
 
 .. code-block:: bash
 
-    $ curl "http://localhost:8000/metrics/8/data/?d=basic.transform.country_agg.country" | jq
-    $ curl "http://localhost:8000/metrics/8/data/?f=basic.transform.country_agg.country='France'" | jq
+    $ curl "http://localhost:8000/data/avg_time_to_dispatch/?dimensions=dispatcher.company_name" | jq
+    $ curl "http://localhost:8000/data/avg_time_to_dispatch/?filters=hard_hat.state='AZ'" | jq
 
 Similarly, you can request the SQL for a given metric with given constraints:
 
 .. code-block:: bash
 
-    $ curl "http://localhost:8000/metrics/8/sql/?d=basic.transform.country_agg.country" | jq
+    $ curl "http://localhost:8000/sql/avg_time_to_dispatch/?dimensions=dispatcher.company_name" | jq
     {
-      "database_id": 3,
-      "sql": "SELECT sum("basic.transform.country_agg".num_users) AS sum_1, "basic.transform.country_agg".country \nFROM (SELECT "basic.source.users".country AS country, count("basic.source.users".id) AS num_users \nFROM (SELECT basic.dim_users.id AS id, basic.dim_users.full_name AS full_name, basic.dim_users.age AS age, basic.dim_users.country AS country, basic.dim_users.gender AS gender, basic.dim_users.preferred_language AS preferred_language \nFROM basic.dim_users) AS "basic.source.users" GROUP BY "basic.source.users".country) AS "basic.transform.country_agg" GROUP BY "basic.transform.country_agg".country"
+      "sql": "SELECT  avg(repair_orders.dispatched_date - repair_orders.order_date) AS avg_time_to_dispatch,\n\tdispatcher.company_name \n FROM \"roads\".\"repair_orders\" AS repair_orders\nLEFT JOIN (SELECT  dispatchers.company_name,\n\tdispatchers.dispatcher_id,\n\tdispatchers.phone \n FROM \"roads\".\"dispatchers\" AS dispatchers\n \n) AS dispatcher\n        ON repair_orders.dispatcher_id = dispatcher.dispatcher_id \n GROUP BY  dispatcher.company_name"
     }
 
 You can also run SQL queries against the metrics in DJ, using the special database with ID 0 and referencing a table called ``metrics``:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -8,7 +8,7 @@ from logging.config import fileConfig
 from sqlmodel import SQLModel, create_engine
 
 from alembic import context
-from dj.models import Catalog, Column, Database, Engine, NodeRevision, Query, Table
+from dj.models import Catalog, Column, Database, Engine, NodeRevision, Table
 from dj.utils import get_settings
 
 settings = get_settings()

--- a/alembic/versions/2023_03_12_0158-e3fc8f2f003f_initial_migration.py
+++ b/alembic/versions/2023_03_12_0158-e3fc8f2f003f_initial_migration.py
@@ -205,30 +205,6 @@ def upgrade():
         sa.UniqueConstraint("version", "node_id", name=op.f("uq_noderevision_version")),
     )
     op.create_table(
-        "query",
-        sa.Column("id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
-        sa.Column("database_id", sa.Integer(), nullable=False),
-        sa.Column("catalog", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
-        sa.Column("schema_", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
-        sa.Column(
-            "submitted_query",
-            sqlmodel.sql.sqltypes.AutoString(),
-            nullable=False,
-        ),
-        sa.Column("executed_query", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
-        sa.Column("scheduled", sa.DateTime(), nullable=True),
-        sa.Column("started", sa.DateTime(), nullable=True),
-        sa.Column("finished", sa.DateTime(), nullable=True),
-        sa.Column("state", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.Column("progress", sa.Float(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["database_id"],
-            ["database.id"],
-            name=op.f("fk_query_database_id_database"),
-        ),
-        sa.PrimaryKeyConstraint("id", name=op.f("pk_query")),
-    )
-    op.create_table(
         "table",
         sa.Column("schema_", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
         sa.Column("table", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
@@ -427,7 +403,6 @@ def downgrade():
     op.drop_table("columnattribute")
     op.drop_table("tagnoderelationship")
     op.drop_table("table")
-    op.drop_table("query")
     op.drop_table("noderevision")
     op.drop_table("column")
     op.drop_table("catalogengines")

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -13,7 +13,7 @@ from dj.construction.build import build_node
 from dj.construction.dj_query import build_dj_metric_query
 from dj.construction.extract import extract_dependencies_from_node
 from dj.construction.inference import get_type_of_expression
-from dj.errors import DJError, DJException, ErrorCode
+from dj.errors import DJError, DJException, DJInvalidInputException, ErrorCode
 from dj.models import AttributeType, Catalog, Column, Engine
 from dj.models.attribute import RESERVED_ATTRIBUTE_NAMESPACE
 from dj.models.node import (
@@ -123,14 +123,20 @@ def get_catalog(session: Session, name: str) -> Catalog:
 
 def get_query(  # pylint: disable=too-many-arguments
     session: Session,
-    metric: str,
+    node_name: str,
     dimensions: List[str],
     filters: List[str],
 ) -> ast.Query:
     """
     Get a query for a metric, dimensions, and filters
     """
-    node = get_node_by_name(session=session, name=metric)
+    node = get_node_by_name(session=session, name=node_name)
+
+    if node.type in (NodeType.DIMENSION, NodeType.SOURCE):
+        if dimensions:
+            raise DJInvalidInputException(
+                message=f"Cannot set dimensions for node type {node.type}!",
+            )
 
     query_ast = build_node(
         session=session,

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -130,11 +130,11 @@ def get_query(  # pylint: disable=too-many-arguments
     """
     Get a query for a metric, dimensions, and filters
     """
-    metric = get_node_by_name(session=session, name=metric, node_type=NodeType.METRIC)
+    node = get_node_by_name(session=session, name=metric)
 
     query_ast = build_node(
         session=session,
-        node=metric.current,
+        node=node.current,
         dialect=None,
         filters=filters,
         dimensions=dimensions,

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -23,6 +23,7 @@ from dj.api import (
     metrics,
     nodes,
     query,
+    sql,
     tags,
 )
 from dj.api.attributes import default_attribute_types
@@ -58,6 +59,7 @@ app.include_router(health.router)
 app.include_router(cubes.router)
 app.include_router(tags.router)
 app.include_router(attributes.router)
+app.include_router(sql.router)
 
 
 @app.exception_handler(DJException)

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -29,10 +29,8 @@ from dj.api.attributes import default_attribute_types
 from dj.errors import DJException
 from dj.models.catalog import Catalog
 from dj.models.column import Column
-from dj.models.database import Database
 from dj.models.engine import Engine
 from dj.models.node import NodeRevision
-from dj.models.query import Query
 from dj.models.table import Table
 from dj.utils import get_settings
 

--- a/dj/api/metrics.py
+++ b/dj/api/metrics.py
@@ -9,9 +9,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, select
 
-from dj.api.helpers import get_node_by_name, get_query
+from dj.api.helpers import get_node_by_name
 from dj.errors import DJError, DJException, ErrorCode
-from dj.models.metric import Metric, TranslatedSQL
+from dj.models.metric import Metric
 from dj.models.node import Node, NodeType
 from dj.sql.dag import get_dimensions
 from dj.utils import get_session
@@ -54,31 +54,6 @@ def read_metric(name: str, *, session: Session = Depends(get_session)) -> Metric
     """
     node = get_metric(session, name)
     return Metric.parse_node(node)
-
-
-@router.get("/metrics/{name}/sql/", response_model=TranslatedSQL)
-def read_metrics_sql(
-    name: str,
-    dimensions: List[str] = Query([]),
-    filters: List[str] = Query([]),
-    *,
-    session: Session = Depends(get_session),
-) -> TranslatedSQL:
-    """
-    Return SQL for a metric.
-
-    A database can be optionally specified. If no database is specified the optimal one
-    will be used.
-    """
-    query_ast = get_query(
-        session=session,
-        metric=name,
-        dimensions=dimensions,
-        filters=filters,
-    )
-    return TranslatedSQL(
-        sql=str(query_ast),
-    )
 
 
 @router.get("/metrics/common/dimensions/", response_model=List[str])

--- a/dj/api/query.py
+++ b/dj/api/query.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
 from dj.api.helpers import get_dj_query
-from dj.api.metrics import TranslatedSQL
+from dj.models.metric import TranslatedSQL
 from dj.utils import get_session
 
 router = APIRouter()

--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -1,0 +1,38 @@
+"""
+SQL related APIs.
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+from sqlmodel import Session
+
+from dj.api.helpers import get_query
+from dj.models.metric import TranslatedSQL
+from dj.utils import get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/sql/{node_name}/", response_model=TranslatedSQL)
+def get_sql_for_node(
+    node_name: str,
+    dimensions: List[str] = Query([]),
+    filters: List[str] = Query([]),
+    *,
+    session: Session = Depends(get_session),
+) -> TranslatedSQL:
+    """
+    Return SQL for a node.
+    """
+    query_ast = get_query(
+        session=session,
+        node_name=node_name,
+        dimensions=dimensions,
+        filters=filters,
+    )
+    return TranslatedSQL(
+        sql=str(query_ast),
+    )

--- a/dj/models/__init__.py
+++ b/dj/models/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
     "Engine",
     "Node",
     "NodeRevision",
-    "Query",
     "Table",
     "Tag",
 ]
@@ -22,6 +21,5 @@ from dj.models.column import Column
 from dj.models.database import Database
 from dj.models.engine import Engine
 from dj.models.node import Node, NodeRevision
-from dj.models.query import Query
 from dj.models.table import Table
 from dj.models.tag import Tag

--- a/dj/models/database.py
+++ b/dj/models/database.py
@@ -17,7 +17,6 @@ from dj.typing import UTCDatetime
 
 if TYPE_CHECKING:
     from dj.models.catalog import Catalog
-    from dj.models.query import Query
     from dj.models.table import Table
 
 
@@ -65,11 +64,6 @@ class Database(BaseSQLModel, table=True):  # type: ignore
     )
 
     tables: List["Table"] = Relationship(
-        back_populates="database",
-        sa_relationship_kwargs={"cascade": "all, delete"},
-    )
-
-    queries: List["Query"] = Relationship(
         back_populates="database",
         sa_relationship_kwargs={"cascade": "all, delete"},
     )

--- a/dj/service_clients.py
+++ b/dj/service_clients.py
@@ -1,5 +1,5 @@
 """Clients for various configurable services."""
-from typing import List, Optional
+from typing import List
 from urllib.parse import urljoin
 from uuid import UUID
 
@@ -9,7 +9,7 @@ from urllib3 import Retry
 
 from dj.errors import DJQueryServiceClientException
 from dj.models.column import Column
-from dj.models.query import QueryWithResults
+from dj.models.query import QueryCreate, QueryWithResults
 from dj.typing import ColumnType
 
 
@@ -88,24 +88,14 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
 
     def submit_query(  # pylint: disable=too-many-arguments
         self,
-        engine_name: str,
-        engine_version: str,
-        query: str,
-        catalog_name: Optional[str] = "default",
-        async_: Optional[bool] = False,
+        query_create: QueryCreate,
     ) -> QueryWithResults:
         """
         Submit a query to the query service
         """
         response = self.requests_session.post(
             "/queries/",
-            json={
-                "engine_name": engine_name,
-                "catalog_name": catalog_name,
-                "engine_version": engine_version,
-                "query": query,
-                "async_": async_,
-            },
+            json=query_create.dict(),
         )
         response_data = response.json()
         if not response.ok:

--- a/dj/sql/dag.py
+++ b/dj/sql/dag.py
@@ -1,10 +1,9 @@
 """
 DAG related functions.
 """
-
 from typing import List
 
-from dj.models.node import Node
+from dj.models.node import Node, NodeRevision
 from dj.utils import get_settings
 
 settings = get_settings()

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -1396,7 +1396,7 @@ class Select(Expression):  # pylint: disable=R0902
         parts = ["SELECT "]
         if self.distinct:
             parts.append("DISTINCT ")
-        projection = ",\n\t".join(str(exp) for exp in self.projection)
+        projection = ",\n\t".join(sorted([str(exp) for exp in self.projection]))
         parts.extend((projection, "\n", str(self.from_), "\n"))
         if self.where is not None:
             parts.extend(("WHERE ", str(self.where), "\n"))
@@ -1464,6 +1464,10 @@ class Query(Expression):
 
     def __str__(self) -> str:
         subquery = bool(self.parent)
+        # self.select.projection = sorted(
+        #     self.select.projection,
+        #     key=lambda col: col.name.name
+        # )
         ctes = ",\n".join(f"{cte.name} AS {(cte.child)}" for cte in self.ctes)
         with_ = "WITH" if ctes else ""
         select = f"({(self.select)})" if subquery else (self.select)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,8 @@ services:
     ports:
       - "5433:5432"
 
-  postgres_roads:
-    container_name: postgres_roads
+  postgres-roads:
+    container_name: postgres-roads
     networks:
       - core
     image: postgres:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - .:/code
     ports:
       - "8000:8000"
-      - "8001:8001"
     depends_on:
       - db_migration
       - postgres_examples

--- a/examples/docker/postgres_init.roads.sql
+++ b/examples/docker/postgres_init.roads.sql
@@ -30,18 +30,19 @@ CREATE TABLE roads.municipality (
     contact_name character varying(30),
     contact_title character varying(50),
     local_region character varying(30),
+    phone character varying(30),
     state_id smallint NOT NULL
 );
-INSERT INTO roads.municipality VALUES ('New York', 'Alexander Wilkinson', 'Assistant City Clerk', 'Manhattan', 33);
-INSERT INTO roads.municipality VALUES ('Los Angeles', 'Hugh Moser', 'Administrative Assistant', 'Santa Monica',5 );
-INSERT INTO roads.municipality VALUES ('Chicago', 'Phillip Bradshaw', 'Director of Community Engagement', 'West Ridge', 14);
-INSERT INTO roads.municipality VALUES ('Houston', 'Leo Ackerman', 'Municipal Roads Specialist', 'The Woodlands', 44);
-INSERT INTO roads.municipality VALUES ('Phoenix', 'Jessie Paul', 'Director of Finance and Administration', 'Old Town Scottsdale', 3);
-INSERT INTO roads.municipality VALUES ('Philadelphia', 'Willie Chaney', 'Municipal Manager', 'Center City', 39);
-INSERT INTO roads.municipality VALUES ('San Antonio', 'Chester Lyon', 'Treasurer', 'Alamo Heights', 44);
-INSERT INTO roads.municipality VALUES ('San Diego', 'Ralph Helms', 'Senior Electrical Project Manager', 'Del Mar', 5);
-INSERT INTO roads.municipality VALUES ('Dallas', 'Virgil Craft', 'Assistant Assessor (Town/Municipality)', 'Deep Ellum', 44);
-INSERT INTO roads.municipality VALUES ('San Jose', 'Charles Carney', 'Municipal Accounting Manager', 'Santana Row', 5);
+INSERT INTO roads.municipality VALUES ('New York', 'Alexander Wilkinson', 'Assistant City Clerk', 'Manhattan', '505-101-1929', 33);
+INSERT INTO roads.municipality VALUES ('Los Angeles', 'Hugh Moser', 'Administrative Assistant', 'Santa Monica', '505-122-1929', 5 );
+INSERT INTO roads.municipality VALUES ('Chicago', 'Phillip Bradshaw', 'Director of Community Engagement', 'West Ridge', '102-222-2033', 14);
+INSERT INTO roads.municipality VALUES ('Houston', 'Leo Ackerman', 'Municipal Roads Specialist', 'The Woodlands', '303-111-1929', 44);
+INSERT INTO roads.municipality VALUES ('Phoenix', 'Jessie Paul', 'Director of Finance and Administration', 'Old Town Scottsdale', '122-101-1111',3);
+INSERT INTO roads.municipality VALUES ('Philadelphia', 'Willie Chaney', 'Municipal Manager', 'Center City', '241-223-3224', 39);
+INSERT INTO roads.municipality VALUES ('San Antonio', 'Chester Lyon', 'Treasurer', 'Alamo Heights', '412-987-8236', 44);
+INSERT INTO roads.municipality VALUES ('San Diego', 'Ralph Helms', 'Senior Electrical Project Manager', 'Del Mar', '324-443-1157', 5);
+INSERT INTO roads.municipality VALUES ('Dallas', 'Virgil Craft', 'Assistant Assessor (Town/Municipality)', 'Deep Ellum', '442-101-3429', 44);
+INSERT INTO roads.municipality VALUES ('San Jose', 'Charles Carney', 'Municipal Accounting Manager', 'Santana Row', '408-331-1245', 5);
 
 CREATE TABLE roads.hard_hats (
     hard_hat_id smallint NOT NULL,

--- a/notebooks/Modeling the Roads Example Database.ipynb
+++ b/notebooks/Modeling the Roads Example Database.ipynb
@@ -1090,9 +1090,9 @@
    "outputs": [],
    "source": [
     "response = requests.get(\n",
-    "    f\"{DJ_URL}/metrics/num_repair_orders/sql/?dimensions=hard_hat.first_name,hard_hat.last_name&check_database_online=false\",\n",
+    "    f\"{DJ_URL}/sql/num_repair_orders/?dimensions=hard_hat.first_name,hard_hat.last_name\",\n",
     ")\n",
-    "print(response.json()[\"sql\"])"
+    "print(response.json())"
    ]
   },
   {
@@ -1105,7 +1105,7 @@
    "outputs": [],
    "source": [
     "response = requests.get(\n",
-    "    f\"{DJ_URL}/metrics/total_repair_order_discounts/sql/?dimensions=repair_order.hard_hat_id&check_database_online=false\",\n",
+    "    f\"{DJ_URL}/sql/total_repair_order_discounts/?dimensions=repair_order.hard_hat_id\",\n",
     ")\n",
     "print(response.json()[\"sql\"])"
    ]
@@ -1120,7 +1120,7 @@
    "outputs": [],
    "source": [
     "response = requests.get(\n",
-    "    f\"{DJ_URL}/metrics/avg_time_to_dispatch/sql/?dimensions=hard_hat.state&check_database_online=false\",\n",
+    "    f\"{DJ_URL}/sql/avg_time_to_dispatch/?dimensions=hard_hat.state\",\n",
     ")\n",
     "print(response.json()[\"sql\"])"
    ]
@@ -1135,7 +1135,7 @@
    "outputs": [],
    "source": [
     "response = requests.get(\n",
-    "    f\"{DJ_URL}/metrics/avg_repair_price/sql/?dimensions=repair_order.municipality_id&check_database_online=false\",\n",
+    "    f\"{DJ_URL}/sql/avg_repair_price/?dimensions=repair_order.municipality_id\",\n",
     ")\n",
     "print(response.json()[\"sql\"])"
    ]
@@ -1198,7 +1198,7 @@
    "outputs": [],
    "source": [
     "response = requests.get(\n",
-    "    f\"{DJ_URL}/metrics/avg_repair_price/sql/?dimensions=repair_order.municipality_id\",\n",
+    "    f\"{DJ_URL}/sql/avg_repair_price/?dimensions=repair_order.municipality_id\",\n",
     ")\n",
     "print(response.json()[\"sql\"])"
    ]
@@ -1226,7 +1226,12 @@
     "tags": []
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/num_repair_orders/?dimensions=hard_hat.first_name,hard_hat.last_name\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
   },
   {
    "cell_type": "code",
@@ -1234,7 +1239,38 @@
    "id": "27a03f70-66f7-4166-8883-95576f5e86be",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/total_repair_order_discounts/?dimensions=repair_order.hard_hat_id\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f141414",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/avg_time_to_dispatch/?dimensions=hard_hat.state\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dafd0bf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/avg_repair_price/?dimensions=repair_order.municipality_id\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/Modeling the Roads Example Database.ipynb
+++ b/notebooks/Modeling the Roads Example Database.ipynb
@@ -31,7 +31,9 @@
     "DJ_PROTOCOL = \"http\"\n",
     "DJ_HOST = \"localhost\"\n",
     "DJ_PORT = 8000\n",
-    "DJ_URL = f\"{DJ_PROTOCOL}://{DJ_HOST}:{DJ_PORT}\""
+    "DJ_URL = f\"{DJ_PROTOCOL}://{DJ_HOST}:{DJ_PORT}\"\n",
+    "\n",
+    "DJQS_URL = \"http://localhost:8001\""
    ]
   },
   {
@@ -58,14 +60,42 @@
     "    json={\"name\": \"default\"},\n",
     ")\n",
     "print(response.json())\n",
-    "response = requests.post(  # Add spark as an engine\n",
-    "    f\"{DJ_URL}/engines/\",\n",
-    "    json={\"name\": \"spark\", \"version\": \"3.1.1\"},\n",
+    "\n",
+    "response = requests.post(  # Add a catalog named public\n",
+    "    f\"{DJQS_URL}/catalogs/\",\n",
+    "    json={\"name\": \"default\"},\n",
     ")\n",
     "print(response.json())\n",
-    "response = requests.post(  # Attach the spark engine to the public catalog\n",
+    "\n",
+    "response = requests.post(  # Add postgres as an engine\n",
+    "    f\"{DJ_URL}/engines/\",\n",
+    "    json={\n",
+    "        \"name\": \"postgres\",\n",
+    "        \"version\": \"\",\n",
+    "        \"uri\": \"postgresql://dj:dj@postgres-roads:5432/djdb\",\n",
+    "    },\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Add postgres as an engine\n",
+    "    f\"{DJQS_URL}/engines/\",\n",
+    "    json={\n",
+    "        \"name\": \"postgres\",\n",
+    "        \"version\": \"\",\n",
+    "        \"uri\": \"postgresql://dj:dj@postgres-roads:5432/djdb\",\n",
+    "    },\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Attach postgres engine to the public catalog\n",
     "    f\"{DJ_URL}/catalogs/default/engines/\",\n",
-    "    json=[{\"name\": \"spark\", \"version\": \"3.1.1\"}],\n",
+    "    json=[{\"name\": \"postgres\", \"version\": \"\"}],\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Attach postgres engine to the public catalog\n",
+    "    f\"{DJQS_URL}/catalogs/default/engines/\",\n",
+    "    json=[{\"name\": \"postgres\", \"version\": \"\"}],\n",
     ")\n",
     "print(response.json())"
    ]
@@ -1123,7 +1153,7 @@
    "id": "d65c0337",
    "metadata": {},
    "source": [
-    "### Materializations can be reported by adding an `availability` to a node. When DJ builds the query, it will use any availability states it finds. Let's add an availability to the `repair_order` dimension node."
+    "Materializations can be reported by adding an `availability` to a node. When DJ builds the query, it will use any availability states it finds. Let's add an availability to the `repair_order` dimension node."
    ]
   },
   {
@@ -1137,7 +1167,7 @@
    "source": [
     "# Add an availability for the contractor dimension node\n",
     "response = requests.post(\n",
-    "    f\"{DJ_URL}/data/availability/repair_order/\",\n",
+    "    f\"{DJ_URL}/data/repair_order/availability/\",\n",
     "    json={\n",
     "        \"catalog\": \"default\",\n",
     "        \"schema_\": \"roads\",\n",
@@ -1177,6 +1207,31 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1d28d942-e41f-4da4-89d7-a6eb62d0d145",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/hard_hat/\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14a5d5ac-1417-4e59-9438-ddad3b2d4245",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27a03f70-66f7-4166-8883-95576f5e86be",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/Modeling the Roads Example Database.ipynb
+++ b/notebooks/Modeling the Roads Example Database.ipynb
@@ -1198,7 +1198,7 @@
    "outputs": [],
    "source": [
     "response = requests.get(\n",
-    "    f\"{DJ_URL}/metrics/avg_repair_price/sql/?dimensions=repair_order.municipality_id&check_database_online=false\",\n",
+    "    f\"{DJ_URL}/metrics/avg_repair_price/sql/?dimensions=repair_order.municipality_id\",\n",
     ")\n",
     "print(response.json()[\"sql\"])"
    ]

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -8,9 +8,104 @@ from sqlmodel import Session, select
 from dj.models.node import Node
 
 
+class TestDataForNode:
+    """
+    Test ``POST /data/{node_name}/``.
+    """
+
+    def test_get_dimension_data_failed(
+        self,
+        client_with_examples: TestClient,
+    ) -> None:
+        """
+        Test trying to get dimensions data while setting dimensions
+        """
+        response = client_with_examples.get(
+            "/data/payment_type/",
+            params={
+                "dimensions": ["something"],
+                "filters": [],
+            },
+        )
+        data = response.json()
+        assert response.status_code == 422
+        assert (
+            data["message"]
+            == "Cannot set filters or dimensions for node type dimension!"
+        )
+
+    def test_get_dimension_data(
+        self,
+        client_with_query_service: TestClient,
+    ) -> None:
+        """
+        Test trying to get dimensions data while setting dimensions
+        """
+        response = client_with_query_service.get(
+            "/data/payment_type/",
+        )
+        data = response.json()
+        assert response.status_code == 200
+        assert data == [
+            {
+                "submitted_query": (
+                    "SELECT  payment_type_table.id,\n\tpayment_type_table.payment_type_name,"
+                    "\n\tpayment_type_table.payment_type_classification \n FROM "
+                    '"accounting"."payment_type_table"'
+                    " AS payment_type_table"
+                ),
+                "state": "FINISHED",
+                "results": {
+                    "columns": [
+                        {"name": "id", "type": "INT"},
+                        {"name": "payment_type_name", "type": "STR"},
+                        {"name": "payment_type_classification", "type": "STR"},
+                    ],
+                    "rows": [[1, "VISA", "CARD"], [2, "MASTERCARD", "CARD"]],
+                },
+                "errors": [],
+            },
+        ]
+
+    def test_get_unsupported_node_type_data(
+        self,
+        client_with_query_service: TestClient,
+    ) -> None:
+        """
+        Trying to get transform or source data should fail
+        """
+        response = client_with_query_service.get("/data/revenue/")
+        data = response.json()
+        assert response.status_code == 500
+        assert data["message"] == "Can't get data for node type source!"
+
+        response = client_with_query_service.get("/data/large_revenue_payments_only/")
+        data = response.json()
+        assert response.status_code == 500
+        assert data["message"] == "Can't get data for node type transform!"
+
+    def test_get_metric_data(
+        self,
+        client_with_query_service: TestClient,
+    ) -> None:
+        """
+        Trying to get transform or source data should fail
+        """
+        response = client_with_query_service.get("/data/basic.num_comments/")
+        data = response.json()
+        assert response.status_code == 200
+        assert data == {
+            "errors": [],
+            "results": {"columns": [{"name": "cnt", "type": "INT"}], "rows": [[1]]},
+            "state": "FINISHED",
+            "submitted_query": "SELECT  COUNT(1) AS cnt \n"
+            ' FROM "basic"."comments" AS basic_DOT_source_DOT_comments',
+        }
+
+
 class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     """
-    Test ``POST /data/availability/{node_name}/``.
+    Test ``POST /data/{node_name}/availability/``.
     """
 
     def test_setting_availability_state(
@@ -22,7 +117,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test adding an availability state
         """
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_and_business_only/",
+            "/data/large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -61,7 +156,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test raising when the catalog does not match
         """
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_and_business_only/",
+            "/data/large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "public",
                 "schema_": "accounting",
@@ -87,7 +182,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test adding multiple availability states
         """
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_and_business_only/",
+            "/data/large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -103,7 +198,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_and_business_only/",
+            "/data/large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -119,7 +214,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_and_business_only/",
+            "/data/large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "new_accounting",
@@ -159,7 +254,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the `updated_at` attribute is being updated
         """
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_and_business_only/",
+            "/data/large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -181,7 +276,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         )
 
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_and_business_only/",
+            "/data/large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -210,7 +305,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test raising when setting availability state on non-existent node
         """
         response = client_with_examples.post(
-            "/data/availability/nonexistentnode/",
+            "/data/nonexistentnode/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -238,7 +333,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the higher max_partition value is used when merging in an availability state
         """
         client_with_examples.post(
-            "/data/availability/large_revenue_payments_only/",
+            "/data/large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -249,7 +344,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             },
         )
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_only/",
+            "/data/large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -297,7 +392,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the lower min_partition value is used when merging in an availability state
         """
         client_with_examples.post(
-            "/data/availability/large_revenue_payments_only/",
+            "/data/large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -308,7 +403,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             },
         )
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_only/",
+            "/data/large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -356,7 +451,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the valid through timestamp can be moved backwards
         """
         client_with_examples.post(
-            "/data/availability/large_revenue_payments_only/",
+            "/data/large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -367,7 +462,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             },
         )
         response = client_with_examples.post(
-            "/data/availability/large_revenue_payments_only/",
+            "/data/large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -415,7 +510,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test setting the availability state on a source node
         """
         response = client_with_examples.post(
-            "/data/availability/revenue/",
+            "/data/revenue/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -454,7 +549,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test raising availability state doesn't match existing source node table
         """
         response = client_with_examples.post(
-            "/data/availability/revenue/",
+            "/data/revenue/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -7,8 +7,8 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from dj.models.column import Column
+from dj.models.database import Database
 from dj.models.node import Node, NodeRevision, NodeType
-from dj.models.query import Database
 from dj.models.table import Table
 from dj.typing import ColumnType
 

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -111,45 +111,6 @@ def test_read_metrics_errors(session: Session, client: TestClient) -> None:
     assert response.json() == {"detail": "Not a metric node: `a-metric`"}
 
 
-def test_read_metrics_sql(
-    session: Session,
-    client: TestClient,
-) -> None:
-    """
-    Test ``GET /metrics/{node_id}/sql/``.
-    """
-    database = Database(name="test", URI="blah://", tables=[])
-
-    source_node = Node(name="my_table", type=NodeType.SOURCE, current_version="1")
-    source_node_rev = NodeRevision(
-        name=source_node.name,
-        node=source_node,
-        version="1",
-        schema_="rev",
-        table="my_table",
-        columns=[Column(name="one", type=ColumnType["STR"])],
-        type=NodeType.SOURCE,
-    )
-
-    node = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
-    node_revision = NodeRevision(
-        name=node.name,
-        node=node,
-        version="1",
-        query="SELECT COUNT(*) FROM my_table",
-        type=NodeType.METRIC,
-    )
-    session.add(database)
-    session.add(node_revision)
-    session.add(source_node_rev)
-    session.commit()
-
-    response = client.get("/metrics/a-metric/sql/")
-    assert response.json() == {
-        "sql": 'SELECT  COUNT(*) AS col0 \n FROM "rev"."my_table" AS my_table',
-    }
-
-
 def test_common_dimensions(
     client_with_examples: TestClient,
 ) -> None:

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -1,0 +1,280 @@
+"""Tests for the /sql/ endpoint"""
+import pytest
+from sqlmodel import Session
+from starlette.testclient import TestClient
+
+from dj.models import Column, Database, Node
+from dj.models.node import NodeRevision, NodeType
+from dj.typing import ColumnType
+from tests.sql.utils import compare_query_strings
+
+
+def test_sql(
+    session: Session,
+    client: TestClient,
+) -> None:
+    """
+    Test ``GET /sql/{name}/``.
+    """
+    database = Database(name="test", URI="blah://", tables=[])
+
+    source_node = Node(name="my_table", type=NodeType.SOURCE, current_version="1")
+    source_node_rev = NodeRevision(
+        name=source_node.name,
+        node=source_node,
+        version="1",
+        schema_="rev",
+        table="my_table",
+        columns=[Column(name="one", type=ColumnType["STR"])],
+        type=NodeType.SOURCE,
+    )
+
+    node = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        node=node,
+        version="1",
+        query="SELECT COUNT(*) FROM my_table",
+        type=NodeType.METRIC,
+    )
+    session.add(database)
+    session.add(node_revision)
+    session.add(source_node_rev)
+    session.commit()
+
+    response = client.get("/sql/a-metric/")
+    assert response.json() == {
+        "sql": 'SELECT  COUNT(*) AS col0 \n FROM "rev"."my_table" AS my_table',
+    }
+
+
+@pytest.mark.parametrize(
+    "node_name, dimensions, filters, sql",
+    [
+        # querying on source node with filter on joinable dimension
+        (
+            "repair_orders",
+            [],
+            ["hard_hat.state='CA'"],
+            """
+            SELECT  repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.order_date,
+                repair_orders.required_date,
+                repair_orders.dispatched_date,
+                repair_orders.dispatcher_id
+             FROM "roads"."repair_orders" AS repair_orders
+            LEFT JOIN (SELECT  hard_hats.hard_hat_id,
+                hard_hats.last_name,
+                hard_hats.first_name,
+                hard_hats.title,
+                hard_hats.birth_date,
+                hard_hats.hire_date,
+                hard_hats.address,
+                hard_hats.city,
+                hard_hats.state,
+                hard_hats.postal_code,
+                hard_hats.country,
+                hard_hats.manager,
+                hard_hats.contractor_id
+             FROM "roads"."hard_hats" AS hard_hats
+
+            ) AS hard_hat
+                    ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
+             WHERE  hard_hat.state = 'CA'
+            """,
+        ),
+        # querying source node with filters directly on the node
+        (
+            "repair_orders",
+            [],
+            ["repair_orders.order_date='2009-08-14'"],
+            """
+                SELECT  repair_orders.repair_order_id,
+                    repair_orders.municipality_id,
+                    repair_orders.hard_hat_id,
+                    repair_orders.order_date,
+                    repair_orders.required_date,
+                    repair_orders.dispatched_date,
+                    repair_orders.dispatcher_id
+                 FROM "roads"."repair_orders" AS repair_orders
+                 WHERE  repair_orders.order_date = '2009-08-14'
+                """,
+        ),
+        # querying transform node with filters on joinable dimension
+        (
+            "long_events",
+            [],
+            ["country_dim.events_cnt >= 20"],
+            """
+            SELECT  event_source.event_id,
+                event_source.event_latency,
+                event_source.device_id,
+                event_source.country
+            FROM "logs"."log_events" AS event_source
+            LEFT JOIN (SELECT  event_source.country,
+                COUNT(DISTINCT event_source.event_id) AS events_cnt
+             FROM "logs"."log_events" AS event_source
+
+             GROUP BY  event_source.country) AS country_dim
+                    ON event_source.country = country_dim.country
+             WHERE  event_source.event_latency > 1000000 AND country_dim.events_cnt >= 20
+            """,
+        ),
+        # querying transform node with filters directly on the node
+        (
+            "long_events",
+            [],
+            ["event_source.device_id = 'Android'"],
+            """
+            SELECT
+              event_source.event_id,
+              event_source.event_latency,
+              event_source.device_id,
+              event_source.country
+            FROM "logs"."log_events" AS event_source
+            WHERE event_source.event_latency > 1000000 AND event_source.device_id = 'Android'
+            """,
+        ),
+        (
+            "municipality_dim",
+            [],
+            ["state_id = 'CA'"],
+            """
+            SELECT  municipality.municipality_id,
+                municipality.contact_name,
+                municipality.contact_title,
+                municipality.local_region,
+                municipality.phone,
+                municipality.state_id,
+                municipality_municipality_type.municipality_type_id,
+                municipality_type.municipality_type_desc
+             FROM "roads"."municipality" AS municipality
+            LEFT JOIN "roads"."municipality_municipality_type" AS municipality_municipality_type
+                    ON municipality.municipality_id = municipality_municipality_type.municipality_id
+            LEFT JOIN "roads"."municipality_type" AS municipality_type
+                    ON municipality_municipality_type.municipality_type_id
+                        = municipality_type.municipality_type_desc
+             WHERE  municipality.state_id = 'CA'
+            """,
+        ),
+        (
+            "num_repair_orders",
+            [],
+            [],
+            """SELECT  count(repair_orders.repair_order_id) AS num_repair_orders
+               FROM "roads"."repair_orders" AS repair_orders
+            """,
+        ),
+        (
+            "num_repair_orders",
+            ["hard_hat.state"],
+            ["repair_orders.dispatcher_id=1", "hard_hat.state='AZ'"],
+            """SELECT  count(repair_orders.repair_order_id) AS num_repair_orders,
+                 hard_hat.state
+               FROM "roads"."repair_orders" AS repair_orders
+               LEFT JOIN (SELECT  hard_hats.address,
+                 hard_hats.birth_date,
+                 hard_hats.city,
+                 hard_hats.contractor_id,
+                 hard_hats.country,
+                 hard_hats.first_name,
+                 hard_hats.hard_hat_id,
+                 hard_hats.hire_date,
+                 hard_hats.last_name,
+                 hard_hats.manager,
+                 hard_hats.postal_code,
+                 hard_hats.state,
+                 hard_hats.title
+               FROM "roads"."hard_hats" AS hard_hats
+            ) AS hard_hat
+                    ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
+             WHERE  repair_orders.dispatcher_id = 1 AND hard_hat.state = 'AZ'
+             GROUP BY  hard_hat.state""",
+        ),
+        (
+            "num_repair_orders",
+            [
+                "hard_hat.city",
+                "hard_hat.last_name",
+                "dispatcher.company_name",
+                "municipality_dim.local_region",
+            ],
+            [
+                "repair_orders.dispatcher_id=1",
+                "hard_hat.state != 'AZ'",
+                "dispatcher.phone = '4082021022'",
+                "repair_orders.order_date >= '2020-01-01'",
+            ],
+            """SELECT  count(repair_orders.repair_order_id) AS num_repair_orders,
+                hard_hat.city,
+                municipality_dim.local_region,
+                dispatcher.company_name,
+                hard_hat.last_name
+             FROM "roads"."repair_orders" AS repair_orders
+            LEFT JOIN (SELECT  hard_hats.hard_hat_id,
+                hard_hats.last_name,
+                hard_hats.first_name,
+                hard_hats.title,
+                hard_hats.birth_date,
+                hard_hats.hire_date,
+                hard_hats.address,
+                hard_hats.city,
+                hard_hats.state,
+                hard_hats.postal_code,
+                hard_hats.country,
+                hard_hats.manager,
+                hard_hats.contractor_id
+             FROM "roads"."hard_hats" AS hard_hats
+
+            ) AS hard_hat
+                    ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
+            LEFT JOIN (SELECT  dispatchers.dispatcher_id,
+                dispatchers.company_name,
+                dispatchers.phone
+             FROM "roads"."dispatchers" AS dispatchers
+
+            ) AS dispatcher
+                    ON repair_orders.dispatcher_id = dispatcher.dispatcher_id
+            LEFT JOIN (SELECT  municipality.municipality_id,
+                municipality.contact_name,
+                municipality.contact_title,
+                municipality.local_region,
+                municipality.phone,
+                municipality.state_id,
+                municipality_municipality_type.municipality_type_id,
+                municipality_type.municipality_type_desc
+             FROM "roads"."municipality" AS municipality
+            LEFT JOIN "roads"."municipality_municipality_type" AS municipality_municipality_type
+                    ON municipality.municipality_id = municipality_municipality_type.municipality_id
+            LEFT JOIN "roads"."municipality_type" AS municipality_type
+                    ON municipality_municipality_type.municipality_type_id
+                    = municipality_type.municipality_type_desc
+            ) AS municipality_dim
+                    ON repair_orders.municipality_id = municipality_dim.municipality_id
+             WHERE  repair_orders.dispatcher_id = 1 AND hard_hat.state <> 'AZ'
+                AND dispatcher.phone = '4082021022' AND repair_orders.order_date >= '2020-01-01'
+             GROUP BY  hard_hat.city, hard_hat.last_name, dispatcher.company_name,
+             municipality_dim.local_region""",
+        ),
+    ],
+)
+def test_sql_with_filters(
+    node_name,
+    dimensions,
+    filters,
+    sql,
+    client_with_examples: TestClient,
+):
+    """
+    Test ``GET /sqk/{node_name}/`` with various filters and dimensions.
+    The cases to cover include:
+    * filters from
+    """
+    response = client_with_examples.get(
+        f"/sql/{node_name}/",
+        params={"dimensions": dimensions, "filters": filters},
+    )
+    data = response.json()
+    assert compare_query_strings(data["sql"], sql)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
     def mock_submit_query(
         query_create: QueryCreate,
     ) -> Collection[Collection[str]]:
+        print("sub_query", query_create.submitted_query)
         return QUERY_DATA_MAPPINGS[query_create.submitted_query]
 
     mocker.patch.object(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ Fixtures for testing.
 """
 # pylint: disable=redefined-outer-name, invalid-name, W0611
 
-from typing import Iterator, List
+from typing import Collection, Iterator, List, Optional
 
 import pytest
 from cachelib.simple import SimpleCache
@@ -20,7 +20,7 @@ from dj.service_clients import QueryServiceClient
 from dj.utils import get_query_service_client, get_session, get_settings
 
 from .construction.fixtures import build_expectation, construction_session
-from .examples import COLUMN_MAPPINGS, EXAMPLES
+from .examples import COLUMN_MAPPINGS, EXAMPLES, QUERY_DATA_MAPPINGS
 from .sql.parsing.queries import (
     case_when_null,
     cte_query,
@@ -88,6 +88,21 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         qs_client,
         "get_columns_for_table",
         mock_get_columns_for_table,
+    )
+
+    def mock_submit_query(
+        engine_name: str,  # pylint: disable=unused-argument
+        engine_version: str,  # pylint: disable=unused-argument
+        query: str,
+        catalog_name: str,  # pylint: disable=unused-argument
+        async_: Optional[bool] = False,  # pylint: disable=unused-argument
+    ) -> Collection[Collection[str]]:
+        return QUERY_DATA_MAPPINGS[query]
+
+    mocker.patch.object(
+        qs_client,
+        "submit_query",
+        mock_submit_query,
     )
 
     yield qs_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ Fixtures for testing.
 """
 # pylint: disable=redefined-outer-name, invalid-name, W0611
 
-from typing import Collection, Iterator, List, Optional
+from typing import Collection, Iterator, List
 
 import pytest
 from cachelib.simple import SimpleCache
@@ -16,6 +16,7 @@ from sqlmodel.pool import StaticPool
 from dj.api.main import app
 from dj.config import Settings
 from dj.models import Column
+from dj.models.query import QueryCreate
 from dj.service_clients import QueryServiceClient
 from dj.utils import get_query_service_client, get_session, get_settings
 
@@ -91,13 +92,9 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
     )
 
     def mock_submit_query(
-        engine_name: str,  # pylint: disable=unused-argument
-        engine_version: str,  # pylint: disable=unused-argument
-        query: str,
-        catalog_name: str,  # pylint: disable=unused-argument
-        async_: Optional[bool] = False,  # pylint: disable=unused-argument
+        query_create: QueryCreate,
     ) -> Collection[Collection[str]]:
-        return QUERY_DATA_MAPPINGS[query]
+        return QUERY_DATA_MAPPINGS[query_create.submitted_query]
 
     mocker.patch.object(
         qs_client,

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -107,9 +107,10 @@ async def test_raise_on_build_without_required_dimension_column(request):
         type=node_bar_ref.type,
         node=node_bar_ref,
         version="1",
-        query="""SELECT num_users FROM foo GROUP BY basic.dimension.countries.country""",
+        query="SELECT SUM(num_users) AS num_users "
+        "FROM foo GROUP BY basic.dimension.countries.country",
         columns=[
-            Column(name="num_users", type=ColumnType.STR),
+            Column(name="num_users", type=ColumnType.INT),
         ],
     )
     with pytest.raises(DJException) as exc_info:
@@ -142,8 +143,7 @@ async def test_build_metric_with_dimensions_filters(request):
         filters=["basic.dimension.users.age>=25", "basic.dimension.users.age<50"],
     )
 
-    expected = """SELECT  COUNT(1) AS cnt,
-        basic_DOT_dimension_DOT_users.age
+    expected = """SELECT  COUNT(1) AS cnt
  FROM "basic.source.comments" AS basic_DOT_source_DOT_comments
 LEFT JOIN (SELECT  basic_DOT_source_DOT_users.id,
         basic_DOT_source_DOT_users.full_name,

--- a/tests/construction/fixtures.py
+++ b/tests/construction/fixtures.py
@@ -36,14 +36,18 @@ def build_expectation() -> Dict[str, Dict[Optional[int], Tuple[bool, str]]]:
     return {
         """basic.source.users""": {
             None: (
-                False,
-                """Node has no query. Cannot generate a build plan without a query.""",
+                True,
+                """
+                SELECT * FROM "basic.source.users"
+                """,
             ),
         },
         """basic.source.comments""": {
             None: (
-                False,
-                """Node has no query. Cannot generate a build plan without a query.""",
+                True,
+                """
+                SELECT * FROM "basic.source.comments"
+                """,
             ),
         },
         """basic.dimension.users""": {

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,6 +1,8 @@
 """
 Post requests for all example entities
 """
+
+# pylint: disable=too-many-lines
 from dj.models import Column
 from dj.typing import ColumnType, QueryState
 
@@ -769,6 +771,10 @@ EXAMPLES = (  # type: ignore
         },
     ),
     (
+        "/nodes/event_source/columns/country/?dimension=country_dim&dimension_column=country",
+        {},
+    ),
+    (
         "/nodes/metric/",
         {
             "name": "device_ids_count",
@@ -933,27 +939,27 @@ COLUMN_MAPPINGS = {
 
 QUERY_DATA_MAPPINGS = {
     (
-        "SELECT  payment_type_table.id,\n\tpayment_type_table.payment_type_name,"
-        '\n\tpayment_type_table.payment_type_classification \n FROM "accounting".'
-        '"payment_type_table" AS payment_type_table'
+        "SELECT  payment_type_table.id,\n\tpayment_type_table.payment_type_classification,\n\t"
+        'payment_type_table.payment_type_name \n FROM "accounting"."payment_type_table" AS '
+        "payment_type_table"
     ): [
         {
             "submitted_query": (
-                "SELECT  payment_type_table.id,\n\tpayment_type_table.payment_type_name,"
-                "\n\tpayment_type_table.payment_type_classification \n "
-                'FROM "accounting"."payment_type_table"'
-                " AS payment_type_table"
+                "SELECT  payment_type_table.id,\n\tpayment_type_table."
+                "payment_type_classification,\n\t"
+                'payment_type_table.payment_type_name \n FROM "accounting"."payment_type_table" '
+                "AS payment_type_table"
             ),
             "state": QueryState.FINISHED,
             "results": {
                 "columns": [
                     {"name": "id", "type": "INT"},
-                    {"name": "payment_type_name", "type": "STR"},
                     {"name": "payment_type_classification", "type": "STR"},
+                    {"name": "payment_type_name", "type": "STR"},
                 ],
                 "rows": [
-                    (1, "VISA", "CARD"),
-                    (2, "MASTERCARD", "CARD"),
+                    (1, "CARD", "VISA"),
+                    (2, "CARD", "MASTERCARD"),
                 ],
             },
             "errors": [],
@@ -968,6 +974,44 @@ QUERY_DATA_MAPPINGS = {
             "columns": [{"name": "cnt", "type": "INT"}],
             "rows": [
                 (1,),
+            ],
+        },
+        "errors": [],
+    },
+    'SELECT  * \n FROM "accounting"."revenue"': {
+        "submitted_query": ('SELECT  * \n FROM "accounting"."revenue"'),
+        "state": QueryState.FINISHED,
+        "results": {
+            "columns": [{"name": "profit", "type": "FLOAT"}],
+            "rows": [
+                (129.19,),
+            ],
+        },
+        "errors": [],
+    },
+    (
+        "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
+        '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n '
+        "WHERE  revenue.payment_amount > 1000000"
+    ): {
+        "submitted_query": (
+            "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
+            '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n '
+            "WHERE  revenue.payment_amount > 1000000"
+        ),
+        "state": QueryState.FINISHED,
+        "results": {
+            "columns": [
+                {"name": "account_type", "type": "STR"},
+                {"name": "customer_id", "type": "INT"},
+                {"name": "payment_amount", "type": "STR"},
+                {"name": "payment_id", "type": "INT"},
+            ],
+            "rows": [
+                ("CHECKING", 2, "22.50", 1),
+                ("SAVINGS", 2, "100.50", 1),
+                ("CREDIT", 1, "11.50", 1),
+                ("CHECKING", 2, "2.50", 1),
             ],
         },
         "errors": [],

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -2,7 +2,7 @@
 Post requests for all example entities
 """
 from dj.models import Column
-from dj.typing import ColumnType
+from dj.typing import ColumnType, QueryState
 
 EXAMPLES = (  # type: ignore
     (
@@ -929,4 +929,47 @@ COLUMN_MAPPINGS = {
         Column(name="timestamp", type=ColumnType("TIMESTAMP")),
         Column(name="text", type=ColumnType("STR")),
     ],
+}
+
+QUERY_DATA_MAPPINGS = {
+    (
+        "SELECT  payment_type_table.id,\n\tpayment_type_table.payment_type_name,"
+        '\n\tpayment_type_table.payment_type_classification \n FROM "accounting".'
+        '"payment_type_table" AS payment_type_table'
+    ): [
+        {
+            "submitted_query": (
+                "SELECT  payment_type_table.id,\n\tpayment_type_table.payment_type_name,"
+                "\n\tpayment_type_table.payment_type_classification \n "
+                'FROM "accounting"."payment_type_table"'
+                " AS payment_type_table"
+            ),
+            "state": QueryState.FINISHED,
+            "results": {
+                "columns": [
+                    {"name": "id", "type": "INT"},
+                    {"name": "payment_type_name", "type": "STR"},
+                    {"name": "payment_type_classification", "type": "STR"},
+                ],
+                "rows": [
+                    (1, "VISA", "CARD"),
+                    (2, "MASTERCARD", "CARD"),
+                ],
+            },
+            "errors": [],
+        },
+    ],
+    'SELECT  COUNT(1) AS cnt \n FROM "basic"."comments" AS basic_DOT_source_DOT_comments': {
+        "submitted_query": (
+            'SELECT  COUNT(1) AS cnt \n FROM "basic"."comments" AS basic_DOT_source_DOT_comments'
+        ),
+        "state": QueryState.FINISHED,
+        "results": {
+            "columns": [{"name": "cnt", "type": "INT"}],
+            "rows": [
+                (1,),
+            ],
+        },
+        "errors": [],
+    },
 }

--- a/tests/models/query_test.py
+++ b/tests/models/query_test.py
@@ -9,8 +9,9 @@ import msgpack
 
 from dj.models.query import (
     ColumnMetadata,
-    QueryExecutionResult,
+    QueryResults,
     QueryWithResults,
+    StatementResults,
     decode_results,
     encode_results,
 )
@@ -25,16 +26,23 @@ def test_msgpack() -> None:
         catalog=None,
         schema=None,
         id=UUID("5599b970-23f0-449b-baea-c87a2735423b"),
-        query="SELECT 42 AS answer",
+        submitted_query="SELECT 42 AS answer",
         executed_query="SELECT 42 AS answer",
-        created=datetime(2021, 1, 1),
+        scheduled=datetime(2021, 1, 1),
         started=datetime(2021, 1, 2),
         finished=datetime(2021, 1, 3),
         state=QueryState.FINISHED,
         progress=1,
-        results=QueryExecutionResult(
-            columns=[ColumnMetadata(name="answer", type=ColumnType.INT)],
-            rows=[(42,)],
+        output_table=None,
+        results=QueryResults(
+            __root__=[
+                StatementResults(
+                    sql="SELECT 42 AS answer",
+                    columns=[ColumnMetadata(name="answer", type=ColumnType.INT)],
+                    rows=[(42,)],
+                    row_count=1,
+                ),
+            ],
         ),
         next=None,
         previous=None,
@@ -47,18 +55,24 @@ def test_msgpack() -> None:
     decoded = msgpack.unpackb(encoded, ext_hook=decode_results)
     assert decoded == {
         "id": UUID("5599b970-23f0-449b-baea-c87a2735423b"),
-        "query": "SELECT 42 AS answer",
+        "submitted_query": "SELECT 42 AS answer",
+        "executed_query": "SELECT 42 AS answer",
         "engine_name": None,
         "engine_version": None,
         "output_table": None,
-        "created": datetime(2021, 1, 1, 0, 0),
+        "scheduled": datetime(2021, 1, 1, 0, 0),
         "started": datetime(2021, 1, 2, 0, 0),
         "finished": datetime(2021, 1, 3, 0, 0),
+        "progress": 1.0,
         "state": "FINISHED",
-        "results": {
-            "columns": [{"name": "answer", "type": "INT"}],
-            "rows": [[42]],
-        },
+        "results": [
+            {
+                "sql": "SELECT 42 AS answer",
+                "columns": [{"name": "answer", "type": "INT"}],
+                "rows": [[42]],
+                "row_count": 1,
+            },
+        ],
         "next": None,
         "previous": None,
         "errors": [],

--- a/tests/models/query_test.py
+++ b/tests/models/query_test.py
@@ -9,9 +9,8 @@ import msgpack
 
 from dj.models.query import (
     ColumnMetadata,
-    QueryResults,
+    QueryExecutionResult,
     QueryWithResults,
-    StatementResults,
     decode_results,
     encode_results,
 )
@@ -23,26 +22,19 @@ def test_msgpack() -> None:
     Test the msgpack encoding/decoding
     """
     query_with_results = QueryWithResults(
-        database_id=1,
         catalog=None,
         schema=None,
         id=UUID("5599b970-23f0-449b-baea-c87a2735423b"),
-        submitted_query="SELECT 42 AS answer",
+        query="SELECT 42 AS answer",
         executed_query="SELECT 42 AS answer",
-        scheduled=datetime(2021, 1, 1),
+        created=datetime(2021, 1, 1),
         started=datetime(2021, 1, 2),
         finished=datetime(2021, 1, 3),
         state=QueryState.FINISHED,
         progress=1,
-        results=QueryResults(
-            __root__=[
-                StatementResults(
-                    sql="SELECT 42 AS answer",
-                    columns=[ColumnMetadata(name="answer", type=ColumnType.INT)],
-                    rows=[(42,)],
-                    row_count=1,
-                ),
-            ],
+        results=QueryExecutionResult(
+            columns=[ColumnMetadata(name="answer", type=ColumnType.INT)],
+            rows=[(42,)],
         ),
         next=None,
         previous=None,
@@ -54,25 +46,19 @@ def test_msgpack() -> None:
     )
     decoded = msgpack.unpackb(encoded, ext_hook=decode_results)
     assert decoded == {
-        "database_id": 1,
-        "catalog": None,
-        "schema": None,
         "id": UUID("5599b970-23f0-449b-baea-c87a2735423b"),
-        "submitted_query": "SELECT 42 AS answer",
-        "executed_query": "SELECT 42 AS answer",
-        "scheduled": datetime(2021, 1, 1, 0, 0),
+        "query": "SELECT 42 AS answer",
+        "engine_name": None,
+        "engine_version": None,
+        "output_table": None,
+        "created": datetime(2021, 1, 1, 0, 0),
         "started": datetime(2021, 1, 2, 0, 0),
         "finished": datetime(2021, 1, 3, 0, 0),
         "state": "FINISHED",
-        "progress": 1.0,
-        "results": [
-            {
-                "sql": "SELECT 42 AS answer",
-                "columns": [{"name": "answer", "type": "INT"}],
-                "rows": [[42]],
-                "row_count": 1,
-            },
-        ],
+        "results": {
+            "columns": [{"name": "answer", "type": "INT"}],
+            "rows": [[42]],
+        },
         "next": None,
         "previous": None,
         "errors": [],

--- a/tests/service_clients_test.py
+++ b/tests/service_clients_test.py
@@ -104,21 +104,17 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "engine_name": "postgres",
             "engine_version": "15.2",
             "id": "ef209eef-c31a-4089-aae6-833259a08e22",
-            "submitted_query": "SELECT 1 as num",
+            "query": "SELECT 1 as num",
             "executed_query": "SELECT 1 as num",
             "scheduled": "2023-01-01T00:00:00.000000",
             "started": "2023-01-01T00:00:00.000000",
             "finished": "2023-01-01T00:00:00.000001",
             "state": "FINISHED",
             "progress": 1,
-            "results": [
-                {
-                    "sql": "SELECT 1 as num",
-                    "columns": [{"name": "num", "type": "INT"}],
-                    "rows": [[1]],
-                    "row_count": 1,
-                },
-            ],
+            "results": {
+                "columns": [{"name": "num", "type": "INT"}],
+                "rows": [[1]],
+            },
             "next": None,
             "previous": None,
             "errors": [],
@@ -132,20 +128,19 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
 
         query_service_client = QueryServiceClient(uri=self.endpoint)
         query_service_client.submit_query(
-            engine="postgres",
+            engine_name="postgres",
             engine_version="15.2",
-            submitted_query="SELECT 1",
-            catalog="public",
+            query="SELECT 1",
             async_=False,
         )
 
         mock_request.assert_called_with(
             "/queries/",
             json={
-                "catalog_name": "public",
-                "engine": "postgres",
+                "catalog_name": "default",
+                "engine_name": "postgres",
                 "engine_version": "15.2",
-                "submitted_query": "SELECT 1",
+                "query": "SELECT 1",
                 "async_": False,
             },
         )
@@ -161,21 +156,17 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "engine_name": "postgres",
             "engine_version": "15.2",
             "id": "ef209eef-c31a-4089-aae6-833259a08e22",
-            "submitted_query": "SELECT 1 as num",
+            "query": "SELECT 1 as num",
             "executed_query": "SELECT 1 as num",
             "scheduled": "2023-01-01T00:00:00.000000",
             "started": "2023-01-01T00:00:00.000000",
             "finished": "2023-01-01T00:00:00.000001",
             "state": "FINISHED",
             "progress": 1,
-            "results": [
-                {
-                    "sql": "SELECT 1 as num",
-                    "columns": [{"name": "num", "type": "INT"}],
-                    "rows": [[1]],
-                    "row_count": 1,
-                },
-            ],
+            "results": {
+                "columns": [{"name": "num", "type": "INT"}],
+                "rows": [[1]],
+            },
             "next": None,
             "previous": None,
             "errors": [],
@@ -218,10 +209,9 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
 
         with pytest.raises(DJQueryServiceClientException) as exc_info:
             query_service_client.submit_query(
-                engine="postgres",
+                engine_name="postgres",
                 engine_version="15.2",
-                submitted_query="SELECT 1",
-                catalog="public",
+                query="SELECT 1",
                 async_=False,
             )
         assert "Error response from query service" in str(exc_info.value)


### PR DESCRIPTION
### Summary

This PR adds two endpoints:
* `/data/{node_name}` to retrieve data for a node
* `/sql/{node_name}` to retrieve SQL for a node

These endpoints work for sources, transforms, metrics and dimensions. In order to support data/sql generation for source and transform nodes, I removed the check for a `query` on the node and included a stage that builds the AST for a source node. This also required an additional check to make sure that we don't include any fields in the `SELECT` clause that aren't in the `GROUP BY` clause, when the latter exists. 

I'll work on support for cube nodes in a separate PR.

Other changes:
* Bugfix for generated SQL: When users provide a filter, it shouldn't be included in the `SELECT` clause by default. In addition to not making sense, including it in `SELECT` will also generate a query that doesn't run for metrics or any other node with an aggregation (fails in Postgres with `must appear in the GROUP BY clause or be used in an aggregate function`). 
* Removes `query` table as that is now part of djqs.
* Moved the availability state posting from `/data/availability/{node_name}/` to `/data/{node_name}/availability/` to be consistent with the URL order of `/data/{node_name}/...`
* Added docs to `CONTRIBUTING.rst`

These changes require a minor companion change to DJQS: https://github.com/DataJunction/djqs/pull/10

### Test Plan

Added some tests with a mocked query service client. I also ran this with (a slightly modified) DJQS against the DJ Roads tables.

- [X] PR has an associated issue: #342
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
