### PR TITLE
Client code popover for node creation, dimension linking, and add materialization

### DIFF
--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -1,0 +1,168 @@
+"""
+APIs related to generating client code used for performing various actions in DJ.
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from datajunction_server.api.helpers import get_node_by_name
+from datajunction_server.models.node import NodeType
+from datajunction_server.utils import get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/client/python/new_node/{node_name}", response_model=str)
+def client_code_for_creating_node(
+    node_name: str, *, session: Session = Depends(get_session)  
+) -> str:
+    """
+    Generate the Python client code used for creating this node
+    """
+    node_short_name = node_name.split(".")[-1]
+    node = get_node_by_name(session, node_name)
+
+    # Generic user-configurable node creation params
+    params = node.current.dict(
+        exclude={
+            "id",
+            "version",
+            "type",
+            "catalog_id",
+            "status",
+            "mode",
+            "node_id",
+            "updated_at",
+            "query" if node.type == NodeType.CUBE else "",
+        },
+        exclude_none=True,
+    )
+
+    params["primary_key"] = [col.name for col in node.current.primary_key()]
+
+    for key in params:
+        if not isinstance(params[key], list) and key != "query":
+            params[key] = f'"{params[key]}"'
+        if key == "query":
+            params[key] = f'"""{params[key]}"""'
+
+    # Cube-specific params
+    cube_params = []
+    if node.type == NodeType.CUBE:
+        cube_metrics = ", ".join(
+            [
+                '"' + elem.node_revisions[-1].name + '"'
+                for elem in node.current.cube_elements
+                if elem.node_revisions[-1].type == NodeType.METRIC
+            ],
+        )
+        cube_dimensions = ", ".join(
+            [
+                '"' + elem.node_revisions[-1].name + "." + elem.name + '"'
+                for elem in node.current.cube_elements
+                if elem.node_revisions[-1].type == NodeType.DIMENSION
+            ],
+        )
+        cube_params = [
+            f"    metrics=[{cube_metrics}]",
+            f"    dimensions=[{cube_dimensions}]",
+        ]
+
+    formatted_params = ",\n".join(
+        [f"    {k}={v}" for k, v in params.items()] + cube_params,
+    )
+
+    client_code = f"""from datajunction import DJClient, NodeMode
+
+dj = DJClient(DJ_URL)
+
+{node_short_name} = dj.new_{node.type}(
+{formatted_params}
+)
+{node_short_name}.save(NodeMode.{node.current.mode.upper()})"""
+    return client_code  # type: ignore
+
+
+@router.get(
+    "/client/python/add_materialization/{node_name}/{materialization_name}",
+    response_model=str,
+)
+def client_code_for_adding_materialization(
+    node_name: str,
+    materialization_name: str,
+    *,
+    session: Session = Depends(get_session),
+) -> str:
+    """
+    Generate the Python client code used for adding this materialization
+    """
+    node_short_name = node_name.split(".")[-1]
+    node = get_node_by_name(session, node_name)
+    materialization = [
+        materialization
+        for materialization in node.current.materializations
+        if materialization.name == materialization_name
+    ][0]
+    user_modified_config = {
+        key: materialization.config[key]
+        for key in materialization.config
+        if key in ("partitions", "spark", "druid", "")
+    }
+    with_b = "\n".join(
+        [
+            f"    {line}"
+            for line in json.dumps(user_modified_config, indent=4).split("\n")
+        ],
+    )
+    client_code = f"""from datajunction import DJClient, MaterializationConfig
+
+dj = DJClient(DJ_URL)
+
+{node_short_name} = dj.{node.type}(
+    "{node.name}"
+)
+materialization = MaterializationConfig(
+    engine=Engine(
+        name="{materialization.engine.name}",
+        version="{materialization.engine.version}",
+    ),
+    schedule="{materialization.schedule}",
+    config={with_b.strip()},
+)
+{node_short_name}.add_materialization(
+    materialization
+)"""
+    return client_code  # type: ignore
+
+
+@router.get(
+    "/client/python/link_dimension/{node_name}/{column}/{dimension}/",
+    response_model=str,
+)
+def client_code_for_linking_dimension_to_node(
+    node_name: str,
+    column: str,
+    dimension: str,
+    *,
+    session: Session = Depends(get_session),
+) -> str:
+    """
+    Generate the Python client code used for linking this node's column to a dimension
+    """
+    node_short_name = node_name.split(".")[-1]
+    node = get_node_by_name(session, node_name)
+    client_code = f"""from datajunction import DJClient, MaterializationConfig
+
+dj = DJClient(DJ_URL)
+{node_short_name} = dj.{node.type}(
+    "{node.name}"
+)
+{node_short_name}.link_dimension(
+    "{column}",
+    "{dimension}",
+)"""
+    return client_code  # type: ignore

--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 @router.get("/client/python/new_node/{node_name}", response_model=str)
 def client_code_for_creating_node(
-    node_name: str, *, session: Session = Depends(get_session)  
+    node_name: str, *, session: Session = Depends(get_session)
 ) -> str:
     """
     Generate the Python client code used for creating this node

--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -73,7 +73,7 @@ def client_code_for_creating_node(
         ]
 
     formatted_params = ",\n".join(
-        [f"    {k}={v}" for k, v in params.items()] + cube_params,
+        [f"    {k}={params[k]}" for k in sorted(params.keys())] + cube_params,
     )
 
     client_code = f"""from datajunction import DJClient, NodeMode

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -19,6 +19,7 @@ from datajunction_server import __version__
 from datajunction_server.api import (
     attributes,
     catalogs,
+    client,
     cubes,
     data,
     engines,
@@ -84,6 +85,7 @@ def get_dj_app(
     application.include_router(tags.router)
     application.include_router(attributes.router)
     application.include_router(sql.router)
+    application.include_router(client.router)
 
     @application.exception_handler(DJException)
     async def dj_exception_handler(  # pylint: disable=unused-argument

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -282,60 +282,6 @@ def get_a_node(name: str, *, session: Session = Depends(get_session)) -> NodeOut
     return node  # type: ignore
 
 
-@router.get("/nodes/{name}/client/python/", response_model=str)
-def client_code_python(
-    name: str, *, action: str = "create", session: Session = Depends(get_session)
-) -> str:
-    """
-    Generate python client create node code
-    """
-    node_short_name = name.split(".")[-1]
-    node = get_node_by_name(session, name)
-    triple_quotes = '"""'
-    query = (
-        f"query={triple_quotes}{node.current.query.strip()}{triple_quotes},"
-        if node.type in (NodeType.DIMENSION, NodeType.TRANSFORM, NodeType.METRIC)
-        else ""
-    )
-    catalog = (
-        f"catalog=\"{node.current.catalog.name}\"," if node.type == NodeType.SOURCE else ""
-    )
-    schema_ = (
-        f"schema_=\"{node.current.schema_}\"," if node.type == NodeType.SOURCE else ""
-    )
-    table = (
-        f"table=\"{node.current.table}\"," if node.type == NodeType.SOURCE else ""
-    )
-    source_params = f"""{catalog}
-    {schema_}
-    {table}""" if node.type == NodeType.SOURCE else ""
-    cube_metrics = (
-        ", ".join(['"' + elem.node_revisions[-1].name + '"'
-                   for elem in node.current.cube_elements if elem.node_revisions[-1].type == NodeType.METRIC])
-        if node.type == NodeType.CUBE else ""
-    )
-    cube_dimensions = (
-        ", ".join(['"' + elem.node_revisions[-1].name + '.' + elem.name + '"'
-                   for elem in node.current.cube_elements if elem.node_revisions[-1].type == NodeType.DIMENSION])
-        if node.type == NodeType.CUBE else ""
-    )
-    cube_params = f"""metrics=[{cube_metrics}],
-    dimensions=[{cube_dimensions}],""" if node.type == NodeType.CUBE else ""
-    client_code = f"""from datajunction import DJClient, NodeMode
-
-dj = DJClient(DJ_URL)
-
-{node_short_name} = dj.new_{node.type}(
-    name="{node.name}",
-    display_name="{node.current.display_name}",
-    description="{node.current.description}",
-    tags=[{", ".join('"' + tag.name + '"' for tag in node.tags)}],
-    {query}{source_params}{cube_params}
-)
-{node_short_name}.save(NodeMode.{node.current.mode.upper()})"""
-    return client_code  # type: ignore
-
-
 @router.post("/nodes/{name}/deactivate/", status_code=201)
 def deactivate_a_node(name: str, *, session: Session = Depends(get_session)):
     """

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -20,13 +20,13 @@ dj = DJClient(DJ_URL)
 
 num_repair_orders = dj.new_metric(
     description="Number of repair orders",
-    query=\"\"\"SELECT  count(repair_order_id) default_DOT_num_repair_orders
- FROM default.repair_orders
-
-\"\"\",
     display_name="Default: Num Repair Orders",
     name="default.num_repair_orders",
-    primary_key=[]
+    primary_key=[],
+    query=\"\"\"SELECT  count(repair_order_id) default_DOT_num_repair_orders 
+ FROM default.repair_orders
+
+\"\"\"
 )
 num_repair_orders.save(NodeMode.PUBLISHED)"""
     )
@@ -47,11 +47,11 @@ dj = DJClient(DJ_URL)
 
 repair_order_details = dj.new_source(
     description="Details on repair orders",
-    table="repair_order_details",
     display_name="Default: Repair Order Details",
     name="default.repair_order_details",
+    primary_key=[],
     schema_="roads",
-    primary_key=[]
+    table="repair_order_details"
 )
 repair_order_details.save(NodeMode.PUBLISHED)"""
     )
@@ -70,6 +70,9 @@ dj = DJClient(DJ_URL)
 
 repair_order = dj.new_dimension(
     description="Repair order dimension",
+    display_name="Default: Repair Order",
+    name="default.repair_order",
+    primary_key=['repair_order_id'],
     query=\"\"\"
                         SELECT
                         repair_order_id,
@@ -80,10 +83,7 @@ repair_order = dj.new_dimension(
                         dispatched_date,
                         dispatcher_id
                         FROM default.repair_orders
-                    \"\"\",
-    display_name="Default: Repair Order",
-    name="default.repair_order",
-    primary_key=['repair_order_id']
+                    \"\"\"
 )
 repair_order.save(NodeMode.PUBLISHED)"""
     )

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -20,7 +20,7 @@ dj = DJClient(DJ_URL)
 
 num_repair_orders = dj.new_metric(
     description="Number of repair orders",
-    query=\"\"\"SELECT  count(repair_order_id) default_DOT_num_repair_orders 
+    query=\"\"\"SELECT  count(repair_order_id) default_DOT_num_repair_orders
  FROM default.repair_orders
 
 \"\"\",

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -23,8 +23,9 @@ num_repair_orders = dj.new_metric(
     display_name="Default: Num Repair Orders",
     name="default.num_repair_orders",
     primary_key=[],
-    query=\"\"\"SELECT  count(repair_order_id) default_DOT_num_repair_orders 
- FROM default.repair_orders
+    query=\"\"\"SELECT  count(repair_order_id) default_DOT_num_repair_orders"""
+        + " \n"
+        + """ FROM default.repair_orders
 
 \"\"\"
 )

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -1,0 +1,221 @@
+"""
+Tests for client code generator.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_generated_python_client_code_new_metric(client_with_examples: TestClient):
+    """
+    Test generating Python client code for creating a new metric
+    """
+    response = client_with_examples.get(
+        "/client/python/new_node/default.num_repair_orders",
+    )
+    assert (
+        response.json()
+        == """from datajunction import DJClient, NodeMode
+
+dj = DJClient(DJ_URL)
+
+num_repair_orders = dj.new_metric(
+    description="Number of repair orders",
+    query=\"\"\"SELECT  count(repair_order_id) default_DOT_num_repair_orders 
+ FROM default.repair_orders
+
+\"\"\",
+    display_name="Default: Num Repair Orders",
+    name="default.num_repair_orders",
+    primary_key=[]
+)
+num_repair_orders.save(NodeMode.PUBLISHED)"""
+    )
+
+
+def test_generated_python_client_code_new_source(client_with_examples: TestClient):
+    """
+    Test generating Python client code for creating a new source
+    """
+    response = client_with_examples.get(
+        "/client/python/new_node/default.repair_order_details",
+    )
+    assert (
+        response.json()
+        == """from datajunction import DJClient, NodeMode
+
+dj = DJClient(DJ_URL)
+
+repair_order_details = dj.new_source(
+    description="Details on repair orders",
+    table="repair_order_details",
+    display_name="Default: Repair Order Details",
+    name="default.repair_order_details",
+    schema_="roads",
+    primary_key=[]
+)
+repair_order_details.save(NodeMode.PUBLISHED)"""
+    )
+
+
+def test_generated_python_client_code_new_dimension(client_with_examples: TestClient):
+    """
+    Test generating Python client code for creating a new dimension
+    """
+    response = client_with_examples.get("/client/python/new_node/default.repair_order")
+    assert (
+        response.json()
+        == """from datajunction import DJClient, NodeMode
+
+dj = DJClient(DJ_URL)
+
+repair_order = dj.new_dimension(
+    description="Repair order dimension",
+    query=\"\"\"
+                        SELECT
+                        repair_order_id,
+                        municipality_id,
+                        hard_hat_id,
+                        order_date,
+                        required_date,
+                        dispatched_date,
+                        dispatcher_id
+                        FROM default.repair_orders
+                    \"\"\",
+    display_name="Default: Repair Order",
+    name="default.repair_order",
+    primary_key=['repair_order_id']
+)
+repair_order.save(NodeMode.PUBLISHED)"""
+    )
+
+
+def test_generated_python_client_code_new_cube(client_with_examples: TestClient):
+    """
+    Test generating Python client code for creating a new dimension
+    """
+    client_with_examples.post(
+        "/nodes/cube/",
+        json={
+            "metrics": ["default.num_repair_orders", "default.total_repair_cost"],
+            "dimensions": [
+                "default.hard_hat.country",
+                "default.hard_hat.city",
+            ],
+            "description": "Cube of various metrics related to repairs",
+            "mode": "published",
+            "name": "default.repairs_cube",
+        },
+    )
+    response = client_with_examples.get("/client/python/new_node/default.repairs_cube")
+    assert (
+        response.json()
+        == """from datajunction import DJClient, NodeMode
+
+dj = DJClient(DJ_URL)
+
+repairs_cube = dj.new_cube(
+    description="Cube of various metrics related to repairs",
+    display_name="Default: Repairs Cube",
+    name="default.repairs_cube",
+    primary_key=[],
+    metrics=["default.num_repair_orders", "default.total_repair_cost"],
+    dimensions=["default.hard_hat.country", "default.hard_hat.city"]
+)
+repairs_cube.save(NodeMode.PUBLISHED)"""
+    )
+
+
+def test_generated_python_client_code_adding_materialization(
+    client_with_query_service: TestClient,
+):
+    """
+    Test that generating python client code for adding materialization works
+    """
+    client_with_query_service.post(
+        "/engines/",
+        json={
+            "name": "spark",
+            "version": "2.4.4",
+            "dialect": "spark",
+        },
+    )
+    client_with_query_service.post(
+        "/nodes/basic.transform.country_agg/materialization/",
+        json={
+            "engine": {
+                "name": "spark",
+                "version": "2.4.4",
+            },
+            "config": {
+                "partitions": [
+                    {
+                        "name": "country",
+                        "values": ["DE", "MY"],
+                        "type_": "categorical",
+                    },
+                ],
+            },
+            "schedule": "0 * * * *",
+        },
+    )
+    response = client_with_query_service.get(
+        "/client/python/add_materialization/basic.transform.country_agg/country_3491792861",
+    )
+    assert (
+        response.json()
+        == """from datajunction import DJClient, MaterializationConfig
+
+dj = DJClient(DJ_URL)
+
+country_agg = dj.transform(
+    "basic.transform.country_agg"
+)
+materialization = MaterializationConfig(
+    engine=Engine(
+        name="spark",
+        version="2.4.4",
+    ),
+    schedule="0 * * * *",
+    config={
+        "partitions": [
+            {
+                "name": "country",
+                "values": [
+                    "DE",
+                    "MY"
+                ],
+                "range": null,
+                "expression": null,
+                "type_": "categorical"
+            }
+        ],
+        "spark": {}
+    },
+)
+country_agg.add_materialization(
+    materialization
+)"""
+    )
+
+
+def test_generated_python_client_code_link_dimension(client_with_examples: TestClient):
+    """
+    Test generating Python client code for creating a new dimension
+    """
+    response = client_with_examples.get(
+        "/client/python/link_dimension/foo.bar.repair_orders/"
+        "municipality_id/foo.bar.municipality_dim/",
+    )
+    assert (
+        response.json()
+        == """from datajunction import DJClient, MaterializationConfig
+
+dj = DJClient(DJ_URL)
+repair_orders = dj.source(
+    "foo.bar.repair_orders"
+)
+repair_orders.link_dimension(
+    "municipality_id",
+    "foo.bar.municipality_dim",
+)"""
+    )

--- a/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
+++ b/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
     value={
       Object {
         "DataJunctionAPI": Object {
+          "clientCode": [Function],
           "commonDimensions": [Function],
           "compiledSql": [Function],
           "cube": [Function],
@@ -59,6 +60,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
               <ListNamespacesPage
                 djClient={
                   Object {
+                    "clientCode": [Function],
                     "commonDimensions": [Function],
                     "compiledSql": [Function],
                     "cube": [Function],

--- a/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
+++ b/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
       Object {
         "DataJunctionAPI": Object {
           "clientCode": [Function],
+          "columns": [Function],
           "commonDimensions": [Function],
           "compiledSql": [Function],
           "cube": [Function],
@@ -61,6 +62,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
                 djClient={
                   Object {
                     "clientCode": [Function],
+                    "columns": [Function],
                     "commonDimensions": [Function],
                     "compiledSql": [Function],
                     "cube": [Function],

--- a/datajunction-ui/src/app/components/djgraph/DJNode.jsx
+++ b/datajunction-ui/src/app/components/djgraph/DJNode.jsx
@@ -37,10 +37,13 @@ export function DJNode({ id, data }) {
       },
     };
   };
-
+  const highlightNodeClass =
+    data.is_current === true ? ' dj-node_highlight' : '';
   return (
     <>
-      <div className={'dj-node__full node_type__' + data.type}>
+      <div
+        className={'dj-node__full node_type__' + data.type + highlightNodeClass}
+      >
         <div style={handleWrapperStyle}>
           <Handle
             type="target"

--- a/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
@@ -4,7 +4,7 @@ import { nightOwl } from 'react-syntax-highlighter/src/styles/hljs';
 
 export default function ClientCodePopover({ code }) {
   const [codeAnchor, setCodeAnchor] = useState(false);
-  const open = Boolean(codeAnchor);
+
   return (
     <>
       <button

--- a/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
@@ -1,0 +1,76 @@
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { useState } from 'react';
+import { nightOwl } from 'react-syntax-highlighter/src/styles/hljs';
+
+export default function ClientCodePopover({ code }) {
+  const [codeAnchor, setCodeAnchor] = useState(false);
+  const open = Boolean(codeAnchor);
+  return (
+    <>
+      <button
+        className="code-button"
+        tabIndex="0"
+        height="45px"
+        onClick={() => setCodeAnchor(!codeAnchor)}
+      >
+        <svg
+          width="45px"
+          height="45px"
+          viewBox="0 0 64 64"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+          <g
+            id="SVGRepo_tracerCarrier"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></g>
+          <g id="SVGRepo_iconCarrier">
+            <path
+              d="M31.885 16c-8.124 0-7.617 3.523-7.617 3.523l.01 3.65h7.752v1.095H21.197S16 23.678 16 31.876c0 8.196 4.537 7.906 4.537 7.906h2.708v-3.804s-.146-4.537 4.465-4.537h7.688s4.32.07 4.32-4.175v-7.019S40.374 16 31.885 16zm-4.275 2.454c.771 0 1.395.624 1.395 1.395s-.624 1.395-1.395 1.395a1.393 1.393 0 0 1-1.395-1.395c0-.771.624-1.395 1.395-1.395z"
+              fill="url(#a)"
+            ></path>
+            <path
+              d="M32.115 47.833c8.124 0 7.617-3.523 7.617-3.523l-.01-3.65H31.97v-1.095h10.832S48 40.155 48 31.958c0-8.197-4.537-7.906-4.537-7.906h-2.708v3.803s.146 4.537-4.465 4.537h-7.688s-4.32-.07-4.32 4.175v7.019s-.656 4.247 7.833 4.247zm4.275-2.454a1.393 1.393 0 0 1-1.395-1.395c0-.77.624-1.394 1.395-1.394s1.395.623 1.395 1.394c0 .772-.624 1.395-1.395 1.395z"
+              fill="url(#b)"
+            ></path>
+            <defs>
+              <linearGradient
+                id="a"
+                x1="19.075"
+                y1="18.782"
+                x2="34.898"
+                y2="34.658"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stop-color="#387EB8"></stop>
+                <stop offset="1" stop-color="#366994"></stop>
+              </linearGradient>
+              <linearGradient
+                id="b"
+                x1="28.809"
+                y1="28.882"
+                x2="45.803"
+                y2="45.163"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stop-color="#FFE052"></stop>
+                <stop offset="1" stop-color="#FFC331"></stop>
+              </linearGradient>
+            </defs>
+          </g>
+        </svg>
+      </button>
+      <div
+        id={`node-create-code`}
+        onClose={() => setCodeAnchor(null)}
+        style={{ display: codeAnchor === false ? 'none' : 'block' }}
+      >
+        <SyntaxHighlighter language="python" style={nightOwl}>
+          {code}
+        </SyntaxHighlighter>
+      </div>
+    </>
+  );
+}

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -1,8 +1,17 @@
-import { Component } from 'react';
+import { Component, useEffect, useState } from 'react';
+import ClientCodePopover from './ClientCodePopover';
 
-export default class NodeColumnTab extends Component {
-  columnList = node => {
-    return node.columns.map(col => (
+export default function NodeColumnTab({ node, djClient }) {
+  const [columns, setColumns] = useState([]);
+  useEffect(() => {
+    const fetchData = async () => {
+      setColumns(await djClient.columns(node));
+    };
+    fetchData().catch(console.error);
+  }, [djClient, node]);
+
+  const columnList = columns => {
+    return columns.map(col => (
       <tr>
         <td className="text-start">{col.name}</td>
         <td>
@@ -10,7 +19,16 @@ export default class NodeColumnTab extends Component {
             {col.type}
           </span>
         </td>
-        <td>{col.dimension ? col.dimension.name : ''}</td>
+        <td>
+          {col.dimension ? (
+            <>
+              <a href={`/nodes/${col.dimension.name}`}>{col.dimension.name}</a>
+              <ClientCodePopover code={col.clientCode} />
+            </>
+          ) : (
+            ''
+          )}{' '}
+        </td>
         <td>
           {col.attributes.find(
             attr => attr.attribute_type.name === 'dimension',
@@ -26,19 +44,17 @@ export default class NodeColumnTab extends Component {
     ));
   };
 
-  render() {
-    return (
-      <div className="table-responsive">
-        <table className="card-inner-table table">
-          <thead className="fs-7 fw-bold text-gray-400 border-bottom-0">
-            <th className="text-start">Column</th>
-            <th>Type</th>
-            <th>Dimension</th>
-            <th>Attributes</th>
-          </thead>
-          {this.columnList(this.props.node)}
-        </table>
-      </div>
-    );
-  }
+  return (
+    <div className="table-responsive">
+      <table className="card-inner-table table">
+        <thead className="fs-7 fw-bold text-gray-400 border-bottom-0">
+          <th className="text-start">Column</th>
+          <th>Type</th>
+          <th>Dimension</th>
+          <th>Attributes</th>
+        </thead>
+        {columnList(columns)}
+      </table>
+    </div>
+  );
 }

--- a/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
@@ -73,6 +73,7 @@ const NodeLineage = djNode => {
 
     const dagFetch = async () => {
       let related_nodes = await djClient.node_dag(djNode.djNode.name);
+      // djNode.djNode.is_current = true;
       var djNodes = [djNode.djNode];
       for (const iterable of [related_nodes]) {
         for (const item of iterable) {
@@ -152,6 +153,7 @@ const NodeLineage = djNode => {
             type: node.type,
             primary_key: primary_key,
             column_names: column_names,
+            is_current: node.name === djNode.djNode.name,
           },
         };
       });

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -7,6 +7,7 @@ import NodeStatus from './NodeStatus';
 import ListGroupItem from '../../components/ListGroupItem';
 import ToggleSwitch from '../../components/ToggleSwitch';
 import DJClientContext from '../../providers/djclient';
+import * as React from 'react';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 foundation.hljs['padding'] = '2rem';
@@ -135,11 +136,21 @@ export default function NodeInfoTab({ node }) {
             <h6 className="mb-0 w-100">Tags</h6>
             <p className="mb-0 opacity-75">{nodeTags}</p>
           </div>
+          <div>
+            <h6 className="mb-0 w-100">Primary Key</h6>
+            <p className="mb-0 opacity-75">{node?.primary_key}</p>
+          </div>
+
+          <div>
+            <h6 className="mb-0 w-100">Last Updated</h6>
+            <p className="mb-0 opacity-75">
+              {new Date(node?.updated_at).toDateString()}
+            </p>
+          </div>
         </div>
       </div>
       {node?.type !== 'cube' ? queryDiv : ''}
       {cubeElementsDiv}
-      <div className="list-group-item d-flex">{node?.primary_key}</div>
     </div>
   );
 }

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import ClientCodePopover from './ClientCodePopover';
 
 const cronstrue = require('cronstrue');
 
@@ -36,6 +37,7 @@ export default function NodeMaterializationTab({ node, djClient }) {
       <tr>
         <td className="text-start node_name">
           <a href={materialization.urls[0]}>{materialization.name}</a>
+          <ClientCodePopover code={materialization.clientCode} />
         </td>
         <td>
           <span className={`badge cron`}>{materialization.schedule}</span>

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -10,6 +10,7 @@ import NodeHistory from './NodeHistory';
 import DJClientContext from '../../providers/djclient';
 import NodeSQLTab from './NodeSQLTab';
 import NodeMaterializationTab from './NodeMaterializationTab';
+import ClientCodePopover from './ClientCodePopover';
 
 export function NodePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
@@ -40,6 +41,7 @@ export function NodePage() {
   useEffect(() => {
     const fetchData = async () => {
       const data = await djClient.node(name);
+      data.createNodeClientCode = await djClient.clientCode(name);
       setNode(data);
       if (data.type === 'metric') {
         const metric = await djClient.metric(name);
@@ -114,17 +116,15 @@ export function NodePage() {
       <NamespaceHeader namespace={name.split('.').slice(0, -1).join('.')} />
       <div className="card">
         <div className="card-header">
-          <h3 className="card-title align-items-start flex-column">
+          <h3
+            className="card-title align-items-start flex-column"
+            style={{ display: 'inline-block' }}
+          >
             <span className="card-label fw-bold text-gray-800">
               {node?.display_name}
             </span>
           </h3>
-          <span
-            className="fs-6 fw-semibold text-gray-400"
-            style={{ marginTop: '-4rem' }}
-          >
-            Updated {new Date(node?.updated_at).toDateString()}
-          </span>
+          <ClientCodePopover code={node?.createNodeClientCode} />
           <div className="align-items-center row">
             {TabsJson.map(buildTabs)}
           </div>

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -91,7 +91,7 @@ export function NodePage() {
       tabToDisplay = node ? <NodeInfoTab node={node} /> : '';
       break;
     case 1:
-      tabToDisplay = <NodeColumnTab node={node} />;
+      tabToDisplay = <NodeColumnTab node={node} djClient={djClient} />;
       break;
     case 2:
       tabToDisplay = <NodeLineage djNode={node} djClient={djClient} />;

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -7,6 +7,11 @@ const DJ_URL = process.env.REACT_APP_DJ_URL
 export const DataJunctionAPI = {
   node: async function (name) {
     const data = await (await fetch(DJ_URL + '/nodes/' + name + '/')).json();
+    data.primary_key = data.columns
+      .filter(col =>
+        col.attributes.some(attr => attr.attribute_type.name === 'primary_key'),
+      )
+      .map(col => col.name);
     return data;
   },
 
@@ -33,6 +38,13 @@ export const DataJunctionAPI = {
 
   metric: async function (name) {
     const data = await (await fetch(DJ_URL + '/metrics/' + name + '/')).json();
+    return data;
+  },
+
+  clientCode: async function (name) {
+    const data = await (
+      await fetch(DJ_URL + '/nodes/' + name + '/client/python/')
+    ).json();
     return data;
   },
 

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -43,7 +43,7 @@ export const DataJunctionAPI = {
 
   clientCode: async function (name) {
     const data = await (
-      await fetch(DJ_URL + '/nodes/' + name + '/client/python/')
+      await fetch(DJ_URL + '/client/python/new_node/' + name)
     ).json();
     return data;
   },
@@ -105,8 +105,34 @@ export const DataJunctionAPI = {
     const data = await (
       await fetch(DJ_URL + `/nodes/${node}/materializations/`)
     ).json();
-    return data;
+
+    return await Promise.all(
+      data.map(async materialization => {
+        materialization.clientCode = await (
+          await fetch(
+            DJ_URL +
+              `/client/python/add_materialization/${node}/${materialization.name}`,
+          )
+        ).json();
+        return materialization;
+      }),
+    );
   },
+
+  columns: async function (node) {
+    return await Promise.all(
+      node.columns.map(async col => {
+        col.clientCode = await (
+          await fetch(
+            DJ_URL +
+              `/client/python/link_dimension/${node.name}/${col.name}/${col.dimension?.name}`,
+          )
+        ).json();
+        return col;
+      }),
+    );
+  },
+
   sqls: async function (metricSelection, dimensionSelection) {
     const params = new URLSearchParams();
     metricSelection.map(metric => params.append('metrics', metric));

--- a/datajunction-ui/src/styles/dag.css
+++ b/datajunction-ui/src/styles/dag.css
@@ -74,6 +74,10 @@
   border-radius: 0 0 8px 8px;
 }
 
+.dj-node_highlight {
+  border: 10px solid #cccccc !important;
+}
+
 .react-flow__node {
   z-index: -1 !important;
 }

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -814,9 +814,9 @@ pre {
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
   background-color: transparent;
-  outline: 0px;
-  border: 0px;
-  margin: 0px;
+  outline: 0;
+  border: 0;
+  margin: 0;
   cursor: pointer;
   user-select: none;
   vertical-align: middle;
@@ -825,7 +825,7 @@ pre {
   text-align: center;
   flex: 0 0 auto;
   font-size: 1.5rem;
-  padding: 8px;
+  padding: 0;
   border-radius: 50%;
   overflow: visible;
   color: rgba(0, 0, 0, 0.54);
@@ -836,4 +836,7 @@ pre {
   padding: 1rem !important;
   max-height: 300px;
   overflow: scroll;
+  text-align: left;
+  position: absolute;
+  z-index: 1;
 }

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -803,3 +803,37 @@ pre {
 .cube-element .badge {
   margin-left: 0.4rem;
 }
+
+.code-button {
+  display: inline-flex;
+  -webkit-box-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0px;
+  border: 0px;
+  margin: 0px;
+  cursor: pointer;
+  user-select: none;
+  vertical-align: middle;
+  appearance: none;
+  text-decoration: none;
+  text-align: center;
+  flex: 0 0 auto;
+  font-size: 1.5rem;
+  padding: 8px;
+  border-radius: 50%;
+  overflow: visible;
+  color: rgba(0, 0, 0, 0.54);
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+#node-create-code pre {
+  padding: 1rem !important;
+  max-height: 300px;
+  overflow: scroll;
+}


### PR DESCRIPTION
### Summary

This change adds a popover (controlled via a toggle) that displays the Python client code for various actions:
* Creating a node
* Linking a dimension to a column on a node
* Adding materialization to a node

This may be useful in several ways:
* Users can use the client code as a template to perform one of these actions (stand in for before we have an actual creation/modification UI)
* Users can copy a particular node, make minor changes, and create a new node
* Demos (so that we don't have to move to a separate notebook window)

https://github.com/DataJunction/dj/assets/9524628/fa879cb4-b5ad-45ac-bf15-837baa7dbe4e

I'm not 100% sure about having the client code generation live in the backend, but it does work for now.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
