### PR TITLE
Optimize build + add dialect + `UNNEST` + type compatibility fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM python:3.10
 
-ARG RELOAD="--reload"
-ENV RELOAD ${RELOAD}
-
 WORKDIR /code
 COPY . /code
 RUN pip install --no-cache-dir --upgrade -r /code/requirements/docker.txt
 RUN pip install -e .
 RUN pip install opentelemetry-distro==0.38b0 opentelemetry-exporter-otlp-proto-grpc==1.17.0
 
-CMD ["opentelemetry-instrument", "uvicorn", "dj.api.main:app", "--host", "0.0.0.0", "--port", "8000", "${RELOAD}"]
+CMD ["opentelemetry-instrument", "uvicorn", "dj.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM python:3.10
+
+ARG RELOAD="--reload"
+ENV RELOAD ${RELOAD}
+
 WORKDIR /code
 COPY . /code
 RUN pip install --no-cache-dir --upgrade -r /code/requirements/docker.txt
 RUN pip install -e .
 RUN pip install opentelemetry-distro==0.38b0 opentelemetry-exporter-otlp-proto-grpc==1.17.0
 
-CMD ["opentelemetry-instrument", "uvicorn", "dj.api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["opentelemetry-instrument", "uvicorn", "dj.api.main:app", "--host", "0.0.0.0", "--port", "8000", "${RELOAD}"]
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements/docker.txt
 RUN pip install -e .
 RUN pip install opentelemetry-distro==0.38b0 opentelemetry-exporter-otlp-proto-grpc==1.17.0
 
-CMD ["opentelemetry-instrument", "uvicorn", "dj.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["opentelemetry-instrument", "uvicorn", "dj.api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 EXPOSE 8000

--- a/alembic/versions/2023_04_13_2048-4f6449741463_initial_migration.py
+++ b/alembic/versions/2023_04_13_2048-4f6449741463_initial_migration.py
@@ -81,6 +81,15 @@ def upgrade():
         sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("version", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("uri", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column(
+            "dialect",
+            sa.Enum(
+                "SPARK",
+                "TRINO",
+                name="dialect",
+            ),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_engine")),
     )
     op.create_table(

--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -3,7 +3,7 @@ Data related APIs.
 """
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
@@ -11,6 +11,7 @@ from sqlmodel import Session
 
 from dj.api.helpers import get_node_by_name, get_query
 from dj.errors import DJException
+from dj.models.engine import Dialect
 from dj.models.metric import TranslatedSQL
 from dj.models.node import AvailabilityState, AvailabilityStateBase, NodeType
 from dj.models.query import ColumnMetadata, QueryCreate, QueryWithResults
@@ -98,6 +99,7 @@ def get_data(
     async_: bool = False,
     session: Session = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
+    dialect: Optional[Dialect] = None,
 ) -> QueryWithResults:
     """
     Gets data for a node
@@ -108,6 +110,7 @@ def get_data(
         node_name=node_name,
         dimensions=dimensions,
         filters=filters,
+        dialect=dialect,
     )
     columns = [
         ColumnMetadata(name=col.alias_or_name.name, type=str(col.type))  # type: ignore

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -161,14 +161,15 @@ def get_query(  # pylint: disable=too-many-arguments
             )
 
     # Builds the node for the engine's dialect if one is set or defaults to Spark
-    if not engine and node.current and node.current.catalog and node.current.catalog.engines:
+    if (
+        not engine
+        and node.current
+        and node.current.catalog
+        and node.current.catalog.engines
+    ):
         engine = node.current.catalog.engines[0]
     build_criteria = BuildCriteria(
-        dialect=(
-            engine.dialect
-            if engine and engine.dialect
-            else Dialect.SPARK
-        ),
+        dialect=(engine.dialect if engine and engine.dialect else Dialect.SPARK),
     )
 
     query_ast = build_node(

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -16,6 +16,7 @@ from dj.models import AttributeType, Catalog, Column, Engine
 from dj.models.attribute import RESERVED_ATTRIBUTE_NAMESPACE
 from dj.models.engine import Dialect
 from dj.models.node import (
+    BuildCriteria,
     MissingParent,
     Node,
     NodeMissingParents,
@@ -162,10 +163,9 @@ def get_query(  # pylint: disable=too-many-arguments
     query_ast = build_node(
         session=session,
         node=node.current,
-        dialect=dialect,
         filters=filters,
         dimensions=dimensions,
-        build_criteria=None,
+        build_criteria=BuildCriteria(dialect=dialect if dialect else Dialect.SPARK),
     )
     return query_ast
 

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -14,6 +14,7 @@ from dj.construction.dj_query import build_dj_metric_query
 from dj.errors import DJError, DJException, DJInvalidInputException, ErrorCode
 from dj.models import AttributeType, Catalog, Column, Engine
 from dj.models.attribute import RESERVED_ATTRIBUTE_NAMESPACE
+from dj.models.engine import Dialect
 from dj.models.node import (
     MissingParent,
     Node,
@@ -145,6 +146,7 @@ def get_query(  # pylint: disable=too-many-arguments
     node_name: str,
     dimensions: List[str],
     filters: List[str],
+    dialect: Optional[Dialect],
 ) -> ast.Query:
     """
     Get a query for a metric, dimensions, and filters
@@ -160,7 +162,7 @@ def get_query(  # pylint: disable=too-many-arguments
     query_ast = build_node(
         session=session,
         node=node.current,
-        dialect=None,
+        dialect=dialect,
         filters=filters,
         dimensions=dimensions,
         build_criteria=None,

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -184,7 +184,7 @@ def set_column_attributes_on_node(
             ].add(column.name)
 
     for (attribute, _), columns in attributes_columns_map.items():
-        if len(columns) > 1:
+        if len(columns) > 1 and attribute.uniqueness_scope:
             for col in columns:
                 modified_columns_map[col].attributes = []
             raise DJException(
@@ -606,7 +606,7 @@ def create_a_node_namespace(
         return JSONResponse(
             status_code=409,
             content={
-                "message": (f"Node namespace`{namespace}` already exists"),
+                "message": (f"Node namespace `{namespace}` already exists"),
             },
         )
     node_namespace = NodeNamespace(namespace=namespace)
@@ -615,7 +615,7 @@ def create_a_node_namespace(
     return JSONResponse(
         status_code=201,
         content={
-            "message": (f"Node namespace`{namespace}` has been successfully created"),
+            "message": (f"Node namespace `{namespace}` has been successfully created"),
         },
     )
 
@@ -749,7 +749,7 @@ def link_a_dimension(
         column_from_dimension = get_column(dimension_node.current, dimension_column)
 
         # Check the dimension column's type is compatible with the target column's type
-        if column_from_dimension.type != target_column.type:
+        if not column_from_dimension.type.is_compatible(target_column.type):
             raise DJInvalidInputException(
                 f"The column {target_column.name} has type {target_column.type} "
                 f"and is being linked to the dimension {dimension} via the dimension"

--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -8,8 +8,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
-from dj.api.helpers import get_query, get_engine
-from dj.models.engine import Dialect
+from dj.api.helpers import get_engine, get_query
 from dj.models.metric import TranslatedSQL
 from dj.models.query import ColumnMetadata
 from dj.utils import get_session
@@ -31,7 +30,11 @@ def get_sql(
     """
     Return SQL for a node.
     """
-    engine = get_engine(session, engine_name, engine_version) if engine_name else None
+    engine = (
+        get_engine(session, engine_name, engine_version)  # type: ignore
+        if engine_name
+        else None
+    )
     query_ast = get_query(
         session=session,
         node_name=node_name,

--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -3,12 +3,13 @@ SQL related APIs.
 """
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
 from dj.api.helpers import get_query
+from dj.models.engine import Dialect
 from dj.models.metric import TranslatedSQL
 from dj.models.query import ColumnMetadata
 from dj.utils import get_session
@@ -24,6 +25,7 @@ def get_sql(
     filters: List[str] = Query([]),
     *,
     session: Session = Depends(get_session),
+    dialect: Optional[Dialect] = None,
 ) -> TranslatedSQL:
     """
     Return SQL for a node.
@@ -33,6 +35,7 @@ def get_sql(
         node_name=node_name,
         dimensions=dimensions,
         filters=filters,
+        dialect=dialect,
     )
     columns = [
         ColumnMetadata(name=col.alias_or_name.name, type=str(col.type))  # type: ignore
@@ -41,4 +44,5 @@ def get_sql(
     return TranslatedSQL(
         sql=str(query_ast),
         columns=columns,
+        dialect=dialect,
     )

--- a/dj/models/engine.py
+++ b/dj/models/engine.py
@@ -1,12 +1,24 @@
 """
 Models for columns.
 """
-
+import enum
 from typing import Optional
 
+from sqlalchemy.sql.schema import Column as SqlaColumn
+from sqlalchemy.types import Enum
 from sqlmodel import Field, SQLModel
 
 from dj.models.base import BaseSQLModel
+
+
+class Dialect(str, enum.Enum):
+    """
+    SQL dialect
+    """
+
+    SPARK = "spark"
+    TRINO = "trino"
+    POSTGRES = "postgres"
 
 
 class Engine(BaseSQLModel, table=True):  # type: ignore
@@ -18,6 +30,7 @@ class Engine(BaseSQLModel, table=True):  # type: ignore
     name: str
     version: str
     uri: Optional[str]
+    dialect: Optional[Dialect] = Field(sa_column=SqlaColumn(Enum(Dialect)))
 
 
 class EngineInfo(SQLModel):
@@ -28,3 +41,4 @@ class EngineInfo(SQLModel):
     name: str
     version: str
     uri: Optional[str]
+    dialect: Optional[Dialect]

--- a/dj/models/engine.py
+++ b/dj/models/engine.py
@@ -18,7 +18,6 @@ class Dialect(str, enum.Enum):
 
     SPARK = "spark"
     TRINO = "trino"
-    POSTGRES = "postgres"
 
 
 class Engine(BaseSQLModel, table=True):  # type: ignore

--- a/dj/models/metric.py
+++ b/dj/models/metric.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from sqlmodel import SQLModel
 
+from dj.models.engine import Dialect
 from dj.models.node import Node
 from dj.models.query import ColumnMetadata
 from dj.sql.dag import get_dimensions
@@ -53,3 +54,4 @@ class TranslatedSQL(SQLModel):
     # columns attribute can be required
     sql: str
     columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover
+    dialect: Optional[Dialect] = None

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -372,7 +372,12 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
     node_id: Optional[int] = Field(foreign_key="node.id")
     node: Node = Relationship(back_populates="revisions")
     catalog_id: int = Field(default=None, foreign_key="catalog.id")
-    catalog: Catalog = Relationship(back_populates="node_revisions")
+    catalog: Catalog = Relationship(
+        back_populates="node_revisions",
+        sa_relationship_kwargs={
+            "lazy": "joined",
+        },
+    )
     schema_: Optional[str] = None
     table: Optional[str] = None
     cube_elements: List["Node"] = Relationship(  # Only used by cube nodes

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -23,7 +23,7 @@ from dj.models.base import BaseSQLModel, generate_display_name
 from dj.models.catalog import Catalog
 from dj.models.column import Column, ColumnYAML
 from dj.models.database import Database
-from dj.models.engine import Engine, EngineInfo
+from dj.models.engine import Dialect, Engine, EngineInfo
 from dj.models.tag import Tag, TagNodeRelationship
 from dj.sql.parse import is_metric
 from dj.sql.parsing.types import ColumnType
@@ -42,6 +42,7 @@ class BuildCriteria:
     """
 
     timestamp: Optional[UTCDatetime] = None
+    dialect: Dialect = Dialect.SPARK
 
 
 class NodeRelationship(BaseSQLModel, table=True):  # type: ignore

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1243,7 +1243,7 @@ class Unnest(TableFunction):  # pylint: disable=abstract-method
 def infer_type(  # noqa: F811  # pylint: disable=function-redefined
     arg: ct.ListType,
 ) -> List[ct.NestedField]:
-    return [arg.element]
+    return [arg.element]  # pragma: no cover
 
 
 @Unnest.register

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1231,6 +1231,28 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
     return [arg.key, arg.value]
 
 
+class Unnest(TableFunction):  # pylint: disable=abstract-method
+    """
+    The unnest function is used to explode the specified array,
+    nested array, or map column into multiple rows.
+    It will generate a new row for each element in the specified column.
+    """
+
+
+@Unnest.register
+def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+    arg: ct.ListType,
+) -> List[ct.NestedField]:
+    return [arg.element]
+
+
+@Unnest.register
+def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+    arg: ct.MapType,
+) -> List[ct.NestedField]:
+    return [arg.key, arg.value]
+
+
 function_registry = FunctionRegistryDict()
 for cls in Function.__subclasses__():
     snake_cased = re.sub(r"(?<!^)(?=[A-Z])", "_", cls.__name__)

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -922,9 +922,14 @@ class TableExpression(Aliasable, Expression):
         # For table-valued functions, add the list of columns that gets
         # returned as reference columns and compile them
         if isinstance(self, FunctionTable):
-            if not self.alias and not column.name.namespace or (
-                self.alias and column.name.namespace
-                and self.alias == column.name.namespace
+            if (
+                not self.alias
+                and not column.name.namespace
+                or (
+                    self.alias
+                    and column.name.namespace
+                    and self.alias == column.name.namespace
+                )
             ):
                 for col in self.column_list:
                     if column.name.name == col.alias_or_name.name:
@@ -1839,8 +1844,12 @@ class FunctionTable(FunctionTableExpression):
             if self.column_list
             else ""
         )
+        if alias:
+            column_list_str = f"({cols})"
+        else:
+            column_list_str = str(cols)
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
-        return f"{self.name}{args_str}{alias}{as_}({cols})"
+        return f"{self.name}{args_str}{alias}{as_}{column_list_str}"
 
     def set_alias(self: TNode, alias: Name) -> TNode:
         self.alias = alias

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -919,18 +919,13 @@ class TableExpression(Aliasable, Expression):
                 )
             self.compile(ctx)
 
-        # SOMEWHERE IN HERE LIES THE GOLDEN EGG, gets called from add_ref_column(self, ctx) under correlation_tables
+        # For table-valued functions, add the list of columns that gets
+        # returned as reference columns and compile them
         if isinstance(self, FunctionTable):
-            matched = False
-            if not self.alias and not column.name.namespace:
-                matched = True
-            elif (
-                self.alias
-                and column.name.namespace
+            if not self.alias and not column.name.namespace or (
+                self.alias and column.name.namespace
                 and self.alias == column.name.namespace
             ):
-                matched = True
-            if matched:
                 for col in self.column_list:
                     if column.name.name == col.alias_or_name.name:
                         self._ref_columns.append(column)

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -1844,10 +1844,7 @@ class FunctionTable(FunctionTableExpression):
             if self.column_list
             else ""
         )
-        if alias:
-            column_list_str = f"({cols})"
-        else:
-            column_list_str = str(cols)
+        column_list_str = f"({cols})" if alias else str(cols)
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
         return f"{self.name}{args_str}{alias}{as_}{column_list_str}"
 

--- a/tests/api/catalog_test.py
+++ b/tests/api/catalog_test.py
@@ -33,6 +33,7 @@ def test_catalog_list(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -45,6 +46,7 @@ def test_catalog_list(
                 {
                     "name": "spark",
                     "version": "3.3.1",
+                    "dialect": "spark",
                 },
             ],
         },
@@ -72,7 +74,9 @@ def test_catalog_list(
     assert response.json() == [
         {
             "name": "dev",
-            "engines": [{"name": "spark", "version": "3.3.1", "uri": None}],
+            "engines": [
+                {"name": "spark", "version": "3.3.1", "uri": None, "dialect": "spark"},
+            ],
         },
         {"name": "test", "engines": []},
         {"name": "prod", "engines": []},
@@ -90,6 +94,7 @@ def test_catalog_get_catalog(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -102,6 +107,7 @@ def test_catalog_get_catalog(
                 {
                     "name": "spark",
                     "version": "3.3.1",
+                    "dialect": "spark",
                 },
             ],
         },
@@ -115,7 +121,9 @@ def test_catalog_get_catalog(
     data = response.json()
     assert data == {
         "name": "dev",
-        "engines": [{"name": "spark", "uri": None, "version": "3.3.1"}],
+        "engines": [
+            {"name": "spark", "uri": None, "version": "3.3.1", "dialect": "spark"},
+        ],
     }
 
 
@@ -131,6 +139,7 @@ def test_catalog_adding_a_new_catalog_with_engines(
             "name": "spark",
             "uri": None,
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     data = response.json()
@@ -144,6 +153,7 @@ def test_catalog_adding_a_new_catalog_with_engines(
                 {
                     "name": "spark",
                     "version": "3.3.1",
+                    "dialect": "spark",
                 },
             ],
         },
@@ -157,6 +167,7 @@ def test_catalog_adding_a_new_catalog_with_engines(
                 "name": "spark",
                 "uri": None,
                 "version": "3.3.1",
+                "dialect": "spark",
             },
         ],
     }
@@ -174,6 +185,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
             "name": "spark",
             "uri": None,
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     data = response.json()
@@ -193,6 +205,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
             {
                 "name": "spark",
                 "version": "3.3.1",
+                "dialect": "spark",
             },
         ],
     )
@@ -206,6 +219,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
                 "name": "spark",
                 "uri": None,
                 "version": "3.3.1",
+                "dialect": "spark",
             },
         ],
     }
@@ -223,6 +237,7 @@ def test_catalog_adding_without_duplicating(
             "name": "spark",
             "uri": None,
             "version": "2.4.4",
+            "dialect": "spark",
         },
     )
     data = response.json()
@@ -233,6 +248,7 @@ def test_catalog_adding_without_duplicating(
         json={
             "name": "spark",
             "version": "3.3.0",
+            "dialect": "spark",
         },
     )
     data = response.json()
@@ -243,6 +259,7 @@ def test_catalog_adding_without_duplicating(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     data = response.json()
@@ -252,6 +269,7 @@ def test_catalog_adding_without_duplicating(
         "/catalogs/",
         json={
             "name": "dev",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -262,14 +280,17 @@ def test_catalog_adding_without_duplicating(
             {
                 "name": "spark",
                 "version": "2.4.4",
+                "dialect": "spark",
             },
             {
                 "name": "spark",
                 "version": "3.3.0",
+                "dialect": "spark",
             },
             {
                 "name": "spark",
                 "version": "3.3.1",
+                "dialect": "spark",
             },
         ],
     )
@@ -281,14 +302,17 @@ def test_catalog_adding_without_duplicating(
             {
                 "name": "spark",
                 "version": "2.4.4",
+                "dialect": "spark",
             },
             {
                 "name": "spark",
                 "version": "3.3.0",
+                "dialect": "spark",
             },
             {
                 "name": "spark",
                 "version": "3.3.1",
+                "dialect": "spark",
             },
         ],
     )
@@ -301,16 +325,19 @@ def test_catalog_adding_without_duplicating(
                 "name": "spark",
                 "uri": None,
                 "version": "2.4.4",
+                "dialect": "spark",
             },
             {
                 "name": "spark",
                 "uri": None,
                 "version": "3.3.0",
+                "dialect": "spark",
             },
             {
                 "name": "spark",
                 "uri": None,
                 "version": "3.3.1",
+                "dialect": "spark",
             },
         ],
     }
@@ -330,6 +357,7 @@ def test_catalog_raise_on_adding_a_new_catalog_with_nonexistent_engines(
                 {
                     "name": "spark",
                     "version": "4.0.0",
+                    "dialect": "spark",
                 },
             ],
         },

--- a/tests/api/engine_test.py
+++ b/tests/api/engine_test.py
@@ -16,11 +16,17 @@ def test_engine_adding_a_new_engine(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     data = response.json()
     assert response.status_code == 201
-    assert data == {"name": "spark", "uri": None, "version": "3.3.1"}
+    assert data == {
+        "dialect": "spark",
+        "name": "spark",
+        "uri": None,
+        "version": "3.3.1",
+    }
 
 
 def test_engine_list(
@@ -34,6 +40,7 @@ def test_engine_list(
         json={
             "name": "spark",
             "version": "2.4.4",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -43,6 +50,7 @@ def test_engine_list(
         json={
             "name": "spark",
             "version": "3.3.0",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -52,6 +60,7 @@ def test_engine_list(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -64,16 +73,19 @@ def test_engine_list(
             "name": "spark",
             "uri": None,
             "version": "2.4.4",
+            "dialect": "spark",
         },
         {
             "name": "spark",
             "uri": None,
             "version": "3.3.0",
+            "dialect": "spark",
         },
         {
             "name": "spark",
             "uri": None,
             "version": "3.3.1",
+            "dialect": "spark",
         },
     ]
 
@@ -89,6 +101,7 @@ def test_engine_get_engine(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -98,7 +111,12 @@ def test_engine_get_engine(
     )
     assert response.status_code == 200
     data = response.json()
-    assert data == {"name": "spark", "uri": None, "version": "3.3.1"}
+    assert data == {
+        "name": "spark",
+        "uri": None,
+        "version": "3.3.1",
+        "dialect": "spark",
+    }
 
 
 def test_engine_raise_on_engine_already_exists(
@@ -112,6 +130,7 @@ def test_engine_raise_on_engine_already_exists(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 201
@@ -121,6 +140,7 @@ def test_engine_raise_on_engine_already_exists(
         json={
             "name": "spark",
             "version": "3.3.1",
+            "dialect": "spark",
         },
     )
     assert response.status_code == 409

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -859,7 +859,11 @@ class TestCreateOrUpdateNodes:
         # Setting the materialization config for a source node should fail
         response = client_with_examples.post(
             "/nodes/basic.source.comments/materialization/",
-            json={"engine_name": "spark", "engine_version": "2.4.4", "config": "{}"},
+            json={
+                "engine_name": "spark",
+                "engine_version": "2.4.4",
+                "config": "{}",
+            },
         )
         assert response.status_code == 400
         assert (
@@ -879,7 +883,7 @@ class TestCreateOrUpdateNodes:
         # Create the engine and check the existing transform node
         client_with_examples.post(
             "/engines/",
-            json={"name": "spark", "version": "2.4.4"},
+            json={"name": "spark", "version": "2.4.4", "dialect": "spark"},
         )
 
         response = client_with_examples.get("/nodes/basic.transform.country_agg/")
@@ -910,7 +914,12 @@ class TestCreateOrUpdateNodes:
         assert data["materialization_configs"] == [
             {
                 "config": "blahblah",
-                "engine": {"name": "spark", "uri": None, "version": "2.4.4"},
+                "engine": {
+                    "name": "spark",
+                    "uri": None,
+                    "version": "2.4.4",
+                    "dialect": "spark",
+                },
             },
         ]
         assert old_node_data["node_revision_id"] < data["node_revision_id"]
@@ -922,6 +931,7 @@ class TestCreateOrUpdateNodes:
                 "engine_name": "spark",
                 "engine_version": "2.4.4",
                 "config": "blahblah",
+                "dialect": "spark",
             },
         )
         assert response.status_code == 204

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -9,7 +9,7 @@ from dj.sql.parsing.types import StringType
 from tests.sql.utils import compare_query_strings
 
 
-def test_sql00(
+def test_sql(
     session: Session,
     client: TestClient,
 ) -> None:

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -70,15 +70,16 @@ async def test_build_metric_with_dimensions_aggs(request):
           basic_DOT_dimension_DOT_users.country,
           basic_DOT_dimension_DOT_users.gender,
           COUNT(1) AS cnt
-        FROM basic.source.comments AS basic_DOT_source_DOT_comments LEFT OUTER JOIN (SELECT  basic_DOT_source_DOT_users.age,
-        basic_DOT_source_DOT_users.country,
-        basic_DOT_source_DOT_users.full_name,
-        basic_DOT_source_DOT_users.gender,
-        basic_DOT_source_DOT_users.id,
-        basic_DOT_source_DOT_users.preferred_language,
-        basic_DOT_source_DOT_users.secret_number
-         FROM basic.source.users AS basic_DOT_source_DOT_users) AS basic_DOT_dimension_DOT_users ON basic_DOT_source_DOT_comments.user_id = basic_DOT_dimension_DOT_users.id
-         GROUP BY  basic_DOT_dimension_DOT_users.country, basic_DOT_dimension_DOT_users.gender
+        FROM basic.source.comments AS basic_DOT_source_DOT_comments
+        LEFT OUTER JOIN (
+          SELECT
+            basic_DOT_source_DOT_users.country,
+            basic_DOT_source_DOT_users.gender,
+            basic_DOT_source_DOT_users.id
+          FROM basic.source.users AS basic_DOT_source_DOT_users
+        ) AS basic_DOT_dimension_DOT_users ON basic_DOT_source_DOT_comments.user_id = basic_DOT_dimension_DOT_users.id
+         GROUP BY
+           basic_DOT_dimension_DOT_users.country, basic_DOT_dimension_DOT_users.gender
     """
     assert compare_query_strings(str(query), expected)
 
@@ -160,12 +161,7 @@ async def test_build_metric_with_dimensions_filters(request):
     LEFT OUTER JOIN (
       SELECT
         basic_DOT_source_DOT_users.age,
-        basic_DOT_source_DOT_users.country,
-        basic_DOT_source_DOT_users.full_name,
-        basic_DOT_source_DOT_users.gender,
-        basic_DOT_source_DOT_users.id,
-        basic_DOT_source_DOT_users.preferred_language,
-        basic_DOT_source_DOT_users.secret_number
+        basic_DOT_source_DOT_users.id
       FROM basic.source.users AS basic_DOT_source_DOT_users
     ) AS basic_DOT_dimension_DOT_users
       ON basic_DOT_source_DOT_comments.user_id = basic_DOT_dimension_DOT_users.id

--- a/tests/construction/dj_query_test.py
+++ b/tests/construction/dj_query_test.py
@@ -74,17 +74,12 @@ async def test_build_dj_metric_query(request):
         AND basic_DOT_num_users_us.b_DOT_secret_number = basic_DOT_source_DOT_users.secret_number
     LEFT OUTER JOIN (
       SELECT
-        basic_DOT_source_DOT_users.age,
         basic_DOT_source_DOT_users.country,
-        basic_DOT_source_DOT_users.full_name,
-        basic_DOT_source_DOT_users.gender,
-        basic_DOT_source_DOT_users.id,
-        basic_DOT_source_DOT_users.preferred_language,
-        basic_DOT_source_DOT_users.secret_number
+        basic_DOT_source_DOT_users.id
       FROM basic.source.users AS basic_DOT_source_DOT_users
     ) AS basic_DOT_dimension_DOT_users
       ON basic_DOT_transform_DOT_country_agg.country = basic_DOT_dimension_DOT_users.country
-    GROUP BY  basic_DOT_dimension_DOT_users.country
+    GROUP BY basic_DOT_dimension_DOT_users.country
     """
     query_ast = build_dj_metric_query(construction_session, query)
     assert compare_query_strings(expected, str(query_ast))

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -21,11 +21,11 @@ EXAMPLES = (  # type: ignore
     ),
     (
         "/engines/",
-        {"name": "spark", "version": "3.1.1"},
+        {"name": "spark", "version": "3.1.1", "dialect": "spark"},
     ),
     (
         "/catalogs/default/engines/",
-        [{"name": "spark", "version": "3.1.1"}],
+        [{"name": "spark", "version": "3.1.1", "dialect": "spark"}],
     ),
     (
         "/catalogs/",

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1529,6 +1529,123 @@ EXAMPLES = (  # type: ignore
             "name": "total_profit",
         },
     ),
+    # lateral view explode/cross join unnest examples
+    (
+        "/nodes/source/",
+        {
+            "columns": {
+                "id": {"type": "int"},
+                "painter": {"type": "string"},
+                "colors": {
+                    "type": "map<string, string>",
+                },
+            },
+            "description": "Murals",
+            "mode": "published",
+            "name": "basic.murals",
+            "catalog": "public",
+            "schema_": "basic",
+            "table": "murals",
+        },
+    ),
+    (
+        "/nodes/source/",
+        {
+            "columns": {
+                "color_id": {"type": "int"},
+                "color_name": {"type": "string"},
+                "opacity": {
+                    "type": "float",
+                },
+                "luminosity": {
+                    "type": "float",
+                },
+                "garishness": {
+                    "type": "float",
+                },
+            },
+            "description": "Patch",
+            "mode": "published",
+            "name": "basic.patches",
+            "catalog": "public",
+            "schema_": "basic",
+            "table": "patches",
+        },
+    ),
+    (
+        "/nodes/transform/",
+        {
+            "query": """
+            SELECT
+              cast(color_id as varchar) color_id,
+              color_name,
+              opacity,
+              luminosity,
+              garishness
+            FROM basic.patches
+            """,
+            "description": "Corrected patches",
+            "mode": "published",
+            "name": "basic.corrected_patches",
+        },
+    ),
+    (
+        "/nodes/dimension/",
+        {
+            "query": """
+            SELECT
+              id AS mural_id,
+              t.color_id,
+              t.color_name color_name
+            FROM
+            (
+              select
+                id,
+                colors
+              from basic.murals
+             ) murals
+             CROSS JOIN UNNEST(colors) AS t(color_id, color_name)
+            """,
+            "description": "Mural paint colors",
+            "mode": "published",
+            "name": "basic.paint_colors_trino",
+            "primary_key": ["color_id", "color_name"],
+        },
+    ),
+    (
+        "/nodes/dimension/",
+        {
+            "query": """
+            SELECT
+              id AS mural_id,
+              color_id,
+              color_name color_name
+            FROM
+            (
+              select
+                id,
+                colors
+              from basic.murals
+            ) murals
+            LATERAL VIEW EXPLODE(colors) AS color_id, color_name
+            """,
+            "description": "Mural paint colors",
+            "mode": "published",
+            "name": "basic.paint_colors_spark",
+            "primary_key": ["color_id", "color_name"],
+        },
+    ),
+    (
+        "/nodes/metric/",
+        {
+            "query": """
+        SELECT AVG(luminosity) as cnt FROM basic.corrected_patches
+        """,
+            "description": "Average luminosity of color patch",
+            "mode": "published",
+            "name": "basic.avg_luminosity_patches",
+        },
+    ),
 )
 
 

--- a/tests/sql/parsing/backends/types_test.py
+++ b/tests/sql/parsing/backends/types_test.py
@@ -1,0 +1,25 @@
+"""
+Tests for types
+"""
+import dj.sql.parsing.types as ct
+
+
+def test_types_compatible():
+    """
+    Checks whether type compatibility checks work
+    """
+    assert ct.IntegerType().is_compatible(ct.IntegerType())
+    assert ct.IntegerType().is_compatible(ct.LongType())
+    assert ct.LongType().is_compatible(ct.IntegerType())
+    assert ct.TinyIntType().is_compatible(ct.BigIntType())
+    assert ct.LongType().is_compatible(ct.BigIntType())
+    assert ct.BigIntType().is_compatible(ct.IntegerType())
+    assert ct.FloatType().is_compatible(ct.DoubleType())
+    assert ct.StringType().is_compatible(ct.VarcharType())
+    assert ct.DateType().is_compatible(ct.TimeType())
+
+    assert not ct.StringType().is_compatible(ct.IntegerType())
+    assert not ct.StringType().is_compatible(ct.BooleanType())
+    assert not ct.StringType().is_compatible(ct.BinaryType())
+    assert not ct.StringType().is_compatible(ct.BigIntType())
+    assert not ct.StringType().is_compatible(ct.DateType())


### PR DESCRIPTION
### Summary

This PR has a number of miscellaneous fixes.

**Build optimization**

This change optimizes the SQL built by pruning unnecessary columns from the select of each joined subquery. It only includes columns that are (a) explicitly used in the outer query's select, where or group by clauses, (b) part of the primary key, or (c) useable as a dimension join column.

**Dialect**

This allows users to optionally set a dialect for each engine. Engines themselves can have arbitrary names, but the dialects are restricted to a set of supported SQL dialects. When users ask for SQL or data, they can either specify a dialect or rely on DJ to determine an appropriate dialect based on the available engines. There is currently no detection of nodes with incompatible dialects.

**`UNNEST`**

Adds the `UNNEST` function to support Trino's version of `EXPLODE`. 

Also added tests for SQL building of metric nodes that bring in dimensions with both `LATERAL VIEW ... EXPLODE` and the equivalent version in `CROSS JOIN ... UNNEST` and make sure that both versions can be built and resolve to runnable queries.

**Type Compatibility + More Types**

The original type compatibility checks when attaching dimensions to columns was just a simple check on column type equality, but this doesn't work because types like `int` and `long` weren't considered compatible, but they should be for the purposes of joining.

This adds a function that checks for common ancestors between two types, up to the top-level ancestors like `ColumnType` or `PrimitiveType`, meaning that that `int` and `long` will both resolve to their common ancestor `IntegerBase`, thus resolving as compatible, whereas `int` and `string` will resolve to `ColumnType` as their common ancestor, thus resolving as incompatible.

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue:
  - #458
  - #446
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
