### PR TITLE
dimension parsing bugfix in graph tab

### DIFF
--- a/djui/src/app/components/djgraph/DJNode.jsx
+++ b/djui/src/app/components/djgraph/DJNode.jsx
@@ -83,8 +83,8 @@ export function DJNode({ id, data }) {
   const dimensionsRenderer = dimensions =>
     dimensions.map(dim => (
       <tr>
-        <a href={`/nodes/${dim.substring(0, dim.lastIndexOf('.'))}`}>
-          <td>{dim}</td>
+        <a href={`/nodes/${dim.name.substring(0, dim.name.lastIndexOf('.'))}`}>
+          <td>{dim.name}</td>
         </a>
       </tr>
     ));


### PR DESCRIPTION
### Summary

This is a small bugfix from the new change that includes dimension types. In the graph tab the object was used but the `name` attribute needed to be pulled out.

### Test Plan

`docker compose up`

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
