### PR TITLE
Updating a node's query should trigger node materializations updates

### DIFF
--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -94,7 +94,6 @@ class DruidCubeMaterializationJob(MaterializationJob):
             if cube_config.partitions
             else []
         )
-        print("cube_config.partitions", cube_config.partitions)
         if not temporal_partitions:
             raise DJException(
                 "Druid ingestion requires a temporal partition to be specified",

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -147,6 +147,7 @@ class DruidCubeMaterializationJob(MaterializationJob):
             DruidMaterializationInput(
                 name=materialization.name,
                 node_name=materialization.node_revision.name,
+                node_version=materialization.node_revision.version,
                 node_type=materialization.node_revision.type,
                 schedule=materialization.schedule,
                 query=cube_config.query,

--- a/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
@@ -77,11 +77,12 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
             GenericMaterializationInput(
                 name=materialization.name,  # type: ignore
                 node_name=materialization.node_revision.name,
+                node_version=materialization.node_revision.version,
                 node_type=materialization.node_revision.type.value,
                 schedule=materialization.schedule,
                 query=generic_config.query,
                 upstream_tables=generic_config.upstream_tables,
-                spark_conf=materialization.config["spark"],
+                spark_conf=generic_config.spark.__root__,
                 partitions=[
                     partition.dict() for partition in generic_config.partitions
                 ],

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -24,6 +24,7 @@ class GenericMaterializationInput(BaseModel):
 
     name: str
     node_name: str
+    node_version: str
     node_type: str
     schedule: str
     query: str
@@ -126,6 +127,7 @@ class GenericMaterializationConfigInput(BaseModel):
     """
     User-input portions of the materialization config
     """
+
     # List of partitions that materialization jobs (ongoing and backfill) will operate on.
     partitions: Optional[List[Partition]]
     # Spark config
@@ -192,6 +194,7 @@ class DruidCubeConfigInput(GenericCubeConfigInput):
     """
     Specific Druid cube materialization fields that require user input
     """
+
     prefix: Optional[str] = ""
     suffix: Optional[str] = ""
     druid: DruidConf
@@ -223,7 +226,9 @@ class Materialization(BaseSQLModel, table=True):  # type: ignore
     schedule: str
 
     # Arbitrary config relevant to the materialization engine
-    config: Union[GenericMaterializationConfig, DruidCubeConfig] = Field(default={}, sa_column=SqlaColumn(JSON))
+    config: Union[GenericMaterializationConfig, DruidCubeConfig] = Field(
+        default={}, sa_column=SqlaColumn(JSON),
+    )
 
     # The name of the plugin that handles materialization, if any
     job: str = Field(
@@ -244,7 +249,9 @@ class UpsertMaterialization(BaseSQLModel):
 
     name: Optional[str]
     engine: EngineRef
-    config: Union[DruidCubeConfigInput, GenericCubeConfigInput, GenericMaterializationConfigInput]
+    config: Union[
+        DruidCubeConfigInput, GenericCubeConfigInput, GenericMaterializationConfigInput,
+    ]
     schedule: str
 
 

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -237,7 +237,7 @@ class Materialization(BaseSQLModel, table=True):  # type: ignore
     )
 
     @validator("config")
-    def val_b(cls, value):
+    def config_validator(cls, value):
         return value.dict()
 
 

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -236,9 +236,8 @@ class Materialization(BaseSQLModel, table=True):  # type: ignore
         sa_column=SqlaColumn("job", String),
     )
 
-    @validator('config')
+    @validator("config")
     def val_b(cls, value):
-        print(value)
         return value.dict()
 
 
@@ -252,15 +251,4 @@ class UpsertMaterialization(BaseSQLModel):
     config: Union[
         DruidCubeConfigInput, GenericCubeConfigInput, GenericMaterializationConfigInput,
     ]
-    schedule: str
-
-
-class UpsertCubeMaterialization(BaseSQLModel):
-    """
-    An upsert object for cube materialization configs
-    """
-
-    name: Optional[str]
-    engine: EngineRef
-    config: Union[DruidCubeConfigInput, GenericCubeConfigInput]
     schedule: str

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -227,7 +227,8 @@ class Materialization(BaseSQLModel, table=True):  # type: ignore
 
     # Arbitrary config relevant to the materialization engine
     config: Union[GenericMaterializationConfig, DruidCubeConfig] = Field(
-        default={}, sa_column=SqlaColumn(JSON),
+        default={},
+        sa_column=SqlaColumn(JSON),
     )
 
     # The name of the plugin that handles materialization, if any
@@ -237,7 +238,8 @@ class Materialization(BaseSQLModel, table=True):  # type: ignore
     )
 
     @validator("config")
-    def config_validator(cls, value):
+    def config_validator(cls, value):  # pylint: disable=no-self-argument
+        """Changes `config` to a dict prior to saving"""
         return value.dict()
 
 
@@ -249,6 +251,8 @@ class UpsertMaterialization(BaseSQLModel):
     name: Optional[str]
     engine: EngineRef
     config: Union[
-        DruidCubeConfigInput, GenericCubeConfigInput, GenericMaterializationConfigInput,
+        DruidCubeConfigInput,
+        GenericCubeConfigInput,
+        GenericMaterializationConfigInput,
     ]
     schedule: str

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -31,7 +31,7 @@ from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import (
     Materialization,
     MaterializationConfigOutput,
-    UpsertCubeMaterializationConfig,
+    UpsertCubeMaterialization,
 )
 from datajunction_server.models.tag import Tag, TagNodeRelationship
 from datajunction_server.sql.parsing.types import ColumnType
@@ -716,7 +716,7 @@ class CreateCubeNode(ImmutableNodeFields, CubeNodeFields):
     A create object for cube nodes
     """
 
-    materializations: Optional[List[UpsertCubeMaterializationConfig]] = []
+    materializations: Optional[List[UpsertCubeMaterialization]] = []
 
 
 class UpdateNode(MutableNodeFields, SourceNodeFields):

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -31,7 +31,6 @@ from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import (
     Materialization,
     MaterializationConfigOutput,
-    UpsertCubeMaterialization,
 )
 from datajunction_server.models.tag import Tag, TagNodeRelationship
 from datajunction_server.sql.parsing.types import ColumnType
@@ -715,8 +714,6 @@ class CreateCubeNode(ImmutableNodeFields, CubeNodeFields):
     """
     A create object for cube nodes
     """
-
-    materializations: Optional[List[UpsertCubeMaterialization]] = []
 
 
 class UpdateNode(MutableNodeFields, SourceNodeFields):

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -159,14 +159,15 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
 
     def get_materialization_info(
         self,
-        node_name,
-        materialization_name,
+        node_name: str,
+        node_version: str,
+        materialization_name: str,
     ) -> MaterializationInfo:
         """
         Gets materialization info for the node and materialization config name.
         """
         response = self.requests_session.get(
-            f"/materialization/{node_name}/{materialization_name}/",
+            f"/materialization/{node_name}/{node_version}/{materialization_name}/",
             timeout=3,
         )
         if not response.ok:

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -341,186 +341,185 @@ def test_create_cube(  # pylint: disable=redefined-outer-name
 
     expected_query = """
 WITH
-m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        CAST(sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) AS DOUBLE) / count(*) AS default_DOT_discounted_orders_rate
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        count(default_DOT_repair_orders.repair_order_id) default_DOT_num_repair_orders
  FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        avg(default_DOT_repair_order_details.price) AS default_DOT_avg_repair_price
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price) default_DOT_total_repair_cost
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) default_DOT_total_repair_order_discounts
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
-    default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_hard_hat.state
+m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.country,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.state,
+        default_DOT_municipality_dim.local_region,
+        sum(default_DOT_repair_order_details.price) + sum(default_DOT_repair_order_details.price) AS default_DOT_double_total_repair_cost
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 )SELECT  m0_default_DOT_discounted_orders_rate.default_DOT_discounted_orders_rate,
-    m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
-    m2_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
-    m3_default_DOT_total_repair_cost.default_DOT_total_repair_cost,
-    m4_default_DOT_total_repair_order_discounts.default_DOT_total_repair_order_discounts,
-    m5_default_DOT_double_total_repair_cost.default_DOT_double_total_repair_cost,
-    COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
-    COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
-    COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
-    COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
-    COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
-    COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state
- FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
-FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state
-FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state
-FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state
-FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state
-
+        m1_default_DOT_num_repair_orders.default_DOT_num_repair_orders,
+        m2_default_DOT_avg_repair_price.default_DOT_avg_repair_price,
+        m3_default_DOT_total_repair_cost.default_DOT_total_repair_cost,
+        m4_default_DOT_total_repair_order_discounts.default_DOT_total_repair_order_discounts,
+        m5_default_DOT_double_total_repair_cost.default_DOT_double_total_repair_cost,
+        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
+        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
+        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
+        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region
+ FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
+FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
+FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
+FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
     """
     assert compare_query_strings(results["query"], expected_query)
 
@@ -581,190 +580,189 @@ def test_cube_materialization_sql_and_measures(
     ]
     expected_materialization_query = """
 WITH
-m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_dispatcher.company_name,
-    count(*) placeholder_count,
-    default_DOT_hard_hat.country,
-    sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        count(*) placeholder_count,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_dispatcher.company_name,
-    count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m1_default_DOT_num_repair_orders AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        count(default_DOT_repair_orders.repair_order_id) repair_order_id_count,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name
  FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_orders.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_orders.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_orders.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m2_default_DOT_avg_repair_price AS (SELECT  count(default_DOT_repair_order_details.price) price_count,
-    default_DOT_dispatcher.company_name,
-    sum(default_DOT_repair_order_details.price) price_sum,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        sum(default_DOT_repair_order_details.price) price_sum,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        count(default_DOT_repair_order_details.price) price_count,
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
-    sum(default_DOT_repair_order_details.price) price_sum,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        sum(default_DOT_repair_order_details.price) price_sum,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_dispatcher.company_name,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name,
+        sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 ),
-m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_dispatcher.company_name,
-    sum(default_DOT_repair_order_details.price) price_sum,
-    default_DOT_hard_hat.country,
-    default_DOT_hard_hat.city,
-    default_DOT_hard_hat.postal_code,
-    default_DOT_municipality_dim.local_region,
-    default_DOT_hard_hat.state
+m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_municipality_dim.local_region,
+        default_DOT_hard_hat.city,
+        sum(default_DOT_repair_order_details.price) price_sum,
+        default_DOT_hard_hat.state,
+        default_DOT_hard_hat.postal_code,
+        default_DOT_hard_hat.country,
+        default_DOT_dispatcher.company_name
  FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
-    default_DOT_repair_orders.hard_hat_id,
-    default_DOT_repair_orders.municipality_id,
-    default_DOT_repair_orders.repair_order_id
+        default_DOT_repair_orders.hard_hat_id,
+        default_DOT_repair_orders.municipality_id,
+        default_DOT_repair_orders.repair_order_id
  FROM roads.repair_orders AS default_DOT_repair_orders) AS default_DOT_repair_order ON default_DOT_repair_order_details.repair_order_id = default_DOT_repair_order.repair_order_id
 LEFT OUTER JOIN (SELECT  default_DOT_dispatchers.company_name,
-    default_DOT_dispatchers.dispatcher_id
+        default_DOT_dispatchers.dispatcher_id
  FROM roads.dispatchers AS default_DOT_dispatchers) AS default_DOT_dispatcher ON default_DOT_repair_order.dispatcher_id = default_DOT_dispatcher.dispatcher_id
 LEFT OUTER JOIN (SELECT  default_DOT_hard_hats.city,
-    default_DOT_hard_hats.country,
-    default_DOT_hard_hats.hard_hat_id,
-    default_DOT_hard_hats.postal_code,
-    default_DOT_hard_hats.state
+        default_DOT_hard_hats.country,
+        default_DOT_hard_hats.hard_hat_id,
+        default_DOT_hard_hats.postal_code,
+        default_DOT_hard_hats.state
  FROM roads.hard_hats AS default_DOT_hard_hats) AS default_DOT_hard_hat ON default_DOT_repair_order.hard_hat_id = default_DOT_hard_hat.hard_hat_id
 LEFT OUTER JOIN (SELECT  default_DOT_municipality.local_region,
-    default_DOT_municipality.municipality_id
+        default_DOT_municipality.municipality_id
  FROM roads.municipality AS default_DOT_municipality LEFT  JOIN roads.municipality_municipality_type AS default_DOT_municipality_municipality_type ON default_DOT_municipality.municipality_id = default_DOT_municipality_municipality_type.municipality_id
 LEFT  JOIN roads.municipality_type AS default_DOT_municipality_type ON default_DOT_municipality_municipality_type.municipality_type_id = default_DOT_municipality_type.municipality_type_desc) AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
  WHERE  default_DOT_hard_hat.state = 'AZ'
  GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
 )SELECT  m0_default_DOT_discounted_orders_rate.placeholder_count m0_default_DOT_discounted_orders_rate_placeholder_count,
-    m0_default_DOT_discounted_orders_rate.discount_sum m0_default_DOT_discounted_orders_rate_discount_sum,
-    m1_default_DOT_num_repair_orders.repair_order_id_count m1_default_DOT_num_repair_orders_repair_order_id_count,
-    m2_default_DOT_avg_repair_price.price_count m2_default_DOT_avg_repair_price_price_count,
-    m2_default_DOT_avg_repair_price.price_sum m2_default_DOT_avg_repair_price_price_sum,
-    m3_default_DOT_total_repair_cost.price_sum m3_default_DOT_total_repair_cost_price_sum,
-    m4_default_DOT_total_repair_order_discounts.price_discount_sum m4_default_DOT_total_repair_order_discounts_price_discount_sum,
-    m5_default_DOT_double_total_repair_cost.price_sum m5_default_DOT_double_total_repair_cost_price_sum,
-    COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
-    COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
-    COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
-    COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
-    COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
-    COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state
- FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state
-FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state
-FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state
-FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state
-FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state
-
+        m0_default_DOT_discounted_orders_rate.discount_sum m0_default_DOT_discounted_orders_rate_discount_sum,
+        m1_default_DOT_num_repair_orders.repair_order_id_count m1_default_DOT_num_repair_orders_repair_order_id_count,
+        m2_default_DOT_avg_repair_price.price_sum m2_default_DOT_avg_repair_price_price_sum,
+        m2_default_DOT_avg_repair_price.price_count m2_default_DOT_avg_repair_price_price_count,
+        m3_default_DOT_total_repair_cost.price_sum m3_default_DOT_total_repair_cost_price_sum,
+        m4_default_DOT_total_repair_order_discounts.price_discount_sum m4_default_DOT_total_repair_order_discounts_price_discount_sum,
+        m5_default_DOT_double_total_repair_cost.price_sum m5_default_DOT_double_total_repair_cost_price_sum,
+        COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
+        COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+        COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
+        COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
+        COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
+        COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name
+ FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
+FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
+FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
+FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
+FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
     """
     assert compare_query_strings(
         data["materializations"][0]["config"]["query"],

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -259,6 +259,7 @@ def test_create_cube_with_materialization(client_with_query_service: TestClient)
             ],
         },
     )
+    print(response.json())
     default_materialization = response.json()["materializations"][0]
     assert default_materialization["job"] == "DruidCubeMaterializationJob"
     assert default_materialization["schedule"] == "0 * * * *"
@@ -855,7 +856,7 @@ def test_add_materialization_cube_failures(
     assert response.json() == {
         "message": "No change has been made to the materialization config for node "
         "`default.repairs_cube` and engine `druid` as the config does not have valid "
-        "configuration for engine `druid`. \nExpecting 'druid' key in `config`.",
+        "configuration for engine `druid`.",
     }
 
     response = client_with_repairs_cube.post(
@@ -898,9 +899,7 @@ def test_add_materialization_cube_failures(
     assert response.json() == {
         "message": "No change has been made to the materialization config for node "
         "`default.repairs_cube` and engine `druid` as the config does not have "
-        "valid configuration for engine `druid`. "
-        "\n* field required: granularity"
-        "\n* field required: timestamp_column",
+        "valid configuration for engine `druid`."
     }
 
 

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -837,11 +837,11 @@ def test_add_materialization_cube_failures(
             "schedule": "",
         },
     )
-    assert response.json() == {
-        "message": "No change has been made to the materialization config for node "
+    assert response.json()["message"] == (
+        "No change has been made to the materialization config for node "
         "`default.repairs_cube` and engine `druid` as the config does not have valid "
-        "configuration for engine `druid`.",
-    }
+        "configuration for engine `druid`."
+    )
 
     response = client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization/",
@@ -880,11 +880,11 @@ def test_add_materialization_cube_failures(
             "schedule": "",
         },
     )
-    assert response.json() == {
-        "message": "No change has been made to the materialization config for node "
+    assert response.json()["message"] == (
+        "No change has been made to the materialization config for node "
         "`default.repairs_cube` and engine `druid` as the config does not have "
-        "valid configuration for engine `druid`.",
-    }
+        "valid configuration for engine `druid`."
+    )
 
 
 def test_add_materialization_config_to_cube(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1419,7 +1419,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
                     "AS languages,\n\tCOUNT( DISTINCT basic_DOT_source_DOT_users.id) "
                     "AS num_users \n FROM basic.dim_users AS basic_DOT_source_DOT_users "
                     "\n WHERE  basic_DOT_source_DOT_users.country IN ('DE', 'MY') \n "
-                    "GROUP BY  1\n",
+                    "GROUP BY  1\n\n",
                     "upstream_tables": ["public.basic.dim_users"],
                 },
                 "schedule": "0 * * * *",

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -235,6 +235,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             GenericMaterializationInput(
                 name="default",
                 node_name="default.hard_hat",
+                node_version="v1",
                 node_type=NodeType.DIMENSION,
                 schedule="0 * * * *",
                 query="",
@@ -249,6 +250,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             json={
                 "name": "default",
                 "node_name": "default.hard_hat",
+                "node_version": "v1",
                 "node_type": "dimension",
                 "partitions": [],
                 "query": "",
@@ -312,6 +314,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             GenericMaterializationInput(
                 name="default",
                 node_name="default.hard_hat",
+                node_version="v1",
                 node_type=NodeType.DIMENSION,
                 schedule="0 * * * *",
                 query="",
@@ -325,6 +328,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             json={
                 "name": "default",
                 "node_name": "default.hard_hat",
+                "node_version": "v1",
                 "node_type": "dimension",
                 "schedule": "0 * * * *",
                 "query": "",

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -357,10 +357,11 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         query_service_client = QueryServiceClient(uri=self.endpoint)
         response = query_service_client.get_materialization_info(
             node_name="default.hard_hat",
+            node_version="v3.1",
             materialization_name="default",
         )
         mock_request.assert_called_with(
-            "/materialization/default.hard_hat/default/",
+            "/materialization/default.hard_hat/v3.1/default/",
             timeout=3,
         )
         assert response == {
@@ -385,6 +386,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         query_service_client = QueryServiceClient(uri=self.endpoint)
         response = query_service_client.get_materialization_info(
             node_name="default.hard_hat",
+            node_version="v3.1",
             materialization_name="default",
         )
         assert response == {


### PR DESCRIPTION
### Summary

When a node is updated and its query changes, we should update its configured materializations and call the query service to reschedule all corresponding new materialization jobs. The existing behavior did not handle this case, meaning that updating a node's query would additionally require calling the upsert materialization endpoint in order to reschedule updated materialization jobs.

This PR also rolls in a few other more minor changes:
* Add Pydantic schema on the `config` field in a `Materialization`, so that it's not just an arbitrary dict but actually has a set of expected schemas (these differ depending on the materialization type)
* Remove the abillity to set materializations on cube node creation. This was originally added in only for cube nodes, which is inconsistent with the creation behavior for all nodes. It's also unwieldy having the materialization creation logic be available through multiple paths.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
