### PR TITLE
Struct type inference in select

### DIFF
--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -711,8 +711,11 @@ class Column(Aliasable, Named, Expression):
     def is_compiled(self):
         return self._is_compiled or (self.table and self._type)
 
-    # flake8: noqa
-    def find_table_sources(self, ctx: CompileContext) -> List["TableExpression"]:
+    def find_table_sources(
+        self,
+        ctx: CompileContext,
+    ) -> List["TableExpression"]:
+        # flake8: noqa
         """
         Find all tables that this column could have originated from.
         """

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -647,7 +647,6 @@ class Column(Aliasable, Named, Expression):
 
     @property
     def type(self):
-        print("Col", self.name, type(self))
         if self._type:
             return self._type
 
@@ -744,6 +743,10 @@ class Column(Aliasable, Named, Expression):
             if not namespace or table.alias_or_name.identifier(False) == namespace:
                 if table.add_ref_column(self, ctx):
                     found.append(table)
+
+            # The column's namespace may match the name of a column on the table, which
+            # implies that the column on the table is likely a struct and the dereferencing
+            # will happen on the struct object
             for col in table.columns:
                 if col.alias_or_name.name == namespace:
                     table.add_ref_column(self, ctx)

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -50,10 +50,11 @@ from dj.sql.parsing.types import (
     NestedField,
     NullType,
     StringType,
+    StructType,
     TimestampType,
     TimestamptzType,
     WildcardType,
-    YearMonthIntervalType, StructType,
+    YearMonthIntervalType,
 )
 
 PRIMITIVES = {int, float, str, bool, type(None)}
@@ -711,6 +712,7 @@ class Column(Aliasable, Named, Expression):
     def is_compiled(self):
         return self._is_compiled or (self.table and self._type)
 
+    # flake8: noqa
     def find_table_sources(self, ctx: CompileContext) -> List["TableExpression"]:
         """
         Find all tables that this column could have originated from.
@@ -960,16 +962,15 @@ class TableExpression(Aliasable, Expression):
                 # the search column's namespace and if there's a nested field that matches the
                 # search column's name
                 if isinstance(col.type, StructType):
-                    column_namespace = ".".join([name.name for name in column.namespace])
-                    print("column_namepace col_name", column_namespace, current_col_name)
+                    column_namespace = ".".join(
+                        [name.name for name in column.namespace],
+                    )
                     if column_namespace == current_col_name:
-                        for field in col.type.fields:
-                            print("field:", field.name.name, column.name.name)
-                            if field.name.name == column.name.name:
-                                print("ADDING", field.type)
+                        for type_field in col.type.fields:
+                            if type_field.name.name == column.name.name:
                                 column.add_table(self)
                                 column.add_expression(col)
-                                column.add_type(field.type)
+                                column.add_type(type_field.type)
         return False
 
     def is_compiled(self) -> bool:  # noqa: F811

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -4,14 +4,11 @@ Tests for the metrics API.
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from dj.errors import DJException
 from dj.models import AttributeType, ColumnAttribute
 from dj.models.column import Column
 from dj.models.database import Database
 from dj.models.node import Node, NodeRevision, NodeType
 from dj.models.table import Table
-from dj.sql.parsing.ast import CompileContext
-from dj.sql.parsing.backends.antlr4 import parse
 from dj.sql.parsing.types import FloatType, IntegerType, StringType
 
 
@@ -276,7 +273,8 @@ def test_type_inference_structs(client_with_examples: TestClient):
     """
     Testing type resolution for structs select
     """
-    client_with_examples.post("/nodes/source/",
+    client_with_examples.post(
+        "/nodes/source/",
         json={
             "columns": [
                 {
@@ -293,7 +291,8 @@ def test_type_inference_structs(client_with_examples: TestClient):
         },
     )
 
-    response = client_with_examples.post("/nodes/metric/",
+    response = client_with_examples.post(
+        "/nodes/metric/",
         json={
             "query": "SELECT SUM(counts.b) FROM basic.dreams",
             "description": "Dream Counts",

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -545,7 +545,14 @@ class TestCreateOrUpdateNodes:
                         "Unable to infer type for some columns on node "
                         "`avg_length_of_employment_plus_one`"
                     ),
-                    "debug": {"columns": ["avg_length_of_employment"]},
+                    "debug": {
+                        "columns": {
+                            "avg_length_of_employment": "Incompatible types in binary "
+                            "operation NOW() - hard_hats.hire_date + 1. Got left "
+                            "timestamp, right int.",
+                        },
+                        "errors": [],
+                    },
                     "context": "",
                 },
             ],


### PR DESCRIPTION
### Summary

We weren't doing type inference correctly for struct selections -- for more details see https://github.com/DataJunction/dj/issues/491.

This fixes it by adding a check in `add_ref_column` to see if the search column is a struct, and if it is, tries to check if there's a column that matches the search column's joined namespace and a nested field that matches the search column's name. If such a column exists, we add the table to the search column and assign the nested field's type as the column's type.

### Test Plan

Unit tests + running tests of some local metric definitions

- [X] PR has an associated issue: #491
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
