### PR TITLE
Add ability to remove dimension links

### DIFF
--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -531,7 +531,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
         )
         return response.json()
 
-    def unlink_dimension_to_node(
+    def _unlink_dimension_from_node(
         self,
         node_name: str,
         column_name: str,
@@ -846,7 +846,7 @@ class Node(ClientEntity):
         """
         Removes the dimension link on the node's `column` to the dimension.
         """
-        link_response = self.dj_client.unlink_dimension_to_node(
+        link_response = self.dj_client._unlink_dimension_from_node(
             self.name,
             column,
             dimension,

--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -846,7 +846,7 @@ class Node(ClientEntity):
         """
         Removes the dimension link on the node's `column` to the dimension.
         """
-        link_response = self.dj_client._unlink_dimension_from_node(
+        link_response = self.dj_client._unlink_dimension_from_node(  # pylint: disable=protected-access
             self.name,
             column,
             dimension,

--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -398,7 +398,6 @@ class DJClient:  # pylint: disable=too-many-public-methods
             timeout=self._timeout,
         )
         json_response = response.json()
-        print(json_response)
         if response.status_code == 409:
             raise DJNamespaceAlreadyExists(json_response["message"])
         return json_response

--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -74,6 +74,8 @@ class RequestsSessionWithEndpoint(requests.Session):  # pragma: no cover
             return response
         except requests.exceptions.RequestException as exc:
             error_message = None
+            if not exc.response:
+                raise DJClientException(exc) from exc
             if exc.response.headers.get("Content-Type") == "application/json":
                 error_message = exc.response.json().get("message")
             if not error_message:

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "requests<3.0.0,>=2.28.2",
-    "pydantic>=1.10.7,<=2",
+    "pydantic>=1.10.7,<2",
     "alive-progress>=3.1.2",
 ]
 requires-python = ">=3.8,<4.0"

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -445,7 +445,6 @@ class TestDJClient:
             "foo.bar.contractor",
             "contractor_id",
         )
-        print("result", result)
         assert result["message"] == (
             "The dimension link on the node foo.bar.repair_type's contractor_id to "
             "foo.bar.contractor has been successfully removed."

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -424,9 +424,9 @@ class TestDJClient:
             "default.number_of_account_types" in client.namespace("default").metrics()
         )
 
-    def test_link_dimension(self, client):  # pylint: disable=unused-argument
+    def test_link_unlink_dimension(self, client):  # pylint: disable=unused-argument
         """
-        Check linking dimensions works
+        Check that linking and unlinking dimensions to a node's column works
         """
         repair_type = client.source("foo.bar.repair_type")
         result = repair_type.link_dimension(
@@ -437,6 +437,18 @@ class TestDJClient:
         assert result["message"] == (
             "Dimension node foo.bar.contractor has been successfully linked to "
             "column contractor_id on node foo.bar.repair_type"
+        )
+
+        # Unlink the dimension
+        result = repair_type.unlink_dimension(
+            "contractor_id",
+            "foo.bar.contractor",
+            "contractor_id",
+        )
+        print("result", result)
+        assert result["message"] == (
+            "The dimension link on the node foo.bar.repair_type's contractor_id to "
+            "foo.bar.contractor has been successfully removed."
         )
 
     def test_sql(self, client):  # pylint: disable=unused-argument

--- a/client/python/tests/test_integration.py
+++ b/client/python/tests/test_integration.py
@@ -115,6 +115,16 @@ def test_integration():  # pylint: disable=too-many-statements
         dimension=f"{namespace}.all_dispatchers",
         dimension_column="dispatcher_id",
     )
+    source.unlink_dimension(
+        column="dispatcher_id",
+        dimension=f"{namespace}.all_dispatchers",
+        dimension_column="dispatcher_id",
+    )
+    source.link_dimension(
+        column="dispatcher_id",
+        dimension=f"{namespace}.all_dispatchers",
+        dimension_column="dispatcher_id",
+    )
 
     # List dimensions for a metric
     dj.metric(f"{namespace}.num_repair_orders").dimensions()

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1345,9 +1345,9 @@ def delete_dimension_link(
     """
     node = get_node_by_name(session=session, name=name)
     target_column = get_column(node.current, column)
-    if (
-        target_column.dimension.name != dimension
-        and target_column.dimension_column != dimension_column
+    if (not target_column.dimension or target_column.dimension.name != dimension) and (
+        not target_column.dimension_column
+        or target_column.dimension_column != dimension_column
     ):
         return JSONResponse(
             status_code=304,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1341,7 +1341,7 @@ def delete_dimension_link(
     session: Session = Depends(get_session),
 ) -> JSONResponse:
     """
-    Add information to a node column
+    Remove the link between a node column and a dimension node
     """
     node = get_node_by_name(session=session, name=name)
     target_column = get_column(node.current, column)

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2345,7 +2345,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         }
         response = client_with_examples.get("/nodes/default.revenue")
         data = response.json()
-        assert all([col["dimension"] is None for col in data["columns"]])
+        assert all(col["dimension"] is None for col in data["columns"])
 
         # Removing the dimension link again will result in no change
         response = client_with_examples.delete(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2313,7 +2313,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
 
     def test_adding_dimensions_to_node_columns(self, client_with_examples: TestClient):
         """
-        Test adding tables to existing nodes
+        Test linking dimensions to node columns
         """
         # Attach the payment_type dimension to the payment_type column on the revenue node
         response = client_with_examples.post(
@@ -2325,6 +2325,37 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "Dimension node default.payment_type has been successfully "
                 "linked to column payment_type on node default.revenue"
             ),
+        }
+        response = client_with_examples.get("/nodes/default.revenue")
+        data = response.json()
+        assert [
+            col["dimension"]["name"] for col in data["columns"] if col["dimension"]
+        ] == ["default.payment_type"]
+
+        # Check that after deleting the dimension link, none of the columns have links
+        response = client_with_examples.delete(
+            "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
+        )
+        data = response.json()
+        assert data == {
+            "message": (
+                "The dimension link on the node default.revenue's payment_type to "
+                "default.payment_type has been successfully removed."
+            ),
+        }
+        response = client_with_examples.get("/nodes/default.revenue")
+        data = response.json()
+        assert all([col["dimension"] is None for col in data["columns"]])
+
+        # Removing the dimension link again will result in no change
+        response = client_with_examples.delete(
+            "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
+        )
+        data = response.json()
+        assert response.status_code == 304
+        assert data == {
+            "message": "No change was made to payment_type on node default.revenue as the"
+            " specified dimension link to default.payment_type on None was not found.",
         }
 
         # Check that the proper error is raised when the column doesn't exist


### PR DESCRIPTION
### Summary

This adds a new API endpoint that allows users to remove a dimension linked to a node's column: 
```
DELETE /nodes/{name}/columns/{column}
```

It also adds the corresponding Python client call:
```python
source.unlink_dimension("payment_type", "default.payment_type", "payment_type_id")
```

### Test Plan

Ran locally. Added tests.

- [X] PR has an associated issue: #620 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
