### PR TITLE
add ordering `order by`s in sql and data routes

### DIFF
--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -151,10 +151,11 @@ def get_data(  # pylint: disable=too-many-locals
 
 
 @router.get("/data/", response_model=QueryWithResults)
-def get_data_for_metrics(  # pylint: disable=R0914
+def get_data_for_metrics(  # pylint: disable=R0914, R0913
     metrics: List[str] = Query([]),
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
+    orderbys: List[str] = Query([]),
     limit: Optional[int] = None,
     async_: bool = False,
     *,
@@ -189,6 +190,7 @@ def get_data_for_metrics(  # pylint: disable=R0914
         metric_nodes,
         filters=filters or [],
         dimensions=dimensions or [],
+        orderbys=orderbys or [],
         limit=limit,
     )
     columns = [

--- a/dj/api/data.py
+++ b/dj/api/data.py
@@ -95,6 +95,7 @@ def get_data(  # pylint: disable=too-many-locals
     *,
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
+    orderby: List[str] = Query([]),
     limit: Optional[int] = None,
     async_: bool = False,
     session: Session = Depends(get_session),
@@ -124,6 +125,7 @@ def get_data(  # pylint: disable=too-many-locals
         node_name=node_name,
         dimensions=dimensions,
         filters=filters,
+        orderby=orderby,
         limit=limit,
         engine=engine,
     )
@@ -155,7 +157,7 @@ def get_data_for_metrics(  # pylint: disable=R0914, R0913
     metrics: List[str] = Query([]),
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
-    orderbys: List[str] = Query([]),
+    orderby: List[str] = Query([]),
     limit: Optional[int] = None,
     async_: bool = False,
     *,
@@ -190,7 +192,7 @@ def get_data_for_metrics(  # pylint: disable=R0914, R0913
         metric_nodes,
         filters=filters or [],
         dimensions=dimensions or [],
-        orderbys=orderbys or [],
+        orderby=orderby or [],
         limit=limit,
     )
     columns = [

--- a/dj/api/helpers.py
+++ b/dj/api/helpers.py
@@ -170,6 +170,7 @@ def get_query(  # pylint: disable=too-many-arguments
     node_name: str,
     dimensions: List[str],
     filters: List[str],
+    orderby: List[str],
     limit: Optional[int] = None,
     engine: Optional[Engine] = None,
 ) -> ast.Query:
@@ -201,6 +202,7 @@ def get_query(  # pylint: disable=too-many-arguments
         node=node.current,
         filters=filters,
         dimensions=dimensions,
+        orderby=orderby,
         limit=limit,
         build_criteria=build_criteria,
     )

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -702,6 +702,8 @@ def create_cube_node_revision(  # pylint: disable=too-many-locals
         metric_nodes,
         filters=data.filters or [],
         dimensions=data.dimensions or [],
+        orderbys=data.orderbys or [],
+        limit=data.limit or None,
     )
     dimension_attribute = session.exec(
         select(AttributeType).where(AttributeType.name == "dimension"),

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -702,7 +702,7 @@ def create_cube_node_revision(  # pylint: disable=too-many-locals
         metric_nodes,
         filters=data.filters or [],
         dimensions=data.dimensions or [],
-        orderbys=data.orderbys or [],
+        orderby=data.orderby or [],
         limit=data.limit or None,
     )
     dimension_attribute = session.exec(

--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -23,6 +23,7 @@ def get_sql(
     node_name: str,
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
+    orderby: List[str] = Query([]),
     limit: Optional[int] = None,
     *,
     session: Session = Depends(get_session),
@@ -42,6 +43,7 @@ def get_sql(
         node_name=node_name,
         dimensions=dimensions,
         filters=filters,
+        orderby=orderby,        
         limit=limit,
         engine=engine,
     )
@@ -61,7 +63,7 @@ def get_sql_for_metrics(
     metrics: List[str] = Query([]),
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
-    orderbys: List[str] = Query([]),
+    orderby: List[str] = Query([]),
     limit: Optional[int] = None,
     *,
     session: Session = Depends(get_session),
@@ -86,7 +88,7 @@ def get_sql_for_metrics(
         metric_nodes,
         filters=filters or [],
         dimensions=dimensions or [],
-        orderbys=orderbys or [],
+        orderby=orderby or [],
         limit=limit,
     )
     columns = [

--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -61,6 +61,7 @@ def get_sql_for_metrics(
     metrics: List[str] = Query([]),
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
+    orderbys: List[str] = Query([]),
     limit: Optional[int] = None,
     *,
     session: Session = Depends(get_session),
@@ -85,6 +86,7 @@ def get_sql_for_metrics(
         metric_nodes,
         filters=filters or [],
         dimensions=dimensions or [],
+        orderbys=orderbys or [],
         limit=limit,
     )
     columns = [

--- a/dj/api/sql.py
+++ b/dj/api/sql.py
@@ -43,7 +43,7 @@ def get_sql(
         node_name=node_name,
         dimensions=dimensions,
         filters=filters,
-        orderby=orderby,        
+        orderby=orderby,
         limit=limit,
         engine=engine,
     )

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -661,7 +661,7 @@ def build_metric_nodes(
             for col in metric_ast.select.projection
         ]
         metric_column_idents = {
-            col.alias_or_name.name
+            col.alias_or_name.name  # type: ignore
             for col in parse(metric_node.current.query).select.projection
         }
 

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -353,7 +353,7 @@ def _consolidate_tables(query: ast.Query):
     column_tables_map = {}
     for tbl in query.find_all(ast.Table):
         if tbl.get_nearest_parent_of_type(ast.Query) is not query:
-            continue#pragma: no cover
+            continue  # pragma: no cover
         ident = tbl.identifier(False)
         if isinstance(tbl.parent, ast.Column):
             if ident not in column_tables_map:
@@ -364,11 +364,11 @@ def _consolidate_tables(query: ast.Query):
             if ident not in foundation_tables_map:
                 foundation_tables_map[ident] = [tbl]
             else:
-                foundation_tables_map[ident].append(tbl)#pragma: no cover
+                foundation_tables_map[ident].append(tbl)  # pragma: no cover
 
     for ident, tbls in foundation_tables_map.items():
         for tbl in tbls[1:]:
-            tbl.swap(tbls[0])#pragma: no cover
+            tbl.swap(tbls[0])  # pragma: no cover
         if ident in column_tables_map:
             for col_tbl in column_tables_map[ident]:
                 col_tbl.swap(tbls[0])
@@ -403,7 +403,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             for col in temp_select.find_all(ast.Column):
                 projection_addition[col.identifier(False)] = col
                 col.namespace_table()
-                if col.table:#pragma: no cover
+                if col.table:  # pragma: no cover
                     dimension_tables.add(cast(ast.Table, col.table).identifier(False))
 
     if filters:
@@ -420,7 +420,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             for col in temp_select.find_all(ast.Column):
                 projection_addition[col.identifier(False)] = col
                 col.namespace_table()
-                if col.table:#pragma: no cover
+                if col.table:  # pragma: no cover
                     dimension_tables.add(cast(ast.Table, col.table).identifier(False))
         query.select.where = ast.BinaryOp.And(*filter_asts)
 
@@ -447,13 +447,13 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                     col.swap(projection_addition[ident])
                 else:
                     projection_addition[ident] = col
-                if col.table:#pragma: no cover
+                if col.table:  # pragma: no cover
                     orderby_tables.add(cast(ast.Table, col.table).identifier(False))
-            
+
             query.organization.order += temp_query.organization.order  # type:ignore
 
     if diff := orderby_tables - dimension_tables:
-        raise DJInvalidInputException(
+        raise DJInvalidInputException(  # pragma: no cover
             "Order by columns can only be from "
             "dimensions used in filters or dimensions arguments"
             f"found {', '.join(str(d) for d in diff)}.",

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -455,7 +455,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
     if diff := orderby_tables - dimension_tables:
         raise DJInvalidInputException(  # pragma: no cover
             "Order by columns can only be from "
-            "dimensions used in filters or dimensions arguments"
+            "dimensions used in filters or group bys"
             f"found {', '.join(str(d) for d in diff)}.",
         )
 

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -4,8 +4,10 @@ import collections
 # pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks,too-many-branches,R0401
 from typing import DefaultDict, Deque, Dict, List, Optional, Set, Tuple, Union, cast
 
-from sqlmodel import Session
+from sqlalchemy.sql import operators
 
+from sqlmodel import Session
+import operator
 from dj.construction.utils import to_namespaced_name
 from dj.errors import DJException, DJInvalidInputException
 from dj.models.column import Column
@@ -298,7 +300,8 @@ def _build_tables_on_select(
                     if col in set(tbl.child.select.projection)
                 ]
             node_ast.compile(context)
-            select.replace(tbl, node_ast)
+
+            select.replace(tbl, node_ast)#, lambda x, y: type(x)==type(y) and hasattr(x, 'identifier') and hasattr(y, 'identifier') and x.identifier(False) == y.identifier(False))
 
 
 def dimension_columns_mapping(
@@ -338,7 +341,42 @@ def _build_select_ast(
     join_tables_for_dimensions(session, dimension_columns, tables, build_criteria)
     _build_tables_on_select(session, select, tables, build_criteria)
 
+def _consolidate_tables(query: ast.Query):
+    """
+    Checks all the tables whose nearest query is 
+    the one given, matching identifiers, and makes them
+    all the same `Table` in memory
+    """
+    foundation_tables_map = {}
+    column_tables_map = {}
+    for tbl in query.find_all(ast.Table):
+        if tbl.get_nearest_parent_of_type(ast.Query) is not query:
+            continue
+        ident = tbl.identifier(False)
+        if isinstance(tbl.parent, ast.Column):
+            if ident not in column_tables_map:
+                column_tables_map[ident]=[tbl]
+            else:
+                column_tables_map[ident].append(tbl)
+        else:
+            if ident not in foundation_tables_map:
+                foundation_tables_map[ident]=[tbl]
+            else:
+                foundation_tables_map[ident].append(tbl)
 
+    for ident, tbls in foundation_tables_map.items():
+        for tbl in tbls[1:]:
+            tbl.swap(tbls[0])
+        if ident in column_tables_map:
+            for col_tbl in column_tables_map[ident]:
+                col_tbl.swap(tbls[0])
+            del column_tables_map[ident]
+ 
+    for tbls in column_tables_map.values():
+        for tbl in tbls[1:]:
+            tbl.swap(tbls[0])
+
+    
 def add_filters_dimensions_orderby_limit_to_query_ast(
     query: ast.Query,
     dialect: Optional[str] = None,  # pylint: disable=unused-argument
@@ -350,7 +388,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
     """
     Add filters and dimensions to a query ast
     """
-    projection_addition = set()
+    projection_addition = {}
 
     dimension_tables = set()
     if dimensions:
@@ -359,8 +397,11 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 f"select * group by {agg}",
             ).select
             query.select.group_by += temp_select.group_by  # type:ignore
-            projection_addition |= set(temp_select.find_all(ast.Column))
-            dimension_tables |= set(temp_select.find_all(ast.Table))
+            for col in temp_select.find_all(ast.Column):
+                projection_addition[col.identifier(False)] = col
+                col.namespace_table()
+                if col.table:
+                    dimension_tables.add(cast(ast.Table, col.table).identifier(False))
 
     if filters:
         filter_asts = (  # pylint: disable=consider-using-ternary
@@ -373,22 +414,39 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             filter_asts.append(
                 temp_select.where,  # type:ignore
             )
-            dimension_tables |= set(temp_select.find_all(ast.Table))
-            projection_addition |= set(temp_select.find_all(ast.Column))
+            for col in temp_select.find_all(ast.Column):
+                projection_addition[col.identifier(False)] = col
+                col.namespace_table()
+                if col.table:
+                    dimension_tables.add(cast(ast.Table, col.table).identifier(False))
         query.select.where = ast.BinaryOp.And(*filter_asts)
-
+        
     if not query.organization:
         query.organization = ast.Organization([])
-
-    orderby_tables = set()
+        
+    # for order bys, we must be using dimensions
+    # that are already used in dimensions, filters
+    # so for the sake of building rn, we will dupe cols
+    # if used already, otherwise, the orderby col will
+    # be put in the projection as with the dimensions, filters
+    # columns
+    orderby_tables=set()
     if orderbys:
         for order in orderbys:
-            temp_query = parse(
+            temp_select = parse(
                 f"select * order by {order}",
             )
-            orderby_tables |= set(temp_query.find_all(ast.Table))
-            projection_addition |= set(temp_query.find_all(ast.Column))
-            query.organization.order += temp_query.organization.order  # type:ignore
+            
+            for col in temp_select.find_all(ast.Column):
+                ident = col.identifier(False)
+                col.namespace_table()
+                if ident in projection_addition:
+                    col.swap(projection_addition[ident])
+                else:
+                    projection_addition[ident] = col
+                if col.table:
+                    orderby_tables.add(cast(ast.Table, col.table).identifier(False))
+            query.organization.order += temp_select.organization.order  # type:ignore
 
     if diff := orderby_tables - dimension_tables:
         raise DJInvalidInputException(
@@ -397,17 +455,37 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             f"found {', '.join(str(d) for d in diff)}.",
         )
 
-    # add all used dimension columns to the projection
-    query.select.projection += list(projection_addition)
+    # add all used dimension columns to the projection without duplicates
+    projection_update = []
+    for exp in query.select.projection:
+        if not isinstance(exp, ast.Column):
+            projection_update.append(exp)
+        else:
+            ident = exp.identifier(False)
+            added = None
+            for k, v in projection_addition.items():
+                if k.endswith(ident):
+                    projection_update.append(v)
+                    added = k
+                    break
+
+            if added is None:
+                projection_update.append(exp)
+            else:
+                del projection_addition[added]
+        
+    projection_update+=list(projection_addition.values())
+    
+    query.select.projection = projection_update
 
     # Cannot select for columns that aren't in GROUP BY and aren't aggregations
-    if query.select.group_by:
-        query.select.projection = [
-            col
-            for col in query.select.projection
-            if col.is_aggregation()  # type: ignore
-            or col.name.name in {gc.name.name for gc in query.select.group_by}  # type: ignore
-        ]
+    # if query.select.group_by:
+    #     query.select.projection = [
+    #         col
+    #         for col in query.select.projection
+    #         if col.is_aggregation()  # type: ignore
+    #         or col.name.name in {gc.name.name for gc in query.select.group_by}  # type: ignore
+    #     ]
 
     if limit is not None:
         query.limit = ast.Number(limit)
@@ -478,7 +556,7 @@ def build_node(  # pylint: disable=too-many-arguments
         )
 
     # if no dimensions need to be added then we can see if the node is directly materialized
-    if not (filters or dimensions):
+    if not (filters or dimensions or limit):
         if select := cast(
             ast.Select,
             _get_node_table(node, build_criteria, as_select=True),
@@ -498,7 +576,7 @@ def build_node(  # pylint: disable=too-many-arguments
         orderbys,
         limit,
     )
-
+    _consolidate_tables(query) 
     return build_ast(session, query, build_criteria)
 
 

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -680,7 +680,7 @@ class CubeNodeFields(BaseSQLModel):
     metrics: List[str]
     dimensions: List[str]
     filters: Optional[List[str]]
-    orderbys: Optional[List[str]]
+    orderby: Optional[List[str]]
     limit: Optional[int]
     description: str
     mode: NodeMode

--- a/dj/models/node.py
+++ b/dj/models/node.py
@@ -680,6 +680,8 @@ class CubeNodeFields(BaseSQLModel):
     metrics: List[str]
     dimensions: List[str]
     filters: Optional[List[str]]
+    orderbys: Optional[List[str]]
+    limit: Optional[int]
     description: str
     mode: NodeMode
 

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -859,7 +859,8 @@ class Column(Aliasable, Named, Expression):
         if self.is_compiled():
             return
 
-        if self.table and self.table.parent is self:
+        # check if the column was already given a table
+        if self.table and isinstance(self.table.parent, Column):
             self.table.add_ref_column(self, ctx)
         else:
             found_sources = self.find_table_sources(ctx)

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -579,8 +579,8 @@ class Name(Node):
 
     def __post_init__(self):
         if isinstance(self.name, Name):
-            self.quote_style=self.quote_style or self.name.quote_style
-            self.namespace=self.namespace or self.name.namespace
+            self.quote_style = self.quote_style or self.name.quote_style
+            self.namespace = self.namespace or self.name.namespace
             self.name = self.name.name
 
     def __str__(self) -> str:
@@ -597,7 +597,7 @@ class Name(Node):
 
     def identifier(self, quotes: bool = True) -> str:
         """
-        Yield a string of all the names making up 
+        Yield a string of all the names making up
         the name with or without quotes
         """
         quote_style = "" if not quotes else self.quote_style
@@ -619,13 +619,20 @@ class Named(Node):
     name: Name
 
     @staticmethod
-    def namespaces_intersect(namespace_a: List[Name], namespace_b: List[Name], quotes: bool = False):
-        return all(na.name==nb.name if not quotes else str(na)==str(nb) for na, nb in zip(reversed(namespace_a), reversed(namespace_b)))
-    
+    def namespaces_intersect(
+        namespace_a: List[Name],
+        namespace_b: List[Name],
+        quotes: bool = False,
+    ):
+        return all(
+            na.name == nb.name if not quotes else str(na) == str(nb)
+            for na, nb in zip(reversed(namespace_a), reversed(namespace_b))
+        )
+
     @property
     def names(self) -> List[Name]:
         return self.name.names
-    
+
     @property
     def namespace(self) -> List[Name]:
         return self.names[:-1]
@@ -700,8 +707,8 @@ class Column(Aliasable, Named, Expression):
             self._table = Table(name=self.name.namespace)
             self.name.namespace = None
             self._table.parent = self
-            self._table.parent_key='_table' 
-    
+            self._table.parent_key = "_table"
+
     def add_expression(self, expression: "Expression") -> "Column":
         """
         Add a referenced expression where the column came from
@@ -718,13 +725,13 @@ class Column(Aliasable, Named, Expression):
         Return the table the column was referenced from
         """
         return self._table
-    
+
     @property
-    def children(self)->Iterator[Node]:
+    def children(self) -> Iterator[Node]:
         if self.table and self.table.parent is self:
             return chain(super().children, (self.table,))
         return super().children
-            
+
     @property
     def is_api_column(self) -> bool:
         """

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -2141,15 +2141,15 @@ class Organization(Node):
     Sets up organization for the query
     """
 
-    order: List[SortItem]
-    sort: List[SortItem]
+    order: Optional[List[SortItem]] = None
+    sort: Optional[List[SortItem]] = None
 
     def __str__(self) -> str:
         ret = ""
-        ret += f"ORDER BY {', '.join(str(i) for i in self.order)}" if self.order else ""
+        ret += f"ORDER BY {', '.join(str(i) for i in self.order)}" if self.order is not None else ""
         if ret:
             ret += "\n"
-        ret += f"SORT BY {', '.join(str(i) for i in self.sort)}" if self.sort else ""
+        ret += f"SORT BY {', '.join(str(i) for i in self.sort)}" if self.sort is not None else ""
         return ret
 
 

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -877,7 +877,7 @@ class Column(Aliasable, Named, Expression):
                 ctx.exception.errors.append(
                     DJError(
                         code=ErrorCode.INVALID_COLUMN,
-                        message=f"Column `{self.name.name}` found in multiple tables. Consider namespacing.",
+                        message=f"Column `{self.name.name}` found in multiple tables. Consider using fully qualified name.",
                     ),
                 )
                 return

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -2146,10 +2146,10 @@ class Organization(Node):
 
     def __str__(self) -> str:
         ret = ""
-        ret += f"ORDER BY {', '.join(str(i) for i in self.order)}" if self.order is not None else ""
+        ret += f"ORDER BY {', '.join(str(i) for i in self.order)}" if self.order else ""
         if ret:
             ret += "\n"
-        ret += f"SORT BY {', '.join(str(i) for i in self.sort)}" if self.sort is not None else ""
+        ret += f"SORT BY {', '.join(str(i) for i in self.sort)}" if self.sort else ""
         return ret
 
 

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -129,8 +129,8 @@ def test_create_invalid_cube(client_with_examples: TestClient):
     assert response.status_code == 422
     data = response.json()
     assert data == {
-        "message": "The dimension attribute `default.payment_type.payment_type_name` is not "
-        "available on every metric and thus cannot be included.",
+        "message": "The dimension attribute `default.payment_type.payment_type_name` "
+        "is not available on every requested metric and thus cannot be included.",
         "errors": [],
         "warnings": [],
     }
@@ -323,8 +323,8 @@ def test_invalid_cube(client_with_examples: TestClient):
         },
     )
     assert response.json()["message"] == (
-        "The dimension attribute `default.contractor.company_name` is not available "
-        "on every metric and thus cannot be included."
+        "The dimension attribute `default.contractor.company_name` "
+        "is not available on every requested metric and thus cannot be included."
     )
 
 

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -135,7 +135,7 @@ def test_create_invalid_cube(client_with_examples: TestClient):
     data = response.json()
     assert data == {
         "message": "The dimension attribute `default.payment_type.payment_type_name` "
-        "is not available on every requested metric and thus cannot be included.",
+        "is not available on every metric and thus cannot be included.",
         "errors": [],
         "warnings": [],
     }
@@ -329,7 +329,7 @@ def test_invalid_cube(client_with_examples: TestClient):
     )
     assert response.json()["message"] == (
         "The dimension attribute `default.contractor.company_name` "
-        "is not available on every requested metric and thus cannot be included."
+        "is not available on every metric and thus cannot be included."
     )
 
 
@@ -346,186 +346,187 @@ def test_create_cube(  # pylint: disable=redefined-outer-name
     assert results["display_name"] == "Default: Repairs Cube"
     assert results["description"] == "Cube of various metrics related to repairs"
     expected_query = """
-    WITH
-    m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
-        default_DOT_hard_hat.city,
-        default_DOT_hard_hat.country,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state,
-        default_DOT_municipality_dim.local_region,
-        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate
-     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-        default_DOT_repair_orders.hard_hat_id,
-        default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id
-     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id
-     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
-     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
-     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-     WHERE  default_DOT_hard_hat.state = 'AZ'
-     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-    ),
-    m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
-        default_DOT_hard_hat.city,
-        default_DOT_hard_hat.country,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state,
-        default_DOT_municipality_dim.local_region,
-        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders
-     FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id
-     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
-     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
-     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
-     WHERE  default_DOT_hard_hat.state = 'AZ'
-     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-    ),
-    m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_dispatcher.company_name,
-        default_DOT_hard_hat.city,
-        default_DOT_hard_hat.country,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state,
-        default_DOT_municipality_dim.local_region,
-        avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price
-     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-        default_DOT_repair_orders.hard_hat_id,
-        default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id
-     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id
-     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
-     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
-     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-     WHERE  default_DOT_hard_hat.state = 'AZ'
-     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-    ),
-    m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
-        default_DOT_hard_hat.city,
-        default_DOT_hard_hat.country,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state,
-        default_DOT_municipality_dim.local_region,
-        sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost
-     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-        default_DOT_repair_orders.hard_hat_id,
-        default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id
-     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id
-     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
-     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
-     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-     WHERE  default_DOT_hard_hat.state = 'AZ'
-     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-    ),
-    m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
-        default_DOT_hard_hat.city,
-        default_DOT_hard_hat.country,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state,
-        default_DOT_municipality_dim.local_region,
-        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts
-     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-        default_DOT_repair_orders.hard_hat_id,
-        default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id
-     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id
-     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
-     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
-     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-     WHERE  default_DOT_hard_hat.state = 'AZ'
-     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-    ),
-    m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
-        default_DOT_hard_hat.city,
-        default_DOT_hard_hat.country,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state,
-        default_DOT_municipality_dim.local_region,
-        sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost
-     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-        default_DOT_repair_orders.hard_hat_id,
-        default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id
-     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id
-     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
-     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
-     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-     WHERE  default_DOT_hard_hat.state = 'AZ'
-     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-    )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
-        m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
-        m2_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
-        m3_default_DOT_total_repair_cost.default_DOT_total_repair_cost,
-        m4_default_DOT_total_repair_order_discounts.default_DOT_total_repair_order_discounts,
-        m5_default_DOT_double_total_repair_cost.default_DOT_double_total_repair_cost,
-        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
-        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
-        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
-        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
-        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
-        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region
-     FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
-    FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
-    FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
-    FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
-    FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
+WITH
+m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.city,
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.country,
+    CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_hard_hat.city,
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.country,
+    count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state
+ FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_hard_hat.city,
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.country,
+    avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.country,
+    sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_hard_hat.city,
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.country,
+    sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.country,
+    sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+)SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
+    m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+    m2_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
+    m3_default_DOT_total_repair_cost.default_DOT_total_repair_cost,
+    m4_default_DOT_total_repair_order_discounts.default_DOT_total_repair_order_discounts,
+    m5_default_DOT_double_total_repair_cost.default_DOT_double_total_repair_cost,
+    COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+    COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
+    COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+    COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
+    COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
+    COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state
+ FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
+FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state
+FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state
+FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state
+FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state
+
     """
     print("RES", results["query"])
     assert compare_query_strings(results["query"], expected_query)
@@ -586,190 +587,191 @@ def test_cube_materialization_sql_and_measures(
         },
     ]
     expected_materialization_query = """
-    WITH
-        m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.country,
-            default_DOT_hard_hat.state,
-            default_DOT_municipality_dim.local_region,
-            sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
-            default_DOT_dispatcher.company_name,
-            default_DOT_hard_hat.city,
-            default_DOT_hard_hat.postal_code,
-            count(*) placeholder_count
-         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-            default_DOT_repair_orders.hard_hat_id,
-            default_DOT_repair_orders.municipality_id,
-            default_DOT_repair_orders.repair_order_id
-         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-            default_DOT_dispatchers.dispatcher_id
-         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-            default_DOT_hard_hats.country,
-            default_DOT_hard_hats.hard_hat_id,
-            default_DOT_hard_hats.postal_code,
-            default_DOT_hard_hats.state
-         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-            default_DOT_municipality.municipality_id
-         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-         WHERE  default_DOT_hard_hat.state = 'AZ'
-         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-        ),
-        m1_default_DOT_num_repair_orders AS (SELECT  count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
-            default_DOT_hard_hat.country,
-            default_DOT_hard_hat.state,
-            default_DOT_municipality_dim.local_region,
-            default_DOT_dispatcher.company_name,
-            default_DOT_hard_hat.city,
-            default_DOT_hard_hat.postal_code
-         FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-            default_DOT_dispatchers.dispatcher_id
-         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-            default_DOT_hard_hats.country,
-            default_DOT_hard_hats.hard_hat_id,
-            default_DOT_hard_hats.postal_code,
-            default_DOT_hard_hats.state
-         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-            default_DOT_municipality.municipality_id
-         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
-         WHERE  default_DOT_hard_hat.state = 'AZ'
-         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-        ),
-        m2_default_DOT_avg_repair_price AS (SELECT  count(default_DOT_repair_order_details.price) price_count,
-            default_DOT_hard_hat.country,
-            default_DOT_hard_hat.state,
-            default_DOT_municipality_dim.local_region,
-            default_DOT_dispatcher.company_name,
-            default_DOT_hard_hat.city,
-            default_DOT_hard_hat.postal_code,
-            sum(default_DOT_repair_order_details.price) price_sum
-         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-            default_DOT_repair_orders.hard_hat_id,
-            default_DOT_repair_orders.municipality_id,
-            default_DOT_repair_orders.repair_order_id
-         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-            default_DOT_dispatchers.dispatcher_id
-         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-            default_DOT_hard_hats.country,
-            default_DOT_hard_hats.hard_hat_id,
-            default_DOT_hard_hats.postal_code,
-            default_DOT_hard_hats.state
-         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-            default_DOT_municipality.municipality_id
-         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-         WHERE  default_DOT_hard_hat.state = 'AZ'
-         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-        ),
-        m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_hard_hat.country,
-            default_DOT_hard_hat.state,
-            default_DOT_municipality_dim.local_region,
-            default_DOT_dispatcher.company_name,
-            default_DOT_hard_hat.city,
-            default_DOT_hard_hat.postal_code,
-            sum(default_DOT_repair_order_details.price) price_sum
-         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-            default_DOT_repair_orders.hard_hat_id,
-            default_DOT_repair_orders.municipality_id,
-            default_DOT_repair_orders.repair_order_id
-         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-            default_DOT_dispatchers.dispatcher_id
-         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-            default_DOT_hard_hats.country,
-            default_DOT_hard_hats.hard_hat_id,
-            default_DOT_hard_hats.postal_code,
-            default_DOT_hard_hats.state
-         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-            default_DOT_municipality.municipality_id
-         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-         WHERE  default_DOT_hard_hat.state = 'AZ'
-         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-        ),
-        m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_hard_hat.country,
-            default_DOT_hard_hat.state,
-            default_DOT_municipality_dim.local_region,
-            sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
-            default_DOT_dispatcher.company_name,
-            default_DOT_hard_hat.city,
-            default_DOT_hard_hat.postal_code
-         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-            default_DOT_repair_orders.hard_hat_id,
-            default_DOT_repair_orders.municipality_id,
-            default_DOT_repair_orders.repair_order_id
-         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-            default_DOT_dispatchers.dispatcher_id
-         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-            default_DOT_hard_hats.country,
-            default_DOT_hard_hats.hard_hat_id,
-            default_DOT_hard_hats.postal_code,
-            default_DOT_hard_hats.state
-         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-            default_DOT_municipality.municipality_id
-         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-         WHERE  default_DOT_hard_hat.state = 'AZ'
-         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-        ),
-        m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_hard_hat.country,
-            default_DOT_hard_hat.state,
-            default_DOT_municipality_dim.local_region,
-            default_DOT_dispatcher.company_name,
-            default_DOT_hard_hat.city,
-            default_DOT_hard_hat.postal_code,
-            sum(default_DOT_repair_order_details.price) price_sum
-         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-            default_DOT_repair_orders.hard_hat_id,
-            default_DOT_repair_orders.municipality_id,
-            default_DOT_repair_orders.repair_order_id
-         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-            default_DOT_dispatchers.dispatcher_id
-         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-            default_DOT_hard_hats.country,
-            default_DOT_hard_hats.hard_hat_id,
-            default_DOT_hard_hats.postal_code,
-            default_DOT_hard_hats.state
-         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-            default_DOT_municipality.municipality_id
-         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-         WHERE  default_DOT_hard_hat.state = 'AZ'
-         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-        )SELECT  m0_default_DOT_discounted_orders_rate.discount_sum,
-            m0_default_DOT_discounted_orders_rate.placeholder_count,
-            m1_default_DOT_num_repair_orders.repair_order_id_count,
-            m2_default_DOT_avg_repair_price.price_count,
-            m2_default_DOT_avg_repair_price.price_sum,
-            m3_default_DOT_total_repair_cost.price_sum,
-            m4_default_DOT_total_repair_order_discounts.price_discount_sum,
-            m5_default_DOT_double_total_repair_cost.price_sum,
-            COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
-            COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
-            COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
-            COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
-            COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
-            COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code
-         FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
-        FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
-        FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
-        FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
-        FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
+WITH
+m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
+    count(*) placeholder_count,
+    default_DOT_hard_hat.country,
+    sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
+    count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.state
+ FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m2_default_DOT_avg_repair_price AS (SELECT  count(default_DOT_repair_order_details.price) price_count,
+    default_DOT_dispatcher.company_name,
+    sum(default_DOT_repair_order_details.price) price_sum,
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+    sum(default_DOT_repair_order_details.price) price_sum,
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.postal_code,
+    sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+),
+m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+    sum(default_DOT_repair_order_details.price) price_sum,
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_municipality_dim.local_region,
+    default_DOT_hard_hat.state
+ FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.repair_order_id
+ FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+    default_DOT_dispatchers.dispatcher_id
+ FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+    default_DOT_hard_hats.country,
+    default_DOT_hard_hats.hard_hat_id,
+    default_DOT_hard_hats.postal_code,
+    default_DOT_hard_hats.state
+ FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+    default_DOT_municipality.municipality_id
+ FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
+ GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+)SELECT  m0_default_DOT_discounted_orders_rate.placeholder_count,
+    m0_default_DOT_discounted_orders_rate.discount_sum,
+    m1_default_DOT_num_repair_orders.repair_order_id_count,
+    m2_default_DOT_avg_repair_price.price_count,
+    m2_default_DOT_avg_repair_price.price_sum,
+    m3_default_DOT_total_repair_cost.price_sum,
+    m4_default_DOT_total_repair_order_discounts.price_discount_sum,
+    m5_default_DOT_double_total_repair_cost.price_sum,
+    COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
+    COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+    COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+    COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
+    COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
+    COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state
+ FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
+FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state
+FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state
+FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state
+FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state
+
     """
     assert compare_query_strings(
         data["materialization_configs"][0]["config"]["query"],

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -931,7 +931,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
                         "columns": {
                             "default_DOT_avg_length_of_employment_plus_one": (
                                 "Incompatible types in binary operation NOW() - "
-                                "hard_hats.hire_date + 1. Got left timestamp, right int."
+                                "foo.bar.hard_hats.hire_date + 1. Got left timestamp, right int."
                             ),
                         },
                         "errors": [],

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -134,19 +134,19 @@ def test_sql(
             [],
             ["default.municipality.state_id = 'CA'"],
             """
-            SELECT 
-              default_DOT_municipality.contact_name, 
-              default_DOT_municipality.contact_title, 
-              default_DOT_municipality.local_region, 
-              default_DOT_municipality.municipality_id, 
-              default_DOT_municipality_municipality_type.municipality_type_id, 
-              default_DOT_municipality_type.municipality_type_desc, 
-              default_DOT_municipality.state_id 
-            FROM 
-              roads.municipality AS default_DOT_municipality 
-              LEFT JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id 
-              LEFT JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc 
-            WHERE 
+            SELECT
+              default_DOT_municipality.contact_name,
+              default_DOT_municipality.contact_title,
+              default_DOT_municipality.local_region,
+              default_DOT_municipality.municipality_id,
+              default_DOT_municipality_municipality_type.municipality_type_id,
+              default_DOT_municipality_type.municipality_type_desc,
+              default_DOT_municipality.state_id
+            FROM
+              roads.municipality AS default_DOT_municipality
+              LEFT JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+              LEFT JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
+            WHERE
               default_DOT_municipality.state_id = 'CA'
             """,
         ),
@@ -166,7 +166,7 @@ def test_sql(
             """
               SELECT  count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
                       default_DOT_repair_orders.dispatcher_id,
-                      default_DOT_hard_hat.state 
+                      default_DOT_hard_hat.state
               FROM roads.repair_orders AS default_DOT_repair_orders
               LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
                       default_DOT_hard_hats.state
@@ -198,21 +198,21 @@ def test_sql(
                     default_DOT_municipality_dim.local_region,
                     default_DOT_repair_orders.order_date,
                     default_DOT_dispatcher.phone,
-                    default_DOT_hard_hat.state 
+                    default_DOT_hard_hat.state
             FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
                     default_DOT_dispatchers.dispatcher_id,
-                    default_DOT_dispatchers.phone 
+                    default_DOT_dispatchers.phone
             FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
             LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
                     default_DOT_hard_hats.hard_hat_id,
                     default_DOT_hard_hats.last_name,
-                    default_DOT_hard_hats.state 
+                    default_DOT_hard_hats.state
             FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
             LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-                    default_DOT_municipality.municipality_id 
+                    default_DOT_municipality.municipality_id
             FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-            LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id 
-            WHERE  default_DOT_repair_orders.dispatcher_id = 1 AND default_DOT_hard_hat.state != 'AZ' AND default_DOT_dispatcher.phone = '4082021022' AND default_DOT_repair_orders.order_date >= '2020-01-01' 
+            LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+            WHERE  default_DOT_repair_orders.dispatcher_id = 1 AND default_DOT_hard_hat.state != 'AZ' AND default_DOT_dispatcher.phone = '4082021022' AND default_DOT_repair_orders.order_date >= '2020-01-01'
             GROUP BY  default_DOT_hard_hat.city, default_DOT_hard_hat.last_name, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
             """,
         ),
@@ -314,10 +314,10 @@ def test_sql_with_filters(
                     foo_DOT_bar_DOT_repair_orders.municipality_id,
                     foo_DOT_bar_DOT_repair_orders.order_date,
                     foo_DOT_bar_DOT_repair_orders.repair_order_id,
-                    foo_DOT_bar_DOT_repair_orders.required_date 
+                    foo_DOT_bar_DOT_repair_orders.required_date
             FROM roads.repair_orders AS foo_DOT_bar_DOT_repair_orders LEFT OUTER JOIN (SELECT  foo_DOT_bar_DOT_hard_hats.hard_hat_id,
-                    foo_DOT_bar_DOT_hard_hats.state 
-            FROM roads.hard_hats AS foo_DOT_bar_DOT_hard_hats) AS foo_DOT_bar_DOT_hard_hat ON foo_DOT_bar_DOT_repair_orders.hard_hat_id = foo_DOT_bar_DOT_hard_hat.hard_hat_id 
+                    foo_DOT_bar_DOT_hard_hats.state
+            FROM roads.hard_hats AS foo_DOT_bar_DOT_hard_hats) AS foo_DOT_bar_DOT_hard_hat ON foo_DOT_bar_DOT_repair_orders.hard_hat_id = foo_DOT_bar_DOT_hard_hat.hard_hat_id
             WHERE  foo_DOT_bar_DOT_hard_hat.state = 'CA'
             """,
         ),
@@ -357,11 +357,11 @@ def test_sql_with_filters(
             """
             SELECT  foo_DOT_bar_DOT_repair_orders.dispatcher_id,
                     count(foo_DOT_bar_DOT_repair_orders.repair_order_id) AS foo_DOT_bar_DOT_num_repair_orders,
-                    foo_DOT_bar_DOT_hard_hat.state 
+                    foo_DOT_bar_DOT_hard_hat.state
             FROM roads.repair_orders AS foo_DOT_bar_DOT_repair_orders LEFT OUTER JOIN (SELECT  foo_DOT_bar_DOT_hard_hats.hard_hat_id,
-                    foo_DOT_bar_DOT_hard_hats.state 
-            FROM roads.hard_hats AS foo_DOT_bar_DOT_hard_hats) AS foo_DOT_bar_DOT_hard_hat ON foo_DOT_bar_DOT_repair_orders.hard_hat_id = foo_DOT_bar_DOT_hard_hat.hard_hat_id 
-            WHERE  foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1 AND foo_DOT_bar_DOT_hard_hat.state = 'AZ' 
+                    foo_DOT_bar_DOT_hard_hats.state
+            FROM roads.hard_hats AS foo_DOT_bar_DOT_hard_hats) AS foo_DOT_bar_DOT_hard_hat ON foo_DOT_bar_DOT_repair_orders.hard_hat_id = foo_DOT_bar_DOT_hard_hat.hard_hat_id
+            WHERE  foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1 AND foo_DOT_bar_DOT_hard_hat.state = 'AZ'
             GROUP BY  foo_DOT_bar_DOT_hard_hat.state
             """,
         ),
@@ -380,55 +380,55 @@ def test_sql_with_filters(
                 "foo.bar.repair_orders.order_date >= '2020-01-01'",
             ],
             """
-            SELECT 
-              foo_DOT_bar_DOT_hard_hat.city, 
-              foo_DOT_bar_DOT_dispatcher.company_name, 
-              foo_DOT_bar_DOT_repair_orders.dispatcher_id, 
+            SELECT
+              foo_DOT_bar_DOT_hard_hat.city,
+              foo_DOT_bar_DOT_dispatcher.company_name,
+              foo_DOT_bar_DOT_repair_orders.dispatcher_id,
               count(
                 foo_DOT_bar_DOT_repair_orders.repair_order_id
-              ) AS foo_DOT_bar_DOT_num_repair_orders, 
-              foo_DOT_bar_DOT_hard_hat.last_name, 
-              foo_DOT_bar_DOT_municipality_dim.local_region, 
-              foo_DOT_bar_DOT_repair_orders.order_date, 
-              foo_DOT_bar_DOT_dispatcher.phone, 
-              foo_DOT_bar_DOT_hard_hat.state 
-            FROM 
-              roads.repair_orders AS foo_DOT_bar_DOT_repair_orders 
+              ) AS foo_DOT_bar_DOT_num_repair_orders,
+              foo_DOT_bar_DOT_hard_hat.last_name,
+              foo_DOT_bar_DOT_municipality_dim.local_region,
+              foo_DOT_bar_DOT_repair_orders.order_date,
+              foo_DOT_bar_DOT_dispatcher.phone,
+              foo_DOT_bar_DOT_hard_hat.state
+            FROM
+              roads.repair_orders AS foo_DOT_bar_DOT_repair_orders
               LEFT OUTER JOIN (
-                SELECT 
-                  foo_DOT_bar_DOT_dispatchers.company_name, 
-                  foo_DOT_bar_DOT_dispatchers.dispatcher_id, 
-                  foo_DOT_bar_DOT_dispatchers.phone 
-                FROM 
+                SELECT
+                  foo_DOT_bar_DOT_dispatchers.company_name,
+                  foo_DOT_bar_DOT_dispatchers.dispatcher_id,
+                  foo_DOT_bar_DOT_dispatchers.phone
+                FROM
                   roads.dispatchers AS foo_DOT_bar_DOT_dispatchers
-              ) AS foo_DOT_bar_DOT_dispatcher ON foo_DOT_bar_DOT_repair_orders.dispatcher_id = foo_DOT_bar_DOT_dispatcher.dispatcher_id 
+              ) AS foo_DOT_bar_DOT_dispatcher ON foo_DOT_bar_DOT_repair_orders.dispatcher_id = foo_DOT_bar_DOT_dispatcher.dispatcher_id
               LEFT OUTER JOIN (
-                SELECT 
-                  foo_DOT_bar_DOT_hard_hats.city, 
-                  foo_DOT_bar_DOT_hard_hats.hard_hat_id, 
-                  foo_DOT_bar_DOT_hard_hats.last_name, 
-                  foo_DOT_bar_DOT_hard_hats.state 
-                FROM 
+                SELECT
+                  foo_DOT_bar_DOT_hard_hats.city,
+                  foo_DOT_bar_DOT_hard_hats.hard_hat_id,
+                  foo_DOT_bar_DOT_hard_hats.last_name,
+                  foo_DOT_bar_DOT_hard_hats.state
+                FROM
                   roads.hard_hats AS foo_DOT_bar_DOT_hard_hats
-              ) AS foo_DOT_bar_DOT_hard_hat ON foo_DOT_bar_DOT_repair_orders.hard_hat_id = foo_DOT_bar_DOT_hard_hat.hard_hat_id 
+              ) AS foo_DOT_bar_DOT_hard_hat ON foo_DOT_bar_DOT_repair_orders.hard_hat_id = foo_DOT_bar_DOT_hard_hat.hard_hat_id
               LEFT OUTER JOIN (
-                SELECT 
-                  foo_DOT_bar_DOT_municipality.local_region, 
-                  foo_DOT_bar_DOT_municipality.municipality_id 
-                FROM 
-                  roads.municipality AS foo_DOT_bar_DOT_municipality 
-                  LEFT JOIN roads.municipality_municipality_type AS foo_DOT_bar_DOT_municipality_municipality_type ON foo_DOT_bar_DOT_municipality.municipality_id = foo_DOT_bar_DOT_municipality_municipality_type.municipality_id 
+                SELECT
+                  foo_DOT_bar_DOT_municipality.local_region,
+                  foo_DOT_bar_DOT_municipality.municipality_id
+                FROM
+                  roads.municipality AS foo_DOT_bar_DOT_municipality
+                  LEFT JOIN roads.municipality_municipality_type AS foo_DOT_bar_DOT_municipality_municipality_type ON foo_DOT_bar_DOT_municipality.municipality_id = foo_DOT_bar_DOT_municipality_municipality_type.municipality_id
                   LEFT JOIN roads.municipality_type AS foo_DOT_bar_DOT_municipality_type ON foo_DOT_bar_DOT_municipality_municipality_type.municipality_type_id = foo_DOT_bar_DOT_municipality_type.municipality_type_desc
-              ) AS foo_DOT_bar_DOT_municipality_dim ON foo_DOT_bar_DOT_repair_orders.municipality_id = foo_DOT_bar_DOT_municipality_dim.municipality_id 
-            WHERE 
-              foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1 
-              AND foo_DOT_bar_DOT_hard_hat.state != 'AZ' 
-              AND foo_DOT_bar_DOT_dispatcher.phone = '4082021022' 
-              AND foo_DOT_bar_DOT_repair_orders.order_date >= '2020-01-01' 
-            GROUP BY 
-              foo_DOT_bar_DOT_hard_hat.city, 
-              foo_DOT_bar_DOT_hard_hat.last_name, 
-              foo_DOT_bar_DOT_dispatcher.company_name, 
+              ) AS foo_DOT_bar_DOT_municipality_dim ON foo_DOT_bar_DOT_repair_orders.municipality_id = foo_DOT_bar_DOT_municipality_dim.municipality_id
+            WHERE
+              foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1
+              AND foo_DOT_bar_DOT_hard_hat.state != 'AZ'
+              AND foo_DOT_bar_DOT_dispatcher.phone = '4082021022'
+              AND foo_DOT_bar_DOT_repair_orders.order_date >= '2020-01-01'
+            GROUP BY
+              foo_DOT_bar_DOT_hard_hat.city,
+              foo_DOT_bar_DOT_hard_hat.last_name,
+              foo_DOT_bar_DOT_dispatcher.company_name,
               foo_DOT_bar_DOT_municipality_dim.local_region
             """,
         ),
@@ -682,4 +682,13 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
       LIMIT 100
     """
     assert compare_query_strings(data["sql"], expected_sql)
-    assert data["columns"] == [{'name': 'city', 'type': 'string'}, {'name': 'company_name', 'type': 'string'}, {'name': 'country', 'type': 'string'}, {'name': 'default_DOT_num_repair_orders', 'type': 'bigint'}, {'name': 'local_region', 'type': 'string'}, {'name': 'postal_code', 'type': 'string'}, {'name': 'state', 'type': 'string'}, {'name': 'default_DOT_discounted_orders_rate', 'type': 'double'}]
+    assert data["columns"] == [
+        {"name": "city", "type": "string"},
+        {"name": "company_name", "type": "string"},
+        {"name": "country", "type": "string"},
+        {"name": "default_DOT_num_repair_orders", "type": "bigint"},
+        {"name": "local_region", "type": "string"},
+        {"name": "postal_code", "type": "string"},
+        {"name": "state", "type": "string"},
+        {"name": "default_DOT_discounted_orders_rate", "type": "double"},
+    ]

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -470,7 +470,7 @@ def test_sql_with_filters(
         ),
     ],
 )
-def test_sql_with_filters_on_namespaced_nodes(
+def test_sql_with_filters_on_namespaced_nodes(  # pylint: disable=R0913
     node_name,
     dimensions,
     filters,
@@ -655,37 +655,73 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
                 "default.municipality_dim.local_region",
             ],
             "filters": [],
-            "orderby": ["default.hard_hat.country", "default.dispatcher.address"],
+            "orderby": ["default.hard_hat.country", "default.dispatcher.phone"],
             "limit": 100,
         },
     )
     data = response.json()
     expected_sql = """
-      SELECT  default_DOT_dispatcher.company_name,
-              default_DOT_dispatcher.address,
-              default_DOT_hard_hat.city,
-              default_DOT_hard_hat.country,
-              default_DOT_hard_hat.postal_code,
-              default_DOT_hard_hat.state,
-              default_DOT_municipality_dim.local_region,
-              count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-              CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate
-      FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-              default_DOT_dispatchers.dispatcher_id
-      FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-      LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-              default_DOT_hard_hats.country,
-              default_DOT_hard_hats.hard_hat_id,
-              default_DOT_hard_hats.postal_code,
-              default_DOT_hard_hats.state
-      FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-      LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-              default_DOT_municipality.municipality_id
-      FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-      LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
-      GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-      ORDER BY default_DOT_hard_hat.country, default_DOT_dispatcher.address
-      LIMIT 100
+                  SELECT
+                    default_DOT_hard_hat.city,
+                    default_DOT_dispatcher.company_name,
+                    default_DOT_hard_hat.country,
+                    count(
+                      default_DOT_repair_orders.repair_order_id
+                    ) default_DOT_num_repair_orders,
+                    default_DOT_municipality_dim.local_region,
+                    default_DOT_dispatcher.phone,
+                    default_DOT_hard_hat.postal_code,
+                    default_DOT_hard_hat.state,
+                    CAST(
+                      sum(
+                        if(
+                          default_DOT_repair_order_details.discount > 0.0,
+                          1, 0
+                        )
+                      ) AS DOUBLE
+                    ) / count(*) AS default_DOT_discounted_orders_rate
+                  FROM
+                    roads.repair_orders AS default_DOT_repair_orders
+                    LEFT OUTER JOIN (
+                      SELECT
+                        default_DOT_dispatchers.company_name,
+                        default_DOT_dispatchers.dispatcher_id,
+                        default_DOT_dispatchers.phone
+                      FROM
+                        roads.dispatchers AS default_DOT_dispatchers
+                    ) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+                    LEFT OUTER JOIN (
+                      SELECT
+                        default_DOT_hard_hats.city,
+                        default_DOT_hard_hats.country,
+                        default_DOT_hard_hats.hard_hat_id,
+                        default_DOT_hard_hats.postal_code,
+                        default_DOT_hard_hats.state
+                      FROM
+                        roads.hard_hats AS default_DOT_hard_hats
+                    ) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+                    LEFT OUTER JOIN (
+                      SELECT
+                        default_DOT_municipality.local_region,
+                        default_DOT_municipality.municipality_id
+                      FROM
+                        roads.municipality AS default_DOT_municipality
+                        LEFT JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+                        LEFT JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
+                    ) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+                  GROUP BY
+                    default_DOT_hard_hat.country,
+                    default_DOT_hard_hat.postal_code,
+                    default_DOT_hard_hat.city,
+                    default_DOT_hard_hat.state,
+                    default_DOT_dispatcher.company_name,
+                    default_DOT_municipality_dim.local_region
+                  ORDER BY
+                    default_DOT_hard_hat.country,
+                    default_DOT_dispatcher.phone
+                  LIMIT
+                    100
+
     """
     assert compare_query_strings(data["sql"], expected_sql)
     assert data["columns"] == [
@@ -694,6 +730,7 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
         {"name": "country", "type": "string"},
         {"name": "default_DOT_num_repair_orders", "type": "bigint"},
         {"name": "local_region", "type": "string"},
+        {"name": "phone", "type": "string"},
         {"name": "postal_code", "type": "string"},
         {"name": "state", "type": "string"},
         {"name": "default_DOT_discounted_orders_rate", "type": "double"},

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -606,6 +606,7 @@ def test_lateral_view_explode(client_with_examples: TestClient):
     GROUP BY
       paint_colors_spark.color_id,
       basic_DOT_paint_colors_trino.color_name
+
     LIMIT 5
     """
     query = response.json()["sql"]
@@ -668,7 +669,8 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
                 "default.municipality_dim.local_region",
             ],
             "filters": [],
-            "limit": 10,
+            "orderbys": ["default.hard_hat.country"],
+            "limit": 100,
         },
     )
     data = response.json()
@@ -695,7 +697,8 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
       FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
       LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
       GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-      LIMIT 10
+      ORDER BY default_DOT_hard_hat.country
+      LIMIT 100
     """
     assert compare_query_strings(data["sql"], expected_sql)
     assert data["columns"] == [

--- a/tests/construction/build_test.py
+++ b/tests/construction/build_test.py
@@ -157,6 +157,7 @@ async def test_build_metric_with_dimensions_filters(request):
     )
     expected = """
     SELECT
+        basic_DOT_dimension_DOT_users.age,
       COUNT(1) AS cnt
     FROM basic.source.comments AS basic_DOT_source_DOT_comments
     LEFT OUTER JOIN (

--- a/tests/construction/compile_test.py
+++ b/tests/construction/compile_test.py
@@ -80,8 +80,11 @@ def test_raise_on_unnamed_subquery_in_implicit_join(construction_session: Sessio
         exception=DJException(),
     )
     query.extract_dependencies(context)
-    assert "Column `country` found in multiple tables. Consider namespacing." in str(
-        context.exception.errors,
+    assert (
+        "Column `country` found in multiple tables. Consider using fully qualified name."
+        in str(
+            context.exception.errors,
+        )
     )
 
 
@@ -98,8 +101,11 @@ def test_raise_on_ambiguous_column(construction_session: Session):
         exception=DJException(),
     )
     query.compile(context)
-    assert "Column `country` found in multiple tables. Consider namespacing." in str(
-        context.exception.errors,
+    assert (
+        "Column `country` found in multiple tables. Consider using fully qualified name."
+        in str(
+            context.exception.errors,
+        )
     )
 
 

--- a/tests/sql/parsing/test_ast.py
+++ b/tests/sql/parsing/test_ast.py
@@ -143,7 +143,7 @@ def test_ast_compile_raise_on_ambiguous_column(
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
     assert (
-        "Column `country` found in multiple tables. Consider namespacing."
+        "Column `country` found in multiple tables. Consider using fully qualified name."
         in exc.errors[0].message
     )
 


### PR DESCRIPTION
### Summary

**_WIP working on coverage_**

Adds order by dimension columns to the `sql` and `data` api routes
Adds filter cols to the projection

#### Bug fixes:
- `Name`s as `Name.name` stripped to be just `str`
- tables referencing nodes can be pre-bound to columns and build will discover and add them as it used to

### Test Plan

Needs changes/additional unit tests

- [x] PR has an associated issue: https://github.com/DataJunction/dj/issues/515
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
