### PR TITLE
chore: add back superset db engine spec (for now)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ uvicorn = [
     "uvicorn[standard]>=0.21.1",
 ]
 
+[project.entry-points.'superset.db_engine_specs']
+dj = 'dj.superset:DJEngineSpec'
+
 [tool.hatch.version]
 path = "dj/__about__.py"
 


### PR DESCRIPTION
During the migration from setuptools to pdm/hatch and PEP-621, we lost
the entrypoint for the Superset Engine spec.

Maybe the engine spec will actually live somewhere else in the future
and then the entry point can be removed again, but for now this should
allow doing a `pip install datajunction-server` on a Superset instance
to load the engine spec.
