### PR TITLE
add array_append function

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1299,6 +1299,20 @@ def infer_type(  # noqa: F811
     return ct.ListType(element_type=element_type)
 
 
+class Array_Append(Function):  # pylint: disable=abstract-method,disable=invalid-name
+    """
+    Add the element at the end of the array passed as first argument
+    """
+
+
+@Array_Append.register  # type: ignore
+def infer_type(  # noqa: F811
+    array: ct.ListType,
+    item: ct.ColumnType,
+) -> ct.ListType:
+    return ct.ListType(element_type=item.type)
+
+
 class Map(Function):  # pylint: disable=abstract-method
     """
     Returns a map of constants

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1280,7 +1280,7 @@ def infer_type(  # noqa: F811
     return ct.ListType(element_type=element_type)
 
 
-class ArrayAgg(Function):  # pylint: disable=abstract-method,disable=invalid-name
+class ArrayAgg(Function):  # pylint: disable=abstract-method
     """
     Collects and returns a list of non-unique elements.
     """
@@ -1299,13 +1299,13 @@ def infer_type(  # noqa: F811
     return ct.ListType(element_type=element_type)
 
 
-class Array_Append(Function):  # pylint: disable=abstract-method,disable=invalid-name
+class ArrayAppend(Function):  # pylint: disable=abstract-method
     """
     Add the element at the end of the array passed as first argument
     """
 
 
-@Array_Append.register  # type: ignore
+@ArrayAppend.register  # type: ignore
 def infer_type(  # noqa: F811
     array: ct.ListType,
     item: ct.ColumnType,

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -396,3 +396,29 @@ def test_array_agg(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
+
+
+def test_array_append(session: Session):
+    """
+    Test the `array_append` Spark function
+    """
+    query = parse("SELECT array_append(array('b', 'd', 'c', 'a'), 'd')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
+
+    query = parse("SELECT array_append(array(1, 2, 3, 4), 5)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
+
+    query = parse("SELECT array_append(array(true, false, true, true), false)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.BooleanType())  # type: ignore


### PR DESCRIPTION
### Summary

This adds type inference for the `array_append` function.

```sql
SELECT array_append(array('b', 'd', 'c', 'a'), 'd')
/* inferred as ListType(StringType()) */
```

```sql
SELECT array_append(array(1, 2, 3, 4), 5)
/* inferred as ListType(IntegerType()) */
```

```sql
SELECT array_append(array(true, false, true, true), false)
/* inferred as ListType(BooleanType()) */
```

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #544 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
