### PR TITLE
Fix orderby building

### DIFF
--- a/client/python/tests/examples.py
+++ b/client/python/tests/examples.py
@@ -1116,21 +1116,18 @@ QUERY_DATA_MAPPINGS: Dict[str, Union[DJException, QueryWithResults]] = {
             "errors": [],
         }
     ),
-    """
-    WITHm0_default_DOT_avg_repair_priceAS(SELECTavg(default_DOT_repair_order_details.price
-    )ASdefault_DOT_avg_repair_price,\tdefault_DOT_hard_hat.stateFROMroads.
-    repair_order_detailsASdefault_DOT_repair_order_detailsLEFTOUTERJOIN(SELECT
-    default_DOT_repair_orders.dispatcher_id,\tdefault_DOT_repair_orders.hard_hat_id,\t
-    default_DOT_repair_orders.municipality_id,\tdefault_DOT_repair_orders.repair_order_id
-    FROMroads.repair_ordersASdefault_DOT_repair_orders)ASdefault_DOT_repair_orderON
-    default_DOT_repair_order_details.repair_order_id=default_DOT_repair_order.
-    repair_order_idLEFTOUTERJOIN(SELECTdefault_DOT_hard_hats.hard_hat_id,\t
-    default_DOT_hard_hats.stateFROMroads.hard_hatsASdefault_DOT_hard_hats)AS
-    default_DOT_hard_hatONdefault_DOT_repair_order.hard_hat_id=default_DOT_hard_hat.
-    hard_hat_idGROUPBYdefault_DOT_hard_hat.state)SELECTm0_default_DOT_avg_repair_price.
-    default_DOT_avg_repair_price,\tm0_default_DOT_avg_repair_price.stateFROM
-    m0_default_DOT_avg_repair_price
-    """.strip()
+    """WITHm0_default_DOT_avg_repair_priceAS(SELECTdefault_DOT_hard_hat.state,\t
+    avg(default_DOT_repair_order_details.price)ASdefault_DOT_avg_repair_priceFROM
+    roads.repair_order_detailsASdefault_DOT_repair_order_detailsLEFTOUTERJOIN
+    (SELECTdefault_DOT_repair_orders.dispatcher_id,\tdefault_DOT_repair_orders.hard_hat_id,
+    \tdefault_DOT_repair_orders.municipality_id,\tdefault_DOT_repair_orders.repair_order_id
+    FROMroads.repair_ordersASdefault_DOT_repair_orders)ASdefault_DOT_repair_order
+    ONdefault_DOT_repair_order_details.repair_order_id=default_DOT_repair_order.repair_order_id
+    LEFTOUTERJOIN(SELECTdefault_DOT_hard_hats.hard_hat_id,\tdefault_DOT_hard_hats.state
+    FROMroads.hard_hatsASdefault_DOT_hard_hats)ASdefault_DOT_hard_hatON
+    default_DOT_repair_order.hard_hat_id=default_DOT_hard_hat.hard_hat_idGROUPBY
+    default_DOT_hard_hat.state)SELECTm0_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
+    \tm0_default_DOT_avg_repair_price.stateFROMm0_default_DOT_avg_repair_price""".strip()
     .replace('"', "")
     .replace("\n", "")
     .replace(" ", ""): QueryWithResults(
@@ -1142,21 +1139,19 @@ QUERY_DATA_MAPPINGS: Dict[str, Union[DJException, QueryWithResults]] = {
             "errors": [],
         }
     ),
-    """
-    WITHm0_default_DOT_avg_repair_priceAS(SELECTavg(default_DOT_repair_order_details.price)
-    ASdefault_DOT_avg_repair_price,\tdefault_DOT_hard_hat.postal_codeFROMroads.repair_order
-    _detailsASdefault_DOT_repair_order_detailsLEFTOUTERJOIN(SELECTdefault_DOT_repair_orders.
-    dispatcher_id,\tdefault_DOT_repair_orders.hard_hat_id,\tdefault_DOT_repair_orders.
-    municipality_id,\tdefault_DOT_repair_orders.repair_order_idFROMroads.repair_ordersAS
-    default_DOT_repair_orders)ASdefault_DOT_repair_orderONdefault_DOT_repair_order_details
-    .repair_order_id=default_DOT_repair_order.repair_order_idLEFTOUTERJOIN(SELECT
-    default_DOT_hard_hats.hard_hat_id,\tdefault_DOT_hard_hats.postal_code,\tdefault_DOT_
-    hard_hats.stateFROMroads.hard_hatsASdefault_DOT_hard_hats)ASdefault_DOT_hard_hatON
-    default_DOT_repair_order.hard_hat_id=default_DOT_hard_hat.hard_hat_idGROUPBYdefault_
-    DOT_hard_hat.postal_code)SELECTm0_default_DOT_avg_repair_price.default_DOT_avg_
-    repair_price,\tm0_default_DOT_avg_repair_price.postal_codeFROMm0_default_DOT_
-    avg_repair_price
-    """.strip()
+    """WITHm0_default_DOT_avg_repair_priceAS(SELECTdefault_DOT_hard_hat.postal_code,
+    \tavg(default_DOT_repair_order_details.price)ASdefault_DOT_avg_repair_priceFROM
+    roads.repair_order_detailsASdefault_DOT_repair_order_detailsLEFTOUTERJOIN
+    (SELECTdefault_DOT_repair_orders.dispatcher_id,\tdefault_DOT_repair_orders.hard_hat_id,
+    \tdefault_DOT_repair_orders.municipality_id,\tdefault_DOT_repair_orders.repair_order_id
+    FROMroads.repair_ordersASdefault_DOT_repair_orders)ASdefault_DOT_repair_orderON
+    default_DOT_repair_order_details.repair_order_id=default_DOT_repair_order.repair_order_id
+    LEFTOUTERJOIN(SELECTdefault_DOT_hard_hats.hard_hat_id,\tdefault_DOT_hard_hats.postal_code,
+    \tdefault_DOT_hard_hats.stateFROMroads.hard_hatsASdefault_DOT_hard_hats)ASdefault_DOT_hard_hat
+    ONdefault_DOT_repair_order.hard_hat_id=default_DOT_hard_hat.hard_hat_idGROUPBY
+    default_DOT_hard_hat.postal_code)SELECTm0_default_DOT_avg_repair_price.
+    default_DOT_avg_repair_price,\tm0_default_DOT_avg_repair_price.postal_code
+    FROMm0_default_DOT_avg_repair_price""".strip()
     .replace('"', "")
     .replace("\n", "")
     .replace(" ", ""): (

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -239,7 +239,7 @@ class TestDJClient:
         assert num_repair_orders.name == "default.num_repair_orders"
         assert num_repair_orders.query == (
             "SELECT  count(repair_order_id) default_DOT_num_repair_orders "
-            "\n FROM default.repair_orders\n"
+            "\n FROM default.repair_orders\n\n"
         )
         assert num_repair_orders.type == "metric"
 

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -14,6 +14,7 @@ from datajunction_server.api.helpers import (
     get_node_by_name,
     get_query,
     validate_cube,
+    validate_orderby,
 )
 from datajunction_server.construction.build import build_metric_nodes
 from datajunction_server.errors import DJException, DJInvalidInputException
@@ -132,7 +133,7 @@ def get_data(  # pylint: disable=too-many-locals
             f"The selected engine is not available for the node {node_name}. "
             f"Available engines include: {', '.join(engine.name for engine in available_engines)}",
         )
-
+    validate_orderby(orderby, [node_name], dimensions)
     query_ast = get_query(
         session=session,
         node_name=node_name,
@@ -200,6 +201,7 @@ def get_data_for_metrics(  # pylint: disable=R0914, R0913
         metrics,
         dimensions,
     )
+    validate_orderby(orderby, metrics, dimensions)
     query_ast = build_metric_nodes(
         session,
         metric_nodes,

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -595,3 +595,20 @@ def get_history(
         .offset(offset)
         .limit(limit),
     ).all()
+
+
+def validate_orderby(orderby: List[str], metrics: List[str], dimension_attributes: List[str]):
+    """
+    Validate that all elements in an order by match a metric or dimension attribute
+    """
+    invalid_orderbys = []
+    for ob in orderby:
+        if ob not in metrics + dimension_attributes:
+            invalid_orderbys.append(ob)
+    if invalid_orderbys:
+        raise DJException(
+            message=(
+                f"Columns {invalid_orderbys} in order by clause must also be "
+                "specified in the metrics or dimensions"
+            )
+        )

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -597,18 +597,22 @@ def get_history(
     ).all()
 
 
-def validate_orderby(orderby: List[str], metrics: List[str], dimension_attributes: List[str]):
+def validate_orderby(
+    orderby: List[str],
+    metrics: List[str],
+    dimension_attributes: List[str],
+):
     """
     Validate that all elements in an order by match a metric or dimension attribute
     """
     invalid_orderbys = []
-    for ob in orderby:
-        if ob not in metrics + dimension_attributes:
-            invalid_orderbys.append(ob)
+    for orderby_element in orderby:
+        if orderby_element not in metrics + dimension_attributes:
+            invalid_orderbys.append(orderby_element)
     if invalid_orderbys:
         raise DJException(
             message=(
                 f"Columns {invalid_orderbys} in order by clause must also be "
                 "specified in the metrics or dimensions"
-            )
+            ),
         )

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -8,9 +8,13 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
-from datajunction_server.api.helpers import get_engine, get_query, validate_cube, validate_orderby
+from datajunction_server.api.helpers import (
+    get_engine,
+    get_query,
+    validate_cube,
+    validate_orderby,
+)
 from datajunction_server.construction.build import build_metric_nodes
-from datajunction_server.errors import DJException
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.utils import get_session

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -8,8 +8,9 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
-from datajunction_server.api.helpers import get_engine, get_query, validate_cube
+from datajunction_server.api.helpers import get_engine, get_query, validate_cube, validate_orderby
 from datajunction_server.construction.build import build_metric_nodes
+from datajunction_server.errors import DJException
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.utils import get_session
@@ -38,6 +39,7 @@ def get_sql(
         if engine_name
         else None
     )
+    validate_orderby(orderby, [node_name], dimensions)
     query_ast = get_query(
         session=session,
         node_name=node_name,
@@ -83,6 +85,7 @@ def get_sql_for_metrics(
         metrics,
         dimensions,
     )
+    validate_orderby(orderby, metrics, dimensions)
     query_ast = build_metric_nodes(
         session,
         metric_nodes,

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -1,6 +1,5 @@
 """Functions to add to an ast DJ node queries"""
 import collections
-from itertools import chain
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks,too-many-branches,R0401
 from typing import DefaultDict, Deque, Dict, List, Optional, Set, Tuple, Union, cast
@@ -392,7 +391,9 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             temp_query = parse(
                 f"select * order by {order}",
             )
-            query.select.organization.order += temp_query.select.organization.order  # type:ignore
+            query.select.organization.order += (  # type:ignore
+                temp_query.select.organization.order  # type:ignore
+            )
 
     # add all used dimension columns to the projection without duplicates
     projection_update = []

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -419,7 +419,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
     query.select.projection = projection_update
 
     if limit is not None:
-        query.limit = ast.Number(limit)
+        query.select.limit = ast.Number(limit)
 
 
 def _get_node_table(
@@ -710,7 +710,7 @@ def build_metric_nodes(
     combined_ast.select.organization = ast.Organization(orderby_sort_items)
 
     if limit is not None:
-        combined_ast.limit = ast.Number(limit)
+        combined_ast.select.limit = ast.Number(limit)
 
     return combined_ast
 

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -607,7 +607,7 @@ def build_metric_nodes(
         current_table = ast.Table(metric_ast_alias)
 
         organization = cast(ast.Organization, metric_ast.select.organization)
-
+        metric_ast.select.organization=None
         # if an orderby referred to this metric node, parse and add it to the order items
         if metric_order := (
             [None]
@@ -617,7 +617,7 @@ def build_metric_nodes(
                 if metric_node.name == order_metric
             ]
         ).pop():
-            metric_sort_item = parse(f"select * order by {metric_order}").organization.order[0]  # type: ignore #pylint: disable=C0301
+            metric_sort_item = parse(f"select * order by {metric_order}").select.organization.order[0]  # type: ignore #pylint: disable=C0301
             metric_col = ast.Column(
                 name=ast.Name(
                     [
@@ -707,7 +707,7 @@ def build_metric_nodes(
         if isinstance(sort_item, ast.SortItem):
             orderby_sort_items.insert(idx, sort_item)
 
-    combined_ast.organization = ast.Organization(orderby_sort_items)
+    combined_ast.select.organization = ast.Organization(orderby_sort_items)
 
     if limit is not None:
         combined_ast.limit = ast.Number(limit)

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -607,7 +607,7 @@ def build_metric_nodes(
         current_table = ast.Table(metric_ast_alias)
 
         organization = cast(ast.Organization, metric_ast.select.organization)
-        metric_ast.select.organization=None
+        metric_ast.select.organization = None
         # if an orderby referred to this metric node, parse and add it to the order items
         if metric_order := (
             [None]

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -679,11 +679,11 @@ class Column(Aliasable, Named, Expression):
     def type(self):
         if self._type:
             return self._type
-
         # Column was derived from some other expression we can get the type of
         if self.expression:
             self.add_type(self.expression.type)
             return self.expression.type
+
         raise DJParseException(f"Cannot resolve type of column {self}.")
 
     def add_type(self, type_: ColumnType) -> "Column":

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -891,7 +891,10 @@ class Column(Aliasable, Named, Expression):
         as_ = " AS " if self.as_ else " "
         alias = "" if not self.alias else f"{as_}{self.alias}"
         if self.table is not None and not isinstance(self.table, FunctionTable):
-            ret = f"{self.table.alias_or_name.identifier()}.{self.name.quote_style}{self.name.name}{self.name.quote_style}"
+            try:
+                ret = f"{self.table.alias_or_name.identifier()}.{self.name.quote_style}{self.name.name}{self.name.quote_style}"
+            except:
+                import pdb; pdb.set_trace()
         else:
             ret = str(self.name)
         if self.parenthesized:

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2176,9 +2176,6 @@ class Select(SelectExpression):
             parts.extend(("HAVING ", str(self.having), "\n"))
         select = " ".join(parts).strip()
 
-        # Add set operations
-        if self.set_op:
-            select += f"\n{self.set_op}"
         if self.organization:
             select += f"\n{self.organization}"
         if self.limit:
@@ -2186,6 +2183,8 @@ class Select(SelectExpression):
         if self.parenthesized:
             select = f"({select})"
 
+        if self.set_op:
+            select += f"\n{self.set_op}"
         if self.alias:
             as_ = " AS " if self.as_ else " "
             return f"{select}{as_}{self.alias}"

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -891,10 +891,7 @@ class Column(Aliasable, Named, Expression):
         as_ = " AS " if self.as_ else " "
         alias = "" if not self.alias else f"{as_}{self.alias}"
         if self.table is not None and not isinstance(self.table, FunctionTable):
-            try:
-                ret = f"{self.table.alias_or_name.identifier()}.{self.name.quote_style}{self.name.name}{self.name.quote_style}"
-            except:
-                import pdb; pdb.set_trace()
+            ret = f"{self.table.alias_or_name.identifier()}.{self.name.quote_style}{self.name.name}{self.name.quote_style}"
         else:
             ret = str(self.name)
         if self.parenthesized:
@@ -2054,33 +2051,7 @@ class From(Node):
         return "".join(parts)
 
 
-@dataclass(eq=False)
-class SetOp(TableExpression):
-    """
-    A set operation
-    """
 
-    kind: str = ""  # Union, intersect, ...
-    left: Optional[TableExpression] = None
-    right: Optional[TableExpression] = None
-
-    def __str__(self) -> str:
-        return f"{self.left}\n{self.kind}\n{self.right}"
-
-    def compile(self, ctx: CompileContext):
-        """
-        Compile a set operation
-        """
-        if self.is_compiled():
-            return
-        # things we could check here:
-        # - all table expressions in the setop must have the same number of columns and the pairwise types must be the same
-
-        # column names are taken from the leading query i.e. left
-        left = cast(self.left, TableExpression)
-        left.compile(ctx)
-        if left.is_compiled():
-            self._columns = left.columns[:]
 
 
 @dataclass(eq=False)
@@ -2101,103 +2072,6 @@ class Cast(Expression):
         Return the type of the expression
         """
         return self.data_type
-
-
-@dataclass(eq=False)
-class SelectExpression(Aliasable, Expression):
-    """
-    An uninitializable Type for Select for use as a default where
-    a Select is required.
-    """
-
-    quantifier: str = ""  # Distinct, All
-    projection: List[Union[Aliasable, Expression]] = field(default_factory=list)
-    from_: Optional[From] = None
-    group_by: List[Expression] = field(default_factory=list)
-    having: Optional[Expression] = None
-    where: Optional[Expression] = None
-    set_op: List[SetOp] = field(default_factory=list)
-    lateral_views: List[LateralView] = field(default_factory=list)
-
-    def add_aliases_to_unnamed_columns(self) -> None:
-        """
-        Add an alias to any unnamed columns in the projection (`col{n}`)
-        """
-        projection = []
-        for i, expression in enumerate(self.projection):
-            if not isinstance(expression, Aliasable):
-                name = f"col{i}"
-                projection.append(expression.set_alias(Name(name)))
-            else:
-                projection.append(expression)
-        self.projection = projection
-
-
-class Select(SelectExpression):
-    """
-    A single select statement type
-    """
-
-    def add_set_op(self, set_op: SetOp):
-        """
-        Add a set op such as UNION, UNION ALL or INTERSECT
-        """
-        self.set_op.append(set_op)
-
-    def __str__(self) -> str:
-        parts = ["SELECT "]
-        if self.quantifier:
-            parts.append(f"{self.quantifier}\n")
-        parts.append(",\n\t".join(str(exp) for exp in self.projection))
-        if self.from_ is not None:
-            parts.extend(("\n", str(self.from_), "\n"))
-        for view in self.lateral_views:
-            parts.append(f"\n{view}")
-        if self.where is not None:
-            parts.extend(("WHERE ", str(self.where), "\n"))
-        if self.group_by:
-            parts.extend(("GROUP BY ", ", ".join(str(exp) for exp in self.group_by)))
-        if self.having is not None:
-            parts.extend(("HAVING ", str(self.having), "\n"))
-        select = " ".join(parts).strip()
-
-        # Add set operations
-        if self.set_op:
-            if self.parenthesized:
-                select = f"({select})"  # Add additional parentheses inclusive of set operations
-            select += "\n" + "\n".join([str(so) for so in self.set_op])
-
-        if self.parenthesized:
-            select = f"({select})"
-
-        if self.alias:
-            as_ = " AS " if self.as_ else " "
-            return f"{select}{as_}{self.alias}"
-        return select
-
-    @property
-    def type(self) -> ColumnType:
-        if len(self.projection) != 1:
-            raise DJParseException(
-                "Can only infer type of a SELECT when it "
-                f"has a single expression in its projection. In {self}.",
-            )
-        return self.projection[0].type
-
-    def compile(self, ctx: CompileContext):
-        if not self.group_by and self.having:
-            ctx.exception.errors.append(
-                DJError(
-                    code=ErrorCode.INVALID_SQL_QUERY,
-                    message=(
-                        "HAVING without a GROUP BY is not allowed. "
-                        "Did you want to use a WHERE clause instead?"
-                    ),
-                    context=str(self),
-                ),
-            )
-
-        super().compile(ctx)
 
 
 @dataclass(eq=False)
@@ -2233,6 +2107,136 @@ class Organization(Node):
 
 
 @dataclass(eq=False)
+class SelectExpression(TableExpression):
+    """
+    An uninitializable Type for Select for use as a default where
+    a Select is required.
+    """
+
+    limit: Optional[Expression] = None
+    organization: Optional[Organization] = None
+
+    def add_aliases_to_unnamed_columns(self) -> None:
+        """
+        Add an alias to any unnamed columns in the projection (`col{n}`)
+        """
+        projection = []
+        for i, expression in enumerate(self.projection):
+            if not isinstance(expression, Aliasable):
+                name = f"col{i}"
+                projection.append(expression.set_alias(Name(name)))
+            else:
+                projection.append(expression)
+        self.projection = projection
+
+@dataclass(eq=False)
+class SetOp(SelectExpression):
+    """
+    A set operation
+    """
+
+    kind: str = ""  # Union, intersect, ...
+    left: Optional[TableExpression] = None
+    right: Optional[TableExpression] = None
+
+    def __str__(self) -> str:
+        setop = f"{self.left}\n{self.kind}\n{self.right}"
+        if self.organization:
+            setop+=f"\n{self.organization}"
+        if self.limit:
+            setop+=f"LIMIT {self.limit}"
+        return setop
+    
+    def compile(self, ctx: CompileContext):
+        """
+        Compile a set operation
+        """
+        if self.is_compiled():
+            return
+        # things we could check here:
+        # - all table expressions in the setop must have the same number of columns and the pairwise types must be the same
+
+        # column names are taken from the leading query i.e. left
+        left = cast(self.left, TableExpression)
+        left.compile(ctx)
+        if left.is_compiled():
+            self._columns = left.columns[:]
+            
+
+@dataclass(eq=False)
+class Select(SelectExpression):
+    """
+    A single select statement type
+    """
+    quantifier: str = ""  # Distinct, All
+    projection: List[Union[Aliasable, Expression]] = field(default_factory=list)
+    from_: Optional[From] = None
+    group_by: List[Expression] = field(default_factory=list)
+    having: Optional[Expression] = None
+    where: Optional[Expression] = None
+    lateral_views: List[LateralView] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        parts = ["SELECT "]
+        if self.quantifier:
+            parts.append(f"{self.quantifier}\n")
+        parts.append(",\n\t".join(str(exp) for exp in self.projection))
+        if self.from_ is not None:
+            parts.extend(("\n", str(self.from_), "\n"))
+        for view in self.lateral_views:
+            parts.append(f"\n{view}")
+        if self.where is not None:
+            parts.extend(("WHERE ", str(self.where), "\n"))
+        if self.group_by:
+            parts.extend(("GROUP BY ", ", ".join(str(exp) for exp in self.group_by)))
+        if self.having is not None:
+            parts.extend(("HAVING ", str(self.having), "\n"))
+        select = " ".join(parts).strip()
+
+        if self.organization:
+            select+=f"\n{self.organization}"
+        if self.limit:
+            select+=f"LIMIT {self.limit}"
+        if self.parenthesized:
+            select = f"({select})"
+
+        if self.alias:
+            as_ = " AS " if self.as_ else " "
+            return f"{select}{as_}{self.alias}"
+        return select
+
+    @property
+    def type(self) -> ColumnType:
+        if len(self.projection) != 1:
+            raise DJParseException(
+                "Can only infer type of a SELECT when it "
+                f"has a single expression in its projection. In {self}.",
+            )
+        return self.projection[0].type
+
+    def is_compiled(self) -> bool:
+        return super(Expression, self).is_compiled()
+    
+    def compile(self, ctx: CompileContext):
+        if self.is_compiled():
+            return
+        if not self.group_by and self.having:
+            ctx.exception.errors.append(
+                DJError(
+                    code=ErrorCode.INVALID_SQL_QUERY,
+                    message=(
+                        "HAVING without a GROUP BY is not allowed. "
+                        "Did you want to use a WHERE clause instead?"
+                    ),
+                    context=str(self),
+                ),
+            )
+        self._is_compiled = True
+        super(Expression, self).compile(ctx)
+        
+
+
+@dataclass(eq=False)
 class Query(TableExpression):
     """
     Overarching query type
@@ -2240,8 +2244,6 @@ class Query(TableExpression):
 
     select: SelectExpression = field(default_factory=SelectExpression)
     ctes: List["Query"] = field(default_factory=list)
-    limit: Optional[Expression] = None
-    organization: Optional[Organization] = None
 
     def is_compiled(self) -> bool:
         return not any(
@@ -2275,11 +2277,6 @@ class Query(TableExpression):
         with_ = f"WITH\n{ctes}" if ctes else ""
 
         parts = [f"{with_}{self.select}\n"]
-        if self.organization:
-            parts.append(str(self.organization))
-        if self.limit is not None:
-            limit = f"LIMIT {self.limit}"
-            parts.append(limit)
         query = "".join(parts)
         if self.parenthesized:
             query = f"({query})"

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2185,8 +2185,6 @@ class Select(SelectExpression):
         if self.limit:
             select += f"LIMIT {self.limit}"
 
-
-
         if self.alias:
             as_ = " AS " if self.as_ else " "
             return f"{select}{as_}{self.alias}"

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2175,16 +2175,18 @@ class Select(SelectExpression):
         if self.having is not None:
             parts.extend(("HAVING ", str(self.having), "\n"))
         select = " ".join(parts).strip()
+        if self.parenthesized:
+            select = f"({select})"
+        if self.set_op:
+            select += f"\n{self.set_op}"
 
         if self.organization:
             select += f"\n{self.organization}"
         if self.limit:
             select += f"LIMIT {self.limit}"
-        if self.parenthesized:
-            select = f"({select})"
 
-        if self.set_op:
-            select += f"\n{self.set_op}"
+
+
         if self.alias:
             as_ = " AS " if self.as_ else " "
             return f"{select}{as_}{self.alias}"

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -272,8 +272,6 @@ def _(ctx: sbp.QueryContext):
         ctes = visit(ctes_ctx)
     limit, organization = visit(ctx.queryOrganization())
     select = visit(ctx.queryTerm())
-    
-    if limit: import pdb; pdb.set_trace()
     select.limit = limit
     select.organization = organization
     return ast.Query(ctes=ctes, select=select)
@@ -865,11 +863,14 @@ def _(ctx: sbp.SubqueryExpressionContext):
 def _(ctx: sbp.SetOperationContext):
     operator = ctx.operator.text
     quantifier = f" {visit(ctx.setQuantifier())}" if ctx.setQuantifier() else ""
-    return ast.SetOp(
-        left=visit(ctx.left),
-        kind=f"{operator}{quantifier}",
-        right=visit(ctx.right),
+    left = visit(ctx.left)
+    left.add_set_op(
+        ast.SetOp(
+            kind=f"{operator}{quantifier}",
+            right=visit(ctx.right),
+        ),
     )
+    return left
 
 
 @visit.register

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -272,8 +272,11 @@ def _(ctx: sbp.QueryContext):
         ctes = visit(ctes_ctx)
     limit, organization = visit(ctx.queryOrganization())
     select = visit(ctx.queryTerm())
-
-    return ast.Query(ctes=ctes, select=select, limit=limit, organization=organization)
+    
+    if limit: import pdb; pdb.set_trace()
+    select.limit = limit
+    select.organization = organization
+    return ast.Query(ctes=ctes, select=select)
 
 
 @visit.register

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -363,26 +363,26 @@ m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.state,
         default_DOT_municipality_dim.local_region,
-        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate 
+        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
@@ -391,21 +391,21 @@ m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.state,
         default_DOT_municipality_dim.local_region,
-        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders 
+        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders
  FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_dispatcher.company_name,
@@ -414,26 +414,26 @@ m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_dispatcher.company_name,
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.state,
         default_DOT_municipality_dim.local_region,
-        avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price 
+        avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
@@ -442,26 +442,26 @@ m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.state,
         default_DOT_municipality_dim.local_region,
-        sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost 
+        sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
@@ -470,26 +470,26 @@ m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.c
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.state,
         default_DOT_municipality_dim.local_region,
-        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts 
+        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
@@ -498,26 +498,26 @@ m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.compa
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.state,
         default_DOT_municipality_dim.local_region,
-        sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost 
+        sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
         m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
@@ -530,7 +530,7 @@ LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_D
         COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
         COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
         COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
-        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region 
+        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region
  FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
 FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
 FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
@@ -604,26 +604,26 @@ m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_municipality_dim.l
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.country,
         sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
-        default_DOT_dispatcher.company_name 
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_municipality_dim.local_region,
@@ -632,21 +632,21 @@ m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_municipality_dim.local_
         default_DOT_hard_hat.state,
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.country,
-        default_DOT_dispatcher.company_name 
+        default_DOT_dispatcher.company_name
  FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_municipality_dim.local_region,
@@ -656,26 +656,26 @@ m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_municipality_dim.local_r
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.country,
         count(default_DOT_repair_order_details.price) price_count,
-        default_DOT_dispatcher.company_name 
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_municipality_dim.local_region,
@@ -684,26 +684,26 @@ m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_municipality_dim.local_
         default_DOT_hard_hat.state,
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.country,
-        default_DOT_dispatcher.company_name 
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_municipality_dim.local_region,
@@ -712,26 +712,26 @@ m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_municipality
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.country,
         default_DOT_dispatcher.company_name,
-        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum 
+        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
 m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_municipality_dim.local_region,
@@ -740,26 +740,26 @@ m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_municipality_dim
         default_DOT_hard_hat.state,
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.country,
-        default_DOT_dispatcher.company_name 
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.repair_order_id 
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.dispatcher_id 
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
         default_DOT_hard_hats.country,
         default_DOT_hard_hats.hard_hat_id,
         default_DOT_hard_hats.postal_code,
-        default_DOT_hard_hats.state 
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-        default_DOT_municipality.municipality_id 
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
- WHERE  default_DOT_hard_hat.state = 'AZ' 
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+ WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 )SELECT  m0_default_DOT_discounted_orders_rate.placeholder_count m0_default_DOT_discounted_orders_rate_placeholder_count,
         m0_default_DOT_discounted_orders_rate.discount_sum m0_default_DOT_discounted_orders_rate_discount_sum,
@@ -774,7 +774,7 @@ LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_D
         COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
         COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
         COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
-        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name 
+        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name
  FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
 FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
 FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -357,186 +357,185 @@ def test_create_cube(  # pylint: disable=redefined-outer-name
     assert results["description"] == "Cube of various metrics related to repairs"
     expected_query = """
 WITH
-m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders 
  FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
-    m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
-    m2_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
-    m3_default_DOT_total_repair_cost.default_DOT_total_repair_cost,
-    m4_default_DOT_total_repair_order_discounts.default_DOT_total_repair_order_discounts,
-    m5_default_DOT_double_total_repair_cost.default_DOT_double_total_repair_cost,
-    COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
-    COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
-    COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
-    COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
-    COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
-    COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state
- FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
-FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state
-FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state
-FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state
-FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state
-
+        m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+        m2_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
+        m3_default_DOT_total_repair_cost.default_DOT_total_repair_cost,
+        m4_default_DOT_total_repair_order_discounts.default_DOT_total_repair_order_discounts,
+        m5_default_DOT_double_total_repair_cost.default_DOT_double_total_repair_cost,
+        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
+        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
+        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
+        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region 
+ FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
+FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
+FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
+FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
     """
     print("RES", results["query"])
     assert compare_query_strings(results["query"], expected_query)
@@ -598,190 +597,189 @@ def test_cube_materialization_sql_and_measures(
     ]
     expected_materialization_query = """
 WITH
-m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
-    count(*) placeholder_count,
-    default_DOT_hard_hat.country,
-    sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        count(*) placeholder_count,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
+        default_DOT_dispatcher.company_name 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
-    count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name 
  FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m2_default_DOT_avg_repair_price AS (SELECT  count(default_DOT_repair_order_details.price) price_count,
-    default_DOT_dispatcher.company_name,
-    sum(default_DOT_repair_order_details.price) price_sum,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        sum(default_DOT_repair_order_details.price) price_sum,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        count(default_DOT_repair_order_details.price) price_count,
+        default_DOT_dispatcher.company_name 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
-    sum(default_DOT_repair_order_details.price) price_sum,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        sum(default_DOT_repair_order_details.price) price_sum,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name,
+        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
-    sum(default_DOT_repair_order_details.price) price_sum,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        sum(default_DOT_repair_order_details.price) price_sum,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name 
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id 
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id 
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state 
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id 
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
- WHERE  default_DOT_hard_hat.state = 'AZ'
+LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id 
+ WHERE  default_DOT_hard_hat.state = 'AZ' 
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 )SELECT  m0_default_DOT_discounted_orders_rate.placeholder_count m0_default_DOT_discounted_orders_rate_placeholder_count,
-    m0_default_DOT_discounted_orders_rate.discount_sum m0_default_DOT_discounted_orders_rate_discount_sum,
-    m1_default_DOT_num_repair_orders.repair_order_id_count m1_default_DOT_num_repair_orders_repair_order_id_count,
-    m2_default_DOT_avg_repair_price.price_count m2_default_DOT_avg_repair_price_price_count,
-    m2_default_DOT_avg_repair_price.price_sum m2_default_DOT_avg_repair_price_price_sum,
-    m3_default_DOT_total_repair_cost.price_sum m3_default_DOT_total_repair_cost_price_sum,
-    m4_default_DOT_total_repair_order_discounts.price_discount_sum m4_default_DOT_total_repair_order_discounts_price_discount_sum,
-    m5_default_DOT_double_total_repair_cost.price_sum m5_default_DOT_double_total_repair_cost_price_sum,
-    COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
-    COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
-    COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
-    COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
-    COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
-    COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state
- FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
-FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state
-FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state
-FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state
-FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state
-
+        m0_default_DOT_discounted_orders_rate.discount_sum m0_default_DOT_discounted_orders_rate_discount_sum,
+        m1_default_DOT_num_repair_orders.repair_order_id_count m1_default_DOT_num_repair_orders_repair_order_id_count,
+        m2_default_DOT_avg_repair_price.price_sum m2_default_DOT_avg_repair_price_price_sum,
+        m2_default_DOT_avg_repair_price.price_count m2_default_DOT_avg_repair_price_price_count,
+        m3_default_DOT_total_repair_cost.price_sum m3_default_DOT_total_repair_cost_price_sum,
+        m4_default_DOT_total_repair_order_discounts.price_discount_sum m4_default_DOT_total_repair_order_discounts_price_discount_sum,
+        m5_default_DOT_double_total_repair_cost.price_sum m5_default_DOT_double_total_repair_cost_price_sum,
+        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
+        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
+        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
+        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name 
+ FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
+FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
+FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
+FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
     """
     assert compare_query_strings(
         data["materializations"][0]["config"]["query"],

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1,6 +1,7 @@
 """
 Tests for the metrics API.
 """
+from tests.sql.utils import compare_query_strings
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
@@ -343,7 +344,7 @@ def test_metric_expression_auto_aliased(client_with_examples: TestClient):
         },
     )
     assert response.status_code == 201
-    assert response.json()["query"] == (
+    assert compare_query_strings(response.json()["query"],
         "SELECT  SUM(counts.b) + SUM(counts.b) basic_DOT_dream_count \n FROM basic.dreams\n"
     )
 

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1,7 +1,6 @@
 """
 Tests for the metrics API.
 """
-from tests.sql.utils import compare_query_strings
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
@@ -11,6 +10,7 @@ from datajunction_server.models.database import Database
 from datajunction_server.models.node import Node, NodeRevision, NodeType
 from datajunction_server.models.table import Table
 from datajunction_server.sql.parsing.types import FloatType, IntegerType, StringType
+from tests.sql.utils import compare_query_strings
 
 
 def test_read_metrics(client_with_examples: TestClient) -> None:
@@ -344,8 +344,9 @@ def test_metric_expression_auto_aliased(client_with_examples: TestClient):
         },
     )
     assert response.status_code == 201
-    assert compare_query_strings(response.json()["query"],
-        "SELECT  SUM(counts.b) + SUM(counts.b) basic_DOT_dream_count \n FROM basic.dreams\n"
+    assert compare_query_strings(
+        response.json()["query"],
+        "SELECT  SUM(counts.b) + SUM(counts.b) basic_DOT_dream_count \n FROM basic.dreams\n",
     )
 
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -16,6 +16,8 @@ from tests.sql.utils import compare_query_strings
 
 
 def materialization_compare(response, expected):
+    """Compares two materialization lists of json
+    configs paying special attention to query comparison"""
     for (materialization_response, materialization_expected) in zip(response, expected):
         assert compare_query_strings(
             materialization_response["config"]["query"],

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1443,7 +1443,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get("/nodes/basic.transform.country_agg/")
         data = response.json()
         assert data["version"] == "v1.0"
-        assert materialization_compare(
+        materialization_compare(
             data["materializations"],
             [
                 {
@@ -1540,7 +1540,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get("/nodes/default.hard_hat/")
         data = response.json()
         assert data["version"] == "v1.0"
-        assert materialization_compare(
+        materialization_compare(
             data["materializations"],
             [
                 {
@@ -1598,7 +1598,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get(
             "/nodes/default.hard_hat/materializations/",
         )
-        assert materialization_compare(
+        materialization_compare(
             response.json(),
             [
                 {

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -12,14 +12,20 @@ from datajunction_server.models import Database, Table
 from datajunction_server.models.column import Column
 from datajunction_server.models.node import Node, NodeRevision, NodeStatus, NodeType
 from datajunction_server.sql.parsing.types import IntegerType, StringType, TimestampType
-
 from tests.sql.utils import compare_query_strings
+
+
 def materialization_compare(response, expected):
-    for (materialization_response, materialization_expected) in (zip(response, expected)):
-        assert compare_query_strings(materialization_response['config']['query'], materialization_expected['config']['query'])
-        del materialization_response['config']['query']
-        del materialization_expected['config']['query']
-        assert materialization_response==materialization_expected
+    for (materialization_response, materialization_expected) in zip(response, expected):
+        assert compare_query_strings(
+            materialization_response["config"]["query"],
+            materialization_expected["config"]["query"],
+        )
+        del materialization_response["config"]["query"]
+        del materialization_expected["config"]["query"]
+        assert materialization_response == materialization_expected
+
+
 def test_read_node(client_with_examples: TestClient) -> None:
     """
     Test ``GET /nodes/{node_id}``.
@@ -1338,8 +1344,6 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data["detail"] == "Engine not found: `spark` version `2.4.4`"
 
-
-            
     def test_add_materialization_success(self, client_with_query_service: TestClient):
         """
         Verifies success cases of adding materialization config.
@@ -1439,58 +1443,61 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get("/nodes/basic.transform.country_agg/")
         data = response.json()
         assert data["version"] == "v1.0"
-        assert materialization_compare(data["materializations"], [
-            {
-                "name": "country_3491792861",
-                "engine": {
-                    "name": "spark",
-                    "version": "2.4.4",
-                    "uri": None,
-                    "dialect": "spark",
+        assert materialization_compare(
+            data["materializations"],
+            [
+                {
+                    "name": "country_3491792861",
+                    "engine": {
+                        "name": "spark",
+                        "version": "2.4.4",
+                        "uri": None,
+                        "dialect": "spark",
+                    },
+                    "config": {
+                        "query": "SELECT  basic_DOT_source_DOT_users.country,\n\tCOUNT( "
+                        "DISTINCT basic_DOT_source_DOT_users.id) AS num_users \n "
+                        "FROM basic.dim_users AS basic_DOT_source_DOT_users \n WHERE"
+                        "  basic_DOT_source_DOT_users.country IN ('DE', 'MY') \n "
+                        "GROUP BY  1\n",
+                        "partitions": [
+                            {
+                                "name": "country",
+                                "values": ["DE", "MY"],
+                                "range": None,
+                                "type_": "categorical",
+                                "expression": None,
+                            },
+                        ],
+                        "spark": {},
+                        "upstream_tables": ["public.basic.dim_users"],
+                    },
+                    "schedule": "0 * * * *",
+                    "job": "SparkSqlMaterializationJob",
                 },
-                "config": {
-                    "query": "SELECT  basic_DOT_source_DOT_users.country,\n\tCOUNT( "
-                    "DISTINCT basic_DOT_source_DOT_users.id) AS num_users \n "
-                    "FROM basic.dim_users AS basic_DOT_source_DOT_users \n WHERE"
-                    "  basic_DOT_source_DOT_users.country IN ('DE', 'MY') \n "
-                    "GROUP BY  1\n",
-                    "partitions": [
-                        {
-                            "name": "country",
-                            "values": ["DE", "MY"],
-                            "range": None,
-                            "type_": "categorical",
-                            "expression": None,
-                        },
-                    ],
-                    "spark": {},
-                    "upstream_tables": ["public.basic.dim_users"],
+                {
+                    "config": {
+                        "partitions": [],
+                        "query": "SELECT  basic_DOT_source_DOT_users.country,\n"
+                        "\tCOUNT( DISTINCT basic_DOT_source_DOT_users.id) AS "
+                        "num_users \n"
+                        " FROM basic.dim_users AS basic_DOT_source_DOT_users \n"
+                        " GROUP BY  1\n",
+                        "spark": {},
+                        "upstream_tables": ["public.basic.dim_users"],
+                    },
+                    "engine": {
+                        "dialect": "spark",
+                        "name": "spark",
+                        "uri": None,
+                        "version": "2.4.4",
+                    },
+                    "job": "SparkSqlMaterializationJob",
+                    "name": "default",
+                    "schedule": "0 * * * *",
                 },
-                "schedule": "0 * * * *",
-                "job": "SparkSqlMaterializationJob",
-            },
-            {
-                "config": {
-                    "partitions": [],
-                    "query": "SELECT  basic_DOT_source_DOT_users.country,\n"
-                    "\tCOUNT( DISTINCT basic_DOT_source_DOT_users.id) AS "
-                    "num_users \n"
-                    " FROM basic.dim_users AS basic_DOT_source_DOT_users \n"
-                    " GROUP BY  1\n",
-                    "spark": {},
-                    "upstream_tables": ["public.basic.dim_users"],
-                },
-                "engine": {
-                    "dialect": "spark",
-                    "name": "spark",
-                    "uri": None,
-                    "version": "2.4.4",
-                },
-                "job": "SparkSqlMaterializationJob",
-                "name": "default",
-                "schedule": "0 * * * *",
-            },
-        ])
+            ],
+        )
 
         # Setting the materialization config with a temporal partition should succeed
         response = client_with_query_service.post(
@@ -1533,121 +1540,126 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_query_service.get("/nodes/default.hard_hat/")
         data = response.json()
         assert data["version"] == "v1.0"
-        assert materialization_compare(data["materializations"], [
-            {
-                "name": "country_birth_date_contractor_id_379232101",
-                "engine": {
-                    "name": "spark",
-                    "version": "2.4.4",
-                    "uri": None,
-                    "dialect": "spark",
+        assert materialization_compare(
+            data["materializations"],
+            [
+                {
+                    "name": "country_birth_date_contractor_id_379232101",
+                    "engine": {
+                        "name": "spark",
+                        "version": "2.4.4",
+                        "uri": None,
+                        "dialect": "spark",
+                    },
+                    "config": {
+                        "query": "SELECT  default_DOT_hard_hats.address,\n\tdefault_DOT_hard_hats."
+                        "birth_date,\n\tdefault_DOT_hard_hats.city,\n\tdefault_DOT_hard_hats."
+                        "contractor_id,\n\tdefault_DOT_hard_hats.country,\n\tdefault_DOT_hard"
+                        "_hats.first_name,\n\tdefault_DOT_hard_hats.hard_hat_id,\n\tdefault_D"
+                        "OT_hard_hats.hire_date,\n\tdefault_DOT_hard_hats.last_name,\n\tdefau"
+                        "lt_DOT_hard_hats.manager,\n\tdefault_DOT_hard_hats.postal_code,\n\t"
+                        "default_DOT_hard_hats.state,\n\tdefault_DOT_hard_hats.title \n FROM"
+                        " roads.hard_hats AS default_DOT_hard_hats \n WHERE  default_DOT_har"
+                        "d_hats.country IN ('DE', 'MY') AND default_DOT_hard_hats.contractor"
+                        "_id BETWEEN 1 AND 10\n",
+                        "partitions": [
+                            {
+                                "name": "country",
+                                "values": ["DE", "MY"],
+                                "range": None,
+                                "type_": "categorical",
+                                "expression": None,
+                            },
+                            {
+                                "name": "birth_date",
+                                "values": None,
+                                "range": [20010101, 20020101],
+                                "type_": "temporal",
+                                "expression": None,
+                            },
+                            {
+                                "name": "contractor_id",
+                                "values": None,
+                                "range": [1, 10],
+                                "type_": "categorical",
+                                "expression": None,
+                            },
+                        ],
+                        "spark": {},
+                        "upstream_tables": ["default.roads.hard_hats"],
+                    },
+                    "schedule": "0 * * * *",
+                    "job": "SparkSqlMaterializationJob",
                 },
-                "config": {
-                    "query": "SELECT  default_DOT_hard_hats.address,\n\tdefault_DOT_hard_hats."
-                    "birth_date,\n\tdefault_DOT_hard_hats.city,\n\tdefault_DOT_hard_hats."
-                    "contractor_id,\n\tdefault_DOT_hard_hats.country,\n\tdefault_DOT_hard"
-                    "_hats.first_name,\n\tdefault_DOT_hard_hats.hard_hat_id,\n\tdefault_D"
-                    "OT_hard_hats.hire_date,\n\tdefault_DOT_hard_hats.last_name,\n\tdefau"
-                    "lt_DOT_hard_hats.manager,\n\tdefault_DOT_hard_hats.postal_code,\n\t"
-                    "default_DOT_hard_hats.state,\n\tdefault_DOT_hard_hats.title \n FROM"
-                    " roads.hard_hats AS default_DOT_hard_hats \n WHERE  default_DOT_har"
-                    "d_hats.country IN ('DE', 'MY') AND default_DOT_hard_hats.contractor"
-                    "_id BETWEEN 1 AND 10\n",
-                    "partitions": [
-                        {
-                            "name": "country",
-                            "values": ["DE", "MY"],
-                            "range": None,
-                            "type_": "categorical",
-                            "expression": None,
-                        },
-                        {
-                            "name": "birth_date",
-                            "values": None,
-                            "range": [20010101, 20020101],
-                            "type_": "temporal",
-                            "expression": None,
-                        },
-                        {
-                            "name": "contractor_id",
-                            "values": None,
-                            "range": [1, 10],
-                            "type_": "categorical",
-                            "expression": None,
-                        },
-                    ],
-                    "spark": {},
-                    "upstream_tables": ["default.roads.hard_hats"],
-                },
-                "schedule": "0 * * * *",
-                "job": "SparkSqlMaterializationJob",
-            },
-        ])
+            ],
+        )
 
         # Check listing materializations of the node
         response = client_with_query_service.get(
             "/nodes/default.hard_hat/materializations/",
         )
-        assert materialization_compare(response.json(), [
-            {
-                "config": {
-                    "partitions": [
-                        {
-                            "expression": None,
-                            "name": "country",
-                            "range": None,
-                            "type_": "categorical",
-                            "values": ["DE", "MY"],
-                        },
-                        {
-                            "expression": None,
-                            "name": "birth_date",
-                            "range": [20010101, 20020101],
-                            "type_": "temporal",
-                            "values": None,
-                        },
-                        {
-                            "expression": None,
-                            "name": "contractor_id",
-                            "range": [1, 10],
-                            "type_": "categorical",
-                            "values": None,
-                        },
-                    ],
-                    "query": "SELECT  default_DOT_hard_hats.address,\n"
-                    "\tdefault_DOT_hard_hats.birth_date,\n"
-                    "\tdefault_DOT_hard_hats.city,\n"
-                    "\tdefault_DOT_hard_hats.contractor_id,\n"
-                    "\tdefault_DOT_hard_hats.country,\n"
-                    "\tdefault_DOT_hard_hats.first_name,\n"
-                    "\tdefault_DOT_hard_hats.hard_hat_id,\n"
-                    "\tdefault_DOT_hard_hats.hire_date,\n"
-                    "\tdefault_DOT_hard_hats.last_name,\n"
-                    "\tdefault_DOT_hard_hats.manager,\n"
-                    "\tdefault_DOT_hard_hats.postal_code,\n"
-                    "\tdefault_DOT_hard_hats.state,\n"
-                    "\tdefault_DOT_hard_hats.title \n"
-                    " FROM roads.hard_hats AS default_DOT_hard_hats \n"
-                    " WHERE  default_DOT_hard_hats.country IN ('DE', 'MY') "
-                    "AND default_DOT_hard_hats.contractor_id BETWEEN 1 AND "
-                    "10\n",
-                    "spark": {},
-                    "upstream_tables": ["default.roads.hard_hats"],
+        assert materialization_compare(
+            response.json(),
+            [
+                {
+                    "config": {
+                        "partitions": [
+                            {
+                                "expression": None,
+                                "name": "country",
+                                "range": None,
+                                "type_": "categorical",
+                                "values": ["DE", "MY"],
+                            },
+                            {
+                                "expression": None,
+                                "name": "birth_date",
+                                "range": [20010101, 20020101],
+                                "type_": "temporal",
+                                "values": None,
+                            },
+                            {
+                                "expression": None,
+                                "name": "contractor_id",
+                                "range": [1, 10],
+                                "type_": "categorical",
+                                "values": None,
+                            },
+                        ],
+                        "query": "SELECT  default_DOT_hard_hats.address,\n"
+                        "\tdefault_DOT_hard_hats.birth_date,\n"
+                        "\tdefault_DOT_hard_hats.city,\n"
+                        "\tdefault_DOT_hard_hats.contractor_id,\n"
+                        "\tdefault_DOT_hard_hats.country,\n"
+                        "\tdefault_DOT_hard_hats.first_name,\n"
+                        "\tdefault_DOT_hard_hats.hard_hat_id,\n"
+                        "\tdefault_DOT_hard_hats.hire_date,\n"
+                        "\tdefault_DOT_hard_hats.last_name,\n"
+                        "\tdefault_DOT_hard_hats.manager,\n"
+                        "\tdefault_DOT_hard_hats.postal_code,\n"
+                        "\tdefault_DOT_hard_hats.state,\n"
+                        "\tdefault_DOT_hard_hats.title \n"
+                        " FROM roads.hard_hats AS default_DOT_hard_hats \n"
+                        " WHERE  default_DOT_hard_hats.country IN ('DE', 'MY') "
+                        "AND default_DOT_hard_hats.contractor_id BETWEEN 1 AND "
+                        "10\n",
+                        "spark": {},
+                        "upstream_tables": ["default.roads.hard_hats"],
+                    },
+                    "engine": {
+                        "dialect": "spark",
+                        "name": "spark",
+                        "uri": None,
+                        "version": "2.4.4",
+                    },
+                    "job": "SparkSqlMaterializationJob",
+                    "name": "country_birth_date_contractor_id_379232101",
+                    "output_tables": ["common.a", "common.b"],
+                    "schedule": "0 * * * *",
+                    "urls": ["http://fake.url/job"],
                 },
-                "engine": {
-                    "dialect": "spark",
-                    "name": "spark",
-                    "uri": None,
-                    "version": "2.4.4",
-                },
-                "job": "SparkSqlMaterializationJob",
-                "name": "country_birth_date_contractor_id_379232101",
-                "output_tables": ["common.a", "common.b"],
-                "schedule": "0 * * * *",
-                "urls": ["http://fake.url/job"],
-            },
-        ])
-
+            ],
+        )
 
 
 class TestNodeColumnsAttributes:

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -865,6 +865,6 @@ def test_get_sql_for_metrics_orderby_not_in_dimensions(
     )
     data = response.json()
     assert data["message"] == (
-        "Column default.hard_hat.city found in order-by "
-        "clause must also be specified in the metrics or dimensions."
+        "Columns ['default.hard_hat.city'] in order by "
+        "clause must also be specified in the metrics or dimensions"
     )

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -657,77 +657,167 @@ def test_get_sql_for_metrics(client_with_examples: TestClient):
     )
     data = response.json()
     expected_sql = """
-      WITH
-      m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.city,
-              m0_default_DOT_discounted_orders_rate.company_name,
-              m0_default_DOT_discounted_orders_rate.country,
-              CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate,
-              default_DOT_municipality_dim.local_region,
-              default_DOT_hard_hat.postal_code,
-              default_DOT_hard_hat.state
-      FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-              default_DOT_repair_orders.hard_hat_id,
-              default_DOT_repair_orders.municipality_id,
-              default_DOT_repair_orders.repair_order_id
-      FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
-      LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-              default_DOT_dispatchers.dispatcher_id
-      FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-      LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-              default_DOT_hard_hats.country,
-              default_DOT_hard_hats.hard_hat_id,
-              default_DOT_hard_hats.postal_code,
-              default_DOT_hard_hats.state
-      FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-      LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-              default_DOT_municipality.municipality_id
-      FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-      LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
-      GROUP BY  m0_default_DOT_discounted_orders_rate.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, m0_default_DOT_discounted_orders_rate.company_name, default_DOT_municipality_dim.local_region
-      ),
-      m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_hard_hat.city,
-              default_DOT_dispatcher.company_name,
-              default_DOT_hard_hat.country,
-              count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-              default_DOT_municipality_dim.local_region,
-              default_DOT_hard_hat.postal_code,
-              default_DOT_hard_hat.state
-      FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-              default_DOT_dispatchers.dispatcher_id
-      FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
-      LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-              default_DOT_hard_hats.country,
-              default_DOT_hard_hats.hard_hat_id,
-              default_DOT_hard_hats.postal_code,
-              default_DOT_hard_hats.state
-      FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-      LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-              default_DOT_municipality.municipality_id
-      FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-      LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
-      GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-      )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
-              m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
-              COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city) city,
-              COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name) company_name,
-              COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country) country,
-              COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region) local_region,
-              COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code) postal_code,
-              COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state) state
-      FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
-      ORDER BY m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders, m0_default_DOT_discounted_orders_rate.company_name, m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate
-      LIMIT 100
+WITH m0_default_DOT_discounted_orders_rate AS (
+  SELECT
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state,
+    default_DOT_municipality_dim.local_region,
+    CAST(
+      sum(
+        if(
+          default_DOT_repair_order_details.discount > 0.0,
+          1, 0
+        )
+      ) AS DOUBLE
+    ) / count(*) AS default_DOT_discounted_orders_rate
+  FROM
+    roads.repair_order_details AS default_DOT_repair_order_details
+    LEFT OUTER JOIN (
+      SELECT
+        default_DOT_repair_orders.dispatcher_id,
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
+      FROM
+        roads.repair_orders AS default_DOT_repair_orders
+    ) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
+    LEFT OUTER JOIN (
+      SELECT
+        default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+      FROM
+        roads.dispatchers AS default_DOT_dispatchers
+    ) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (
+      SELECT
+        default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+      FROM
+        roads.hard_hats AS default_DOT_hard_hats
+    ) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (
+      SELECT
+        default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+      FROM
+        roads.municipality AS default_DOT_municipality
+        LEFT JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
+    ) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
+  GROUP BY
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.state,
+    default_DOT_dispatcher.company_name,
+    default_DOT_municipality_dim.local_region
+),
+m1_default_DOT_num_repair_orders AS (
+  SELECT
+    default_DOT_dispatcher.company_name,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.state,
+    default_DOT_municipality_dim.local_region,
+    count(
+      default_DOT_repair_orders.repair_order_id
+    ) default_DOT_num_repair_orders
+  FROM
+    roads.repair_orders AS default_DOT_repair_orders
+    LEFT OUTER JOIN (
+      SELECT
+        default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.dispatcher_id
+      FROM
+        roads.dispatchers AS default_DOT_dispatchers
+    ) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    LEFT OUTER JOIN (
+      SELECT
+        default_DOT_hard_hats.city,
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
+      FROM
+        roads.hard_hats AS default_DOT_hard_hats
+    ) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+    LEFT OUTER JOIN (
+      SELECT
+        default_DOT_municipality.local_region,
+        default_DOT_municipality.municipality_id
+      FROM
+        roads.municipality AS default_DOT_municipality
+        LEFT JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
+        LEFT JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
+    ) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
+  GROUP BY
+    default_DOT_hard_hat.country,
+    default_DOT_hard_hat.postal_code,
+    default_DOT_hard_hat.city,
+    default_DOT_hard_hat.state,
+    default_DOT_dispatcher.company_name,
+    default_DOT_municipality_dim.local_region
+)
+SELECT
+  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
+  m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+  COALESCE(
+    m0_default_DOT_discounted_orders_rate.company_name,
+    m1_default_DOT_num_repair_orders.company_name
+  ) company_name,
+  COALESCE(
+    m0_default_DOT_discounted_orders_rate.city,
+    m1_default_DOT_num_repair_orders.city
+  ) city,
+  COALESCE(
+    m0_default_DOT_discounted_orders_rate.country,
+    m1_default_DOT_num_repair_orders.country
+  ) country,
+  COALESCE(
+    m0_default_DOT_discounted_orders_rate.postal_code,
+    m1_default_DOT_num_repair_orders.postal_code
+  ) postal_code,
+  COALESCE(
+    m0_default_DOT_discounted_orders_rate.state,
+    m1_default_DOT_num_repair_orders.state
+  ) state,
+  COALESCE(
+    m0_default_DOT_discounted_orders_rate.local_region,
+    m1_default_DOT_num_repair_orders.local_region
+  ) local_region
+FROM
+  m0_default_DOT_discounted_orders_rate FULL
+  OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name
+  AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city
+  AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country
+  AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code
+  AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
+  AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+ORDER BY
+  m0_default_DOT_discounted_orders_rate.country,
+  m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+  m0_default_DOT_discounted_orders_rate.company_name,
+  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate
+LIMIT
+  100
     """
     assert compare_query_strings(data["sql"], expected_sql)
     assert data["columns"] == [
         {"name": "default_DOT_discounted_orders_rate", "type": "double"},
         {"name": "default_DOT_num_repair_orders", "type": "bigint"},
-        {"name": "city", "type": "string"},
         {"name": "company_name", "type": "string"},
+        {"name": "city", "type": "string"},
         {"name": "country", "type": "string"},
-        {"name": "local_region", "type": "string"},
         {"name": "postal_code", "type": "string"},
         {"name": "state", "type": "string"},
+        {"name": "local_region", "type": "string"},
     ]
 
 

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -131,24 +131,18 @@ def test_sql(
             """,
         ),
         (
-            "default.municipality_dim",
+            "default.municipality",
             [],
             ["default.municipality.state_id = 'CA'"],
             """
-            SELECT
-              default_DOT_municipality.contact_name,
-              default_DOT_municipality.contact_title,
-              default_DOT_municipality.local_region,
-              default_DOT_municipality.municipality_id,
-              default_DOT_municipality_municipality_type.municipality_type_id,
-              default_DOT_municipality_type.municipality_type_desc,
-              default_DOT_municipality.state_id
-            FROM
-              roads.municipality AS default_DOT_municipality
-              LEFT JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
-              LEFT JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc
-            WHERE
-              default_DOT_municipality.state_id = 'CA'
+              SELECT  default_DOT_municipality.contact_name,
+                      default_DOT_municipality.contact_title,
+                      default_DOT_municipality.state_id,
+                      default_DOT_municipality.local_region,
+                      default_DOT_municipality.municipality_id,
+                      default_DOT_municipality.phone
+              FROM roads.municipality AS default_DOT_municipality
+              WHERE  default_DOT_municipality.state_id = 'CA'
             """,
         ),
         (

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -44,8 +44,11 @@ def test_sql(
     session.commit()
 
     response = client.get("/sql/a-metric/").json()
-    assert compare_query_strings(response['sql'], "SELECT  COUNT(*) col0 \n FROM rev.my_table AS my_table\n")
-    assert response["columns"]==[{"name": "col0", "type": "bigint"}]
+    assert compare_query_strings(
+        response["sql"],
+        "SELECT  COUNT(*) col0 \n FROM rev.my_table AS my_table\n",
+    )
+    assert response["columns"] == [{"name": "col0", "type": "bigint"}]
     assert response["dialect"] is None
 
 

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -43,12 +43,10 @@ def test_sql(
     session.add(source_node_rev)
     session.commit()
 
-    response = client.get("/sql/a-metric/")
-    assert response.json() == {
-        "sql": "SELECT  COUNT(*) col0 \n FROM rev.my_table AS my_table\n",
-        "columns": [{"name": "col0", "type": "bigint"}],
-        "dialect": None,
-    }
+    response = client.get("/sql/a-metric/").json()
+    assert compare_query_strings(response['sql'], "SELECT  COUNT(*) col0 \n FROM rev.my_table AS my_table\n")
+    assert response["columns"]==[{"name": "col0", "type": "bigint"}]
+    assert response["dialect"] is None
 
 
 @pytest.mark.parametrize(

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -119,7 +119,7 @@ def test_sql(
         (
             "default.long_events",
             [],
-            ["event_source.device_id = 'Android'"],
+            ["default.event_source.device_id = 'Android'"],
             """
               SELECT  default_DOT_event_source.country,
                       default_DOT_event_source.device_id,


### PR DESCRIPTION
### Summary

Fixes a bug where multiple metric builds were not building join key column tables.
Changes the AST so SetOp is now a linked list bound to a select. This also correct a hidden type error from the parser visitors.

### Test Plan

New multi metric test. All tests passing

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
