### PR TITLE
fix column injection bug

### DIFF
--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -127,5 +127,7 @@ def data_for_node(
         async_=async_,
     )
     result = query_service_client.submit_query(query_create)
-    result["results"]["columns"] = columns
+    # Inject column info if there are results
+    if result.results.__root__:  # pragma: no cover
+        result.results.__root__[0].columns = columns
     return result

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -44,19 +44,37 @@ class TestDataForNode:
         data = response.json()
         assert response.status_code == 200
         assert data == {
-            "submitted_query": "SELECT  payment_type_table.id,\n\tpayment_type_table."
-            "payment_type_classification,\n\tpayment_type_table."
-            'payment_type_name \n FROM "accounting"."payment_type_table"'
-            " AS payment_type_table",
+            "id": "0cb5478c-fd7d-4159-a414-68c50f4b9914",
+            "engine_name": None,
+            "engine_version": None,
+            "submitted_query": (
+                "SELECT  payment_type_table.id,\n\t"
+                "payment_type_table.payment_type_classification,"
+                "\n\tpayment_type_table.payment_type_name \n FROM "
+                '"accounting"."payment_type_table" '
+                "AS payment_type_table"
+            ),
+            "executed_query": None,
+            "scheduled": None,
+            "started": None,
+            "finished": None,
             "state": "FINISHED",
-            "results": {
-                "columns": [
-                    {"name": "id", "type": "int"},
-                    {"name": "payment_type_classification", "type": "string"},
-                    {"name": "payment_type_name", "type": "string"},
-                ],
-                "rows": [[1, "CARD", "VISA"], [2, "CARD", "MASTERCARD"]],
-            },
+            "progress": 0.0,
+            "output_table": None,
+            "results": [
+                {
+                    "sql": "",
+                    "columns": [
+                        {"name": "id", "type": "int"},
+                        {"name": "payment_type_classification", "type": "string"},
+                        {"name": "payment_type_name", "type": "string"},
+                    ],
+                    "rows": [[1, "CARD", "VISA"], [2, "CARD", "MASTERCARD"]],
+                    "row_count": 0,
+                },
+            ],
+            "next": None,
+            "previous": None,
             "errors": [],
         }
 
@@ -71,12 +89,27 @@ class TestDataForNode:
         data = response.json()
         assert response.status_code == 200
         assert data == {
+            "id": "8a8bb03a-74c8-448a-8630-e9439bd5a01b",
+            "engine_name": None,
+            "engine_version": None,
             "submitted_query": 'SELECT  * \n FROM "accounting"."revenue"',
+            "executed_query": None,
+            "scheduled": None,
+            "started": None,
+            "finished": None,
             "state": "FINISHED",
-            "results": {
-                "columns": [{"name": "*", "type": "wildcard"}],
-                "rows": [[129.19]],
-            },
+            "progress": 0.0,
+            "output_table": None,
+            "results": [
+                {
+                    "sql": "",
+                    "columns": [{"name": "*", "type": "wildcard"}],
+                    "rows": [[129.19]],
+                    "row_count": 0,
+                },
+            ],
+            "next": None,
+            "previous": None,
             "errors": [],
         }
 
@@ -91,25 +124,41 @@ class TestDataForNode:
         data = response.json()
         assert response.status_code == 200
         assert data == {
-            "submitted_query": "SELECT  revenue.account_type,\n\trevenue.customer_id,"
-            "\n\trevenue.payment_amount,\n\trevenue.payment_id \n "
-            'FROM "accounting"."revenue" AS revenue\n \n WHERE  '
-            "revenue.payment_amount > 1000000",
+            "id": "1b049fb1-652e-458a-ba9d-3669412b34bd",
+            "engine_name": None,
+            "engine_version": None,
+            "submitted_query": (
+                "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
+                '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n WHERE  '
+                "revenue.payment_amount > 1000000"
+            ),
+            "executed_query": None,
+            "scheduled": None,
+            "started": None,
+            "finished": None,
             "state": "FINISHED",
-            "results": {
-                "columns": [
-                    {"name": "account_type", "type": "string"},
-                    {"name": "customer_id", "type": "int"},
-                    {"name": "payment_amount", "type": "float"},
-                    {"name": "payment_id", "type": "int"},
-                ],
-                "rows": [
-                    ["CHECKING", 2, "22.50", 1],
-                    ["SAVINGS", 2, "100.50", 1],
-                    ["CREDIT", 1, "11.50", 1],
-                    ["CHECKING", 2, "2.50", 1],
-                ],
-            },
+            "progress": 0.0,
+            "output_table": None,
+            "results": [
+                {
+                    "sql": "",
+                    "columns": [
+                        {"name": "account_type", "type": "string"},
+                        {"name": "customer_id", "type": "int"},
+                        {"name": "payment_amount", "type": "float"},
+                        {"name": "payment_id", "type": "int"},
+                    ],
+                    "rows": [
+                        ["CHECKING", 2, "22.50", 1],
+                        ["SAVINGS", 2, "100.50", 1],
+                        ["CREDIT", 1, "11.50", 1],
+                        ["CHECKING", 2, "2.50", 1],
+                    ],
+                    "row_count": 0,
+                },
+            ],
+            "next": None,
+            "previous": None,
             "errors": [],
         }
 
@@ -124,10 +173,30 @@ class TestDataForNode:
         data = response.json()
         assert response.status_code == 200
         assert data == {
-            "submitted_query": 'SELECT  COUNT(1) AS cnt \n FROM "basic".'
-            '"comments" AS basic_DOT_source_DOT_comments',
+            "id": "ee41ea6c-2303-4fe1-8bf0-f0ce3d6a35ca",
+            "engine_name": None,
+            "engine_version": None,
+            "submitted_query": (
+                'SELECT  COUNT(1) AS cnt \n FROM "basic"."comments" '
+                "AS basic_DOT_source_DOT_comments"
+            ),
+            "executed_query": None,
+            "scheduled": None,
+            "started": None,
+            "finished": None,
             "state": "FINISHED",
-            "results": {"columns": [{"name": "cnt", "type": "long"}], "rows": [[1]]},
+            "progress": 0.0,
+            "output_table": None,
+            "results": [
+                {
+                    "sql": "",
+                    "columns": [{"name": "cnt", "type": "long"}],
+                    "rows": [[1]],
+                    "row_count": 0,
+                },
+            ],
+            "next": None,
+            "previous": None,
             "errors": [],
         }
 

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -3,8 +3,10 @@
 """
 Post requests for all example entities
 """
+import uuid
 
 from dj.models import Column
+from dj.models.query import QueryWithResults
 from dj.sql.parsing.types import IntegerType, StringType, TimestampType
 from dj.typing import QueryState
 
@@ -1497,57 +1499,76 @@ QUERY_DATA_MAPPINGS = {
     .strip()
     .replace('"', "")
     .replace("\n", "")
-    .replace(" ", ""): {
-        "submitted_query": (
-            "SELECT  payment_type_table.id,\n\tpayment_type_table."
-            "payment_type_classification,\n\t"
-            'payment_type_table.payment_type_name \n FROM "accounting"."payment_type_table" '
-            "AS payment_type_table"
-        ),
-        "state": QueryState.FINISHED,
-        "results": {
-            "columns": [
-                {"name": "id", "type": "int"},
-                {"name": "payment_type_classification", "type": "string"},
-                {"name": "payment_type_name", "type": "string"},
+    .replace(" ", ""): QueryWithResults(
+        **{
+            "id": uuid.UUID("0cb5478c-fd7d-4159-a414-68c50f4b9914"),
+            "submitted_query": (
+                "SELECT  payment_type_table.id,\n\tpayment_type_table."
+                "payment_type_classification,\n\t"
+                'payment_type_table.payment_type_name \n FROM "accounting"."payment_type_table" '
+                "AS payment_type_table"
+            ),
+            "state": QueryState.FINISHED,
+            "results": [
+                {
+                    "columns": [
+                        {"name": "id", "type": "int"},
+                        {"name": "payment_type_classification", "type": "string"},
+                        {"name": "payment_type_name", "type": "string"},
+                    ],
+                    "rows": [
+                        (1, "CARD", "VISA"),
+                        (2, "CARD", "MASTERCARD"),
+                    ],
+                    "sql": "",
+                },
             ],
-            "rows": [
-                (1, "CARD", "VISA"),
-                (2, "CARD", "MASTERCARD"),
-            ],
-        },
-        "errors": [],
-    },
+            "errors": [],
+        }
+    ),
     'SELECT  COUNT(1) AS cnt \n FROM "basic"."comments" AS basic_DOT_source_DOT_comments'.strip()
     .replace('"', "")
     .replace("\n", "")
-    .replace(" ", ""): {
-        "submitted_query": (
-            'SELECT  COUNT(1) AS cnt \n FROM "basic"."comments" AS basic_DOT_source_DOT_comments'
-        ),
-        "state": QueryState.FINISHED,
-        "results": {
-            "columns": [{"name": "cnt", "type": "long"}],
-            "rows": [
-                (1,),
+    .replace(" ", ""): QueryWithResults(
+        **{
+            "id": uuid.UUID("ee41ea6c-2303-4fe1-8bf0-f0ce3d6a35ca"),
+            "submitted_query": (
+                'SELECT  COUNT(1) AS cnt \n FROM "basic"."comments" '
+                "AS basic_DOT_source_DOT_comments"
+            ),
+            "state": QueryState.FINISHED,
+            "results": [
+                {
+                    "columns": [{"name": "cnt", "type": "long"}],
+                    "rows": [
+                        (1,),
+                    ],
+                    "sql": "",
+                },
             ],
-        },
-        "errors": [],
-    },
+            "errors": [],
+        }
+    ),
     'SELECT  * \n FROM "accounting"."revenue"'.strip()
     .replace('"', "")
     .replace("\n", "")
-    .replace(" ", ""): {
-        "submitted_query": ('SELECT  * \n FROM "accounting"."revenue"'),
-        "state": QueryState.FINISHED,
-        "results": {
-            "columns": [{"name": "profit", "type": "float"}],
-            "rows": [
-                (129.19,),
+    .replace(" ", ""): QueryWithResults(
+        **{
+            "id": uuid.UUID("8a8bb03a-74c8-448a-8630-e9439bd5a01b"),
+            "submitted_query": ('SELECT  * \n FROM "accounting"."revenue"'),
+            "state": QueryState.FINISHED,
+            "results": [
+                {
+                    "columns": [{"name": "profit", "type": "float"}],
+                    "rows": [
+                        (129.19,),
+                    ],
+                    "sql": "",
+                },
             ],
-        },
-        "errors": [],
-    },
+            "errors": [],
+        }
+    ),
     (
         "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
         '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n '
@@ -1556,27 +1577,33 @@ QUERY_DATA_MAPPINGS = {
     .strip()
     .replace('"', "")
     .replace("\n", "")
-    .replace(" ", ""): {
-        "submitted_query": (
-            "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
-            '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n '
-            "WHERE  revenue.payment_amount > 1000000"
-        ),
-        "state": QueryState.FINISHED,
-        "results": {
-            "columns": [
-                {"name": "account_type", "type": "string"},
-                {"name": "customer_id", "type": "int"},
-                {"name": "payment_amount", "type": "string"},
-                {"name": "payment_id", "type": "int"},
+    .replace(" ", ""): QueryWithResults(
+        **{
+            "id": uuid.UUID("1b049fb1-652e-458a-ba9d-3669412b34bd"),
+            "submitted_query": (
+                "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
+                '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n '
+                "WHERE  revenue.payment_amount > 1000000"
+            ),
+            "state": QueryState.FINISHED,
+            "results": [
+                {
+                    "columns": [
+                        {"name": "account_type", "type": "string"},
+                        {"name": "customer_id", "type": "int"},
+                        {"name": "payment_amount", "type": "string"},
+                        {"name": "payment_id", "type": "int"},
+                    ],
+                    "rows": [
+                        ("CHECKING", 2, "22.50", 1),
+                        ("SAVINGS", 2, "100.50", 1),
+                        ("CREDIT", 1, "11.50", 1),
+                        ("CHECKING", 2, "2.50", 1),
+                    ],
+                    "sql": "",
+                },
             ],
-            "rows": [
-                ("CHECKING", 2, "22.50", 1),
-                ("SAVINGS", 2, "100.50", 1),
-                ("CREDIT", 1, "11.50", 1),
-                ("CHECKING", 2, "2.50", 1),
-            ],
-        },
-        "errors": [],
-    },
+            "errors": [],
+        }
+    ),
 }


### PR DESCRIPTION
### Summary

I introduced a bug in #440 by developing to the tests instead of developing to an actual deployment. 😄 

The mocked query responses were dictionaries instead of `QueryWithResults` objects. This PR fixes the bug and also updates the mocked query responses to be `QueryWithResults` instances to be more representative.

### Test Plan

`make check`, `make test`, and tested it in dj-demo.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
