### PR TITLE
show query info in UI and allow settings display rows

### DIFF
--- a/datajunction-ui/src/app/components/QueryInfo.jsx
+++ b/datajunction-ui/src/app/components/QueryInfo.jsx
@@ -8,6 +8,7 @@ export default function QueryInfo({
   output_table,
   scheduled,
   started,
+  numRows,
 }) {
   const stateIcon =
     state === 'FINISHED' ? (
@@ -51,6 +52,7 @@ export default function QueryInfo({
             <th>Errors</th>
             <th>Links</th>
             <th>Output Table</th>
+            <th>Number of Rows</th>
           </tr>
         </thead>
         <tbody>
@@ -95,6 +97,7 @@ export default function QueryInfo({
               )}
             </td>
             <td>{output_table}</td>
+            <td>{numRows}</td>
           </tr>
         </tbody>
       </table>

--- a/datajunction-ui/src/app/components/QueryInfo.jsx
+++ b/datajunction-ui/src/app/components/QueryInfo.jsx
@@ -1,0 +1,103 @@
+export default function QueryInfo({
+  id,
+  state,
+  engine_name,
+  engine_version,
+  errors,
+  links,
+  output_table,
+  scheduled,
+  started,
+}) {
+  const stateIcon =
+    state === 'FINISHED' ? (
+      <span className="status__valid status" style={{ alignContent: 'center' }}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="25"
+          height="25"
+          fill="currentColor"
+          className="bi bi-check-circle-fill"
+          viewBox="0 0 16 16"
+        >
+          <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z" />
+        </svg>
+      </span>
+    ) : (
+      <span className="status__valid status" style={{ alignContent: 'center' }}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-x-circle-fill"
+          viewBox="0 0 16 16"
+        >
+          <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z" />
+        </svg>
+      </span>
+    );
+
+  return (
+    <div className="table-responsive">
+      <table className="card-inner-table table">
+        <thead className="fs-7 fw-bold text-gray-400 border-bottom-0">
+          <tr>
+            <th>Query ID</th>
+            <th>Engine</th>
+            <th>State</th>
+            <th>Scheduled</th>
+            <th>Started</th>
+            <th>Errors</th>
+            <th>Links</th>
+            <th>Output Table</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <span className="rounded-pill badge bg-secondary-soft">{id}</span>
+            </td>
+            <td>
+              <span className="rounded-pill badge bg-secondary-soft">
+                {engine_name}
+                {' - '}
+                {engine_version}
+              </span>
+            </td>
+            <td>{stateIcon}</td>
+            <td>{scheduled}</td>
+            <td>{started}</td>
+            <td>
+              {errors.length ? (
+                errors.map(e => (
+                  <p>
+                    <span className="rounded-pill badge bg-secondary-error">
+                      {e}
+                    </span>
+                  </p>
+                ))
+              ) : (
+                <></>
+              )}
+            </td>
+            <td>
+              {links?.length ? (
+                links.map(link => (
+                  <p>
+                    <a href={link} target="_blank" rel="noreferrer">
+                      {link}
+                    </a>
+                  </p>
+                ))
+              ) : (
+                <></>
+              )}
+            </td>
+            <td>{output_table}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1,6 +1,8 @@
 import { MarkerType } from 'reactflow';
 
-const DJ_URL = 'http://localhost:8000'; //process.env.REACT_APP_DJ_URL;
+const DJ_URL = process.env.REACT_APP_DJ_URL
+  ? process.env.REACT_APP_DJ_URL
+  : 'http://localhost:8000';
 
 export const DataJunctionAPI = {
   node: async function (name) {

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -186,6 +186,10 @@ h6 {
 .badge.bg-secondary-soft {
   color: #6e84a3;
 }
+.badge.bg-secondary-error {
+  color: #6e84a3;
+  background-color: #fad7dd;
+}
 .badge.rounded-pill {
   padding-right: 0.6em;
   padding-left: 0.6em;

--- a/datajunction-ui/webpack.config.js
+++ b/datajunction-ui/webpack.config.js
@@ -1,7 +1,9 @@
 const webpack = require('webpack');
+const dotenv = require('dotenv').config()
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 // const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+require('dotenv').config({ path: './.env' }); 
 
 var babelOptions = {
   presets: ['@babel/preset-react'],
@@ -100,7 +102,7 @@ module.exports = {
       template: path.resolve(__dirname, 'public', 'index.html'),
     }),
     new webpack.DefinePlugin({
-      REACT_APP_DJ_URL: 'http://localhost:8000',
+      "process.env": JSON.stringify(process.env)
     }),
     // new MiniCssExtractPlugin({
     //   filename: './styles/index.css',

--- a/datajunction-ui/webpack.config.js
+++ b/datajunction-ui/webpack.config.js
@@ -2,7 +2,6 @@ const webpack = require('webpack');
 const dotenv = require('dotenv').config()
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-// const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 require('dotenv').config({ path: './.env' }); 
 
 var babelOptions = {
@@ -104,8 +103,5 @@ module.exports = {
     new webpack.DefinePlugin({
       "process.env": JSON.stringify(process.env)
     }),
-    // new MiniCssExtractPlugin({
-    //   filename: './styles/index.css',
-    // }),
   ],
 };


### PR DESCRIPTION
### Summary

I've updated this PR after some feedback. Now the changes are only located in the UI:

**datajunction-ui**
- The SQL page recently added in #574 now also includes query information after clicking the "Run Query" button
- The results show 10 records by default with a dropdown that lets you increase that to 100 or 1000 (the total number of rows is included in the query information displayed)
- Instead of re-generating the SQL on every select, it now stages the metrics and dimensions as the drop-down is open and selections are being made. When `onMenuClose` is triggered, the SQL is generated once as opposed to on every individual selection.


https://github.com/DataJunction/dj/assets/43911210/c183df72-9069-4b80-bdbf-11a94251096d



### Test Plan

- [x] PR has an associated issue: #583 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
