### PR TITLE
Fix publish directory in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 [build]
   base = "docs/"
   command = "./build-docs.sh 0.1.0 true $DEPLOY_URL"
-  publish = "docs/public"
+  publish = "public"
 
 [build.environment]
   HUGO_VERSION = "0.113.0"


### PR DESCRIPTION
Since the base directory is `docs/` the publish directory only needs to be `public` instead of `docs/public`