### PR TITLE
refactor: make uvicorn+otel optional for server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "celery<6.0.0,>=5.2.7",
     "fastapi<0.80.0,>=0.79.0",
     "msgpack<2.0.0,>=1.0.5",
+    "opentelemetry-instrumentation-fastapi==0.38b0",
     "python-dotenv<1.0.0,>=0.19.0",
     "redis<5.0.0,>=4.5.4",
     "requests<3.0.0,>=2.28.2",
@@ -46,7 +47,6 @@ classifiers = [
 
 [project.optional-dependencies]
 uvicorn = [
-    "opentelemetry-instrumentation-fastapi==0.38b0",
     "uvicorn[standard]>=0.21.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "celery<6.0.0,>=5.2.7",
     "fastapi<0.80.0,>=0.79.0",
     "msgpack<2.0.0,>=1.0.5",
-    "opentelemetry-instrumentation-fastapi==0.38b0",
     "python-dotenv<1.0.0,>=0.19.0",
     "redis<5.0.0,>=4.5.4",
     "requests<3.0.0,>=2.28.2",
@@ -31,7 +30,6 @@ dependencies = [
     "sqlmodel<1.0.0,>=0.0.8",
     "sqlparse<1.0.0,>=0.4.3",
     "yarl<2.0.0,>=1.8.2",
-    "uvicorn[standard]>=0.21.1",
 ]
 requires-python = ">=3.8,<4.0"
 readme = "README.md"
@@ -44,6 +42,12 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
+]
+
+[project.optional-dependencies]
+uvicorn = [
+    "opentelemetry-instrumentation-fastapi==0.38b0",
+    "uvicorn[standard]>=0.21.1",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Choosing the ASGI server is something that users may do themselves. The
uvicorn AGSI server should be an extras requirement in the PEP-621
dependencies metadata.

Uvicorn can still be installed at the same time as datajunction-server
via: `pip install 'datajunction-server[uvicorn]'`
