### PR TITLE
Client functionality for availability + column attributes

### DIFF
--- a/client/python/datajunction/__init__.py
+++ b/client/python/datajunction/__init__.py
@@ -13,7 +13,13 @@ from datajunction.client import (
     Source,
     Transform,
 )
-from datajunction.models import Engine, MaterializationConfig, NodeMode
+from datajunction.models import (
+    AvailabilityState,
+    ColumnAttribute,
+    Engine,
+    MaterializationConfig,
+    NodeMode,
+)
 
 try:
     # Change here if project is renamed and does not equal the package name
@@ -26,6 +32,8 @@ finally:
 
 
 __all__ = [
+    "AvailabilityState",
+    "ColumnAttribute",
     "DJClient",
     "Source",
     "Dimension",

--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -708,6 +708,34 @@ class DJClient:  # pylint: disable=too-many-public-methods
         )
         return response.json()
 
+    def add_availability_state(
+        self,
+        node_name: str,
+        availability: models.AvailabilityState,
+    ):
+        """
+        Adds an availability state for the node
+        """
+        response = self._session.post(
+            f"/data/{node_name}/availability/",
+            json=availability.dict(),
+        )
+        return response.json()
+
+    def set_column_attributes(
+        self,
+        node_name,
+        attributes: List[models.ColumnAttribute],
+    ):
+        """
+        Sets attributes for columns on the node
+        """
+        response = self._session.post(
+            f"/nodes/{node_name}/attributes/",
+            json=[attribute.dict() for attribute in attributes],
+        )
+        return response.json()
+
 
 class ClientEntity(BaseModel):
     """
@@ -737,7 +765,7 @@ class Node(ClientEntity):
     mode: Optional[models.NodeMode]
     status: Optional[str] = None
     display_name: Optional[str]
-    availability: Optional[Dict]
+    availability: Optional[models.AvailabilityState]
     tags: Optional[List[models.Tag]]
     primary_key: Optional[List[str]]
     materializations: Optional[List[Dict[str, Any]]]
@@ -867,6 +895,18 @@ class Node(ClientEntity):
         List all revisions of this node
         """
         return self.dj_client.get_node_revisions(self.name)
+
+    def add_availability(self, availability: models.AvailabilityState):
+        """
+        Adds an availability state to the node
+        """
+        return self.dj_client.add_availability_state(self.name, availability)
+
+    def set_column_attributes(self, attributes: List[models.ColumnAttribute]):
+        """
+        Sets attributes for columns on the node
+        """
+        return self.dj_client.set_column_attributes(self.name, attributes)
 
 
 class Source(Node):

--- a/client/python/datajunction/models.py
+++ b/client/python/datajunction/models.py
@@ -133,7 +133,7 @@ class Column(BaseModel):
 
     name: str
     type: str
-    attributes: List
+    attributes: Optional[List]
 
 
 END_JOB_STATES = [QueryState.FINISHED, QueryState.CANCELED, QueryState.FAILED]

--- a/client/python/datajunction/models.py
+++ b/client/python/datajunction/models.py
@@ -92,15 +92,6 @@ class QueryState(str, enum.Enum):
         return list(map(lambda c: c.value, cls))  # type: ignore
 
 
-class Column(BaseModel):
-    """
-    Represents a column
-    """
-
-    name: str
-    type: str
-
-
 class Tag(BaseModel):
     """
     Node tags
@@ -109,6 +100,40 @@ class Tag(BaseModel):
     name: str
     display_name: str
     tag_type: str
+
+
+class AvailabilityState(BaseModel):
+    """
+    Represents the availability state for a node.
+    """
+
+    min_temporal_partition: Optional[List[str]] = None
+    max_temporal_partition: Optional[List[str]] = None
+
+    catalog: str
+    schema_: Optional[str]
+    table: str
+    valid_through_ts: int
+
+
+class ColumnAttribute(BaseModel):
+    """
+    Represents a column attribute
+    """
+
+    attribute_type_namespace: Optional[str] = "system"
+    attribute_type_name: str
+    column_name: str
+
+
+class Column(BaseModel):
+    """
+    Represents a column
+    """
+
+    name: str
+    type: str
+    attributes: List
 
 
 END_JOB_STATES = [QueryState.FINISHED, QueryState.CANCELED, QueryState.FAILED]

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -456,7 +456,7 @@ class TestDJClient:
 
         # Retrieve SQL for multiple metrics using the client object
         result = client.sql(
-            metrics=["default.num_repair_orders", "default.avg_repair_price"],
+            metrics=["default.total_repair_cost", "default.avg_repair_price"],
             dimensions=[
                 "default.hard_hat.city",
                 "default.hard_hat.state",


### PR DESCRIPTION
### Summary

Add client functionality to set availability state and column attributes on a node.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
