### PR TITLE
Add convenience urls to README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: (^docs/|^openapi/|^client/python/|^client/javascript/|^dj/sql/parsing/backends/grammar/generated|^djqs|^djui|^djrs)
+exclude: (^docs/|^openapi/|^client/python/|^client/javascript/|^dj/sql/parsing/backends/grammar/generated|^djqs|^djui|^djrs|^README.md)
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ DataJunction reflection service specifications, use the `demo` profile.
 docker compose --profile demo up
 ```
 
+DJUI: [http://localhost:3000/](http://localhost:3000/)  
+DJ Swagger Docs: [http://localhost:8000/docs](http://localhost:8000/docs)  
+DJQS Swagger Docs: [http://localhost:8001/docs](http://localhost:8001/docs)  
+Jaeger UI: [http://localhost:16686/search](http://localhost:16686/search)  
+Jupyter Lab: [http://localhost:8888](http://localhost:8888)  
+
 ## How does this work?
 
 At its core, DJ stores metrics and their upstream abstractions as interconnected nodes.


### PR DESCRIPTION
### Summary

This adds a few convenience urls to the README.

DJUI: [http://localhost:3000/](http://localhost:3000/)  
DJ Swagger Docs: [http://localhost:8000/docs](http://localhost:8000/docs)  
DJQS Swagger Docs: [http://localhost:8001/docs](http://localhost:8001/docs)  
Jaeger UI: [http://localhost:16686/search](http://localhost:16686/search)  
Jupyter Lab: [http://localhost:8888](http://localhost:8888)  