### PR TITLE
Fix type compatibility check for IF statements

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -495,7 +495,7 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
     then: ct.ColumnType,
     else_: ct.ColumnType,
 ) -> ct.ColumnType:
-    if then.type != else_.type:
+    if not then.type.is_compatible(else_.type):
         raise DJInvalidInputException(
             message="The then result and else result must match in type! "
             f"Got {then.type} and {else_.type}",


### PR DESCRIPTION
### Summary

Missed a type compatibility check for `IF` statements - they should always use `is_compatible` rather than `==`

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
