### PR TITLE
Fix typo in arg, baseUrl -> baseURL

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -15,11 +15,11 @@ SET_AS_LATEST=$2   # false
 BASE_URL=$3        # http://localhost:55555
 
 if [ "$SET_AS_LATEST" = true ] ; then
-    hugo -d public --contentDir content/${VERSION}/ --configDir config --baseUrl $BASE_URL --cleanDestinationDir
+    hugo -d public --contentDir content/${VERSION}/ --configDir config --baseURL $BASE_URL --cleanDestinationDir
 fi
 
 # Build the versions site (sits outside of docs sites for each version)
-hugo -d public/versions --contentDir content/versions/ --configDir config --baseUrl $BASE_URL --environment versions --cleanDestinationDir
+hugo -d public/versions --contentDir content/versions/ --configDir config --baseURL $BASE_URL --environment versions --cleanDestinationDir
 
 # Build the docs site for specified version
-hugo -d public/${VERSION} --contentDir content/${VERSION}/ --configDir config --baseUrl "${BASE_URL}${VERSION}" --cleanDestinationDir
+hugo -d public/${VERSION} --contentDir content/${VERSION}/ --configDir config --baseURL "${BASE_URL}${VERSION}" --cleanDestinationDir


### PR DESCRIPTION
### Summary

Small PR to fix the docs building script. The arg `--baseUrl` should be `--baseURL`.

### Test Plan

Ran the script, opened the docs site in a live server.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
