### PR TITLE
Add a `POST /nodes/{name}/validate/` endpoint for revalidating already existing nodes by name

### DIFF
--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2511,6 +2511,19 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.us_state",
         }
 
+    def test_revalidating_existing_nodes(self, client_with_examples: TestClient):
+        """
+        Test revalidating all example nodes and confirm that they are set to valid
+        """
+        for node in client_with_examples.get("/nodes/").json():
+            status = client_with_examples.post(
+                f"/nodes/{node['name']}/validate/",
+            ).json()["status"]
+            assert status == "valid"
+        # Confirm that they still show as valid server-side
+        for node in client_with_examples.get("/nodes/").json():
+            assert node["status"] == "valid"
+
 
 def test_node_similarity(session: Session, client: TestClient):
     """


### PR DESCRIPTION
### Summary

Currently DJ attempts to validate nodes as any live change is being made to the system. When things are missed or preconditions are fulfilled after the fact, this PR provides a mechanism to request the server to revalidate an existing node, requiring that you simply provide the node name. Over time, we should catch these scenarios more and more so that system status is more accurately captured in realtime and revalidation is never required.

Here's a video example of how this was added to the UI. I manually set nodes in the metadata that I knew to be valid as invalid, and clicking the icon revalidated them and updated the status. If they were invalid, the status icon would have stayed as a red x.

https://github.com/DataJunction/dj/assets/43911210/3416b0ef-4822-4379-954a-f2c8f3eb885d

### Test Plan

`docker compose --profile demo up` and tested it in the UI. Also tested curl commands directly to the dj server.

- [ ] PR has an associated issue: Related to but does not solve #618 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
