### PR TITLE
Require primary key for dimension nodes + type check compatibility during linking

### DIFF
--- a/client/python/djclient/dj.py
+++ b/client/python/djclient/dj.py
@@ -294,6 +294,7 @@ class Node(ClientEntity):
     display_name: Optional[str]
     availability: Optional[Dict]
     tags: Optional[List[Tag]]
+    primary_key: Optional[List[str]]
 
     def publish(self):
         """

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -656,10 +656,21 @@ def link_a_dimension(
                 f"{node.current.catalog.name}, {dimension_node.current.catalog.name}"
             ),
         )
-    if dimension_column:  # Check that the column exists before linking
-        get_column(dimension_node.current, dimension_column)
 
     target_column = get_column(node.current, column)
+    if dimension_column:
+        # Check that the dimension column exists
+        column_from_dimension = get_column(dimension_node.current, dimension_column)
+
+        # Check the dimension column's type is compatible with the target column's type
+        if column_from_dimension.type != target_column.type:
+            raise DJInvalidInputException(
+                f"The column {target_column.name} has type {target_column.type} "
+                f"and is being linked to the dimension {dimension} via the dimension"
+                f" column {dimension_column}, which has type {column_from_dimension.type}."
+                " These column types are incompatible and the dimension cannot be linked!",
+            )
+
     target_column.dimension = dimension_node
     target_column.dimension_id = dimension_node.id
     target_column.dimension_column = dimension_column

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -154,13 +154,6 @@ def _build_joins_for_dimension(
         # Assemble join ON clause
         for join_col in join_columns:
             join_table_pk = table_node.primary_key()
-            if len(join_table_pk) > 1 and not join_col.dimension_column:
-                raise DJInvalidInputException(
-                    "Must provide an explicit `dimension_column` for each join "
-                    f"column that links to the dimension node `{table_node.name}`,"
-                    " as the dimensions node has a compound primary key: "
-                    f"`{','.join(join_table_pk)}`",
-                )
             if (
                 len(join_table_pk) == 1
                 and join_col.name in join_left_columns

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -475,6 +475,7 @@ class MutableNodeFields(BaseSQLModel):
     display_name: Optional[str]
     description: str
     mode: NodeMode
+    primary_key: Optional[List[str]]
 
 
 class MutableNodeQueryField(BaseSQLModel):

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -429,6 +429,16 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
     def __hash__(self) -> int:
         return hash(self.id)
 
+    def primary_key(self) -> List[Column]:
+        """
+        Returns the primary key columns of this node.
+        """
+        primary_key_columns = []
+        for col in self.columns:  # pylint: disable=not-an-iterable
+            if "primary_key" in {attr.attribute_type.name for attr in col.attributes}:
+                primary_key_columns.append(col)
+        return primary_key_columns
+
     def extra_validation(self) -> None:
         """
         Extra validation for node data.

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -1427,11 +1427,13 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "?dimension=payment_type"
             "&dimension_column=payment_type_name",
         )
-        assert response.status_code == 201
+        assert response.status_code == 422
         data = response.json()
         assert data["message"] == (
-            "Dimension node payment_type has been successfully "
-            "linked to column payment_type on node revenue"
+            "The column payment_type has type int and is being linked "
+            "to the dimension payment_type via the dimension column "
+            "payment_type_name, which has type string. These column "
+            "types are incompatible and the dimension cannot be linked!"
         )
 
         response = client_with_examples.post(

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -134,6 +134,7 @@ class TestCreateOrUpdateNodes:
             "FROM basic.source.users GROUP BY country",
             "mode": "published",
             "name": "countries",
+            "primary_key": ["country"],
         }
 
     @pytest.fixture
@@ -662,7 +663,6 @@ class TestCreateOrUpdateNodes:
         """
         Test creating and updating a dimension node that references an existing source.
         """
-
         response = client.post(
             "/nodes/dimension/",
             json=create_dimension_node_payload,
@@ -680,7 +680,14 @@ class TestCreateOrUpdateNodes:
             "FROM basic.source.users GROUP BY country"
         )
         assert data["columns"] == [
-            {"name": "country", "type": "string", "attributes": [], "dimension": None},
+            {
+                "name": "country",
+                "type": "string",
+                "attributes": [
+                    {"attribute_type": {"namespace": "system", "name": "primary_key"}},
+                ],
+                "dimension": None,
+            },
             {"name": "user_cnt", "type": "long", "attributes": [], "dimension": None},
         ]
 
@@ -747,7 +754,14 @@ class TestCreateOrUpdateNodes:
             "FROM basic.source.users GROUP BY country"
         )
         assert data["columns"] == [
-            {"name": "country", "type": "string", "attributes": [], "dimension": None},
+            {
+                "name": "country",
+                "type": "string",
+                "attributes": [
+                    {"attribute_type": {"namespace": "system", "name": "primary_key"}},
+                ],
+                "dimension": None,
+            },
             {"name": "user_cnt", "type": "long", "attributes": [], "dimension": None},
         ]
 
@@ -1023,6 +1037,7 @@ class TestNodeColumnsAttributes:
         response = client_with_examples.get(
             "/nodes/basic.source.comments/",
         )
+        print("BASIC.SOURCE", response.json())
 
         response = client_with_examples.post(
             "/nodes/basic.source.comments/attributes/",
@@ -1094,6 +1109,7 @@ class TestNodeColumnsAttributes:
             ],
         )
         data = response.json()
+        print("data", data)
         assert data == {
             "message": "The column attribute `event_time` is scoped to be unique to the "
             "`['node', 'column_type']` level, but there is more than one column"

--- a/tests/construction/fixtures.py
+++ b/tests/construction/fixtures.py
@@ -7,7 +7,14 @@ from typing import Dict, List, Optional, Tuple
 import pytest
 from sqlmodel import Session
 
-from dj.models import Column, Database, NodeRevision, Table
+from dj.models import (
+    AttributeType,
+    Column,
+    ColumnAttribute,
+    Database,
+    NodeRevision,
+    Table,
+)
 from dj.models.node import Node, NodeType
 from dj.sql.parsing.types import (
     DateType,
@@ -163,7 +170,7 @@ def construction_session(  # pylint: disable=too-many-locals
     postgres = Database(name="postgres", URI="", cost=10, id=1)
 
     gsheets = Database(name="gsheets", URI="", cost=100, id=2)
-
+    primary_key = AttributeType(namespace="system", name="primary_key", description="")
     countries_dim_ref = Node(
         name="basic.dimension.countries",
         type=NodeType.DIMENSION,
@@ -181,7 +188,11 @@ def construction_session(  # pylint: disable=too-many-locals
           GROUP BY country
         """,
         columns=[
-            Column(name="country", type=StringType()),
+            Column(
+                name="country",
+                type=StringType(),
+                attributes=[ColumnAttribute(attribute_type=primary_key)],
+            ),
             Column(name="user_cnt", type=IntegerType()),
         ],
     )
@@ -207,7 +218,11 @@ def construction_session(  # pylint: disable=too-many-locals
           FROM basic.source.users
         """,
         columns=[
-            Column(name="id", type=IntegerType()),
+            Column(
+                name="id",
+                type=IntegerType(),
+                attributes=[ColumnAttribute(attribute_type=primary_key)],
+            ),
             Column(name="full_name", type=StringType()),
             Column(name="age", type=IntegerType()),
             Column(name="country", type=StringType()),
@@ -480,7 +495,11 @@ def construction_session(  # pylint: disable=too-many-locals
           FROM dbt.source.jaffle_shop.customers
         """,
         columns=[
-            Column(name="id", type=IntegerType()),
+            Column(
+                name="id",
+                type=IntegerType(),
+                attributes=[ColumnAttribute(attribute_type=primary_key)],
+            ),
             Column(name="first_name", type=StringType()),
             Column(name="last_name", type=StringType()),
         ],

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -526,13 +526,13 @@ EXAMPLES = (  # type: ignore
         ),
         {},
     ),
-    (
-        (
-            "/nodes/local_hard_hats/columns/state_id/"
-            "?dimension=us_state&dimension_column=state_id"
-        ),
-        {},
-    ),
+    # (
+    #     (
+    #         "/nodes/local_hard_hats/columns/state_id/"
+    #         "?dimension=us_state&dimension_column=state_id"
+    #     ),
+    #     {},
+    # ),
     (
         (
             "/nodes/hard_hat/columns/state/"
@@ -1055,13 +1055,13 @@ EXAMPLES = (  # type: ignore
         ),
         {},
     ),
-    (
-        (
-            "/nodes/foo.bar.local_hard_hats/columns/state_id/"
-            "?dimension=foo.bar.us_state&dimension_column=state_id"
-        ),
-        {},
-    ),
+    # (
+    #     (
+    #         "/nodes/foo.bar.local_hard_hats/columns/state_id/"
+    #         "?dimension=foo.bar.us_state&dimension_column=state_id"
+    #     ),
+    #     {},
+    # ),
     (
         (
             "/nodes/foo.bar.repair_order_details/columns/repair_order_id/"

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -526,13 +526,6 @@ EXAMPLES = (  # type: ignore
         ),
         {},
     ),
-    # (
-    #     (
-    #         "/nodes/local_hard_hats/columns/state_id/"
-    #         "?dimension=us_state&dimension_column=state_id"
-    #     ),
-    #     {},
-    # ),
     (
         (
             "/nodes/hard_hat/columns/state/"
@@ -1055,13 +1048,6 @@ EXAMPLES = (  # type: ignore
         ),
         {},
     ),
-    # (
-    #     (
-    #         "/nodes/foo.bar.local_hard_hats/columns/state_id/"
-    #         "?dimension=foo.bar.us_state&dimension_column=state_id"
-    #     ),
-    #     {},
-    # ),
     (
         (
             "/nodes/foo.bar.repair_order_details/columns/repair_order_id/"

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -271,6 +271,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "repair_order",
+            "primary_key": ["repair_order_id"],
         },
     ),
     (
@@ -293,6 +294,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "contractor",
+            "primary_key": ["contractor_id"],
         },
     ),
     (
@@ -318,6 +320,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "hard_hat",
+            "primary_key": ["hard_hat_id"],
         },
     ),
     (
@@ -347,6 +350,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "local_hard_hats",
+            "primary_key": ["hard_hat_id"],
         },
     ),
     (
@@ -366,6 +370,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "us_state",
+            "primary_key": ["state_id"],
         },
     ),
     (
@@ -381,6 +386,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "dispatcher",
+            "primary_key": ["dispatcher_id"],
         },
     ),
     (
@@ -404,6 +410,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "municipality_dim",
+            "primary_key": ["municipality_id"],
         },
     ),
     (
@@ -793,6 +800,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "foo.bar.repair_order",
+            "primary_key": ["repair_order_id"],
         },
     ),
     (
@@ -815,6 +823,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "foo.bar.contractor",
+            "primary_key": ["contractor_id"],
         },
     ),
     (
@@ -840,6 +849,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "foo.bar.hard_hat",
+            "primary_key": ["hard_hat_id"],
         },
     ),
     (
@@ -869,6 +879,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "foo.bar.local_hard_hats",
+            "primary_key": ["hard_hat_id"],
         },
     ),
     (
@@ -888,6 +899,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "foo.bar.us_state",
+            "primary_key": ["state_id"],
         },
     ),
     (
@@ -903,6 +915,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "foo.bar.dispatcher",
+            "primary_key": ["dispatcher_id"],
         },
     ),
     (
@@ -926,6 +939,7 @@ EXAMPLES = (  # type: ignore
                     """,
             "mode": "published",
             "name": "foo.bar.municipality_dim",
+            "primary_key": ["municipality_id"],
         },
     ),
     (
@@ -1137,6 +1151,7 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "payment_type",
+            "primary_key": ["id"],
         },
     ),
     (
@@ -1150,6 +1165,7 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "account_type",
+            "primary_key": ["id"],
         },
     ),
     (
@@ -1220,6 +1236,7 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "basic.dimension.users",
+            "primary_key": ["id"],
         },
     ),
     (
@@ -1253,6 +1270,7 @@ EXAMPLES = (  # type: ignore
             "FROM basic.source.users GROUP BY country",
             "mode": "published",
             "name": "basic.dimension.countries",
+            "primary_key": ["country"],
         },
     ),
     (
@@ -1321,6 +1339,7 @@ EXAMPLES = (  # type: ignore
             "query": "SELECT country, COUNT(DISTINCT event_id) AS events_cnt "
             "FROM event_source GROUP BY country",
             "mode": "published",
+            "primary_key": ["country"],
         },
     ),
     (
@@ -1371,6 +1390,7 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "dbt.dimension.customers",
+            "primary_key": ["id"],
         },
     ),
     (
@@ -1458,6 +1478,7 @@ EXAMPLES = (  # type: ignore
             "query": ("SELECT item_name " "account_type_classification FROM " "sales"),
             "mode": "published",
             "name": "items",
+            "primary_key": ["account_type_classification"],
         },
     ),
     (


### PR DESCRIPTION
### Summary

When someone creates a dimension node, they should set the column(s) that are part of dimension's primary key. During query building, when we assemble the join to bring in the dimension, we'll default to the dimension's primary key when no `dimension_column` is explicitly provided. The existing setup just uses `id` by default, which is not accurate for the majority of use cases as `id` may or may not exist in the columns in the node.

This change also adds a check to make sure the types of the target and dimension columns are compatible during dimension node linking.

One additional requirement that might be worth adding: making sure that links only happen on the dimension node's primary key columns, rather than allowing arbitrary column linking.

### Test Plan

- [X] PR has an associated issue: 
  - #454
  - #446
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A