### PR TITLE
Return column names and types with TranslatedSQL

### DIFF
--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -13,7 +13,7 @@ from dj.api.helpers import get_node_by_name, get_query
 from dj.errors import DJException
 from dj.models.metric import TranslatedSQL
 from dj.models.node import AvailabilityState, AvailabilityStateBase, NodeType
-from dj.models.query import QueryCreate, QueryWithResults
+from dj.models.query import ColumnMetadata, QueryCreate, QueryWithResults
 from dj.service_clients import QueryServiceClient
 from dj.utils import get_query_service_client, get_session
 
@@ -109,7 +109,14 @@ def data_for_node(
         dimensions=dimensions,
         filters=filters,
     )
-    query = TranslatedSQL(sql=str(query_ast))
+    columns = [
+        ColumnMetadata(name=col.alias_or_name.name, type=str(col.type))  # type: ignore
+        for col in query_ast.select.projection
+    ]
+    query = TranslatedSQL(
+        sql=str(query_ast),
+        columns=columns,
+    )
 
     available_engines = node.current.catalog.engines
     query_create = QueryCreate(

--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -10,6 +10,7 @@ from sqlmodel import Session
 
 from dj.api.helpers import get_query
 from dj.models.metric import TranslatedSQL
+from dj.models.query import ColumnMetadata
 from dj.utils import get_session
 
 _logger = logging.getLogger(__name__)
@@ -33,6 +34,11 @@ def get_sql_for_node(
         dimensions=dimensions,
         filters=filters,
     )
+    columns = [
+        ColumnMetadata(name=col.alias_or_name.name, type=str(col.type))  # type: ignore
+        for col in query_ast.select.projection
+    ]
     return TranslatedSQL(
         sql=str(query_ast),
+        columns=columns,
     )

--- a/dj/models/metric.py
+++ b/dj/models/metric.py
@@ -1,11 +1,12 @@
 """
 Models for metrics.
 """
-from typing import List
+from typing import List, Optional
 
 from sqlmodel import SQLModel
 
 from dj.models.node import Node
+from dj.models.query import ColumnMetadata
 from dj.sql.dag import get_dimensions
 from dj.typing import UTCDatetime
 
@@ -47,5 +48,7 @@ class TranslatedSQL(SQLModel):
     """
     Class for SQL generated from a given metric.
     """
-
+    # TODO once type-inference is added to /query/ endpoint
+    # columns attribute can be required
     sql: str
+    columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover

--- a/dj/models/metric.py
+++ b/dj/models/metric.py
@@ -48,7 +48,8 @@ class TranslatedSQL(SQLModel):
     """
     Class for SQL generated from a given metric.
     """
-    # TODO once type-inference is added to /query/ endpoint
+
+    # TODO: once type-inference is added to /query/ endpoint  # pylint: disable=fixme
     # columns attribute can be required
     sql: str
     columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -45,6 +45,7 @@ def test_sql(
     response = client.get("/sql/a-metric/")
     assert response.json() == {
         "sql": "SELECT  COUNT(*) col0 \n FROM rev.my_table AS my_table\n",
+        "columns": [{"name": "col0", "type": "long"}],
     }
 
 


### PR DESCRIPTION
### Summary

This updates the endpoints that return generated SQL to include the column names and types.

### Test Plan

`make check` & `make test`

- [x] PR has an associated issue: #428 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A