### PR TITLE
function registry more use of dispatch/correct typings

### DIFF
--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -44,7 +44,7 @@ from dj.sql.parsing.types import (
     DoubleType,
     FloatType,
     IntegerType,
-    LongType,
+    BigIntType,
     MapType,
     NestedField,
     NullType,
@@ -1195,7 +1195,7 @@ class BinaryOp(Operation):
                 [
                     str(DoubleType()),
                     str(FloatType()),
-                    str(LongType()),
+                    str(BigIntType()),
                     str(IntegerType()),
                 ],
             )
@@ -1422,7 +1422,7 @@ class Number(Value):
         # We won't assume that anyone wants SHORT by default
         if isinstance(self.value, int):
             if self.value <= IntegerType.min or self.value >= IntegerType.max:
-                return LongType()
+                return BigIntType()
             return IntegerType()
         #
         # # Arbitrary-precision floating point

--- a/dj/sql/parsing/types.py
+++ b/dj/sql/parsing/types.py
@@ -571,7 +571,28 @@ class BigIntType(IntegerBase):
 
     def __init__(self):
         super().__init__("bigint", "BigIntType()")
+        
+class LongType(BigIntType):
+    """A Long data type can be represented using an instance of this class. Longs are
+    64-bit signed integers.
 
+    Example:
+        >>> column_foo = LongType()
+        >>> isinstance(column_foo, LongType)
+        True
+
+    Attributes:
+        max (int): The maximum allowed value for Longs, inherited from the
+        canonical Column implementation
+          in Java. (returns `9223372036854775807`)
+        min (int): The minimum allowed value for Longs, inherited from the
+        canonical Column implementation
+          in Java (returns `-9223372036854775808`)
+    """
+    def __new__(cls, *args, **kwargs):
+        self = super().__new__(BigIntType, *args, **kwargs)
+        super(BigIntType, self).__init__("long", "LongType()")
+        return self
 
 class FloatingBase(NumberType, Singleton):
     """Base class for all floating types"""

--- a/dj/sql/parsing/types.py
+++ b/dj/sql/parsing/types.py
@@ -13,6 +13,7 @@ field_type=IntegerType(), is_optional=True, doc='an optional field'))
 """
 
 import re
+from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generator, Optional, Tuple, cast
 
 from pydantic import BaseModel, Extra
@@ -156,8 +157,7 @@ class NullType(PrimitiveType, Singleton):  # pylint: disable=too-few-public-meth
     """
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("NULL", "NullType()")
+        super().__init__("NULL", "NullType()")
 
 
 class FixedType(PrimitiveType):
@@ -212,12 +212,14 @@ class DecimalType(NumberType):
         return cls._instances[key]
 
     def __init__(self, precision: int, scale: int):
-        super().__init__(
-            f"decimal({precision}, {scale})",
-            f"DecimalType(precision={precision}, scale={scale})",
-        )
-        self._precision = min(precision, DecimalType.max_precision)
-        self._scale = min(scale, DecimalType.max_scale)
+
+        if not self._initialized:
+            super().__init__(
+                f"decimal({precision}, {scale})",
+                f"DecimalType(precision={precision}, scale={scale})",
+            )
+            self._precision = min(precision, DecimalType.max_precision)
+            self._scale = min(scale, DecimalType.max_scale)
 
     @property
     def precision(self) -> int:  # pragma: no cover
@@ -270,14 +272,13 @@ class NestedField(ColumnType):
         is_optional: bool = True,
         doc: Optional[str] = None,
     ):
-        if isinstance(name, str):  # pragma: no cover
-            from dj.sql.parsing.ast import (  # pylint: disable=import-outside-toplevel
-                Name,
-            )
-
-            name = Name(name)
-
         if not self._initialized:
+            if isinstance(name, str):  # pragma: no cover
+                from dj.sql.parsing.ast import (  # pylint: disable=import-outside-toplevel
+                    Name,
+                )
+
+                name = Name(name)
             doc_string = "" if doc is None else f", doc={repr(doc)}"
             super().__init__(
                 (
@@ -389,12 +390,12 @@ class ListType(ColumnType):
         self,
         element_type: ColumnType,
     ):
+
         if not self._initialized:
             super().__init__(
                 f"array<{element_type}>",
                 f"ListType(element_type={repr(element_type)})",
             )
-
             self._element_field = NestedField(
                 name="col",  # type: ignore
                 field_type=element_type,
@@ -428,6 +429,7 @@ class MapType(ColumnType):
         key_type: ColumnType,
         value_type: ColumnType,
     ):
+        
         if not self._initialized:
             super().__init__(
                 f"map<{key_type}, {value_type}>",
@@ -468,7 +470,6 @@ class BooleanType(PrimitiveType, Singleton):
     """
 
     def __init__(self):
-        # if not self._initialized:
         super().__init__("boolean", "BooleanType()")
 
 
@@ -499,8 +500,7 @@ class IntegerType(IntegerBase):
     min: ClassVar[int] = -2147483648
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("int", "IntegerType()")
+        super().__init__("int", "IntegerType()")
 
 
 class TinyIntType(IntegerBase):
@@ -522,17 +522,38 @@ class TinyIntType(IntegerBase):
     min: ClassVar[int] = -128
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("tinyint", "TinyIntType()")
+        super().__init__("tinyint", "TinyIntType()")
 
 
-class LongType(IntegerBase):
+class SmallIntType(IntegerBase):  # pylint: disable=R0901
+    """A SmallInt data type can be represented using an instance of this class. SmallInts are
+    16-bit signed integers.
+
+    Example:
+        >>> column_foo = SmallIntType()
+        >>> isinstance(column_foo, SmallIntType)
+        True
+
+    Attributes:
+        max (int): The maximum allowed value for SmallInts (returns `32767`).
+        min (int): The minimum allowed value for SmallInts (returns `-32768`).
+    """
+
+    max: ClassVar[int] = 32767
+
+    min: ClassVar[int] = -32768
+
+    def __init__(self):
+        super().__init__("smallint", "SmallIntType()")
+
+
+class BigIntType(IntegerBase):
     """A Long data type can be represented using an instance of this class. Longs are
     64-bit signed integers.
 
     Example:
-        >>> column_foo = LongType()
-        >>> isinstance(column_foo, LongType)
+        >>> column_foo = BigIntType()
+        >>> isinstance(column_foo, BigIntType)
         True
 
     Attributes:
@@ -549,19 +570,121 @@ class LongType(IntegerBase):
     min: ClassVar[int] = -9223372036854775808
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("long", "LongType()")
+        super().__init__("bigint", "BigIntType()")
 
 
-class BigIntType(IntegerBase):
-    """Bigint type, as known as Long."""
+class FloatingBase(NumberType, Singleton):
+    """Base class for all floating types"""
 
-    max: ClassVar[int] = 9223372036854775807
 
-    min: ClassVar[int] = -9223372036854775808
+class FloatType(FloatingBase):
+    """A Float data type can be represented using an instance of this class. Floats are
+    32-bit IEEE 754 floating points and can be promoted to Doubles.
+
+    Example:
+        >>> column_foo = FloatType()
+        >>> isinstance(column_foo, FloatType)
+        True
+    """
 
     def __init__(self):
-        super().__init__("bigint", "BigIntType()")
+        super().__init__("float", "FloatType()")
+
+
+class DoubleType(FloatingBase):
+    """A Double data type can be represented using an instance of this class. Doubles are
+    64-bit IEEE 754 floating points.
+
+    Example:
+        >>> column_foo = DoubleType()
+        >>> isinstance(column_foo, DoubleType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("double", "DoubleType()")
+
+
+class DateTimeBase(PrimitiveType, Singleton):
+    """
+    Base class for date and time types.
+    """
+
+    # pylint: disable=invalid-name
+    class Unit(str, Enum):
+        """
+        Units used for date and time functions and intervals
+        """
+
+        dayofyear = "DAYOFYEAR"
+        year = "YEAR"
+        day = "DAY"
+        microsecond = "MICROSECOND"
+        month = "MONTH"
+        week = "WEEK"
+        minute = "MINUTE"
+        second = "SECOND"
+        quarter = "QUARTER"
+        hour = "HOUR"
+        millisecond = "MILLISECOND"
+
+    # pylint: enable=invalid-name
+
+
+class DateType(DateTimeBase):
+    """A Date data type can be represented using an instance of this class. Dates are
+    calendar dates without a timezone or time.
+
+    Example:
+        >>> column_foo = DateType()
+        >>> isinstance(column_foo, DateType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("date", "DateType()")
+
+
+class TimeType(DateTimeBase):
+    """A Time data type can be represented using an instance of this class. Times
+    have microsecond precision and are a time of day without a date or timezone.
+
+    Example:
+        >>> column_foo = TimeType()
+        >>> isinstance(column_foo, TimeType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("time", "TimeType()")
+
+
+class TimestampType(PrimitiveType, Singleton):
+    """A Timestamp data type can be represented using an instance of this class. Timestamps in
+    Column have microsecond precision and include a date and a time of day without a timezone.
+
+    Example:
+        >>> column_foo = TimestampType()
+        >>> isinstance(column_foo, TimestampType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("timestamp", "TimestampType()")
+
+
+class TimestamptzType(PrimitiveType, Singleton):
+    """A Timestamptz data type can be represented using an instance of this class. Timestamptzs in
+    Column are stored as UTC and include a date and a time of day with a timezone.
+
+    Example:
+        >>> column_foo = TimestamptzType()
+        >>> isinstance(column_foo, TimestamptzType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("timestamptz", "TimestamptzType()")
 
 
 class IntervalTypeBase(PrimitiveType):
@@ -580,8 +703,8 @@ class DayTimeIntervalType(IntervalTypeBase):
 
     def __new__(
         cls,
-        from_: Optional[str] = "DAY",
-        to_: Optional[str] = "SECOND",
+        from_: DateTimeBase.Unit = DateTimeBase.Unit.day,
+        to_: Optional[DateTimeBase.Unit] = DateTimeBase.Unit.second,
     ):
         key = (from_.upper(), to_.upper())  # type: ignore
         cls._instances[key] = cls._instances.get(key) or object.__new__(cls)
@@ -589,19 +712,20 @@ class DayTimeIntervalType(IntervalTypeBase):
 
     def __init__(
         self,
-        from_: str = "DAY",
-        to_: Optional[str] = "SECOND",
+        from_: DateTimeBase.Unit = DateTimeBase.Unit.day,
+        to_: Optional[DateTimeBase.Unit] = DateTimeBase.Unit.second,
     ):
-        from_ = from_.upper()
-        to_ = to_.upper()  # type: ignore
-        to_str = f" TO {to_}" if to_ else ""
-        to_repr = f', to="{to_}"' if to_ else ""
-        super().__init__(
-            f"INTERVAL {from_}{to_str}",
-            f'DayTimeIntervalType(from="{from_}"{to_repr})',
-        )
-        self._from = from_
-        self._to = to_
+        if not self._initialized:
+            from_ = from_.upper()  # type: ignore
+            to_ = to_.upper()  # type: ignore
+            to_str = f" TO {to_}" if to_ else ""
+            to_repr = f', to="{to_}"' if to_ else ""
+            super().__init__(
+                f"INTERVAL {from_}{to_str}",
+                f'DayTimeIntervalType(from="{from_}"{to_repr})',
+            )
+            self._from = from_
+            self._to = to_
 
     @property
     def from_(self) -> str:  # pylint: disable=missing-function-docstring
@@ -624,26 +748,31 @@ class YearMonthIntervalType(IntervalTypeBase):
 
     _instances: Dict[Tuple[str, str], "YearMonthIntervalType"] = {}
 
-    def __new__(cls, from_: Optional[str] = "YEAR", to_: Optional[str] = "MONTH"):
+    def __new__(
+        cls,
+        from_: DateTimeBase.Unit = DateTimeBase.Unit.year,
+        to_: Optional[DateTimeBase.Unit] = DateTimeBase.Unit.month,
+    ):
         key = (from_.upper(), to_.upper())  # type: ignore
         cls._instances[key] = cls._instances.get(key) or object.__new__(cls)
         return cls._instances[key]
 
     def __init__(
         self,
-        from_: str = "YEAR",
-        to_: Optional[str] = "MONTH",
+        from_: DateTimeBase.Unit = DateTimeBase.Unit.year,
+        to_: Optional[DateTimeBase.Unit] = DateTimeBase.Unit.month,
     ):
-        from_ = from_.upper()
-        to_ = to_.upper()  # type: ignore
-        to_str = f" TO {to_}" if to_ else ""
-        to_repr = f', to="{to_}"' if to_ else ""
-        super().__init__(
-            f"INTERVAL {from_}{to_str}",
-            f'YearMonthIntervalType(from="{from_}"{to_repr})',
-        )
-        self._from = from_
-        self._to = to_
+        if not self._initialized:
+            from_ = from_.upper()  # type: ignore
+            to_ = to_.upper()  # type: ignore
+            to_str = f" TO {to_}" if to_ else ""
+            to_repr = f', to="{to_}"' if to_ else ""
+            super().__init__(
+                f"INTERVAL {from_}{to_str}",
+                f'YearMonthIntervalType(from="{from_}"{to_repr})',
+            )
+            self._from = from_
+            self._to = to_
 
     @property
     def from_(self) -> str:  # pylint: disable=missing-function-docstring
@@ -654,106 +783,6 @@ class YearMonthIntervalType(IntervalTypeBase):
         self,
     ) -> Optional[str]:
         return self._to  # pragma: no cover
-
-
-class FloatingBase(NumberType, Singleton):
-    """Base class for all floating types"""
-
-
-class FloatType(FloatingBase):
-    """A Float data type can be represented using an instance of this class. Floats are
-    32-bit IEEE 754 floating points and can be promoted to Doubles.
-
-    Example:
-        >>> column_foo = FloatType()
-        >>> isinstance(column_foo, FloatType)
-        True
-    """
-
-    def __init__(self):
-        if not self._initialized:
-            super().__init__("float", "FloatType()")
-
-
-class DoubleType(FloatingBase):
-    """A Double data type can be represented using an instance of this class. Doubles are
-    64-bit IEEE 754 floating points.
-
-    Example:
-        >>> column_foo = DoubleType()
-        >>> isinstance(column_foo, DoubleType)
-        True
-    """
-
-    def __init__(self):
-        if not self._initialized:
-            super().__init__("double", "DoubleType()")
-
-
-class DateTimeBase(PrimitiveType, Singleton):
-    """
-    Date time base type
-    """
-
-
-class DateType(DateTimeBase):
-    """A Date data type can be represented using an instance of this class. Dates are
-    calendar dates without a timezone or time.
-
-    Example:
-        >>> column_foo = DateType()
-        >>> isinstance(column_foo, DateType)
-        True
-    """
-
-    def __init__(self):
-        if not self._initialized:
-            super().__init__("date", "DateType()")
-
-
-class TimeType(DateTimeBase):
-    """A Time data type can be represented using an instance of this class. Times
-    have microsecond precision and are a time of day without a date or timezone.
-
-    Example:
-        >>> column_foo = TimeType()
-        >>> isinstance(column_foo, TimeType)
-        True
-    """
-
-    def __init__(self):
-        if not self._initialized:
-            super().__init__("time", "TimeType()")
-
-
-class TimestampType(PrimitiveType, Singleton):
-    """A Timestamp data type can be represented using an instance of this class. Timestamps in
-    Column have microsecond precision and include a date and a time of day without a timezone.
-
-    Example:
-        >>> column_foo = TimestampType()
-        >>> isinstance(column_foo, TimestampType)
-        True
-    """
-
-    def __init__(self):
-        if not self._initialized:
-            super().__init__("timestamp", "TimestampType()")
-
-
-class TimestamptzType(PrimitiveType, Singleton):
-    """A Timestamptz data type can be represented using an instance of this class. Timestamptzs in
-    Column are stored as UTC and include a date and a time of day with a timezone.
-
-    Example:
-        >>> column_foo = TimestamptzType()
-        >>> isinstance(column_foo, TimestamptzType)
-        True
-    """
-
-    def __init__(self):
-        if not self._initialized:
-            super().__init__("timestamptz", "TimestamptzType()")
 
 
 class StringBase(PrimitiveType, Singleton):
@@ -771,8 +800,7 @@ class StringType(StringBase):
     """
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("string", "StringType()")
+        super().__init__("string", "StringType()")
 
 
 class VarcharType(StringBase):
@@ -787,8 +815,7 @@ class VarcharType(StringBase):
     """
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("varchar", "VarcharType()")
+        super().__init__("varchar", "VarcharType()")
 
 
 class UUIDType(PrimitiveType, Singleton):
@@ -802,8 +829,7 @@ class UUIDType(PrimitiveType, Singleton):
     """
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("uuid", "UUIDType()")
+        super().__init__("uuid", "UUIDType()")
 
 
 class BinaryType(PrimitiveType, Singleton):
@@ -817,8 +843,7 @@ class BinaryType(PrimitiveType, Singleton):
     """
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("binary", "BinaryType()")
+        super().__init__("binary", "BinaryType()")
 
 
 class WildcardType(PrimitiveType, Singleton):
@@ -831,8 +856,7 @@ class WildcardType(PrimitiveType, Singleton):
     """
 
     def __init__(self):
-        if not self._initialized:
-            super().__init__("wildcard", "WildcardType()")
+        super().__init__("wildcard", "WildcardType()")
 
 
 # Define the primitive data types and their corresponding Python classes
@@ -842,7 +866,7 @@ PRIMITIVE_TYPES: Dict[str, PrimitiveType] = {
     "varchar": VarcharType(),
     "bigint": BigIntType(),
     "int": IntegerType(),
-    "long": LongType(),
+    "long": BigIntType(),
     "float": FloatType(),
     "double": DoubleType(),
     "date": DateType(),

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -190,7 +190,7 @@ class TestDataForNode:
             "results": [
                 {
                     "sql": "",
-                    "columns": [{"name": "cnt", "type": "long"}],
+                    "columns": [{"name": "cnt", "type": "bigint"}],
                     "rows": [[1]],
                     "row_count": 0,
                 },

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -549,7 +549,12 @@ class TestCreateOrUpdateNodes:
         )
         assert data["columns"] == [
             {"name": "country", "type": "string", "attributes": [], "dimension": None},
-            {"name": "num_users", "type": "bigint", "attributes": [], "dimension": None},
+            {
+                "name": "num_users",
+                "type": "bigint",
+                "attributes": [],
+                "dimension": None,
+            },
         ]
         assert data["parents"] == [{"name": "basic.source.users"}]
 
@@ -601,7 +606,12 @@ class TestCreateOrUpdateNodes:
         )
         assert data["columns"] == [
             {"name": "country", "type": "string", "attributes": [], "dimension": None},
-            {"name": "num_users", "type": "bigint", "attributes": [], "dimension": None},
+            {
+                "name": "num_users",
+                "type": "bigint",
+                "attributes": [],
+                "dimension": None,
+            },
             {
                 "name": "num_entries",
                 "type": "bigint",

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -549,7 +549,7 @@ class TestCreateOrUpdateNodes:
         )
         assert data["columns"] == [
             {"name": "country", "type": "string", "attributes": [], "dimension": None},
-            {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
+            {"name": "num_users", "type": "bigint", "attributes": [], "dimension": None},
         ]
         assert data["parents"] == [{"name": "basic.source.users"}]
 
@@ -601,10 +601,10 @@ class TestCreateOrUpdateNodes:
         )
         assert data["columns"] == [
             {"name": "country", "type": "string", "attributes": [], "dimension": None},
-            {"name": "num_users", "type": "long", "attributes": [], "dimension": None},
+            {"name": "num_users", "type": "bigint", "attributes": [], "dimension": None},
             {
                 "name": "num_entries",
-                "type": "long",
+                "type": "bigint",
                 "attributes": [],
                 "dimension": None,
             },
@@ -634,7 +634,7 @@ class TestCreateOrUpdateNodes:
                 },
                 {
                     "name": "num_users",
-                    "type": "long",
+                    "type": "bigint",
                     "attributes": [],
                     "dimension": None,
                 },
@@ -648,7 +648,7 @@ class TestCreateOrUpdateNodes:
                 },
                 {
                     "name": "num_users",
-                    "type": "long",
+                    "type": "bigint",
                     "attributes": [],
                     "dimension": None,
                 },
@@ -662,13 +662,13 @@ class TestCreateOrUpdateNodes:
                 },
                 {
                     "name": "num_users",
-                    "type": "long",
+                    "type": "bigint",
                     "attributes": [],
                     "dimension": None,
                 },
                 {
                     "name": "num_entries",
-                    "type": "long",
+                    "type": "bigint",
                     "attributes": [],
                     "dimension": None,
                 },
@@ -752,7 +752,7 @@ class TestCreateOrUpdateNodes:
                 ],
                 "dimension": None,
             },
-            {"name": "user_cnt", "type": "long", "attributes": [], "dimension": None},
+            {"name": "user_cnt", "type": "bigint", "attributes": [], "dimension": None},
         ]
 
         # Test updating the dimension node with a new query
@@ -826,7 +826,7 @@ class TestCreateOrUpdateNodes:
                 ],
                 "dimension": None,
             },
-            {"name": "user_cnt", "type": "long", "attributes": [], "dimension": None},
+            {"name": "user_cnt", "type": "bigint", "attributes": [], "dimension": None},
         ]
 
         response = client.patch(

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -45,7 +45,7 @@ def test_sql(
     response = client.get("/sql/a-metric/")
     assert response.json() == {
         "sql": "SELECT  COUNT(*) col0 \n FROM rev.my_table AS my_table\n",
-        "columns": [{"name": "col0", "type": "long"}],
+        "columns": [{"name": "col0", "type": "bigint"}],
         "dialect": None,
     }
 

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -271,7 +271,40 @@ def test_infer_types_complicated(construction_session: Session):
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
     query.compile(ctx)
-    types = [IntegerType(), TimestampType(), TimestamptzType(), IntegerType(), NullType(), NullType(), IntegerType(), IntegerType(), IntegerType(), DoubleType(), BigIntType(), BigIntType(), BooleanType(), IntegerType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), BooleanType(), StringType(), StringType(), BooleanType(), StringType(), BooleanType(), FloatType(), BigIntType()]
+    types = [
+        IntegerType(),
+        TimestampType(),
+        TimestamptzType(),
+        IntegerType(),
+        NullType(),
+        NullType(),
+        IntegerType(),
+        IntegerType(),
+        IntegerType(),
+        DoubleType(),
+        BigIntType(),
+        BigIntType(),
+        BooleanType(),
+        IntegerType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        BooleanType(),
+        StringType(),
+        StringType(),
+        BooleanType(),
+        StringType(),
+        BooleanType(),
+        FloatType(),
+        BigIntType(),
+    ]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
@@ -509,7 +542,23 @@ def test_infer_types_exp(construction_session: Session):
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
     query.compile(ctx)
-    types = [DoubleType(), BigIntType(), IntegerType(), IntegerType(), DoubleType(), DoubleType(), DoubleType(), DoubleType(), DoubleType(), FloatType(), FloatType(), DoubleType(), DecimalType(precision=9, scale=6), DoubleType()]
+    types = [
+        DoubleType(),
+        BigIntType(),
+        IntegerType(),
+        IntegerType(),
+        DoubleType(),
+        DoubleType(),
+        DoubleType(),
+        DoubleType(),
+        DoubleType(),
+        FloatType(),
+        FloatType(),
+        DoubleType(),
+        DecimalType(precision=9, scale=6),
+        DecimalType(precision=3, scale=0),
+        DoubleType(),
+    ]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
@@ -591,5 +640,23 @@ def test_infer_types_datetime(construction_session: Session):
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
     query.compile(ctx)
-    types = [DateType(), TimestampType(), TimeType(), TimestampType(), TimestamptzType(), DateType(), DateType(), DateType(), DateType(), IntegerType(), IntegerType(), IntegerType(), DecimalType(precision=8, scale=6), IntegerType(), TinyIntType(), TinyIntType(), TinyIntType()]
+    types = [
+        DateType(),
+        TimestampType(),
+        TimeType(),
+        TimestampType(),
+        TimestamptzType(),
+        DateType(),
+        DateType(),
+        DateType(),
+        DateType(),
+        IntegerType(),
+        IntegerType(),
+        IntegerType(),
+        DecimalType(precision=8, scale=6),
+        IntegerType(),
+        TinyIntType(),
+        TinyIntType(),
+        TinyIntType(),
+    ]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -9,11 +9,11 @@ from dj.errors import DJNotImplementedException
 from dj.sql.functions import Avg, Coalesce, Count, Max, Min, Now, Sum, function_registry
 from dj.sql.parsing import ast
 from dj.sql.parsing.types import (
+    BigIntType,
     DecimalType,
     DoubleType,
     FloatType,
     IntegerType,
-    LongType,
     NullType,
     StringType,
     TimestamptzType,
@@ -26,7 +26,8 @@ def test_count() -> None:
     Test ``Count`` function.
     """
     assert (
-        Count.infer_type(ast.Column(ast.Name("x"), _type=WildcardType())) == LongType()
+        Count.infer_type(ast.Column(ast.Name("x"), _type=WildcardType()))
+        == BigIntType()
     )
     assert Count.is_aggregation is True
 
@@ -38,7 +39,7 @@ def test_min() -> None:
     assert (
         Min.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == IntegerType()
     )
-    assert Min.infer_type(ast.Column(ast.Name("x"), _type=LongType())) == LongType()
+    assert Min.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
     assert Min.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
     assert Min.infer_type(
         ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
@@ -56,7 +57,7 @@ def test_max() -> None:
     assert (
         Max.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == IntegerType()
     )
-    assert Max.infer_type(ast.Column(ast.Name("x"), _type=LongType())) == LongType()
+    assert Max.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
     assert Max.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
     assert Max.infer_type(
         ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
@@ -93,7 +94,7 @@ def test_coalesce_infer_type() -> None:
         Coalesce.infer_type(
             ast.Column(ast.Name("x"), _type=IntegerType()),
             ast.Column(ast.Name("x"), _type=NullType()),
-            ast.Column(ast.Name("x"), _type=LongType()),
+            ast.Column(ast.Name("x"), _type=BigIntType()),
         )
         == IntegerType()
     )
@@ -136,12 +137,12 @@ def test_sum() -> None:
     Test ``sum`` function.
     """
     assert (
-        Sum.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == IntegerType()
+        Sum.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == BigIntType()
     )
-    assert Sum.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
+    assert Sum.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == DoubleType()
     assert Sum.infer_type(
         ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
-    ) == DecimalType(8, 6)
+    ) == DecimalType(18, 6)
 
 
 def test_avg() -> None:

--- a/tests/sql/parsing/backends/types_test.py
+++ b/tests/sql/parsing/backends/types_test.py
@@ -9,10 +9,10 @@ def test_types_compatible():
     Checks whether type compatibility checks work
     """
     assert ct.IntegerType().is_compatible(ct.IntegerType())
-    assert ct.IntegerType().is_compatible(ct.LongType())
-    assert ct.LongType().is_compatible(ct.IntegerType())
+    assert ct.IntegerType().is_compatible(ct.BigIntType())
+    assert ct.BigIntType().is_compatible(ct.IntegerType())
     assert ct.TinyIntType().is_compatible(ct.BigIntType())
-    assert ct.LongType().is_compatible(ct.BigIntType())
+    assert ct.BigIntType().is_compatible(ct.BigIntType())
     assert ct.BigIntType().is_compatible(ct.IntegerType())
     assert ct.FloatType().is_compatible(ct.DoubleType())
     assert ct.StringType().is_compatible(ct.VarcharType())


### PR DESCRIPTION
### Summary

WIP prelim review

Just adding more use of dispatch to get the type checks in the function registry + correcting typings 

I'm using these as references:

Spark:
https://github.com/apache/spark/tree/74cddcfda3ac4779de80696cdae2ba64d53fc635/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions

https://spark.apache.org/docs/2.3.0/api/sql/index.html

As I've come upon functions that are not in that last link, I am removing them for now 

Java strictmath reference
https://docs.oracle.com/javase/8/docs/api/java/lang/StrictMath.html

Databricks reference:
https://docs.databricks.com/sql/language-manual/sql-ref-functions-builtin-alpha.html

I've also ~~gotten rid of~~ _aliased_ Long in favor of bigint and added smallint

### Test Plan

unit and doctests

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

