### PR TITLE
Docker compose docs update

### DIFF
--- a/docs/content/0.1.0/docs/getting-started/docker-compose.md
+++ b/docs/content/0.1.0/docs/getting-started/docker-compose.md
@@ -15,6 +15,7 @@ Clone the DJ demo repository along with the DJ and DJQS repositories.
 git clone git@github.com:DataJunction/dj-demo.git
 git clone git@github.com:DataJunction/dj.git
 git clone git@github.com:DataJunction/djqs.git
+git clone git@github.com:DataJunction/djrs.git
 ```
 
 Change into the `dj-demo/` directory and start the docker compose environment.

--- a/docs/content/0.1.0/docs/getting-started/docker-compose.md
+++ b/docs/content/0.1.0/docs/getting-started/docker-compose.md
@@ -9,13 +9,14 @@ weight: 10
 The easiest way to try out DJ is to use the [dj-demo](https://github.com/DataJunction/dj-demo) docker compose setup. This setup will launch and connect
 a DJ server, a DJRS server, and a jupyter lab instance with a few example notebooks.
 
-Clone the DJ demo repository along with the DJ, DJRS and DJQS repositories.
+Clone the DJ demo repository along with the DJ, DJRS, DJQS and DJ-UI repositories.
 
 ```sh
 git clone git@github.com:DataJunction/dj-demo.git
 git clone git@github.com:DataJunction/dj.git
 git clone git@github.com:DataJunction/djqs.git
 git clone git@github.com:DataJunction/djrs.git
+git clone git@github.com:DataJunction/dj-ui.git
 ```
 
 Change into the `dj-demo/` directory and start the docker compose environment.

--- a/docs/content/0.1.0/docs/getting-started/docker-compose.md
+++ b/docs/content/0.1.0/docs/getting-started/docker-compose.md
@@ -9,7 +9,7 @@ weight: 10
 The easiest way to try out DJ is to use the [dj-demo](https://github.com/DataJunction/dj-demo) docker compose setup. This setup will launch and connect
 a DJ server, a DJRS server, and a jupyter lab instance with a few example notebooks.
 
-Clone the DJ demo repository along with the DJ and DJQS repositories.
+Clone the DJ demo repository along with the DJ, DJRS and DJQS repositories.
 
 ```sh
 git clone git@github.com:DataJunction/dj-demo.git


### PR DESCRIPTION
### Summary

Made changes to the getting started documentation to include pulling djrs from git up. Running docker compose up with djrs errored out with: 'unable to prepare context: path "../djrs" not found' causing the build to fail.

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
