### PR TITLE
Fix node update status bug

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1389,9 +1389,10 @@ def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-ma
         parents=[],
         mode=data.mode if data and data.mode else old_revision.mode,
         materializations=[],
+        status=old_revision.status,
     )
 
-    # Link the new revision to its parents if the query has changed
+    # Link the new revision to its parents if the query has changed and update its status
     if new_revision.type != NodeType.SOURCE and (query_changes or pk_changes):
         (
             validated_node,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1060,6 +1060,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             data["query"]
             == "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users"
         )
+        assert data["status"] == "valid"
         assert data["columns"] == [
             {"name": "country", "type": "string", "attributes": [], "dimension": None},
             {
@@ -1089,6 +1090,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             data["query"]
             == "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users"
         )
+        assert data["status"] == "valid"
 
         # Try to update with a new query that references a non-existent source
         response = client.patch(
@@ -1132,6 +1134,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
                 "dimension": None,
             },
         ]
+        assert data["status"] == "valid"
 
         # Verify that asking for revisions for a non-existent transform fails
         response = client.get("/nodes/random_transform/revisions/")


### PR DESCRIPTION
### Summary

There is a bug when we update any non-source node, where if we make a minor change that doesn't involve the node's query, it will not assign a status to the new node revision, and just defaults to invalid. This fixes it so that it assigns it to the old node revision's status and then updates it if anything has changed that warrants updating.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
