### PR TITLE
Set primary key on all nodes in Python client

### DIFF
--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -192,10 +192,20 @@ class DJClient:  # pylint: disable=too-many-public-methods
         Retrieves a dimension node with that name if one exists.
         """
         node_dict = self.verify_node_exists(node_name, "dimension")
-        return Dimension(
+        dimension = Dimension(
             **node_dict,
             dj_client=self,
         )
+        dimension.primary_key = [
+            col["name"]
+            for col in node_dict["columns"]
+            if any(
+                attr["attribute_type"]["name"] == "primary_key"
+                for attr in col["attributes"]
+                if attr
+            )
+        ]
+        return dimension
 
     def new_dimension(  # pylint: disable=too-many-arguments
         self,

--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -122,10 +122,12 @@ class DJClient:  # pylint: disable=too-many-public-methods
         Retrieves a source node with that name if one exists.
         """
         node_dict = self.verify_node_exists(node_name, "source")
-        return Source(
+        node = Source(
             **node_dict,
             dj_client=self,
         )
+        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
+        return node
 
     def new_source(  # pylint: disable=too-many-arguments
         self,
@@ -160,10 +162,12 @@ class DJClient:  # pylint: disable=too-many-public-methods
         Retrieves a transform node with that name if one exists.
         """
         node_dict = self.verify_node_exists(node_name, "transform")
-        return Transform(
+        node = Transform(
             **node_dict,
             dj_client=self,
         )
+        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
+        return node
 
     def new_transform(  # pylint: disable=too-many-arguments
         self,
@@ -192,20 +196,12 @@ class DJClient:  # pylint: disable=too-many-public-methods
         Retrieves a dimension node with that name if one exists.
         """
         node_dict = self.verify_node_exists(node_name, "dimension")
-        dimension = Dimension(
+        node = Dimension(
             **node_dict,
             dj_client=self,
         )
-        dimension.primary_key = [
-            col["name"]
-            for col in node_dict["columns"]
-            if any(
-                attr["attribute_type"]["name"] == "primary_key"
-                for attr in col["attributes"]
-                if attr
-            )
-        ]
-        return dimension
+        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
+        return node
 
     def new_dimension(  # pylint: disable=too-many-arguments
         self,
@@ -234,10 +230,12 @@ class DJClient:  # pylint: disable=too-many-public-methods
         Retrieves a metric node with that name if one exists.
         """
         node_dict = self.verify_node_exists(node_name, "metric")
-        return Metric(
+        node = Metric(
             **node_dict,
             dj_client=self,
         )
+        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
+        return node
 
     def new_metric(  # pylint: disable=too-many-arguments
         self,
@@ -260,6 +258,21 @@ class DJClient:  # pylint: disable=too-many-public-methods
             primary_key=primary_key,
             query=query,
         )
+
+    @staticmethod
+    def primary_key_from_columns(columns) -> List[str]:
+        """
+        Extracts the primary key from the columns
+        """
+        return [
+            column["name"]
+            for column in columns
+            if any(
+                attr["attribute_type"]["name"] == "primary_key"
+                for attr in column["attributes"]
+                if attr
+            )
+        ]
 
     def cube(self, node_name: str) -> "Cube":  # pragma: no cover
         """

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -217,6 +217,7 @@ class TestDJClient:
         assert repair_order_dim.name == "default.repair_order"
         assert "FROM default.repair_orders" in repair_order_dim.query
         assert repair_order_dim.type == "dimension"
+        assert repair_order_dim.primary_key == ["repair_order_id"]
 
         # transforms
         result = client.namespace("default").transforms()

--- a/dj/api/nodes.py
+++ b/dj/api/nodes.py
@@ -1169,7 +1169,7 @@ def create_new_revision_from_existing(  # pylint: disable=too-many-locals
     pk_changes = (
         data is not None
         and data.primary_key
-        and {col.name for col in old_revision.primary_key()} != data.primary_key
+        and {col.name for col in old_revision.primary_key()} != set(data.primary_key)
     )
     major_changes = query_changes or column_changes or pk_changes
 


### PR DESCRIPTION
### Summary

In the Python client, we should set the `primary_key` attribute on each node type to reflect the columns that make up the primary key. For example:
```python
repair_order_dim = dj.dimension("default.repair_order")
repair_order_dim.primary_key  # should be set, currently empty
```

### Test Plan

Verified locally by running the client

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A