### PR TITLE
`boolean` is a valid type and `MAX` should take strings

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1,5 +1,5 @@
-# mypy: ignore-errors
 # pylint: disable=too-many-lines
+# mypy: ignore-errors
 
 """
 SQL functions for type inference.
@@ -234,6 +234,13 @@ class Max(Function):  # pylint: disable=abstract-method
 def infer_type(  # noqa: F811  # pylint: disable=function-redefined
     arg: ct.NumberType,
 ) -> ct.NumberType:
+    return arg.type
+
+
+@Max.register  # type: ignore
+def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+    arg: ct.StringType,
+) -> ct.StringType:
     return arg.type
 
 

--- a/dj/sql/parsing/types.py
+++ b/dj/sql/parsing/types.py
@@ -770,6 +770,7 @@ class WildcardType(PrimitiveType, Singleton):
 # Define the primitive data types and their corresponding Python classes
 PRIMITIVE_TYPES: Dict[str, PrimitiveType] = {
     "bool": BooleanType(),
+    "boolean": BooleanType(),
     "int": IntegerType(),
     "long": LongType(),
     "float": FloatType(),

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -61,10 +61,12 @@ def test_max() -> None:
     assert Max.infer_type(
         ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
     ) == DecimalType(8, 6)
-    with pytest.raises(Exception):
-        Max.infer_type(  # pylint: disable=expression-not-assigned
+    assert (
+        Max.infer_type(
             ast.Column(ast.Name("x"), _type=StringType()),
-        ) == StringType()
+        )
+        == StringType()
+    )
 
 
 def test_now() -> None:


### PR DESCRIPTION
### Summary

* Support `boolean` in addition to `bool` (Arguably we can remove the latter, since the actual valid Spark type expected by the parser is `boolean`)
* `MAX` should work on `string` too

### Test Plan

Running things end-to-end and I discovered these two bugs.

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
