### PR TITLE
Replace automatic "default" namespace attribution with explicit namespacing

### DIFF
--- a/client/python/tests/examples.py
+++ b/client/python/tests/examples.py
@@ -50,7 +50,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "All repair orders",
             "mode": "published",
-            "name": "repair_orders",
+            "name": "default.repair_orders",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_orders",
@@ -68,7 +68,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Details on repair orders",
             "mode": "published",
-            "name": "repair_order_details",
+            "name": "default.repair_order_details",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_order_details",
@@ -84,7 +84,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on types of repairs",
             "mode": "published",
-            "name": "repair_type",
+            "name": "default.repair_type",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_type",
@@ -107,7 +107,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on contractors",
             "mode": "published",
-            "name": "contractors",
+            "name": "default.contractors",
             "catalog": "default",
             "schema_": "roads",
             "table": "contractors",
@@ -122,7 +122,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Lookup table for municipality and municipality types",
             "mode": "published",
-            "name": "municipality_municipality_type",
+            "name": "default.municipality_municipality_type",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality_municipality_type",
@@ -137,7 +137,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on municipality types",
             "mode": "published",
-            "name": "municipality_type",
+            "name": "default.municipality_type",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality_type",
@@ -156,7 +156,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on municipalities",
             "mode": "published",
-            "name": "municipality",
+            "name": "default.municipality",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality",
@@ -172,7 +172,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on dispatchers",
             "mode": "published",
-            "name": "dispatchers",
+            "name": "default.dispatchers",
             "catalog": "default",
             "schema_": "roads",
             "table": "dispatchers",
@@ -198,7 +198,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on employees",
             "mode": "published",
-            "name": "hard_hats",
+            "name": "default.hard_hats",
             "catalog": "default",
             "schema_": "roads",
             "table": "hard_hats",
@@ -213,7 +213,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Lookup table for employee's current state",
             "mode": "published",
-            "name": "hard_hat_state",
+            "name": "default.hard_hat_state",
             "catalog": "default",
             "schema_": "roads",
             "table": "hard_hat_state",
@@ -230,7 +230,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on different types of repairs",
             "mode": "published",
-            "name": "us_states",
+            "name": "default.us_states",
             "catalog": "default",
             "schema_": "roads",
             "table": "us_states",
@@ -245,7 +245,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on US regions",
             "mode": "published",
-            "name": "us_region",
+            "name": "default.us_region",
             "catalog": "default",
             "schema_": "roads",
             "table": "us_region",
@@ -264,10 +264,10 @@ EXAMPLES = (  # type: ignore
                         required_date,
                         dispatched_date,
                         dispatcher_id
-                        FROM repair_orders
+                        FROM default.repair_orders
                     """,
             "mode": "published",
-            "name": "repair_order",
+            "name": "default.repair_order",
             "primary_key": ["repair_order_id"],
         },
     ),
@@ -287,10 +287,10 @@ EXAMPLES = (  # type: ignore
                         postal_code,
                         country,
                         phone
-                        FROM contractors
+                        FROM default.contractors
                     """,
             "mode": "published",
-            "name": "contractor",
+            "name": "default.contractor",
             "primary_key": ["contractor_id"],
         },
     ),
@@ -313,10 +313,10 @@ EXAMPLES = (  # type: ignore
                         country,
                         manager,
                         contractor_id
-                        FROM hard_hats
+                        FROM default.hard_hats
                     """,
             "mode": "published",
-            "name": "hard_hat",
+            "name": "default.hard_hat",
             "primary_key": ["hard_hat_id"],
         },
     ),
@@ -340,13 +340,13 @@ EXAMPLES = (  # type: ignore
                         manager,
                         contractor_id,
                         hhs.state_id AS state_id
-                        FROM hard_hats hh
-                        LEFT JOIN hard_hat_state hhs
+                        FROM default.hard_hats hh
+                        LEFT JOIN default.hard_hat_state hhs
                         ON hh.hard_hat_id = hhs.hard_hat_id
                         WHERE hh.state_id = 'NY'
                     """,
             "mode": "published",
-            "name": "local_hard_hats",
+            "name": "default.local_hard_hats",
             "primary_key": ["hard_hat_id"],
         },
     ),
@@ -361,12 +361,12 @@ EXAMPLES = (  # type: ignore
                         state_abbr AS state_short,
                         state_region,
                         r.us_region_description AS state_region_description
-                        FROM us_states s
-                        LEFT JOIN us_region r
+                        FROM default.us_states s
+                        LEFT JOIN default.us_region r
                         ON s.state_region = r.us_region_id
                     """,
             "mode": "published",
-            "name": "us_state",
+            "name": "default.us_state",
             "primary_key": ["state_id"],
         },
     ),
@@ -379,10 +379,10 @@ EXAMPLES = (  # type: ignore
                         dispatcher_id,
                         company_name,
                         phone
-                        FROM dispatchers
+                        FROM default.dispatchers
                     """,
             "mode": "published",
-            "name": "dispatcher",
+            "name": "default.dispatcher",
             "primary_key": ["dispatcher_id"],
         },
     ),
@@ -399,14 +399,14 @@ EXAMPLES = (  # type: ignore
                         state_id,
                         mmt.municipality_type_id,
                         mt.municipality_type_desc
-                        FROM municipality AS m
-                        LEFT JOIN municipality_municipality_type AS mmt
+                        FROM default.municipality AS m
+                        LEFT JOIN default.municipality_municipality_type AS mmt
                         ON m.municipality_id = mmt.municipality_id
-                        LEFT JOIN municipality_type AS mt
+                        LEFT JOIN default.municipality_type AS mt
                         ON mmt.municipality_type_id = mt.municipality_type_desc
                     """,
             "mode": "published",
-            "name": "municipality_dim",
+            "name": "default.municipality_dim",
             "primary_key": ["municipality_id"],
         },
     ),
@@ -416,28 +416,28 @@ EXAMPLES = (  # type: ignore
             "description": "Number of repair orders",
             "query": (
                 "SELECT count(repair_order_id) as num_repair_orders "
-                "FROM repair_orders"
+                "FROM default.repair_orders"
             ),
             "mode": "published",
-            "name": "num_repair_orders",
+            "name": "default.num_repair_orders",
         },
     ),
     (
         "/nodes/metric/",
         {
             "description": "Average repair price",
-            "query": "SELECT avg(price) as avg_repair_price FROM repair_order_details",
+            "query": "SELECT avg(price) as avg_repair_price FROM default.repair_order_details",
             "mode": "published",
-            "name": "avg_repair_price",
+            "name": "default.avg_repair_price",
         },
     ),
     (
         "/nodes/metric/",
         {
             "description": "Total repair cost",
-            "query": "SELECT sum(price) as total_repair_cost FROM repair_order_details",
+            "query": "SELECT sum(price) as total_repair_cost FROM default.repair_order_details",
             "mode": "published",
-            "name": "total_repair_cost",
+            "name": "default.total_repair_cost",
         },
     ),
     (
@@ -446,10 +446,10 @@ EXAMPLES = (  # type: ignore
             "description": "Average length of employment",
             "query": (
                 "SELECT avg(NOW() - hire_date) as avg_length_of_employment "
-                "FROM hard_hats"
+                "FROM default.hard_hats"
             ),
             "mode": "published",
-            "name": "avg_length_of_employment",
+            "name": "default.avg_length_of_employment",
         },
     ),
     (
@@ -458,10 +458,10 @@ EXAMPLES = (  # type: ignore
             "description": "Total repair order discounts",
             "query": (
                 "SELECT sum(price * discount) as total_discount "
-                "FROM repair_order_details"
+                "FROM default.repair_order_details"
             ),
             "mode": "published",
-            "name": "total_repair_order_discounts",
+            "name": "default.total_repair_order_discounts",
         },
     ),
     (
@@ -470,10 +470,10 @@ EXAMPLES = (  # type: ignore
             "description": "Total repair order discounts",
             "query": (
                 "SELECT avg(price * discount) as avg_repair_order_discount "
-                "FROM repair_order_details"
+                "FROM default.repair_order_details"
             ),
             "mode": "published",
-            "name": "avg_repair_order_discounts",
+            "name": "default.avg_repair_order_discounts",
         },
     ),
     (
@@ -482,79 +482,79 @@ EXAMPLES = (  # type: ignore
             "description": "Average time to dispatch a repair order",
             "query": (
                 "SELECT avg(dispatched_date - order_date) as avg_time_to_dispatch "
-                "FROM repair_orders"
+                "FROM default.repair_orders"
             ),
             "mode": "published",
-            "name": "avg_time_to_dispatch",
+            "name": "default.avg_time_to_dispatch",
         },
     ),
     (
         (
-            "/nodes/repair_order_details/columns/repair_order_id/"
-            "?dimension=repair_order&dimension_column=repair_order_id"
+            "/nodes/default.repair_order_details/columns/repair_order_id/"
+            "?dimension=default.repair_order&dimension_column=repair_order_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_orders/columns/municipality_id/"
-            "?dimension=municipality_dim&dimension_column=municipality_id"
+            "/nodes/default.repair_orders/columns/municipality_id/"
+            "?dimension=default.municipality_dim&dimension_column=municipality_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_type/columns/contractor_id/"
-            "?dimension=contractor&dimension_column=contractor_id"
+            "/nodes/default.repair_type/columns/contractor_id/"
+            "?dimension=default.contractor&dimension_column=contractor_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_orders/columns/hard_hat_id/"
-            "?dimension=hard_hat&dimension_column=hard_hat_id"
+            "/nodes/default.repair_orders/columns/hard_hat_id/"
+            "?dimension=default.hard_hat&dimension_column=hard_hat_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_orders/columns/dispatcher_id/"
-            "?dimension=dispatcher&dimension_column=dispatcher_id"
+            "/nodes/default.repair_orders/columns/dispatcher_id/"
+            "?dimension=default.dispatcher&dimension_column=dispatcher_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/hard_hat/columns/state/"
-            "?dimension=us_state&dimension_column=state_short"
+            "/nodes/default.hard_hat/columns/state/"
+            "?dimension=default.us_state&dimension_column=state_short"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order_details/columns/repair_order_id/"
-            "?dimension=repair_order&dimension_column=repair_order_id"
+            "/nodes/default.repair_order_details/columns/repair_order_id/"
+            "?dimension=default.repair_order&dimension_column=repair_order_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order/columns/dispatcher_id/"
-            "?dimension=dispatcher&dimension_column=dispatcher_id"
+            "/nodes/default.repair_order/columns/dispatcher_id/"
+            "?dimension=default.dispatcher&dimension_column=dispatcher_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order/columns/hard_hat_id/"
-            "?dimension=hard_hat&dimension_column=hard_hat_id"
+            "/nodes/default.repair_order/columns/hard_hat_id/"
+            "?dimension=default.hard_hat&dimension_column=hard_hat_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order/columns/municipality_id/"
-            "?dimension=municipality_dim&dimension_column=municipality_id"
+            "/nodes/default.repair_order/columns/municipality_id/"
+            "?dimension=default.municipality_dim&dimension_column=municipality_id"
         ),
         {},
     ),

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -147,32 +147,32 @@ class TestDJClient:
         specific calls like `client.sources()` work.
         """
         expected_names_only = {
-            "repair_orders",
-            "repair_order_details",
-            "repair_type",
-            "contractors",
-            "municipality_municipality_type",
-            "municipality_type",
-            "municipality",
-            "dispatchers",
-            "hard_hats",
-            "hard_hat_state",
-            "us_states",
-            "us_region",
-            "repair_order",
-            "contractor",
-            "hard_hat",
-            "local_hard_hats",
-            "us_state",
-            "dispatcher",
-            "municipality_dim",
-            "num_repair_orders",
-            "avg_repair_price",
-            "total_repair_cost",
-            "avg_length_of_employment",
-            "total_repair_order_discounts",
-            "avg_repair_order_discounts",
-            "avg_time_to_dispatch",
+            "default.repair_orders",
+            "default.repair_order_details",
+            "default.repair_type",
+            "default.contractors",
+            "default.municipality_municipality_type",
+            "default.municipality_type",
+            "default.municipality",
+            "default.dispatchers",
+            "default.hard_hats",
+            "default.hard_hat_state",
+            "default.us_states",
+            "default.us_region",
+            "default.repair_order",
+            "default.contractor",
+            "default.hard_hat",
+            "default.local_hard_hats",
+            "default.us_state",
+            "default.dispatcher",
+            "default.municipality_dim",
+            "default.num_repair_orders",
+            "default.avg_repair_price",
+            "default.total_repair_cost",
+            "default.avg_length_of_employment",
+            "default.total_repair_order_discounts",
+            "default.avg_repair_order_discounts",
+            "default.avg_time_to_dispatch",
         }
         result_names_only = client.namespace("default").nodes()
         assert set(result_names_only) == expected_names_only
@@ -180,22 +180,22 @@ class TestDJClient:
         # sources
         result_names_only = client.namespace("default").sources()
         assert set(result_names_only) == {
-            "repair_orders",
-            "repair_order_details",
-            "repair_type",
-            "contractors",
-            "municipality_municipality_type",
-            "municipality_type",
-            "municipality",
-            "dispatchers",
-            "hard_hats",
-            "hard_hat_state",
-            "us_states",
-            "us_region",
+            "default.repair_orders",
+            "default.repair_order_details",
+            "default.repair_type",
+            "default.contractors",
+            "default.municipality_municipality_type",
+            "default.municipality_type",
+            "default.municipality",
+            "default.dispatchers",
+            "default.hard_hats",
+            "default.hard_hat_state",
+            "default.us_states",
+            "default.us_region",
         }
 
-        repair_orders = client.source("repair_orders")
-        assert repair_orders.name == "repair_orders"
+        repair_orders = client.source("default.repair_orders")
+        assert repair_orders.name == "default.repair_orders"
         assert repair_orders.catalog == "default"
         assert repair_orders.schema_ == "roads"
         assert repair_orders.table == "repair_orders"
@@ -204,17 +204,17 @@ class TestDJClient:
         # dimensions
         result_names_only = client.namespace("default").dimensions()
         assert set(result_names_only) == {
-            "repair_order",
-            "contractor",
-            "hard_hat",
-            "local_hard_hats",
-            "us_state",
-            "dispatcher",
-            "municipality_dim",
+            "default.repair_order",
+            "default.contractor",
+            "default.hard_hat",
+            "default.local_hard_hats",
+            "default.us_state",
+            "default.dispatcher",
+            "default.municipality_dim",
         }
-        repair_order_dim = client.dimension("repair_order")
-        assert repair_order_dim.name == "repair_order"
-        assert "FROM repair_orders" in repair_order_dim.query
+        repair_order_dim = client.dimension("default.repair_order")
+        assert repair_order_dim.name == "default.repair_order"
+        assert "FROM default.repair_orders" in repair_order_dim.query
         assert repair_order_dim.type == "dimension"
 
         # transforms
@@ -224,20 +224,20 @@ class TestDJClient:
         # metrics
         result_names_only = client.namespace("default").metrics()
         assert set(result_names_only) == {
-            "num_repair_orders",
-            "avg_repair_price",
-            "total_repair_cost",
-            "avg_length_of_employment",
-            "total_repair_order_discounts",
-            "avg_repair_order_discounts",
-            "avg_time_to_dispatch",
+            "default.num_repair_orders",
+            "default.avg_repair_price",
+            "default.total_repair_cost",
+            "default.avg_length_of_employment",
+            "default.total_repair_order_discounts",
+            "default.avg_repair_order_discounts",
+            "default.avg_time_to_dispatch",
         }
 
-        num_repair_orders = client.metric("num_repair_orders")
-        assert num_repair_orders.name == "num_repair_orders"
+        num_repair_orders = client.metric("default.num_repair_orders")
+        assert num_repair_orders.name == "default.num_repair_orders"
         assert (
             num_repair_orders.query
-            == "SELECT count(repair_order_id) as num_repair_orders FROM repair_orders"
+            == "SELECT count(repair_order_id) as num_repair_orders FROM default.repair_orders"
         )
         assert num_repair_orders.type == "metric"
 
@@ -252,19 +252,22 @@ class TestDJClient:
         """
         Verifies that deleting a node works.
         """
-        length_metric = client.metric("avg_length_of_employment")
+        length_metric = client.metric("default.avg_length_of_employment")
         response = length_metric.delete()
-        assert response == "Successfully deleted `avg_length_of_employment`"
-        assert "avg_length_of_employment" not in client.namespace("default").metrics()
+        assert response == "Successfully deleted `default.avg_length_of_employment`"
+        assert (
+            "default.avg_length_of_employment"
+            not in client.namespace("default").metrics()
+        )
 
     def test_create_node(self, client):  # pylint: disable=unused-argument
         """
         Verifies that creating a new node works.
         """
         account_type_table = client.new_source(
-            name="account_type_table",
+            name="default.account_type_table",
             description="A source table for account type data",
-            display_name="Account Type Table",
+            display_name="Default: Account Type Table",
             catalog="default",
             schema_="store",
             table="account_type_table",
@@ -276,13 +279,13 @@ class TestDJClient:
             ],
         )
         result = account_type_table.save(NodeMode.PUBLISHED)
-        assert result["name"] == "account_type_table"
-        assert "account_type_table" in client.namespace("default").sources()
+        assert result["name"] == "default.account_type_table"
+        assert "default.account_type_table" in client.namespace("default").sources()
 
         payment_type_table = client.new_source(
-            name="payment_type_table",
+            name="default.payment_type_table",
             description="A source table for different types of payments",
-            display_name="Payment Type Table",
+            display_name="Default: Payment Type Table",
             catalog="default",
             schema_="accounting",
             table="payment_type_table",
@@ -293,13 +296,13 @@ class TestDJClient:
             ],
         )
         result = payment_type_table.save(NodeMode.PUBLISHED)
-        assert result["name"] == "payment_type_table"
-        assert "payment_type_table" in client.namespace("default").sources()
+        assert result["name"] == "default.payment_type_table"
+        assert "default.payment_type_table" in client.namespace("default").sources()
 
         revenue = client.new_source(
-            name="revenue",
+            name="default.revenue",
             description="Record of payments",
-            display_name="Payment Records",
+            display_name="Default: Payment Records",
             catalog="default",
             schema_="accounting",
             table="revenue",
@@ -312,49 +315,52 @@ class TestDJClient:
             ],
         )
         result = revenue.save(NodeMode.PUBLISHED)
-        assert result["name"] == "revenue"
-        assert "revenue" in client.namespace("default").sources()
+        assert result["name"] == "default.revenue"
+        assert "default.revenue" in client.namespace("default").sources()
 
         payment_type_dim = client.new_dimension(
-            name="payment_type",
+            name="default.payment_type",
             description="Payment type dimension",
-            display_name="Payment Type",
+            display_name="Default: Payment Type",
             query=(
                 "SELECT id, payment_type_name, payment_type_classification "
-                "FROM payment_type_table"
+                "FROM default.payment_type_table"
             ),
             primary_key=["id"],
         )
         result = payment_type_dim.save(NodeMode.PUBLISHED)
-        assert result["name"] == "payment_type"
-        assert "payment_type" in client.namespace("default").dimensions()
+        assert result["name"] == "default.payment_type"
+        assert "default.payment_type" in client.namespace("default").dimensions()
 
         account_type_dim = client.new_dimension(
-            name="account_type",
+            name="default.account_type",
             description="Account type dimension",
-            display_name="Account Type",
+            display_name="Default: Account Type",
             query=(
                 "SELECT id, account_type_name, "
                 "account_type_classification FROM "
-                "account_type_table"
+                "default.account_type_table"
             ),
             primary_key=["id"],
         )
         result = account_type_dim.save(NodeMode.PUBLISHED)
-        assert result["name"] == "account_type"
-        assert "account_type" in client.namespace("default").dimensions()
+        assert result["name"] == "default.account_type"
+        assert "default.account_type" in client.namespace("default").dimensions()
 
         large_revenue_payments_only = client.new_transform(
-            name="large_revenue_payments_only",
-            description="Only large revenue payments",
+            name="default.large_revenue_payments_only",
+            description="Default: Only large revenue payments",
             query=(
                 "SELECT payment_id, payment_amount, customer_id, account_type "
-                "FROM revenue WHERE payment_amount > 1000000"
+                "FROM default.revenue WHERE payment_amount > 1000000"
             ),
         )
         result = large_revenue_payments_only.save(NodeMode.PUBLISHED)
-        assert result["name"] == "large_revenue_payments_only"
-        assert "large_revenue_payments_only" in client.namespace("default").transforms()
+        assert result["name"] == "default.large_revenue_payments_only"
+        assert (
+            "default.large_revenue_payments_only"
+            in client.namespace("default").transforms()
+        )
 
         result = large_revenue_payments_only.add_materialization_config(
             MaterializationConfig(
@@ -366,37 +372,39 @@ class TestDJClient:
         )
         assert result == {
             "message": "Successfully updated materialization config for node "
-            "`large_revenue_payments_only` and engine `spark`.",
+            "`default.large_revenue_payments_only` and engine `spark`.",
         }
 
         large_revenue_payments_and_business_only = client.new_transform(
-            name="large_revenue_payments_and_business_only",
+            name="default.large_revenue_payments_and_business_only",
             description="Only large revenue payments from business accounts",
             query=(
                 "SELECT payment_id, payment_amount, customer_id, account_type "
-                "FROM revenue WHERE "
-                "large_revenue_payments_and_business_only > 1000000 "
+                "FROM default.revenue WHERE "
+                "default.large_revenue_payments_and_business_only > 1000000 "
                 "AND account_type='BUSINESS'"
             ),
         )
         large_revenue_payments_and_business_only.save(NodeMode.PUBLISHED)
-        result = client.transform("large_revenue_payments_and_business_only")
-        assert result.name == "large_revenue_payments_and_business_only"
+        result = client.transform("default.large_revenue_payments_and_business_only")
+        assert result.name == "default.large_revenue_payments_and_business_only"
         assert (
-            "large_revenue_payments_and_business_only"
+            "default.large_revenue_payments_and_business_only"
             in client.namespace(
                 "default",
             ).transforms()
         )
 
         number_of_account_types = client.new_metric(
-            name="number_of_account_types",
+            name="default.number_of_account_types",
             description="Total number of account types",
-            query="SELECT count(id) as num_accounts FROM account_type",
+            query="SELECT count(id) as num_accounts FROM default.account_type",
         )
         result = number_of_account_types.save(NodeMode.PUBLISHED)
-        assert result["name"] == "number_of_account_types"
-        assert "number_of_account_types" in client.namespace("default").metrics()
+        assert result["name"] == "default.number_of_account_types"
+        assert (
+            "default.number_of_account_types" in client.namespace("default").metrics()
+        )
 
     def test_link_dimension(self, client):  # pylint: disable=unused-argument
         """
@@ -430,9 +438,13 @@ class TestDJClient:
 
         # Retrieve SQL for multiple metrics using the client object
         result = client.sql(
-            metrics=["num_repair_orders", "avg_repair_price"],
-            dimensions=["hard_hat.city", "hard_hat.state", "dispatcher.company_name"],
-            filters=["hard_hat.state = 'AZ'"],
+            metrics=["default.num_repair_orders", "default.avg_repair_price"],
+            dimensions=[
+                "default.hard_hat.city",
+                "default.hard_hat.state",
+                "default.dispatcher.company_name",
+            ],
+            filters=["default.hard_hat.state = 'AZ'"],
             engine_name="spark",
             engine_version="3.1.1",
         )
@@ -441,13 +453,13 @@ class TestDJClient:
         # Should fail due to dimension not being available
         result = client.sql(
             metrics=["foo.bar.num_repair_orders", "foo.bar.avg_repair_price"],
-            dimensions=["hard_hat.city"],
-            filters=["hard_hat.state = 'AZ'"],
+            dimensions=["default.hard_hat.city"],
+            filters=["default.hard_hat.state = 'AZ'"],
             engine_name="spark",
             engine_version="3.1.1",
         )
         assert result["message"] == (
-            "The dimension attribute `hard_hat.city` is not available on "
+            "The dimension attribute `default.hard_hat.city` is not available on "
             "every metric and thus cannot be included."
         )
 
@@ -457,13 +469,13 @@ class TestDJClient:
         """
         metrics = client.metrics()
         assert metrics == [
-            "num_repair_orders",
-            "avg_repair_price",
-            "total_repair_cost",
-            "avg_length_of_employment",
-            "total_repair_order_discounts",
-            "avg_repair_order_discounts",
-            "avg_time_to_dispatch",
+            "default.num_repair_orders",
+            "default.avg_repair_price",
+            "default.total_repair_cost",
+            "default.avg_length_of_employment",
+            "default.total_repair_order_discounts",
+            "default.avg_repair_order_discounts",
+            "default.avg_time_to_dispatch",
             "foo.bar.num_repair_orders",
             "foo.bar.avg_repair_price",
             "foo.bar.total_repair_cost",
@@ -486,8 +498,8 @@ class TestDJClient:
         Test some client failure modes when retrieving nodes.
         """
         with pytest.raises(DJClientException) as excinfo:
-            client.transform(node_name="fruit")
-        assert "No node with name fruit exists!" in str(excinfo)
+            client.transform(node_name="default.fruit")
+        assert "No node with name default.fruit exists!" in str(excinfo)
 
         with pytest.raises(DJClientException) as excinfo:
             client.transform(node_name="foo.bar.avg_repair_price")

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -655,7 +655,6 @@ def create_a_source(
     """
     raise_if_node_exists(session, data.name)
 
-    # Extract and assign namespace if one exists
     namespace = get_namespace_from_name(data.name)
     get_node_namespace(
         session=session,
@@ -767,7 +766,7 @@ def create_a_node(
         key_column not in column_names for key_column in data.primary_key
     ):
         raise DJInvalidInputException(
-            f"Some columns in the primary key {','.join(data.primary_key)} "
+            f"Some columns in the primary key [{','.join(data.primary_key)}] "
             f"were not found in the list of available columns for the node {node.name}.",
         )
     if data.primary_key:
@@ -796,7 +795,6 @@ def create_a_cube(
     """
     raise_if_node_exists(session, data.name)
 
-    # Extract and assign namespace if one exists
     namespace = get_namespace_from_name(data.name)
     get_node_namespace(
         session=session,
@@ -819,16 +817,13 @@ def create_a_cube(
 def link_a_dimension(
     name: str,
     column: str,
-    dimension: Optional[str] = None,
+    dimension: str,
     dimension_column: Optional[str] = None,
     session: Session = Depends(get_session),
 ) -> JSONResponse:
     """
     Add information to a node column
     """
-    if not dimension:  # If no dimension is set, assume it matches the column name
-        dimension = column
-
     node = get_node_by_name(session=session, name=name)
     dimension_node = get_node_by_name(
         session=session,
@@ -854,7 +849,7 @@ def link_a_dimension(
                 f"The column {target_column.name} has type {target_column.type} "
                 f"and is being linked to the dimension {dimension} via the dimension"
                 f" column {dimension_column}, which has type {column_from_dimension.type}."
-                " These column types are incompatible and the dimension cannot be linked!",
+                " These column types are incompatible and the dimension cannot be linked",
             )
 
     target_column.dimension = dimension_node

--- a/dj/utils.py
+++ b/dj/utils.py
@@ -156,6 +156,6 @@ def get_namespace_from_name(name: str) -> str:
     """
     if "." in name:
         node_namespace, _ = name.rsplit(".", 1)
-    else:
+    else: # pragma: no cover
         raise DJException(f"No namespace provided: {name}")
     return node_namespace

--- a/dj/utils.py
+++ b/dj/utils.py
@@ -156,6 +156,6 @@ def get_namespace_from_name(name: str) -> str:
     """
     if "." in name:
         node_namespace, _ = name.rsplit(".", 1)
-    else: # pragma: no cover
+    else:  # pragma: no cover
         raise DJException(f"No namespace provided: {name}")
     return node_namespace

--- a/dj/utils.py
+++ b/dj/utils.py
@@ -157,5 +157,5 @@ def get_namespace_from_name(name: str) -> str:
     if "." in name:
         node_namespace, _ = name.rsplit(".", 1)
     else:
-        node_namespace = "default"
+        raise DJException(f"No namespace provided: {name}")
     return node_namespace

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -15,44 +15,47 @@ def test_read_cube(client_with_examples: TestClient) -> None:
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": ["number_of_account_types"],
-            "dimensions": ["account_type.account_type_name"],
+            "metrics": ["default.number_of_account_types"],
+            "dimensions": ["default.account_type.account_type_name"],
             "filters": [],
             "description": "A cube of number of accounts grouped by account type",
             "mode": "published",
-            "name": "number_of_accounts_by_account_type",
+            "name": "default.number_of_accounts_by_account_type",
         },
     )
     assert response.status_code == 201
     data = response.json()
     assert data["version"] == "v1.0"
     assert data["type"] == "cube"
-    assert data["name"] == "number_of_accounts_by_account_type"
-    assert data["display_name"] == "Number Of Accounts By Account Type"
+    assert data["name"] == "default.number_of_accounts_by_account_type"
+    assert data["display_name"] == "Default: Number Of Accounts By Account Type"
 
     # Read the cube
-    response = client_with_examples.get("/cubes/number_of_accounts_by_account_type")
+    response = client_with_examples.get(
+        "/cubes/default.number_of_accounts_by_account_type",
+    )
     assert response.status_code == 200
     data = response.json()
     assert data["type"] == "cube"
-    assert data["name"] == "number_of_accounts_by_account_type"
-    assert data["display_name"] == "Number Of Accounts By Account Type"
+    assert data["name"] == "default.number_of_accounts_by_account_type"
+    assert data["display_name"] == "Default: Number Of Accounts By Account Type"
     assert data["version"] == "v1.0"
     assert data["description"] == "A cube of number of accounts grouped by account type"
     assert compare_query_strings(
         data["query"],
         """
         SELECT
-          account_type.account_type_name,
-          count(account_type.id) AS num_accounts
+          default_DOT_account_type.account_type_name,
+          count(default_DOT_account_type.id) AS num_accounts
         FROM (
           SELECT
-            account_type_table.account_type_classification,
-            account_type_table.account_type_name,
-            account_type_table.id
-          FROM accounting.account_type_table AS account_type_table) AS account_type
+            default_DOT_account_type_table.account_type_classification,
+            default_DOT_account_type_table.account_type_name,
+            default_DOT_account_type_table.id
+          FROM accounting.account_type_table AS default_DOT_account_type_table)
+          AS default_DOT_account_type
           GROUP BY
-            account_type.account_type_name
+            default_DOT_account_type.account_type_name
         """,
     )
 
@@ -67,8 +70,11 @@ def test_create_invalid_cube(client_with_examples: TestClient):
             "description": "A cube of number of accounts grouped by account type",
             "mode": "published",
             "query": "SELECT 1",
-            "cube_elements": ["number_of_account_types", "account_type"],
-            "name": "cubes_shouldnt_have_queries",
+            "cube_elements": [
+                "default.number_of_account_types",
+                "default.account_type",
+            ],
+            "name": "default.cubes_shouldnt_have_queries",
         },
     )
     assert response.status_code == 422
@@ -90,17 +96,17 @@ def test_create_invalid_cube(client_with_examples: TestClient):
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": ["account_type"],
-            "dimensions": ["account_type.account_type_name"],
+            "metrics": ["default.account_type"],
+            "dimensions": ["default.account_type.account_type_name"],
             "description": "A cube of number of accounts grouped by account type",
             "mode": "published",
-            "name": "cubes_must_have_elements",
+            "name": "default.cubes_must_have_elements",
         },
     )
     assert response.status_code == 422
     data = response.json()
     assert data == {
-        "message": "Node account_type of type dimension cannot be added to a cube. "
+        "message": "Node default.account_type of type dimension cannot be added to a cube. "
         "Did you mean to add a dimension attribute?",
         "errors": [],
         "warnings": [],
@@ -110,17 +116,17 @@ def test_create_invalid_cube(client_with_examples: TestClient):
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": ["number_of_account_types"],
-            "dimensions": ["payment_type.payment_type_name"],
+            "metrics": ["default.number_of_account_types"],
+            "dimensions": ["default.payment_type.payment_type_name"],
             "description": "",
             "mode": "published",
-            "name": "cubes_cant_use_source_nodes",
+            "name": "default.cubes_cant_use_source_nodes",
         },
     )
     assert response.status_code == 422
     data = response.json()
     assert data == {
-        "message": "The dimension attribute `payment_type.payment_type_name` is not "
+        "message": "The dimension attribute `default.payment_type.payment_type_name` is not "
         "available on every metric and thus cannot be included.",
         "errors": [],
         "warnings": [],
@@ -131,10 +137,10 @@ def test_create_invalid_cube(client_with_examples: TestClient):
         "/nodes/cube/",
         json={
             "metrics": [],
-            "dimensions": ["account_type.account_type_name"],
+            "dimensions": ["default.account_type.account_type_name"],
             "description": "",
             "mode": "published",
-            "name": "cubes_must_have_metrics",
+            "name": "default.cubes_must_have_metrics",
         },
     )
     assert response.status_code == 422
@@ -149,11 +155,11 @@ def test_create_invalid_cube(client_with_examples: TestClient):
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": ["number_of_account_types"],
+            "metrics": ["default.number_of_account_types"],
             "dimensions": [],
             "description": "A cube of number of accounts grouped by account type",
             "mode": "published",
-            "name": "cubes_must_have_dimensions",
+            "name": "default.cubes_must_have_dimensions",
         },
     )
     assert response.status_code == 422
@@ -175,11 +181,11 @@ def test_raise_on_cube_with_multiple_catalogs(
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": ["number_of_account_types", "basic.num_comments"],
-            "dimensions": ["account_type.account_type_name"],
+            "metrics": ["default.number_of_account_types", "basic.num_comments"],
+            "dimensions": ["default.account_type.account_type_name"],
             "description": "multicatalog cube's raise an error",
             "mode": "published",
-            "name": "multicatalog",
+            "name": "default.multicatalog",
         },
     )
     assert not response.ok
@@ -192,11 +198,11 @@ def test_cube_sql(client_with_examples: TestClient):
     Test that the generated cube materialization SQL makes sense
     """
     metrics_list = [
-        "discounted_orders_rate",
-        "num_repair_orders",
-        "avg_repair_price",
-        "total_repair_cost",
-        "total_repair_order_discounts",
+        "default.discounted_orders_rate",
+        "default.num_repair_orders",
+        "default.avg_repair_price",
+        "default.total_repair_cost",
+        "default.total_repair_order_discounts",
     ]
     # Should fail because dimension attribute isn't available
     response = client_with_examples.post(
@@ -204,120 +210,94 @@ def test_cube_sql(client_with_examples: TestClient):
         json={
             "metrics": metrics_list,
             "dimensions": [
-                "contractor.company_name",
+                "default.contractor.company_name",
             ],
             "description": "Cube of various metrics related to repairs",
             "mode": "published",
-            "name": "repairs_cube",
+            "name": "default.repairs_cube",
         },
     )
     assert response.json()["message"] == (
-        "The dimension attribute `contractor.company_name` is not available "
+        "The dimension attribute `default.contractor.company_name` is not available "
         "on every metric and thus cannot be included."
     )
 
     # Metric that doubles the total repair cost to test the sum(x) + sum(y) scenario
-    client_with_examples.post(
+    response = client_with_examples.post(
         "/nodes/metric/",
         json={
             "description": "Double total repair cost",
             "query": (
                 "SELECT sum(price) + sum(price) as double_total_repair_cost "
-                "FROM repair_order_details"
+                "FROM default.repair_order_details"
             ),
             "mode": "published",
-            "name": "double_total_repair_cost",
+            "name": "default.double_total_repair_cost",
         },
     )
+    assert response.ok
     # Should succeed
     response = client_with_examples.post(
         "/nodes/cube/",
         json={
-            "metrics": metrics_list + ["double_total_repair_cost"],
+            "metrics": metrics_list + ["default.double_total_repair_cost"],
             "dimensions": [
-                "hard_hat.country",
-                "hard_hat.postal_code",
-                "hard_hat.city",
-                "hard_hat.state",
-                "dispatcher.company_name",
-                "municipality_dim.local_region",
+                "default.hard_hat.country",
+                "default.hard_hat.postal_code",
+                "default.hard_hat.city",
+                "default.hard_hat.state",
+                "default.dispatcher.company_name",
+                "default.municipality_dim.local_region",
             ],
-            "filters": ["hard_hat.state='AZ'"],
+            "filters": ["default.hard_hat.state='AZ'"],
             "description": "Cube of various metrics related to repairs",
             "mode": "published",
-            "name": "repairs_cube",
+            "name": "default.repairs_cube",
         },
     )
     results = response.json()
 
-    assert results["name"] == "repairs_cube"
-    assert results["display_name"] == "Repairs Cube"
+    assert results["name"] == "default.repairs_cube"
+    assert results["display_name"] == "Default: Repairs Cube"
     assert results["description"] == "Cube of various metrics related to repairs"
     expected_query = """
-        SELECT
-          dispatcher.company_name,
-          hard_hat.city,
-          hard_hat.country,
-          hard_hat.postal_code,
-          hard_hat.state,
-          municipality_dim.local_region,
-          sum(repair_order_details.price) + sum(repair_order_details.price) AS double_total_repair_cost,
-          sum(repair_order_details.price * repair_order_details.discount) AS total_discount,
-          sum(repair_order_details.price) AS total_repair_cost,
-          avg(repair_order_details.price) AS avg_repair_price,
-          count(repair_orders.repair_order_id) AS num_repair_orders,
-          CAST(sum(if(repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*)
-            AS discounted_orders_rate
-        FROM roads.repair_order_details AS repair_order_details
-        LEFT OUTER JOIN (
-          SELECT
-            repair_orders.dispatcher_id,
-            repair_orders.hard_hat_id,
-            repair_orders.municipality_id,
-            repair_orders.repair_order_id
-          FROM roads.repair_orders AS repair_orders
-        ) AS repair_order
-        ON repair_order_details.repair_order_id = repair_order.repair_order_id
-        LEFT OUTER JOIN (
-          SELECT
-            dispatchers.company_name,
-            dispatchers.dispatcher_id
-          FROM roads.dispatchers AS dispatchers
-        ) AS dispatcher ON repair_order.dispatcher_id = dispatcher.dispatcher_id
-        LEFT OUTER JOIN (
-          SELECT
-            hard_hats.city,
-            hard_hats.country,
-            hard_hats.hard_hat_id,
-            hard_hats.postal_code,
-            hard_hats.state
-          FROM roads.hard_hats AS hard_hats
-        ) AS hard_hat ON repair_order.hard_hat_id = hard_hat.hard_hat_id
-        LEFT OUTER JOIN (
-          SELECT
-            municipality.local_region,
-            municipality.municipality_id
-          FROM roads.municipality AS municipality
-          LEFT JOIN roads.municipality_municipality_type AS municipality_municipality_type
-          ON municipality.municipality_id = municipality_municipality_type.municipality_id
-          LEFT JOIN roads.municipality_type AS municipality_type
-          ON municipality_municipality_type.municipality_type_id
-             = municipality_type.municipality_type_desc
-        ) AS municipality_dim
-        ON repair_order.municipality_id = municipality_dim.municipality_id
-        WHERE hard_hat.state = 'AZ'
-        GROUP BY
-          hard_hat.country,
-          hard_hat.postal_code,
-          hard_hat.city,
-          hard_hat.state,
-          dispatcher.company_name,
-          municipality_dim.local_region
+        SELECT  default_DOT_dispatcher.company_name,
+                default_DOT_hard_hat.city,
+                default_DOT_hard_hat.country,
+                default_DOT_hard_hat.postal_code,
+                default_DOT_hard_hat.state,
+                default_DOT_municipality_dim.local_region,
+                sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS double_total_repair_cost,
+                avg(default_DOT_repair_order_details.price) AS avg_repair_price,
+                sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) AS total_discount,
+                CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS discounted_orders_rate,
+                count(default_DOT_repair_orders.repair_order_id) AS num_repair_orders,
+                sum(default_DOT_repair_order_details.price) AS total_repair_cost
+        FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+                default_DOT_repair_orders.hard_hat_id,
+                default_DOT_repair_orders.municipality_id,
+                default_DOT_repair_orders.repair_order_id
+        FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+                default_DOT_dispatchers.dispatcher_id
+        FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+                default_DOT_hard_hats.country,
+                default_DOT_hard_hats.hard_hat_id,
+                default_DOT_hard_hats.postal_code,
+                default_DOT_hard_hats.state
+        FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+                default_DOT_municipality.municipality_id
+        FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+        WHERE  default_DOT_hard_hat.state = 'AZ'
+        GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
     """
     assert compare_query_strings(results["query"], expected_query)
 
     response = client_with_examples.post(
-        "/nodes/repairs_cube/materialization/",
+        "/nodes/default.repairs_cube/materialization/",
         json={
             "engine_name": "druid",
             "engine_version": "",
@@ -327,156 +307,149 @@ def test_cube_sql(client_with_examples: TestClient):
     )
     assert response.json() == {
         "message": "Successfully updated materialization config "
-        "for node `repairs_cube` and engine `druid`.",
+        "for node `default.repairs_cube` and engine `druid`.",
     }
 
-    response = client_with_examples.get("/cubes/repairs_cube/")
+    response = client_with_examples.get("/cubes/default.repairs_cube/")
     data = response.json()
     assert data["cube_elements"] == [
         {
             "name": "discounted_orders_rate",
-            "node_name": "discounted_orders_rate",
+            "node_name": "default.discounted_orders_rate",
             "type": "metric",
         },
         {
             "name": "num_repair_orders",
-            "node_name": "num_repair_orders",
+            "node_name": "default.num_repair_orders",
             "type": "metric",
         },
-        {"name": "avg_repair_price", "node_name": "avg_repair_price", "type": "metric"},
+        {
+            "name": "avg_repair_price",
+            "node_name": "default.avg_repair_price",
+            "type": "metric",
+        },
         {
             "name": "total_repair_cost",
-            "node_name": "total_repair_cost",
+            "node_name": "default.total_repair_cost",
             "type": "metric",
         },
         {
             "name": "total_discount",
-            "node_name": "total_repair_order_discounts",
+            "node_name": "default.total_repair_order_discounts",
             "type": "metric",
         },
         {
             "name": "double_total_repair_cost",
-            "node_name": "double_total_repair_cost",
+            "node_name": "default.double_total_repair_cost",
             "type": "metric",
         },
-        {"name": "country", "node_name": "hard_hat", "type": "dimension"},
-        {"name": "postal_code", "node_name": "hard_hat", "type": "dimension"},
-        {"name": "city", "node_name": "hard_hat", "type": "dimension"},
-        {"name": "state", "node_name": "hard_hat", "type": "dimension"},
-        {"name": "company_name", "node_name": "dispatcher", "type": "dimension"},
-        {"name": "local_region", "node_name": "municipality_dim", "type": "dimension"},
+        {"name": "country", "node_name": "default.hard_hat", "type": "dimension"},
+        {"name": "postal_code", "node_name": "default.hard_hat", "type": "dimension"},
+        {"name": "city", "node_name": "default.hard_hat", "type": "dimension"},
+        {"name": "state", "node_name": "default.hard_hat", "type": "dimension"},
+        {
+            "name": "company_name",
+            "node_name": "default.dispatcher",
+            "type": "dimension",
+        },
+        {
+            "name": "local_region",
+            "node_name": "default.municipality_dim",
+            "type": "dimension",
+        },
     ]
     expected_materialization_query = """
-        SELECT
-          count(repair_order_details.price) price_count,
-          dispatcher.company_name,
-          count(repair_orders.repair_order_id) repair_order_id_count,
-          sum(repair_order_details.price * repair_order_details.discount) price_discount_sum,
-          hard_hat.city,
-          count(*) placeholder_count,
-          sum(if(repair_order_details.discount > 0.0, 1, 0)) discount_sum,
-          hard_hat.state,
-          municipality_dim.local_region,
-          hard_hat.postal_code,
-          sum(repair_order_details.price) price_sum,
-          hard_hat.country
-        FROM roads.repair_order_details AS repair_order_details
-        LEFT OUTER JOIN (
-          SELECT
-            repair_orders.dispatcher_id,
-            repair_orders.hard_hat_id,
-            repair_orders.municipality_id,
-            repair_orders.repair_order_id
-          FROM roads.repair_orders AS repair_orders
-        ) AS repair_order
-        ON repair_order_details.repair_order_id = repair_order.repair_order_id
-        LEFT OUTER JOIN (
-          SELECT
-            dispatchers.company_name,
-            dispatchers.dispatcher_id
-          FROM roads.dispatchers AS dispatchers
-        ) AS dispatcher ON repair_order.dispatcher_id = dispatcher.dispatcher_id
-        LEFT OUTER JOIN (
-          SELECT
-            hard_hats.city,
-            hard_hats.country,
-            hard_hats.hard_hat_id,
-            hard_hats.postal_code,
-            hard_hats.state
-          FROM roads.hard_hats AS hard_hats
-        ) AS hard_hat ON repair_order.hard_hat_id = hard_hat.hard_hat_id
-        LEFT OUTER JOIN (
-          SELECT
-            municipality.local_region,
-            municipality.municipality_id
-          FROM roads.municipality AS municipality
-          LEFT JOIN roads.municipality_municipality_type AS municipality_municipality_type
-          ON municipality.municipality_id = municipality_municipality_type.municipality_id
-          LEFT JOIN roads.municipality_type AS municipality_type
-          ON municipality_municipality_type.municipality_type_id
-             = municipality_type.municipality_type_desc
-        ) AS municipality_dim
-        ON repair_order.municipality_id = municipality_dim.municipality_id
-        WHERE hard_hat.state = 'AZ'
-        GROUP BY
-          hard_hat.country,
-          hard_hat.postal_code,
-          hard_hat.city,
-          hard_hat.state,
-          dispatcher.company_name,
-          municipality_dim.local_region
+        SELECT  count(*) placeholder_count,
+                sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
+                default_DOT_hard_hat.city,
+                sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
+                default_DOT_hard_hat.country,
+                count(default_DOT_repair_order_details.price) price_count,
+                default_DOT_hard_hat.state,
+                default_DOT_dispatcher.company_name,
+                default_DOT_hard_hat.postal_code,
+                default_DOT_municipality_dim.local_region,
+                count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
+                sum(default_DOT_repair_order_details.price) price_sum
+        FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER  JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+                default_DOT_repair_orders.hard_hat_id,
+                default_DOT_repair_orders.municipality_id,
+                default_DOT_repair_orders.repair_order_id
+        FROM roads.repair_orders AS default_DOT_repair_orders
+        ) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+        LEFT OUTER  JOIN (SELECT  default_DOT_dispatchers.company_name,
+                default_DOT_dispatchers.dispatcher_id
+        FROM roads.dispatchers AS default_DOT_dispatchers
+        ) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER  JOIN (SELECT  default_DOT_hard_hats.city,
+                default_DOT_hard_hats.country,
+                default_DOT_hard_hats.hard_hat_id,
+                default_DOT_hard_hats.postal_code,
+                default_DOT_hard_hats.state
+        FROM roads.hard_hats AS default_DOT_hard_hats
+        ) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER  JOIN (SELECT  default_DOT_municipality.local_region,
+                default_DOT_municipality.municipality_id
+        FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
+        ) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+        WHERE  default_DOT_hard_hat.state = 'AZ'
+        GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
     """
     assert compare_query_strings(
         data["materialization_configs"][0]["config"]["query"],
         expected_materialization_query,
     )
     assert data["materialization_configs"][0]["config"]["measures"] == {
-        "avg_repair_price": [
-            {
-                "name": "price_count",
-                "agg": "count",
-                "expr": "count(repair_order_details.price)",
-            },
-            {
-                "name": "price_sum",
-                "agg": "sum",
-                "expr": "sum(repair_order_details.price)",
-            },
-        ],
         "double_total_repair_cost": [
             {
-                "agg": "sum",
-                "expr": "sum(repair_order_details.price)",
                 "name": "price_sum",
-            },
-        ],
-        "discounted_orders_rate": [
-            {
                 "agg": "sum",
-                "expr": "sum(if(repair_order_details.discount > " "0.0, 1, 0))",
-                "name": "discount_sum",
-            },
-            {"agg": "count", "expr": "count(*)", "name": "placeholder_count"},
-        ],
-        "num_repair_orders": [
-            {
-                "name": "repair_order_id_count",
-                "agg": "count",
-                "expr": "count(repair_orders.repair_order_id)",
+                "expr": "sum(default_DOT_repair_order_details.price)",
             },
         ],
         "total_discount": [
             {
-                "agg": "sum",
-                "expr": "sum(repair_order_details.price * repair_order_details.discount)",
                 "name": "price_discount_sum",
+                "agg": "sum",
+                "expr": (
+                    "sum(default_DOT_repair_order_details.price * "
+                    "default_DOT_repair_order_details.discount)"
+                ),
             },
         ],
         "total_repair_cost": [
             {
                 "name": "price_sum",
                 "agg": "sum",
-                "expr": "sum(repair_order_details.price)",
+                "expr": "sum(default_DOT_repair_order_details.price)",
             },
+        ],
+        "avg_repair_price": [
+            {
+                "name": "price_count",
+                "agg": "count",
+                "expr": "count(default_DOT_repair_order_details.price)",
+            },
+            {
+                "name": "price_sum",
+                "agg": "sum",
+                "expr": "sum(default_DOT_repair_order_details.price)",
+            },
+        ],
+        "num_repair_orders": [
+            {
+                "name": "repair_order_id_count",
+                "agg": "count",
+                "expr": "count(default_DOT_repair_orders.repair_order_id)",
+            },
+        ],
+        "discounted_orders_rate": [
+            {
+                "name": "discount_sum",
+                "agg": "sum",
+                "expr": "sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0))",
+            },
+            {"name": "placeholder_count", "agg": "count", "expr": "count(*)"},
         ],
     }

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -21,7 +21,7 @@ class TestDataForNode:
         Test trying to get dimensions data while setting dimensions
         """
         response = client_with_examples.get(
-            "/data/payment_type/",
+            "/data/default.payment_type/",
             params={
                 "dimensions": ["something"],
                 "filters": [],
@@ -39,7 +39,7 @@ class TestDataForNode:
         Test trying to get dimensions data while setting dimensions
         """
         response = client_with_query_service.get(
-            "/data/payment_type/",
+            "/data/default.payment_type/",
         )
         data = response.json()
         assert response.status_code == 200
@@ -85,7 +85,7 @@ class TestDataForNode:
         """
         Test retrieving data for a source node
         """
-        response = client_with_query_service.get("/data/revenue/")
+        response = client_with_query_service.get("/data/default.revenue/")
         data = response.json()
         assert response.status_code == 200
         assert data == {
@@ -120,7 +120,9 @@ class TestDataForNode:
         """
         Test retrieving data for a transform node
         """
-        response = client_with_query_service.get("/data/large_revenue_payments_only/")
+        response = client_with_query_service.get(
+            "/data/default.large_revenue_payments_only/",
+        )
         data = response.json()
         assert response.status_code == 200
         assert data == {
@@ -129,8 +131,8 @@ class TestDataForNode:
             "engine_version": None,
             "submitted_query": (
                 "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
-                '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n WHERE  '
-                "revenue.payment_amount > 1000000"
+                '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n '
+                "WHERE  revenue.payment_amount > 1000000"
             ),
             "executed_query": None,
             "scheduled": None,
@@ -208,8 +210,8 @@ class TestDataForNode:
         Test getting multiple metrics and dimensions
         """
         response = client_with_query_service.get(
-            "/data?metrics=num_repair_orders&metrics="
-            "avg_repair_price&dimensions=dispatcher.company_name",
+            "/data?metrics=default.num_repair_orders&metrics="
+            "default.avg_repair_price&dimensions=default.dispatcher.company_name",
         )
         data = response.json()
         assert response.status_code == 200
@@ -239,20 +241,21 @@ class TestDataForNode:
             "scheduled": None,
             "started": None,
             "state": "FINISHED",
-            "submitted_query": "SELECT  avg(repair_order_details.price) AS "
-            "avg_repair_price,\\n\\tdispatcher.company_name,\\n\\t"
-            "count(repair_orders.repair_order_id) "
-            "AS num_repair_orders \\n FROM roads.repair_order_details "
-            "AS repair_order_details LEFT OUTER JOIN (SELECT  "
-            "repair_orders.dispatcher_id,\\n\\trepair_orders.hard_hat_id,"
-            "\\n\\trepair_orders.municipality_id,\\n\\trepair_orders.repair_order_id "
-            "\\n FROM roads.repair_orders AS repair_orders) AS "
-            "repair_order ON repair_order_details.repair_order_id = "
-            "repair_order.repair_order_id\\nLEFT OUTER JOIN (SELECT  "
-            "dispatchers.company_name,\\n\\tdispatchers.dispatcher_id "
-            "\\n FROM roads.dispatchers AS dispatchers) AS dispatcher "
-            "ON repair_order.dispatcher_id = dispatcher.dispatcher_id "
-            "\\n GROUP BY  dispatcher.company_name\\n",
+            "submitted_query": (
+                "SELECT  avg(repair_order_details.price) AS avg_repair_price,\\n\\t"
+                "dispatcher.company_name,\\n\\tcount(repair_orders.repair_order_id) AS "
+                "num_repair_orders \\n FROM roads.repair_order_details AS repair_order_details "
+                "LEFT OUTER JOIN (SELECT  repair_orders.dispatcher_id,\\n\\t"
+                "repair_orders.hard_hat_id,"
+                "\\n\\trepair_orders.municipality_id,\\n\\trepair_orders.repair_order_id \\n FROM "
+                "roads.repair_orders AS repair_orders) AS repair_order ON "
+                "repair_order_details.repair_order_id "
+                "= repair_order.repair_order_id\\nLEFT OUTER JOIN (SELECT  "
+                "dispatchers.company_name,\\n\\tdispatchers.dispatcher_id \\n FROM "
+                "roads.dispatchers AS dispatchers) AS dispatcher "
+                "ON repair_order.dispatcher_id = dispatcher.dispatcher_id \\n GROUP BY  "
+                "dispatcher.company_name\\n"
+            ),
         }
 
 
@@ -270,7 +273,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test adding an availability state
         """
         response = client_with_examples.post(
-            "/data/large_revenue_payments_and_business_only/availability/",
+            "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -286,7 +289,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         statement = select(Node).where(
-            Node.name == "large_revenue_payments_and_business_only",
+            Node.name == "default.large_revenue_payments_and_business_only",
         )
         large_revenue_payments_and_business_only = session.exec(statement).one()
         node_dict = large_revenue_payments_and_business_only.current.availability.dict()
@@ -309,7 +312,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test raising when the catalog does not match
         """
         response = client_with_examples.post(
-            "/data/large_revenue_payments_and_business_only/availability/",
+            "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "public",
                 "schema_": "accounting",
@@ -335,7 +338,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test adding multiple availability states
         """
         response = client_with_examples.post(
-            "/data/large_revenue_payments_and_business_only/availability/",
+            "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -351,7 +354,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         response = client_with_examples.post(
-            "/data/large_revenue_payments_and_business_only/availability/",
+            "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -367,7 +370,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         response = client_with_examples.post(
-            "/data/large_revenue_payments_and_business_only/availability/",
+            "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "new_accounting",
@@ -383,7 +386,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         statement = select(Node).where(
-            Node.name == "large_revenue_payments_and_business_only",
+            Node.name == "default.large_revenue_payments_and_business_only",
         )
         large_revenue_payments_and_business_only = session.exec(statement).one()
         node_dict = large_revenue_payments_and_business_only.current.availability.dict()
@@ -407,7 +410,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the `updated_at` attribute is being updated
         """
         response = client_with_examples.post(
-            "/data/large_revenue_payments_and_business_only/availability/",
+            "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -419,7 +422,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         )
         assert response.status_code == 200
         statement = select(Node).where(
-            Node.name == "large_revenue_payments_and_business_only",
+            Node.name == "default.large_revenue_payments_and_business_only",
         )
         large_revenue_payments_and_business_only = session.exec(statement).one()
         updated_at_1 = (
@@ -429,7 +432,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         )
 
         response = client_with_examples.post(
-            "/data/large_revenue_payments_and_business_only/availability/",
+            "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -458,7 +461,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test raising when setting availability state on non-existent node
         """
         response = client_with_examples.post(
-            "/data/nonexistentnode/availability/",
+            "/data/default.nonexistentnode/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -472,7 +475,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
         assert response.status_code == 404
         assert data == {
-            "message": "A node with name `nonexistentnode` does not exist.",
+            "message": "A node with name `default.nonexistentnode` does not exist.",
             "errors": [],
             "warnings": [],
         }
@@ -486,7 +489,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the higher max_partition value is used when merging in an availability state
         """
         client_with_examples.post(
-            "/data/large_revenue_payments_only/availability/",
+            "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -497,7 +500,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             },
         )
         response = client_with_examples.post(
-            "/data/large_revenue_payments_only/availability/",
+            "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -521,7 +524,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         statement = select(Node).where(
-            Node.name == "large_revenue_payments_only",
+            Node.name == "default.large_revenue_payments_only",
         )
         large_revenue_payments_only = session.exec(statement).one()
         node_dict = large_revenue_payments_only.current.availability.dict()
@@ -545,7 +548,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the lower min_partition value is used when merging in an availability state
         """
         client_with_examples.post(
-            "/data/large_revenue_payments_only/availability/",
+            "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -556,7 +559,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             },
         )
         response = client_with_examples.post(
-            "/data/large_revenue_payments_only/availability/",
+            "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -580,7 +583,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         statement = select(Node).where(
-            Node.name == "large_revenue_payments_only",
+            Node.name == "default.large_revenue_payments_only",
         )
         large_revenue_payments_only = session.exec(statement).one()
         node_dict = large_revenue_payments_only.current.availability.dict()
@@ -604,7 +607,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test that the valid through timestamp can be moved backwards
         """
         client_with_examples.post(
-            "/data/large_revenue_payments_only/availability/",
+            "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -615,7 +618,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             },
         )
         response = client_with_examples.post(
-            "/data/large_revenue_payments_only/availability/",
+            "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -639,7 +642,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         statement = select(Node).where(
-            Node.name == "large_revenue_payments_only",
+            Node.name == "default.large_revenue_payments_only",
         )
         large_revenue_payments_only = session.exec(statement).one()
         node_dict = large_revenue_payments_only.current.availability.dict()
@@ -663,7 +666,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test setting the availability state on a source node
         """
         response = client_with_examples.post(
-            "/data/revenue/availability/",
+            "/data/default.revenue/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",
@@ -679,7 +682,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         statement = select(Node).where(
-            Node.name == "revenue",
+            Node.name == "default.revenue",
         )
         revenue = session.exec(statement).one()
         node_dict = revenue.current.availability.dict()
@@ -702,7 +705,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         Test raising availability state doesn't match existing source node table
         """
         response = client_with_examples.post(
-            "/data/revenue/availability/",
+            "/data/default.revenue/availability/",
             json={
                 "catalog": "default",
                 "schema_": "accounting",

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -136,46 +136,46 @@ def test_common_dimensions(
     Test ``GET /metrics/common/dimensions``.
     """
     response = client_with_examples.get(
-        "/metrics/common/dimensions?metric=total_repair_order_discounts&metric=total_repair_cost",
+        "/metrics/common/dimensions?metric=default.total_repair_order_discounts&metric=default.total_repair_cost",
     )
     assert response.status_code == 200
     assert set(response.json()) == set(
         [
-            "dispatcher.company_name",
-            "dispatcher.dispatcher_id",
-            "dispatcher.phone",
-            "hard_hat.address",
-            "hard_hat.birth_date",
-            "hard_hat.city",
-            "hard_hat.contractor_id",
-            "hard_hat.country",
-            "hard_hat.first_name",
-            "hard_hat.hard_hat_id",
-            "hard_hat.hire_date",
-            "hard_hat.last_name",
-            "hard_hat.manager",
-            "hard_hat.postal_code",
-            "hard_hat.state",
-            "hard_hat.title",
-            "municipality_dim.contact_name",
-            "municipality_dim.contact_title",
-            "municipality_dim.local_region",
-            "municipality_dim.municipality_id",
-            "municipality_dim.municipality_type_desc",
-            "municipality_dim.municipality_type_id",
-            "municipality_dim.state_id",
-            "repair_order.dispatched_date",
-            "repair_order.dispatcher_id",
-            "repair_order.hard_hat_id",
-            "repair_order.municipality_id",
-            "repair_order.order_date",
-            "repair_order.repair_order_id",
-            "repair_order.required_date",
-            "us_state.state_id",
-            "us_state.state_name",
-            "us_state.state_region",
-            "us_state.state_region_description",
-            "us_state.state_short",
+            "default.dispatcher.company_name",
+            "default.dispatcher.dispatcher_id",
+            "default.dispatcher.phone",
+            "default.hard_hat.address",
+            "default.hard_hat.birth_date",
+            "default.hard_hat.city",
+            "default.hard_hat.contractor_id",
+            "default.hard_hat.country",
+            "default.hard_hat.first_name",
+            "default.hard_hat.hard_hat_id",
+            "default.hard_hat.hire_date",
+            "default.hard_hat.last_name",
+            "default.hard_hat.manager",
+            "default.hard_hat.postal_code",
+            "default.hard_hat.state",
+            "default.hard_hat.title",
+            "default.municipality_dim.contact_name",
+            "default.municipality_dim.contact_title",
+            "default.municipality_dim.local_region",
+            "default.municipality_dim.municipality_id",
+            "default.municipality_dim.municipality_type_desc",
+            "default.municipality_dim.municipality_type_id",
+            "default.municipality_dim.state_id",
+            "default.repair_order.dispatched_date",
+            "default.repair_order.dispatcher_id",
+            "default.repair_order.hard_hat_id",
+            "default.repair_order.municipality_id",
+            "default.repair_order.order_date",
+            "default.repair_order.repair_order_id",
+            "default.repair_order.required_date",
+            "default.us_state.state_id",
+            "default.us_state.state_name",
+            "default.us_state.state_region",
+            "default.us_state.state_region_description",
+            "default.us_state.state_short",
         ],
     )
 
@@ -187,10 +187,10 @@ def test_raise_common_dimensions_not_a_metric_node(
     Test raising ``GET /metrics/common/dimensions`` when not a metric node
     """
     response = client_with_examples.get(
-        "/metrics/common/dimensions?metric=total_repair_order_discounts&metric=payment_type",
+        "/metrics/common/dimensions?metric=default.total_repair_order_discounts&metric=default.payment_type",
     )
     assert response.status_code == 500
-    assert response.json()["message"] == "Not a metric node: payment_type"
+    assert response.json()["message"] == "Not a metric node: default.payment_type"
 
 
 def test_raise_common_dimensions_metric_not_found(
@@ -200,21 +200,21 @@ def test_raise_common_dimensions_metric_not_found(
     Test raising ``GET /metrics/common/dimensions`` when metric not found
     """
     response = client_with_examples.get(
-        "/metrics/common/dimensions?metric=foo&metric=bar",
+        "/metrics/common/dimensions?metric=default.foo&metric=default.bar",
     )
     assert response.status_code == 500
     assert response.json() == {
-        "message": "Metric node not found: foo\nMetric node not found: bar",
+        "message": "Metric node not found: default.foo\nMetric node not found: default.bar",
         "errors": [
             {
                 "code": 203,
-                "message": "Metric node not found: foo",
+                "message": "Metric node not found: default.foo",
                 "debug": None,
                 "context": "",
             },
             {
                 "code": 203,
-                "message": "Metric node not found: bar",
+                "message": "Metric node not found: default.bar",
                 "debug": None,
                 "context": "",
             },
@@ -227,45 +227,45 @@ def test_get_dimensions(client_with_examples: TestClient):
     """
     Testing get dimensions for a metric
     """
-    response = client_with_examples.get("/metrics/avg_repair_price/")
+    response = client_with_examples.get("/metrics/default.avg_repair_price/")
 
     data = response.json()
     assert data["dimensions"] == [
-        "dispatcher.company_name",
-        "dispatcher.dispatcher_id",
-        "dispatcher.phone",
-        "hard_hat.address",
-        "hard_hat.birth_date",
-        "hard_hat.city",
-        "hard_hat.contractor_id",
-        "hard_hat.country",
-        "hard_hat.first_name",
-        "hard_hat.hard_hat_id",
-        "hard_hat.hire_date",
-        "hard_hat.last_name",
-        "hard_hat.manager",
-        "hard_hat.postal_code",
-        "hard_hat.state",
-        "hard_hat.title",
-        "municipality_dim.contact_name",
-        "municipality_dim.contact_title",
-        "municipality_dim.local_region",
-        "municipality_dim.municipality_id",
-        "municipality_dim.municipality_type_desc",
-        "municipality_dim.municipality_type_id",
-        "municipality_dim.state_id",
-        "repair_order.dispatched_date",
-        "repair_order.dispatcher_id",
-        "repair_order.hard_hat_id",
-        "repair_order.municipality_id",
-        "repair_order.order_date",
-        "repair_order.repair_order_id",
-        "repair_order.required_date",
-        "us_state.state_id",
-        "us_state.state_name",
-        "us_state.state_region",
-        "us_state.state_region_description",
-        "us_state.state_short",
+        "default.dispatcher.company_name",
+        "default.dispatcher.dispatcher_id",
+        "default.dispatcher.phone",
+        "default.hard_hat.address",
+        "default.hard_hat.birth_date",
+        "default.hard_hat.city",
+        "default.hard_hat.contractor_id",
+        "default.hard_hat.country",
+        "default.hard_hat.first_name",
+        "default.hard_hat.hard_hat_id",
+        "default.hard_hat.hire_date",
+        "default.hard_hat.last_name",
+        "default.hard_hat.manager",
+        "default.hard_hat.postal_code",
+        "default.hard_hat.state",
+        "default.hard_hat.title",
+        "default.municipality_dim.contact_name",
+        "default.municipality_dim.contact_title",
+        "default.municipality_dim.local_region",
+        "default.municipality_dim.municipality_id",
+        "default.municipality_dim.municipality_type_desc",
+        "default.municipality_dim.municipality_type_id",
+        "default.municipality_dim.state_id",
+        "default.repair_order.dispatched_date",
+        "default.repair_order.dispatcher_id",
+        "default.repair_order.hard_hat_id",
+        "default.repair_order.municipality_id",
+        "default.repair_order.order_date",
+        "default.repair_order.repair_order_id",
+        "default.repair_order.required_date",
+        "default.us_state.state_id",
+        "default.us_state.state_name",
+        "default.us_state.state_region",
+        "default.us_state.state_region_description",
+        "default.us_state.state_short",
     ]
 
 

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -136,7 +136,9 @@ def test_common_dimensions(
     Test ``GET /metrics/common/dimensions``.
     """
     response = client_with_examples.get(
-        "/metrics/common/dimensions?metric=default.total_repair_order_discounts&metric=default.total_repair_cost",
+        "/metrics/common/dimensions?"
+        "metric=default.total_repair_order_discounts"
+        "&metric=default.total_repair_cost",
     )
     assert response.status_code == 200
     assert set(response.json()) == set(
@@ -187,7 +189,9 @@ def test_raise_common_dimensions_not_a_metric_node(
     Test raising ``GET /metrics/common/dimensions`` when not a metric node
     """
     response = client_with_examples.get(
-        "/metrics/common/dimensions?metric=default.total_repair_order_discounts&metric=default.payment_type",
+        "/metrics/common/dimensions?"
+        "metric=default.total_repair_order_discounts"
+        "&metric=default.payment_type",
     )
     assert response.status_code == 500
     assert response.json()["message"] == "Not a metric node: default.payment_type"

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -1,4 +1,5 @@
 """Tests for the /sql/ endpoint"""
+# pylint: disable=line-too-long
 import pytest
 from sqlmodel import Session
 from starlette.testclient import TestClient
@@ -66,9 +67,11 @@ def test_sql(
                       default_DOT_repair_orders.order_date,
                       default_DOT_repair_orders.repair_order_id,
                       default_DOT_repair_orders.required_date
-              FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
+              FROM roads.repair_orders AS default_DOT_repair_orders
+              LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
                       default_DOT_hard_hats.state
-              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat
+              ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
               WHERE  default_DOT_hard_hat.state = 'CA'
             """,
         ),
@@ -99,11 +102,14 @@ def test_sql(
                       default_DOT_event_source.device_id,
                       default_DOT_event_source.event_id,
                       default_DOT_event_source.event_latency
-              FROM logs.log_events AS default_DOT_event_source LEFT OUTER JOIN (SELECT  default_DOT_event_source.country,
+              FROM logs.log_events AS default_DOT_event_source
+              LEFT OUTER JOIN (SELECT  default_DOT_event_source.country,
                       COUNT( DISTINCT default_DOT_event_source.event_id) AS events_cnt
               FROM logs.log_events AS default_DOT_event_source
-              GROUP BY  default_DOT_event_source.country) AS default_DOT_country_dim ON default_DOT_event_source.country = default_DOT_country_dim.country
-              WHERE  default_DOT_event_source.event_latency > 1000000 AND default_DOT_country_dim.events_cnt >= 20
+              GROUP BY  default_DOT_event_source.country) AS default_DOT_country_dim
+              ON default_DOT_event_source.country = default_DOT_country_dim.country
+              WHERE  default_DOT_event_source.event_latency > 1000000
+              AND default_DOT_country_dim.events_cnt >= 20
             """,
         ),
         # querying transform node with filters directly on the node
@@ -117,7 +123,8 @@ def test_sql(
                       default_DOT_event_source.event_id,
                       default_DOT_event_source.event_latency
               FROM logs.log_events AS default_DOT_event_source
-              WHERE  default_DOT_event_source.event_latency > 1000000 AND event_source.device_id = 'Android'
+              WHERE  default_DOT_event_source.event_latency > 1000000
+              AND event_source.device_id = 'Android'
             """,
         ),
         (
@@ -132,8 +139,11 @@ def test_sql(
                       default_DOT_municipality_municipality_type.municipality_type_id,
                       default_DOT_municipality_type.municipality_type_desc,
                       default_DOT_municipality.state_id
-              FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-              LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
+              FROM roads.municipality AS default_DOT_municipality
+              LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type
+              ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+              LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type
+              ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
               WHERE  default_DOT_municipality.state_id = 'CA'
             """,
         ),
@@ -153,7 +163,8 @@ def test_sql(
             """
               SELECT  default_DOT_hard_hat.state,
                       count(default_DOT_repair_orders.repair_order_id) AS num_repair_orders
-              FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
+              FROM roads.repair_orders AS default_DOT_repair_orders
+              LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
                       default_DOT_hard_hats.state
               FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
               WHERE  default_DOT_repair_orders.dispatcher_id = 1 AND hard_hat.state = 'AZ'

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -55,305 +55,208 @@ def test_sql(
     [
         # querying on source node with filter on joinable dimension
         (
-            "repair_orders",
+            "default.repair_orders",
             [],
-            ["hard_hat.state='CA'"],
+            ["default.hard_hat.state='CA'"],
             """
-            SELECT
-              repair_orders.dispatched_date,
-              repair_orders.dispatcher_id,
-              repair_orders.hard_hat_id,
-              repair_orders.municipality_id,
-              repair_orders.order_date,
-              repair_orders.repair_order_id,
-              repair_orders.required_date
-            FROM roads.repair_orders AS repair_orders
-            LEFT OUTER JOIN (
-              SELECT
-                hard_hats.hard_hat_id,
-                hard_hats.state
-              FROM roads.hard_hats AS hard_hats
-            ) AS hard_hat ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
-            WHERE
-              hard_hat.state = 'CA'
+              SELECT  default_DOT_repair_orders.dispatched_date,
+                      default_DOT_repair_orders.dispatcher_id,
+                      default_DOT_repair_orders.hard_hat_id,
+                      default_DOT_repair_orders.municipality_id,
+                      default_DOT_repair_orders.order_date,
+                      default_DOT_repair_orders.repair_order_id,
+                      default_DOT_repair_orders.required_date
+              FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
+                      default_DOT_hard_hats.state
+              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              WHERE  default_DOT_hard_hat.state = 'CA'
             """,
         ),
         # querying source node with filters directly on the node
         (
-            "repair_orders",
+            "default.repair_orders",
             [],
-            ["repair_orders.order_date='2009-08-14'"],
+            ["default.repair_orders.order_date='2009-08-14'"],
             """
-            SELECT
-              repair_orders.repair_order_id,
-              repair_orders.municipality_id,
-              repair_orders.hard_hat_id,
-              repair_orders.order_date,
-              repair_orders.required_date,
-              repair_orders.dispatched_date,
-              repair_orders.dispatcher_id
-            FROM roads.repair_orders AS repair_orders
-            WHERE
-              repair_orders.order_date = '2009-08-14'
+              SELECT  default_DOT_repair_orders.dispatched_date,
+                      default_DOT_repair_orders.dispatcher_id,
+                      default_DOT_repair_orders.hard_hat_id,
+                      default_DOT_repair_orders.municipality_id,
+                      default_DOT_repair_orders.order_date,
+                      default_DOT_repair_orders.repair_order_id,
+                      default_DOT_repair_orders.required_date
+              FROM roads.repair_orders AS default_DOT_repair_orders
+              WHERE  default_DOT_repair_orders.order_date = '2009-08-14'
             """,
         ),
         # querying transform node with filters on joinable dimension
         (
-            "long_events",
+            "default.long_events",
             [],
-            ["country_dim.events_cnt >= 20"],
+            ["default.country_dim.events_cnt >= 20"],
             """
-            SELECT
-              event_source.event_id,
-              event_source.event_latency,
-              event_source.device_id,
-              event_source.country
-            FROM logs.log_events AS event_source
-            LEFT OUTER JOIN (
-              SELECT
-                event_source.country,
-                COUNT(DISTINCT event_source.event_id) AS events_cnt
-              FROM logs.log_events AS event_source
-              GROUP BY
-                event_source.country
-            ) AS country_dim
-                    ON event_source.country = country_dim.country
-             WHERE
-               event_source.event_latency > 1000000 AND
-               country_dim.events_cnt >= 20
+              SELECT  default_DOT_event_source.country,
+                      default_DOT_event_source.device_id,
+                      default_DOT_event_source.event_id,
+                      default_DOT_event_source.event_latency
+              FROM logs.log_events AS default_DOT_event_source LEFT OUTER JOIN (SELECT  default_DOT_event_source.country,
+                      COUNT( DISTINCT default_DOT_event_source.event_id) AS events_cnt
+              FROM logs.log_events AS default_DOT_event_source
+              GROUP BY  default_DOT_event_source.country) AS default_DOT_country_dim ON default_DOT_event_source.country = default_DOT_country_dim.country
+              WHERE  default_DOT_event_source.event_latency > 1000000 AND default_DOT_country_dim.events_cnt >= 20
             """,
         ),
         # querying transform node with filters directly on the node
         (
-            "long_events",
+            "default.long_events",
             [],
             ["event_source.device_id = 'Android'"],
             """
-            SELECT
-              event_source.event_id,
-              event_source.event_latency,
-              event_source.device_id,
-              event_source.country
-            FROM logs.log_events AS event_source
-            WHERE event_source.event_latency > 1000000 AND event_source.device_id = 'Android'
+              SELECT  default_DOT_event_source.country,
+                      default_DOT_event_source.device_id,
+                      default_DOT_event_source.event_id,
+                      default_DOT_event_source.event_latency
+              FROM logs.log_events AS default_DOT_event_source
+              WHERE  default_DOT_event_source.event_latency > 1000000 AND event_source.device_id = 'Android'
             """,
         ),
         (
-            "municipality_dim",
+            "default.municipality_dim",
             [],
             ["state_id = 'CA'"],
             """
-            SELECT
-              municipality.contact_name,
-              municipality.contact_title,
-              municipality.local_region,
-              municipality.municipality_id,
-              municipality_municipality_type.municipality_type_id,
-              municipality_type.municipality_type_desc,
-              municipality.state_id
-            FROM roads.municipality AS municipality
-            LEFT JOIN roads.municipality_municipality_type AS municipality_municipality_type
-            ON municipality.municipality_id = municipality_municipality_type.municipality_id
-            LEFT JOIN roads.municipality_type AS municipality_type
-            ON municipality_municipality_type.municipality_type_id
-               = municipality_type.municipality_type_desc
-            WHERE
-              municipality.state_id = 'CA'""",
-        ),
-        (
-            "num_repair_orders",
-            [],
-            [],
-            """
-            SELECT
-              count(repair_orders.repair_order_id) AS num_repair_orders
-            FROM roads.repair_orders AS repair_orders
+              SELECT  default_DOT_municipality.contact_name,
+                      default_DOT_municipality.contact_title,
+                      default_DOT_municipality.local_region,
+                      default_DOT_municipality.municipality_id,
+                      default_DOT_municipality_municipality_type.municipality_type_id,
+                      default_DOT_municipality_type.municipality_type_desc,
+                      default_DOT_municipality.state_id
+              FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+              LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
+              WHERE  default_DOT_municipality.state_id = 'CA'
             """,
         ),
         (
-            "num_repair_orders",
-            ["hard_hat.state"],
-            ["repair_orders.dispatcher_id=1", "hard_hat.state='AZ'"],
+            "default.num_repair_orders",
+            [],
+            [],
             """
-            SELECT
-              hard_hat.state,
-              count(repair_orders.repair_order_id) AS num_repair_orders
-            FROM roads.repair_orders AS repair_orders
-            LEFT OUTER JOIN (
-              SELECT
-                hard_hats.hard_hat_id,
-                hard_hats.state
-              FROM roads.hard_hats AS hard_hats
-            ) AS hard_hat
-            ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
-            WHERE
-              repair_orders.dispatcher_id = 1 AND
-              hard_hat.state = 'AZ'
-            GROUP BY
-              hard_hat.state
+              SELECT  count(default_DOT_repair_orders.repair_order_id) AS num_repair_orders
+              FROM roads.repair_orders AS default_DOT_repair_orders
             """,
         ),
         (
-            "num_repair_orders",
+            "default.num_repair_orders",
+            ["default.hard_hat.state"],
+            ["default.repair_orders.dispatcher_id=1", "hard_hat.state='AZ'"],
+            """
+              SELECT  default_DOT_hard_hat.state,
+                      count(default_DOT_repair_orders.repair_order_id) AS num_repair_orders
+              FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
+                      default_DOT_hard_hats.state
+              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              WHERE  default_DOT_repair_orders.dispatcher_id = 1 AND hard_hat.state = 'AZ'
+              GROUP BY  default_DOT_hard_hat.state
+            """,
+        ),
+        (
+            "default.num_repair_orders",
             [
-                "hard_hat.city",
-                "hard_hat.last_name",
-                "dispatcher.company_name",
-                "municipality_dim.local_region",
+                "default.hard_hat.city",
+                "default.hard_hat.last_name",
+                "default.dispatcher.company_name",
+                "default.municipality_dim.local_region",
             ],
             [
-                "repair_orders.dispatcher_id=1",
-                "hard_hat.state != 'AZ'",
-                "dispatcher.phone = '4082021022'",
-                "repair_orders.order_date >= '2020-01-01'",
+                "default.repair_orders.dispatcher_id=1",
+                "default.hard_hat.state != 'AZ'",
+                "default.dispatcher.phone = '4082021022'",
+                "default.repair_orders.order_date >= '2020-01-01'",
             ],
             """
-            SELECT
-              dispatcher.company_name,
-              hard_hat.city,
-              hard_hat.last_name,
-              municipality_dim.local_region,
-              count(repair_orders.repair_order_id) AS num_repair_orders
-            FROM roads.repair_orders AS repair_orders
-            LEFT OUTER JOIN (
-              SELECT
-                dispatchers.company_name,
-                dispatchers.dispatcher_id,
-                dispatchers.phone
-              FROM roads.dispatchers AS dispatchers
-            ) AS dispatcher
-              ON repair_orders.dispatcher_id = dispatcher.dispatcher_id
-            LEFT OUTER JOIN (
-              SELECT
-                hard_hats.city,
-                hard_hats.hard_hat_id,
-                hard_hats.last_name,
-                hard_hats.state
-              FROM roads.hard_hats AS hard_hats
-            ) AS hard_hat
-              ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
-            LEFT OUTER JOIN (
-              SELECT
-                municipality.local_region,
-                municipality.municipality_id
-              FROM roads.municipality AS municipality
-              LEFT JOIN roads.municipality_municipality_type AS municipality_municipality_type
-                ON municipality.municipality_id =
-                   municipality_municipality_type.municipality_id
-              LEFT JOIN roads.municipality_type AS municipality_type
-                ON municipality_municipality_type.municipality_type_id =
-                   municipality_type.municipality_type_desc
-            ) AS municipality_dim
-            ON repair_orders.municipality_id = municipality_dim.municipality_id
-            WHERE
-              repair_orders.dispatcher_id = 1
-              AND hard_hat.state != 'AZ'
-              AND dispatcher.phone = '4082021022'
-              AND repair_orders.order_date >= '2020-01-01'
-            GROUP BY
-              hard_hat.city,
-              hard_hat.last_name,
-              dispatcher.company_name,
-              municipality_dim.local_region
+              SELECT  default_DOT_dispatcher.company_name,
+                      default_DOT_hard_hat.city,
+                      default_DOT_hard_hat.last_name,
+                      default_DOT_municipality_dim.local_region,
+                      count(default_DOT_repair_orders.repair_order_id) AS num_repair_orders
+              FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+                      default_DOT_dispatchers.dispatcher_id,
+                      default_DOT_dispatchers.phone
+              FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+              LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+                      default_DOT_hard_hats.hard_hat_id,
+                      default_DOT_hard_hats.last_name,
+                      default_DOT_hard_hats.state
+              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+                      default_DOT_municipality.municipality_id
+              FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+              LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+              WHERE  default_DOT_repair_orders.dispatcher_id = 1 AND default_DOT_hard_hat.state != 'AZ' AND default_DOT_dispatcher.phone = '4082021022' AND default_DOT_repair_orders.order_date >= '2020-01-01'
+              GROUP BY  default_DOT_hard_hat.city, default_DOT_hard_hat.last_name, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
             """,
         ),
         # metric with second-order dimension
         (
-            "avg_repair_price",
-            ["hard_hat.city"],
+            "default.avg_repair_price",
+            ["default.hard_hat.city"],
             [],
             """
-            SELECT
-              avg(repair_order_details.price) AS avg_repair_price,
-              hard_hat.city
-            FROM roads.repair_order_details AS repair_order_details
-            LEFT OUTER JOIN (
-              SELECT
-                repair_orders.dispatcher_id,
-                repair_orders.hard_hat_id,
-                repair_orders.municipality_id,
-                repair_orders.repair_order_id
-              FROM roads.repair_orders AS repair_orders
-            ) AS repair_order
-              ON repair_order_details.repair_order_id = repair_order.repair_order_id
-            LEFT OUTER JOIN (
-              SELECT
-                hard_hats.city,
-                hard_hats.hard_hat_id,
-                hard_hats.state
-              FROM roads.hard_hats AS hard_hats
-            ) AS hard_hat
-              ON repair_order.hard_hat_id = hard_hat.hard_hat_id
-            GROUP BY
-              hard_hat.city
+              SELECT  avg(default_DOT_repair_order_details.price) AS avg_repair_price,
+                      default_DOT_hard_hat.city
+              FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+                      default_DOT_repair_orders.hard_hat_id,
+                      default_DOT_repair_orders.municipality_id,
+                      default_DOT_repair_orders.repair_order_id
+              FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+              LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+                      default_DOT_hard_hats.hard_hat_id,
+                      default_DOT_hard_hats.state
+              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              GROUP BY  default_DOT_hard_hat.city
             """,
         ),
         # metric with multiple nth order dimensions that can share some of the joins
         (
-            "avg_repair_price",
-            ["hard_hat.city", "dispatcher.company_name"],
+            "default.avg_repair_price",
+            ["default.hard_hat.city", "default.dispatcher.company_name"],
             [],
             """
-            SELECT
-              avg(repair_order_details.price) AS avg_repair_price,
-              dispatcher.company_name,
-              hard_hat.city
-            FROM roads.repair_order_details AS repair_order_details
-            LEFT OUTER JOIN (
-              SELECT
-                repair_orders.dispatcher_id,
-                repair_orders.hard_hat_id,
-                repair_orders.municipality_id,
-                repair_orders.repair_order_id
-              FROM roads.repair_orders AS repair_orders
-            ) AS repair_order ON repair_order_details.repair_order_id = repair_order.repair_order_id
-            LEFT OUTER JOIN (
-              SELECT
-                dispatchers.company_name,
-                dispatchers.dispatcher_id
-              FROM roads.dispatchers AS dispatchers
-            ) AS dispatcher ON repair_order.dispatcher_id = dispatcher.dispatcher_id
-            LEFT OUTER JOIN (
-              SELECT
-                hard_hats.city,
-                hard_hats.hard_hat_id,
-                hard_hats.state
-              FROM roads.hard_hats AS hard_hats
-            ) AS hard_hat ON repair_order.hard_hat_id = hard_hat.hard_hat_id
-            GROUP BY
-              hard_hat.city,
-              dispatcher.company_name
+              SELECT  avg(default_DOT_repair_order_details.price) AS avg_repair_price,
+                      default_DOT_dispatcher.company_name,
+                      default_DOT_hard_hat.city
+              FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+                      default_DOT_repair_orders.hard_hat_id,
+                      default_DOT_repair_orders.municipality_id,
+                      default_DOT_repair_orders.repair_order_id
+              FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+              LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+                      default_DOT_dispatchers.dispatcher_id
+              FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+              LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+                      default_DOT_hard_hats.hard_hat_id,
+                      default_DOT_hard_hats.state
+              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              GROUP BY  default_DOT_hard_hat.city, default_DOT_dispatcher.company_name
             """,
         ),
         # dimension with aliased join key should just use the alias directly
         (
-            "num_repair_orders",
-            ["us_state.state_region_description"],
+            "default.num_repair_orders",
+            ["default.us_state.state_region_description"],
             [],
             """
-            SELECT
-              count(repair_orders.repair_order_id) AS num_repair_orders,
-              us_state.state_region_description
-            FROM roads.repair_orders AS repair_orders
-            LEFT OUTER JOIN (
-              SELECT
-                hard_hats.hard_hat_id,
-                hard_hats.state
-              FROM roads.hard_hats AS hard_hats
-            ) AS hard_hat
-            ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
-            LEFT OUTER JOIN (
-              SELECT
-                us_states.state_id,
-                us_region.us_region_description AS state_region_description,
-                us_states.state_abbr AS state_short
-              FROM roads.us_states AS us_states
-              LEFT JOIN roads.us_region AS us_region
-              ON us_states.state_region = us_region.us_region_id
-            ) AS us_state
-            ON hard_hat.state = us_state.state_short
-            GROUP BY
-              us_state.state_region_description
+              SELECT  default_DOT_us_state.state_region_description,
+                      count(default_DOT_repair_orders.repair_order_id) AS num_repair_orders
+              FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
+                      default_DOT_hard_hats.state
+              FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              LEFT OUTER JOIN (SELECT  default_DOT_us_states.state_id,
+                      default_DOT_us_region.us_region_description AS state_region_description,
+                      default_DOT_us_states.state_abbr AS state_short
+              FROM roads.us_states AS default_DOT_us_states LEFT  JOIN roads.us_region AS default_DOT_us_region ON default_DOT_us_states.state_region = default_DOT_us_region.us_region_id) AS default_DOT_us_state ON default_DOT_hard_hat.state = default_DOT_us_state.state_short
+              GROUP BY  default_DOT_us_state.state_region_description
             """,
         ),
     ],
@@ -427,27 +330,18 @@ def test_sql_with_filters(
         (
             "foo.bar.municipality_dim",
             [],
-            ["state_id = 'CA'"],
+            ["default.state_id = 'CA'"],
             """
-            SELECT
-              foo_DOT_bar_DOT_municipality.contact_name,
-              foo_DOT_bar_DOT_municipality.contact_title,
-              foo_DOT_bar_DOT_municipality.local_region,
-              foo_DOT_bar_DOT_municipality.municipality_id,
-              foo_DOT_bar_DOT_municipality_municipality_type.municipality_type_id,
-              foo_DOT_bar_DOT_municipality_type.municipality_type_desc,
-              foo_DOT_bar_DOT_municipality.state_id
-            FROM roads.municipality AS foo_DOT_bar_DOT_municipality
-            LEFT JOIN roads.municipality_municipality_type
-              AS foo_DOT_bar_DOT_municipality_municipality_type
-              ON foo_DOT_bar_DOT_municipality.municipality_id =
-                 foo_DOT_bar_DOT_municipality_municipality_type.municipality_id
-            LEFT JOIN roads.municipality_type
-              AS foo_DOT_bar_DOT_municipality_type
-              ON foo_DOT_bar_DOT_municipality_municipality_type.municipality_type_id =
-                 foo_DOT_bar_DOT_municipality_type.municipality_type_desc
-            WHERE
-              foo_DOT_bar_DOT_municipality.state_id = 'CA'
+              SELECT  foo_DOT_bar_DOT_municipality.contact_name,
+                      foo_DOT_bar_DOT_municipality.contact_title,
+                      foo_DOT_bar_DOT_municipality.local_region,
+                      foo_DOT_bar_DOT_municipality.municipality_id,
+                      foo_DOT_bar_DOT_municipality_municipality_type.municipality_type_id,
+                      foo_DOT_bar_DOT_municipality_type.municipality_type_desc,
+                      foo_DOT_bar_DOT_municipality.state_id
+              FROM roads.municipality AS foo_DOT_bar_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS foo_DOT_bar_DOT_municipality_municipality_type ON foo_DOT_bar_DOT_municipality.municipality_id = foo_DOT_bar_DOT_municipality_municipality_type.municipality_id
+              LEFT  JOIN roads.municipality_type AS foo_DOT_bar_DOT_municipality_type ON foo_DOT_bar_DOT_municipality_municipality_type.municipality_type_id = foo_DOT_bar_DOT_municipality_type.municipality_type_desc
+              WHERE  default.state_id = 'CA'
             """,
         ),
         (
@@ -714,7 +608,7 @@ def test_get_sql_for_metrics_failures(client_with_examples: TestClient):
         "/sql/",
         params={
             "metrics": [],
-            "dimensions": ["account_type.account_type_name"],
+            "dimensions": ["default.account_type.account_type_name"],
             "filters": [],
         },
     )
@@ -730,7 +624,7 @@ def test_get_sql_for_metrics_failures(client_with_examples: TestClient):
     response = client_with_examples.get(
         "/sql/",
         params={
-            "metrics": ["number_of_account_types"],
+            "metrics": ["default.number_of_account_types"],
             "dimensions": [],
             "filters": [],
         },
@@ -751,63 +645,42 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
     response = client_with_examples.get(
         "/sql/",
         params={
-            "metrics": ["discounted_orders_rate", "num_repair_orders"],
+            "metrics": ["default.discounted_orders_rate", "default.num_repair_orders"],
             "dimensions": [
-                "hard_hat.country",
-                "hard_hat.postal_code",
-                "hard_hat.city",
-                "hard_hat.state",
-                "dispatcher.company_name",
-                "municipality_dim.local_region",
+                "default.hard_hat.country",
+                "default.hard_hat.postal_code",
+                "default.hard_hat.city",
+                "default.hard_hat.state",
+                "default.dispatcher.company_name",
+                "default.municipality_dim.local_region",
             ],
             "filters": [],
         },
     )
     data = response.json()
     expected_sql = """
-    SELECT
-      dispatcher.company_name,
-      hard_hat.city,
-      hard_hat.country,
-      hard_hat.postal_code,
-      hard_hat.state,
-      municipality_dim.local_region,
-      count(repair_orders.repair_order_id) AS num_repair_orders,
-      CAST(sum(if(repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS discounted_orders_rate
-    FROM roads.repair_orders AS repair_orders
-    LEFT OUTER JOIN (
-      SELECT
-        dispatchers.company_name,
-        dispatchers.dispatcher_id
-      FROM roads.dispatchers AS dispatchers
-    ) AS dispatcher ON repair_orders.dispatcher_id = dispatcher.dispatcher_id
-    LEFT OUTER JOIN (
-      SELECT
-        hard_hats.city,
-        hard_hats.country,
-        hard_hats.hard_hat_id,
-        hard_hats.postal_code,
-        hard_hats.state
-      FROM roads.hard_hats AS hard_hats
-    ) AS hard_hat ON repair_orders.hard_hat_id = hard_hat.hard_hat_id
-    LEFT OUTER JOIN (
-      SELECT
-        municipality.local_region,
-        municipality.municipality_id
-      FROM roads.municipality AS municipality
-      LEFT JOIN roads.municipality_municipality_type AS municipality_municipality_type
-        ON municipality.municipality_id = municipality_municipality_type.municipality_id
-      LEFT JOIN roads.municipality_type AS municipality_type
-        ON municipality_municipality_type.municipality_type_id
-           = municipality_type.municipality_type_desc
-    ) AS municipality_dim ON repair_orders.municipality_id = municipality_dim.municipality_id
-    GROUP BY
-      hard_hat.country,
-      hard_hat.postal_code,
-      hard_hat.city,
-      hard_hat.state,
-      dispatcher.company_name,
-      municipality_dim.local_region
+      SELECT  default_DOT_dispatcher.company_name,
+              default_DOT_hard_hat.city,
+              default_DOT_hard_hat.country,
+              default_DOT_hard_hat.postal_code,
+              default_DOT_hard_hat.state,
+              default_DOT_municipality_dim.local_region,
+              count(default_DOT_repair_orders.repair_order_id) AS num_repair_orders,
+              CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS discounted_orders_rate
+      FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+              default_DOT_dispatchers.dispatcher_id
+      FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+      LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+              default_DOT_hard_hats.country,
+              default_DOT_hard_hats.hard_hat_id,
+              default_DOT_hard_hats.postal_code,
+              default_DOT_hard_hats.state
+      FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+      LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+              default_DOT_municipality.municipality_id
+      FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+      LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+      GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
     """
     assert compare_query_strings(data["sql"], expected_sql)
     assert data["columns"] == [

--- a/tests/api/tags_test.py
+++ b/tests/api/tags_test.py
@@ -178,7 +178,7 @@ class TestTags:
 
         # Trying tag a node with a nonexistent tag should fail
         response = client_with_examples.post(
-            "/nodes/items_sold_count/tag/?tag_name=random_tag",
+            "/nodes/default.items_sold_count/tag/?tag_name=random_tag",
         )
         assert response.status_code == 404
         response_data = response.json()
@@ -188,13 +188,16 @@ class TestTags:
 
         # Trying tag a node with an existing tag should succeed
         response = client_with_examples.post(
-            "/nodes/items_sold_count/tag/?tag_name=sales_report",
+            "/nodes/default.items_sold_count/tag/?tag_name=sales_report",
         )
         assert response.status_code == 201
         response_data = response.json()
         assert (
             response_data["message"]
-            == "Node `items_sold_count` has been successfully tagged with tag `sales_report`"
+            == (
+                "Node `default.items_sold_count` has been "
+                "successfully tagged with tag `sales_report`"
+            )
         )
 
         # Test finding all nodes for that tag
@@ -205,18 +208,18 @@ class TestTags:
         response_data = response.json()
         assert len(response_data) == 1
         assert response_data == [
-            "items_sold_count",
+            "default.items_sold_count",
         ]
 
         # Tag a second node
         response = client_with_examples.post(
-            "/nodes/total_profit/tag/?tag_name=sales_report",
+            "/nodes/default.total_profit/tag/?tag_name=sales_report",
         )
         assert response.status_code == 201
         response_data = response.json()
         assert (
             response_data["message"]
-            == "Node `total_profit` has been successfully tagged with tag `sales_report`"
+            == "Node `default.total_profit` has been successfully tagged with tag `sales_report`"
         )
 
         # Check finding nodes for tag
@@ -227,8 +230,8 @@ class TestTags:
         response_data = response.json()
         assert len(response_data) == 2
         assert response_data == [
-            "items_sold_count",
-            "total_profit",
+            "default.items_sold_count",
+            "default.total_profit",
         ]
 
         # Check finding nodes for tag

--- a/tests/api/tags_test.py
+++ b/tests/api/tags_test.py
@@ -192,12 +192,9 @@ class TestTags:
         )
         assert response.status_code == 201
         response_data = response.json()
-        assert (
-            response_data["message"]
-            == (
-                "Node `default.items_sold_count` has been "
-                "successfully tagged with tag `sales_report`"
-            )
+        assert response_data["message"] == (
+            "Node `default.items_sold_count` has been "
+            "successfully tagged with tag `sales_report`"
         )
 
         # Test finding all nodes for that tag

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -65,7 +65,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "All repair orders",
             "mode": "published",
-            "name": "repair_orders",
+            "name": "default.repair_orders",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_orders",
@@ -83,7 +83,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Details on repair orders",
             "mode": "published",
-            "name": "repair_order_details",
+            "name": "default.repair_order_details",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_order_details",
@@ -99,7 +99,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on types of repairs",
             "mode": "published",
-            "name": "repair_type",
+            "name": "default.repair_type",
             "catalog": "default",
             "schema_": "roads",
             "table": "repair_type",
@@ -122,7 +122,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on contractors",
             "mode": "published",
-            "name": "contractors",
+            "name": "default.contractors",
             "catalog": "default",
             "schema_": "roads",
             "table": "contractors",
@@ -137,7 +137,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Lookup table for municipality and municipality types",
             "mode": "published",
-            "name": "municipality_municipality_type",
+            "name": "default.municipality_municipality_type",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality_municipality_type",
@@ -152,7 +152,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on municipality types",
             "mode": "published",
-            "name": "municipality_type",
+            "name": "default.municipality_type",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality_type",
@@ -171,7 +171,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on municipalities",
             "mode": "published",
-            "name": "municipality",
+            "name": "default.municipality",
             "catalog": "default",
             "schema_": "roads",
             "table": "municipality",
@@ -187,7 +187,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on dispatchers",
             "mode": "published",
-            "name": "dispatchers",
+            "name": "default.dispatchers",
             "catalog": "default",
             "schema_": "roads",
             "table": "dispatchers",
@@ -213,7 +213,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on employees",
             "mode": "published",
-            "name": "hard_hats",
+            "name": "default.hard_hats",
             "catalog": "default",
             "schema_": "roads",
             "table": "hard_hats",
@@ -228,7 +228,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Lookup table for employee's current state",
             "mode": "published",
-            "name": "hard_hat_state",
+            "name": "default.hard_hat_state",
             "catalog": "default",
             "schema_": "roads",
             "table": "hard_hat_state",
@@ -245,7 +245,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on different types of repairs",
             "mode": "published",
-            "name": "us_states",
+            "name": "default.us_states",
             "catalog": "default",
             "schema_": "roads",
             "table": "us_states",
@@ -260,7 +260,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "Information on US regions",
             "mode": "published",
-            "name": "us_region",
+            "name": "default.us_region",
             "catalog": "default",
             "schema_": "roads",
             "table": "us_region",
@@ -279,10 +279,10 @@ EXAMPLES = (  # type: ignore
                         required_date,
                         dispatched_date,
                         dispatcher_id
-                        FROM repair_orders
+                        FROM default.repair_orders
                     """,
             "mode": "published",
-            "name": "repair_order",
+            "name": "default.repair_order",
             "primary_key": ["repair_order_id"],
         },
     ),
@@ -302,10 +302,10 @@ EXAMPLES = (  # type: ignore
                         postal_code,
                         country,
                         phone
-                        FROM contractors
+                        FROM default.contractors
                     """,
             "mode": "published",
-            "name": "contractor",
+            "name": "default.contractor",
             "primary_key": ["contractor_id"],
         },
     ),
@@ -328,10 +328,10 @@ EXAMPLES = (  # type: ignore
                         country,
                         manager,
                         contractor_id
-                        FROM hard_hats
+                        FROM default.hard_hats
                     """,
             "mode": "published",
-            "name": "hard_hat",
+            "name": "default.hard_hat",
             "primary_key": ["hard_hat_id"],
         },
     ),
@@ -355,13 +355,13 @@ EXAMPLES = (  # type: ignore
                         manager,
                         contractor_id,
                         hhs.state_id AS state_id
-                        FROM hard_hats hh
-                        LEFT JOIN hard_hat_state hhs
+                        FROM default.hard_hats hh
+                        LEFT JOIN default.hard_hat_state hhs
                         ON hh.hard_hat_id = hhs.hard_hat_id
                         WHERE hh.state_id = 'NY'
                     """,
             "mode": "published",
-            "name": "local_hard_hats",
+            "name": "default.local_hard_hats",
             "primary_key": ["hard_hat_id"],
         },
     ),
@@ -376,12 +376,12 @@ EXAMPLES = (  # type: ignore
                         state_abbr AS state_short,
                         state_region,
                         r.us_region_description AS state_region_description
-                        FROM us_states s
-                        LEFT JOIN us_region r
+                        FROM default.us_states s
+                        LEFT JOIN default.us_region r
                         ON s.state_region = r.us_region_id
                     """,
             "mode": "published",
-            "name": "us_state",
+            "name": "default.us_state",
             "primary_key": ["state_id"],
         },
     ),
@@ -394,10 +394,10 @@ EXAMPLES = (  # type: ignore
                         dispatcher_id,
                         company_name,
                         phone
-                        FROM dispatchers
+                        FROM default.dispatchers
                     """,
             "mode": "published",
-            "name": "dispatcher",
+            "name": "default.dispatcher",
             "primary_key": ["dispatcher_id"],
         },
     ),
@@ -414,14 +414,14 @@ EXAMPLES = (  # type: ignore
                         state_id,
                         mmt.municipality_type_id,
                         mt.municipality_type_desc
-                        FROM municipality AS m
-                        LEFT JOIN municipality_municipality_type AS mmt
+                        FROM default.municipality AS m
+                        LEFT JOIN default.municipality_municipality_type AS mmt
                         ON m.municipality_id = mmt.municipality_id
-                        LEFT JOIN municipality_type AS mt
+                        LEFT JOIN default.municipality_type AS mt
                         ON mmt.municipality_type_id = mt.municipality_type_desc
                     """,
             "mode": "published",
-            "name": "municipality_dim",
+            "name": "default.municipality_dim",
             "primary_key": ["municipality_id"],
         },
     ),
@@ -431,28 +431,28 @@ EXAMPLES = (  # type: ignore
             "description": "Number of repair orders",
             "query": (
                 "SELECT count(repair_order_id) as num_repair_orders "
-                "FROM repair_orders"
+                "FROM default.repair_orders"
             ),
             "mode": "published",
-            "name": "num_repair_orders",
+            "name": "default.num_repair_orders",
         },
     ),
     (
         "/nodes/metric/",
         {
             "description": "Average repair price",
-            "query": "SELECT avg(price) as avg_repair_price FROM repair_order_details",
+            "query": "SELECT avg(price) as avg_repair_price FROM default.repair_order_details",
             "mode": "published",
-            "name": "avg_repair_price",
+            "name": "default.avg_repair_price",
         },
     ),
     (
         "/nodes/metric/",
         {
             "description": "Total repair cost",
-            "query": "SELECT sum(price) as total_repair_cost FROM repair_order_details",
+            "query": "SELECT sum(price) as total_repair_cost FROM default.repair_order_details",
             "mode": "published",
-            "name": "total_repair_cost",
+            "name": "default.total_repair_cost",
         },
     ),
     (
@@ -461,22 +461,22 @@ EXAMPLES = (  # type: ignore
             "description": "Average length of employment",
             "query": (
                 "SELECT avg(NOW() - hire_date) as avg_length_of_employment "
-                "FROM hard_hats"
+                "FROM default.hard_hats"
             ),
             "mode": "published",
-            "name": "avg_length_of_employment",
+            "name": "default.avg_length_of_employment",
         },
     ),
     (
         "/nodes/metric/",
         {
-            "name": "discounted_orders_rate",
+            "name": "default.discounted_orders_rate",
             "query": (
                 """
                 SELECT
                   cast(sum(if(discount > 0.0, 1, 0)) as double) / count(*)
                     AS discounted_orders_rate
-                FROM repair_order_details
+                FROM default.repair_order_details
                 """
             ),
             "mode": "published",
@@ -489,10 +489,10 @@ EXAMPLES = (  # type: ignore
             "description": "Total repair order discounts",
             "query": (
                 "SELECT sum(price * discount) as total_discount "
-                "FROM repair_order_details"
+                "FROM default.repair_order_details"
             ),
             "mode": "published",
-            "name": "total_repair_order_discounts",
+            "name": "default.total_repair_order_discounts",
         },
     ),
     (
@@ -501,10 +501,10 @@ EXAMPLES = (  # type: ignore
             "description": "Total repair order discounts",
             "query": (
                 "SELECT avg(price * discount) as avg_repair_order_discount "
-                "FROM repair_order_details"
+                "FROM default.repair_order_details"
             ),
             "mode": "published",
-            "name": "avg_repair_order_discounts",
+            "name": "default.avg_repair_order_discounts",
         },
     ),
     (
@@ -513,79 +513,79 @@ EXAMPLES = (  # type: ignore
             "description": "Average time to dispatch a repair order",
             "query": (
                 "SELECT avg(dispatched_date - order_date) as avg_time_to_dispatch "
-                "FROM repair_orders"
+                "FROM default.repair_orders"
             ),
             "mode": "published",
-            "name": "avg_time_to_dispatch",
+            "name": "default.avg_time_to_dispatch",
         },
     ),
     (
         (
-            "/nodes/repair_order_details/columns/repair_order_id/"
-            "?dimension=repair_order&dimension_column=repair_order_id"
+            "/nodes/default.repair_order_details/columns/repair_order_id/"
+            "?dimension=default.repair_order&dimension_column=repair_order_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_orders/columns/municipality_id/"
-            "?dimension=municipality_dim&dimension_column=municipality_id"
+            "/nodes/default.repair_orders/columns/municipality_id/"
+            "?dimension=default.municipality_dim&dimension_column=municipality_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_type/columns/contractor_id/"
-            "?dimension=contractor&dimension_column=contractor_id"
+            "/nodes/default.repair_type/columns/contractor_id/"
+            "?dimension=default.contractor&dimension_column=contractor_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_orders/columns/hard_hat_id/"
-            "?dimension=hard_hat&dimension_column=hard_hat_id"
+            "/nodes/default.repair_orders/columns/hard_hat_id/"
+            "?dimension=default.hard_hat&dimension_column=hard_hat_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_orders/columns/dispatcher_id/"
-            "?dimension=dispatcher&dimension_column=dispatcher_id"
+            "/nodes/default.repair_orders/columns/dispatcher_id/"
+            "?dimension=default.dispatcher&dimension_column=dispatcher_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/hard_hat/columns/state/"
-            "?dimension=us_state&dimension_column=state_short"
+            "/nodes/default.hard_hat/columns/state/"
+            "?dimension=default.us_state&dimension_column=state_short"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order_details/columns/repair_order_id/"
-            "?dimension=repair_order&dimension_column=repair_order_id"
+            "/nodes/default.repair_order_details/columns/repair_order_id/"
+            "?dimension=default.repair_order&dimension_column=repair_order_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order/columns/dispatcher_id/"
-            "?dimension=dispatcher&dimension_column=dispatcher_id"
+            "/nodes/default.repair_order/columns/dispatcher_id/"
+            "?dimension=default.dispatcher&dimension_column=dispatcher_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order/columns/hard_hat_id/"
-            "?dimension=hard_hat&dimension_column=hard_hat_id"
+            "/nodes/default.repair_order/columns/hard_hat_id/"
+            "?dimension=default.hard_hat&dimension_column=hard_hat_id"
         ),
         {},
     ),
     (
         (
-            "/nodes/repair_order/columns/municipality_id/"
-            "?dimension=municipality_dim&dimension_column=municipality_id"
+            "/nodes/default.repair_order/columns/municipality_id/"
+            "?dimension=default.municipality_dim&dimension_column=municipality_id"
         ),
         {},
     ),
@@ -1119,7 +1119,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "A source table for account type data",
             "mode": "published",
-            "name": "account_type_table",
+            "name": "default.account_type_table",
             "catalog": "default",
             "schema_": "accounting",
             "table": "account_type_table",
@@ -1135,7 +1135,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "A source table for different types of payments",
             "mode": "published",
-            "name": "payment_type_table",
+            "name": "default.payment_type_table",
             "catalog": "default",
             "schema_": "accounting",
             "table": "payment_type_table",
@@ -1153,7 +1153,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "All repair orders",
             "mode": "published",
-            "name": "revenue",
+            "name": "default.revenue",
             "catalog": "default",
             "schema_": "accounting",
             "table": "revenue",
@@ -1165,10 +1165,10 @@ EXAMPLES = (  # type: ignore
             "description": "Payment type dimensions",
             "query": (
                 "SELECT id, payment_type_name, payment_type_classification "
-                "FROM payment_type_table"
+                "FROM default.payment_type_table"
             ),
             "mode": "published",
-            "name": "payment_type",
+            "name": "default.payment_type",
             "primary_key": ["id"],
         },
     ),
@@ -1179,10 +1179,10 @@ EXAMPLES = (  # type: ignore
             "query": (
                 "SELECT id, account_type_name, "
                 "account_type_classification FROM "
-                "account_type_table"
+                "default.account_type_table"
             ),
             "mode": "published",
-            "name": "account_type",
+            "name": "default.account_type",
             "primary_key": ["id"],
         },
     ),
@@ -1191,11 +1191,11 @@ EXAMPLES = (  # type: ignore
         {
             "query": (
                 "SELECT payment_id, payment_amount, customer_id, account_type "
-                "FROM revenue WHERE payment_amount > 1000000"
+                "FROM default.revenue WHERE payment_amount > 1000000"
             ),
             "description": "Only large revenue payments",
             "mode": "published",
-            "name": "large_revenue_payments_only",
+            "name": "default.large_revenue_payments_only",
         },
     ),
     (
@@ -1203,22 +1203,22 @@ EXAMPLES = (  # type: ignore
         {
             "query": (
                 "SELECT payment_id, payment_amount, customer_id, account_type "
-                "FROM revenue WHERE "
+                "FROM default.revenue WHERE "
                 "large_revenue_payments_and_business_only > 1000000 "
                 "AND account_type='BUSINESS'"
             ),
             "description": "Only large revenue payments from business accounts",
             "mode": "published",
-            "name": "large_revenue_payments_and_business_only",
+            "name": "default.large_revenue_payments_and_business_only",
         },
     ),
     (
         "/nodes/metric/",
         {
             "description": "Total number of account types",
-            "query": "SELECT count(id) as num_accounts FROM account_type",
+            "query": "SELECT count(id) as num_accounts FROM default.account_type",
             "mode": "published",
-            "name": "number_of_account_types",
+            "name": "default.number_of_account_types",
         },
     ),
     (
@@ -1342,7 +1342,7 @@ EXAMPLES = (  # type: ignore
     (  # Event examples
         "/nodes/source/",
         {
-            "name": "event_source",
+            "name": "default.event_source",
             "description": "Events",
             "columns": [
                 {"name": "event_id", "type": "int"},
@@ -1359,43 +1359,46 @@ EXAMPLES = (  # type: ignore
     (
         "/nodes/transform/",
         {
-            "name": "long_events",
+            "name": "default.long_events",
             "description": "High-Latency Events",
             "query": "SELECT event_id, event_latency, device_id, country "
-            "FROM event_source WHERE event_latency > 1000000",
+            "FROM default.event_source WHERE event_latency > 1000000",
             "mode": "published",
         },
     ),
     (
         "/nodes/dimension/",
         {
-            "name": "country_dim",
+            "name": "default.country_dim",
             "description": "Country Dimension",
             "query": "SELECT country, COUNT(DISTINCT event_id) AS events_cnt "
-            "FROM event_source GROUP BY country",
+            "FROM default.event_source GROUP BY country",
             "mode": "published",
             "primary_key": ["country"],
         },
     ),
     (
-        "/nodes/event_source/columns/country/?dimension=country_dim&dimension_column=country",
+        (
+            "/nodes/default.event_source/columns/country/?"
+            "dimension=default.country_dim&dimension_column=country"
+        ),
         {},
     ),
     (
         "/nodes/metric/",
         {
-            "name": "device_ids_count",
+            "name": "default.device_ids_count",
             "description": "Number of Distinct Devices",
-            "query": "SELECT COUNT(DISTINCT device_id) " "FROM event_source",
+            "query": "SELECT COUNT(DISTINCT device_id) " "FROM default.event_source",
             "mode": "published",
         },
     ),
     (
         "/nodes/metric/",
         {
-            "name": "long_events_distinct_countries",
+            "name": "default.long_events_distinct_countries",
             "description": "Number of Distinct Countries for Long Events",
-            "query": "SELECT COUNT(DISTINCT country) " "FROM long_events",
+            "query": "SELECT COUNT(DISTINCT country) " "FROM default.long_events",
             "mode": "published",
         },
     ),
@@ -1521,7 +1524,7 @@ EXAMPLES = (  # type: ignore
             ],
             "description": "A source table for sales",
             "mode": "published",
-            "name": "sales",
+            "name": "default.sales",
             "catalog": "default",
             "schema_": "revenue",
             "table": "sales",
@@ -1531,9 +1534,11 @@ EXAMPLES = (  # type: ignore
         "/nodes/dimension/",
         {
             "description": "Item dimension",
-            "query": ("SELECT item_name " "account_type_classification FROM " "sales"),
+            "query": (
+                "SELECT item_name " "account_type_classification FROM default.sales"
+            ),
             "mode": "published",
-            "name": "items",
+            "name": "default.items",
             "primary_key": ["account_type_classification"],
         },
     ),
@@ -1541,18 +1546,18 @@ EXAMPLES = (  # type: ignore
         "/nodes/metric/",
         {
             "description": "Total units sold",
-            "query": "SELECT SUM(sold_count) as num_sold FROM sales",
+            "query": "SELECT SUM(sold_count) as num_sold FROM default.sales",
             "mode": "published",
-            "name": "items_sold_count",
+            "name": "default.items_sold_count",
         },
     ),
     (
         "/nodes/metric/",
         {
             "description": "Total profit",
-            "query": "SELECT SUM(sold_count * price_per_unit) as num_sold FROM sales",
+            "query": "SELECT SUM(sold_count * price_per_unit) as num_sold FROM default.sales",
             "mode": "published",
-            "name": "total_profit",
+            "name": "default.total_profit",
         },
     ),
     # lateral view explode/cross join unnest examples
@@ -1690,21 +1695,21 @@ COLUMN_MAPPINGS = {
 
 QUERY_DATA_MAPPINGS = {
     (
-        "SELECT  avg(repair_order_details.price) AS "
-        "avg_repair_price,\n\tdispatcher.company_name,"
-        "\n\tcount(repair_orders.repair_order_id) AS "
+        "SELECT  avg(default_DOT_repair_order_details.price) AS "
+        "avg_repair_price,\n\tdefault_DOT_dispatcher.company_name,"
+        "\n\tcount(default_DOT_repair_orders.repair_order_id) AS "
         "num_repair_orders \n FROM roads.repair_order_details "
-        "AS repair_order_details LEFT OUTER JOIN (SELECT  "
-        "repair_orders.dispatcher_id,\n\t"
-        "repair_orders.hard_hat_id,\n\trepair_orders.municipality_id"
-        ",\n\trepair_orders.repair_order_id \n FROM "
-        "roads.repair_orders AS repair_orders) AS repair_order "
-        "ON repair_order_details.repair_order_id = "
-        "repair_order.repair_order_id\nLEFT OUTER JOIN (SELECT  "
-        "dispatchers.company_name,\n\tdispatchers.dispatcher_id "
-        "\n FROM roads.dispatchers AS dispatchers) AS dispatcher "
-        "ON repair_order.dispatcher_id = dispatcher.dispatcher_id "
-        "\n GROUP BY  dispatcher.company_name"
+        "AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  "
+        "default_DOT_repair_orders.dispatcher_id,\n\t"
+        "default_DOT_repair_orders.hard_hat_id,\n\tdefault_DOT_repair_orders.municipality_id"
+        ",\n\tdefault_DOT_repair_orders.repair_order_id \n FROM "
+        "roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order "
+        "ON default_DOT_repair_order_details.repair_order_id = "
+        "default_DOT_repair_order.repair_order_id\nLEFT OUTER JOIN (SELECT  "
+        "default_DOT_dispatchers.company_name,\n\tdefault_DOT_dispatchers.dispatcher_id "
+        "\n FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher "
+        "ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id "
+        "\n GROUP BY  default_DOT_dispatcher.company_name"
     )
     .strip()
     .replace('"', "")
@@ -1746,9 +1751,10 @@ QUERY_DATA_MAPPINGS = {
         }
     ),
     (
-        "SELECT  payment_type_table.id,\n\tpayment_type_table.payment_type_classification,\n\t"
-        "payment_type_table.payment_type_name \n FROM accounting.payment_type_table AS "
-        "payment_type_table"
+        "SELECT  default_DOT_payment_type_table.id,\n\t"
+        "default_DOT_payment_type_table.payment_type_classification,\n\t"
+        "default_DOT_payment_type_table.payment_type_name \n FROM "
+        "accounting.payment_type_table AS default_DOT_payment_type_table"
     )
     .strip()
     .replace('"', "")
@@ -1824,9 +1830,11 @@ QUERY_DATA_MAPPINGS = {
         }
     ),
     (
-        "SELECT  revenue.account_type,\n\trevenue.customer_id,\n\trevenue.payment_amount,"
-        '\n\trevenue.payment_id \n FROM "accounting"."revenue" AS revenue\n \n '
-        "WHERE  revenue.payment_amount > 1000000"
+        "SELECT  default_DOT_revenue.account_type,\n\tdefault_DOT_revenue.customer_id,"
+        "\n\tdefault_DOT_revenue.payment_amount,"
+        '\n\tdefault_DOT_revenue.payment_id \n FROM "accounting"."revenue" '
+        "AS default_DOT_revenue\n \n WHERE  default_DOT_revenue.payment_amount "
+        "> 1000000"
     )
     .strip()
     .replace('"', "")

--- a/tests/sql/parsing/test_ast.py
+++ b/tests/sql/parsing/test_ast.py
@@ -19,7 +19,7 @@ def test_ast_compile_table(
 
     Includes client_with_examples fixture so that examples are loaded into session
     """
-    query = parse("SELECT hard_hat_id, last_name, first_name FROM hard_hats")
+    query = parse("SELECT hard_hat_id, last_name, first_name FROM default.hard_hats")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.select.from_.relations[0].primary.compile(ctx)
@@ -29,7 +29,7 @@ def test_ast_compile_table(
         0
     ].primary._dj_node
     assert node
-    assert node.name == "hard_hats"
+    assert node.name == "default.hard_hats"
 
 
 def test_ast_compile_table_missing_node(session):
@@ -78,7 +78,7 @@ def test_ast_compile_query(
     """
     Test compiling an entire query
     """
-    query = parse("SELECT hard_hat_id, last_name, first_name FROM hard_hats")
+    query = parse("SELECT hard_hat_id, last_name, first_name FROM default.hard_hats")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -88,7 +88,7 @@ def test_ast_compile_query(
         0
     ].primary._dj_node
     assert node
-    assert node.name == "hard_hats"
+    assert node.name == "default.hard_hats"
 
 
 def test_ast_compile_query_missing_columns(
@@ -98,7 +98,7 @@ def test_ast_compile_query_missing_columns(
     """
     Test compiling a query with missing columns
     """
-    query = parse("SELECT hard_hat_id, column_foo, column_bar FROM hard_hats")
+    query = parse("SELECT hard_hat_id, column_foo, column_bar FROM default.hard_hats")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -113,7 +113,7 @@ def test_ast_compile_query_missing_columns(
         0
     ].primary._dj_node
     assert node
-    assert node.name == "hard_hats"
+    assert node.name == "default.hard_hats"
 
 
 def test_ast_compile_missing_references(session: Session):
@@ -419,7 +419,7 @@ def test_ast_compile_lateral_view_explode4(session: Session, client: TestClient)
             ],
             "description": "Placeholder source node",
             "mode": "published",
-            "name": "a",
+            "name": "default.a",
             "catalog": "default",
             "schema_": "a",
             "table": "a",
@@ -430,9 +430,9 @@ def test_ast_compile_lateral_view_explode4(session: Session, client: TestClient)
         "/nodes/transform/",
         json={
             "description": "A projection with an array",
-            "query": "SELECT ARRAY(30, 60) as foo_array FROM a",
+            "query": "SELECT ARRAY(30, 60) as foo_array FROM default.a",
             "mode": "published",
-            "name": "foo_array_example",
+            "name": "default.foo_array_example",
         },
     )
     assert response.ok
@@ -440,7 +440,7 @@ def test_ast_compile_lateral_view_explode4(session: Session, client: TestClient)
     query = parse(
         """
         SELECT foo_array, a, b
-        FROM foo_array_example
+        FROM default.foo_array_example
         LATERAL VIEW EXPLODE(foo_array) AS a
         LATERAL VIEW EXPLODE(foo_array) AS b;
     """,
@@ -473,7 +473,7 @@ def test_ast_compile_lateral_view_explode4(session: Session, client: TestClient)
     assert query.columns[0].table.alias_or_name == ast.Name(  # type: ignore
         name="foo_array_example",
         quote_style="",
-        namespace=None,
+        namespace=ast.Name(name="default", quote_style="", namespace=None),
     )
     assert query.columns[1].table.alias_or_name == ast.Name(  # type: ignore
         name="EXPLODE",


### PR DESCRIPTION
### Summary

This PR makes namespaces required with no automatic namespace attribution when no namespace is provided. Based on the discussion in #488, explicit namespace requirements should lead to more consistent behavior that should be more intuitive to users and simplifies some of the server side logic.

The source code change is pretty minimal here (barely 3 lines) and the rest of the line changes here were made to tests (we've used the "automatic default namespace assignment" pretty aggressively in tests, part of the reason why the bug in #488 was able to sneak by unnoticed).

### Test Plan

`make check`, `make test`, and a few adhoc testing

- [x] PR has an associated issue: #488 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
