### PR TITLE
no filters in projection if no dimensions; orderby cols must be dimensions

### DIFF
--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -444,7 +444,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                     col.swap(projection_addition[ident])
                 else:
                     raise DJInvalidInputException(
-                        f"Order by columns must be used as dimensions but found {col}.",
+                        f"Column {col} found in order-by clause must also be specified in the dimensions.",
                     )
             query.organization.order += temp_query.organization.order  # type:ignore
 

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -393,7 +393,6 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
     """
     projection_addition = {}
 
-    dimension_tables = set()
     if dimensions:
         for agg in dimensions:
             temp_select = parse(
@@ -403,8 +402,6 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             for col in temp_select.find_all(ast.Column):
                 projection_addition[col.identifier(False)] = col
                 col.namespace_table()
-                if col.table:  # pragma: no cover
-                    dimension_tables.add(cast(ast.Table, col.table).identifier(False))
 
     if filters:
         filter_asts = (  # pylint: disable=consider-using-ternary
@@ -418,10 +415,10 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 temp_select.where,  # type:ignore
             )
             for col in temp_select.find_all(ast.Column):
-                projection_addition[col.identifier(False)] = col
+                if not dimensions:
+                    projection_addition[col.identifier(False)] = col
                 col.namespace_table()
-                if col.table:  # pragma: no cover
-                    dimension_tables.add(cast(ast.Table, col.table).identifier(False))
+
         query.select.where = ast.BinaryOp.And(*filter_asts)
 
     if not query.organization:
@@ -433,7 +430,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
     # if used already, otherwise, the orderby col will
     # be put in the projection as with the dimensions, filters
     # columns
-    orderby_tables = set()
+
     if orderby:
         for order in orderby:
             temp_query = parse(
@@ -446,18 +443,10 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 if ident in projection_addition:
                     col.swap(projection_addition[ident])
                 else:
-                    projection_addition[ident] = col
-                if col.table:  # pragma: no cover
-                    orderby_tables.add(cast(ast.Table, col.table).identifier(False))
-
+                    raise DJInvalidInputException(
+                        f"Order by columns must be used as dimensions but found {col}.",
+                    )
             query.organization.order += temp_query.organization.order  # type:ignore
-
-    if diff := orderby_tables - dimension_tables:
-        raise DJInvalidInputException(  # pragma: no cover
-            "Order by columns can only be from "
-            "dimensions used in filters or group bys"
-            f"found {', '.join(str(d) for d in diff)}.",
-        )
 
     # add all used dimension columns to the projection without duplicates
     projection_update = []

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -444,7 +444,8 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                     col.swap(projection_addition[ident])
                 else:
                     raise DJInvalidInputException(
-                        f"Column {col} found in order-by clause must also be specified in the dimensions.",
+                        f"Column {col} found in order-by clause must"
+                        " also be specified in the dimensions.",
                     )
             query.organization.order += temp_query.organization.order  # type:ignore
 

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -165,7 +165,6 @@ def test_sql(
             ["default.repair_orders.dispatcher_id=1", "default.hard_hat.state='AZ'"],
             """
               SELECT  count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-                      default_DOT_repair_orders.dispatcher_id,
                       default_DOT_hard_hat.state
               FROM roads.repair_orders AS default_DOT_repair_orders
               LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.hard_hat_id,
@@ -193,12 +192,8 @@ def test_sql(
             SELECT  default_DOT_hard_hat.city,
                     default_DOT_dispatcher.company_name,
                     count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-                    default_DOT_repair_orders.dispatcher_id,
                     default_DOT_hard_hat.last_name,
-                    default_DOT_municipality_dim.local_region,
-                    default_DOT_repair_orders.order_date,
-                    default_DOT_dispatcher.phone,
-                    default_DOT_hard_hat.state
+                    default_DOT_municipality_dim.local_region
             FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
                     default_DOT_dispatchers.dispatcher_id,
                     default_DOT_dispatchers.phone
@@ -359,8 +354,7 @@ def test_sql_with_filters(
             ["foo.bar.repair_orders.dispatcher_id=1", "foo.bar.hard_hat.state='AZ'"],
             [],
             """
-            SELECT  foo_DOT_bar_DOT_repair_orders.dispatcher_id,
-                    count(foo_DOT_bar_DOT_repair_orders.repair_order_id) AS foo_DOT_bar_DOT_num_repair_orders,
+            SELECT  count(foo_DOT_bar_DOT_repair_orders.repair_order_id) AS foo_DOT_bar_DOT_num_repair_orders,
                     foo_DOT_bar_DOT_hard_hat.state
             FROM roads.repair_orders AS foo_DOT_bar_DOT_repair_orders LEFT OUTER JOIN (SELECT  foo_DOT_bar_DOT_hard_hats.hard_hat_id,
                     foo_DOT_bar_DOT_hard_hats.state
@@ -388,15 +382,11 @@ def test_sql_with_filters(
             SELECT
               foo_DOT_bar_DOT_hard_hat.city,
               foo_DOT_bar_DOT_dispatcher.company_name,
-              foo_DOT_bar_DOT_repair_orders.dispatcher_id,
               count(
                 foo_DOT_bar_DOT_repair_orders.repair_order_id
               ) AS foo_DOT_bar_DOT_num_repair_orders,
               foo_DOT_bar_DOT_hard_hat.last_name,
-              foo_DOT_bar_DOT_municipality_dim.local_region,
-              foo_DOT_bar_DOT_repair_orders.order_date,
-              foo_DOT_bar_DOT_dispatcher.phone,
-              foo_DOT_bar_DOT_hard_hat.state
+              foo_DOT_bar_DOT_municipality_dim.local_region
             FROM
               roads.repair_orders AS foo_DOT_bar_DOT_repair_orders
               LEFT OUTER JOIN (
@@ -655,75 +645,72 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
                 "default.municipality_dim.local_region",
             ],
             "filters": [],
-            "orderby": ["default.hard_hat.country", "default.dispatcher.phone"],
+            "orderby": ["default.hard_hat.country", "default.dispatcher.company_name"],
             "limit": 100,
         },
     )
     data = response.json()
     expected_sql = """
-WITH
-m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.city,
-        default_DOT_dispatcher.company_name,
-        m0_default_DOT_discounted_orders_rate.country,
-        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate,
-        default_DOT_municipality_dim.local_region,
-        m0_default_DOT_discounted_orders_rate.phone,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state
- FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-        default_DOT_repair_orders.hard_hat_id,
-        default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id
- FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id,
-        default_DOT_dispatchers.phone
- FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
- FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
- FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- GROUP BY  m0_default_DOT_discounted_orders_rate.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-),
-m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_hard_hat.city,
-        default_DOT_dispatcher.company_name,
-        default_DOT_hard_hat.country,
-        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-        default_DOT_municipality_dim.local_region,
-        default_DOT_hard_hat.postal_code,
-        default_DOT_hard_hat.state
- FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id
- FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-        default_DOT_hard_hats.country,
-        default_DOT_hard_hats.hard_hat_id,
-        default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state
- FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id
- FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
- GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-)SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
-        m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
-        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city) city,
-        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name) company_name,
-        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country) country,
-        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region) local_region,
-        m0_default_DOT_discounted_orders_rate.phone,
-        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code) postal_code,
-        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state) state
- FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.phone = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.state
-ORDER BY m0_default_DOT_discounted_orders_rate.country, m0_default_DOT_discounted_orders_rate.phone
-LIMIT 100
+      WITH
+      m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.city,
+              m0_default_DOT_discounted_orders_rate.company_name,
+              m0_default_DOT_discounted_orders_rate.country,
+              CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate,
+              default_DOT_municipality_dim.local_region,
+              default_DOT_hard_hat.postal_code,
+              default_DOT_hard_hat.state
+      FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
+              default_DOT_repair_orders.hard_hat_id,
+              default_DOT_repair_orders.municipality_id,
+              default_DOT_repair_orders.repair_order_id
+      FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+      LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+              default_DOT_dispatchers.dispatcher_id
+      FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+      LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+              default_DOT_hard_hats.country,
+              default_DOT_hard_hats.hard_hat_id,
+              default_DOT_hard_hats.postal_code,
+              default_DOT_hard_hats.state
+      FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+      LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+              default_DOT_municipality.municipality_id
+      FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+      LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+      GROUP BY  m0_default_DOT_discounted_orders_rate.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, m0_default_DOT_discounted_orders_rate.company_name, default_DOT_municipality_dim.local_region
+      ),
+      m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_hard_hat.city,
+              default_DOT_dispatcher.company_name,
+              default_DOT_hard_hat.country,
+              count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
+              default_DOT_municipality_dim.local_region,
+              default_DOT_hard_hat.postal_code,
+              default_DOT_hard_hat.state
+      FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
+              default_DOT_dispatchers.dispatcher_id
+      FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+      LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
+              default_DOT_hard_hats.country,
+              default_DOT_hard_hats.hard_hat_id,
+              default_DOT_hard_hats.postal_code,
+              default_DOT_hard_hats.state
+      FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+      LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
+              default_DOT_municipality.municipality_id
+      FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+      LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+      GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
+      )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
+              m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+              COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city) city,
+              COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name) company_name,
+              COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country) country,
+              COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region) local_region,
+              COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code) postal_code,
+              COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state) state
+      FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
+      ORDER BY m0_default_DOT_discounted_orders_rate.country, m0_default_DOT_discounted_orders_rate.company_name
+      LIMIT 100
     """
     assert compare_query_strings(data["sql"], expected_sql)
     assert data["columns"] == [
@@ -733,7 +720,6 @@ LIMIT 100
         {"name": "company_name", "type": "string"},
         {"name": "country", "type": "string"},
         {"name": "local_region", "type": "string"},
-        {"name": "phone", "type": "string"},
         {"name": "postal_code", "type": "string"},
         {"name": "state", "type": "string"},
     ]
@@ -761,4 +747,28 @@ def test_get_sql_for_metrics_filters_validate_dimensions(
         "The filter `default.hard_hat.city = 'Las Vegas'` references the dimension "
         "attribute `default.hard_hat.city`, which is not available on every metric and "
         "thus cannot be included."
+    )
+
+
+def test_get_sql_for_metrics_orderby_not_in_dimensions(
+    client_with_examples: TestClient,
+):
+    """
+    Test that we extract the columns from filters to validate that they are from shared dimensions
+    """
+    response = client_with_examples.get(
+        "/sql/",
+        params={
+            "metrics": ["foo.bar.num_repair_orders", "foo.bar.avg_repair_price"],
+            "dimensions": [
+                "foo.bar.hard_hat.country",
+            ],
+            "orderby": ["default.hard_hat.city"],
+            "limit": 10,
+        },
+    )
+    data = response.json()
+    assert data["message"] == (
+        "Order by columns must be used as "
+        "dimensions but found default.hard_hat.city."
     )

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -769,6 +769,6 @@ def test_get_sql_for_metrics_orderby_not_in_dimensions(
     )
     data = response.json()
     assert data["message"] == (
-        "Order by columns must be used as "
-        "dimensions but found default.hard_hat.city."
+        "Column default.hard_hat.city found in order-by "
+        "clause must also be specified in the dimensions."
     )


### PR DESCRIPTION
### Summary

Fixes the issue introduced in https://github.com/DataJunction/dj/pull/520 that @agorajek (thank you!) pointed out where filter columns were introduced into the projection even if there were no aggregations.

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage