### PR TITLE
Fix OpenAPI spec generation action

### DIFF
--- a/.github/workflows/generate-openapi-spec.yml
+++ b/.github/workflows/generate-openapi-spec.yml
@@ -19,13 +19,24 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
       - name: Install DJ
         run: |
           python -m pip install --upgrade pip
           pip install .
 
       - name: Generate OpenAPI Spec
-        run: ./scripts/generate-openapi.py -o openapi.json
+        run: |
+          ./scripts/generate-openapi.py -o ../openapi.json
+
+      - name: Generate Markdown Docs from Spec
+        run: |
+          npm install -g widdershins
+          widdershins ../openapi.json -o ../docs/content/0.1.0/docs/developers/the-datajunction-api-specification.md --code=true --omitBody=true --summary=true
 
       - name: Configure Git
         run: |
@@ -38,7 +49,8 @@ jobs:
 
       - name: Commit OpenAPI Spec
         run: |
-          git add openapi.json
+          git add ../openapi.json
+          git add ../docs/content/0.1.0/docs/developers/the-datajunction-api-specification.md
           git commit -m "Updating OpenAPI Spec"
           git checkout -b ci-pr/python-client-${{ steps.sha.outputs.short_sha }}
           git push --set-upstream origin ci-pr/python-client-${{ steps.sha.outputs.short_sha }}

--- a/.github/workflows/generate-openapi-spec.yml
+++ b/.github/workflows/generate-openapi-spec.yml
@@ -2,11 +2,14 @@ name: Generate OpenAPI Spec
 on:
   workflow_dispatch:
 jobs:
-  generate-python-client:
+  generate-openapi-spec:
     env:
       PDM_DEPS: 'urllib3<2'
+    defaults:
+      run:
+        working-directory: ./datajunction-server
     runs-on: ubuntu-latest
-    name: Generate Python Client
+    name: OpenAPI Spec
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
   dj:
     container_name: dj
     stdin_open: true
-    env_file:
-      - ./datajunction-server/.docker-env/.env
     tty: true
     networks:
       - core
@@ -35,8 +33,6 @@ services:
 
   db_migration:
     container_name: db_migration
-    env_file:
-      - ./datajunction-server/.docker-env/.env
     networks:
       - core
     build:


### PR DESCRIPTION
### Summary

Now that we've moved the relevant script to live under `datajunction-server/scripts/generate-openapi.py`, we need to change this action to reference the right location to run the script.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
