### PR TITLE
inject columns into query results before returning

### DIFF
--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -127,4 +127,5 @@ def data_for_node(
         async_=async_,
     )
     result = query_service_client.submit_query(query_create)
+    result["results"]["columns"] = columns
     return result

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -43,24 +43,22 @@ class TestDataForNode:
         )
         data = response.json()
         assert response.status_code == 200
-        assert data == [
-            {
-                "submitted_query": "SELECT  payment_type_table.id,\n\tpayment_type_table."
-                "payment_type_classification,\n\tpayment_type_table."
-                'payment_type_name \n FROM "accounting"."payment_type_table"'
-                " AS payment_type_table",
-                "state": "FINISHED",
-                "results": {
-                    "columns": [
-                        {"name": "id", "type": "int"},
-                        {"name": "payment_type_classification", "type": "string"},
-                        {"name": "payment_type_name", "type": "string"},
-                    ],
-                    "rows": [[1, "CARD", "VISA"], [2, "CARD", "MASTERCARD"]],
-                },
-                "errors": [],
+        assert data == {
+            "submitted_query": "SELECT  payment_type_table.id,\n\tpayment_type_table."
+            "payment_type_classification,\n\tpayment_type_table."
+            'payment_type_name \n FROM "accounting"."payment_type_table"'
+            " AS payment_type_table",
+            "state": "FINISHED",
+            "results": {
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "payment_type_classification", "type": "string"},
+                    {"name": "payment_type_name", "type": "string"},
+                ],
+                "rows": [[1, "CARD", "VISA"], [2, "CARD", "MASTERCARD"]],
             },
-        ]
+            "errors": [],
+        }
 
     def test_get_source_data(
         self,
@@ -76,7 +74,7 @@ class TestDataForNode:
             "submitted_query": 'SELECT  * \n FROM "accounting"."revenue"',
             "state": "FINISHED",
             "results": {
-                "columns": [{"name": "profit", "type": "float"}],
+                "columns": [{"name": "*", "type": "wildcard"}],
                 "rows": [[129.19]],
             },
             "errors": [],
@@ -102,7 +100,7 @@ class TestDataForNode:
                 "columns": [
                     {"name": "account_type", "type": "string"},
                     {"name": "customer_id", "type": "int"},
-                    {"name": "payment_amount", "type": "string"},
+                    {"name": "payment_amount", "type": "float"},
                     {"name": "payment_id", "type": "int"},
                 ],
                 "rows": [
@@ -129,7 +127,7 @@ class TestDataForNode:
             "submitted_query": 'SELECT  COUNT(1) AS cnt \n FROM "basic".'
             '"comments" AS basic_DOT_source_DOT_comments',
             "state": "FINISHED",
-            "results": {"columns": [{"name": "cnt", "type": "int"}], "rows": [[1]]},
+            "results": {"columns": [{"name": "cnt", "type": "long"}], "rows": [[1]]},
             "errors": [],
         }
 

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1090,7 +1090,7 @@ EXAMPLES = (  # type: ignore
             "columns": {
                 "id": {"type": "int"},
                 "payment_type_name": {"type": "string"},
-                "payment_type_classification": {"type": "int"},
+                "payment_type_classification": {"type": "string"},
             },
             "description": "A source table for different types of payments",
             "mode": "published",
@@ -1490,29 +1490,27 @@ QUERY_DATA_MAPPINGS = {
     .strip()
     .replace('"', "")
     .replace("\n", "")
-    .replace(" ", ""): [
-        {
-            "submitted_query": (
-                "SELECT  payment_type_table.id,\n\tpayment_type_table."
-                "payment_type_classification,\n\t"
-                'payment_type_table.payment_type_name \n FROM "accounting"."payment_type_table" '
-                "AS payment_type_table"
-            ),
-            "state": QueryState.FINISHED,
-            "results": {
-                "columns": [
-                    {"name": "id", "type": "int"},
-                    {"name": "payment_type_classification", "type": "string"},
-                    {"name": "payment_type_name", "type": "string"},
-                ],
-                "rows": [
-                    (1, "CARD", "VISA"),
-                    (2, "CARD", "MASTERCARD"),
-                ],
-            },
-            "errors": [],
+    .replace(" ", ""): {
+        "submitted_query": (
+            "SELECT  payment_type_table.id,\n\tpayment_type_table."
+            "payment_type_classification,\n\t"
+            'payment_type_table.payment_type_name \n FROM "accounting"."payment_type_table" '
+            "AS payment_type_table"
+        ),
+        "state": QueryState.FINISHED,
+        "results": {
+            "columns": [
+                {"name": "id", "type": "int"},
+                {"name": "payment_type_classification", "type": "string"},
+                {"name": "payment_type_name", "type": "string"},
+            ],
+            "rows": [
+                (1, "CARD", "VISA"),
+                (2, "CARD", "MASTERCARD"),
+            ],
         },
-    ],
+        "errors": [],
+    },
     'SELECT  COUNT(1) AS cnt \n FROM "basic"."comments" AS basic_DOT_source_DOT_comments'.strip()
     .replace('"', "")
     .replace("\n", "")
@@ -1522,7 +1520,7 @@ QUERY_DATA_MAPPINGS = {
         ),
         "state": QueryState.FINISHED,
         "results": {
-            "columns": [{"name": "cnt", "type": "int"}],
+            "columns": [{"name": "cnt", "type": "long"}],
             "rows": [
                 (1,),
             ],


### PR DESCRIPTION
### Summary

Since DJ already knows the schema from the generated query AST and its type inference, this injects the column names and types into the query results before returning it in the response to `/data/...` requests.

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
