### PR TITLE
simplify PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,4 @@
 
 <!-- What's this change about? -->
 
-### Test Plan
-
-<!-- How did you test your change? -->
-
 - [ ] PR has an associated issue: #
-- [ ] `make check` passes
-- [ ] `make test` shows 100% unit test coverage
-
-### Deployment Plan
-
-<!-- Any special instructions around deployment? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 
 <!-- What's this change about? -->
 
-- [ ] PR has an associated issue: #
+- [ ] Associated issue: #


### PR DESCRIPTION
### Summary

I feel like most times I don't have anything meaningful to add to the `Test Plan` and `Deployment Plan` sections. Also, having to check the boxes that make check passes and make test passes seems redundant since GitHub already shows the green checkmark or red x on the PR page or in the PR list. What does everyone think of removing those parts in favor of a simpler PR template that asks for a summary and a link to an associated issue?
