### PR TITLE
Fix source node schema inference

### DIFF
--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -494,6 +494,7 @@ def create_source_node(
             data.catalog,
             data.schema_,  # type: ignore
             data.table,
+            catalog.engines[0] if len(catalog.engines) >= 1 else None,
         )
 
     node_revision = NodeRevision(

--- a/dj/service_clients.py
+++ b/dj/service_clients.py
@@ -1,5 +1,5 @@
 """Clients for various configurable services."""
-from typing import List
+from typing import TYPE_CHECKING, List, Optional
 from urllib.parse import urljoin
 from uuid import UUID
 
@@ -11,6 +11,9 @@ from dj.errors import DJQueryServiceClientException
 from dj.models.column import Column
 from dj.models.query import QueryCreate, QueryWithResults
 from dj.sql.parsing.types import ColumnType
+
+if TYPE_CHECKING:
+    from dj.models.engine import Engine
 
 
 class RequestsSessionWithEndpoint(requests.Session):
@@ -73,12 +76,19 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         catalog: str,
         schema: str,
         table: str,
+        engine: Optional["Engine"] = None,
     ) -> List[Column]:
         """
         Retrieves columns for a table.
         """
         response = self.requests_session.get(
             f"/table/{catalog}.{schema}.{table}/columns/",
+            params={
+                "engine": engine.name,
+                "engine_version": engine.version,
+            }
+            if engine
+            else {},
         )
         table_columns = response.json()["columns"]
         return [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ Fixtures for testing.
 
 import re
 from http.client import HTTPException
-from typing import Collection, Iterator, List
+from typing import Collection, Iterator, List, Optional
 
 import pytest
 from cachelib.simple import SimpleCache
@@ -17,7 +17,7 @@ from sqlmodel.pool import StaticPool
 
 from dj.api.main import app
 from dj.config import Settings
-from dj.models import Column
+from dj.models import Column, Engine
 from dj.models.query import QueryCreate
 from dj.service_clients import QueryServiceClient
 from dj.utils import get_query_service_client, get_session, get_settings
@@ -75,6 +75,7 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         catalog: str,
         schema: str,
         table: str,
+        engine: Optional[Engine] = None,  # pylint: disable=unused-argument
     ) -> List[Column]:
         return COLUMN_MAPPINGS[f"{catalog}.{schema}.{table}"]
 

--- a/tests/service_clients_test.py
+++ b/tests/service_clients_test.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 from requests import Request
 
 from dj.errors import DJQueryServiceClientException
+from dj.models import Engine
 from dj.models.query import QueryCreate
 from dj.service_clients import QueryServiceClient, RequestsSessionWithEndpoint
 
@@ -86,10 +87,23 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         mock_request = mocker.patch("requests.Session.request")
         query_service_client = QueryServiceClient(uri=self.endpoint)
         query_service_client.get_columns_for_table("hive", "test", "pies")
-
         mock_request.assert_called_with(
             "GET",
             "http://queryservice:8001/table/hive.test.pies/columns/",
+            params={},
+            allow_redirects=True,
+        )
+
+        query_service_client.get_columns_for_table(
+            "hive",
+            "test",
+            "pies",
+            engine=Engine(name="spark", version="2.4.4"),
+        )
+        mock_request.assert_called_with(
+            "GET",
+            "http://queryservice:8001/table/hive.test.pies/columns/",
+            params={"engine": "spark", "engine_version": "2.4.4"},
             allow_redirects=True,
         )
 


### PR DESCRIPTION
### Summary

Upon source node creation, we infer the schema of the node based on the table schema, but this breaks with the new Spark-backed DJQS, as it doesn't specify which engine to use. This change passes in the right engine.

A similar change is also needed in DJRS. Companion to https://github.com/DataJunction/djqs/pull/13 

### Test Plan

Ran it end-to-end. We can actually modify the DJ Roads notebook to not include the column schemas upon source node creation, but I've left that in there for reference purposes. 

- [X] PR has an associated issue: #
- [X] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
