### PR TITLE
Fixing bump version github action

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -68,7 +68,7 @@ jobs:
           export LIBRARY=${{ github.event.inputs.library }}
           git commit -am "Bumping $LIBRARY to version $NEW_VERSION"
           git checkout -b releases/$LIBRARY-$NEW_VERSION
-          git push --set-upstream origin releases/$LIBRARY-$NEW_VERSION
+          git push --set-upstream origin releases/$LIBRARY-$NEW_VERSION -f
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
 
@@ -76,6 +76,6 @@ jobs:
         run: |
           export NEW_VERSION=v$(hatch version)
           export LIBRARY=${{ github.event.inputs.library }}
-          gh pr create -B main -H releases/$LIBRARY-$NEW_VERSION --title 'Bumping $LIBRARY to version $NEW_VERSION'
+          gh pr create -B main -H "releases/$LIBRARY-$NEW_VERSION" --title "Bumping $LIBRARY to version $NEW_VERSION" --body "This is an automated PR triggered by the Bump Version action. Merging this PR will bump the DataJunction $LIBRARY to version $NEW_VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}


### PR DESCRIPTION
### Summary

Using `gh pr create` requires that we provide the body in non-interactive mode. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
