### PR TITLE
Add list materializations endpoint and refactor of models

### DIFF
--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -630,7 +630,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
                 f"Error retrieving data: {response.text}",
             )
 
-    def upsert_materialization_config(
+    def upsert_materialization(
         self,
         node_name: str,
         config: models.MaterializationConfig,
@@ -675,7 +675,7 @@ class Node(ClientEntity):
     availability: Optional[Dict]
     tags: Optional[List[models.Tag]]
     primary_key: Optional[List[str]]
-    materialization_configs: Optional[List[Dict[str, Any]]]
+    materializations: Optional[List[Dict[str, Any]]]
     version: Optional[str]
 
     def save(self, mode: models.NodeMode = models.NodeMode.PUBLISHED):
@@ -726,12 +726,12 @@ class Node(ClientEntity):
         self.sync()
         return link_response
 
-    def add_materialization_config(self, config: models.MaterializationConfig):
+    def add_materialization(self, config: models.MaterializationConfig):
         """
-        Adds a materialization config for the node. This will not work for source nodes
+        Adds a materialization for the node. This will not work for source nodes
         as they don't need to be materialized.
         """
-        upsert_response = self.dj_client.upsert_materialization_config(
+        upsert_response = self.dj_client.upsert_materialization(
             self.name,
             config,
         )

--- a/client/python/tests/conftest.py
+++ b/client/python/tests/conftest.py
@@ -14,7 +14,7 @@ from dj.config import Settings
 from dj.models.materialization import (
     DruidMaterializationInput,
     GenericMaterializationInput,
-    MaterializationOutput,
+    MaterializationInfo,
 )
 from dj.models.query import QueryCreate, QueryWithResults
 from dj.service_clients import QueryServiceClient
@@ -98,19 +98,26 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         mock_submit_query,
     )
 
-    # def mock_materialize(
-    #     materialization_input: Union[GenericMaterializationInput, DruidMaterializationInput],
-    # ) -> MaterializationOutput:
-    #     return MaterializationOutput(
-    #         urls=["http://fake.url/job"],
-    #     )
-
     mock_materialize = MagicMock()
-    mock_materialize.return_value = MaterializationOutput(urls=["http://fake.url/job"])
+    mock_materialize.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=["common.a", "common.b"],
+    )
     mocker.patch.object(
         qs_client,
         "materialize",
         mock_materialize,
+    )
+
+    mock_get_materialization_info = MagicMock()
+    mock_get_materialization_info.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=["common.a", "common.b"],
+    )
+    mocker.patch.object(
+        qs_client,
+        "get_materialization_info",
+        mock_get_materialization_info,
     )
     yield qs_client
 

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -364,7 +364,7 @@ class TestDJClient:
             in client.namespace("default").transforms()
         )
 
-        result = large_revenue_payments_only.add_materialization_config(
+        result = large_revenue_payments_only.add_materialization(
             MaterializationConfig(
                 engine=Engine(name="spark", version="3.1.1"),
                 schedule="0 * * * *",

--- a/datajunction-server/alembic/versions/2023_06_14_0925-807eacf892a8_rename_materialization_config.py
+++ b/datajunction-server/alembic/versions/2023_06_14_0925-807eacf892a8_rename_materialization_config.py
@@ -1,0 +1,28 @@
+"""Rename materialization config
+
+Revision ID: 807eacf892a8
+Revises: 07aa35bab455
+Create Date: 2023-06-14 09:25:34.860520+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+from sqlalchemy.dialects import sqlite
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "807eacf892a8"
+down_revision = "07aa35bab455"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("materializationconfig", "materialization")
+
+
+def downgrade():
+    op.rename_table("materialization", "materializationconfig")

--- a/datajunction-server/dj/api/nodes.py
+++ b/datajunction-server/dj/api/nodes.py
@@ -51,8 +51,18 @@ from dj.models.cube import Measure
 from dj.models.engine import Dialect, Engine
 from dj.models.history import ActivityType, EntityType, History
 from dj.models.materialization import (
+    DruidConf,
+    DruidCubeConfig,
+    GenericCubeConfig,
+    GenericMaterializationConfig,
+    Materialization,
     MaterializationConfigInfoUnified,
     MaterializationInfo,
+    Partition,
+    PartitionType,
+    SparkConf,
+    UpsertCubeMaterializationConfig,
+    UpsertMaterializationConfig,
 )
 from dj.models.node import (
     DEFAULT_DRAFT_VERSION,
@@ -61,11 +71,6 @@ from dj.models.node import (
     CreateCubeNode,
     CreateNode,
     CreateSourceNode,
-    DruidConf,
-    DruidCubeConfig,
-    GenericCubeConfig,
-    GenericMaterializationConfig,
-    MaterializationConfig,
     MissingParent,
     Node,
     NodeMode,
@@ -76,12 +81,7 @@ from dj.models.node import (
     NodeStatus,
     NodeType,
     NodeValidation,
-    Partition,
-    PartitionType,
-    SparkConf,
     UpdateNode,
-    UpsertCubeMaterializationConfig,
-    UpsertMaterializationConfig,
 )
 from dj.service_clients import QueryServiceClient
 from dj.sql.parsing import ast
@@ -485,7 +485,7 @@ def filters_from_partitions(partitions: List[Partition]):
 
 
 @router.post("/nodes/{name}/materialization/", status_code=201)
-def upsert_a_materialization_config(  # pylint: disable=too-many-locals
+def upsert_a_materialization(  # pylint: disable=too-many-locals
     name: str,
     data: UpsertMaterializationConfig,
     *,
@@ -493,7 +493,7 @@ def upsert_a_materialization_config(  # pylint: disable=too-many-locals
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
 ) -> JSONResponse:
     """
-    Update materialization config of the specified node. If a name is specified
+    Add or update a materialization of the specified node. If a name is specified
     for the materialization config, it will always update that named config.
     """
     node = get_node_by_name(session, name, with_current=True)
@@ -539,7 +539,7 @@ def upsert_a_materialization_config(  # pylint: disable=too-many-locals
         # can copy over the default cube setup and layer on specific config as needed
         default_job = [
             conf
-            for conf in current_revision.materialization_configs
+            for conf in current_revision.materializations
             if conf.job == DefaultCubeMaterialization.__name__
         ][0]
         default_job_config = GenericCubeConfig.parse_obj(default_job.config)
@@ -576,29 +576,29 @@ def upsert_a_materialization_config(  # pylint: disable=too-many-locals
                 },
             )
 
-    materialization_config_name = GenericMaterializationConfig.parse_obj(
+    materialization_name = GenericMaterializationConfig.parse_obj(
         data.config,
     ).identifier()
 
-    # Check to see if a config for this engine already exists with the exact same config
-    existing_config_for_engine = [
-        config
-        for config in current_revision.materialization_configs
-        if config.name == materialization_config_name
+    # Check to see if a materialization for this engine already exists with the exact same config
+    existing_materialization_for_engine = [
+        materialization
+        for materialization in current_revision.materializations
+        if materialization.name == materialization_name
     ]
     if (
-        existing_config_for_engine
-        and existing_config_for_engine[0].config == data.config
+        existing_materialization_for_engine
+        and existing_materialization_for_engine[0].config == data.config
     ):
         existing_materialization_info = query_service_client.get_materialization_info(
             name,
-            materialization_config_name,
+            materialization_name,
         )
         return JSONResponse(
             status_code=HTTPStatus.CREATED,
             content={
                 "message": (
-                    f"The same materialization config with name `{materialization_config_name}`"
+                    f"The same materialization config with name `{materialization_name}`"
                     f"already exists for node `{name}` so no update was performed."
                 ),
                 "info": existing_materialization_info.dict(),
@@ -608,10 +608,10 @@ def upsert_a_materialization_config(  # pylint: disable=too-many-locals
     # If changes are detected, save the new materialization config
     unchanged_existing_configs = [
         config
-        for config in current_revision.materialization_configs
-        if config.name != materialization_config_name
+        for config in current_revision.materializations
+        if config.name != materialization_name
     ]
-    new_config = MaterializationConfig(
+    new_config = Materialization(
         name=GenericMaterializationConfig.parse_obj(data.config).identifier(),
         node_revision=current_revision,
         engine=engine,
@@ -619,7 +619,7 @@ def upsert_a_materialization_config(  # pylint: disable=too-many-locals
         schedule=data.schedule or "@daily",
         job=materialization_job_from_engine(engine).__name__,  # type: ignore
     )
-    current_revision.materialization_configs = unchanged_existing_configs + [  # type: ignore
+    current_revision.materializations = unchanged_existing_configs + [  # type: ignore
         new_config,
     ]
 
@@ -660,7 +660,7 @@ def list_node_materializations(
     """
     node = get_node_by_name(session, node_name, with_current=True)
     materializations = []
-    for materialization in node.current.materialization_configs:
+    for materialization in node.current.materializations:
         info = query_service_client.get_materialization_info(
             node_name,
             materialization.name,
@@ -884,40 +884,40 @@ def create_cube_node_revision(  # pylint: disable=too-many-locals
     )
 
     # If a materialization was configured, set it up for the cube
-    node_revision.materialization_configs = []
-    default_materialization_config = UpsertCubeMaterializationConfig(
+    node_revision.materializations = []
+    default_materialization = UpsertCubeMaterializationConfig(
         name="placeholder",
         engine=node_revision.catalog.engines[0],  # pylint: disable=no-member
         schedule="@daily",
         config={},
         job="CubeMaterializationJob",
     )
-    for materialization_config in data.materialization_configs or [
-        default_materialization_config,
+    for materialization in data.materializations or [
+        default_materialization,
     ]:
         engine = get_engine(
             session,
-            name=materialization_config.engine.name,
-            version=materialization_config.engine.version,
+            name=materialization.engine.name,
+            version=materialization.engine.version,
         )
         cube_custom_config = build_cube_config(
             node_revision,
-            materialization_config.config.dict(),
+            materialization.config.dict(),
             combined_ast,
         )
-        new_config = MaterializationConfig(
-            name=materialization_config.name or cube_custom_config.identifier(),
+        new_materialization = Materialization(
+            name=materialization.name or cube_custom_config.identifier(),
             node_revision=node_revision,
             engine=engine,
             config=cube_custom_config.dict(),
-            schedule=materialization_config.schedule,
+            schedule=materialization.schedule,
             job=(
                 DefaultCubeMaterialization.__name__
                 if not isinstance(cube_custom_config, DruidCubeConfig)
                 else DruidCubeMaterializationJob.__name__
             ),
         )
-        node_revision.materialization_configs.append(new_config)
+        node_revision.materializations.append(new_materialization)
     return node_revision
 
 
@@ -1141,14 +1141,14 @@ def create_a_cube(
 
     # Schedule materialization jobs, if any
     schedule_materialization_jobs(
-        node_revision.materialization_configs,
+        node_revision.materializations,
         query_service_client,
     )
     return node  # type: ignore
 
 
 def schedule_materialization_jobs(
-    materialization_configs: List[MaterializationConfig],
+    materializations: List[Materialization],
     query_service_client: QueryServiceClient,
 ) -> Dict[str, MaterializationInfo]:
     """
@@ -1158,7 +1158,7 @@ def schedule_materialization_jobs(
         cls.__name__: cls for cls in MaterializationJob.__subclasses__()
     }
     materialization_to_output = {}
-    for materialization in materialization_configs:
+    for materialization in materializations:
         clazz = materialization_jobs.get(materialization.job)
         if clazz and materialization.name:  # pragma: no cover
             materialization_to_output[materialization.name] = clazz().schedule(  # type: ignore
@@ -1328,7 +1328,7 @@ def create_new_revision_from_existing(  # pylint: disable=too-many-locals
         table=old_revision.table,
         parents=[],
         mode=data.mode if data and data.mode else old_revision.mode,
-        materialization_configs=old_revision.materialization_configs,
+        materializations=old_revision.materializations,
     )
 
     # Link the new revision to its parents if the query has changed

--- a/datajunction-server/dj/config.py
+++ b/datajunction-server/dj/config.py
@@ -28,7 +28,7 @@ class Settings(
     cors_origin_whitelist: List[str] = ["http://localhost:3000"]
 
     # SQLAlchemy URI for the metadata database.
-    index: str = "sqlite:///dj.db?check_same_thread=False"  #
+    index: str = "sqlite:///dj.db?check_same_thread=False"
 
     # Directory where the repository lives. This should have 2 subdirectories, "nodes" and
     # "databases".

--- a/datajunction-server/dj/config.py
+++ b/datajunction-server/dj/config.py
@@ -28,7 +28,7 @@ class Settings(
     cors_origin_whitelist: List[str] = ["http://localhost:3000"]
 
     # SQLAlchemy URI for the metadata database.
-    index: str = "sqlite:///dj.db?check_same_thread=False"
+    index: str = "sqlite:///dj.db?check_same_thread=False"  #
 
     # Directory where the repository lives. This should have 2 subdirectories, "nodes" and
     # "databases".

--- a/datajunction-server/dj/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/dj/materialization/jobs/cube_materialization.py
@@ -6,7 +6,7 @@ from typing import Dict
 from dj.errors import DJException
 from dj.materialization.jobs.materialization_job import MaterializationJob
 from dj.models.engine import Dialect
-from dj.models.materialization import DruidMaterializationInput, MaterializationOutput
+from dj.models.materialization import DruidMaterializationInput, MaterializationInfo
 from dj.models.node import DruidCubeConfig, MaterializationConfig, PartitionType
 from dj.service_clients import QueryServiceClient
 
@@ -128,7 +128,7 @@ class DruidCubeMaterializationJob(MaterializationJob):
         self,
         materialization: MaterializationConfig,
         query_service_client: QueryServiceClient,
-    ) -> MaterializationOutput:
+    ) -> MaterializationInfo:
         """
         Use the query service to kick off the materialization setup.
         """

--- a/datajunction-server/dj/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/dj/materialization/jobs/cube_materialization.py
@@ -6,8 +6,13 @@ from typing import Dict
 from dj.errors import DJException
 from dj.materialization.jobs.materialization_job import MaterializationJob
 from dj.models.engine import Dialect
-from dj.models.materialization import DruidMaterializationInput, MaterializationInfo
-from dj.models.node import DruidCubeConfig, MaterializationConfig, PartitionType
+from dj.models.materialization import (
+    DruidCubeConfig,
+    DruidMaterializationInput,
+    Materialization,
+    MaterializationInfo,
+    PartitionType,
+)
 from dj.service_clients import QueryServiceClient
 
 DRUID_AGG_MAPPING = {
@@ -36,7 +41,7 @@ class DefaultCubeMaterialization(
 
     def schedule(
         self,
-        materialization: MaterializationConfig,
+        materialization: Materialization,
         query_service_client: QueryServiceClient,
     ):
         """
@@ -126,7 +131,7 @@ class DruidCubeMaterializationJob(MaterializationJob):
 
     def schedule(
         self,
-        materialization: MaterializationConfig,
+        materialization: Materialization,
         query_service_client: QueryServiceClient,
     ) -> MaterializationInfo:
         """

--- a/datajunction-server/dj/materialization/jobs/materialization_job.py
+++ b/datajunction-server/dj/materialization/jobs/materialization_job.py
@@ -5,7 +5,7 @@ import abc
 from typing import Optional
 
 from dj.models.engine import Dialect
-from dj.models.materialization import GenericMaterializationInput, MaterializationOutput
+from dj.models.materialization import GenericMaterializationInput, MaterializationInfo
 from dj.models.node import GenericMaterializationConfig, MaterializationConfig
 from dj.service_clients import QueryServiceClient
 
@@ -25,7 +25,7 @@ class MaterializationJob(abc.ABC):  # pylint: disable=too-few-public-methods
         self,
         materialization: MaterializationConfig,
         query_service_client: QueryServiceClient,
-    ) -> MaterializationOutput:
+    ) -> MaterializationInfo:
         """
         Schedules the materialization job, typically done by calling a separate service
         with the configured materialization parameters.
@@ -45,7 +45,7 @@ class TrinoMaterializationJob(  # pylint: disable=too-few-public-methods # pragm
         self,
         materialization: MaterializationConfig,
         query_service_client: QueryServiceClient,
-    ) -> MaterializationOutput:
+    ) -> MaterializationInfo:
         """
         Placeholder for the actual implementation.
         """
@@ -64,12 +64,12 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
         self,
         materialization: MaterializationConfig,
         query_service_client: QueryServiceClient,
-    ) -> MaterializationOutput:
+    ) -> MaterializationInfo:
         """
         Placeholder for the actual implementation.
         """
         generic_config = GenericMaterializationConfig.parse_obj(materialization.config)
-        return query_service_client.materialize(
+        result = query_service_client.materialize(
             GenericMaterializationInput(
                 name=materialization.name,  # type: ignore
                 node_name=materialization.node_revision.name,
@@ -83,3 +83,4 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
                 ],
             ),
         )
+        return result

--- a/datajunction-server/dj/materialization/jobs/materialization_job.py
+++ b/datajunction-server/dj/materialization/jobs/materialization_job.py
@@ -5,8 +5,12 @@ import abc
 from typing import Optional
 
 from dj.models.engine import Dialect
-from dj.models.materialization import GenericMaterializationInput, MaterializationInfo
-from dj.models.node import GenericMaterializationConfig, MaterializationConfig
+from dj.models.materialization import (
+    GenericMaterializationConfig,
+    GenericMaterializationInput,
+    Materialization,
+    MaterializationInfo,
+)
 from dj.service_clients import QueryServiceClient
 
 
@@ -23,7 +27,7 @@ class MaterializationJob(abc.ABC):  # pylint: disable=too-few-public-methods
     @abc.abstractmethod
     def schedule(
         self,
-        materialization: MaterializationConfig,
+        materialization: Materialization,
         query_service_client: QueryServiceClient,
     ) -> MaterializationInfo:
         """
@@ -43,7 +47,7 @@ class TrinoMaterializationJob(  # pylint: disable=too-few-public-methods # pragm
 
     def schedule(
         self,
-        materialization: MaterializationConfig,
+        materialization: Materialization,
         query_service_client: QueryServiceClient,
     ) -> MaterializationInfo:
         """
@@ -62,7 +66,7 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
 
     def schedule(
         self,
-        materialization: MaterializationConfig,
+        materialization: Materialization,
         query_service_client: QueryServiceClient,
     ) -> MaterializationInfo:
         """

--- a/datajunction-server/dj/models/cube.py
+++ b/datajunction-server/dj/models/cube.py
@@ -7,12 +7,8 @@ from typing import List, Optional
 from pydantic import Field, root_validator
 from sqlmodel import SQLModel
 
-from dj.models.node import (
-    AvailabilityState,
-    ColumnOutput,
-    MaterializationConfigOutput,
-    NodeType,
-)
+from dj.models.materialization import MaterializationConfigOutput
+from dj.models.node import AvailabilityState, ColumnOutput, NodeType
 from dj.typing import UTCDatetime
 
 

--- a/datajunction-server/dj/models/cube.py
+++ b/datajunction-server/dj/models/cube.py
@@ -65,7 +65,7 @@ class CubeRevisionMetadata(SQLModel):
     query: str
     columns: List[ColumnOutput]
     updated_at: UTCDatetime
-    materialization_configs: List[MaterializationConfigOutput]
+    materializations: List[MaterializationConfigOutput]
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         allow_population_by_field_name = True

--- a/datajunction-server/dj/models/materialization.py
+++ b/datajunction-server/dj/models/materialization.py
@@ -2,6 +2,9 @@
 from typing import Dict, List, Optional
 
 from pydantic import AnyHttpUrl, BaseModel
+from sqlmodel import SQLModel
+
+from dj.models.engine import EngineInfo
 
 
 class GenericMaterializationInput(BaseModel):
@@ -29,10 +32,32 @@ class DruidMaterializationInput(GenericMaterializationInput):
     druid_spec: Dict
 
 
-class MaterializationOutput(BaseModel):
+class MaterializationInfo(BaseModel):
     """
     The output when calling the query service's materialization
     API endpoint for a cube node.
     """
 
+    output_tables: List[str]
     urls: List[AnyHttpUrl]
+
+
+class MaterializationConfigOutput(SQLModel):
+    """
+    Output for materialization config.
+    """
+
+    name: Optional[str]
+    engine: EngineInfo
+    config: Dict
+    schedule: str
+    job: str
+
+
+class MaterializationConfigInfoUnified(
+    MaterializationInfo,
+    MaterializationConfigOutput,
+):
+    """
+    Materialization config + info
+    """

--- a/datajunction-server/dj/models/materialization.py
+++ b/datajunction-server/dj/models/materialization.py
@@ -1,10 +1,19 @@
 """Models for materialization"""
-from typing import Dict, List, Optional
+import enum
+import zlib
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from pydantic import AnyHttpUrl, BaseModel
-from sqlmodel import SQLModel
+from sqlalchemy import JSON
+from sqlalchemy import Column as SqlaColumn
+from sqlalchemy import String
+from sqlmodel import Field, Relationship, SQLModel
 
-from dj.models.engine import EngineInfo
+from dj.models.base import BaseSQLModel
+from dj.models.engine import Engine, EngineInfo, EngineRef
+
+if TYPE_CHECKING:
+    from dj.models import NodeRevision
 
 
 class GenericMaterializationInput(BaseModel):
@@ -61,3 +70,169 @@ class MaterializationConfigInfoUnified(
     """
     Materialization config + info
     """
+
+
+class UpsertMaterializationConfig(BaseSQLModel):
+    """
+    An upsert object for materialization configs
+    """
+
+    name: Optional[str]
+    engine: EngineRef
+    config: Dict
+    schedule: str
+
+
+class SparkConf(BaseSQLModel):
+    """Spark configuration"""
+
+    __root__: Dict[str, str]
+
+
+class PartitionType(str, enum.Enum):
+    """
+    Partition type.
+
+    A partition can be temporal or categorical
+    """
+
+    TEMPORAL = "temporal"
+    CATEGORICAL = "categorical"
+
+
+class Partition(BaseSQLModel):
+    """
+    A partition specification tells the ongoing and backfill materialization jobs how to partition
+    the materialized dataset and which partition values (a list or range of values) to operate on.
+    Partitions may be temporal or categorical and will be handled differently depending on the type.
+
+    For temporal partition types, the ongoing materialization job will continue to operate on the
+    latest partitions and the partition values specified by `values` and `range` are only relevant
+    to the backfill job.
+
+    Examples:
+        This will tell DJ to backfill for all values of the dateint partition:
+          Partition(name=“dateint”, type="temporal", values=[], range=())
+        This will tell DJ to backfill just 20230601 and 20230605:
+          Partition(name=“dateint”, type="temporal", values=[20230601, 20230605], range=())
+        This will tell DJ to backfill 20230601 and between 20220101 and 20230101:
+          Partition(name=“dateint”, type="temporal", values=[20230601], range=(20220101, 20230101))
+
+        For categorical partition types, the ongoing materialization job will *only* operate on the
+        specified partition values in `values` and `range`:
+            Partition(name=“group_id”, type="categorical", values=["a", "b", "c"], range=())
+    """
+
+    name: str
+    values: Optional[List]
+    range: Optional[List]
+
+    # This expression evaluates to the temporal partition value for scheduled runs
+    expression: Optional[str]
+
+    type_: PartitionType
+
+
+class GenericMaterializationConfig(BaseModel):
+    """
+    Generic node materialization config needed by any materialization choices
+    and engine combinations
+    """
+
+    query: Optional[str]
+
+    # List of partitions that materialization jobs (ongoing and backfill) will operate on.
+    partitions: Optional[List[Partition]]
+
+    spark: Optional[SparkConf]
+    upstream_tables: Optional[List[str]]
+
+    def identifier(self) -> str:
+        """
+        Generates an identifier for this materialization config that is used by default
+        for the materialization config's name if one is not set. Note that this name is
+        based on partition names (both temporal and categorical) and partition values
+        (only categorical).
+        """
+        entities = ["default"] if not self.partitions else []
+        partitions_values = ""
+        if self.partitions:
+            for partition in self.partitions:
+                if partition.type_ != PartitionType.TEMPORAL:
+                    if partition.values:
+                        partitions_values += str(partition.values)
+                    if partition.range is not None:  # pragma: no cover
+                        partitions_values += str(partition.range)
+                entities.append(partition.name)
+            entities.append(str(zlib.crc32(partitions_values.encode("utf-8"))))
+        return "_".join(entities)
+
+
+class Materialization(BaseSQLModel, table=True):  # type: ignore
+    """
+    Materialization configured for a node.
+    """
+
+    node_revision_id: int = Field(foreign_key="noderevision.id", primary_key=True)
+    node_revision: "NodeRevision" = Relationship(
+        back_populates="materializations",
+    )
+
+    engine_id: int = Field(foreign_key="engine.id", primary_key=True)
+    engine: Engine = Relationship()
+
+    name: Optional[str] = Field(primary_key=True)
+
+    # A cron schedule to materialize this node by
+    schedule: str
+
+    # Arbitrary config relevant to the materialization engine
+    config: Dict = Field(default={}, sa_column=SqlaColumn(JSON))
+
+    # The name of the plugin that handles materialization, if any
+    job: str = Field(
+        default="MaterializationJob",
+        sa_column=SqlaColumn("job", String),
+    )
+
+
+class DruidConf(BaseSQLModel):
+    """Druid configuration"""
+
+    granularity: str
+    intervals: Optional[List[str]]
+    timestamp_column: str
+    timestamp_format: Optional[str]
+    parse_spec_format: Optional[str]
+
+
+class GenericCubeConfig(GenericMaterializationConfig):
+    """
+    Generic cube materialization config needed by any materialization
+    choices and engine combinations
+    """
+
+    dimensions: Optional[List[str]]
+    measures: Optional[Dict[str, List[Dict[str, str]]]]
+
+
+class DruidCubeConfig(GenericCubeConfig):
+    """
+    Specific cube materialization implementation with Spark and Druid ingestion and
+    optional prefix and/or suffix to include with the materialized entity's name.
+    """
+
+    prefix: Optional[str] = ""
+    suffix: Optional[str] = ""
+    druid: Optional[DruidConf]
+
+
+class UpsertCubeMaterializationConfig(BaseSQLModel):
+    """
+    An upsert object for cube materialization configs
+    """
+
+    name: Optional[str]
+    engine: EngineRef
+    config: Union[DruidCubeConfig, GenericCubeConfig]
+    schedule: str

--- a/datajunction-server/dj/models/node.py
+++ b/datajunction-server/dj/models/node.py
@@ -24,7 +24,8 @@ from dj.models.base import BaseSQLModel, NodeColumns, generate_display_name
 from dj.models.catalog import Catalog
 from dj.models.column import Column, ColumnYAML
 from dj.models.database import Database
-from dj.models.engine import Dialect, Engine, EngineInfo, EngineRef
+from dj.models.engine import Dialect, Engine, EngineRef
+from dj.models.materialization import MaterializationConfigOutput
 from dj.models.tag import Tag, TagNodeRelationship
 from dj.sql.parsing.types import ColumnType
 from dj.typing import UTCDatetime
@@ -932,18 +933,6 @@ class TableOutput(SQLModel):
     schema_: Optional[str]
     table: Optional[str]
     database: Optional[Database]
-
-
-class MaterializationConfigOutput(SQLModel):
-    """
-    Output for materialization config.
-    """
-
-    name: Optional[str]
-    engine: EngineInfo
-    config: Dict
-    schedule: str
-    job: str
 
 
 class NodeRevisionOutput(SQLModel):

--- a/datajunction-server/dj/models/node.py
+++ b/datajunction-server/dj/models/node.py
@@ -3,11 +3,10 @@ Model for nodes.
 """
 # pylint: disable=too-many-instance-attributes
 import enum
-import zlib
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import partial
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Extra
 from pydantic import Field as PydanticField
@@ -24,8 +23,12 @@ from dj.models.base import BaseSQLModel, NodeColumns, generate_display_name
 from dj.models.catalog import Catalog
 from dj.models.column import Column, ColumnYAML
 from dj.models.database import Database
-from dj.models.engine import Dialect, Engine, EngineRef
-from dj.models.materialization import MaterializationConfigOutput
+from dj.models.engine import Dialect
+from dj.models.materialization import (
+    Materialization,
+    MaterializationConfigOutput,
+    UpsertCubeMaterializationConfig,
+)
 from dj.models.tag import Tag, TagNodeRelationship
 from dj.sql.parsing.types import ColumnType
 from dj.typing import UTCDatetime
@@ -333,34 +336,6 @@ class Node(NodeBase, table=True):  # type: ignore
         return hash(self.id)
 
 
-class MaterializationConfig(BaseSQLModel, table=True):  # type: ignore
-    """
-    Materialization configuration for a node and specific engines.
-    """
-
-    node_revision_id: int = Field(foreign_key="noderevision.id", primary_key=True)
-    node_revision: "NodeRevision" = Relationship(
-        back_populates="materialization_configs",
-    )
-
-    engine_id: int = Field(foreign_key="engine.id", primary_key=True)
-    engine: Engine = Relationship()
-
-    name: Optional[str] = Field(primary_key=True)
-
-    # A cron schedule to materialize this node by
-    schedule: str
-
-    # Arbitrary config relevant to the materialization engine
-    config: Dict = Field(default={}, sa_column=SqlaColumn(JSON))
-
-    # The name of the plugin that handles materialization, if any
-    job: str = Field(
-        default="MaterializationJob",
-        sa_column=SqlaColumn("job", String),
-    )
-
-
 class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
     """
     A node revision.
@@ -441,7 +416,7 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
 
     # Nodes of type SOURCE will not have this property as their materialization
     # is not managed as a part of this service
-    materialization_configs: List[MaterializationConfig] = Relationship(
+    materializations: List[Materialization] = Relationship(
         back_populates="node_revision",
         sa_relationship_kwargs={
             "cascade": "all, delete-orphan",
@@ -730,150 +705,12 @@ class CreateSourceNode(ImmutableNodeFields, MutableNodeFields, SourceNodeFields)
     """
 
 
-class UpsertMaterializationConfig(BaseSQLModel):
-    """
-    An upsert object for materialization configs
-    """
-
-    name: Optional[str]
-    engine: EngineRef
-    config: Dict
-    schedule: str
-
-
-class SparkConf(BaseSQLModel):
-    """Spark configuration"""
-
-    __root__: Dict[str, str]
-
-
-class PartitionType(str, enum.Enum):
-    """
-    Partition type.
-
-    A partition can be temporal or categorical
-    """
-
-    TEMPORAL = "temporal"
-    CATEGORICAL = "categorical"
-
-
-class Partition(BaseSQLModel):
-    """
-    A partition specification tells the ongoing and backfill materialization jobs how to partition
-    the materialized dataset and which partition values (a list or range of values) to operate on.
-    Partitions may be temporal or categorical and will be handled differently depending on the type.
-
-    For temporal partition types, the ongoing materialization job will continue to operate on the
-    latest partitions and the partition values specified by `values` and `range` are only relevant
-    to the backfill job.
-
-    Examples:
-        This will tell DJ to backfill for all values of the dateint partition:
-          Partition(name=“dateint”, type="temporal", values=[], range=())
-        This will tell DJ to backfill just 20230601 and 20230605:
-          Partition(name=“dateint”, type="temporal", values=[20230601, 20230605], range=())
-        This will tell DJ to backfill 20230601 and between 20220101 and 20230101:
-          Partition(name=“dateint”, type="temporal", values=[20230601], range=(20220101, 20230101))
-
-        For categorical partition types, the ongoing materialization job will *only* operate on the
-        specified partition values in `values` and `range`:
-            Partition(name=“group_id”, type="categorical", values=["a", "b", "c"], range=())
-    """
-
-    name: str
-    values: Optional[List]
-    range: Optional[List]
-
-    # This expression evaluates to the temporal partition value for scheduled runs
-    expression: Optional[str]
-
-    type_: PartitionType
-
-
-class GenericMaterializationConfig(BaseModel):
-    """
-    Generic node materialization config needed by any materialization choices
-    and engine combinations
-    """
-
-    query: Optional[str]
-
-    # List of partitions that materialization jobs (ongoing and backfill) will operate on.
-    partitions: Optional[List[Partition]]
-
-    spark: Optional[SparkConf]
-    upstream_tables: Optional[List[str]]
-
-    def identifier(self) -> str:
-        """
-        Generates an identifier for this materialization config that is used by default
-        for the materialization config's name if one is not set. Note that this name is
-        based on partition names (both temporal and categorical) and partition values
-        (only categorical).
-        """
-        entities = ["default"] if not self.partitions else []
-        partitions_values = ""
-        if self.partitions:
-            for partition in self.partitions:
-                if partition.type_ != PartitionType.TEMPORAL:
-                    if partition.values:
-                        partitions_values += str(partition.values)
-                    if partition.range is not None:  # pragma: no cover
-                        partitions_values += str(partition.range)
-                entities.append(partition.name)
-            entities.append(str(zlib.crc32(partitions_values.encode("utf-8"))))
-        return "_".join(entities)
-
-
-class DruidConf(BaseSQLModel):
-    """Druid configuration"""
-
-    granularity: str
-    intervals: Optional[List[str]]
-    timestamp_column: str
-    timestamp_format: Optional[str]
-    parse_spec_format: Optional[str]
-
-
-class GenericCubeConfig(GenericMaterializationConfig):
-    """
-    Generic cube materialization config needed by any materialization
-    choices and engine combinations
-    """
-
-    dimensions: Optional[List[str]]
-    measures: Optional[Dict[str, List[Dict[str, str]]]]
-
-
-class DruidCubeConfig(GenericCubeConfig):
-    """
-    Specific cube materialization implementation with Spark and Druid ingestion and
-    optional prefix and/or suffix to include with the materialized entity's name.
-    """
-
-    prefix: Optional[str] = ""
-    suffix: Optional[str] = ""
-    druid: Optional[DruidConf]
-
-
-class UpsertCubeMaterializationConfig(BaseSQLModel):
-    """
-    An upsert object for cube materialization configs
-    """
-
-    name: Optional[str]
-    engine: EngineRef
-    config: Union[DruidCubeConfig, GenericCubeConfig]
-    schedule: str
-
-
 class CreateCubeNode(ImmutableNodeFields, CubeNodeFields):
     """
     A create object for cube nodes
     """
 
-    materialization_configs: Optional[List[UpsertCubeMaterializationConfig]] = []
+    materializations: Optional[List[UpsertCubeMaterializationConfig]] = []
 
 
 class UpdateNode(MutableNodeFields, SourceNodeFields):
@@ -956,7 +793,7 @@ class NodeRevisionOutput(SQLModel):
     availability: Optional[AvailabilityState] = None
     columns: List[ColumnOutput]
     updated_at: UTCDatetime
-    materialization_configs: List[MaterializationConfigOutput]
+    materializations: List[MaterializationConfigOutput]
     parents: List[NodeNameOutput]
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -231,7 +231,7 @@ def test_create_cube_with_materialization(client_with_query_service: TestClient)
             "description": "Cube of various metrics related to repairs",
             "mode": "published",
             "name": "default.repairs_cube_with_materialization",
-            "materialization_configs": [
+            "materializations": [
                 {
                     "engine": {
                         "name": "druid",
@@ -259,8 +259,7 @@ def test_create_cube_with_materialization(client_with_query_service: TestClient)
             ],
         },
     )
-    print("response.json()", response.json())
-    default_materialization = response.json()["materialization_configs"][0]
+    default_materialization = response.json()["materializations"][0]
     assert default_materialization["job"] == "DruidCubeMaterializationJob"
     assert default_materialization["schedule"] == "0 * * * *"
 
@@ -785,11 +784,11 @@ FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discou
 
     """
     assert compare_query_strings(
-        data["materialization_configs"][0]["config"]["query"],
+        data["materializations"][0]["config"]["query"],
         expected_materialization_query,
     )
-    assert data["materialization_configs"][0]["job"] == "DefaultCubeMaterialization"
-    assert data["materialization_configs"][0]["config"]["measures"] == {
+    assert data["materializations"][0]["job"] == "DefaultCubeMaterialization"
+    assert data["materializations"][0]["config"]["measures"] == {
         "default_DOT_avg_repair_price": [
             {
                 "name": "price_count",
@@ -1014,11 +1013,11 @@ def test_add_materialization_config_to_cube(
         },
     }
     response = client_with_repairs_cube.get("/nodes/default.repairs_cube/")
-    materialization_configs = response.json()["materialization_configs"]
-    assert len(materialization_configs) == 2
+    materializations = response.json()["materializations"]
+    assert len(materializations) == 2
     druid_materialization = [
         materialization
-        for materialization in materialization_configs
+        for materialization in materializations
         if materialization["engine"]["name"] == "druid"
     ][0]
     assert druid_materialization["engine"] == {

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1377,6 +1377,36 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             "`country_3491792861` for node `basic.transform.country_agg`"
         )
 
+        # Setting it again should inform that it already exists
+        response = client_with_query_service.post(
+            "/nodes/basic.transform.country_agg/materialization/",
+            json={
+                "engine": {
+                    "name": "spark",
+                    "version": "2.4.4",
+                },
+                "config": {
+                    "partitions": [
+                        {
+                            "name": "country",
+                            "values": ["DE", "MY"],
+                            "type_": "categorical",
+                        },
+                    ],
+                },
+                "schedule": "0 * * * *",
+            },
+        )
+        assert response.json() == {
+            "info": {
+                "output_tables": ["common.a", "common.b"],
+                "urls": ["http://fake.url/job"],
+            },
+            "message": "The same materialization config with name "
+            "`country_3491792861`already exists for node "
+            "`basic.transform.country_agg` so no update was performed.",
+        }
+
         # Setting the materialization config without partitions should succeed
         response = client_with_query_service.post(
             "/nodes/basic.transform.country_agg/materialization/",
@@ -1543,6 +1573,70 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
                 },
                 "schedule": "0 * * * *",
                 "job": "SparkSqlMaterializationJob",
+            },
+        ]
+
+        # Check listing materializations of the node
+        response = client_with_query_service.get(
+            "/nodes/default.hard_hat/materializations/",
+        )
+        assert response.json() == [
+            {
+                "config": {
+                    "partitions": [
+                        {
+                            "expression": None,
+                            "name": "country",
+                            "range": None,
+                            "type_": "categorical",
+                            "values": ["DE", "MY"],
+                        },
+                        {
+                            "expression": None,
+                            "name": "birth_date",
+                            "range": [20010101, 20020101],
+                            "type_": "temporal",
+                            "values": None,
+                        },
+                        {
+                            "expression": None,
+                            "name": "contractor_id",
+                            "range": [1, 10],
+                            "type_": "categorical",
+                            "values": None,
+                        },
+                    ],
+                    "query": "SELECT  default_DOT_hard_hats.address,\n"
+                    "\tdefault_DOT_hard_hats.birth_date,\n"
+                    "\tdefault_DOT_hard_hats.city,\n"
+                    "\tdefault_DOT_hard_hats.contractor_id,\n"
+                    "\tdefault_DOT_hard_hats.country,\n"
+                    "\tdefault_DOT_hard_hats.first_name,\n"
+                    "\tdefault_DOT_hard_hats.hard_hat_id,\n"
+                    "\tdefault_DOT_hard_hats.hire_date,\n"
+                    "\tdefault_DOT_hard_hats.last_name,\n"
+                    "\tdefault_DOT_hard_hats.manager,\n"
+                    "\tdefault_DOT_hard_hats.postal_code,\n"
+                    "\tdefault_DOT_hard_hats.state,\n"
+                    "\tdefault_DOT_hard_hats.title \n"
+                    " FROM roads.hard_hats AS default_DOT_hard_hats \n"
+                    " WHERE  default_DOT_hard_hats.country IN ('DE', 'MY') "
+                    "AND default_DOT_hard_hats.contractor_id BETWEEN 1 AND "
+                    "10\n",
+                    "spark": {},
+                    "upstream_tables": ["default.roads.hard_hats"],
+                },
+                "engine": {
+                    "dialect": "spark",
+                    "name": "spark",
+                    "uri": None,
+                    "version": "2.4.4",
+                },
+                "job": "SparkSqlMaterializationJob",
+                "name": "country_birth_date_contractor_id_379232101",
+                "output_tables": ["common.a", "common.b"],
+                "schedule": "0 * * * *",
+                "urls": ["http://fake.url/job"],
             },
         ]
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1349,7 +1349,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get("/nodes/basic.transform.country_agg/")
         old_node_data = response.json()
         assert old_node_data["version"] == "v1.0"
-        assert old_node_data["materialization_configs"] == []
+        assert old_node_data["materializations"] == []
 
         # Setting the materialization config should succeed
         response = client_with_query_service.post(
@@ -1431,7 +1431,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get("/nodes/basic.transform.country_agg/")
         data = response.json()
         assert data["version"] == "v1.0"
-        assert data["materialization_configs"] == [
+        assert data["materializations"] == [
             {
                 "name": "country_3491792861",
                 "engine": {
@@ -1525,7 +1525,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get("/nodes/default.hard_hat/")
         data = response.json()
         assert data["version"] == "v1.0"
-        assert data["materialization_configs"] == [
+        assert data["materializations"] == [
             {
                 "name": "country_birth_date_contractor_id_379232101",
                 "engine": {

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -21,7 +21,7 @@ from dj.models import Column, Engine
 from dj.models.materialization import (
     DruidMaterializationInput,
     GenericMaterializationInput,
-    MaterializationOutput,
+    MaterializationInfo,
 )
 from dj.models.query import QueryCreate
 from dj.service_clients import QueryServiceClient
@@ -114,11 +114,25 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
     #     )
 
     mock_materialize = MagicMock()
-    mock_materialize.return_value = MaterializationOutput(urls=["http://fake.url/job"])
+    mock_materialize.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=["common.a", "common.b"],
+    )
     mocker.patch.object(
         qs_client,
         "materialize",
         mock_materialize,
+    )
+
+    mock_get_materialization_info = MagicMock()
+    mock_get_materialization_info.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=["common.a", "common.b"],
+    )
+    mocker.patch.object(
+        qs_client,
+        "get_materialization_info",
+        mock_get_materialization_info,
     )
     yield qs_client
 

--- a/datajunction-server/tests/models/materialization_test.py
+++ b/datajunction-server/tests/models/materialization_test.py
@@ -1,5 +1,5 @@
 """Tests materialization-related models."""
-from dj.models.node import GenericMaterializationConfig, Partition
+from dj.models.materialization import GenericMaterializationConfig, Partition
 
 
 def test_generic_materialization_config():


### PR DESCRIPTION
### Summary

* Added an endpoint `GET /nodes/{node_name}/materializations/` that lists materializations and scheduling info (like urls, output tables etc) for a given node
* Renamed `MaterializationConfig` to `Materialization`. The former ended up being quite confusing since there is also a `config` field under the entity, and the latter is shorter as well.
* Moved all the models relevant to materialization to a separate `models/materialization.py` module, as `models/node.py` was getting very long

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: https://github.com/DataJunction/dj/issues/528
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
