### PR TITLE
Bugfix, dimension parsing now that type is included

### DIFF
--- a/djui/src/app/pages/NodePage/NodeSQLTab.jsx
+++ b/djui/src/app/pages/NodePage/NodeSQLTab.jsx
@@ -28,7 +28,7 @@ const NodeSQLTab = djNode => {
   const dimensionsList = djNode.djNode.dimensions
     ? djNode.djNode.dimensions.map(dim => ({
         value: dim.name,
-        label: dim.name + `, (${dim.type})`,
+        label: dim.name + ` (${dim.type})`,
       }))
     : [''];
 

--- a/djui/src/app/pages/NodePage/NodeSQLTab.jsx
+++ b/djui/src/app/pages/NodePage/NodeSQLTab.jsx
@@ -27,8 +27,8 @@ const NodeSQLTab = djNode => {
 
   const dimensionsList = djNode.djNode.dimensions
     ? djNode.djNode.dimensions.map(dim => ({
-        value: dim,
-        label: dim,
+        value: dim.name,
+        label: dim.name + `, (${dim.type})`,
       }))
     : [''];
 


### PR DESCRIPTION
### Summary

This is a small bugfix in the UI. Now that dimensions return a type we have to pull out the name from the object.

https://github.com/DataJunction/dj/assets/43911210/b32f5d70-4248-4bd5-bc4e-419f16620fee


### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage
