### PR TITLE
SQL building for multiple metrics

### DIFF
--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -8,7 +8,8 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
-from dj.api.helpers import get_engine, get_query
+from dj.api.helpers import get_engine, get_query, validate_cube
+from dj.construction.build import build_metric_nodes
 from dj.models.metric import TranslatedSQL
 from dj.models.query import ColumnMetadata
 from dj.utils import get_session
@@ -41,6 +42,46 @@ def get_sql(
         dimensions=dimensions,
         filters=filters,
         engine=engine,
+    )
+    columns = [
+        ColumnMetadata(name=col.alias_or_name.name, type=str(col.type))  # type: ignore
+        for col in query_ast.select.projection
+    ]
+    return TranslatedSQL(
+        sql=str(query_ast),
+        columns=columns,
+        dialect=engine.dialect if engine else None,
+    )
+
+
+@router.get("/sql/", response_model=TranslatedSQL)
+def get_sql_for_metrics(
+    metrics: List[str] = Query([]),
+    dimensions: List[str] = Query([]),
+    filters: List[str] = Query([]),
+    *,
+    session: Session = Depends(get_session),
+    engine_name: Optional[str] = None,
+    engine_version: Optional[str] = None,
+) -> TranslatedSQL:
+    """
+    Return SQL for a set of metrics with dimensions and filters
+    """
+    engine = (
+        get_engine(session, engine_name, engine_version)  # type: ignore
+        if engine_name
+        else None
+    )
+    _, metric_nodes, _, _ = validate_cube(
+        session,
+        metrics,
+        dimensions,
+    )
+    query_ast = build_metric_nodes(
+        session,
+        metric_nodes,
+        filters=filters or [],
+        dimensions=dimensions or [],
     )
     columns = [
         ColumnMetadata(name=col.alias_or_name.name, type=str(col.type))  # type: ignore

--- a/docs/content/0.1.0/docs/getting-started/requesting-sql.md
+++ b/docs/content/0.1.0/docs/getting-started/requesting-sql.md
@@ -3,3 +3,108 @@ weight: 50
 ---
 
 # Requesting SQL
+
+DJ can generate SQL for one or more metrics with a set of compatible 
+filters and dimensions to group by.
+
+## SQL for Single Metric
+
+Note that the `engine_name` and `engine_version` fields are not required.
+
+{{< tabs "retrieving sql" >}}
+{{< tab "curl" >}}
+```sh
+curl -X POST http://localhost:8000/sql/num_repair_orders/ \
+-H 'Content-Type: application/json' \
+-d '{
+    "dimensions": [
+      "hard_hat.city",
+      "hard_hat.state",
+      "dispatcher.company_name"
+    ],
+    "filters": [
+      "hard_hat.state = ''AZ''"
+    ],
+    "engine_name": "SPARKSQL",
+    "engine_version": "3.1.1"
+}'
+```
+{{< /tab >}}
+{{< tab "python" >}}
+
+```py
+from datajunction import DJClient
+
+dj = DJClient("http://localhost:8000/")
+
+# Assumes that the metric has been created
+metric = dj.metric("num_repair_orders")
+metric.sql(
+    dimensions=[
+      "hard_hat.city",
+      "hard_hat.state",
+      "dispatcher.company_name"
+    ],
+    filters=[
+      "hard_hat.state = 'AZ'"
+    ],
+    engine_name="SPARKSQL",
+    engine_version="3.1.1",
+)
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+
+## SQL for Multiple Metrics
+
+Note that the `engine_name` and `engine_version` fields are not required.
+
+{{< tabs "retrieving sql multiple" >}}
+{{< tab "curl" >}}
+```sh
+curl -X POST http://localhost:8000/sql/ \
+-H 'Content-Type: application/json' \
+-d '{
+    "metrics": [
+      "num_repair_orders",
+      "avg_repair_price"
+    ],
+    "dimensions": [
+      "hard_hat.city",
+      "hard_hat.state",
+      "dispatcher.company_name"
+    ],
+    "filters": [
+      "hard_hat.state = ''AZ''"
+    ],
+    "engine_name": "SPARKSQL",
+    "engine_version": "3.1.1"
+}'
+```
+{{< /tab >}}
+{{< tab "python" >}}
+
+```py
+from datajunction import DJClient
+
+dj = DJClient("http://localhost:8000/")
+dj.sql(
+    metrics=[
+      "num_repair_orders",
+      "avg_repair_price"
+    ],
+    dimensions=[
+      "hard_hat.city",
+      "hard_hat.state",
+      "dispatcher.company_name"
+    ],
+    filters=[
+      "hard_hat.state = 'AZ'"
+    ],
+    engine_name="SPARKSQL",
+    engine_version="3.1.1",
+)
+```
+{{< /tab >}}
+{{< /tabs >}}

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -140,7 +140,7 @@ def test_create_invalid_cube(client_with_examples: TestClient):
     assert response.status_code == 422
     data = response.json()
     assert data == {
-        "message": "At least one metric is required to create a cube node",
+        "message": "At least one metric is required",
         "errors": [],
         "warnings": [],
     }
@@ -159,7 +159,7 @@ def test_create_invalid_cube(client_with_examples: TestClient):
     assert response.status_code == 422
     data = response.json()
     assert data == {
-        "message": "At least one dimension is required to create a cube node",
+        "message": "At least one dimension is required",
         "errors": [],
         "warnings": [],
     }
@@ -184,7 +184,7 @@ def test_raise_on_cube_with_multiple_catalogs(
     )
     assert not response.ok
     data = response.json()
-    assert "Cannot create cube using nodes from multiple catalogs" in data["message"]
+    assert "Metrics and dimensions cannot be from multiple catalogs" in data["message"]
 
 
 def test_cube_sql(client_with_examples: TestClient):
@@ -314,7 +314,6 @@ def test_cube_sql(client_with_examples: TestClient):
           dispatcher.company_name,
           municipality_dim.local_region
     """
-    print(results["query"])
     assert compare_query_strings(results["query"], expected_query)
 
     response = client_with_examples.post(


### PR DESCRIPTION
### Summary

* This adds an API endpoint that exposes SQL building for multiple metrics. It reuses `build_metric_nodes` from cube node creation to build SQL for multiple metrics. There's also some light refactoring to move the common validation part into a helper function, as it applies to this multiple metric SQL endpoint as well as cube creation.
* Added client support for retrieving SQL for multiple metrics. It uses the `dj.sql(...)` method on the client object to expose this functionality. 
* Added some documentation to the `Requesting SQL` page.
<img width="1297" alt="Screenshot 2023-04-28 at 8 37 35 AM" src="https://user-images.githubusercontent.com/9524628/235191912-24665136-7778-4bec-acca-51592c59ac76.png">

### Test Plan

Locally + unit tests.

- [X] PR has an associated issue: #479, #296
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
