### PR TITLE
On the node page for cubes, display the cube elements

### DIFF
--- a/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
+++ b/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
         "DataJunctionAPI": Object {
           "commonDimensions": [Function],
           "compiledSql": [Function],
+          "cube": [Function],
           "dag": [Function],
           "data": [Function],
           "downstreams": [Function],
@@ -60,6 +61,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
                   Object {
                     "commonDimensions": [Function],
                     "compiledSql": [Function],
+                    "cube": [Function],
                     "dag": [Function],
                     "data": [Function],
                     "downstreams": [Function],

--- a/datajunction-ui/src/app/components/djgraph/Collapse.jsx
+++ b/datajunction-ui/src/app/components/djgraph/Collapse.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { DJNodeDimensions } from './DJNodeDimensions';
-import { Handle } from 'reactflow';
 import { DJNodeColumns } from './DJNodeColumns';
 
 export default function Collapse({ collapsed, text, data }) {

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -74,6 +74,34 @@ export default function NodeInfoTab({ node }) {
   ) : (
     <></>
   );
+
+  const cubeElementsDiv = node?.cube_elements ? (
+    <div className="list-group-item d-flex">
+      <div className="d-flex gap-2 w-100 justify-content-between py-3">
+        <div
+          style={{
+            width: window.innerWidth * 0.8,
+          }}
+        >
+          <h6 className="mb-0 w-100">Cube Elements</h6>
+          <div className={`list-group-item`}>
+            {node.cube_elements.map(cubeElem => (
+              <div className="button-3 cube-element">
+                <a href={`/nodes/${cubeElem.node_name}`}>
+                  {cubeElem.node_name}
+                </a>
+                <span className={`badge node_type__${cubeElem.type}`}>
+                  {cubeElem.type}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <></>
+  );
   return (
     <div className="list-group align-items-center justify-content-between flex-md-row gap-2">
       <ListGroupItem label="Description" value={node?.description} />
@@ -109,7 +137,8 @@ export default function NodeInfoTab({ node }) {
           </div>
         </div>
       </div>
-      {queryDiv}
+      {node?.type !== 'cube' ? queryDiv : ''}
+      {cubeElementsDiv}
       <div className="list-group-item d-flex">{node?.primary_key}</div>
     </div>
   );

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -46,6 +46,11 @@ export function NodePage() {
         data.dimensions = metric.dimensions;
         setNode(data);
       }
+      if (data.type === 'cube') {
+        const cube = await djClient.cube(name);
+        data.cube_elements = cube.cube_elements;
+        setNode(data);
+      }
     };
     fetchData().catch(console.error);
   }, [djClient, name]);

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -36,6 +36,11 @@ export const DataJunctionAPI = {
     return data;
   },
 
+  cube: async function (name) {
+    const data = await (await fetch(DJ_URL + '/cubes/' + name + '/')).json();
+    return data;
+  },
+
   metrics: async function (name) {
     const data = await (await fetch(DJ_URL + '/metrics/')).json();
     return data;

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -791,3 +791,15 @@ pre {
 .text-black {
   color: #000000 !important;
 }
+
+.cube-element {
+  color: #757575;
+  font-size: 14px;
+  padding: 0.25rem;
+  flex-grow: 1;
+  line-height: 24px;
+  letter-spacing: normal;
+}
+.cube-element .badge {
+  margin-left: 0.4rem;
+}


### PR DESCRIPTION
### Summary

This change displays the cube elements (metrics + dimensions) on the cube node info page and hides the node query (since it's a generated query and mostly irrelevant to users).

<img width="1063" alt="Screenshot 2023-06-26 at 8 56 03 AM" src="https://github.com/DataJunction/dj/assets/9524628/4307daa5-329a-4c29-beef-30b6b16e6e30">


### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
