### PR TITLE
Allow node updates in Python client + update bugs

### DIFF
--- a/dj/models/column.py
+++ b/dj/models/column.py
@@ -89,8 +89,20 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         """
         Whether the dimension attribute is set on this column.
         """
+        return self.has_attribute("dimension")
+
+    def has_primary_key_attribute(self) -> bool:
+        """
+        Whether the primary key attribute is set on this column.
+        """
+        return self.has_attribute("primary_key")
+
+    def has_attribute(self, attribute_name: str) -> bool:
+        """
+        Whether the given attribute is set on this column.
+        """
         return any(
-            attr.attribute_type.name == "dimension"
+            attr.attribute_type.name == attribute_name
             for attr in self.attributes  # pylint: disable=not-an-iterable
         )
 

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -445,7 +445,7 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         """
         primary_key_columns = []
         for col in self.columns:  # pylint: disable=not-an-iterable
-            if "primary_key" in {attr.attribute_type.name for attr in col.attributes}:
+            if col.has_primary_key_attribute():
                 primary_key_columns.append(col)
         return primary_key_columns
 


### PR DESCRIPTION
### Summary

This change adds node update support to the Python client for sources, dimensions, metrics, and transforms. It also fixes some bugs with node updates:
* Dimension links should be propagated during updates where possible
* A node's primary keys should be modifiable, with the node's status changing accordingly

### Test Plan

Locally and added tests

- [X] PR has an associated issue: #351
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
