### PR TITLE
Support lambda functions (ex: `aggregate`) and add several missing Spark functions

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1158,7 +1158,7 @@ class First(Function):  # pragma: no cover  # pylint: disable=abstract-method
 def infer_type(  # noqa: F811  # pragma: no cover
     arg: "Expression",
 ) -> ct.ColumnType:
-    return arg.type
+    return arg.type  # pragma: no cover
 
 
 @First.register
@@ -1166,7 +1166,7 @@ def infer_type(  # noqa: F811  # pragma: no cover
     arg: "Expression",
     is_ignore_null: ct.BooleanType,
 ) -> ct.ColumnType:
-    return arg.type
+    return arg.type  # pragma: no cover
 
 
 class ElementAt(Function):  # pylint: disable=abstract-method

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -219,7 +219,7 @@ class Aggregate(Function):  # pylint: disable=abstract-method
 
 
 @Aggregate.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     expr: ct.ListType,
     start: ct.PrimitiveType,
     merge: ct.PrimitiveType,
@@ -236,7 +236,7 @@ class Avg(Function):  # pylint: disable=abstract-method
 
 
 @Avg.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.DecimalType,
 ) -> ct.DecimalType:
     type_ = arg.type
@@ -244,21 +244,21 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
 
 
 @Avg.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.IntervalTypeBase,
 ) -> ct.IntervalTypeBase:
     return type(arg.type)()
 
 
 @Avg.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.NumberType,
 ) -> ct.DoubleType:
     return ct.DoubleType()
 
 
 @Avg.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.DateTimeBase,
 ) -> ct.DateTimeBase:
     return type(arg.type)()
@@ -273,7 +273,7 @@ class Min(Function):  # pylint: disable=abstract-method
 
 
 @Min.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.NumberType,
 ) -> ct.NumberType:
     return arg.type
@@ -288,14 +288,14 @@ class Max(Function):  # pylint: disable=abstract-method
 
 
 @Max.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.NumberType,
 ) -> ct.NumberType:
     return arg.type
 
 
 @Max.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.StringType,
 ) -> ct.StringType:
     return arg.type
@@ -310,14 +310,14 @@ class Sum(Function):  # pylint: disable=abstract-method
 
 
 @Sum.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.IntegerBase,
 ) -> ct.BigIntType:
     return ct.BigIntType()
 
 
 @Sum.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.DecimalType,
 ) -> ct.DecimalType:
     precision = arg.type.precision
@@ -326,7 +326,7 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
 
 
 @Sum.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: Union[ct.NumberType, ct.IntervalTypeBase],
 ) -> ct.DoubleType:
     return ct.DoubleType()
@@ -339,7 +339,7 @@ class Ceil(Function):  # pylint: disable=abstract-method
 
 
 @Ceil.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.NumberType,
     _target_scale: ct.IntegerType,
 ) -> ct.DecimalType:
@@ -375,14 +375,14 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
 
 
 @Ceil.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.DecimalType,
 ) -> ct.DecimalType:
     return ct.DecimalType(args.type.precision - args.type.scale + 1, 0)
 
 
 @Ceil.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.NumberType,
 ) -> ct.BigIntType:
     return ct.BigIntType()
@@ -397,7 +397,7 @@ class Count(Function):  # pylint: disable=abstract-method
 
 
 @Count.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     *args: ct.ColumnType,
 ) -> ct.BigIntType:
     return ct.BigIntType()
@@ -412,7 +412,7 @@ class Coalesce(Function):  # pylint: disable=abstract-method
 
 
 @Coalesce.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     *args: ct.ColumnType,
 ) -> ct.ColumnType:
     if not args:  # pragma: no cover
@@ -438,7 +438,7 @@ class CurrentDate(Function):  # pylint: disable=abstract-method
 
 
 @CurrentDate.register  # type: ignore
-def infer_type() -> ct.DateType:  # noqa: F811  # pylint: disable=function-redefined
+def infer_type() -> ct.DateType:  # noqa: F811
     return ct.DateType()
 
 
@@ -449,7 +449,7 @@ class CurrentDatetime(Function):  # pylint: disable=abstract-method
 
 
 @CurrentDatetime.register  # type: ignore
-def infer_type() -> ct.TimestampType:  # noqa: F811  # pylint: disable=function-redefined
+def infer_type() -> ct.TimestampType:  # noqa: F811
     return ct.TimestampType()
 
 
@@ -460,7 +460,7 @@ class CurrentTime(Function):  # pylint: disable=abstract-method
 
 
 @CurrentTime.register  # type: ignore
-def infer_type() -> ct.TimeType:  # noqa: F811  # pylint: disable=function-redefined
+def infer_type() -> ct.TimeType:  # noqa: F811
     return ct.TimeType()
 
 
@@ -471,7 +471,7 @@ class CurrentTimestamp(Function):  # pylint: disable=abstract-method
 
 
 @CurrentTimestamp.register  # type: ignore
-def infer_type() -> ct.TimestampType:  # noqa: F811  # pylint: disable=function-redefined
+def infer_type() -> ct.TimestampType:  # noqa: F811
     return ct.TimestampType()
 
 
@@ -482,7 +482,7 @@ class Now(Function):  # pylint: disable=abstract-method
 
 
 @Now.register  # type: ignore
-def infer_type() -> ct.TimestampType:  # noqa: F811  # pylint: disable=function-redefined
+def infer_type() -> ct.TimestampType:  # noqa: F811
     return ct.TimestampType()
 
 
@@ -493,7 +493,7 @@ class DateAdd(Function):  # pylint: disable=abstract-method
 
 
 @DateAdd.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     start_date: ct.DateType,
     days: ct.IntegerBase,
 ) -> ct.DateType:
@@ -501,7 +501,7 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
 
 
 @DateAdd.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     start_date: ct.StringType,
     days: ct.IntegerBase,
 ) -> ct.DateType:
@@ -515,7 +515,7 @@ class DateSub(Function):  # pylint: disable=abstract-method
 
 
 @DateSub.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     start_date: ct.DateType,
     days: ct.IntegerBase,
 ) -> ct.DateType:
@@ -523,7 +523,7 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
 
 
 @DateSub.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     start_date: ct.StringType,
     days: ct.IntegerBase,
 ) -> ct.DateType:
@@ -540,7 +540,7 @@ class If(Function):  # pylint: disable=abstract-method
 
 
 @If.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     cond: ct.BooleanType,
     then: ct.ColumnType,
     else_: ct.ColumnType,
@@ -561,7 +561,7 @@ class DateDiff(Function):  # pylint: disable=abstract-method
 
 
 @DateDiff.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     start_date: ct.DateType,
     end_date: ct.DateType,
 ) -> ct.IntegerType:
@@ -569,7 +569,7 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
 
 
 @DateDiff.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     start_date: ct.StringType,
     end_date: ct.StringType,
 ) -> ct.IntegerType:
@@ -598,7 +598,7 @@ class ToDate(Function):  # pragma: no cover # pylint: disable=abstract-method
 
 
 @ToDate.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     expr: ct.StringType,
     fmt: Optional[ct.StringType] = None,
 ) -> ct.DateType:
@@ -612,7 +612,7 @@ class Day(Function):  # pylint: disable=abstract-method
 
 
 @Day.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: Union[ct.StringType, ct.DateType, ct.TimestampType],
 ) -> ct.IntegerType:  # type: ignore
     return ct.IntegerType()
@@ -625,7 +625,7 @@ class Exp(Function):  # pylint: disable=abstract-method
 
 
 @Exp.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.ColumnType,
 ) -> ct.DoubleType:
     return ct.DoubleType()
@@ -638,21 +638,21 @@ class Floor(Function):  # pylint: disable=abstract-method
 
 
 @Floor.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.DecimalType,
 ) -> ct.DecimalType:
     return ct.DecimalType(args.type.precision - args.type.scale + 1, 0)
 
 
 @Floor.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.NumberType,
 ) -> ct.BigIntType:
     return ct.BigIntType()
 
 
 @Floor.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.NumberType,
     _target_scale: ct.IntegerType,
 ) -> ct.DecimalType:
@@ -706,7 +706,7 @@ class Length(Function):  # pylint: disable=abstract-method
 
 
 @Length.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.StringType,
 ) -> ct.IntegerType:
     return ct.IntegerType()
@@ -719,7 +719,7 @@ class Levenshtein(Function):  # pylint: disable=abstract-method
 
 
 @Levenshtein.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     string1: ct.StringType,
     string2: ct.StringType,
 ) -> ct.IntegerType:
@@ -733,7 +733,7 @@ class Ln(Function):  # pylint: disable=abstract-method
 
 
 @Ln.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.ColumnType,
 ) -> ct.DoubleType:
     return ct.DoubleType()
@@ -746,7 +746,7 @@ class Log(Function):  # pylint: disable=abstract-method
 
 
 @Log.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     base: ct.ColumnType,
     expr: ct.ColumnType,
 ) -> ct.DoubleType:
@@ -760,7 +760,7 @@ class Log2(Function):  # pylint: disable=abstract-method
 
 
 @Log2.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.ColumnType,
 ) -> ct.DoubleType:
     return ct.DoubleType()
@@ -773,7 +773,7 @@ class Log10(Function):  # pylint: disable=abstract-method
 
 
 @Log10.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     args: ct.ColumnType,
 ) -> ct.DoubleType:
     return ct.DoubleType()
@@ -806,7 +806,7 @@ class Pow(Function):  # pylint: disable=abstract-method
 
 
 @Pow.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     base: ct.ColumnType,
     power: ct.ColumnType,
 ) -> ct.DoubleType:
@@ -875,7 +875,7 @@ class Round(Function):  # pylint: disable=abstract-method
 
 
 @Round.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     child: ct.DecimalType,
     scale: ct.IntegerBase,
 ) -> ct.NumberType:
@@ -892,7 +892,7 @@ def infer_type(  # noqa: F811  # pylint: disable=function-redefined
 
 
 @Round.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined  # type: ignore
+def infer_type(  # noqa: F811  # type: ignore
     child: ct.NumberType,
     scale: ct.IntegerBase,
 ) -> ct.NumberType:
@@ -930,7 +930,7 @@ class StrPosition(Function):  # pylint: disable=abstract-method
 
 
 @StrPosition.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined  # pragma: no cover
+def infer_type(  # noqa: F811  # pragma: no cover
     arg1: ct.StringType,
     arg2: ct.StringType,
 ) -> ct.IntegerType:
@@ -1155,14 +1155,14 @@ class First(Function):  # pragma: no cover  # pylint: disable=abstract-method
 
 
 @First.register
-def infer_type(  # noqa: F811
+def infer_type(  # noqa: F811  # pragma: no cover
     arg: "Expression",
 ) -> ct.ColumnType:
     return arg.type
 
 
 @First.register
-def infer_type(  # noqa: F811
+def infer_type(  # noqa: F811  # pragma: no cover
     arg: "Expression",
     is_ignore_null: ct.BooleanType,
 ) -> ct.ColumnType:
@@ -1194,7 +1194,8 @@ def infer_type(  # noqa: F811
 
 class Split(Function):  # pylint: disable=abstract-method
     """
-    Returns the
+    Splits str around occurrences that match regex and returns an
+    array with a length of at most limit
     """
 
 
@@ -1214,7 +1215,7 @@ class Array(Function):  # pylint: disable=abstract-method
 
 
 @Array.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     *elements: ct.ColumnType,
 ) -> ct.ListType:
     types = {element.type for element in elements}
@@ -1246,7 +1247,7 @@ def extract_consistent_type(elements):
 
 
 @Map.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     *elements: ct.ColumnType,
 ) -> ct.MapType:
     keys = elements[0::2]
@@ -1286,7 +1287,7 @@ class FromJson(Function):  # pragma: no cover  # pylint: disable=abstract-method
 
 
 @FromJson.register  # type: ignore
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined  # pragma: no cover
+def infer_type(  # noqa: F811  # pragma: no cover
     json: ct.StringType,
     schema: ct.StringType,
     options: Optional[Function] = None,
@@ -1333,14 +1334,14 @@ class Explode(TableFunction):  # pylint: disable=abstract-method
 
 
 @Explode.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.ListType,
 ) -> List[ct.NestedField]:
     return [arg.element]
 
 
 @Explode.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.MapType,
 ) -> List[ct.NestedField]:
     return [arg.key, arg.value]
@@ -1355,14 +1356,14 @@ class Unnest(TableFunction):  # pylint: disable=abstract-method
 
 
 @Unnest.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.ListType,
 ) -> List[ct.NestedField]:
     return [arg.element]  # pragma: no cover
 
 
 @Unnest.register
-def infer_type(  # noqa: F811  # pylint: disable=function-redefined
+def infer_type(  # noqa: F811
     arg: ct.MapType,
 ) -> List[ct.NestedField]:
     return [arg.key, arg.value]

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1178,17 +1178,45 @@ class First(Function):  # pragma: no cover  # pylint: disable=abstract-method
 
 @First.register
 def infer_type(  # noqa: F811  # pragma: no cover
-    arg: "Expression",
+    arg: ct.ColumnType,
 ) -> ct.ColumnType:
     return arg.type  # pragma: no cover
 
 
 @First.register
 def infer_type(  # noqa: F811  # pragma: no cover
-    arg: "Expression",
+    arg: ct.ColumnType,
     is_ignore_null: ct.BooleanType,
 ) -> ct.ColumnType:
     return arg.type  # pragma: no cover
+
+
+class CollectList(Function):  # pragma: no cover  # pylint: disable=abstract-method
+    """
+    Collects and returns a list of non-unique elements.
+    """
+
+    is_aggregation = True
+
+
+@CollectList.register
+def infer_type(  # noqa: F811  # pragma: no cover
+    arg: ct.ColumnType,
+) -> ct.ColumnType:
+    return ct.ListType(element_type=arg.type)  # pragma: no cover
+
+
+class ArrayContains(Function):  # pragma: no cover  # pylint: disable=abstract-method
+    """
+    array_contains(array, value) - Returns true if the array contains the value.
+    """
+
+
+@ArrayContains.register
+def infer_type(  # noqa: F811  # pragma: no cover
+    arg: ct.ListType,
+) -> ct.BooleanType:
+    return ct.BooleanType()  # pragma: no cover
 
 
 class ElementAt(Function):  # pylint: disable=abstract-method

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -169,7 +169,12 @@ class Function(Dispatch):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def compile_lambda(*args):
-        pass
+        """
+        Compiles the lambda function used by a given Spark function that takes
+        a lambda function. This allows us to evaluate the lambda's expression and
+        determine the result's type.
+        """
+        ...
 
 
 class TableFunction(Dispatch):  # pylint: disable=too-few-public-methods
@@ -192,7 +197,8 @@ class Aggregate(Function):  # pylint: disable=abstract-method
     @staticmethod
     def compile_lambda(*args):
         """
-        Compiles the lambda function used by the `aggregate` Spark function.
+        Compiles the lambda function used by the `aggregate` Spark function so that
+        the lambda's expression can be evaluated to determine the result's type.
         """
         from dj.sql.parsing import ast  # pylint: disable=import-outside-toplevel
 
@@ -1142,21 +1148,32 @@ class VariancePop(Function):  # pragma: no cover
         return ct.DoubleType()
 
 
-class First(Function):  # pragma: no cover
+class First(Function):  # pragma: no cover  # pylint: disable=abstract-method
     """
     Returns the first value of expr for a group of rows. If isIgnoreNull is
     true, returns only non-null values.
     """
 
-    @staticmethod
-    def infer_type(arg: "Expression") -> ct.ColumnType:
-        return arg.type
+
+@First.register
+def infer_type(  # noqa: F811
+    arg: "Expression",
+) -> ct.ColumnType:
+    return arg.type
+
+
+@First.register
+def infer_type(  # noqa: F811
+    arg: "Expression",
+    is_ignore_null: ct.BooleanType,
+) -> ct.ColumnType:
+    return arg.type
 
 
 class ElementAt(Function):  # pylint: disable=abstract-method
     """
-    Returns the first value of expr for a group of rows. If isIgnoreNull is
-    true, returns only non-null values.
+    element_at(array, index) - Returns element of array at given (1-based) index
+    element_at(map, key) - Returns value for given key.
     """
 
 

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1175,7 +1175,7 @@ def infer_type(  # noqa: F811
     map_arg: ct.MapType,
     _: ct.NumberType,
 ) -> ct.ColumnType:
-    return map_arg.value.type
+    return map_arg.type.value.type
 
 
 class Split(Function):  # pylint: disable=abstract-method

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -65,8 +65,6 @@ def compare_registers(types, register) -> bool:
                 return False  # pragma: no cover
         if type_a == -1:
             register_a = type(register_a)
-        if str(register_a.__name__) == str(register_b):
-            return True
         if not issubclass(register_a, register_b):  # type: ignore
             return False
     return True

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -332,6 +332,26 @@ def infer_type(  # noqa: F811
     return ct.DoubleType()
 
 
+class Cardinality(Function):  # pylint: disable=abstract-method
+    """
+    Returns the size of an array or a map.
+    """
+
+
+@Cardinality.register  # type: ignore
+def infer_type(  # noqa: F811
+    args: ct.ListType,
+) -> ct.IntegerType:
+    return ct.IntegerType()
+
+
+@Cardinality.register  # type: ignore
+def infer_type(  # noqa: F811
+    args: ct.MapType,
+) -> ct.IntegerType:
+    return ct.IntegerType()
+
+
 class Ceil(Function):  # pylint: disable=abstract-method
     """
     Computes the smallest integer greater than or equal to the input value.
@@ -1152,6 +1172,8 @@ class First(Function):  # pragma: no cover  # pylint: disable=abstract-method
     Returns the first value of expr for a group of rows. If isIgnoreNull is
     true, returns only non-null values.
     """
+
+    is_aggregation = True
 
 
 @First.register

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -174,7 +174,6 @@ class Function(Dispatch):  # pylint: disable=too-few-public-methods
         a lambda function. This allows us to evaluate the lambda's expression and
         determine the result's type.
         """
-        ...
 
 
 class TableFunction(Dispatch):  # pylint: disable=too-few-public-methods

--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -1436,13 +1436,11 @@ class Function(Named, Operation):
         return function_registry[self.name.name.upper()]
 
     def is_aggregation(self) -> bool:
-        return function_registry[self.name.name.upper()].is_aggregation
+        return self.function().is_aggregation
 
     @property
     def type(self) -> ColumnType:
-        name = self.name.name.upper()
-        dj_func = function_registry[name]
-        return dj_func.infer_type(*self.args)
+        return self.function().infer_type(*self.args)
 
     def compile(self, ctx: CompileContext):
         """
@@ -1888,14 +1886,6 @@ class Lambda(Expression):
         The return type of the lambda function
         """
         return self.expr.type
-
-    def compile(self, ctx):
-        return super().compile(ctx)
-
-    #     if self.is_compiled():
-    #         return
-    #     self._is_compiled = True
-    #     self.parent.args
 
 
 @dataclass(eq=False)

--- a/dj/sql/parsing/backends/antlr4.py
+++ b/dj/sql/parsing/backends/antlr4.py
@@ -545,6 +545,11 @@ def _(ctx: sbp.RealIdentContext):
 
 
 @visit.register
+def _(ctx: sbp.FirstContext):
+    return ast.Function(ast.Name("FIRST"), args=[visit(ctx.expression())])
+
+
+@visit.register
 def _(ctx: sbp.IdentifierContext):
     return visit(ctx.strictIdentifier())
 
@@ -1032,10 +1037,12 @@ def _(ctx: sbp.TrimContext) -> ast.Function:
 
 
 @visit.register
-def _(ctx: sbp.LambdaContext) -> ast.Function:
+def _(ctx: sbp.LambdaContext) -> ast.Lambda:
     identifier = visit(ctx.identifier())
     expr = visit(ctx.expression())
-    return ast.Lambda(identifiers=identifier, expr=expr)
+    lambda_expr = ast.Lambda(identifiers=identifier, expr=expr)
+    lambda_expr._type = ct.LambdaType
+    return lambda_expr
 
 
 @visit.register

--- a/dj/sql/parsing/types.py
+++ b/dj/sql/parsing/types.py
@@ -192,6 +192,12 @@ class FixedType(PrimitiveType):
         return self._length
 
 
+class LambdaType(ColumnType):
+    """
+    Type representing a lambda function
+    """
+
+
 class DecimalType(NumberType):
     """A fixed data type.
 

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -290,12 +290,14 @@ def test_element_at(session: Session):
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query_with_array.compile(ctx)
+    assert not exc.errors
     assert query_with_array.select.projection[0].type == IntegerType()  # type: ignore
 
     query_with_map = parse("SELECT element_at(map(1, 'a', 2, 'b'), 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query_with_map.compile(ctx)
+    assert not exc.errors
     assert query_with_map.select.projection[0].type == StringType()  # type: ignore
 
 
@@ -307,6 +309,7 @@ def test_split(session: Session):
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
+    assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
@@ -318,10 +321,12 @@ def test_cardinality(session: Session):
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query_with_list.compile(ctx)
+    assert not exc.errors
     assert query_with_list.select.projection[0].type == ct.IntegerType()  # type: ignore
 
     query_with_map = parse("SELECT cardinality(map('a', 1, 'b', 2))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query_with_map.compile(ctx)
+    assert not exc.errors
     assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -308,3 +308,20 @@ def test_split(session: Session):
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
+
+
+def test_cardinality(session: Session):
+    """
+    Test the `cardinality` Spark function
+    """
+    query_with_list = parse("SELECT cardinality(array('b', 'd', 'c', 'a'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_list.compile(ctx)
+    assert query_with_list.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+    query_with_map = parse("SELECT cardinality(map('a', 1, 'b', 2))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_map.compile(ctx)
+    assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -8,8 +8,7 @@ from sqlmodel import Session
 
 import dj.sql.functions as F
 import dj.sql.parsing.types as ct
-from dj.sql.parsing.backends.antlr4 import parse
-from dj.errors import DJNotImplementedException, DJException
+from dj.errors import DJException, DJNotImplementedException
 from dj.sql.functions import (
     Avg,
     Coalesce,
@@ -22,6 +21,7 @@ from dj.sql.functions import (
     function_registry,
 )
 from dj.sql.parsing import ast
+from dj.sql.parsing.backends.antlr4 import parse
 from dj.sql.parsing.types import (
     BigIntType,
     DateType,
@@ -286,17 +286,13 @@ def test_element_at(session: Session):
     """
     Test the `element_at` Spark function
     """
-    query_with_array = parse(
-        "SELECT element_at(array(1, 2, 3, 4), 2)"
-    )
+    query_with_array = parse("SELECT element_at(array(1, 2, 3, 4), 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query_with_array.compile(ctx)
     assert query_with_array.select.projection[0].type == IntegerType()  # type: ignore
 
-    query_with_map = parse(
-        "SELECT element_at(map(1, 'a', 2, 'b'), 2)"
-    )
+    query_with_map = parse("SELECT element_at(map(1, 'a', 2, 'b'), 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query_with_map.compile(ctx)
@@ -307,9 +303,7 @@ def test_split(session: Session):
     """
     Test the `split` Spark function
     """
-    query = parse(
-        "SELECT split('oneAtwoBthreeC', '[ABC]')"
-    )
+    query = parse("SELECT split('oneAtwoBthreeC', '[ABC]')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)

--- a/tests/sql/parsing/test_ast.py
+++ b/tests/sql/parsing/test_ast.py
@@ -8,7 +8,6 @@ from sqlmodel import Session
 from dj.errors import DJException
 from dj.sql.parsing import ast, types
 from dj.sql.parsing.backends.antlr4 import parse
-from dj.sql.parsing.types import StringType
 
 
 def test_ast_compile_table(
@@ -891,25 +890,3 @@ def test_ast_compile_lateral_view_explode8(session: Session):
         quote_style="",
         namespace=None,
     )
-
-
-def test_aggregate(session: Session):
-    """
-    Test the `aggregate` Spark function
-    """
-    query = parse(
-        """
-    select
-      aggregate(items, '', (acc, x) -> (case
-        when acc = '' then element_at(split(x, '::'), 1)
-        when acc = 'a' then acc
-        else element_at(split(x, '::'), 1) end)) as item
-    from (
-      select 1 as id, ARRAY('b', 'c', 'a', 'x', 'g', 'z') AS items
-    )
-    """,
-    )
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert query.select.projection[0].type == StringType()  # type: ignore

--- a/tests/sql/parsing/test_ast.py
+++ b/tests/sql/parsing/test_ast.py
@@ -8,6 +8,7 @@ from sqlmodel import Session
 from dj.errors import DJException
 from dj.sql.parsing import ast, types
 from dj.sql.parsing.backends.antlr4 import parse
+from dj.sql.parsing.types import StringType
 
 
 def test_ast_compile_table(
@@ -890,3 +891,25 @@ def test_ast_compile_lateral_view_explode8(session: Session):
         quote_style="",
         namespace=None,
     )
+
+
+def test_aggregate(session: Session):
+    """
+    Test the `aggregate` Spark function
+    """
+    query = parse(
+        """
+    select
+      aggregate(items, '', (acc, x) -> (case
+        when acc = '' then element_at(split(x, '::'), 1)
+        when acc = 'a' then acc
+        else element_at(split(x, '::'), 1) end)) as item
+    from (
+      select 1 as id, ARRAY('b', 'c', 'a', 'x', 'g', 'z') AS items
+    )
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert query.select.projection[0].type == StringType()  # type: ignore


### PR DESCRIPTION
### Summary

This change adds the following Spark functions:
* `element_at`
* `split`
* `aggregate`
* `first`
* `cardinality`

Note that `aggregate` is a bit of a special case function that relates to https://github.com/DataJunction/dj/issues/543, since it takes in a lambda function as an argument. In order to support other functions that take lambdas (ex: `map_zip_with`, `map_filter`), we modify the way that `ast.Function` is compiled:
1. Compile the arguments of the function
2. Compile the lambda function expression. This is done with a custom method called `compile_lambda` that is defined on each such function's class. The main purpose of this function is to add types to the input arguments of the lambda expression so that we can infer the return type of the lambda by evaluating the expression.
3. Compile all other child elements of the function, if any.

### Test Plan

Added some unit tests. Tested with DJ server locally for a complex query with all of these functions used.

- [X] PR has an associated issue: #543, #544
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A