### PR TITLE
Decompose Cube Metrics

### DIFF
--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -311,14 +311,20 @@ def cube_materialization_config(cube_node: NodeRevision, config: Dict):
         **config,
         **{
             "measures": {
-                metric.alias_or_name.name: [
-                    Measure(
-                        name=str(measure.alias_or_name),
-                        agg=str(measure.child.name),
-                        expr=str(measure.child),
-                    ).dict()
-                    for measure in measures
-                ]
+                metric.alias_or_name.name: sorted(
+                    [
+                        measure_obj.dict()
+                        for measure_obj in {
+                            Measure(
+                                name=str(measure.alias_or_name),
+                                agg=str(measure.child.name),
+                                expr=str(measure.child),
+                            )
+                            for measure in measures
+                        }
+                    ],
+                    key=lambda x: x["name"],
+                )
                 for metric, measures in metrics_to_measures.items()
             },
         },

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """
 Node related APIs.
 """
@@ -6,7 +7,7 @@ import logging
 import os
 from collections import defaultdict
 from http import HTTPStatus
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
@@ -35,6 +36,7 @@ from dj.models import ColumnAttribute
 from dj.models.attribute import AttributeType, UniquenessScope
 from dj.models.base import generate_display_name
 from dj.models.column import Column, ColumnAttributeInput
+from dj.models.cube import Measure
 from dj.models.node import (
     DEFAULT_DRAFT_VERSION,
     DEFAULT_PUBLISHED_VERSION,
@@ -57,6 +59,7 @@ from dj.models.node import (
     UpsertMaterializationConfig,
 )
 from dj.service_clients import QueryServiceClient
+from dj.sql.parsing import ast
 from dj.sql.parsing.backends.antlr4 import parse
 from dj.sql.parsing.backends.exceptions import DJParseException
 from dj.utils import (
@@ -272,6 +275,58 @@ def delete_a_node(name: str, *, session: Session = Depends(get_session)):
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
+def cube_materialization_config(cube_node: NodeRevision, config: Dict):
+    """
+    Builds the materialization config for a cube. This includes two parts:
+    (a) building a query that decomposes each of the cube's metrics into their
+    constituent measures that have simple aggregations
+    (b) adding a metric to measures mapping that tells us which measures
+    in the query map to each selected metric
+
+    The query in the materialization config is different from the one stored
+    on the cube node itself in that this one is meant to create a temporary
+    table in preparation for ingestion into an OLAP database like Druid. The
+    metric to measures mapping then provides information on how to assemble
+    metrics from measures based on this query's output.
+
+    The query directly on the cube node is meant for direct querying of the cube
+    without materialization to an OLAP database.
+    """
+    combined_ast = parse(cube_node.query)
+    dimensions_set = {
+        dim.name for dim in cube_node.columns if dim.has_dimension_attribute()
+    }
+    metrics_to_measures = decompose_metrics(combined_ast, dimensions_set)
+    new_select_projection: Set[Union[ast.Aliasable, ast.Expression]] = set()
+    for expr in combined_ast.select.projection:
+        if expr in metrics_to_measures:
+            new_select_projection = set(new_select_projection).union(
+                metrics_to_measures[expr],
+            )
+        else:
+            new_select_projection.add(expr)
+    combined_ast.select.projection = list(new_select_projection)
+
+    config = {
+        **config,
+        **{
+            "measures": {
+                metric.alias_or_name.name: [
+                    Measure(
+                        name=str(measure.alias_or_name),
+                        agg=str(measure.child.name),
+                        expr=str(measure.child),
+                    ).dict()
+                    for measure in measures
+                ]
+                for metric, measures in metrics_to_measures.items()
+            },
+        },
+        **{"query": str(combined_ast)},
+    }
+    return config
+
+
 @router.post("/nodes/{name}/materialization/", status_code=201)
 def upsert_a_materialization_config(
     name: str,
@@ -318,6 +373,10 @@ def upsert_a_materialization_config(
         for config in current_revision.materialization_configs
         if config.engine.name != data.engine_name
     ]
+
+    if current_revision.type == NodeType.CUBE:
+        data.config = cube_materialization_config(current_revision, data.config)
+
     new_config = MaterializationConfig(
         node_revision=current_revision,
         engine=engine,
@@ -414,6 +473,75 @@ def create_node_revision(
     node_revision.columns = validated_node.columns or []
     node_revision.catalog_id = catalog_id
     return node_revision
+
+
+def decompose_expression(expr: Union[ast.Aliasable, ast.Expression]) -> List[ast.Alias]:
+    """
+    Simple aggregations are operations that can be computed incrementally as new
+    data is ingested, without relying on the results of other aggregations.
+    Examples include SUM, COUNT, MIN, MAX.
+
+    Some complex aggregations can be decomposed to simple aggregations: i.e., AVG(x) can
+    be decomposed to SUM(x)/COUNT(x).
+    """
+    if isinstance(expr, ast.Alias):
+        expr = expr.child
+
+    simple_aggregations = {"sum", "count", "min", "max"}
+    if isinstance(expr, ast.Function):
+        function_name = expr.alias_or_name.name.lower()
+        columns = [col for arg in expr.args for col in arg.find_all(ast.Column)]
+        readable_name = (
+            "_".join(
+                str(col.alias_or_name).rsplit(".", maxsplit=1)[-1] for col in columns
+            )
+            if columns
+            else "placeholder"
+        )
+        if function_name in simple_aggregations:
+            return [expr.set_alias(ast.Name(f"{readable_name}_{function_name}"))]
+        if function_name == "avg":  # pragma: no cover
+            return [
+                (
+                    ast.Function(ast.Name("sum"), args=expr.args).set_alias(
+                        ast.Name(f"{readable_name}_sum"),
+                    )
+                ),
+                (
+                    ast.Function(ast.Name("count"), args=expr.args).set_alias(
+                        ast.Name(f"{readable_name}_count"),
+                    )
+                ),
+            ]
+    acceptable_binary_ops = {
+        ast.BinaryOpKind.Plus,
+        ast.BinaryOpKind.Minus,
+        ast.BinaryOpKind.Multiply,
+        ast.BinaryOpKind.Divide,
+    }
+    if isinstance(expr, ast.BinaryOp):
+        if expr.op in acceptable_binary_ops:  # pragma: no cover
+            measures_left = decompose_expression(expr.left)
+            measures_right = decompose_expression(expr.right)
+            return measures_left + measures_right
+    if isinstance(expr, ast.Cast):
+        return decompose_expression(expr.expression)
+    raise DJInvalidInputException(  # pragma: no cover
+        f"Metric expression {expr} cannot be decomposed into its constituent measures",
+    )
+
+
+def decompose_metrics(combined_ast: ast.Query, dimensions_set: Set[str]):
+    """
+    Decompose each metric into simple constituent measures and return a dict
+    that maps each metric to its measures.
+    """
+    metrics_to_measures = {}
+    for expr in combined_ast.select.projection:
+        if expr.alias_or_name.name not in dimensions_set:  # type: ignore
+            measure_expressions = decompose_expression(expr)
+            metrics_to_measures[expr] = measure_expressions
+    return metrics_to_measures
 
 
 def create_cube_node_revision(  # pylint: disable=too-many-locals

--- a/dj/models/column.py
+++ b/dj/models/column.py
@@ -85,6 +85,15 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         """
         return self.name, self.type
 
+    def has_dimension_attribute(self) -> bool:
+        """
+        Whether the dimension attribute is set on this column.
+        """
+        return any(
+            attr.attribute_type.name == "dimension"
+            for attr in self.attributes  # pylint: disable=not-an-iterable
+        )
+
     def __hash__(self) -> int:
         return hash(self.id)
 

--- a/dj/models/cube.py
+++ b/dj/models/cube.py
@@ -7,7 +7,12 @@ from typing import List, Optional
 from pydantic import Field, root_validator
 from sqlmodel import SQLModel
 
-from dj.models.node import AvailabilityState, ColumnOutput, NodeType
+from dj.models.node import (
+    AvailabilityState,
+    ColumnOutput,
+    MaterializationConfig,
+    NodeType,
+)
 from dj.typing import UTCDatetime
 
 
@@ -31,6 +36,16 @@ class CubeElementMetadata(SQLModel):
         return values
 
 
+class Measure(SQLModel):
+    """
+    A measure with a simple aggregation
+    """
+
+    name: str
+    agg: str
+    expr: str
+
+
 class CubeRevisionMetadata(SQLModel):
     """
     Metadata for a cube node
@@ -48,6 +63,7 @@ class CubeRevisionMetadata(SQLModel):
     query: str
     columns: List[ColumnOutput]
     updated_at: UTCDatetime
+    materialization_configs: List[MaterializationConfig]
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         allow_population_by_field_name = True

--- a/dj/models/cube.py
+++ b/dj/models/cube.py
@@ -45,6 +45,12 @@ class Measure(SQLModel):
     agg: str
     expr: str
 
+    def __eq__(self, other):
+        return tuple(self.__dict__.items()) == tuple(other.__dict__.items())
+
+    def __hash__(self):
+        return hash(tuple(self.__dict__.items()))
+
 
 class CubeRevisionMetadata(SQLModel):
     """

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -473,6 +473,9 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
                     f"Node {self.name} of type cube node needs cube elements",
                 )
 
+    class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        extra = Extra.allow
+
 
 class ImmutableNodeFields(BaseSQLModel):
     """

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -220,7 +220,7 @@ def test_cube_sql(client_with_examples: TestClient):
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": ["num_repair_orders", "avg_repair_price", "total_repair_cost"],
+            "metrics": metrics_list,
             "dimensions": [
                 "hard_hat.country",
                 "hard_hat.postal_code",
@@ -300,6 +300,7 @@ def test_cube_sql(client_with_examples: TestClient):
           dispatcher.company_name,
           municipality_dim.local_region
     """
+    print(results["query"])
     assert compare_query_strings(results["query"], expected_query)
 
     response = client_with_examples.post(

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -191,8 +191,13 @@ def test_cube_sql(client_with_examples: TestClient):
     """
     Test that the generated cube materialization SQL makes sense
     """
-    metrics_list = ["num_repair_orders", "avg_repair_price", "total_repair_cost"]
-
+    metrics_list = [
+        "discounted_orders_rate",
+        "num_repair_orders",
+        "avg_repair_price",
+        "total_repair_cost",
+        "total_repair_order_discounts",
+    ]
     # Should fail because dimension attribute isn't available
     response = client_with_examples.post(
         "/nodes/cube/",
@@ -237,22 +242,34 @@ def test_cube_sql(client_with_examples: TestClient):
     assert results["description"] == "Cube of various metrics related to repairs"
     expected_query = """
         SELECT
-          avg(price) AS avg_repair_price,
           dispatcher.company_name,
           hard_hat.city,
           hard_hat.country,
           hard_hat.postal_code,
           hard_hat.state,
           municipality_dim.local_region,
+          sum(repair_order_details.price * repair_order_details.discount) AS total_discount,
+          sum(repair_order_details.price) AS total_repair_cost,
+          avg(repair_order_details.price) AS avg_repair_price,
           count(repair_orders.repair_order_id) AS num_repair_orders,
-          sum(price) AS total_repair_cost
-        FROM roads.repair_orders AS repair_orders
+          CAST(sum(if(repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*)
+            AS discounted_orders_rate
+        FROM roads.repair_order_details AS repair_order_details
+        LEFT OUTER JOIN (
+          SELECT
+            repair_orders.dispatcher_id,
+            repair_orders.hard_hat_id,
+            repair_orders.municipality_id,
+            repair_orders.repair_order_id
+          FROM roads.repair_orders AS repair_orders
+        ) AS repair_order
+        ON repair_order_details.repair_order_id = repair_order.repair_order_id
         LEFT OUTER JOIN (
           SELECT
             dispatchers.company_name,
             dispatchers.dispatcher_id
           FROM roads.dispatchers AS dispatchers
-        ) AS dispatcher ON repair_orders.dispatcher_id = dispatcher.dispatcher_id
+        ) AS dispatcher ON repair_order.dispatcher_id = dispatcher.dispatcher_id
         LEFT OUTER JOIN (
           SELECT
             hard_hats.city,
@@ -261,7 +278,7 @@ def test_cube_sql(client_with_examples: TestClient):
             hard_hats.postal_code,
             hard_hats.state
           FROM roads.hard_hats AS hard_hats
-        ) AS hard_hat ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
+        ) AS hard_hat ON repair_order.hard_hat_id = hard_hat.hard_hat_id
         LEFT OUTER JOIN (
           SELECT
             municipality.local_region,
@@ -273,8 +290,8 @@ def test_cube_sql(client_with_examples: TestClient):
           ON municipality_municipality_type.municipality_type_id
              = municipality_type.municipality_type_desc
         ) AS municipality_dim
-        ON repair_orders.municipality_id = municipality_dim.municipality_id
-        WHERE hard_hat.state='AZ'
+        ON repair_order.municipality_id = municipality_dim.municipality_id
+        WHERE hard_hat.state = 'AZ'
         GROUP BY
           hard_hat.country,
           hard_hat.postal_code,
@@ -285,9 +302,28 @@ def test_cube_sql(client_with_examples: TestClient):
     """
     assert compare_query_strings(results["query"], expected_query)
 
+    response = client_with_examples.post(
+        "/nodes/repairs_cube/materialization/",
+        json={
+            "engine_name": "druid",
+            "engine_version": "",
+            "config": {},
+            "schedule": "",
+        },
+    )
+    assert response.json() == {
+        "message": "Successfully updated materialization config "
+        "for node `repairs_cube` and engine `druid`.",
+    }
+
     response = client_with_examples.get("/cubes/repairs_cube/")
     data = response.json()
     assert data["cube_elements"] == [
+        {
+            "name": "discounted_orders_rate",
+            "node_name": "discounted_orders_rate",
+            "type": "metric",
+        },
         {
             "name": "num_repair_orders",
             "node_name": "num_repair_orders",
@@ -299,6 +335,11 @@ def test_cube_sql(client_with_examples: TestClient):
             "node_name": "total_repair_cost",
             "type": "metric",
         },
+        {
+            "name": "total_discount",
+            "node_name": "total_repair_order_discounts",
+            "type": "metric",
+        },
         {"name": "country", "node_name": "hard_hat", "type": "dimension"},
         {"name": "postal_code", "node_name": "hard_hat", "type": "dimension"},
         {"name": "city", "node_name": "hard_hat", "type": "dimension"},
@@ -306,3 +347,110 @@ def test_cube_sql(client_with_examples: TestClient):
         {"name": "company_name", "node_name": "dispatcher", "type": "dimension"},
         {"name": "local_region", "node_name": "municipality_dim", "type": "dimension"},
     ]
+    expected_materialization_query = """
+        SELECT
+          count(repair_order_details.price) price_count,
+          dispatcher.company_name,
+          count(repair_orders.repair_order_id) repair_order_id_count,
+          sum(repair_order_details.price * repair_order_details.discount) price_discount_sum,
+          hard_hat.city,
+          count(*) placeholder_count,
+          sum(if(repair_order_details.discount > 0.0, 1, 0)) discount_sum,
+          hard_hat.state,
+          municipality_dim.local_region,
+          hard_hat.postal_code,
+          sum(repair_order_details.price) price_sum,
+          hard_hat.country
+        FROM roads.repair_order_details AS repair_order_details
+        LEFT OUTER JOIN (
+          SELECT
+            repair_orders.dispatcher_id,
+            repair_orders.hard_hat_id,
+            repair_orders.municipality_id,
+            repair_orders.repair_order_id
+          FROM roads.repair_orders AS repair_orders
+        ) AS repair_order
+        ON repair_order_details.repair_order_id = repair_order.repair_order_id
+        LEFT OUTER JOIN (
+          SELECT
+            dispatchers.company_name,
+            dispatchers.dispatcher_id
+          FROM roads.dispatchers AS dispatchers
+        ) AS dispatcher ON repair_order.dispatcher_id = dispatcher.dispatcher_id
+        LEFT OUTER JOIN (
+          SELECT
+            hard_hats.city,
+            hard_hats.country,
+            hard_hats.hard_hat_id,
+            hard_hats.postal_code,
+            hard_hats.state
+          FROM roads.hard_hats AS hard_hats
+        ) AS hard_hat ON repair_order.hard_hat_id = hard_hat.hard_hat_id
+        LEFT OUTER JOIN (
+          SELECT
+            municipality.local_region,
+            municipality.municipality_id
+          FROM roads.municipality AS municipality
+          LEFT JOIN roads.municipality_municipality_type AS municipality_municipality_type
+          ON municipality.municipality_id = municipality_municipality_type.municipality_id
+          LEFT JOIN roads.municipality_type AS municipality_type
+          ON municipality_municipality_type.municipality_type_id
+             = municipality_type.municipality_type_desc
+        ) AS municipality_dim
+        ON repair_order.municipality_id = municipality_dim.municipality_id
+        WHERE hard_hat.state = 'AZ'
+        GROUP BY
+          hard_hat.country,
+          hard_hat.postal_code,
+          hard_hat.city,
+          hard_hat.state,
+          dispatcher.company_name,
+          municipality_dim.local_region
+    """
+    assert compare_query_strings(
+        data["materialization_configs"][0]["config"]["query"],
+        expected_materialization_query,
+    )
+    assert data["materialization_configs"][0]["config"]["measures"] == {
+        "avg_repair_price": [
+            {
+                "name": "price_sum",
+                "agg": "sum",
+                "expr": "sum(repair_order_details.price)",
+            },
+            {
+                "name": "price_count",
+                "agg": "count",
+                "expr": "count(repair_order_details.price)",
+            },
+        ],
+        "discounted_orders_rate": [
+            {
+                "agg": "sum",
+                "expr": "sum(if(repair_order_details.discount > " "0.0, 1, 0))",
+                "name": "discount_sum",
+            },
+            {"agg": "count", "expr": "count(*)", "name": "placeholder_count"},
+        ],
+        "num_repair_orders": [
+            {
+                "name": "repair_order_id_count",
+                "agg": "count",
+                "expr": "count(repair_orders.repair_order_id)",
+            },
+        ],
+        "total_discount": [
+            {
+                "agg": "sum",
+                "expr": "sum(repair_order_details.price * repair_order_details.discount)",
+                "name": "price_discount_sum",
+            },
+        ],
+        "total_repair_cost": [
+            {
+                "name": "price_sum",
+                "agg": "sum",
+                "expr": "sum(repair_order_details.price)",
+            },
+        ],
+    }

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -28,6 +28,14 @@ EXAMPLES = (  # type: ignore
         [{"name": "spark", "version": "3.1.1", "dialect": "spark"}],
     ),
     (
+        "/engines/",
+        {"name": "druid", "version": "", "dialect": "druid"},
+    ),
+    (
+        "/catalogs/default/engines/",
+        [{"name": "druid", "version": "", "dialect": "druid"}],
+    ),
+    (
         "/catalogs/",
         {"name": "public"},
     ),
@@ -457,6 +465,22 @@ EXAMPLES = (  # type: ignore
             ),
             "mode": "published",
             "name": "avg_length_of_employment",
+        },
+    ),
+    (
+        "/nodes/metric/",
+        {
+            "name": "discounted_orders_rate",
+            "query": (
+                """
+                SELECT
+                  cast(sum(if(discount > 0.0, 1, 0)) as double) / count(*)
+                    AS discounted_orders_rate
+                FROM repair_order_details
+                """
+            ),
+            "mode": "published",
+            "description": "Proportion of Discounted Orders",
         },
     ),
     (


### PR DESCRIPTION
### Summary

When we attach a materialization config to a cube node, the implication is that we want to ingest the underlying data into an analytics database. However, many such databases are only configured to work with simple aggregations, so each metric expression needs to be broken down into constituent simple aggregation measures. These needs to be ingested into separate columns and then combined when the user requests metric data, in the post-aggregation operation stage. See https://github.com/DataJunction/dj/issues/470 for a more detailed description.

This PR adds the decomposed query and measures list to the materialization config. Note that the query in the materialization config is different from the one stored on the cube node, as the materialization config's query is meant for building a temporary table in preparation for ingestion into an analytics database like Druid. The query on the cube node is meant for direct querying of the cube without materialization to an OLAP database (i.e., if no materialization config is specified but the user wants to query the cube).

### Test Plan

Some unit tests + end-to-end verification

- [X] PR has an associated issue: #470
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
