### PR TITLE
Add node deletion

### DIFF
--- a/client/python/djclient/dj.py
+++ b/client/python/djclient/dj.py
@@ -244,7 +244,7 @@ class Node(BaseModel):
 
     def delete(self):
         """
-        Sets the node's mode to DRAFT and pushes it to the server.
+        Deletes the node
         """
         session = self._get_initialized_client()
         response = session.delete_node(self)

--- a/client/python/djclient/dj.py
+++ b/client/python/djclient/dj.py
@@ -137,6 +137,13 @@ class DJClient:
         """
         return self._nodes_by_type(type_="cube", names_only=names_only)
 
+    def delete_node(self, node: "Node"):
+        """
+        Delete this node
+        """
+        response = self._session.delete(f"/nodes/{node.name}/", timeout=self._timeout)
+        return response
+
     def create_node(self, node: "Node", mode: "NodeMode"):
         """
         Helper function to create a node.
@@ -234,6 +241,15 @@ class Node(BaseModel):
         """
         session = self._get_initialized_client()
         session.create_node(self, NodeMode.DRAFT)
+
+    def delete(self):
+        """
+        Sets the node's mode to DRAFT and pushes it to the server.
+        """
+        session = self._get_initialized_client()
+        response = session.delete_node(self)
+        assert response.status_code == 204
+        return f"Successfully deleted `{self.name}`"
 
 
 class Source(Node):

--- a/client/python/tests/test_dj_client.py
+++ b/client/python/tests/test_dj_client.py
@@ -110,6 +110,27 @@ class TestDJClient:
         assert result_names_only == ["node5"]
 
     @responses.activate
+    def test_delete_node(self, client):  # pylint: disable=unused-argument
+        """
+        Verifies that deleting a node works.
+        """
+        source = Source(
+            name="apples",
+            description="A record of all apples in the store.",
+            display_name="Apples",
+            catalog="prod",
+            schema_="store",
+            table="apples",
+        )
+        responses.add(
+            responses.DELETE,
+            "http://localhost:8000/nodes/apples/",
+            status=204,
+        )
+        response = source.delete()
+        assert response == "Successfully deleted `apples`"
+
+    @responses.activate
     def test_create_node(self, client):  # pylint: disable=unused-argument
         """
         Verifies that retrieving nodes with `client.nodes()` or

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -213,6 +213,16 @@ def read_node(name: str, *, session: Session = Depends(get_session)) -> NodeOutp
     return node  # type: ignore
 
 
+@router.delete("/nodes/{name}/", status_code=204)
+def delete_node(name: str, *, session: Session = Depends(get_session)):
+    """
+    Delete the specified node.
+    """
+    node = get_node_by_name(session, name, with_current=True)
+    session.delete(node)
+    return session.commit()
+
+
 @router.post("/nodes/{name}/materialization/", status_code=201)
 def upsert_node_materialization_config(
     name: str,

--- a/dj/sql/parsing/types.py
+++ b/dj/sql/parsing/types.py
@@ -782,6 +782,7 @@ PRIMITIVE_TYPES: Dict[str, PrimitiveType] = {
     "string": StringType(),
     "uuid": UUIDType(),
     "byte": BinaryType(),
+    "binary": BinaryType(),
     "none": NullType(),
     "null": NullType(),
 }

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -10,7 +10,7 @@ from sqlmodel import Session
 
 from dj.models import Database, Table
 from dj.models.column import Column
-from dj.models.node import Node, NodeRevision, NodeType
+from dj.models.node import Node, NodeRevision, NodeStatus, NodeType
 from dj.sql.parsing.types import IntegerType, StringType, TimestampType
 
 
@@ -228,6 +228,34 @@ class TestCreateOrUpdateNodes:
         """
         response = client_with_examples.delete("/nodes/basic.source.users/")
         assert response.status_code == 204
+
+        # All downstream nodes should be invalid
+        expected_downstreams = [
+            "basic.dimension.users",
+            "basic.transform.country_agg",
+            "basic.dimension.countries",
+            "basic.num_users",
+        ]
+        for downstream in expected_downstreams:
+            response = client_with_examples.get(f"/nodes/{downstream}/")
+            assert response.json()["status"] == NodeStatus.INVALID
+
+        node_with_link = client_with_examples.get("/nodes/repair_order_details/").json()
+        assert [
+            col["dimension"]["name"]
+            for col in node_with_link["columns"]
+            if col["name"] == "repair_order_id"
+        ] == ["repair_order"]
+
+        response = client_with_examples.delete("/nodes/repair_order/")
+        assert response.status_code == 204
+
+        node_with_link = client_with_examples.get("/nodes/repair_order_details/").json()
+        assert [
+            col["dimension"]
+            for col in node_with_link["columns"]
+            if col["name"] == "repair_order_id"
+        ] == [None]
 
     def test_create_source_node_without_cols_or_query_service(
         self,

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -219,6 +219,16 @@ class TestCreateOrUpdateNodes:
         session.commit()
         return node
 
+    def test_delete_node(
+        self,
+        client_with_examples: TestClient,
+    ):
+        """
+        Test deleting a node
+        """
+        response = client_with_examples.delete("/nodes/basic.source.users/")
+        assert response.status_code == 204
+
     def test_create_source_node_without_cols_or_query_service(
         self,
         client_with_examples: TestClient,


### PR DESCRIPTION
### Summary

Adds node deletion. Also provides Python client support for deletion.

### Test Plan

Ran locally through the client and through the REST API directly. Also testing just from regular use of this functionality as I create broken nodes 😆 

- [x] PR has an associated issue: #448
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A