### PR TITLE
fix: reenable pdm lock check hook for all packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
           export tests_dir=${{ matrix.library == 'server' && './datajunction-server' || matrix.library == 'client' && './client/python' || matrix.library == 'djqs' && './datajunction-query' || matrix.library == 'djrs' && './datajunction-reflection'}}
           cd $tests_dir; pdm install -d -G pandas
 
+      - uses: pre-commit/action@v3.0.0
+        name: Force check of all pdm.lock files
+        with:
+          extra_args: pdm-lock-check --all-files
+
       - name: Python Linters
         run: |
           export tests_dir=${{ matrix.library == 'server' && './datajunction-server' || matrix.library == 'client' && './client/python' || matrix.library == 'djqs' && './datajunction-query' || matrix.library == 'djrs' && './datajunction-reflection'}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-files: (^datajunction-server/)
+files: ^datajunction-(server|query|reflection)/
 exclude: (^docs/|^openapi/|^client/python/|^client/javascript/|^datajunction-server/dj/sql/parsing/backends/grammar/generated|^README.md)
 
 repos:
@@ -107,3 +107,27 @@ repos:
   rev: 2.6.1
   hooks:
     - id: pdm-lock-check
+      name: pdm-lock-check-root
+      entry: pdm lock --check --project .
+      files: ^pyproject.toml$
+- repo: https://github.com/pdm-project/pdm
+  rev: 2.6.1
+  hooks:
+    - id: pdm-lock-check
+      name: pdm-lock-check-server
+      entry: pdm lock --check --project datajunction-server
+      files: ^datajunction-server/pyproject.toml$
+# - repo: https://github.com/pdm-project/pdm
+#   rev: 2.6.1
+#   hooks:
+#     - id: pdm-lock-check
+#       name: pdm-lock-check-query
+#       entry: pdm lock --check --project datajunction-query
+#       files: ^datajunction-query/pyproject.toml$
+- repo: https://github.com/pdm-project/pdm
+  rev: 2.6.1
+  hooks:
+    - id: pdm-lock-check
+      name: pdm-lock-check-reflection
+      entry: pdm lock --check --project datajunction-reflection
+      files: ^datajunction-reflection/pyproject.toml$


### PR DESCRIPTION
pdm lock check doesn't run for any of the packages after the monorepo
move

only the root level pdm lock check (which only has pylint and pre-commit
in it) actually runs.

keeping only one single top-level pdm.lock file at the repo root level
may work for simple development tasks (e.g. pdm sync from repo root),
but any pdm functions that depend on more granular pdm.lock input (e.g.
pdm export) will break when run from an individual package folder if the
individual pdm.lock files in each package folder is not kept in sync as
well.

adding all packages back into the .pre-commit config fixes this

a new dedicated Github Action step to force a pdm.lock check on every PR
also has been added.
