### PR TITLE
Fixing invalid query building on dimensions with aliased join keys

### DIFF
--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -160,15 +160,11 @@ def _build_joins_for_dimension(
                 left_table.add_ref_column(
                     cast(ast.Column, join_left_columns[join_col.name]),
                 )
-                join_right_col = join_right_columns[
-                    join_col.dimension_column or "id"
-                ].copy()
-                join_right_col.name = join_right_col.alias_or_name
-                join_right_col.alias = None
                 join_on.append(
                     ast.BinaryOp.Eq(
                         join_left_columns[join_col.name],
-                        join_right_col,
+                        join_right_columns[join_col.dimension_column or "id"],
+                        use_alias_as_name=True,
                     ),
                 )
             else:

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -160,10 +160,15 @@ def _build_joins_for_dimension(
                 left_table.add_ref_column(
                     cast(ast.Column, join_left_columns[join_col.name]),
                 )
+                join_right_col = join_right_columns[
+                    join_col.dimension_column or "id"
+                ].copy()
+                join_right_col.name = join_right_col.alias_or_name
+                join_right_col.alias = None
                 join_on.append(
                     ast.BinaryOp.Eq(
                         join_left_columns[join_col.name],
-                        join_right_columns[join_col.dimension_column or "id"],
+                        join_right_col,
                     ),
                 )
             else:

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -168,6 +168,11 @@ def test_common_dimensions(
             "repair_order.order_date",
             "repair_order.repair_order_id",
             "repair_order.required_date",
+            "us_state.state_id",
+            "us_state.state_name",
+            "us_state.state_region",
+            "us_state.state_region_description",
+            "us_state.state_short",
         ],
     )
 
@@ -253,4 +258,9 @@ def test_get_dimensions(client_with_examples: TestClient):
         "repair_order.order_date",
         "repair_order.repair_order_id",
         "repair_order.required_date",
+        "us_state.state_id",
+        "us_state.state_name",
+        "us_state.state_region",
+        "us_state.state_region_description",
+        "us_state.state_short",
     ]

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -440,6 +440,7 @@ def test_sql_with_filters(
         params={"dimensions": dimensions, "filters": filters},
     )
     data = response.json()
+    print("DATA", data["sql"])
     assert compare_query_strings(data["sql"], sql)
 
 

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -379,6 +379,50 @@ def test_sql(
               dispatcher.company_name
             """,
         ),
+        # dimension with aliased join key should just use the alias directly
+        (
+            "num_repair_orders",
+            ["us_state.state_region_description"],
+            [],
+            """
+            SELECT
+              count(repair_orders.repair_order_id) AS num_repair_orders,
+              us_state.state_region_description
+            FROM roads.repair_orders AS repair_orders
+            LEFT OUTER JOIN (
+              SELECT
+                hard_hats.address,
+                hard_hats.birth_date,
+                hard_hats.city,
+                hard_hats.contractor_id,
+                hard_hats.country,
+                hard_hats.first_name,
+                hard_hats.hard_hat_id,
+                hard_hats.hire_date,
+                hard_hats.last_name,
+                hard_hats.manager,
+                hard_hats.postal_code,
+                hard_hats.state,
+                hard_hats.title
+              FROM roads.hard_hats AS hard_hats
+            ) AS hard_hat
+            ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
+            LEFT OUTER JOIN (
+              SELECT
+                us_states.state_id,
+                us_states.state_name,
+                us_states.state_region,
+                us_region.us_region_description AS state_region_description,
+                us_states.state_abbr AS state_short
+              FROM roads.us_states AS us_states
+              LEFT JOIN roads.us_region AS us_region
+              ON us_states.state_region = us_region.us_region_id
+            ) AS us_state
+            ON hard_hat.state = us_state.state_short
+            GROUP BY
+              us_state.state_region_description
+            """,
+        ),
     ],
 )
 def test_sql_with_filters(
@@ -396,7 +440,6 @@ def test_sql_with_filters(
         params={"dimensions": dimensions, "filters": filters},
     )
     data = response.json()
-    print("DATA", data["sql"])
     assert compare_query_strings(data["sql"], sql)
 
 

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -355,7 +355,7 @@ EXAMPLES = (  # type: ignore
                         SELECT
                         state_id,
                         state_name,
-                        state_abbr,
+                        state_abbr AS state_short,
                         state_region,
                         r.us_region_description AS state_region_description
                         FROM us_states s
@@ -521,6 +521,13 @@ EXAMPLES = (  # type: ignore
         (
             "/nodes/local_hard_hats/columns/state_id/"
             "?dimension=us_state&dimension_column=state_id"
+        ),
+        {},
+    ),
+    (
+        (
+            "/nodes/hard_hat/columns/state/"
+            "?dimension=us_state&dimension_column=state_short"
         ),
         {},
     ),


### PR DESCRIPTION
### Summary

During query building, joining in dimensions with an aliased join key should use the alias directly, rather than constructing an invalid join `ON` with the `AS` clause. This fix "promotes" the alias name to the actual join column name, which results in a valid query. 

### Test Plan

Wrote unit tests. Also tested on some actual queries running locally and they're generating runnable queries.

- [X] PR has an associated issue: #438 438
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A