### PR TITLE
Add specialized exception to Python client.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,13 +5,14 @@ Contributing
 Pre-requisites
 ==============
 
-DataJunction (DJ) is currently supported in Python 3.8, 3.9, and 3.10. It's recommended to use ``pyenv`` to create a virtual environment called "dj", so you can use the included ``Makefile``:
+DataJunction (DJ) is currently supported in Python 3.8, 3.9, and 3.10. It's recommended to use ``pyenv`` to create a virtual environment called "dj":
 
 .. code-block:: bash
 
     $ pyenv virtualenv 3.8 dj  # or 3.9/3.10
 
-Then you can just run ``make test`` to install all the dependencies.
+Then you can pick any of the components you want to develop on, say ``cd datajunction-server`` or ``cd client/python``,
+install required dependencies with ``pdm install`` and call ``make test`` to run all the unit tests for that component.
 
 DJ relies heavily on these libraries:
 

--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field, validator
 from requests.adapters import CaseInsensitiveDict, HTTPAdapter
 
 from datajunction import models
-from datajunction.exceptions import DJClientException
+from datajunction.exceptions import DJClientException, DJNamespaceAlreadyExists
 
 DEFAULT_NAMESPACE = "default"
 _logger = logging.getLogger(__name__)
@@ -401,7 +401,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
         )
         json_response = response.json()
         if response.status_code == 409:
-            raise DJClientException(json_response["message"])
+            raise DJNamespaceAlreadyExists(json_response["message"])
         return json_response
 
     def deactivate_node(self, node: "Node"):

--- a/client/python/datajunction/exceptions.py
+++ b/client/python/datajunction/exceptions.py
@@ -5,3 +5,9 @@ class DJClientException(Exception):
     """
     Base class for errors.
     """
+
+
+class DJNamespaceAlreadyExists(DJClientException):
+    """
+    Raised when a namespace to be created already exists.
+    """

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -3,7 +3,7 @@ import pandas
 import pytest
 
 from datajunction import DJClient
-from datajunction.exceptions import DJClientException
+from datajunction.exceptions import DJClientException, DJNamespaceAlreadyExists
 from datajunction.models import (
     AvailabilityState,
     Column,
@@ -541,7 +541,7 @@ class TestDJClient:
         """
         namespace = client.new_namespace(namespace="roads.demo")
         assert namespace.namespace == "roads.demo"
-        with pytest.raises(DJClientException) as exc_info:
+        with pytest.raises(DJNamespaceAlreadyExists) as exc_info:
             client.new_namespace(namespace="roads.demo")
         assert "Node namespace `roads.demo` already exists" in str(exc_info.value)
 


### PR DESCRIPTION
### Summary

When trying Python client I wanted to have this code be idempotent:
```
dj.new_namespace(namespace="foo.bar")
```
, but it is not because we get
```
DJClientException: Node namespace `foo.bar` already exists
```

With this addition of specialized exceptions it will be easier to catch the exceptions that are safe to pass. And instead of doing something like:
```
try:
    dj.new_namespace(namespace="foo.bar")
except DJClientException as e:
    if "already exists" not in str(e):
        raise e
```
I'll be able to do:
```
try:
    dj.new_namespace(namespace="foo.bar")
except DJNamespaceAlreadyExists:
   pass
```

Also adjusted the contributing guide.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

n/a