### PR TITLE
fix: new 'uvicorn' group missing from pdm.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,3 +102,7 @@ repos:
   hooks:
     - id: black-nb
       files: '\.ipynb$'
+- repo: https://github.com/pdm-project/pdm
+  rev: 2.5.3
+  hooks:
+    - id: pdm-lock-check

--- a/pdm.lock
+++ b/pdm.lock
@@ -913,8 +913,8 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.2"
-groups = ["default", "test"]
-content_hash = "sha256:2922f9b404816ede9daa47832f6091d89be1df171fe096daac5df8bfb99cdc49"
+groups = ["default", "test", "uvicorn"]
+content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792cea499490"
 
 [metadata.files]
 "accept-types 0.4.1" = [


### PR DESCRIPTION
In commit 4b38435 I of course forgot to refresh the lock file so that it
passes a `pdm lock --check`.

This commit fixes that, AND it also adds the pre-commit hook to catch
this common mistake.

The command to refresh the lockfile is `pdm lock -G :all --refresh`
