### PR TITLE
orderby can be used on metrics

### DIFF
--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -757,18 +757,12 @@ def build_metric_nodes(
     combined_ast.select.projection.extend(dimension_columns)
 
     # go through the orderby items and make sure we put them in the order the user requested them in
-    orderby_sort_items_resorted = orderby_sort_items + [  # type: ignore
-        None,  # type: ignore
-    ] * len(orderby_mapping)
+
     for idx, sort_item in enumerate(orderby_mapping.values()):
         if isinstance(sort_item, ast.SortItem):
-            orderby_sort_items_resorted.insert(idx, sort_item)
-    orderby_sort_items_resorted = [
-        sort_item for sort_item in orderby_sort_items_resorted if sort_item is not None
-    ]
+            orderby_sort_items.insert(idx, sort_item)
 
-    combined_ast.organization = ast.Organization([])
-    combined_ast.organization.order = orderby_sort_items_resorted
+    combined_ast.organization = ast.Organization(orderby_sort_items)
 
     if limit is not None:
         combined_ast.limit = ast.Number(limit)

--- a/dj/construction/build.py
+++ b/dj/construction/build.py
@@ -445,7 +445,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 else:
                     raise DJInvalidInputException(
                         f"Column {col} found in order-by clause must"
-                        " also be specified in the dimensions.",
+                        " also be specified in the metrics or dimensions.",
                     )
             query.organization.order += temp_query.organization.order  # type:ignore
 
@@ -620,15 +620,34 @@ def build_metric_nodes(
     initial_dimension_columns = []
     all_dimension_columns = []
 
-    organization = None
+    orderby_sort_items: List[ast.SortItem] = []
+    orderby = orderby or []
+    orderby_mapping = {}
+    for order in orderby:
+        orderby_metric = None
+        for metric_node in metric_nodes:
+            if metric_node.name.lower() in order.lower():
+                orderby_metric = metric_node.name
+                break
+        orderby_mapping[order] = orderby_metric
+
     for (idx, metric_node) in enumerate(metric_nodes):
         # Build each metric node separately
+        curr_orderby = None
+
+        if (not orderby_sort_items) and orderby_mapping:
+            curr_orderby = [
+                order
+                for order, metric_name in orderby_mapping.items()
+                if metric_name is None
+            ]
+
         metric_ast = build_node(
             session=session,
             node=metric_node.current,
             filters=filters,
             dimensions=dimensions,
-            orderby=orderby if organization is None else None,
+            orderby=curr_orderby,
             build_criteria=build_criteria,
         )
 
@@ -642,11 +661,37 @@ def build_metric_nodes(
         # Add the metric and dimensions to the final query layer's SELECT
         current_table = ast.Table(metric_ast_alias)
 
-        if orderby and organization is None:
-            organization = cast(ast.Organization, metric_ast.organization)
-            metric_ast.organization = None
-            for col in organization.find_all(ast.Column):
-                col.add_table(current_table)
+        organization = cast(ast.Organization, metric_ast.organization)
+
+        # if an orderby referred to this metric node, parse and add it to the order items
+        if metric_order := (
+            [None]
+            + [
+                order_key  # type: ignore
+                for order_key, order_metric in orderby_mapping.items()
+                if metric_node.name == order_metric
+            ]
+        ).pop():
+            metric_sort_item = parse(f"select * order by {metric_order}").organization.order[0]  # type: ignore #pylint: disable=C0301
+            metric_col = ast.Column(
+                name=ast.Name(
+                    [
+                        exp.alias_or_name.identifier(False)
+                        for exp in metric_ast.select.projection
+                        if exp.is_aggregation()
+                    ][0],
+                ),
+                _table=current_table,
+            )
+            for col in metric_sort_item.find_all(ast.Column):
+                col.swap(metric_col)
+            orderby_mapping[metric_order] = metric_sort_item  # type: ignore
+
+        # bind the table for this built metric to all columns in the
+        metric_ast.organization = None
+        for col in organization.find_all(ast.Column):
+            col.add_table(current_table)
+        orderby_sort_items += organization.order  # type: ignore
 
         final_select_columns = [
             ast.Column(
@@ -708,10 +753,22 @@ def build_metric_nodes(
         else columns[0]
         for col_name, columns in dimension_grouping.items()
     ]
+
     combined_ast.select.projection.extend(dimension_columns)
 
-    if organization is not None:
-        combined_ast.organization = organization
+    # go through the orderby items and make sure we put them in the order the user requested them in
+    orderby_sort_items_resorted = orderby_sort_items + [  # type: ignore
+        None,  # type: ignore
+    ] * len(orderby_mapping)
+    for idx, sort_item in enumerate(orderby_mapping.values()):
+        if isinstance(sort_item, ast.SortItem):
+            orderby_sort_items_resorted.insert(idx, sort_item)
+    orderby_sort_items_resorted = [
+        sort_item for sort_item in orderby_sort_items_resorted if sort_item is not None
+    ]
+
+    combined_ast.organization = ast.Organization([])
+    combined_ast.organization.order = orderby_sort_items_resorted
 
     if limit is not None:
         combined_ast.limit = ast.Number(limit)

--- a/tests/api/sql_test.py
+++ b/tests/api/sql_test.py
@@ -645,7 +645,12 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
                 "default.municipality_dim.local_region",
             ],
             "filters": [],
-            "orderby": ["default.hard_hat.country", "default.dispatcher.company_name"],
+            "orderby": [
+                "default.hard_hat.country",
+                "default.num_repair_orders",
+                "default.dispatcher.company_name",
+                "default.discounted_orders_rate",
+            ],
             "limit": 100,
         },
     )
@@ -709,7 +714,7 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
               COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code) postal_code,
               COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state) state
       FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
-      ORDER BY m0_default_DOT_discounted_orders_rate.country, m0_default_DOT_discounted_orders_rate.company_name
+      ORDER BY m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders, m0_default_DOT_discounted_orders_rate.company_name, m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate
       LIMIT 100
     """
     assert compare_query_strings(data["sql"], expected_sql)
@@ -770,5 +775,5 @@ def test_get_sql_for_metrics_orderby_not_in_dimensions(
     data = response.json()
     assert data["message"] == (
         "Column default.hard_hat.city found in order-by "
-        "clause must also be specified in the dimensions."
+        "clause must also be specified in the metrics or dimensions."
     )


### PR DESCRIPTION
### Summary

Currently, `orderby` from the api only supports dimension columns. This adds support to orderby any selected metrics as well.

### Test Plan

Add to a sql test some metrics in different positions in the `orderby`

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
