### PR TITLE
Creating two workflows for release, one for bumping the version of th…

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -68,7 +68,7 @@ jobs:
           export LIBRARY=${{ github.event.inputs.library }}
           git commit -am "Bumping $LIBRARY to version $NEW_VERSION"
           git checkout -b releases/$LIBRARY-$NEW_VERSION
-          git push --set-upstream origin releases/version-bump-$LIBRARY-$NEW_VERSION
+          git push --set-upstream origin releases/$LIBRARY-$NEW_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
 
@@ -77,20 +77,5 @@ jobs:
           export NEW_VERSION=v$(hatch version)
           export LIBRARY=${{ github.event.inputs.library }}
           gh pr create -B main -H releases/$LIBRARY-$NEW_VERSION --title 'Bumping $LIBRARY to version $NEW_VERSION'
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
-
-      - name: Publish to pypi
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          hatch build
-          hatch publish
-
-      - name: Create Github release
-        run: |
-          export LIBRARY=${{ github.event.inputs.library }}
-          gh release create $(hatch version)-$LIBRARY --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -61,7 +61,7 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
 
-      - name: Bump release version with poetry and tag
+      - name: Bump release version with hatch and commit
         run: |
           hatch version ${{ github.event.inputs.bump }}
           export NEW_VERSION=v$(hatch version)
@@ -72,7 +72,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
 
-      - name: Open a PR
+      - name: Open a PR with the version bump
         run: |
           export NEW_VERSION=v$(hatch version)
           export LIBRARY=${{ github.event.inputs.library }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,8 +1,28 @@
 name: Release
 on:
-  push:
-    branches: [ main ]
-    paths: '**/__about__.py'
+  workflow_dispatch:
+    inputs:
+      library:
+        type: choice
+        description: Which library to bump
+        required: true
+        options:
+          - server
+          - client
+      bump:
+        type: choice
+        description: Hatch version bump rule
+        required: true
+        options:
+          - release
+          - major
+          - minor
+          - patch
+          - alpha
+          - beta
+          - rc
+          - post
+          - dev
 
 jobs:
   publish:
@@ -41,12 +61,22 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
 
-      - name: Tag release
+      - name: Bump release version with poetry and tag
+        run: |
+          hatch version ${{ github.event.inputs.bump }}
+          export NEW_VERSION=v$(hatch version)
+          export LIBRARY=${{ github.event.inputs.library }}
+          git commit -am "Bumping $LIBRARY to version $NEW_VERSION"
+          git checkout -b releases/$LIBRARY-$NEW_VERSION
+          git push --set-upstream origin releases/version-bump-$LIBRARY-$NEW_VERSION
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
+
+      - name: Open a PR
         run: |
           export NEW_VERSION=v$(hatch version)
           export LIBRARY=${{ github.event.inputs.library }}
-          git tag -a $NEW_VERSION-$LIBRARY -m $NEW_VERSION-$LIBRARY
-          git push origin $NEW_VERSION-$LIBRARY
+          gh pr create -B main -H releases/$LIBRARY-$NEW_VERSION --title 'Bumping $LIBRARY to version $NEW_VERSION'
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Bump Version
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 on:
   push:
     branches: [ main ]
-    paths: '**/__about__.py'
+    paths:
+      - 'dj/__about__.py'
+      - 'datajunction/__about__.py'
 
 jobs:
   publish:
@@ -41,10 +43,19 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
 
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+           filters: |
+              server:
+                - 'dj/__about__.py'
+              client:
+                - 'datajunction/__about__.py'
+
       - name: Tag release
         run: |
           export NEW_VERSION=v$(hatch version)
-          export LIBRARY=${{ github.event.inputs.library }}
+          export LIBRARY=${{ "server" ? steps.changes.outputs.server : "client" }}
           git tag -a $NEW_VERSION-$LIBRARY -m $NEW_VERSION-$LIBRARY
           git push origin $NEW_VERSION-$LIBRARY
         env:
@@ -60,7 +71,7 @@ jobs:
 
       - name: Create Github release
         run: |
-          export LIBRARY=${{ github.event.inputs.library }}
+          export LIBRARY=${{ "server" ? steps.changes.outputs.server : "client" }}
           gh release create $(hatch version)-$LIBRARY --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ version:
 	@hatch version
 
 release:
-	@hatch publish --build
+	@hatch publish


### PR DESCRIPTION
### Summary

This splits up the release process into two parts (see https://github.com/DataJunction/dj/issues/522 for rationale):

#### Version Bump

This action is triggered manually by someone who wants to release a new version of DJ. They will select either client or server for the library they want to release and select a version bump type like alpha, beta etc. This action will then:

1. Bump the DJ <server|client> version with hatch version <bump-type>.
2. Automatically create a pull request with this version bump and wait for manual approval + merge.

#### Release

This action is triggered when a version bump pull request (from the above action) is merged. It will then do the following:

1. Create tags for the new version and push them.
2. Build the new version with hatch build
3. Publish the new version to PyPi with hatch publish
4. Create a GH release for this newly released version.

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #522
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
