### PR TITLE
Add CORS support and include dimensions attribute on columns

### DIFF
--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -11,6 +11,7 @@ import logging
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
+from starlette.middleware.cors import CORSMiddleware
 
 from dj import __version__
 from dj.api import (
@@ -49,6 +50,14 @@ app = FastAPI(
     },
     dependencies=[Depends(default_attribute_types)],
 )
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(catalogs.router)
 app.include_router(engines.router)
 app.include_router(metrics.router)

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -52,7 +52,7 @@ app = FastAPI(
 )
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=settings.cors_origin_whitelist,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/dj/config.py
+++ b/dj/config.py
@@ -4,7 +4,7 @@ Configuration for the metric repository.
 import urllib.parse
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 from cachelib.base import BaseCache
 from cachelib.file import FileSystemCache
@@ -23,6 +23,9 @@ class Settings(
     name: str = "DJ server"
     description: str = "A DataJunction metrics layer"
     url: str = "http://localhost:8000/"
+
+    # A list of hostnames that are allowed to make cross-site HTTP requests
+    cors_origin_whitelist: List[str] = ["http://localhost:3000"]
 
     # SQLAlchemy URI for the metadata database.
     index: str = "sqlite:///dj.db?check_same_thread=False"

--- a/dj/config.py
+++ b/dj/config.py
@@ -4,7 +4,7 @@ Configuration for the metric repository.
 import urllib.parse
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, List
+from typing import List, Optional
 
 from cachelib.base import BaseCache
 from cachelib.file import FileSystemCache

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -620,6 +620,13 @@ class AttributeOutput(BaseSQLModel):
     attribute_type: AttributeTypeName
 
 
+class NodeNameOutput(SQLModel):
+    """
+    Node name only
+    """
+    name: str
+
+
 class ColumnOutput(SQLModel):
     """
     A simplified column schema, without ID or dimensions.
@@ -628,6 +635,7 @@ class ColumnOutput(SQLModel):
     name: str
     type: ColumnType
     attributes: List[AttributeOutput]
+    dimension: Optional[NodeNameOutput]
 
     class Config:  # pylint: disable=too-few-public-methods
         """
@@ -688,6 +696,7 @@ class NodeRevisionOutput(SQLModel):
     columns: List[ColumnOutput]
     updated_at: UTCDatetime
     materialization_configs: List[MaterializationConfigOutput]
+    parents: List[NodeNameOutput]
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         allow_population_by_field_name = True

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -624,6 +624,7 @@ class NodeNameOutput(SQLModel):
     """
     Node name only
     """
+
     name: str
 
 

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -99,6 +99,7 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
             "name": "answer",
             "type": "int",
             "attributes": [],
+            "dimension": None,
         },
     ]
 
@@ -109,6 +110,7 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
             "name": "_col0",
             "type": "int",
             "attributes": [],
+            "dimension": None,
         },
     ]
 
@@ -281,10 +283,10 @@ class TestCreateOrUpdateNodes:
         assert data["schema_"] == "basic"
         assert data["table"] == "comments"
         assert data["columns"] == [
-            {"name": "id", "type": "int", "attributes": []},
-            {"name": "user_id", "type": "int", "attributes": []},
-            {"name": "timestamp", "type": "timestamp", "attributes": []},
-            {"name": "text", "type": "string", "attributes": []},
+            {"name": "id", "type": "int", "attributes": [], "dimension": None},
+            {"name": "user_id", "type": "int", "attributes": [], "dimension": None},
+            {"name": "timestamp", "type": "timestamp", "attributes": [], "dimension": None},
+            {"name": "text", "type": "string", "attributes": [], "dimension": None},
         ]
         assert response.status_code == 201
 
@@ -361,10 +363,10 @@ class TestCreateOrUpdateNodes:
         data = response.json()
         assert data["version"] == "v2.0"
         assert data["columns"] == [
-            {"name": "id", "type": "int", "attributes": []},
-            {"name": "user_id", "type": "int", "attributes": []},
-            {"name": "timestamp", "type": "timestamp", "attributes": []},
-            {"name": "text_v2", "type": "string", "attributes": []},
+            {"name": "id", "type": "int", "attributes": [], "dimension": None},
+            {"name": "user_id", "type": "int", "attributes": [], "dimension": None},
+            {"name": "timestamp", "type": "timestamp", "attributes": [], "dimension": None},
+            {"name": "text_v2", "type": "string", "attributes": [], "dimension": None},
         ]
 
     def test_update_nonexistent_node(
@@ -473,8 +475,8 @@ class TestCreateOrUpdateNodes:
             == "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users"
         )
         assert data["columns"] == [
-            {"name": "country", "type": "string", "attributes": []},
-            {"name": "num_users", "type": "long", "attributes": []},
+            {"name": "country", "type": "string", "attributes": [], "dimension": None},
+            {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
         ]
 
         # Update the transform node with two minor changes
@@ -524,9 +526,9 @@ class TestCreateOrUpdateNodes:
             "COUNT(*) AS num_entries FROM basic.source.users"
         )
         assert data["columns"] == [
-            {"name": "country", "type": "string", "attributes": []},
-            {"name": "num_users", "type": "long", "attributes": []},
-            {"name": "num_entries", "type": "long", "attributes": []},
+            {"name": "country", "type": "string", "attributes": [], "dimension": None},
+            {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
+            {"name": "num_entries", "type": "long", "attributes": [], "dimension": None},
         ]
 
         # Verify that asking for revisions for a non-existent transform fails
@@ -545,17 +547,17 @@ class TestCreateOrUpdateNodes:
         }
         assert {rev["version"]: rev["columns"] for rev in data} == {
             "v1.0": [
-                {"name": "country", "type": "string", "attributes": []},
-                {"name": "num_users", "type": "long", "attributes": []},
+                {"name": "country", "type": "string", "attributes": [], "dimension": None},
+                {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
             ],
             "v1.1": [
-                {"name": "country", "type": "string", "attributes": []},
-                {"name": "num_users", "type": "long", "attributes": []},
+                {"name": "country", "type": "string", "attributes": [], "dimension": None},
+                {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
             ],
             "v2.0": [
-                {"name": "country", "type": "string", "attributes": []},
-                {"name": "num_users", "type": "long", "attributes": []},
-                {"name": "num_entries", "type": "long", "attributes": []},
+                {"name": "country", "type": "string", "attributes": [], "dimension": None},
+                {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
+                {"name": "num_entries", "type": "long", "attributes": [], "dimension": None},
             ],
         }
 
@@ -587,8 +589,8 @@ class TestCreateOrUpdateNodes:
             "FROM basic.source.users GROUP BY country"
         )
         assert data["columns"] == [
-            {"name": "country", "type": "string", "attributes": []},
-            {"name": "user_cnt", "type": "long", "attributes": []},
+            {"name": "country", "type": "string", "attributes": [], "dimension": None},
+            {"name": "user_cnt", "type": "long", "attributes": [], "dimension": None},
         ]
 
         # Test updating the dimension node with a new query
@@ -602,7 +604,7 @@ class TestCreateOrUpdateNodes:
 
         # The columns should have been updated
         assert data["columns"] == [
-            {"name": "country", "type": "string", "attributes": []},
+            {"name": "country", "type": "string", "attributes": [], "dimension": None},
         ]
 
     def test_raise_on_multi_catalog_node(self, client_with_examples: TestClient):
@@ -654,8 +656,8 @@ class TestCreateOrUpdateNodes:
             "FROM basic.source.users GROUP BY country"
         )
         assert data["columns"] == [
-            {"name": "country", "type": "string", "attributes": []},
-            {"name": "user_cnt", "type": "long", "attributes": []},
+            {"name": "country", "type": "string", "attributes": [], "dimension": None},
+            {"name": "user_cnt", "type": "long", "attributes": [], "dimension": None},
         ]
 
         response = client.patch(
@@ -863,6 +865,7 @@ class TestNodeColumnsAttributes:
                 "attributes": [
                     {"attribute_type": {"name": "primary_key", "namespace": "system"}},
                 ],
+
             },
         ]
 
@@ -1016,14 +1019,15 @@ class TestNodeColumnsAttributes:
                     {"attribute_type": {"namespace": "system", "name": "primary_key"}},
                 ],
             },
-            {"name": "timestamp", "type": "timestamp", "attributes": []},
-            {"name": "text", "type": "string", "attributes": []},
-            {"name": "event_timestamp", "type": "timestamp", "attributes": []},
-            {"name": "created_at", "type": "timestamp", "attributes": []},
+            {"name": "timestamp", "type": "timestamp", "attributes": [], "dimension": None},
+            {"name": "text", "type": "string", "attributes": [], "dimension": None},
+            {"name": "event_timestamp", "type": "timestamp", "attributes": [], "dimension": None},
+            {"name": "created_at", "type": "timestamp", "attributes": [], "dimension": None},
             {
                 "name": "post_processing_timestamp",
                 "type": "timestamp",
                 "attributes": [],
+                "dimension": None,
             },
         ]
 

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -285,7 +285,12 @@ class TestCreateOrUpdateNodes:
         assert data["columns"] == [
             {"name": "id", "type": "int", "attributes": [], "dimension": None},
             {"name": "user_id", "type": "int", "attributes": [], "dimension": None},
-            {"name": "timestamp", "type": "timestamp", "attributes": [], "dimension": None},
+            {
+                "name": "timestamp",
+                "type": "timestamp",
+                "attributes": [],
+                "dimension": None,
+            },
             {"name": "text", "type": "string", "attributes": [], "dimension": None},
         ]
         assert response.status_code == 201
@@ -365,7 +370,12 @@ class TestCreateOrUpdateNodes:
         assert data["columns"] == [
             {"name": "id", "type": "int", "attributes": [], "dimension": None},
             {"name": "user_id", "type": "int", "attributes": [], "dimension": None},
-            {"name": "timestamp", "type": "timestamp", "attributes": [], "dimension": None},
+            {
+                "name": "timestamp",
+                "type": "timestamp",
+                "attributes": [],
+                "dimension": None,
+            },
             {"name": "text_v2", "type": "string", "attributes": [], "dimension": None},
         ]
 
@@ -528,7 +538,12 @@ class TestCreateOrUpdateNodes:
         assert data["columns"] == [
             {"name": "country", "type": "string", "attributes": [], "dimension": None},
             {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
-            {"name": "num_entries", "type": "long", "attributes": [], "dimension": None},
+            {
+                "name": "num_entries",
+                "type": "long",
+                "attributes": [],
+                "dimension": None,
+            },
         ]
 
         # Verify that asking for revisions for a non-existent transform fails
@@ -547,17 +562,52 @@ class TestCreateOrUpdateNodes:
         }
         assert {rev["version"]: rev["columns"] for rev in data} == {
             "v1.0": [
-                {"name": "country", "type": "string", "attributes": [], "dimension": None},
-                {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
+                {
+                    "name": "country",
+                    "type": "string",
+                    "attributes": [],
+                    "dimension": None,
+                },
+                {
+                    "name": "num_users",
+                    "type": "long",
+                    "attributes": [],
+                    "dimension": None,
+                },
             ],
             "v1.1": [
-                {"name": "country", "type": "string", "attributes": [], "dimension": None},
-                {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
+                {
+                    "name": "country",
+                    "type": "string",
+                    "attributes": [],
+                    "dimension": None,
+                },
+                {
+                    "name": "num_users",
+                    "type": "long",
+                    "attributes": [],
+                    "dimension": None,
+                },
             ],
             "v2.0": [
-                {"name": "country", "type": "string", "attributes": [], "dimension": None},
-                {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
-                {"name": "num_entries", "type": "long", "attributes": [], "dimension": None},
+                {
+                    "name": "country",
+                    "type": "string",
+                    "attributes": [],
+                    "dimension": None,
+                },
+                {
+                    "name": "num_users",
+                    "type": "long",
+                    "attributes": [],
+                    "dimension": None,
+                },
+                {
+                    "name": "num_entries",
+                    "type": "long",
+                    "attributes": [],
+                    "dimension": None,
+                },
             ],
         }
 
@@ -865,7 +915,7 @@ class TestNodeColumnsAttributes:
                 "attributes": [
                     {"attribute_type": {"name": "primary_key", "namespace": "system"}},
                 ],
-
+                "dimension": None,
             },
         ]
 
@@ -892,6 +942,7 @@ class TestNodeColumnsAttributes:
                 "attributes": [
                     {"attribute_type": {"name": "primary_key", "namespace": "system"}},
                 ],
+                "dimension": None,
             },
             {
                 "name": "created_at",
@@ -904,6 +955,7 @@ class TestNodeColumnsAttributes:
                         },
                     },
                 ],
+                "dimension": None,
             },
         ]
 
@@ -983,6 +1035,7 @@ class TestNodeColumnsAttributes:
                 "attributes": [
                     {"attribute_type": {"name": "primary_key", "namespace": "system"}},
                 ],
+                "dimension": {"name": "basic.dimension.users"},
             },
         ]
 
@@ -1011,18 +1064,39 @@ class TestNodeColumnsAttributes:
         response = client_with_examples.get("/nodes/basic.source.comments/")
         data = response.json()
         assert data["columns"] == [
-            {"name": "id", "type": "int", "attributes": []},
+            {
+                "name": "id",
+                "type": "int",
+                "attributes": [],
+                "dimension": None,
+            },
             {
                 "name": "user_id",
                 "type": "int",
                 "attributes": [
                     {"attribute_type": {"namespace": "system", "name": "primary_key"}},
                 ],
+                "dimension": {"name": "basic.dimension.users"},
             },
-            {"name": "timestamp", "type": "timestamp", "attributes": [], "dimension": None},
+            {
+                "name": "timestamp",
+                "type": "timestamp",
+                "attributes": [],
+                "dimension": None,
+            },
             {"name": "text", "type": "string", "attributes": [], "dimension": None},
-            {"name": "event_timestamp", "type": "timestamp", "attributes": [], "dimension": None},
-            {"name": "created_at", "type": "timestamp", "attributes": [], "dimension": None},
+            {
+                "name": "event_timestamp",
+                "type": "timestamp",
+                "attributes": [],
+                "dimension": None,
+            },
+            {
+                "name": "created_at",
+                "type": "timestamp",
+                "attributes": [],
+                "dimension": None,
+            },
             {
                 "name": "post_processing_timestamp",
                 "type": "timestamp",

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -117,7 +117,6 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     assert nodes["a-metric"]["parents"] == []
 
 
-
 class TestCreateOrUpdateNodes:
     """
     Test ``POST /nodes/`` and ``PUT /nodes/{name}``.

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -91,6 +91,7 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     assert nodes["not-a-metric"]["version"] == "1"
     assert nodes["not-a-metric"]["display_name"] == "Not-A-Metric"
     assert not nodes["not-a-metric"]["columns"]
+    assert nodes["not-a-metric"]["parents"] == []
 
     assert nodes["also-not-a-metric"]["query"] == "SELECT 42 AS answer"
     assert nodes["also-not-a-metric"]["display_name"] == "Also-Not-A-Metric"
@@ -113,6 +114,8 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
             "dimension": None,
         },
     ]
+    assert nodes["a-metric"]["parents"] == []
+
 
 
 class TestCreateOrUpdateNodes:
@@ -488,6 +491,7 @@ class TestCreateOrUpdateNodes:
             {"name": "country", "type": "string", "attributes": [], "dimension": None},
             {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
         ]
+        assert data["parents"] == [{"name": "basic.source.users"}]
 
         # Update the transform node with two minor changes
         response = client.patch(


### PR DESCRIPTION
### Summary

* Add CORS support with a configurable `CORS_ORIGIN_WHITELIST` setting that can be modified in the env file
* Include the dimension node name linked in columns when outputting column metadata
* Include a list of parent node names when outputting node data

### Test Plan

Created a React Flow app that sources from this setup and verified that everything works end-to-end.

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
