### PR TITLE
chore: remove pdm-bump from dev dependencies

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -78,12 +78,6 @@ version = "3.6.4.0"
 summary = "Python multiprocessing fork with improvements and bugfixes"
 
 [[package]]
-name = "blinker"
-version = "1.6.2"
-requires_python = ">=3.7"
-summary = "Fast, simple object-to-object and broadcast signaling"
-
-[[package]]
 name = "cachelib"
 version = "0.10.2"
 requires_python = ">=3.7"
@@ -231,15 +225,6 @@ requires_python = ">=3.7"
 summary = "A platform independent file lock."
 
 [[package]]
-name = "findpython"
-version = "0.2.4"
-requires_python = ">=3.7"
-summary = "A utility to find python versions on your system"
-dependencies = [
-    "packaging>=20",
-]
-
-[[package]]
 name = "freezegun"
 version = "1.2.2"
 requires_python = ">=3.6"
@@ -301,12 +286,6 @@ name = "iniconfig"
 version = "2.0.0"
 requires_python = ">=3.7"
 summary = "brain-dead simple config-ini parsing"
-
-[[package]]
-name = "installer"
-version = "0.5.1"
-requires_python = ">=3.7"
-summary = "A library for installing Python wheels."
 
 [[package]]
 name = "isort"
@@ -454,69 +433,6 @@ summary = "Core utilities for Python packages"
 dependencies = [
     "pyparsing>=2.0.2",
 ]
-
-[[package]]
-name = "pdm"
-version = "1.15.5"
-requires_python = ">=3.7"
-summary = "Python Development Master"
-dependencies = [
-    "blinker",
-    "click>=7",
-    "findpython",
-    "installer<0.6,>=0.5.1",
-    "packaging",
-    "pdm-pep517<1,>=0.9",
-    "pep517>=0.11.0",
-    "pip<22.2,>=20.1",
-    "platformdirs",
-    "python-dotenv>=0.15",
-    "resolvelib<0.9,>=0.8",
-    "shellingham>=1.3.2",
-    "tomli>=1.1.0",
-    "tomlkit<1,>=0.8.0",
-    "wheel>=0.36.2",
-]
-
-[[package]]
-name = "pdm-bump"
-version = "0.4.0"
-requires_python = ">=3.8"
-summary = "A plugin for PDM providing the ability to modify the version according to PEP440"
-dependencies = [
-    "pdm~=1.8",
-    "pep440-version-utils~=0.3",
-]
-
-[[package]]
-name = "pdm-pep517"
-version = "0.12.7"
-requires_python = ">=3.7"
-summary = "A PEP 517 backend for PDM that supports PEP 621 metadata"
-
-[[package]]
-name = "pep440-version-utils"
-version = "0.3.0"
-requires_python = ">=3.6,<4.0"
-summary = "Utilities to deal with pep440 versioning"
-dependencies = [
-    "packaging<21.0,>=20.3",
-]
-
-[[package]]
-name = "pep517"
-version = "0.13.0"
-requires_python = ">=3.6"
-summary = "Wrappers to build Python packages using PEP 517 hooks"
-dependencies = [
-    "tomli>=1.1.0; python_version < \"3.11\"",
-]
-
-[[package]]
-name = "pip"
-version = "22.1.2"
-requires_python = ">=3.7"
-summary = "The PyPA recommended tool for installing Python packages."
 
 [[package]]
 name = "platformdirs"
@@ -696,11 +612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "resolvelib"
-version = "0.8.1"
-summary = "Resolve abstract dependencies into concrete ones"
-
-[[package]]
 name = "rich"
 version = "13.3.4"
 requires_python = ">=3.7.0"
@@ -716,12 +627,6 @@ name = "setuptools"
 version = "67.7.2"
 requires_python = ">=3.7"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
-
-[[package]]
-name = "shellingham"
-version = "1.5.0.post1"
-requires_python = ">=3.7"
-summary = "Tool to Detect Surrounding Shell"
 
 [[package]]
 name = "six"
@@ -884,12 +789,6 @@ requires_python = ">=3.7"
 summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [[package]]
-name = "wheel"
-version = "0.40.0"
-requires_python = ">=3.7"
-summary = "A built-package format for Python"
-
-[[package]]
 name = "wrapt"
 version = "1.15.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -914,7 +813,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 [metadata]
 lock_version = "4.2"
 groups = ["default", "test", "uvicorn"]
-content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792cea499490"
+content_hash = "sha256:8950efb99f6d21c6bd40b072f6fc4ee3ba794d21c907a5e26ae80ecf4a7608d5"
 
 [metadata.files]
 "accept-types 0.4.1" = [
@@ -956,10 +855,6 @@ content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792ce
 "billiard 3.6.4.0" = [
     {url = "https://files.pythonhosted.org/packages/2b/89/0c43de91d4e52eaa7bd748771d417f6ac9e51e66b2f61928c2151bf65878/billiard-3.6.4.0-py3-none-any.whl", hash = "sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b"},
     {url = "https://files.pythonhosted.org/packages/92/91/40de1901da8ec9eeb7c6a22143ba5d55d8aaa790761ca31342cedcd5c793/billiard-3.6.4.0.tar.gz", hash = "sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547"},
-]
-"blinker 1.6.2" = [
-    {url = "https://files.pythonhosted.org/packages/0d/f1/5f39e771cd730d347539bb74c6d496737b9d5f0a53bc9fdbf3e170f1ee48/blinker-1.6.2-py3-none-any.whl", hash = "sha256:c3d739772abb7bc2860abf5f2ec284223d9ad5c76da018234f6f50d6f31ab1f0"},
-    {url = "https://files.pythonhosted.org/packages/e8/f9/a05287f3d5c54d20f51a235ace01f50620984bc7ca5ceee781dc645211c5/blinker-1.6.2.tar.gz", hash = "sha256:4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213"},
 ]
 "cachelib 0.10.2" = [
     {url = "https://files.pythonhosted.org/packages/70/0b/e7647e072ff60997d69517072145ef56898278afda7deff7cc6858b1541f/cachelib-0.10.2.tar.gz", hash = "sha256:593faeee62a7c037d50fc835617a01b887503f972fb52b188ae7e50e9cb69740"},
@@ -1155,10 +1050,6 @@ content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792ce
     {url = "https://files.pythonhosted.org/packages/24/85/cf4df939cc0a037ebfe18353005e775916faec24dcdbc7a2f6539ad9d943/filelock-3.12.0.tar.gz", hash = "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"},
     {url = "https://files.pythonhosted.org/packages/ad/73/b094a662ae05cdc4ec95bc54e434e307986a5de5960166b8161b7c1373ee/filelock-3.12.0-py3-none-any.whl", hash = "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9"},
 ]
-"findpython 0.2.4" = [
-    {url = "https://files.pythonhosted.org/packages/21/1a/fa0e5e87180e15a417c6102c4f557398ce5edbfa4416d6ed981c2bdef6e6/findpython-0.2.4.tar.gz", hash = "sha256:61f1768cdd843dc2f8a45971272c58c25641a50b19da91302e2492e32a667362"},
-    {url = "https://files.pythonhosted.org/packages/56/a9/a4e44c5af2ee23cf11ba748be9ada4120873d5e381f890d0f4f400eb0f80/findpython-0.2.4-py3-none-any.whl", hash = "sha256:84eb5177919f0fa72c82e0b258d673146e98a679f31c7591cd8218763463f083"},
-]
 "freezegun 1.2.2" = [
     {url = "https://files.pythonhosted.org/packages/1d/97/002ac49ec52858538b4aa6f6831f83c2af562c17340bdf6043be695f39ac/freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
     {url = "https://files.pythonhosted.org/packages/50/cd/ba1c8319c002727ccfa03049127218d1767232a77219924d03ba170e0601/freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
@@ -1291,10 +1182,6 @@ content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792ce
 "iniconfig 2.0.0" = [
     {url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
     {url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
-]
-"installer 0.5.1" = [
-    {url = "https://files.pythonhosted.org/packages/1b/21/3e6ebd12d8dccc55bcb7338db462c75ac86dbd0ac7439ac114616b21667b/installer-0.5.1-py3-none-any.whl", hash = "sha256:1d6c8d916ed82771945b9c813699e6f57424ded970c9d8bf16bbc23e1e826ed3"},
-    {url = "https://files.pythonhosted.org/packages/74/b7/9187323cd732840f1cddd6a9f05961406636b50c799eef37c920b63110c0/installer-0.5.1.tar.gz", hash = "sha256:f970995ec2bb815e2fdaf7977b26b2091e1e386f0f42eafd5ac811953dc5d445"},
 ]
 "isort 5.12.0" = [
     {url = "https://files.pythonhosted.org/packages/0a/63/4036ae70eea279c63e2304b91ee0ac182f467f24f86394ecfe726092340b/isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
@@ -1583,29 +1470,6 @@ content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792ce
     {url = "https://files.pythonhosted.org/packages/3e/89/7ea760b4daa42653ece2380531c90f64788d979110a2ab51049d92f408af/packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {url = "https://files.pythonhosted.org/packages/86/3c/bcd09ec5df7123abcf695009221a52f90438d877a2f1499453c6938f5728/packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
-"pdm 1.15.5" = [
-    {url = "https://files.pythonhosted.org/packages/7c/25/8e08b04a8f2a71b45648d07535c1bc2d3199e06b792a2d7999995b0e3bd2/pdm-1.15.5-py3-none-any.whl", hash = "sha256:c8e266e651d9d4d2eab32d59b32da29c83faaa91911a3d8fd9b1028b97728c68"},
-    {url = "https://files.pythonhosted.org/packages/9f/24/5830700dbce5a181a3d7064524ec587eb89c403bd3d21f46862e152c350d/pdm-1.15.5.tar.gz", hash = "sha256:ea2372588587f59d1523796bbe4caf0302b0ada94e0b858395dd9213f4066ef2"},
-]
-"pdm-bump 0.4.0" = [
-    {url = "https://files.pythonhosted.org/packages/c6/e6/3d756b99fc2c0a686cd36648f18b60653ca11e49727e9203a6beb4c7de2b/pdm_bump-0.4.0-py3-none-any.whl", hash = "sha256:a22daa07d1b0eb0b594661200dac970d3fd5b2a01ce0cffe2a45b0e34bc0bb3d"},
-]
-"pdm-pep517 0.12.7" = [
-    {url = "https://files.pythonhosted.org/packages/38/ac/d412613c839a632787aa207a616f082d35f23f1ca2793be470d926e64a0a/pdm_pep517-0.12.7-py3-none-any.whl", hash = "sha256:d01ac717a44863844ba3361fcfcd5acefd67f63ee8a4f5a549f0febe12d46cb5"},
-    {url = "https://files.pythonhosted.org/packages/af/4b/739fe47ab7e1e3602de4616ac9c85aee48adf5f27d348a248e87c5702ab9/pdm-pep517-0.12.7.tar.gz", hash = "sha256:6a4ed513edbcfd518e3b07e9118575d3fb35cc04551dd8acf3531e2463ef7fe3"},
-]
-"pep440-version-utils 0.3.0" = [
-    {url = "https://files.pythonhosted.org/packages/b8/cf/fdf3501870629c1602b426f7589e09db7bce1dc97039f3f10d4d4dd767ab/pep440-version-utils-0.3.0.tar.gz", hash = "sha256:ceb8c8da63b54cc555946d91829f72fe323f8d635b22fa54ef0a9800c37f50df"},
-    {url = "https://files.pythonhosted.org/packages/d0/8b/c773814460b43fa1fec8f451c2cdeb6c37af64600f44c4f529a926a9daeb/pep440_version_utils-0.3.0-py3-none-any.whl", hash = "sha256:73780b2c31adad5ca35c89eb008f51c2a47aee0318debe31391b673b90577e1b"},
-]
-"pep517 0.13.0" = [
-    {url = "https://files.pythonhosted.org/packages/4d/19/e11fcc88288f68ae48e3aa9cf5a6fd092a88e629cb723465666c44d487a0/pep517-0.13.0.tar.gz", hash = "sha256:ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59"},
-    {url = "https://files.pythonhosted.org/packages/ee/2f/ef63e64e9429111e73d3d6cbee80591672d16f2725e648ebc52096f3d323/pep517-0.13.0-py3-none-any.whl", hash = "sha256:4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b"},
-]
-"pip 22.1.2" = [
-    {url = "https://files.pythonhosted.org/packages/4b/b6/0fa7aa968a9fa4ef63a51b3ff0644e59f49dcd7235b3fd6cceb23f202e08/pip-22.1.2.tar.gz", hash = "sha256:6d55b27e10f506312894a87ccc59f280136bad9061719fac9101bdad5a6bce69"},
-    {url = "https://files.pythonhosted.org/packages/96/2f/caec18213f6a67852f6997fb0673ae08d2e93d1b81573edb93ba4ef06970/pip-22.1.2-py3-none-any.whl", hash = "sha256:a3edacb89022ef5258bf61852728bf866632a394da837ca49eb4303635835f17"},
-]
 "platformdirs 3.4.0" = [
     {url = "https://files.pythonhosted.org/packages/5e/ac/26d3d2a99b5fc84852229fc8470ae612595900f7f52c78468fd3f3a15a27/platformdirs-3.4.0.tar.gz", hash = "sha256:a5e1536e5ea4b1c238a1364da17ff2993d5bd28e15600c2c8224008aff6bbcad"},
     {url = "https://files.pythonhosted.org/packages/6c/fe/f6001fac1337528c14b353298d38748ee2387db0c262587ff4e7c68b5769/platformdirs-3.4.0-py3-none-any.whl", hash = "sha256:01437886022decaf285d8972f9526397bfae2ac55480ed372ed6d9eca048870a"},
@@ -1758,10 +1622,6 @@ content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792ce
     {url = "https://files.pythonhosted.org/packages/9e/ea/c03f99a9df9086a686fd37072886563b5a9776d33b438147308fd95e4be7/requests-mock-1.10.0.tar.gz", hash = "sha256:59c9c32419a9fb1ae83ec242d98e889c45bd7d7a65d48375cc243ec08441658b"},
     {url = "https://files.pythonhosted.org/packages/b3/f9/6de3ebddd002f92df8c3f3bcb75c59a4dcc3d3b70bd4fd74ad53b20ab78e/requests_mock-1.10.0-py2.py3-none-any.whl", hash = "sha256:2fdbb637ad17ee15c06f33d31169e71bf9fe2bdb7bc9da26185be0dd8d842699"},
 ]
-"resolvelib 0.8.1" = [
-    {url = "https://files.pythonhosted.org/packages/98/c0/46cfa3f56e43033b705965120058c018375600fa8fdb44c4e53d75820673/resolvelib-0.8.1-py2.py3-none-any.whl", hash = "sha256:d9b7907f055c3b3a2cfc56c914ffd940122915826ff5fb5b1de0c99778f4de98"},
-    {url = "https://files.pythonhosted.org/packages/ac/20/9541749d77aebf66dd92e2b803f38a50e3a5c76e7876f45eb2b37e758d82/resolvelib-0.8.1.tar.gz", hash = "sha256:c6ea56732e9fb6fca1b2acc2ccc68a0b6b8c566d8f3e78e0443310ede61dbd37"},
-]
 "rich 13.3.4" = [
     {url = "https://files.pythonhosted.org/packages/31/3b/2360352760b436f822258396e66ffb6d42585518a9cde2f93f142e64c5eb/rich-13.3.4.tar.gz", hash = "sha256:b5d573e13605423ec80bdd0cd5f8541f7844a0e71a13f74cf454ccb2f490708b"},
     {url = "https://files.pythonhosted.org/packages/9d/1a/28117ae737aec7c004ed5067034a8949adab43730420b50312821f466c3f/rich-13.3.4-py3-none-any.whl", hash = "sha256:22b74cae0278fd5086ff44144d3813be1cedc9115bdfabbfefd86400cb88b20a"},
@@ -1769,10 +1629,6 @@ content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792ce
 "setuptools 67.7.2" = [
     {url = "https://files.pythonhosted.org/packages/2f/8c/f336a966d4097c7cef6fc699b2ecb83b5fb63fd698198c1b5c7905a74f0f/setuptools-67.7.2-py3-none-any.whl", hash = "sha256:23aaf86b85ca52ceb801d32703f12d77517b2556af839621c641fca11287952b"},
     {url = "https://files.pythonhosted.org/packages/fd/53/e5d7ae40d03e4ed20b7cba317cf9c0c97097c8debb39f9d72d182a6578a2/setuptools-67.7.2.tar.gz", hash = "sha256:f104fa03692a2602fa0fec6c6a9e63b6c8a968de13e17c026957dd1f53d80990"},
-]
-"shellingham 1.5.0.post1" = [
-    {url = "https://files.pythonhosted.org/packages/1f/13/fab0a3f512478bc387b66c51557ee715ede8e9811c77ce952f9b9a4d8ac1/shellingham-1.5.0.post1.tar.gz", hash = "sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28"},
-    {url = "https://files.pythonhosted.org/packages/ae/2a/7ad62b2c56e71c6330fc35cfd5813376e788146ef7c884cc2fdf5fe77696/shellingham-1.5.0.post1-py2.py3-none-any.whl", hash = "sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744"},
 ]
 "six 1.16.0" = [
     {url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -2004,10 +1860,6 @@ content_hash = "sha256:3b118d5c9f278554e2ccb1606daf01bcf3cf81fbcfe53b155af1792ce
     {url = "https://files.pythonhosted.org/packages/f0/61/c1a45650b8526b19f2aeb9f3e03532e493e6470bd99c4f67c66f5e20915b/websockets-11.0.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2a573c8d71b7af937852b61e7ccb37151d719974146b5dc734aad350ef55a02"},
     {url = "https://files.pythonhosted.org/packages/f8/cb/1178fe699508fc820eead75a8f1848dbc95acdd9fb2530b784db1e4a8f58/websockets-11.0.2-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:518ed6782d9916c5721ebd61bb7651d244178b74399028302c8617d0620af291"},
     {url = "https://files.pythonhosted.org/packages/f8/e9/885a685ddf6a4f9033b6254cb742e4f2f47acee10e5d068f0a7ea8592e52/websockets-11.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:143782041e95b63083b02107f31cda999f392903ae331de1307441f3a4557d51"},
-]
-"wheel 0.40.0" = [
-    {url = "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl", hash = "sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"},
-    {url = "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz", hash = "sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873"},
 ]
 "wrapt 1.15.0" = [
     {url = "https://files.pythonhosted.org/packages/0c/6e/f80c23efc625c10460240e31dcb18dd2b34b8df417bc98521fbfd5bc2e9a/wrapt-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,5 +70,4 @@ test = [
     "pytest>=7.3.0",
     "requests-mock>=1.10.0",
     "typing-extensions>=4.5.0",
-    "pdm-bump>=0.4.0",
 ]


### PR DESCRIPTION
pdm-bump is not used. project builds are happening in `hatch` now (and
`hatch version <major|minor|...>` is used for bumping the project
version during CI)
