### PR TITLE
add a library skeleton for djclient

### DIFF
--- a/client/python/.pre-commit-config.yaml
+++ b/client/python/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: (^docs/|^openapi/|^client/python/)
+files: ^client/python/
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -6,63 +6,32 @@ repos:
   hooks:
   - id: trailing-whitespace
   - id: check-ast
-    exclude: ^templates/
   - id: check-json
   - id: check-merge-conflict
   - id: check-xml
   - id: check-yaml
   - id: debug-statements
-    exclude: ^templates/
   - id: end-of-file-fixer
-    exclude: openapi.json
   - id: requirements-txt-fixer
-    exclude: ^templates/
   - id: mixed-line-ending
     args: ['--fix=auto']  # replace 'auto' with 'lf' to enforce Linux/Mac line endings or 'crlf' for Windows
-
-## If you want to avoid flake8 errors due to unused vars or imports:
-# - repo: https://github.com/myint/autoflake.git
-#   rev: v1.4
-#   hooks:
-#   - id: autoflake
-#     args: [
-#       --in-place,
-#       --remove-all-unused-imports,
-#       --remove-unused-variables,
-#     ]
-
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0
   hooks:
   - id: isort
-
 - repo: https://github.com/psf/black
   rev: 22.8.0
   hooks:
   - id: black
     language_version: python3
-    exclude: ^templates/
-
-## If like to embrace black styles even in the docs:
-# - repo: https://github.com/asottile/blacken-docs
-#   rev: v1.9.1
-#   hooks:
-#   - id: blacken-docs
-#     additional_dependencies: [black]
-
 - repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
   - id: flake8
-    exclude: ^templates/
-  ## You can add flake8 plugins via `additional_dependencies`:
-  #  additional_dependencies: [flake8-bugbear]
-
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: 'v0.931'  # Use the sha / tag you want to point at
   hooks:
   - id: mypy
-    exclude: ^templates/
     additional_dependencies:
     - types-requests
     - types-freezegun
@@ -74,17 +43,11 @@ repos:
   rev: v2.2.1
   hooks:
   - id: add-trailing-comma
-#- repo: https://github.com/asottile/reorder_python_imports
-#  rev: v2.5.0
-#  hooks:
-#  - id: reorder-python-imports
-#    args: [--application-directories=.:src]
 - repo: https://github.com/hadialqattan/pycln
   rev: v1.1.0 # Possible releases: https://github.com/hadialqattan/pycln/tags
   hooks:
   - id: pycln
     args: [--config=pyproject.toml]
-    exclude: ^templates/
 - repo: local
   hooks:
   - id: pylint
@@ -92,13 +55,3 @@ repos:
     entry: pylint --disable=duplicate-code,use-implicit-booleaness-not-comparison
     language: system
     types: [python]
-    exclude: ^templates/
-- repo: https://github.com/kynan/nbstripout
-  rev: 0.6.1
-  hooks:
-    - id: nbstripout
-- repo: https://github.com/tomcatling/black-nb
-  rev: "0.7"
-  hooks:
-    - id: black-nb
-      files: '\.ipynb$'

--- a/client/python/LICENSE.txt
+++ b/client/python/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Beto Dealmeida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/client/python/Makefile
+++ b/client/python/Makefile
@@ -1,0 +1,5 @@
+check:
+	poetry run pre-commit run --all-files
+
+test:
+	poetry run pytest tests/ ${PYTEST_ARGS}

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -1,0 +1,1 @@
+# DataJunction Python Client

--- a/client/python/djclient/__init__.py
+++ b/client/python/djclient/__init__.py
@@ -1,0 +1,4 @@
+"""
+A DataJunction client for connecting to a DataJunction server
+"""
+__version__ = "0.0.1a1"

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "djclient"
+version = "0.0.1a1"
+readme = "README.md"
+repository = "https://github.com/DataJunction/dj"
+description = "DataJunction client library for connecting to a DataJunction server"
+authors = ["DataJunction Authors"]
+license = "MIT"
+packages = [
+    { include = "djclient" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[tool.coverage.run]
+source = ['djclient/']
+
+[tool.isort]
+src_paths = ["djclient/", "tests/"]
+profile = 'black'
+
+[tool.poetry.dependencies]
+python = "^3.8"
+djopenapi = "^0.0.1a1"
+
+[tool.poetry.dev-dependencies]
+coverage = "7.2.2"
+pre-commit = "3.2.0"
+pytest = "7.2.2"


### PR DESCRIPTION
### Summary

This adds a skeleton layout for the `djclient` library which will be the user-facing library/cli that will wrap the `djopenapi` library. This doesn't add any code and we should probably start a design doc for how we should structure this library.

### Test Plan

N/A

- [x] PR has an associated issue: #351 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

When ready for the first release, will run `poetry build` and `poetry publish`.
