### PR TITLE
Cleanup docker config for DJUI.

### DIFF
--- a/datajunction-ui/Dockerfile
+++ b/datajunction-ui/Dockerfile
@@ -1,8 +1,0 @@
-FROM node:19 AS ui-build
-WORKDIR /usr/src/app
-COPY . .
-EXPOSE 3000
-RUN yarn install
-RUN yarn webpack build
-
-CMD ["yarn", "webpack-start", "--host", "0.0.0.0", "--port", "3000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,15 +44,15 @@ services:
 
   djui:
     container_name: djui
-    build:
-      context: ./datajunction-ui
+    image: node:19
+    working_dir: /usr/src/app
     ports:
       - "3000:3000"
     stdin_open: true
     volumes:
       - ./datajunction-ui:/usr/src/app/
       - ./datajunction-ui/node_modules:/usr/src/app/node_modules
-    command: ["yarn", "webpack-start", "--host", "0.0.0.0", "--port", "3000"]
+    command: sh -c "yarn && yarn webpack-build && yarn webpack-start --host 0.0.0.0 --port 3000"
 
   djqs:
     container_name: djqs


### PR DESCRIPTION
### Summary

@shangyian please have a look at this PR and let us know what you think.

Whew... it started with a simple "hey Sam, can you help me out with my djui docker errors?"
```
djui          | yarn run v1.22.19
djui          | $ webpack-dev-server --open --host 0.0.0.0 --port 3000
djui          | /bin/sh: 1: webpack-dev-server: not found
djui          | error Command failed with exit code 127.
djui          | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
djui exited with code 127
```

And we went from there:
- we found one command to be not kosher on the latest yarn/npm version: `s/yarn install/yarn`
- then we started debating what commands should run during building of djui container vs during compose up 
- and then @samredai suggested to delete the Dockerfile for djui and to define all the params in the main docker-compose

Our initial goal was to be able to support both cases (for a newbie):
- quick demo from scratch 
- dev cycle for djui components
@samredai please add any other points I missed in this description. 

@shangyian once we agree on the best configuration, perhaps I should fix some dev docs around this topic. No rush on this, since I am unblocked, we can chat about it as well.

### Test Plan

Tried multiple combinations of `docker compose up` and `docker compose build djui` until we got to a perfect state.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
