### PR TITLE
Set cancel-in-progress concurrency setting for GA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     env:


### PR DESCRIPTION
### Summary

Small tweak to the test CI that cancels previous in progress test runs when additional commits are pushed to a PR. This is scoped to actions within the same PR so if a flurry of commits are sent individually by someone iterating on a PR (including drafts), instead of each commit launching an individual CI action, a single action will run for the final commit. This makes more sense since we'll be squash merging anyway.

### Test Plan

N/A

- [x] PR has an associated issue: #503 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
