### PR TITLE
Several namespaces changes  + Dockerfile reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM python:3.10
 
+ARG RELOAD="--reload"
+ENV RELOAD ${RELOAD}
+
 WORKDIR /code
 COPY . /code
 RUN pip install --no-cache-dir --upgrade -r /code/requirements/docker.txt
 RUN pip install -e .
 RUN pip install opentelemetry-distro==0.38b0 opentelemetry-exporter-otlp-proto-grpc==1.17.0
 
-CMD ["opentelemetry-instrument", "uvicorn", "dj.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "opentelemetry-instrument uvicorn dj.api.main:app --host 0.0.0.0 --port 8000 $RELOAD"]
 EXPOSE 8000

--- a/client/python/.isort.cfg
+++ b/client/python/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile = black
+known_first_party = djclient

--- a/client/python/djclient/__init__.py
+++ b/client/python/djclient/__init__.py
@@ -3,7 +3,16 @@ A DataJunction client for connecting to a DataJunction server
 """
 __version__ = "0.0.1a1"
 
-from djclient.dj import Cube, Dimension, DJClient, Metric, Node, Source, Transform
+from djclient.dj import (
+    Cube,
+    Dimension,
+    DJClient,
+    Metric,
+    Namespace,
+    Node,
+    Source,
+    Transform,
+)
 
 __all__ = [
     "DJClient",
@@ -13,4 +22,5 @@ __all__ = [
     "Metric",
     "Cube",
     "Node",
+    "Namespace",
 ]

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -32,6 +32,8 @@ profile = 'black'
 
 [tool.poetry.dependencies]
 python = "^3.8"
+pandas = ">=2"
+pydantic = ">=1"
 
 [tool.poetry.dev-dependencies]
 coverage = "7.2.2"

--- a/client/python/setup.cfg
+++ b/client/python/setup.cfg
@@ -5,7 +5,7 @@
 
 [metadata]
 name = djclient
-description = Add a short description here!
+description = DJ client library
 author = DataJunction
 license = MIT
 license_files = LICENSE.txt
@@ -31,7 +31,7 @@ zip_safe = False
 packages = find_namespace:
 include_package_data = True
 package_dir =
-    =src
+    =djclient
 
 # Require a min/specific Python version (comma-separated conditions)
 python_requires = >=3.8
@@ -42,11 +42,11 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    pydantic
-    pandas
+    pydantic>=1
+    pandas>=2
 
 [options.packages.find]
-where = src
+where = djclient
 exclude =
     tests
 

--- a/dj/api/main.py
+++ b/dj/api/main.py
@@ -24,6 +24,7 @@ from dj.api import (
     engines,
     health,
     metrics,
+    namespaces,
     nodes,
     query,
     sql,
@@ -74,6 +75,7 @@ def get_dj_app(
     application.include_router(metrics.router)
     application.include_router(query.router)
     application.include_router(nodes.router)
+    application.include_router(namespaces.router)
     application.include_router(data.router)
     application.include_router(health.router)
     application.include_router(cubes.router)

--- a/dj/api/namespaces.py
+++ b/dj/api/namespaces.py
@@ -1,0 +1,90 @@
+"""
+Node namespace related APIs.
+"""
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import joinedload
+from sqlmodel import Session, select
+
+from dj.api.helpers import get_node_namespace
+from dj.models.node import Node, NodeNamespace, NodeOutput
+from dj.utils import get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post("/namespaces/{namespace}/", status_code=201)
+def create_a_node_namespace(
+    namespace: str,
+    session: Session = Depends(get_session),
+) -> JSONResponse:
+    """
+    Create a node namespace
+    """
+    if get_node_namespace(
+        session=session,
+        namespace=namespace,
+        raise_if_not_exists=False,
+    ):  # pragma: no cover
+        return JSONResponse(
+            status_code=409,
+            content={
+                "message": (f"Node namespace `{namespace}` already exists"),
+            },
+        )
+    node_namespace = NodeNamespace(namespace=namespace)
+    session.add(node_namespace)
+    session.commit()
+    return JSONResponse(
+        status_code=201,
+        content={
+            "message": (f"Node namespace `{namespace}` has been successfully created"),
+        },
+    )
+
+
+@router.get(
+    "/namespaces/",
+    response_model=List[NodeNamespace],
+    status_code=200,
+)
+def list_node_namespaces(
+    session: Session = Depends(get_session),
+) -> List[NodeNamespace]:
+    """
+    List node namespaces
+    """
+    namespaces = session.exec(select(NodeNamespace)).all()
+    return namespaces
+
+
+@router.get(
+    "/namespaces/{namespace}/",
+    response_model=List[NodeOutput],
+    status_code=200,
+)
+def list_nodes_in_namespace(
+    namespace: str,
+    session: Session = Depends(get_session),
+) -> List[NodeOutput]:
+    """
+    List nodes in namespace
+    """
+    nodes = (
+        session.exec(
+            select(Node)
+            .options(joinedload(Node.current))
+            .where(
+                Node.namespace.like(  # type: ignore  # pylint: disable=no-member
+                    f"{namespace}%",
+                ),
+            ),
+        )
+        .unique()
+        .all()
+    )
+    return nodes  # type: ignore

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -621,9 +621,9 @@ def create_a_node_namespace(
 
 
 @router.get(
-    "/namespaces/all/",
+    "/namespaces/",
     response_model=List[NodeNamespace],
-    status_code=201,
+    status_code=200,
 )
 def list_node_namespaces(
     session: Session = Depends(get_session),
@@ -633,6 +633,27 @@ def list_node_namespaces(
     """
     namespaces = session.exec(select(NodeNamespace)).all()
     return namespaces
+
+
+@router.get(
+    "/namespaces/{namespace}/",
+    response_model=List[NodeOutput],
+    status_code=200,
+)
+def list_nodes_in_namespace(
+    namespace: str,
+    session: Session = Depends(get_session),
+) -> List[NodeOutput]:
+    """
+    List nodes in namespace
+    """
+    nodes = (
+        session.exec(
+            select(Node).options(joinedload(Node.current))
+            .where(Node.namespace.like(f"{namespace}%"))
+        ).unique().all()
+    )
+    return nodes  # type: ignore
 
 
 @router.post("/nodes/transform/", response_model=NodeOutput, status_code=201)

--- a/tests/api/namespaces_test.py
+++ b/tests/api/namespaces_test.py
@@ -1,0 +1,55 @@
+"""
+Tests for the namespaces API.
+"""
+from fastapi.testclient import TestClient
+
+
+def test_list_all_namespaces(client_with_examples: TestClient) -> None:
+    """
+    Test ``GET /namespaces/``.
+    """
+    response = client_with_examples.get("/namespaces/")
+    assert response.ok
+    assert response.json() == [
+        {"namespace": "default"},
+        {"namespace": "foo.bar"},
+        {"namespace": "basic"},
+        {"namespace": "basic.source"},
+        {"namespace": "basic.transform"},
+        {"namespace": "basic.dimension"},
+        {"namespace": "dbt.source"},
+        {"namespace": "dbt.source.jaffle_shop"},
+        {"namespace": "dbt.transform"},
+        {"namespace": "dbt.dimension"},
+        {"namespace": "dbt.source.stripe"},
+    ]
+
+
+def test_list_nodes_by_namespace(client_with_examples: TestClient) -> None:
+    """
+    Test ``GET /namespaces/{namespace}/``.
+    """
+    response = client_with_examples.get("/namespaces/basic.source/")
+    assert response.ok
+    assert [node["name"] for node in response.json()] == [
+        "basic.source.users",
+        "basic.source.comments",
+    ]
+
+    response = client_with_examples.get("/namespaces/basic/")
+    assert response.ok
+    assert [node["name"] for node in response.json()] == [
+        "basic.source.users",
+        "basic.dimension.users",
+        "basic.source.comments",
+        "basic.dimension.countries",
+        "basic.transform.country_agg",
+        "basic.num_comments",
+        "basic.num_users",
+        "basic.murals",
+        "basic.patches",
+        "basic.corrected_patches",
+        "basic.paint_colors_trino",
+        "basic.paint_colors_spark",
+        "basic.avg_luminosity_patches",
+    ]

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -18,7 +18,7 @@ def test_list_all_namespaces(client_with_examples: TestClient) -> None:
     """
     Test ``GET /namespaces/all/``.
     """
-    response = client_with_examples.get("/namespaces/all")
+    response = client_with_examples.get("/namespaces/")
     assert response.ok
     assert response.json() == [
         {"namespace": "default"},
@@ -32,6 +32,36 @@ def test_list_all_namespaces(client_with_examples: TestClient) -> None:
         {"namespace": "dbt.transform"},
         {"namespace": "dbt.dimension"},
         {"namespace": "dbt.source.stripe"},
+    ]
+
+
+def test_list_nodes_by_namespace(client_with_examples: TestClient) -> None:
+    """
+    Test ``GET /namespaces/all/``.
+    """
+    response = client_with_examples.get("/namespaces/basic.source/")
+    assert response.ok
+    assert [node["name"] for node in response.json()] == [
+        "basic.source.users",
+        "basic.source.comments",
+    ]
+
+    response = client_with_examples.get("/namespaces/basic/")
+    assert response.ok
+    assert [node["name"] for node in response.json()] == [
+        "basic.source.users",
+        "basic.dimension.users",
+        "basic.source.comments",
+        "basic.dimension.countries",
+        "basic.transform.country_agg",
+        "basic.num_comments",
+        "basic.num_users",
+        "basic.murals",
+        "basic.patches",
+        "basic.corrected_patches",
+        "basic.paint_colors_trino",
+        "basic.paint_colors_spark",
+        "basic.avg_luminosity_patches",
     ]
 
 

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -14,57 +14,6 @@ from dj.models.node import Node, NodeRevision, NodeStatus, NodeType
 from dj.sql.parsing.types import IntegerType, StringType, TimestampType
 
 
-def test_list_all_namespaces(client_with_examples: TestClient) -> None:
-    """
-    Test ``GET /namespaces/all/``.
-    """
-    response = client_with_examples.get("/namespaces/")
-    assert response.ok
-    assert response.json() == [
-        {"namespace": "default"},
-        {"namespace": "foo.bar"},
-        {"namespace": "basic"},
-        {"namespace": "basic.source"},
-        {"namespace": "basic.transform"},
-        {"namespace": "basic.dimension"},
-        {"namespace": "dbt.source"},
-        {"namespace": "dbt.source.jaffle_shop"},
-        {"namespace": "dbt.transform"},
-        {"namespace": "dbt.dimension"},
-        {"namespace": "dbt.source.stripe"},
-    ]
-
-
-def test_list_nodes_by_namespace(client_with_examples: TestClient) -> None:
-    """
-    Test ``GET /namespaces/all/``.
-    """
-    response = client_with_examples.get("/namespaces/basic.source/")
-    assert response.ok
-    assert [node["name"] for node in response.json()] == [
-        "basic.source.users",
-        "basic.source.comments",
-    ]
-
-    response = client_with_examples.get("/namespaces/basic/")
-    assert response.ok
-    assert [node["name"] for node in response.json()] == [
-        "basic.source.users",
-        "basic.dimension.users",
-        "basic.source.comments",
-        "basic.dimension.countries",
-        "basic.transform.country_agg",
-        "basic.num_comments",
-        "basic.num_users",
-        "basic.murals",
-        "basic.patches",
-        "basic.corrected_patches",
-        "basic.paint_colors_trino",
-        "basic.paint_colors_spark",
-        "basic.avg_luminosity_patches",
-    ]
-
-
 def test_read_node(client_with_examples: TestClient) -> None:
     """
     Test ``GET /nodes/{node_id}``.

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -1,7 +1,7 @@
+# pylint: disable=too-many-lines
 """
 Tests for the nodes API.
 """
-# pylint: disable=too-many-lines
 from typing import Any, Dict
 
 import pytest


### PR DESCRIPTION
### Summary

A few changes for namespaces:
* Adding the ability to list nodes for a given namespace
* Fixed a bug where source nodes weren't being assigned namespaces
* Moved namespaces out to their own module (there appears to be enough functionality here)
* Added client support for listing nodes in a namespace.

Added reload as an arg to the Dockerfile in case dj-demo wants to use this argument.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
