### PR TITLE
Fix query building for multiple metrics + add filter validation 

### DIFF
--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -502,6 +502,17 @@ def build_metric_nodes(
                 "available on every metric and thus cannot be included.",
             )
 
+    for filter_ in filters:
+        temp_select = parse(f"select * where {filter_}").select
+        columns_in_filter = temp_select.where.find_all(ast.Column)  # type: ignore
+        for col in columns_in_filter:
+            if str(col) not in shared_dimensions:
+                raise DJInvalidInputException(
+                    f"The filter `{filter_}` references the dimension attribute "
+                    f"`{col}`, which is not available on every"
+                    " metric and thus cannot be included.",
+                )
+
     combined_ast: ast.Query = ast.Query(
         select=ast.Select(from_=ast.From(relations=[])),
         ctes=[],

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -2207,7 +2207,7 @@ class Query(TableExpression):
         if self.alias:
             as_ = " AS " if self.as_ else " "
             if is_cte:
-                query = f"{self.alias} AS (\n{query}\n)"
+                query = f"{self.alias}{as_}{query}"
             else:
                 query = f"{query}{as_}{self.alias}"
         return query

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -2207,7 +2207,7 @@ class Query(TableExpression):
         if self.alias:
             as_ = " AS " if self.as_ else " "
             if is_cte:
-                query = f"{self.alias}{as_}{query}"
+                query = f"{self.alias} AS (\n{query}\n)"
             else:
                 query = f"{query}{as_}{self.alias}"
         return query

--- a/tests/api/cubes_test.py
+++ b/tests/api/cubes_test.py
@@ -47,18 +47,23 @@ def test_read_cube(client_with_examples: TestClient) -> None:
     assert compare_query_strings(
         data["query"],
         """
-        SELECT
-          default_DOT_account_type.account_type_name,
-          count(default_DOT_account_type.id) default_DOT_number_of_account_types
-        FROM (
+        WITH m0_default_DOT_number_of_account_types AS (
           SELECT
-            default_DOT_account_type_table.account_type_classification,
-            default_DOT_account_type_table.account_type_name,
-            default_DOT_account_type_table.id
-          FROM accounting.account_type_table AS default_DOT_account_type_table)
-          AS default_DOT_account_type
-          GROUP BY
-            default_DOT_account_type.account_type_name
+            default_DOT_account_type.account_type_name,
+            count(default_DOT_account_type.id) default_DOT_number_of_account_types
+          FROM (
+            SELECT
+              default_DOT_account_type_table.account_type_classification,
+              default_DOT_account_type_table.account_type_name,
+              default_DOT_account_type_table.id
+            FROM accounting.account_type_table AS default_DOT_account_type_table
+          ) AS default_DOT_account_type
+          GROUP BY  default_DOT_account_type.account_type_name
+        )
+        SELECT
+          m0_default_DOT_number_of_account_types.default_DOT_number_of_account_types,
+          m0_default_DOT_number_of_account_types.account_type_name
+        FROM m0_default_DOT_number_of_account_types
         """,
     )
 
@@ -341,39 +346,188 @@ def test_create_cube(  # pylint: disable=redefined-outer-name
     assert results["display_name"] == "Default: Repairs Cube"
     assert results["description"] == "Cube of various metrics related to repairs"
     expected_query = """
-        SELECT  default_DOT_dispatcher.company_name,
-                default_DOT_hard_hat.city,
-                default_DOT_hard_hat.country,
-                default_DOT_hard_hat.postal_code,
-                default_DOT_hard_hat.state,
-                default_DOT_municipality_dim.local_region,
-                sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost,
-                count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-                CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate,
-                sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts,
-                avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price,
-                sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost
-        FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-                default_DOT_repair_orders.hard_hat_id,
-                default_DOT_repair_orders.municipality_id,
-                default_DOT_repair_orders.repair_order_id
-        FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-                default_DOT_dispatchers.dispatcher_id
-        FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-                default_DOT_hard_hats.country,
-                default_DOT_hard_hats.hard_hat_id,
-                default_DOT_hard_hats.postal_code,
-                default_DOT_hard_hats.state
-        FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-                default_DOT_municipality.municipality_id
-        FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-        WHERE  default_DOT_hard_hat.state = 'AZ'
-        GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    WITH
+    m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate
+     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
+     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+     WHERE  default_DOT_hard_hat.state = 'AZ'
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    ),
+    m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders
+     FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+     WHERE  default_DOT_hard_hat.state = 'AZ'
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    ),
+    m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price
+     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
+     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+     WHERE  default_DOT_hard_hat.state = 'AZ'
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    ),
+    m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost
+     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
+     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+     WHERE  default_DOT_hard_hat.state = 'AZ'
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    ),
+    m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts
+     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
+     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+     WHERE  default_DOT_hard_hat.state = 'AZ'
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    ),
+    m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost
+     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
+     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+     WHERE  default_DOT_hard_hat.state = 'AZ'
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
+        m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+        m2_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
+        m3_default_DOT_total_repair_cost.default_DOT_total_repair_cost,
+        m4_default_DOT_total_repair_order_discounts.default_DOT_total_repair_order_discounts,
+        m5_default_DOT_double_total_repair_cost.default_DOT_double_total_repair_cost,
+        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
+        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
+        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
+        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region
+     FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+    FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
+    FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
+    FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
+    FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
     """
+    print("RES", results["query"])
     assert compare_query_strings(results["query"], expected_query)
 
 
@@ -432,42 +586,190 @@ def test_cube_materialization_sql_and_measures(
         },
     ]
     expected_materialization_query = """
-        SELECT  count(*) placeholder_count,
-                sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
-                default_DOT_hard_hat.city,
-                sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
-                default_DOT_hard_hat.country,
-                count(default_DOT_repair_order_details.price) price_count,
-                default_DOT_hard_hat.state,
-                default_DOT_dispatcher.company_name,
-                default_DOT_hard_hat.postal_code,
-                default_DOT_municipality_dim.local_region,
-                count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
-                sum(default_DOT_repair_order_details.price) price_sum
-        FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER  JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-                default_DOT_repair_orders.hard_hat_id,
-                default_DOT_repair_orders.municipality_id,
-                default_DOT_repair_orders.repair_order_id
-        FROM roads.repair_orders AS default_DOT_repair_orders
-        ) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-        LEFT OUTER  JOIN (SELECT  default_DOT_dispatchers.company_name,
-                default_DOT_dispatchers.dispatcher_id
-        FROM roads.dispatchers AS default_DOT_dispatchers
-        ) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-        LEFT OUTER  JOIN (SELECT  default_DOT_hard_hats.city,
-                default_DOT_hard_hats.country,
-                default_DOT_hard_hats.hard_hat_id,
-                default_DOT_hard_hats.postal_code,
-                default_DOT_hard_hats.state
-        FROM roads.hard_hats AS default_DOT_hard_hats
-        ) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-        LEFT OUTER  JOIN (SELECT  default_DOT_municipality.local_region,
-                default_DOT_municipality.municipality_id
-        FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
-        ) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-        WHERE  default_DOT_hard_hat.state = 'AZ'
-        GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    WITH
+        m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.country,
+            default_DOT_hard_hat.state,
+            default_DOT_municipality_dim.local_region,
+            sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
+            default_DOT_dispatcher.company_name,
+            default_DOT_hard_hat.city,
+            default_DOT_hard_hat.postal_code,
+            count(*) placeholder_count
+         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+            default_DOT_repair_orders.hard_hat_id,
+            default_DOT_repair_orders.municipality_id,
+            default_DOT_repair_orders.repair_order_id
+         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+            default_DOT_dispatchers.dispatcher_id
+         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+            default_DOT_hard_hats.country,
+            default_DOT_hard_hats.hard_hat_id,
+            default_DOT_hard_hats.postal_code,
+            default_DOT_hard_hats.state
+         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+            default_DOT_municipality.municipality_id
+         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+         WHERE  default_DOT_hard_hat.state = 'AZ'
+         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+        ),
+        m1_default_DOT_num_repair_orders AS (SELECT  count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
+            default_DOT_hard_hat.country,
+            default_DOT_hard_hat.state,
+            default_DOT_municipality_dim.local_region,
+            default_DOT_dispatcher.company_name,
+            default_DOT_hard_hat.city,
+            default_DOT_hard_hat.postal_code
+         FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+            default_DOT_dispatchers.dispatcher_id
+         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+            default_DOT_hard_hats.country,
+            default_DOT_hard_hats.hard_hat_id,
+            default_DOT_hard_hats.postal_code,
+            default_DOT_hard_hats.state
+         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+            default_DOT_municipality.municipality_id
+         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+         WHERE  default_DOT_hard_hat.state = 'AZ'
+         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+        ),
+        m2_default_DOT_avg_repair_price AS (SELECT  count(default_DOT_repair_order_details.price) price_count,
+            default_DOT_hard_hat.country,
+            default_DOT_hard_hat.state,
+            default_DOT_municipality_dim.local_region,
+            default_DOT_dispatcher.company_name,
+            default_DOT_hard_hat.city,
+            default_DOT_hard_hat.postal_code,
+            sum(default_DOT_repair_order_details.price) price_sum
+         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+            default_DOT_repair_orders.hard_hat_id,
+            default_DOT_repair_orders.municipality_id,
+            default_DOT_repair_orders.repair_order_id
+         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+            default_DOT_dispatchers.dispatcher_id
+         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+            default_DOT_hard_hats.country,
+            default_DOT_hard_hats.hard_hat_id,
+            default_DOT_hard_hats.postal_code,
+            default_DOT_hard_hats.state
+         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+            default_DOT_municipality.municipality_id
+         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+         WHERE  default_DOT_hard_hat.state = 'AZ'
+         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+        ),
+        m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_hard_hat.country,
+            default_DOT_hard_hat.state,
+            default_DOT_municipality_dim.local_region,
+            default_DOT_dispatcher.company_name,
+            default_DOT_hard_hat.city,
+            default_DOT_hard_hat.postal_code,
+            sum(default_DOT_repair_order_details.price) price_sum
+         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+            default_DOT_repair_orders.hard_hat_id,
+            default_DOT_repair_orders.municipality_id,
+            default_DOT_repair_orders.repair_order_id
+         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+            default_DOT_dispatchers.dispatcher_id
+         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+            default_DOT_hard_hats.country,
+            default_DOT_hard_hats.hard_hat_id,
+            default_DOT_hard_hats.postal_code,
+            default_DOT_hard_hats.state
+         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+            default_DOT_municipality.municipality_id
+         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+         WHERE  default_DOT_hard_hat.state = 'AZ'
+         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+        ),
+        m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_hard_hat.country,
+            default_DOT_hard_hat.state,
+            default_DOT_municipality_dim.local_region,
+            sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
+            default_DOT_dispatcher.company_name,
+            default_DOT_hard_hat.city,
+            default_DOT_hard_hat.postal_code
+         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+            default_DOT_repair_orders.hard_hat_id,
+            default_DOT_repair_orders.municipality_id,
+            default_DOT_repair_orders.repair_order_id
+         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+            default_DOT_dispatchers.dispatcher_id
+         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+            default_DOT_hard_hats.country,
+            default_DOT_hard_hats.hard_hat_id,
+            default_DOT_hard_hats.postal_code,
+            default_DOT_hard_hats.state
+         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+            default_DOT_municipality.municipality_id
+         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+         WHERE  default_DOT_hard_hat.state = 'AZ'
+         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+        ),
+        m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_hard_hat.country,
+            default_DOT_hard_hat.state,
+            default_DOT_municipality_dim.local_region,
+            default_DOT_dispatcher.company_name,
+            default_DOT_hard_hat.city,
+            default_DOT_hard_hat.postal_code,
+            sum(default_DOT_repair_order_details.price) price_sum
+         FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+            default_DOT_repair_orders.hard_hat_id,
+            default_DOT_repair_orders.municipality_id,
+            default_DOT_repair_orders.repair_order_id
+         FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+        LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+            default_DOT_dispatchers.dispatcher_id
+         FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+        LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+            default_DOT_hard_hats.country,
+            default_DOT_hard_hats.hard_hat_id,
+            default_DOT_hard_hats.postal_code,
+            default_DOT_hard_hats.state
+         FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+        LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+            default_DOT_municipality.municipality_id
+         FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+         WHERE  default_DOT_hard_hat.state = 'AZ'
+         GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+        )SELECT  m0_default_DOT_discounted_orders_rate.discount_sum,
+            m0_default_DOT_discounted_orders_rate.placeholder_count,
+            m1_default_DOT_num_repair_orders.repair_order_id_count,
+            m2_default_DOT_avg_repair_price.price_count,
+            m2_default_DOT_avg_repair_price.price_sum,
+            m3_default_DOT_total_repair_cost.price_sum,
+            m4_default_DOT_total_repair_order_discounts.price_discount_sum,
+            m5_default_DOT_double_total_repair_cost.price_sum,
+            COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+            COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
+            COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
+            COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
+            COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+            COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code
+         FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+        FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
+        FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
+        FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
+        FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
     """
     assert compare_query_strings(
         data["materialization_configs"][0]["config"]["query"],

--- a/tests/api/data_test.py
+++ b/tests/api/data_test.py
@@ -244,9 +244,9 @@ class TestDataForNode:
                 {
                     "sql": "",
                     "columns": [
-                        {"name": "company_name", "type": "string"},
-                        {"name": "default_DOT_avg_repair_price", "type": "double"},
                         {"name": "default_DOT_num_repair_orders", "type": "bigint"},
+                        {"name": "default_DOT_avg_repair_price", "type": "double"},
+                        {"name": "company_name", "type": "string"},
                     ],
                     "rows": [[1.0, "Foo", 100], [2.0, "Bar", 200]],
                     "row_count": 0,

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -744,3 +744,28 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
         {"name": "state", "type": "string"},
         {"name": "local_region", "type": "string"},
     ]
+
+
+def test_get_sql_for_metrics_filters_validate_dimensions(
+    client_with_examples: TestClient,
+):
+    """
+    Test that we extract the columns from filters to validate that they are from shared dimensions
+    """
+    response = client_with_examples.get(
+        "/sql/",
+        params={
+            "metrics": ["foo.bar.num_repair_orders", "foo.bar.avg_repair_price"],
+            "dimensions": [
+                "foo.bar.hard_hat.country",
+            ],
+            "filters": ["default.hard_hat.city = 'Las Vegas'"],
+            "limit": 10,
+        },
+    )
+    data = response.json()
+    assert data["message"] == (
+        "The filter `default.hard_hat.city = 'Las Vegas'` references the dimension "
+        "attribute `default.hard_hat.city`, which is not available on every metric and "
+        "thus cannot be included."
+    )

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -673,38 +673,74 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
     )
     data = response.json()
     expected_sql = """
-      SELECT  default_DOT_dispatcher.company_name,
-              default_DOT_hard_hat.city,
-              default_DOT_hard_hat.country,
-              default_DOT_hard_hat.postal_code,
-              default_DOT_hard_hat.state,
-              default_DOT_municipality_dim.local_region,
-              count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-              CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate
-      FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-              default_DOT_dispatchers.dispatcher_id
-      FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-      LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-              default_DOT_hard_hats.country,
-              default_DOT_hard_hats.hard_hat_id,
-              default_DOT_hard_hats.postal_code,
-              default_DOT_hard_hats.state
-      FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-      LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-              default_DOT_municipality.municipality_id
-      FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-      LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
-      GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-      LIMIT 10
+    WITH
+    m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate
+     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
+     FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+    LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    ),
+    m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders
+     FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+     FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+     FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+     FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+    LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+    )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
+        m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name) company_name,
+        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city) city,
+        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country) country,
+        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code) postal_code,
+        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state) state,
+        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region) local_region
+     FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+    LIMIT 10
     """
     assert compare_query_strings(data["sql"], expected_sql)
     assert data["columns"] == [
+        {"name": "default_DOT_discounted_orders_rate", "type": "double"},
+        {"name": "default_DOT_num_repair_orders", "type": "bigint"},
         {"name": "company_name", "type": "string"},
         {"name": "city", "type": "string"},
         {"name": "country", "type": "string"},
         {"name": "postal_code", "type": "string"},
         {"name": "state", "type": "string"},
         {"name": "local_region", "type": "string"},
-        {"name": "default_DOT_num_repair_orders", "type": "bigint"},
-        {"name": "default_DOT_discounted_orders_rate", "type": "double"},
     ]

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1686,20 +1686,37 @@ COLUMN_MAPPINGS = {
 
 QUERY_DATA_MAPPINGS = {
     (
-        "SELECT  default_DOT_dispatcher.company_name,\n\t"
-        "avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price,"
-        "\n\tcount(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders "
-        "\n FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN "
-        "(SELECT  default_DOT_repair_orders.dispatcher_id,\n\t"
-        "default_DOT_repair_orders.hard_hat_id,\n\tdefault_DOT_repair_orders.municipality_id,"
-        "\n\tdefault_DOT_repair_orders.repair_order_id \n FROM roads.repair_orders AS "
-        "default_DOT_repair_orders) AS default_DOT_repair_order ON "
-        "default_DOT_repair_order_details.repair_order_id = "
-        "default_DOT_repair_order.repair_order_id\nLEFT OUTER JOIN (SELECT  "
-        "default_DOT_dispatchers.company_name,\n\tdefault_DOT_dispatchers.dispatcher_id "
-        "\n FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher "
-        "ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id "
-        "\n GROUP BY  default_DOT_dispatcher.company_name\n LIMIT 10"
+        "WITHm0_default_DOT_num_repair_ordersAS(SELECTdefault_DOT_dispatcher.company_name,\t"
+        "count(default_DOT_repair_orders.repair_order_id)default_DOT_num_repair_ordersFROM"
+        "roads.repair_ordersASdefault_DOT_repair_ordersLEFTOUTERJOIN("
+        "SELECTdefault_DOT_dispatchers.company_name,\t"
+        "default_DOT_dispatchers.dispatcher_idFROMroads.dispatchersASdefault_DOT_dispatchers)"
+        "ASdefault_DOT_dispatcher"
+        "ONdefault_DOT_repair_orders.dispatcher_id=default_DOT_dispatcher.dispatcher_idGROUPBY"
+        "default_DOT_dispatcher.company_name),m1_default_DOT_avg_repair_priceAS(SELECT"
+        "default_DOT_dispatcher.company_name,\tavg(default_DOT_repair_order_details.price)AS"
+        "default_DOT_avg_repair_priceFROMroads.repair_order_detailsAS"
+        "default_DOT_repair_order_details"
+        "LEFTOUTERJOIN(SELECTdefault_DOT_repair_orders.dispatcher_id,\t"
+        "default_DOT_repair_orders.hard_hat_id,\t"
+        "default_DOT_repair_orders.municipality_id,\tdefault_DOT_repair_orders.repair_order_id"
+        "FROMroads.repair_orders"
+        "ASdefault_DOT_repair_orders)ASdefault_DOT_repair_orderON"
+        "default_DOT_repair_order_details.repair_order_id="
+        "default_DOT_repair_order.repair_order_idLEFTOUTERJOIN(SELECT"
+        "default_DOT_dispatchers.company_name,\t"
+        "default_DOT_dispatchers.dispatcher_idFROMroads.dispatchersAS"
+        "default_DOT_dispatchers)ASdefault_DOT_dispatcher"
+        "ONdefault_DOT_repair_order.dispatcher_id=default_DOT_dispatcher.dispatcher_idGROUPBY"
+        "default_DOT_dispatcher.company_name)SELECT"
+        "m0_default_DOT_num_repair_orders.default_DOT_num_repair_orders,\t"
+        "m1_default_DOT_avg_repair_price.default_DOT_avg_repair_price,\tCOALESCE("
+        "m0_default_DOT_num_repair_orders.company_name,"
+        "m1_default_DOT_avg_repair_price.company_name)company_nameFROM"
+        "m0_default_DOT_num_repair_ordersFULLOUTERJOINm1_default_DOT_avg_repair_priceON"
+        "m0_default_DOT_num_repair_orders.company_name="
+        "m1_default_DOT_avg_repair_price.company_name"
+        "LIMIT10"
     )
     .strip()
     .replace('"', "")
@@ -1726,9 +1743,9 @@ QUERY_DATA_MAPPINGS = {
             "results": [
                 {
                     "columns": [
-                        {"name": "avg_repair_price", "type": "float"},
+                        {"name": "default_DOT_num_repair_orders", "type": "int"},
+                        {"name": "default_DOT_avg_repair_price", "type": "float"},
                         {"name": "company_name", "type": "str"},
-                        {"name": "num_repair_orders", "type": "int"},
                     ],
                     "rows": [
                         (1.0, "Foo", 100),

--- a/tests/sql/utils.py
+++ b/tests/sql/utils.py
@@ -27,11 +27,23 @@ def compare_query_strings(str1: str, str2: str) -> bool:
         query1.select.projection,
         key=lambda x: str(x.alias_or_name),  # type: ignore
     )[:]
+    for cte in query1.ctes:
+        cte.select.projection = sorted(
+            query1.select.projection,
+            key=lambda x: str(x.alias_or_name),  # type: ignore
+        )[:]
+
     query2 = parse(str2)
     query2.select.projection = sorted(
         query2.select.projection,
         key=lambda x: str(x.alias_or_name),  # type: ignore
     )[:]
+    for cte in query2.ctes:
+        cte.select.projection = sorted(
+            query2.select.projection,
+            key=lambda x: str(x.alias_or_name),  # type: ignore
+        )[:]
+
     for relation in query1.find_all(ast.Relation):
         relation.extensions = sorted(
             relation.extensions,


### PR DESCRIPTION
### Summary

We should be able to build queries for any set of metrics, as long as they share the same set of dimensions. This applies even if they have different upstream sources. Given this, the multiple metric query building logic can look like this:

1. Build each metric node query independently
2. Wrap each built metric node query in a `WITH` statement
3. Join the node queries together via the dimension columns
4. In the final select, bring in all metric columns and the coalesced version of all dimension columns

The cube node decomposition also needs to change to accommodate this logic.

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue:
  - #521
  - #519
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
