### PR TITLE
Poetry config for publishing to pypi

### DIFF
--- a/docs/content/0.1.0/docs/developers/publishing-to-pypi.md
+++ b/docs/content/0.1.0/docs/developers/publishing-to-pypi.md
@@ -1,0 +1,25 @@
+---
+weight: 100
+---
+
+# Publishing to PyPI
+
+The DataJunction project publishes server and client libraries to [PyPI](https://pypi.org/) using [poetry](https://python-poetry.org/).
+
+{{< hint info >}}
+To create an API token, go to [PyPI](https://pypi.org/account/login/), navigate to the account settings page,
+and scroll to the API tokens section. 
+{{< /hint >}}
+
+Configure poetry to use your PyPI API token.
+```sh
+poetry config pypi-token.pypi $PYPI_API_TOKEN
+```
+
+Build and publish the project.
+```sh
+poetry publish --build
+```
+{{< hint info >}}
+To publish the `djclient`, run the above command in the `djclient/` directory.
+{{< /hint >}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,24 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 # See configuration details in https://github.com/pypa/setuptools_scm
 version_scheme = "no-guess-dev"
+
+[tool.poetry]
+name = "datajunction"
+version = "0.0.1a1"
+readme = "README.rst"
+repository = "https://github.com/DataJunction/dj"
+description = "DataJunction server library for running to a DataJunction server"
+authors = ["DataJunction Authors"]
+license = "MIT"
+packages = [
+    { include = "dj" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]


### PR DESCRIPTION
### Summary

This adds a poetry config for publishing to pypi. I've reserved the [datajunction](https://pypi.org/project/datajunction/) namespace in PyPI and added some instructions here for how to publish using poetry.

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
