### PR TITLE
Materialization UI minor fixes

### DIFF
--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -153,7 +153,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             json=materialization_input.dict(),
         )
         if not response.ok:  # pragma: no cover
-            return MaterializationInfo(urls=[])
+            return MaterializationInfo(urls=[], output_tables=[])
         result = response.json()
         return MaterializationInfo(**result)
 

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -16,14 +16,10 @@ export default function NodeMaterializationTab({ node, djClient }) {
   const rangePartition = partition => {
     return (
       <div>
-        <div>
-          Min:{' '}
-          <span className="badge partition_value">{partition.range[0]}</span>
-        </div>
-        <div>
-          Max:{' '}
+        <span className="badge partition_value">
+          <span className="badge partition_value">{partition.range[0]}</span>to
           <span className="badge partition_value">{partition.range[1]}</span>
-        </div>
+        </span>
       </div>
     );
   };
@@ -67,6 +63,12 @@ export default function NodeMaterializationTab({ node, djClient }) {
                     {partition.range !== null && partition.range.length > 0
                       ? rangePartition(partition)
                       : null}
+                    {partition.range.length === 0 &&
+                    partition.values.length === 0 ? (
+                      <span className={`badge partition_value_highlight`}>
+                        ALL
+                      </span>
+                    ) : null}
                   </div>
                 </div>
               ) : null,

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -63,8 +63,9 @@ export default function NodeMaterializationTab({ node, djClient }) {
                     {partition.range !== null && partition.range.length > 0
                       ? rangePartition(partition)
                       : null}
-                    {partition.range.length === 0 &&
-                    partition.values.length === 0 ? (
+                    {(partition.range === null && partition.values === null) ||
+                    (partition.range.length === 0 &&
+                      partition.values.length === 0) ? (
                       <span className={`badge partition_value_highlight`}>
                         ALL
                       </span>

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -437,6 +437,13 @@ tbody th {
   margin: 0.25rem;
 }
 
+.partition_value_highlight {
+  border: solid #5c3b8f 0.025em;
+  color: #5c3b8f;
+  background-color: #5c3b8f25;
+  margin: 0.25rem;
+}
+
 .upstreams {
   width: 260px;
   display: flex;

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -252,8 +252,8 @@ tr {
 }
 
 .card-light-shadow {
-  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-  transition: all 0.3s cubic-bezier(.25,.8,.25,1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
   padding: 1rem;
 }
 
@@ -709,9 +709,9 @@ pre {
 
 .button-3 {
   appearance: none;
-  border: 1px solid rgba(27, 31, 35, .15);
+  border: 1px solid rgba(27, 31, 35, 0.15);
   border-radius: 6px;
-  box-shadow: rgba(27, 31, 35, .1) 0 1px 0;
+  box-shadow: rgba(27, 31, 35, 0.1) 0 1px 0;
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;
@@ -736,12 +736,12 @@ pre {
 
 .execute-button {
   background-color: #00b368;
-  color: #fff
+  color: #fff;
 }
 
 .executing-button {
   background-color: #bbbbbb;
-  color: #fff
+  color: #fff;
 }
 
 .neutral-button {


### PR DESCRIPTION
### Summary

A minor change to the materialization UI that (a) modifies the styling for time range values and (b) displays `ALL` in cases where no specific partition value is provided, as that is the implied behavior of DJ when such a partition is configured.

<img width="1134" alt="Screenshot 2023-06-20 at 11 21 50 AM" src="https://github.com/DataJunction/dj/assets/9524628/e221d5da-3ec7-4895-bb26-e0beea401b10">

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
