### PR TITLE
housekeeping: Functions

### DIFF
--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -328,20 +328,18 @@ def infer_type(
     return ct.ListType(element_type=item.type)
 
 
-class ArrayContains(
-    Function,
-):  # pragma: no cover
+class ArrayContains(Function):
     """
     array_contains(array, value) - Returns true if the array contains the value.
     """
 
 
 @ArrayContains.register
-def infer_type(  # pragma: no cover
+def infer_type(
     array: ct.ListType,
     element: ct.ColumnType,
 ) -> ct.BooleanType:
-    return ct.BooleanType()  # pragma: no cover
+    return ct.BooleanType()
 
 
 class ArrayDistinct(Function):
@@ -568,7 +566,7 @@ def infer_type(
     return ct.NullType()
 
 
-class CollectList(Function):  # pragma: no cover
+class CollectList(Function):
     """
     Collects and returns a list of non-unique elements.
     """
@@ -577,10 +575,10 @@ class CollectList(Function):  # pragma: no cover
 
 
 @CollectList.register
-def infer_type(  # pragma: no cover
+def infer_type(
     arg: ct.ColumnType,
 ) -> ct.ColumnType:
-    return ct.ListType(element_type=arg.type)  # pragma: no cover
+    return ct.ListType(element_type=arg.type)
 
 
 class Count(Function):
@@ -761,7 +759,7 @@ class Extract(Function):
         return ct.IntegerType()
 
 
-class First(Function):  # pragma: no cover
+class First(Function):
     """
     Returns the first value of expr for a group of rows. If isIgnoreNull is
     true, returns only non-null values.
@@ -771,18 +769,18 @@ class First(Function):  # pragma: no cover
 
 
 @First.register
-def infer_type(  # pragma: no cover
+def infer_type(
     arg: ct.ColumnType,
 ) -> ct.ColumnType:
-    return arg.type  # pragma: no cover
+    return arg.type
 
 
 @First.register
-def infer_type(  # pragma: no cover
+def infer_type(
     arg: ct.ColumnType,
     is_ignore_null: ct.BooleanType,
 ) -> ct.ColumnType:
-    return arg.type  # pragma: no cover
+    return arg.type
 
 
 class Floor(Function):
@@ -1088,13 +1086,8 @@ class PercentRank(Function):
 
 
 @PercentRank.register
-def infer_type() -> ct.DoubleType:
-    return ct.DoubleType()
-
-
-@PercentRank.register
 def infer_type(arg: ct.NumberType) -> ct.DoubleType:
-    return ct.DoubleType()  # pragma: no cover
+    return ct.DoubleType()
 
 
 class Pow(Function):
@@ -1125,7 +1118,7 @@ def infer_type(
     return ct.DoubleType()
 
 
-class RegexpLike(Function):  # pragma: no cover
+class RegexpLike(Function):
     """
     regexp_like(str, regexp) - Returns true if str matches regexp, or false otherwise
     """
@@ -1210,7 +1203,7 @@ def infer_type(arg: ct.NumberType) -> ct.DoubleType:
     return ct.DoubleType()
 
 
-class StddevPop(Function):  # pragma: no cover
+class StddevPop(Function):
     """
     Computes the population standard deviation of the input column or expression.
     """
@@ -1218,7 +1211,12 @@ class StddevPop(Function):  # pragma: no cover
     is_aggregation = True
 
 
-class StddevSamp(Function):  # pragma: no cover
+@StddevPop.register
+def infer_type(arg: ct.NumberType) -> ct.DoubleType:
+    return ct.DoubleType()
+
+
+class StddevSamp(Function):
     """
     Computes the sample standard deviation of the input column or expression.
     """
@@ -1245,20 +1243,20 @@ class Strpos(Function):
 
 
 @Strpos.register
-def infer_type(  # pragma: no cover
+def infer_type(
     string: ct.StringType,
     substring: ct.StringType,
 ) -> ct.IntegerType:
-    return ct.IntegerType()  # pragma: no cover
+    return ct.IntegerType()
 
 
 @Strpos.register
-def infer_type(  # pragma: no cover
+def infer_type(
     string: ct.StringType,
     substring: ct.StringType,
     instance: ct.IntegerType,
 ) -> ct.IntegerType:
-    return ct.IntegerType()  # pragma: no cover
+    return ct.IntegerType()
 
 
 class Substring(Function):
@@ -1371,17 +1369,18 @@ def infer_type(
     return ct.ListType(element_type=func.expr.type)
 
 
-class Trim(Function):  # pragma: no cover
+class Trim(Function):
     """
     Removes leading and trailing whitespace from a string value.
     """
 
-    @staticmethod
-    def infer_type(arg: "Expression") -> ct.StringType:
-        return ct.StringType()
+
+@Trim.register
+def infer_type(arg: ct.StringType) -> ct.StringType:
+    return ct.StringType()
 
 
-class Upper(Function):  # pragma: no cover
+class Upper(Function):
     """
     Converts a string value to uppercase.
     """
@@ -1392,7 +1391,7 @@ def infer_type(arg: ct.StringType) -> ct.StringType:
     return ct.StringType()
 
 
-class Variance(Function):  # pragma: no cover
+class Variance(Function):
     """
     Computes the sample variance of the input column or expression.
     """
@@ -1405,7 +1404,7 @@ def infer_type(arg: ct.NumberType) -> ct.DoubleType:
     return ct.DoubleType()
 
 
-class VarPop(Function):  # pragma: no cover
+class VarPop(Function):
     """
     Computes the population variance of the input column or expression.
     """

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -494,34 +494,34 @@ def infer_type(
     _target_scale: ct.IntegerType,
 ) -> ct.DecimalType:
     target_scale = _target_scale.value
-    if isinstance(args.type, ct.DecimalType):  # pragma: no cover
+    if isinstance(args.type, ct.DecimalType):
         precision = max(args.type.precision - args.type.scale + 1, -target_scale + 1)
         scale = min(args.type.scale, max(0, target_scale))
         return ct.DecimalType(precision, scale)
-    if args.type == ct.TinyIntType():  # pragma: no cover
+    if args.type == ct.TinyIntType():
         precision = max(3, -target_scale + 1)
         return ct.DecimalType(precision, 0)
-    if args.type == ct.SmallIntType():  # pragma: no cover
+    if args.type == ct.SmallIntType():
         precision = max(5, -target_scale + 1)
         return ct.DecimalType(precision, 0)
-    if args.type == ct.IntegerType():  # pragma: no cover
+    if args.type == ct.IntegerType():
         precision = max(10, -target_scale + 1)
         return ct.DecimalType(precision, 0)
-    if args.type == ct.BigIntType():  # pragma: no cover
+    if args.type == ct.BigIntType():
         precision = max(20, -target_scale + 1)
         return ct.DecimalType(precision, 0)
     if args.type == ct.FloatType():
         precision = max(14, -target_scale + 1)
         scale = min(7, max(0, target_scale))
         return ct.DecimalType(precision, scale)
-    if args.type == ct.DoubleType():  # pragma: no cover
+    if args.type == ct.DoubleType():
         precision = max(30, -target_scale + 1)
         scale = min(15, max(0, target_scale))
         return ct.DecimalType(precision, scale)
 
-    raise DJParseException(
+    raise DJParseException(  # pragma: no cover
         f"Unhandled numeric type in Ceil `{args.type}`",
-    )  # pragma: no cover
+    )
 
 
 @Ceil.register

--- a/dj/sql/functions.py
+++ b/dj/sql/functions.py
@@ -1401,7 +1401,7 @@ class Variance(Function):  # pragma: no cover
 
 
 @Variance.register
-def infer_type(arg: "Expression") -> ct.DoubleType:
+def infer_type(arg: ct.NumberType) -> ct.DoubleType:
     return ct.DoubleType()
 
 
@@ -1414,7 +1414,7 @@ class VarPop(Function):  # pragma: no cover
 
 
 @VarPop.register
-def infer_type(arg: "Expression") -> ct.DoubleType:
+def infer_type(arg: ct.NumberType) -> ct.DoubleType:
     return ct.DoubleType()
 
 

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -344,6 +344,7 @@ def test_infer_types_avg(construction_session: Session):
           AVG(CAST(id AS INTERVAL DAY TO SECOND)),
           STDDEV(id),
           stddev_samp(id),
+          stddev_pop(id),
           variance(id),
           var_pop(id)
         FROM dbt.source.jaffle_shop.customers
@@ -356,6 +357,7 @@ def test_infer_types_avg(construction_session: Session):
         DoubleType(),
         DecimalType(12, 10),
         DayTimeIntervalType(),
+        DoubleType(),
         DoubleType(),
         DoubleType(),
         DoubleType(),
@@ -379,7 +381,7 @@ def test_infer_types_min_max_sum_ceil(construction_session: Session):
           SUM(id) OVER
             (PARTITION BY first_name ORDER BY last_name),
           CEIL(id),
-          PERCENT_RANK() OVER (PARTITION BY id ORDER BY id)
+          PERCENT_RANK(id) OVER (PARTITION BY id ORDER BY id)
         FROM dbt.source.jaffle_shop.customers
     """,
     )

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -342,7 +342,10 @@ def test_infer_types_avg(construction_session: Session):
            (PARTITION BY first_name ORDER BY last_name),
           AVG(CAST(id AS DECIMAL(8, 6))),
           AVG(CAST(id AS INTERVAL DAY TO SECOND)),
-          STDDEV(id)
+          STDDEV(id),
+          stddev_samp(id),
+          variance(id),
+          var_pop(id)
         FROM dbt.source.jaffle_shop.customers
     """,
     )
@@ -353,6 +356,9 @@ def test_infer_types_avg(construction_session: Session):
         DoubleType(),
         DecimalType(12, 10),
         DayTimeIntervalType(),
+        DoubleType(),
+        DoubleType(),
+        DoubleType(),
         DoubleType(),
     ]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
@@ -528,6 +534,7 @@ def test_infer_types_exp(construction_session: Session):
           LOG2(2),
           LOG10(100),
           POW(1, 2),
+          POWER(1, 2),
           ROUND(1.2, 0),
           ROUND(1.2, -1),
           ROUND(CAST(1.233 AS DOUBLE), 1),
@@ -545,6 +552,7 @@ def test_infer_types_exp(construction_session: Session):
         BigIntType(),
         IntegerType(),
         IntegerType(),
+        DoubleType(),
         DoubleType(),
         DoubleType(),
         DoubleType(),

--- a/tests/construction/inference_test.py
+++ b/tests/construction/inference_test.py
@@ -26,7 +26,6 @@ from dj.sql.parsing.types import (
     StringType,
     TimestampType,
     TimeType,
-    TinyIntType,
 )
 
 
@@ -611,7 +610,6 @@ def test_infer_types_datetime(construction_session: Session):
         """
         SELECT
           CURRENT_DATE(),
-          CURRENT_DATETIME(),
           CURRENT_TIME(),
           CURRENT_TIMESTAMP(),
 
@@ -641,7 +639,6 @@ def test_infer_types_datetime(construction_session: Session):
     query.compile(ctx)
     types = [
         DateType(),
-        TimestampType(),
         TimeType(),
         TimestampType(),
         TimestampType(),
@@ -654,8 +651,8 @@ def test_infer_types_datetime(construction_session: Session):
         IntegerType(),
         DecimalType(precision=8, scale=6),
         IntegerType(),
-        TinyIntType(),
-        TinyIntType(),
-        TinyIntType(),
+        BigIntType(),
+        BigIntType(),
+        BigIntType(),
     ]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -35,94 +35,6 @@ from dj.sql.parsing.types import (
 )
 
 
-def test_count() -> None:
-    """
-    Test ``Count`` function.
-    """
-    assert (
-        Count.infer_type(ast.Column(ast.Name("x"), _type=WildcardType()))
-        == BigIntType()
-    )
-    assert Count.is_aggregation is True
-
-
-def test_min() -> None:
-    """
-    Test ``Min`` function.
-    """
-    assert (
-        Min.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == IntegerType()
-    )
-    assert Min.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
-    assert Min.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
-    assert Min.infer_type(
-        ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
-    ) == DecimalType(8, 6)
-    with pytest.raises(Exception):
-        Min.infer_type(  # pylint: disable=expression-not-assigned
-            ast.Column(ast.Name("x"), _type=StringType()),
-        ) == StringType()
-
-
-def test_max() -> None:
-    """
-    Test ``Max`` function.
-    """
-    assert (
-        Max.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == IntegerType()
-    )
-    assert Max.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
-    assert Max.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
-    assert Max.infer_type(
-        ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
-    ) == DecimalType(8, 6)
-    assert (
-        Max.infer_type(
-            ast.Column(ast.Name("x"), _type=StringType()),
-        )
-        == StringType()
-    )
-
-
-def test_now() -> None:
-    """
-    Test ``Now`` function.
-    """
-    assert Now.infer_type() == ct.TimestampType()
-
-
-def test_coalesce_infer_type() -> None:
-    """
-    Test type inference in the ``Coalesce`` function.
-    """
-    assert (
-        Coalesce.infer_type(
-            ast.Column(ast.Name("x"), _type=StringType()),
-            ast.Column(ast.Name("x"), _type=StringType()),
-            ast.Column(ast.Name("x"), _type=StringType()),
-        )
-        == StringType()
-    )
-
-    assert (
-        Coalesce.infer_type(
-            ast.Column(ast.Name("x"), _type=IntegerType()),
-            ast.Column(ast.Name("x"), _type=NullType()),
-            ast.Column(ast.Name("x"), _type=BigIntType()),
-        )
-        == IntegerType()
-    )
-
-    assert (
-        Coalesce.infer_type(
-            ast.Column(ast.Name("x"), _type=StringType()),
-            ast.Column(ast.Name("x"), _type=StringType()),
-            ast.Column(ast.Name("x"), _type=NullType()),
-        )
-        == StringType()
-    )
-
-
 def test_missing_functions() -> None:
     """
     Test missing functions.
@@ -139,38 +51,6 @@ def test_missing_functions() -> None:
     )
 
 
-def test_sum() -> None:
-    """
-    Test ``sum`` function.
-    """
-    assert (
-        Sum.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == BigIntType()
-    )
-    assert Sum.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == DoubleType()
-    assert Sum.infer_type(
-        ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
-    ) == DecimalType(18, 6)
-
-
-def test_avg() -> None:
-    """
-    Test ``avg`` function.
-    """
-    assert (
-        Avg.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == DoubleType()
-    )
-    assert Avg.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == DoubleType()
-
-
-def test_to_date() -> None:
-    """
-    Test ``to_date`` function.
-    """
-    assert (
-        ToDate.infer_type(ast.Column(ast.Name("x"), _type=StringType())) == DateType()
-    )
-
-
 def test_bad_combo_types() -> None:
     """
     Tests dispatch raises on bad types
@@ -178,212 +58,6 @@ def test_bad_combo_types() -> None:
     with pytest.raises(TypeError) as exc:
         Avg.infer_type(ast.Column(ast.Name("x"), _type=StringType()))
     assert "got an invalid combination of types" in str(exc)
-
-
-@pytest.mark.parametrize(
-    "types, expected",
-    [
-        ((ct.IntegerType(),), ct.BigIntType()),
-        ((ct.FloatType(),), ct.BigIntType()),
-        ((ct.DoubleType(),), ct.BigIntType()),
-        ((ct.TinyIntType(), ct.IntegerType()), ct.DecimalType(precision=3, scale=0)),
-        ((ct.SmallIntType(), ct.IntegerType()), ct.DecimalType(precision=5, scale=0)),
-        ((ct.IntegerType(), ct.IntegerType()), ct.DecimalType(precision=10, scale=0)),
-        ((ct.BigIntType(), ct.IntegerType()), ct.DecimalType(precision=20, scale=0)),
-        ((ct.DoubleType(), ct.IntegerType()), ct.DecimalType(precision=30, scale=0)),
-        ((ct.FloatType(), ct.IntegerType()), ct.DecimalType(precision=14, scale=0)),
-        (
-            (ct.DecimalType(10, 2), ct.IntegerType()),
-            ct.DecimalType(precision=9, scale=0),
-        ),
-        (
-            (ct.DecimalType(precision=9, scale=0),),
-            ct.DecimalType(precision=10, scale=0),
-        ),
-    ],
-)
-def test_ceil(types, expected) -> None:
-    """
-    Test ``ceil`` function.
-    """
-    if len(types) == 1:
-        assert F.Ceil.infer_type(ast.Column(ast.Name("x"), _type=types[0])) == expected
-    else:
-        assert (
-            F.Ceil.infer_type(
-                *(
-                    ast.Column(ast.Name("x"), _type=types[0]),
-                    ast.Number(0, _type=types[1]),
-                )
-            )
-            == expected
-        )
-
-
-@pytest.mark.parametrize(
-    "types, expected",
-    [
-        ((ct.IntegerType(),), ct.BigIntType()),
-        ((ct.FloatType(),), ct.BigIntType()),
-        ((ct.DoubleType(),), ct.BigIntType()),
-        ((ct.TinyIntType(), ct.IntegerType()), ct.DecimalType(precision=3, scale=0)),
-        ((ct.SmallIntType(), ct.IntegerType()), ct.DecimalType(precision=5, scale=0)),
-        ((ct.IntegerType(), ct.IntegerType()), ct.DecimalType(precision=10, scale=0)),
-        ((ct.BigIntType(), ct.IntegerType()), ct.DecimalType(precision=20, scale=0)),
-        ((ct.DoubleType(), ct.IntegerType()), ct.DecimalType(precision=30, scale=0)),
-        ((ct.FloatType(), ct.IntegerType()), ct.DecimalType(precision=14, scale=0)),
-        (
-            (ct.DecimalType(10, 2), ct.IntegerType()),
-            ct.DecimalType(precision=9, scale=0),
-        ),
-        (
-            (ct.DecimalType(precision=9, scale=0),),
-            ct.DecimalType(precision=10, scale=0),
-        ),
-    ],
-)
-def test_floor(types, expected) -> None:
-    """
-    Test ``floor`` function.
-    """
-    if len(types) == 1:
-        assert F.Floor.infer_type(ast.Column(ast.Name("x"), _type=types[0])) == expected
-    else:
-        assert (
-            F.Floor.infer_type(
-                *(
-                    ast.Column(ast.Name("x"), _type=types[0]),
-                    ast.Number(0, _type=types[1]),
-                )
-            )
-            == expected
-        )
-
-
-def test_aggregate(session: Session):
-    """
-    Test the `aggregate` Spark function
-    """
-    query = parse(
-        """
-    select
-      aggregate(items, '', (acc, x) -> (case
-        when acc = '' then element_at(split(x, '::'), 1)
-        when acc = 'a' then acc
-        else element_at(split(x, '::'), 1) end)) as item
-    from (
-      select 1 as id, ARRAY('b', 'c', 'a', 'x', 'g', 'z') AS items
-    )
-    """,
-    )
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert query.select.projection[0].type == StringType()  # type: ignore
-
-
-def test_ceil_func(session: Session):
-    """
-    Test the `ceil` function
-    """
-    query = parse("SELECT ceil(-0.1), ceil(5), ceil(3.1411, 3), ceil(3.1411, -3)")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert not exc.errors
-    assert query.select.projection[0].type == BigIntType()  # type: ignore
-    assert query.select.projection[1].type == BigIntType()  # type: ignore
-    assert query.select.projection[2].type == DecimalType(precision=14, scale=3)  # type: ignore
-    assert query.select.projection[3].type == DecimalType(precision=14, scale=0)  # type: ignore
-
-
-def test_collect_list(session: Session):
-    """
-    Test the `collect_list` function
-    """
-    query = parse("SELECT collect_list(col) FROM (SELECT (1), (2) AS col)")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert not exc.errors
-    assert query.select.projection[0].type == ct.ListType(  # type: ignore
-        element_type=ct.IntegerType(),
-    )
-
-
-def test_element_at(session: Session):
-    """
-    Test the `element_at` Spark function
-    """
-    query_with_array = parse("SELECT element_at(array(1, 2, 3, 4), 2)")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_array.compile(ctx)
-    assert not exc.errors
-    assert query_with_array.select.projection[0].type == IntegerType()  # type: ignore
-
-    query_with_map = parse("SELECT element_at(map(1, 'a', 2, 'b'), 2)")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_map.compile(ctx)
-    assert not exc.errors
-    assert query_with_map.select.projection[0].type == StringType()  # type: ignore
-
-
-def test_first(session: Session):
-    """
-    Test `first`
-    """
-    query = parse("SELECT first(col), first(col, true) FROM (SELECT (1), (2) AS col)")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert not exc.errors
-    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
-    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
-
-
-def test_split(session: Session):
-    """
-    Test the `split` Spark function
-    """
-    query = parse("SELECT split('oneAtwoBthreeC', '[ABC]')")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert not exc.errors
-    assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
-
-
-def test_trim(session: Session):
-    """
-    Test `trim`
-    """
-    query = parse("SELECT trim('    lmgi   ')")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert not exc.errors
-    assert query.select.projection[0].type == ct.StringType()  # type: ignore
-
-
-def test_cardinality(session: Session):
-    """
-    Test the `cardinality` Spark function
-    """
-    query_with_list = parse("SELECT cardinality(array('b', 'd', 'c', 'a'))")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_list.compile(ctx)
-    assert not exc.errors
-    assert query_with_list.select.projection[0].type == ct.IntegerType()  # type: ignore
-
-    query_with_map = parse("SELECT cardinality(map('a', 1, 'b', 2))")
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_map.compile(ctx)
-    assert not exc.errors
-    assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
 def test_abs(session: Session):
@@ -411,6 +85,28 @@ def test_abs(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+
+
+def test_aggregate(session: Session):
+    """
+    Test the `aggregate` Spark function
+    """
+    query = parse(
+        """
+    select
+      aggregate(items, '', (acc, x) -> (case
+        when acc = '' then element_at(split(x, '::'), 1)
+        when acc = 'a' then acc
+        else element_at(split(x, '::'), 1) end)) as item
+    from (
+      select 1 as id, ARRAY('b', 'c', 'a', 'x', 'g', 'z') AS items
+    )
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert query.select.projection[0].type == StringType()  # type: ignore
 
 
 def test_approx_percentile(session: Session):
@@ -603,6 +299,264 @@ def test_array_join(session: Session):
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
+def test_avg() -> None:
+    """
+    Test ``avg`` function.
+    """
+    assert (
+        Avg.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == DoubleType()
+    )
+    assert Avg.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == DoubleType()
+
+
+def test_cardinality(session: Session):
+    """
+    Test the `cardinality` Spark function
+    """
+    query_with_list = parse("SELECT cardinality(array('b', 'd', 'c', 'a'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_list.compile(ctx)
+    assert not exc.errors
+    assert query_with_list.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+    query_with_map = parse("SELECT cardinality(map('a', 1, 'b', 2))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_map.compile(ctx)
+    assert not exc.errors
+    assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "types, expected",
+    [
+        ((ct.IntegerType(),), ct.BigIntType()),
+        ((ct.FloatType(),), ct.BigIntType()),
+        ((ct.DoubleType(),), ct.BigIntType()),
+        ((ct.TinyIntType(), ct.IntegerType()), ct.DecimalType(precision=3, scale=0)),
+        ((ct.SmallIntType(), ct.IntegerType()), ct.DecimalType(precision=5, scale=0)),
+        ((ct.IntegerType(), ct.IntegerType()), ct.DecimalType(precision=10, scale=0)),
+        ((ct.BigIntType(), ct.IntegerType()), ct.DecimalType(precision=20, scale=0)),
+        ((ct.DoubleType(), ct.IntegerType()), ct.DecimalType(precision=30, scale=0)),
+        ((ct.FloatType(), ct.IntegerType()), ct.DecimalType(precision=14, scale=0)),
+        (
+            (ct.DecimalType(10, 2), ct.IntegerType()),
+            ct.DecimalType(precision=9, scale=0),
+        ),
+        (
+            (ct.DecimalType(precision=9, scale=0),),
+            ct.DecimalType(precision=10, scale=0),
+        ),
+    ],
+)
+def test_ceil(types, expected) -> None:
+    """
+    Test ``ceil`` function.
+    """
+    if len(types) == 1:
+        assert F.Ceil.infer_type(ast.Column(ast.Name("x"), _type=types[0])) == expected
+    else:
+        assert (
+            F.Ceil.infer_type(
+                *(
+                    ast.Column(ast.Name("x"), _type=types[0]),
+                    ast.Number(0, _type=types[1]),
+                )
+            )
+            == expected
+        )
+
+
+def test_ceil_func(session: Session):
+    """
+    Test the `ceil` function
+    """
+    query = parse("SELECT ceil(-0.1), ceil(5), ceil(3.1411, 3), ceil(3.1411, -3)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == BigIntType()  # type: ignore
+    assert query.select.projection[1].type == BigIntType()  # type: ignore
+    assert query.select.projection[2].type == DecimalType(precision=14, scale=3)  # type: ignore
+    assert query.select.projection[3].type == DecimalType(precision=14, scale=0)  # type: ignore
+
+
+def test_coalesce_infer_type() -> None:
+    """
+    Test type inference in the ``Coalesce`` function.
+    """
+    assert (
+        Coalesce.infer_type(
+            ast.Column(ast.Name("x"), _type=StringType()),
+            ast.Column(ast.Name("x"), _type=StringType()),
+            ast.Column(ast.Name("x"), _type=StringType()),
+        )
+        == StringType()
+    )
+
+    assert (
+        Coalesce.infer_type(
+            ast.Column(ast.Name("x"), _type=IntegerType()),
+            ast.Column(ast.Name("x"), _type=NullType()),
+            ast.Column(ast.Name("x"), _type=BigIntType()),
+        )
+        == IntegerType()
+    )
+
+    assert (
+        Coalesce.infer_type(
+            ast.Column(ast.Name("x"), _type=StringType()),
+            ast.Column(ast.Name("x"), _type=StringType()),
+            ast.Column(ast.Name("x"), _type=NullType()),
+        )
+        == StringType()
+    )
+
+
+def test_collect_list(session: Session):
+    """
+    Test the `collect_list` function
+    """
+    query = parse("SELECT collect_list(col) FROM (SELECT (1), (2) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(  # type: ignore
+        element_type=ct.IntegerType(),
+    )
+
+
+def test_count() -> None:
+    """
+    Test ``Count`` function.
+    """
+    assert (
+        Count.infer_type(ast.Column(ast.Name("x"), _type=WildcardType()))
+        == BigIntType()
+    )
+    assert Count.is_aggregation is True
+
+
+def test_element_at(session: Session):
+    """
+    Test the `element_at` Spark function
+    """
+    query_with_array = parse("SELECT element_at(array(1, 2, 3, 4), 2)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_array.compile(ctx)
+    assert not exc.errors
+    assert query_with_array.select.projection[0].type == IntegerType()  # type: ignore
+
+    query_with_map = parse("SELECT element_at(map(1, 'a', 2, 'b'), 2)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query_with_map.compile(ctx)
+    assert not exc.errors
+    assert query_with_map.select.projection[0].type == StringType()  # type: ignore
+
+
+def test_first(session: Session):
+    """
+    Test `first`
+    """
+    query = parse("SELECT first(col), first(col, true) FROM (SELECT (1), (2) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "types, expected",
+    [
+        ((ct.IntegerType(),), ct.BigIntType()),
+        ((ct.FloatType(),), ct.BigIntType()),
+        ((ct.DoubleType(),), ct.BigIntType()),
+        ((ct.TinyIntType(), ct.IntegerType()), ct.DecimalType(precision=3, scale=0)),
+        ((ct.SmallIntType(), ct.IntegerType()), ct.DecimalType(precision=5, scale=0)),
+        ((ct.IntegerType(), ct.IntegerType()), ct.DecimalType(precision=10, scale=0)),
+        ((ct.BigIntType(), ct.IntegerType()), ct.DecimalType(precision=20, scale=0)),
+        ((ct.DoubleType(), ct.IntegerType()), ct.DecimalType(precision=30, scale=0)),
+        ((ct.FloatType(), ct.IntegerType()), ct.DecimalType(precision=14, scale=0)),
+        (
+            (ct.DecimalType(10, 2), ct.IntegerType()),
+            ct.DecimalType(precision=9, scale=0),
+        ),
+        (
+            (ct.DecimalType(precision=9, scale=0),),
+            ct.DecimalType(precision=10, scale=0),
+        ),
+    ],
+)
+def test_floor(types, expected) -> None:
+    """
+    Test ``floor`` function.
+    """
+    if len(types) == 1:
+        assert F.Floor.infer_type(ast.Column(ast.Name("x"), _type=types[0])) == expected
+    else:
+        assert (
+            F.Floor.infer_type(
+                *(
+                    ast.Column(ast.Name("x"), _type=types[0]),
+                    ast.Number(0, _type=types[1]),
+                )
+            )
+            == expected
+        )
+
+
+def test_max() -> None:
+    """
+    Test ``Max`` function.
+    """
+    assert (
+        Max.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == IntegerType()
+    )
+    assert Max.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
+    assert Max.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
+    assert Max.infer_type(
+        ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
+    ) == DecimalType(8, 6)
+    assert (
+        Max.infer_type(
+            ast.Column(ast.Name("x"), _type=StringType()),
+        )
+        == StringType()
+    )
+
+
+def test_min() -> None:
+    """
+    Test ``Min`` function.
+    """
+    assert (
+        Min.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == IntegerType()
+    )
+    assert Min.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
+    assert Min.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
+    assert Min.infer_type(
+        ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
+    ) == DecimalType(8, 6)
+    with pytest.raises(Exception):
+        Min.infer_type(  # pylint: disable=expression-not-assigned
+            ast.Column(ast.Name("x"), _type=StringType()),
+        ) == StringType()
+
+
+def test_now() -> None:
+    """
+    Test ``Now`` function.
+    """
+    assert Now.infer_type() == ct.TimestampType()
+
+
 def test_regexp_like(session: Session):
     """
     Test `regexp_like`
@@ -615,6 +569,18 @@ def test_regexp_like(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+def test_split(session: Session):
+    """
+    Test the `split` Spark function
+    """
+    query = parse("SELECT split('oneAtwoBthreeC', '[ABC]')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
 def test_strpos(session: Session):
@@ -643,6 +609,19 @@ def test_substring(session: Session):
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
+def test_sum() -> None:
+    """
+    Test ``sum`` function.
+    """
+    assert (
+        Sum.infer_type(ast.Column(ast.Name("x"), _type=IntegerType())) == BigIntType()
+    )
+    assert Sum.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == DoubleType()
+    assert Sum.infer_type(
+        ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
+    ) == DecimalType(18, 6)
+
+
 def test_transform(session: Session):
     """
     Test the `transform` Spark function
@@ -664,6 +643,27 @@ def test_transform(session: Session):
     ctx = ast.CompileContext(session=session, exception=DJException())
     query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
+
+
+def test_to_date() -> None:
+    """
+    Test ``to_date`` function.
+    """
+    assert (
+        ToDate.infer_type(ast.Column(ast.Name("x"), _type=StringType())) == DateType()
+    )
+
+
+def test_trim(session: Session):
+    """
+    Test `trim`
+    """
+    query = parse("SELECT trim('    lmgi   ')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
 def test_upper(session: Session):

--- a/tests/sql/functions_test.py
+++ b/tests/sql/functions_test.py
@@ -297,6 +297,20 @@ def test_ceil_func(session: Session):
     assert query.select.projection[3].type == DecimalType(precision=14, scale=0)  # type: ignore
 
 
+def test_collect_list(session: Session):
+    """
+    Test the `collect_list` function
+    """
+    query = parse("SELECT collect_list(col) FROM (SELECT (1), (2) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(  # type: ignore
+        element_type=ct.IntegerType(),
+    )
+
+
 def test_element_at(session: Session):
     """
     Test the `element_at` Spark function
@@ -316,6 +330,19 @@ def test_element_at(session: Session):
     assert query_with_map.select.projection[0].type == StringType()  # type: ignore
 
 
+def test_first(session: Session):
+    """
+    Test `first`
+    """
+    query = parse("SELECT first(col), first(col, true) FROM (SELECT (1), (2) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
 def test_split(session: Session):
     """
     Test the `split` Spark function
@@ -326,6 +353,18 @@ def test_split(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
+
+
+def test_trim(session: Session):
+    """
+    Test `trim`
+    """
+    query = parse("SELECT trim('    lmgi   ')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
 def test_cardinality(session: Session):

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,7 @@ commands =
     pip install -e .[testing]
     coverage run --source dj --parallel-mode -m pytest {posargs} --without-integration --without-slow-integration
     coverage html --fail-under 100 -d test-reports/{envname}/coverage-html
+
+[flake8]
+per-file-ignores =
+    dj/sql/functions.py:F811


### PR DESCRIPTION
### Summary

Several housekeeping changes for functions:
* Rearranged the functions in `dj/sql/functions.py` to be in alphabetical order.
* Removed several lint ignore statements littered through the file and added them to the top of the file (and `tox.ini` for `flake8`)
* Removed some functions that don't exist in any dialect of SQL (ex: `TsOrDiToDi`).
* Added more test coverage for existing functions

### Test Plan

Added more unit tests

- [X] PR has an associated issue: #553 
- [X] `make check` passes
- [X] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
