### PR TITLE
Replacing ApproxQuantile with ApproxPercentile

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -227,6 +227,34 @@ def infer_type(  # noqa: F811
     return merge.expr.type
 
 
+class ApproxPercentile(Function):  # pylint: disable=abstract-method
+    """
+    approx_percentile(col, percentage [, accuracy]) -
+    Returns the approximate percentile of the numeric or ansi interval
+    column col which is the smallest value in the ordered col values
+    """
+
+    is_aggregation = True
+
+
+@ApproxPercentile.register
+def infer_type(  # noqa: F811
+    col: ct.NumberType,
+    percentage: ct.ListType,
+    accuracy: Optional[ct.NumberType],
+) -> ct.DoubleType:
+    return ct.ListType(element_type=col.type)  # type: ignore
+
+
+@ApproxPercentile.register
+def infer_type(  # noqa: F811
+    col: ct.NumberType,
+    percentage: ct.FloatType,
+    accuracy: Optional[ct.NumberType],
+) -> ct.NumberType:
+    return col.type  # type: ignore
+
+
 class Avg(Function):  # pylint: disable=abstract-method
     """
     Computes the average of the input column or expression.
@@ -858,34 +886,6 @@ class Quantile(Function):  # pragma: no cover
         arg2: "Expression",
     ) -> ct.DoubleType:
         return ct.DoubleType()
-
-
-class ApproxPercentile(Function):  # pylint: disable=abstract-method
-    """
-    approx_percentile(col, percentage [, accuracy]) -
-    Returns the approximate percentile of the numeric or ansi interval
-    column col which is the smallest value in the ordered col values
-    """
-
-    is_aggregation = True
-
-
-@ApproxPercentile.register
-def infer_type(  # noqa: F811
-    col: ct.NumberType,
-    percentage: ct.ListType,
-    accuracy: Optional[ct.NumberType],
-) -> ct.DoubleType:
-    return ct.ListType(element_type=col.type)  # type: ignore
-
-
-@ApproxPercentile.register
-def infer_type(  # noqa: F811
-    col: ct.NumberType,
-    percentage: ct.FloatType,
-    accuracy: Optional[ct.NumberType],
-) -> ct.NumberType:
-    return col.type  # type: ignore
 
 
 class RegexpLike(Function):  # pragma: no cover

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -860,19 +860,32 @@ class Quantile(Function):  # pragma: no cover
         return ct.DoubleType()
 
 
-class ApproxQuantile(Function):  # pragma: no cover
+class ApproxPercentile(Function):
     """
-    Computes the approximate quantile of a numerical column or expression.
+    approx_percentile(col, percentage [, accuracy]) -
+    Returns the approximate percentile of the numeric or ansi interval
+    column col which is the smallest value in the ordered col values
     """
 
     is_aggregation = True
 
-    @staticmethod
-    def infer_type(  # type: ignore
-        arg1: "Expression",
-        arg2: "Expression",
-    ) -> ct.DoubleType:
-        return ct.DoubleType()
+
+@ApproxPercentile.register
+def infer_type(  # type: ignore
+    col: ct.NumberType,
+    percentage: ct.ListType,
+    accuracy: Optional[ct.NumberType],
+) -> ct.DoubleType:
+    return ct.ListType(element_type=col.type)  # type: ignore
+
+
+@ApproxPercentile.register
+def infer_type(  # type: ignore
+    col: ct.NumberType,
+    percentage: ct.FloatType,
+    accuracy: Optional[ct.NumberType],
+) -> ct.NumberType:
+    return col.type  # type: ignore
 
 
 class RegexpLike(Function):  # pragma: no cover

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -860,7 +860,7 @@ class Quantile(Function):  # pragma: no cover
         return ct.DoubleType()
 
 
-class ApproxPercentile(Function):
+class ApproxPercentile(Function):  # pylint: disable=abstract-method
     """
     approx_percentile(col, percentage [, accuracy]) -
     Returns the approximate percentile of the numeric or ansi interval
@@ -871,7 +871,7 @@ class ApproxPercentile(Function):
 
 
 @ApproxPercentile.register
-def infer_type(  # type: ignore
+def infer_type(  # noqa: F811
     col: ct.NumberType,
     percentage: ct.ListType,
     accuracy: Optional[ct.NumberType],
@@ -880,7 +880,7 @@ def infer_type(  # type: ignore
 
 
 @ApproxPercentile.register
-def infer_type(  # type: ignore
+def infer_type(  # noqa: F811
     col: ct.NumberType,
     percentage: ct.FloatType,
     accuracy: Optional[ct.NumberType],

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -426,7 +426,7 @@ def test_array_append(session: Session):
 
 def test_approx_percentile(session: Session):
     """
-    Test the `cardinality` Spark function
+    Test the `approx_percentile` Spark function
     """
     query_with_list = parse("SELECT approx_percentile(10.0, array(0.5, 0.4, 0.1), 100)")
     exc = DJException()

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -422,3 +422,22 @@ def test_array_append(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.BooleanType())  # type: ignore
+
+
+def test_approx_percentile(session: Session):
+    """
+    Test the `cardinality` Spark function
+    """
+    query_with_list = parse("SELECT approx_percentile(10.0, array(0.5, 0.4, 0.1), 100)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_list.compile(ctx)
+    assert not exc.errors
+    assert query_with_list.select.projection[0].type == ct.ListType(element_type=ct.FloatType())  # type: ignore
+
+    query_with_list = parse("SELECT approx_percentile(10.0, 0.5, 100)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_list.compile(ctx)
+    assert not exc.errors
+    assert query_with_list.select.projection[0].type == ct.FloatType()  # type: ignore


### PR DESCRIPTION
### Summary

It turns out that `approx_quantile` doesn't exist for Spark SQL. It does exist on PySpark as `approxQuantile`, but not as a Spark SQL function. Thus, this PR removes that and replaces it with `approx_percentile`. It also converts the type inference to follow the registration pattern.

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #544 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
