### PR TITLE
abs function

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1419,6 +1419,22 @@ def infer_type(  # noqa: F811
     return [arg.key, arg.value]
 
 
+class Abs(Function):  # pylint: disable=abstract-method
+    """
+    Returns the absolute value of the numeric or interval value.
+    """
+
+    is_aggregation = True
+
+
+@Abs.register
+def infer_type(  # noqa: F811
+    arg: ct.NumberType,
+) -> ct.NumberType:
+    type_ = arg.type
+    return type_
+
+
 function_registry = FunctionRegistryDict()
 for cls in Function.__subclasses__():
     snake_cased = re.sub(r"(?<!^)(?=[A-Z])", "_", cls.__name__)

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -330,3 +330,30 @@ def test_cardinality(session: Session):
     query_with_map.compile(ctx)
     assert not exc.errors
     assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_abs(session: Session):
+    """
+    Test the `abs` Spark function
+    """
+    query = parse(
+        """
+    select abs(-1)
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+    query = parse(
+        """
+    select abs(-1.1)
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore


### PR DESCRIPTION
### Summary

Adds type inference support for the `abs` function.

### Test Plan

Added a `test_abs` function.

- [x] PR has an associated issue: #544 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
