### PR TITLE
generic expression aggregation check all children are -> any child is

### DIFF
--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -553,7 +553,7 @@ class Expression(Node):
         """
         Determines whether an Expression is an aggregation or not
         """
-        return any(
+        return all(
             [
                 child.is_aggregation()
                 for child in self.children
@@ -1370,6 +1370,9 @@ class Value(Expression):
     """
     Base class for all values number, string, boolean
     """
+    
+    def is_aggregation(self) -> bool:
+        return True
 
 
 @dataclass(eq=False)

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -553,7 +553,7 @@ class Expression(Node):
         """
         Determines whether an Expression is an aggregation or not
         """
-        return all(
+        return any(
             [
                 child.is_aggregation()
                 for child in self.children

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -1370,7 +1370,7 @@ class Value(Expression):
     """
     Base class for all values number, string, boolean
     """
-    
+
     def is_aggregation(self) -> bool:
         return True
 

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -66,21 +66,6 @@ def test_extra_validation() -> None:
         node_revision.extra_validation()
     assert str(excinfo.value) == "Node A of type metric needs a query"
 
-    node = Node(name="A", type=NodeType.METRIC, current_version="1")
-    node_revision = NodeRevision(
-        name=node.name,
-        type=node.type,
-        node=node,
-        version="1",
-        query="SELECT 42",
-    )
-    with pytest.raises(Exception) as excinfo:
-        node_revision.extra_validation()
-    assert str(excinfo.value) == (
-        "Node A of type metric has an invalid query, "
-        "should have a single aggregation"
-    )
-
     node = Node(name="A", type=NodeType.TRANSFORM, current_version="1")
     node_revision = NodeRevision(
         name=node.name,

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -72,7 +72,9 @@ def test_extra_validation() -> None:
         type=node.type,
         node=node,
         version="1",
-        query="SELECT count(repair_order_id) + repair_order_id AS num_repair_orders FROM repair_orders",
+        query="SELECT count(repair_order_id) +"
+        "repair_order_id AS num_repair_orders"
+        "FROM repair_orders",
     )
     with pytest.raises(Exception) as excinfo:
         node_revision.extra_validation()

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -66,6 +66,21 @@ def test_extra_validation() -> None:
         node_revision.extra_validation()
     assert str(excinfo.value) == "Node A of type metric needs a query"
 
+    node = Node(name="A", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
+        query="SELECT count(repair_order_id) + repair_order_id AS num_repair_orders FROM repair_orders",
+    )
+    with pytest.raises(Exception) as excinfo:
+        node_revision.extra_validation()
+    assert str(excinfo.value) == (
+        "Node A of type metric has an invalid query, "
+        "should have a single aggregation"
+    )
+
     node = Node(name="A", type=NodeType.TRANSFORM, current_version="1")
     node_revision = NodeRevision(
         name=node.name,

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -72,8 +72,8 @@ def test_extra_validation() -> None:
         type=node.type,
         node=node,
         version="1",
-        query="SELECT count(repair_order_id) +"
-        "repair_order_id AS num_repair_orders"
+        query="SELECT count(repair_order_id) + "
+        "repair_order_id AS num_repair_orders "
         "FROM repair_orders",
     )
     with pytest.raises(Exception) as excinfo:


### PR DESCRIPTION
### Summary

changes the generic logic checking if an expression is an aggregation to just checking if there is any child which aggregates rather than all children aggregating

this would be a problem because of the binop default `is_aggregation`:

```sh
curl -X POST http://localhost:8000/nodes/metric/ \
-H 'Content-Type: application/json' \
-d '{
    "name": "num_repair_orders_x_2",
    "description": "Number of repair orders",
    "mode": "published",
    "query": "SELECT 2.0 * count(repair_order_id) as num_repair_orders FROM repair_orders"
}'
```

which would succeed after this change. Now, `2.0 * count(repair_order_id)` is identified as an aggregation

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
