### PR TITLE
Additional functionality for DJ Client

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -9,31 +9,107 @@ pip install djclient
 ## Examples
 
 To initialize the client:
-```
-from djclient import DJClient
+```python
+from djclient.dj import DJClient, Source, Dimension, Transform, Metric
 client = DJClient("http://dj-endpoint:8000")
 ```
 
+### Catalogs and Engines
+
 To list available catalogs for the DJ host:
-```
+```python
 client.catalogs()
 ```
 
 To list available engines for the DJ host:
-```
+```python
 client.engines()
 ```
 
-ALl nodes can be found with:
+To create a catalog:
+```python
+catalog = Catalog(
+    name="prod"
+)
+catalog.publish()
 ```
+
+To create an engine:
+```python
+engine = Engine(
+    name="spark",
+    version="3.2.2",
+    uri="..."
+)
+engine.publish()
+```
+
+To attach an engine to a catalog:
+```python
+catalog.add_engine(engine)
+```
+
+### Nodes
+
+All nodes can be found with:
+```python
 client.nodes()
 ```
 
 Specific node types can be retrieved with:
-```
+```python
 client.sources()
 client.dimensions()
 client.metrics()
 client.transforms()
 client.cubes()
+```
+
+To create a source node:
+```python
+repair_orders = Source(
+    name="repair_orders",
+    display_name="Repair Orders",
+    description="Repair orders",
+    catalog="dj",
+    schema_="roads",
+    table="repair_orders",
+)
+repair_orders.publish()
+```
+
+Nodes can also be created as drafts with:
+```python
+repair_orders.draft()
+```
+
+To create a dimension node:
+```python
+repair_order = Dimension(
+    name="repair_order",
+    query="""
+    SELECT
+      repair_order_id,
+      municipality_id,
+      hard_hat_id,
+      dispatcher_id
+    FROM repair_orders
+    """,
+    description="Repair order dimension",
+)
+repair_order.publish()
+```
+
+To create a metric:
+```python
+num_repair_orders = Metric(
+    name="num_repair_orders",
+    query="""
+    SELECT
+      count(repair_order_id) AS num_repair_orders
+    FROM repair_orders
+    """,
+    description="Number of repair orders",
+)
+num_repair_orders.publish()
 ```

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -104,6 +104,25 @@ repair_order = Dimension(
 repair_order.publish()
 ```
 
+To create a transform node:
+```python
+from djclient import Transform
+large_revenue_payments_only = Transform(
+    name="large_revenue_payments_only",
+    query="""
+    SELECT
+      payment_id,
+      payment_amount,
+      customer_id,
+      account_type
+    FROM revenue
+    WHERE payment_amount > 1000000
+    """,
+    description="Only large revenue payments",
+)
+large_revenue_payments_only.publish()
+```
+
 To create a metric:
 ```python
 from djclient import Metric

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -10,24 +10,25 @@ pip install djclient
 
 To initialize the client:
 ```python
-from djclient.dj import DJClient, Source, Dimension, Transform, Metric
-client = DJClient("http://dj-endpoint:8000")
+from djclient import DJClient
+dj = DJClient("http://dj-endpoint:8000")
 ```
 
 ### Catalogs and Engines
 
 To list available catalogs for the DJ host:
 ```python
-client.catalogs()
+dj.catalogs()
 ```
 
 To list available engines for the DJ host:
 ```python
-client.engines()
+dj.engines()
 ```
 
 To create a catalog:
 ```python
+from djclient import Catalog
 catalog = Catalog(
     name="prod"
 )
@@ -36,6 +37,7 @@ catalog.publish()
 
 To create an engine:
 ```python
+from djclient import Engine
 engine = Engine(
     name="spark",
     version="3.2.2",
@@ -53,20 +55,21 @@ catalog.add_engine(engine)
 
 All nodes can be found with:
 ```python
-client.nodes()
+dj.nodes()
 ```
 
 Specific node types can be retrieved with:
 ```python
-client.sources()
-client.dimensions()
-client.metrics()
-client.transforms()
-client.cubes()
+dj.sources()
+dj.dimensions()
+dj.metrics()
+dj.transforms()
+dj.cubes()
 ```
 
 To create a source node:
 ```python
+from djclient import Source
 repair_orders = Source(
     name="repair_orders",
     display_name="Repair Orders",
@@ -85,6 +88,7 @@ repair_orders.draft()
 
 To create a dimension node:
 ```python
+from djclient import Dimension
 repair_order = Dimension(
     name="repair_order",
     query="""
@@ -102,6 +106,7 @@ repair_order.publish()
 
 To create a metric:
 ```python
+from djclient import Metric
 num_repair_orders = Metric(
     name="num_repair_orders",
     query="""

--- a/client/python/djclient/__init__.py
+++ b/client/python/djclient/__init__.py
@@ -3,16 +3,14 @@ A DataJunction client for connecting to a DataJunction server
 """
 __version__ = "0.0.1a1"
 
-from djclient.dj import DJClient, Source, Catalog, Dimension, Transform, Metric, Cube, Node, Engine
+from djclient.dj import Cube, Dimension, DJClient, Metric, Node, Source, Transform
 
 __all__ = [
     "DJClient",
     "Source",
-    "Catalog",
     "Dimension",
     "Transform",
     "Metric",
     "Cube",
     "Node",
-    "Engine",
 ]

--- a/client/python/djclient/__init__.py
+++ b/client/python/djclient/__init__.py
@@ -2,3 +2,17 @@
 A DataJunction client for connecting to a DataJunction server
 """
 __version__ = "0.0.1a1"
+
+from djclient.dj import DJClient, Source, Catalog, Dimension, Transform, Metric, Cube, Node, Engine
+
+__all__ = [
+    "DJClient",
+    "Source",
+    "Catalog",
+    "Dimension",
+    "Transform",
+    "Metric",
+    "Cube",
+    "Node",
+    "Engine",
+]

--- a/client/python/djclient/dj.py
+++ b/client/python/djclient/dj.py
@@ -253,7 +253,7 @@ class DJClient:
         Attaches the list of engines to a catalog
         """
         response = self._session.post(
-            f"/catalogs/{catalog.name}/",
+            f"/catalogs/{catalog.name}/engines/",
             json=[engine.dict() for engine in engines],
         )
         return response.json()

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -32,7 +32,6 @@ profile = 'black'
 
 [tool.poetry.dependencies]
 python = "^3.8"
-djopenapi = "^0.0.1a1"
 
 [tool.poetry.dev-dependencies]
 coverage = "7.2.2"

--- a/client/python/setup.cfg
+++ b/client/python/setup.cfg
@@ -42,7 +42,8 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-
+    pydantic
+    pandas
 
 [options.packages.find]
 where = src

--- a/client/python/tests/test_dj_client.py
+++ b/client/python/tests/test_dj_client.py
@@ -297,7 +297,7 @@ class TestDJClient:
         expected = {}
         responses.add(
             responses.POST,
-            "http://localhost:8000/catalogs/prodhive/",
+            "http://localhost:8000/catalogs/prodhive/engines/",
             json=expected,
         )
         engine = Engine(

--- a/client/python/tests/test_dj_client.py
+++ b/client/python/tests/test_dj_client.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import responses
 
-from djclient.dj import Catalog, DJClient, Engine, Metric, Source, Transform
+from djclient import DJClient, Metric, Source, Transform
 from djclient.exceptions import DJClientException
 
 
@@ -252,65 +252,3 @@ class TestDJClient:
         )
         result = metric.dimensions()
         assert result == expected["dimensions"]
-
-    @responses.activate
-    def test_add_catalog(self, client):  # pylint: disable=unused-argument
-        """
-        Check that adding a catalog works.
-        """
-        expected = {}
-        responses.add(
-            responses.POST,
-            "http://localhost:8000/catalogs/",
-            json=expected,
-        )
-        catalog = Catalog(
-            name="prodhive",
-        )
-        result = catalog.publish()
-        assert result == expected
-
-    @responses.activate
-    def test_add_engine(self, client):  # pylint: disable=unused-argument
-        """
-        Check that adding an engine works.
-        """
-        expected = {}
-        responses.add(
-            responses.POST,
-            "http://localhost:8000/engines/",
-            json=expected,
-        )
-        engine = Engine(
-            name="spark",
-            version="2.4.4",
-            uri="",
-        )
-        result = engine.publish()
-        assert result == expected
-
-    @responses.activate
-    def test_add_engine_to_catalog(self, client):  # pylint: disable=unused-argument
-        """
-        Check that adding an engine works.
-        """
-        expected = {}
-        responses.add(
-            responses.POST,
-            "http://localhost:8000/catalogs/prodhive/engines/",
-            json=expected,
-        )
-        engine = Engine(
-            name="prodhive",
-            version="",
-            uri="",
-        )
-
-        catalog = Catalog(
-            name="prodhive",
-        )
-        result = catalog.add_engine(engine)
-        assert result == expected
-
-        result = catalog.add_engines([engine])
-        assert result == expected

--- a/client/python/tests/test_dj_client.py
+++ b/client/python/tests/test_dj_client.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import responses
 
-from djclient.dj import DJClient, Source, Metric, Dimension, Transform
+from djclient.dj import DJClient, Metric, Source, Transform
 from djclient.exceptions import DJClientException
 
 
@@ -168,7 +168,7 @@ class TestDJClient:
         source.draft()
 
     @responses.activate
-    def test_link_dimension(self, client):
+    def test_link_dimension(self, client):  # pylint: disable=unused-argument
         """
         Check that `client.engines()` works as expected.
         """
@@ -177,7 +177,7 @@ class TestDJClient:
             responses.POST,
             "http://localhost:8000/nodes/fruit_purchases/columns/fruit/"
             "?dimension=fruits&dimension_column=fruit",
-            json=expected
+            json=expected,
         )
         transform_node = Transform(
             name="fruit_purchases",
@@ -187,12 +187,16 @@ class TestDJClient:
         assert result == expected
 
     @responses.activate
-    def test_sql(self, client):
+    def test_sql(self, client):  # pylint: disable=unused-argument
         """
         Check that `client.engines()` works as expected.
         """
         expected = {"sql": "SELECT count(*) FROM fruit_purchases WHERE fruit='apple'"}
-        responses.add(responses.GET, "http://localhost:8000/sql/apple_count/", json=expected)
+        responses.add(
+            responses.GET,
+            "http://localhost:8000/sql/apple_count/",
+            json=expected,
+        )
         metric = Metric(
             name="apple_count",
             query="SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
@@ -201,16 +205,24 @@ class TestDJClient:
         assert result == expected["sql"]
 
     @responses.activate
-    def test_data(self, client):
+    def test_data(self, client):  # pylint: disable=unused-argument
         """
         Check that `client.engines()` works as expected.
         """
-        expected = {"results": [{
-            "sql": "SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
-            "columns": [{"name": "apple_count"}],
-            "rows": [[1], [2]],
-        }]}
-        responses.add(responses.GET, "http://localhost:8000/data/apple_count/", json=expected)
+        expected = {
+            "results": [
+                {
+                    "sql": "SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
+                    "columns": [{"name": "apple_count"}],
+                    "rows": [[1], [2]],
+                },
+            ],
+        }
+        responses.add(
+            responses.GET,
+            "http://localhost:8000/data/apple_count/",
+            json=expected,
+        )
         metric = Metric(
             name="apple_count",
             query="SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
@@ -219,12 +231,16 @@ class TestDJClient:
         assert isinstance(result, pd.DataFrame)
 
     @responses.activate
-    def test_get_dimensions(self, client):
+    def test_get_dimensions(self, client):  # pylint: disable=unused-argument
         """
         Check that `client.engines()` works as expected.
         """
         expected = {"dimensions": ["fruit"]}
-        responses.add(responses.GET, "http://localhost:8000/metrics/apple_count/", json=expected)
+        responses.add(
+            responses.GET,
+            "http://localhost:8000/metrics/apple_count/",
+            json=expected,
+        )
         metric = Metric(
             name="apple_count",
             query="SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",

--- a/client/python/tests/test_dj_client.py
+++ b/client/python/tests/test_dj_client.py
@@ -1,8 +1,9 @@
 """Tests DJ client"""
+import pandas as pd
 import pytest
 import responses
 
-from djclient.dj import DJClient, Source
+from djclient.dj import DJClient, Source, Metric, Dimension, Transform
 from djclient.exceptions import DJClientException
 
 
@@ -165,3 +166,68 @@ class TestDJClient:
         )
         source.publish()
         source.draft()
+
+    @responses.activate
+    def test_link_dimension(self, client):
+        """
+        Check that `client.engines()` works as expected.
+        """
+        expected = {"message": "success"}
+        responses.add(
+            responses.POST,
+            "http://localhost:8000/nodes/fruit_purchases/columns/fruit/"
+            "?dimension=fruits&dimension_column=fruit",
+            json=expected
+        )
+        transform_node = Transform(
+            name="fruit_purchases",
+            query="SELECT purchase_id, fruit, cost, cost_per_unit FROM purchase_records",
+        )
+        result = transform_node.link_dimension("fruit", "fruits", "fruit")
+        assert result == expected
+
+    @responses.activate
+    def test_sql(self, client):
+        """
+        Check that `client.engines()` works as expected.
+        """
+        expected = {"sql": "SELECT count(*) FROM fruit_purchases WHERE fruit='apple'"}
+        responses.add(responses.GET, "http://localhost:8000/sql/apple_count/", json=expected)
+        metric = Metric(
+            name="apple_count",
+            query="SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
+        )
+        result = metric.sql(dimensions=[], filters=[])
+        assert result == expected["sql"]
+
+    @responses.activate
+    def test_data(self, client):
+        """
+        Check that `client.engines()` works as expected.
+        """
+        expected = {"results": [{
+            "sql": "SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
+            "columns": [{"name": "apple_count"}],
+            "rows": [[1], [2]],
+        }]}
+        responses.add(responses.GET, "http://localhost:8000/data/apple_count/", json=expected)
+        metric = Metric(
+            name="apple_count",
+            query="SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
+        )
+        result = metric.data(dimensions=[], filters=[])
+        assert isinstance(result, pd.DataFrame)
+
+    @responses.activate
+    def test_get_dimensions(self, client):
+        """
+        Check that `client.engines()` works as expected.
+        """
+        expected = {"dimensions": ["fruit"]}
+        responses.add(responses.GET, "http://localhost:8000/metrics/apple_count/", json=expected)
+        metric = Metric(
+            name="apple_count",
+            query="SELECT count(*) FROM fruit_purchases WHERE fruit='apple'",
+        )
+        result = metric.dimensions()
+        assert result == expected["dimensions"]

--- a/client/python/tests/test_dj_client.py
+++ b/client/python/tests/test_dj_client.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import responses
 
-from djclient.dj import DJClient, Metric, Source, Transform
+from djclient.dj import Catalog, DJClient, Engine, Metric, Source, Transform
 from djclient.exceptions import DJClientException
 
 
@@ -164,6 +164,11 @@ class TestDJClient:
             "http://localhost:8000/nodes/source/",
             json=expected,
         )
+        responses.add(
+            responses.GET,
+            "http://localhost:8000/nodes/apples/",
+            json={**expected, **{"node_revision_id": 1}},
+        )
         source.publish()
         source.draft()
 
@@ -247,3 +252,65 @@ class TestDJClient:
         )
         result = metric.dimensions()
         assert result == expected["dimensions"]
+
+    @responses.activate
+    def test_add_catalog(self, client):  # pylint: disable=unused-argument
+        """
+        Check that adding a catalog works.
+        """
+        expected = {}
+        responses.add(
+            responses.POST,
+            "http://localhost:8000/catalogs/",
+            json=expected,
+        )
+        catalog = Catalog(
+            name="prodhive",
+        )
+        result = catalog.publish()
+        assert result == expected
+
+    @responses.activate
+    def test_add_engine(self, client):  # pylint: disable=unused-argument
+        """
+        Check that adding an engine works.
+        """
+        expected = {}
+        responses.add(
+            responses.POST,
+            "http://localhost:8000/engines/",
+            json=expected,
+        )
+        engine = Engine(
+            name="spark",
+            version="2.4.4",
+            uri="",
+        )
+        result = engine.publish()
+        assert result == expected
+
+    @responses.activate
+    def test_add_engine_to_catalog(self, client):  # pylint: disable=unused-argument
+        """
+        Check that adding an engine works.
+        """
+        expected = {}
+        responses.add(
+            responses.POST,
+            "http://localhost:8000/catalogs/prodhive/",
+            json=expected,
+        )
+        engine = Engine(
+            name="prodhive",
+            version="",
+            uri="",
+        )
+
+        catalog = Catalog(
+            name="prodhive",
+        )
+        result = catalog.add_engine(engine)
+        assert result == expected
+
+        result = catalog.add_engines([engine])
+        assert result == expected


### PR DESCRIPTION
### Summary

This adds additional functionality for the DJ client:
* Linking dimensions to a node
* Retrieving dimensions for a metric
* Getting SQL for a node given dimensions and filters
* Retrieving data for a node (for now this only supports retrieval as a pandas dataframe, but we can add additional options later)

### Test Plan

Running locally in a notebook

- [X] PR has an associated issue: #351
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A