### PR TITLE
Listing dimensions for a node should yield all possible dimensions

### DIFF
--- a/dj/sql/dag.py
+++ b/dj/sql/dag.py
@@ -1,9 +1,10 @@
 """
 DAG related functions.
 """
+import collections
 from typing import List
 
-from dj.models.node import Node, NodeRevision
+from dj.models.node import Node
 from dj.utils import get_settings
 
 settings = get_settings()
@@ -11,17 +12,24 @@ settings = get_settings()
 
 def get_dimensions(node: Node) -> List[str]:
     """
-    Return the available dimensions in a given node.
+    Return all available dimensions for a given node.
     """
     dimensions = []
-    for parent in node.current.parents:
-        for column in parent.current.columns:
-            dimensions.append(f"{parent.name}.{column.name}")
+    to_process = collections.deque([node, *node.current.parents])
+    processed = set()
 
-            if column.dimension:
+    while to_process:
+        current_node = to_process.popleft()
+        for column in current_node.current.columns:
+            if any(
+                attr.attribute_type.name == "dimension" for attr in column.attributes
+            ):
+                dimensions.append(f"{current_node.name}.{column.name}")
+            if column.dimension and column.dimension not in processed:
+                processed.add(column.dimension)
+                to_process.extend(column.dimension.current.parents)
                 for dimension_column in column.dimension.current.columns:
                     dimensions.append(
                         f"{column.dimension.name}.{dimension_column.name}",
                     )
-
     return sorted(dimensions)

--- a/dj/sql/dag.py
+++ b/dj/sql/dag.py
@@ -4,7 +4,7 @@ DAG related functions.
 import collections
 from typing import List
 
-from dj.models.node import Node
+from dj.models.node import Node, NodeType
 from dj.utils import get_settings
 
 settings = get_settings()
@@ -15,21 +15,24 @@ def get_dimensions(node: Node) -> List[str]:
     Return all available dimensions for a given node.
     """
     dimensions = []
-    to_process = collections.deque([node, *node.current.parents])
+
+    # Start with the node itself or the node's immediate parent if it's a metric node
+    to_process = collections.deque(
+        [node, *(node.current.parents if node.type == NodeType.METRIC else [])],
+    )
     processed = set()
 
     while to_process:
         current_node = to_process.popleft()
+        processed.add(current_node)
+
         for column in current_node.current.columns:
-            if any(
+            # Include the dimension if it's a column belonging to a dimension node
+            # or if it's tagged with the dimension column attribute
+            if current_node.type == NodeType.DIMENSION or any(
                 attr.attribute_type.name == "dimension" for attr in column.attributes
             ):
                 dimensions.append(f"{current_node.name}.{column.name}")
             if column.dimension and column.dimension not in processed:
-                processed.add(column.dimension)
-                to_process.extend(column.dimension.current.parents)
-                for dimension_column in column.dimension.current.columns:
-                    dimensions.append(
-                        f"{column.dimension.name}.{dimension_column.name}",
-                    )
+                to_process.append(column.dimension)
     return sorted(dimensions)

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -523,6 +523,13 @@ EXAMPLES = (  # type: ignore
         ),
         {},
     ),
+    (
+        (
+            "/nodes/repair_order_details/columns/repair_order_id/"
+            "?dimension=repair_order&dimension_column=repair_order_id"
+        ),
+        {},
+    ),
     (  # Accounts/Revenue examples begin
         "/nodes/source/",
         {

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -530,6 +530,27 @@ EXAMPLES = (  # type: ignore
         ),
         {},
     ),
+    (
+        (
+            "/nodes/repair_order/columns/dispatcher_id/"
+            "?dimension=dispatcher&dimension_column=dispatcher_id"
+        ),
+        {},
+    ),
+    (
+        (
+            "/nodes/repair_order/columns/repair_order_id/"
+            "?dimension=hard_hat&dimension_column=hard_hat_id"
+        ),
+        {},
+    ),
+    (
+        (
+            "/nodes/repair_order/columns/municipality_id/"
+            "?dimension=municipality_dim&dimension_column=municipality_id"
+        ),
+        {},
+    ),
     (  # Accounts/Revenue examples begin
         "/nodes/source/",
         {

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -67,4 +67,4 @@ def test_get_dimensions() -> None:
     )
     child_ref.current = child
 
-    assert get_dimensions(child_ref) == ["A.b_id", "A.ds", "B.attribute", "B.id"]
+    assert get_dimensions(child_ref) == ["B.attribute", "B.id"]

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -58,12 +58,13 @@ def test_get_dimensions() -> None:
     )
     parent_ref.current = parent
 
-    child_ref = Node(name="C", current_version="1")
+    child_ref = Node(name="C", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
         node=child_ref,
         version="1",
         query="SELECT COUNT(*) FROM A",
         parents=[parent_ref],
+        type=NodeType.METRIC,
     )
     child_ref.current = child
 


### PR DESCRIPTION
### Summary

**Nth Order Dimensions:** We currently only display the first-order set of dimensions for a node. However, dimensions can be found on any column in the existing node or on any column in the node's parents, or the parents' parents etc, so we should walk through the parents + dimension links DAG in order to populate the complete set of a node's dimensions.

**Dimension Attributes:** The current setup will yield all columns on a node as available dimensions. However, we should only include them if they've been marked with the `dimension` column attribute.

Note: This doesn't make the necessary changes to the compile + build stages to support query generation for these Nth-order dimensions. A preview of that setup for the old AST [can be found here](https://github.com/DataJunction/dj/compare/main...shangyian:dj:add-multi-level-dims?expand=1), but I'll work on supporting this with the new AST when that's in.

### Test Plan

Ran through some of the existing DJ Roads node examples.

- [X] PR has an associated issue: #411
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
