### PR TITLE
Netlify config file for deploying docs site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+# Helpful gist to see all available values
+# https://gist.github.com/DavidWells/43884f15aed7e4dcb3a6dad06430b756
+[build]
+  base = "docs/"
+  command = "./build-docs.sh 0.1.0 true $DEPLOY_URL"
+  publish = "docs/public"
+
+[build.environment]
+  HUGO_VERSION = "0.113.0"


### PR DESCRIPTION
### Summary

This adds a `netlify.toml` file that configures deployment settings for netlify. https://docs.netlify.com/configure-builds/file-based-configuration/

With this, we should be able to simply point Netlify to the repo and it will build, deploy, and host the docs site. We can add a custom domain to it later through the netlify settings page.

### Test Plan

N/A

- [x] PR has an associated issue: #556
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
