### PR TITLE
array_agg function

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1280,13 +1280,13 @@ def infer_type(  # noqa: F811
     return ct.ListType(element_type=element_type)
 
 
-class Array_Agg(Function):  # pylint: disable=abstract-method,disable=invalid-name
+class ArrayAgg(Function):  # pylint: disable=abstract-method,disable=invalid-name
     """
     Collects and returns a list of non-unique elements.
     """
 
 
-@Array_Agg.register  # type: ignore
+@ArrayAgg.register  # type: ignore
 def infer_type(  # noqa: F811
     *elements: ct.ColumnType,
 ) -> ct.ListType:

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1280,6 +1280,25 @@ def infer_type(  # noqa: F811
     return ct.ListType(element_type=element_type)
 
 
+class Array_Agg(Function):  # pylint: disable=abstract-method,disable=invalid-name
+    """
+    Collects and returns a list of non-unique elements.
+    """
+
+
+@Array_Agg.register  # type: ignore
+def infer_type(  # noqa: F811
+    *elements: ct.ColumnType,
+) -> ct.ListType:
+    types = {element.type for element in elements}
+    if len(types) > 1:  # pragma: no cover
+        raise DJParseException(
+            f"Multiple types {', '.join(sorted(str(typ) for typ in types))} passed to array.",
+        )
+    element_type = elements[0].type if elements else ct.NullType()
+    return ct.ListType(element_type=element_type)
+
+
 class Map(Function):  # pylint: disable=abstract-method
     """
     Returns a map of constants

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -369,3 +369,30 @@ def test_array_contains(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+def test_array_agg(session: Session):
+    """
+    Test the `array_agg` Spark function
+    """
+    query = parse(
+        """
+    SELECT array_agg(col) FROM (select 1 as col)
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
+
+    query = parse(
+        """
+    SELECT array_agg(col) FROM (select 'foo' as col)
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore


### PR DESCRIPTION
### Summary

This adds type inference for the array_agg spark function.

```sql
SELECT array_agg(col) as x FROM (select 1 as col)
/* type of column x is inferred as ListType(IntegerType()) */
```
```sql
SELECT array_agg(col) as x FROM (select 'foo' as col)
/* type of column x is inferred as ListType(StringType()) */
```

### Test Plan

Added a `test_array_agg` test.

- [x] PR has an associated issue: #544 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
