### PR TITLE
Update client to use the factory pattern

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -53,24 +53,24 @@ catalog.add_engine(engine)
 
 ### Nodes
 
-All nodes can be found with:
+All nodes for a given namespace can be found with:
 ```python
-dj.nodes()
+dj.namespace("default").nodes()
 ```
 
 Specific node types can be retrieved with:
 ```python
-dj.sources()
-dj.dimensions()
-dj.metrics()
-dj.transforms()
-dj.cubes()
+dj.namespace("default").sources()
+dj.namespace("default").dimensions()
+dj.namespace("default").metrics()
+dj.namespace("default").transforms()
+dj.namespace("default").cubes()
 ```
 
 To create a source node:
 ```python
-from djclient import Source
-repair_orders = Source(
+from djclient import NodeMode
+repair_orders = dj.new_source(
     name="repair_orders",
     display_name="Repair Orders",
     description="Repair orders",
@@ -78,18 +78,17 @@ repair_orders = Source(
     schema_="roads",
     table="repair_orders",
 )
-repair_orders.publish()
+repair_orders.save(mode=NodeMode.PUBLISHED)
 ```
 
 Nodes can also be created as drafts with:
 ```python
-repair_orders.draft()
+repair_orders.save(mode=NodeMode.DRAFT)
 ```
 
 To create a dimension node:
 ```python
-from djclient import Dimension
-repair_order = Dimension(
+repair_order = dj.new_dimension(
     name="repair_order",
     query="""
     SELECT
@@ -100,14 +99,14 @@ repair_order = Dimension(
     FROM repair_orders
     """,
     description="Repair order dimension",
+    primary_key=["repair_order_id"],
 )
-repair_order.publish()
+repair_order.save()
 ```
 
 To create a transform node:
 ```python
-from djclient import Transform
-large_revenue_payments_only = Transform(
+large_revenue_payments_only = dj.new_transform(
     name="large_revenue_payments_only",
     query="""
     SELECT
@@ -120,13 +119,12 @@ large_revenue_payments_only = Transform(
     """,
     description="Only large revenue payments",
 )
-large_revenue_payments_only.publish()
+large_revenue_payments_only.save()
 ```
 
 To create a metric:
 ```python
-from djclient import Metric
-num_repair_orders = Metric(
+num_repair_orders = dj.new_metric(
     name="num_repair_orders",
     query="""
     SELECT
@@ -135,5 +133,5 @@ num_repair_orders = Metric(
     """,
     description="Number of repair orders",
 )
-num_repair_orders.publish()
+num_repair_orders.save()
 ```

--- a/client/python/djclient/__init__.py
+++ b/client/python/djclient/__init__.py
@@ -10,6 +10,7 @@ from djclient.dj import (
     Metric,
     Namespace,
     Node,
+    NodeMode,
     Source,
     Transform,
 )
@@ -22,5 +23,6 @@ __all__ = [
     "Metric",
     "Cube",
     "Node",
+    "NodeMode",
     "Namespace",
 ]

--- a/client/python/djclient/dj.py
+++ b/client/python/djclient/dj.py
@@ -400,8 +400,8 @@ class DJClient:  # pylint: disable=too-many-public-methods
             "cube": Cube,
         }
         return [
-            node_type_to_classes[node["type"]].parse_obj(  # type: ignore
-                {**node, **{"dj_client": self}},
+            node_type_to_classes[node["type"]](  # type: ignore
+                **{**node, **{"dj_client": self}},
             )
             for node in nodes_list
             if not type_ or node["type"] == type_
@@ -632,16 +632,18 @@ class Source(Node):
     table: str
     columns: Optional[List[Column]]
 
-    @classmethod
     @validator("catalog", pre=True)
-    def parse_cls(cls, value: Union[str, Dict[str, Any]]) -> str:
+    def parse_cls(  # pylint: disable=no-self-argument
+        cls,
+        value: Union[str, Dict[str, Any]],
+    ) -> str:
         """
         When `catalog` is a dictionary, parse out the catalog's
         name, otherwise just return the string.
         """
-        if isinstance(value, str):  # pragma: no cover
+        if isinstance(value, str):
             return value
-        return value["name"]  # pragma: no cover
+        return value["name"]
 
 
 class Transform(Node):

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "djclient"
-version = "0.0.1a1"
+version = "0.0.1a2"
 readme = "README.md"
 repository = "https://github.com/DataJunction/dj"
 description = "DataJunction client library for connecting to a DataJunction server"

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "djclient"
-version = "0.0.1a2"
+version = "0.0.1a3"
 readme = "README.md"
 repository = "https://github.com/DataJunction/dj"
 description = "DataJunction client library for connecting to a DataJunction server"

--- a/client/python/tests/test_dj_client.py
+++ b/client/python/tests/test_dj_client.py
@@ -113,7 +113,7 @@ class TestDJClient:
             {
                 "name": "node1",
                 "type": "source",
-                "catalog": "prod",
+                "catalog": {"name": "prod"},
                 "schema_": "random",
                 "table": "test",
             },

--- a/docs/content/0.1.0/docs/getting-started/creating-nodes/dimensions.md
+++ b/docs/content/0.1.0/docs/getting-started/creating-nodes/dimensions.md
@@ -47,27 +47,25 @@ curl -X POST http://localhost:8000/nodes/dimension/ \
 {{< /tab >}}
 {{< tab "python" >}}
 ```py
-from djclient import DJ, Dimension
+from djclient import DJClient, NodeMode
 
-client = DJ("http://localhost:8000/")
-client.push(
-    Dimension(
-        name="us_state",
-        description="US state dimension",
-        mode="published",
-        query="""
-            SELECT
-            state_id,
-            state_name,
-            state_abbr,
-            state_region,
-            r.us_region_description AS state_region_description
-            FROM us_states s
-            LEFT JOIN us_region r
-            ON s.state_region = r.us_region_id
-        """,
-    )
+dj = DJClient("http://localhost:8000/")
+dimension = dj.new_dimension(
+    name="us_state",
+    description="US state dimension",
+    query="""
+        SELECT
+        state_id,
+        state_name,
+        state_abbr,
+        state_region,
+        r.us_region_description AS state_region_description
+        FROM us_states s
+        LEFT JOIN us_region r
+        ON s.state_region = r.us_region_id
+    """,
 )
+dimension.save(NodeMode.PUBLISHED)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/0.1.0/docs/getting-started/creating-nodes/metrics.md
+++ b/docs/content/0.1.0/docs/getting-started/creating-nodes/metrics.md
@@ -33,17 +33,15 @@ curl -X POST http://localhost:8000/nodes/metric/ \
 {{< /tab >}}
 {{< tab "python" >}}
 ```py
-from djclient import DJ, Metric
+from djclient import DJClient, NodeMode
 
-client = DJ("http://localhost:8000/")
-client.push(
-    Metric(
-        name="num_repair_orders",
-        description="Number of repair orders",
-        mode="published",
-        query="SELECT count(repair_order_id) as num_repair_orders FROM repair_orders",
-    )
+dj = DJClient("http://localhost:8000/")
+metric = dj.new_metric(
+    name="num_repair_orders",
+    description="Number of repair orders",
+    query="SELECT count(repair_order_id) as num_repair_orders FROM repair_orders",
 )
+metric.save(NodeMode.PUBLISHED)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/0.1.0/docs/getting-started/creating-nodes/sources.md
+++ b/docs/content/0.1.0/docs/getting-started/creating-nodes/sources.md
@@ -48,28 +48,26 @@ curl -X POST http://localhost:8000/nodes/source/ \
 {{< /tab >}}
 {{< tab "python" >}}
 ```py
-from djclient import DJ, Source
+from djclient import DJClient, NodeMode
 
-client = DJ("http://localhost:8000/")
-client.push(
-    Source(
-        name="repair_orders",
-        description="Repair orders",
-        mode="published",
-        catalog="default",
-        schema_="roads",
-        table="repair_orders",
-        columns={
-            "repair_order_id": {"type": "int"},
-            "municipality_id": {"type": "string"},
-            "hard_hat_id": {"type": "int"},
-            "order_date": {"type": "timestamp"},
-            "required_date": {"type": "timestamp"},
-            "dispatched_date": {"type": "timestamp"},
-            "dispatcher_id": {"type": "int"}
-        },
-    )
+dj = DJClient("http://localhost:8000/")
+source = dj.new_source(
+    name="repair_orders",
+    description="Repair orders",
+    catalog="default",
+    schema_="roads",
+    table="repair_orders",
+    columns=[
+        {"name": "repair_order_id", "type": "int"},
+        {"name": "municipality_id", "type": "string"},
+        {"name": "hard_hat_id", "type": "int"},
+        {"name": "order_date", "type": "timestamp"},
+        {"name": "required_date", "type": "timestamp"},
+        {"name": "dispatched_date", "type": "timestamp"},
+        {"name": "dispatcher_id", "type": "int"},
+    ],
 )
+source.save(mode=NodeMode.PUBLISHED)
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -97,19 +95,17 @@ curl -X POST http://localhost:8000/nodes/source/ \
 {{< /tab >}}
 {{< tab "python" >}}
 ```py
-from djclient import DJ, Source
+from djclient import DJClient, NodeMode
 
-client = DJ("http://localhost:8000/")
-client.push(
-    Source(
-        name="repair_orders",
-        description="Repair orders",
-        mode="published",
-        catalog="default",
-        schema_="roads",
-        table="repair_orders",
-    )
+dj = DJClient("http://localhost:8000/")
+source = dj.new_source(
+    name="repair_orders",
+    description="Repair orders",
+    catalog="default",
+    schema_="roads",
+    table="repair_orders",
 )
+source.save(NodeMode.PUBLISHED)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/0.1.0/docs/getting-started/creating-nodes/transforms.md
+++ b/docs/content/0.1.0/docs/getting-started/creating-nodes/transforms.md
@@ -43,25 +43,23 @@ curl -X POST http://localhost:8000/nodes/transform/ \
 {{< /tab >}}
 {{< tab "python" >}}
 ```py
-from djclient import DJ, Transform
+from djclient import DJClient, NodeMode
 
-client = DJ("http://localhost:8000/")
-client.push(
-    Transform(
-        name="repair_orders_w_dispatchers",
-        description="Repair orders that have a dispatcher",
-        mode="published",
-        query="""
-            SELECT
-            repair_order_id,
-            municipality_id,
-            hard_hat_id,
-            dispatcher_id
-            FROM repair_orders
-            WHERE dispatcher_id IS NOT NULL
-        """,
-    )
+dj = DJClient("http://localhost:8000/")
+transform = dj.new_transform(
+    name="repair_orders_w_dispatchers",
+    description="Repair orders that have a dispatcher",
+    query="""
+        SELECT
+        repair_order_id,
+        municipality_id,
+        hard_hat_id,
+        dispatcher_id
+        FROM repair_orders
+        WHERE dispatcher_id IS NOT NULL
+    """,
 )
+transform.save(NodeMode.PUBLISHED)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version_scheme = "no-guess-dev"
 
 [tool.poetry]
 name = "datajunction"
-version = "0.0.1a4"
+version = "0.0.1a5"
 readme = "README.rst"
 repository = "https://github.com/DataJunction/dj"
 description = "DataJunction server library for running to a DataJunction server"


### PR DESCRIPTION
### Summary

This change modifies the client to use the factory pattern, which makes it clearer when we're creating objects vs retrieving objects. Also added an optional `requests_session` to the client initializer.

Creating nodes now takes the form of:
```py
from djclient import DJClient, NodeMode

dj = DJClient("http://localhost:8000/")
source = dj.new_source(
    name="repair_orders",
    description="Repair orders",
    catalog="default",
    schema_="roads",
    table="repair_orders",
)
source.save(NodeMode.PUBLISHED)
```

A node can be rehydrated with data from the server using:
```py
node.sync()
```

This also lets us remove the `REGISTRY` global object.

### Test Plan

Tested things end-to-end against a DJ deploy

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

We should be able to release a version of the client once this gets in.