### PR TITLE
bugfix: Node validation check should take into account type inference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,6 @@ docker-build:
 docker-run:
 	docker compose up
 
-docker-run-with-postgres:
-	docker compose -f docker-compose.yml -f docker-compose.postgres.yml up
-
-docker-run-with-druid:
-	docker compose -f docker-compose.yml -f docker-compose.druid.yml up
-
-docker-run-with-cockroachdb:
-	docker compose -f docker-compose.yml -f docker-compose.cockroachdb.yml up
-
 test: pyenv
 	pytest --cov=dj --cov-report=html -vv tests/ --doctest-modules dj --without-integration --without-slow-integration ${PYTEST_ARGS}
 

--- a/dj/errors.py
+++ b/dj/errors.py
@@ -34,7 +34,8 @@ class ErrorCode(int, Enum):
 
     # SQL Build Error
     COMPOUND_BUILD_EXCEPTION = 300
-    MISSING_PARENT = 201
+    MISSING_PARENT = 301
+    TYPE_INFERENCE = 302
 
 
 class DebugType(TypedDict, total=False):

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -207,6 +207,13 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
     return ct.DoubleType()
 
 
+@Avg.register  # type: ignore
+def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+    arg: ct.DateTimeBase,
+) -> ct.DateTimeBase:
+    return type(arg.type)()
+
+
 class Min(Function):  # pylint: disable=abstract-method
     """
     Computes the minimum value of the input column or expression.
@@ -425,8 +432,8 @@ class Now(Function):  # pylint: disable=abstract-method
 
 
 @Now.register  # type: ignore
-def infer_type() -> ct.TimestamptzType:  # noqa: F811  # pylint: disable=function-redefined
-    return ct.TimestamptzType()
+def infer_type() -> ct.TimestampType:  # noqa: F811  # pylint: disable=function-redefined
+    return ct.TimestampType()
 
 
 class DateAdd(Function):  # pylint: disable=abstract-method

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -50,6 +50,8 @@ from dj.sql.parsing.types import (
     NestedField,
     NullType,
     StringType,
+    TimestampType,
+    TimestamptzType,
     WildcardType,
     YearMonthIntervalType,
 )
@@ -1039,9 +1041,6 @@ class UnaryOpKind(DJEnum):
     The accepted unary operations
     """
 
-    #
-    # Plus = "+"
-    # Minus = "-"
     Exists = "EXISTS"
     Not = "NOT"
 
@@ -1206,12 +1205,14 @@ class BinaryOp(Operation):
             left: ColumnType,
             right: ColumnType,
         ):
-            if str(left) not in numeric_types or str(right) not in numeric_types:
+            if not left.is_compatible(right):
                 raise_binop_exception()
-            if str(left) == str(right):
+            if str(left) in numeric_types and str(right) in numeric_types:
+                if str(left) == str(right):
+                    return left
+                if numeric_types[str(left)] > numeric_types[str(right)]:
+                    return right
                 return left
-            if numeric_types[str(left)] > numeric_types[str(right)]:
-                return right
             return left
 
         BINOP_TYPE_COMBO_LOOKUP: Dict[  # pylint: disable=C0103

--- a/dj/sql/parsing/types.py
+++ b/dj/sql/parsing/types.py
@@ -694,7 +694,7 @@ class TimeType(DateTimeBase):
         super().__init__("time", "TimeType()")
 
 
-class TimestampType(PrimitiveType, Singleton):
+class TimestampType(DateTimeBase):
     """A Timestamp data type can be represented using an instance of this class. Timestamps in
     Column have microsecond precision and include a date and a time of day without a timezone.
 

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -215,7 +215,7 @@ def test_cube_sql(client_with_examples: TestClient):
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": metrics_list,
+            "metrics": ["num_repair_orders", "avg_repair_price", "total_repair_cost"],
             "dimensions": [
                 "hard_hat.country",
                 "hard_hat.postal_code",

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -534,11 +534,17 @@ class TestCreateOrUpdateNodes:
         )
         data = response.json()
         assert data == {
-            "message": "Unable to infer type for some columns on node `avg_length_of_employment_plus_one`",
+            "message": (
+                "Unable to infer type for some columns on node "
+                "`avg_length_of_employment_plus_one`"
+            ),
             "errors": [
                 {
                     "code": 302,
-                    "message": "Unable to infer type for some columns on node `avg_length_of_employment_plus_one`",
+                    "message": (
+                        "Unable to infer type for some columns on node "
+                        "`avg_length_of_employment_plus_one`"
+                    ),
                     "debug": {"columns": ["avg_length_of_employment"]},
                     "context": "",
                 },

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -512,6 +512,40 @@ class TestCreateOrUpdateNodes:
             == "Node definition contains references to nodes that do not exist"
         )
 
+    def test_create_node_with_type_inference_failure(
+        self,
+        client_with_examples: TestClient,
+    ):
+        """
+        Attempting to create a published metric where type inference fails should raise
+        an appropriate error and fail.
+        """
+        response = client_with_examples.post(
+            "/nodes/metric/",
+            json={
+                "description": "Average length of employment",
+                "query": (
+                    "SELECT avg(NOW() - hire_date + 1) as avg_length_of_employment "
+                    "FROM foo.bar.hard_hats"
+                ),
+                "mode": "published",
+                "name": "avg_length_of_employment_plus_one",
+            },
+        )
+        data = response.json()
+        assert data == {
+            "message": "Unable to infer type for some columns on node `avg_length_of_employment_plus_one`",
+            "errors": [
+                {
+                    "code": 302,
+                    "message": "Unable to infer type for some columns on node `avg_length_of_employment_plus_one`",
+                    "debug": {"columns": ["avg_length_of_employment"]},
+                    "context": "",
+                },
+            ],
+            "warnings": [],
+        }
+
     def test_create_update_transform_node(
         self,
         database: Database,  # pylint: disable=unused-argument
@@ -1366,7 +1400,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "message": "Node definition contains references to nodes that do not exist",
             "errors": [
                 {
-                    "code": 201,
+                    "code": 301,
                     "message": "Node definition contains references to nodes that do not exist",
                     "debug": {"missing_parents": ["node_that_does_not_exist"]},
                     "context": "",

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -25,7 +25,6 @@ from dj.sql.parsing.types import (
     NullType,
     StringType,
     TimestampType,
-    TimestamptzType,
     TimeType,
     TinyIntType,
 )

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -274,7 +274,7 @@ def test_infer_types_complicated(construction_session: Session):
     types = [
         IntegerType(),
         TimestampType(),
-        TimestamptzType(),
+        TimestampType(),
         IntegerType(),
         NullType(),
         NullType(),
@@ -645,7 +645,7 @@ def test_infer_types_datetime(construction_session: Session):
         TimestampType(),
         TimeType(),
         TimestampType(),
-        TimestamptzType(),
+        TimestampType(),
         DateType(),
         DateType(),
         DateType(),

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -29,7 +29,6 @@ from dj.sql.parsing.types import (
     IntegerType,
     NullType,
     StringType,
-    TimestamptzType,
     WildcardType,
 )
 
@@ -87,7 +86,7 @@ def test_now() -> None:
     """
     Test ``Now`` function.
     """
-    assert Now.infer_type() == TimestamptzType()
+    assert Now.infer_type() == ct.TimestampType()
 
 
 def test_coalesce_infer_type() -> None:


### PR DESCRIPTION
### Summary

When a user tries to create a published node that fails type inference, we should raise an exception rather than allowing the creation of a published node with `status=invalid`. I noticed this bug because in the DJ roads example modelling, `avg_length_of_employment` gets created as a published metric with invalid status (due to a typing mismatch between `NOW()` and `hire_date`, which this also fixes).

### Test Plan

Added unit tests

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
