### PR TITLE
Add endpoint to list all nodes that share a given dimension

### DIFF
--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -1,0 +1,31 @@
+"""
+Cube related APIs.
+"""
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from datajunction_server.api.helpers import get_node_by_name
+from datajunction_server.models.node import NodeRevisionOutput, NodeType
+from datajunction_server.sql.dag import get_nodes_with_dimension
+from datajunction_server.utils import get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/dimensions/{name}/nodes/", response_model=List[NodeRevisionOutput])
+def find_nodes_with_dimension(
+    name: str,
+    *,
+    node_types: Optional[List[NodeType]] = None,
+    session: Session = Depends(get_session),
+) -> List[NodeRevisionOutput]:
+    """
+    List all nodes that have the specified dimension
+    """
+    dimension_node = get_node_by_name(session, name)
+    nodes = get_nodes_with_dimension(session, dimension_node, node_types)
+    return nodes

--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -1,5 +1,5 @@
 """
-Cube related APIs.
+Dimensions related APIs.
 """
 import logging
 from typing import List, Optional

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -22,6 +22,7 @@ from datajunction_server.api import (
     client,
     cubes,
     data,
+    dimensions,
     engines,
     health,
     history,
@@ -86,6 +87,7 @@ def get_dj_app(
     application.include_router(attributes.router)
     application.include_router(sql.router)
     application.include_router(client.router)
+    application.include_router(dimensions.router)
 
     @application.exception_handler(DJException)
     async def dj_exception_handler(  # pylint: disable=unused-argument

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1368,7 +1368,6 @@ def delete_dimension_link(
     )
     if affected_cubes:
         for cube in affected_cubes:
-            print("affected", cube.name)
             cube.status = NodeStatus.INVALID
             session.add(cube)
 

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -171,6 +171,13 @@ def get_nodes_with_dimension(
             statement = (
                 select(NodeRevision)
                 .join(
+                    Node,
+                    onclause=(
+                        (NodeRevision.node_id == Node.id)
+                        & (Node.current_version == NodeRevision.version)
+                    ),  # pylint: disable=superfluous-parens
+                )
+                .join(
                     NodeColumns,
                     onclause=(
                         NodeRevision.id == NodeColumns.node_id

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -3,10 +3,18 @@ DAG related functions.
 """
 import collections
 import itertools
-from typing import Deque, Dict, List, Set, Tuple, Union
+from typing import Deque, Dict, List, Optional, Set, Tuple, Union
+
+from sqlmodel import Session, select
 
 from datajunction_server.models import Column
-from datajunction_server.models.node import DimensionAttributeOutput, Node, NodeType
+from datajunction_server.models.base import NodeColumns
+from datajunction_server.models.node import (
+    DimensionAttributeOutput,
+    Node,
+    NodeRevision,
+    NodeType,
+)
 from datajunction_server.utils import get_settings
 
 settings = get_settings()
@@ -140,3 +148,55 @@ def get_shared_dimensions(
         [y for x in common.values() for y in x],
         key=lambda x: (x.name, x.path),
     )
+
+
+def get_nodes_with_dimension(
+    session: Session,
+    dimension_node: Node,
+    node_types: Optional[List[NodeType]] = None,
+) -> List[NodeRevision]:
+    """
+    Find all nodes that can be joined to a given dimension
+    """
+    to_process = [dimension_node]
+    processed: Set[str] = set()
+    final_set: Set[NodeRevision] = set()
+    while to_process:
+        current_node = to_process.pop()
+        processed.add(current_node.name)
+
+        # Dimension nodes are used to expand the searchable graph by finding
+        # the next layer of nodes that are linked to this dimension
+        if current_node.type == NodeType.DIMENSION:
+            statement = (
+                select(NodeRevision)
+                .join(
+                    NodeColumns,
+                    onclause=(
+                        NodeRevision.id == NodeColumns.node_id
+                    ),  # pylint: disable=superfluous-parens
+                )
+                .join(
+                    Column,
+                    onclause=(
+                        NodeColumns.column_id == Column.id
+                    ),  # pylint: disable=superfluous-parens
+                )
+                .where(
+                    Column.dimension_id.in_(  # type: ignore  # pylint: disable=no-member
+                        [current_node.id],
+                    ),
+                )
+            )
+            node_revisions = session.exec(statement).unique().all()
+            for node_rev in node_revisions:
+                to_process.append(node_rev.node)
+        else:
+            # All other nodes are added to the result set
+            final_set.add(current_node.current)
+            for child in current_node.children:
+                if child.name not in processed:
+                    to_process.append(child.node)
+    if node_types:
+        return [node for node in final_set if node.type in node_types]
+    return list(final_set)

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1174,3 +1174,22 @@ def test_add_availability_to_cube(
         " FROM repairs_cube \n"
         " GROUP BY  country, postal_code\n",
     }
+
+
+def test_unlink_node_column_dimension(
+    client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
+):
+    """
+    When a node column link to a dimension is removed, the cube should be invalidated
+    """
+    response = client_with_repairs_cube.delete(
+        "/nodes/default.repair_order/columns/hard_hat_id/"
+        "?dimension=default.hard_hat&dimension_column=hard_hat_id",
+    )
+    assert response.json() == {
+        "message": "The dimension link on the node default.repair_order's hard_hat_id "
+        "to default.hard_hat has been successfully removed.",
+    }
+    response = client_with_repairs_cube.get("/nodes/default.repairs_cube")
+    data = response.json()
+    assert data["status"] == "invalid"

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -1,0 +1,42 @@
+"""
+Tests for the dimensions API.
+"""
+from fastapi.testclient import TestClient
+
+
+def test_list_nodes_with_dimension(client_with_examples: TestClient) -> None:
+    """
+    Test ``GET /dimensions/{name}/nodes/``.
+    """
+    response = client_with_examples.get("/dimensions/default.hard_hat/nodes/")
+    data = response.json()
+    roads_nodes = [
+        "default.repair_orders",
+        "default.repair_order_details",
+        "default.num_repair_orders",
+        "default.avg_repair_price",
+        "default.total_repair_cost",
+        "default.discounted_orders_rate",
+        "default.total_repair_order_discounts",
+        "default.avg_repair_order_discounts",
+        "default.avg_time_to_dispatch",
+    ]
+    assert [node["name"] for node in data] == roads_nodes
+
+    response = client_with_examples.get("/dimensions/default.repair_order/nodes/")
+    data = response.json()
+    assert [node["name"] for node in data] == roads_nodes
+
+    response = client_with_examples.get("/dimensions/default.us_state/nodes/")
+    data = response.json()
+    assert [node["name"] for node in data] == roads_nodes
+
+    response = client_with_examples.get("/dimensions/default.municipality_dim/nodes/")
+    data = response.json()
+    assert [node["name"] for node in data] == roads_nodes
+
+    response = client_with_examples.get("/dimensions/default.contractor/nodes/")
+    data = response.json()
+    assert [node["name"] for node in data] == [
+        "default.repair_type",
+    ]

--- a/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
+++ b/datajunction-ui/src/app/__tests__/__snapshots__/index.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`<App /> should render and match the snapshot 1`] = `
           "namespaces": [Function],
           "node": [Function],
           "node_dag": [Function],
+          "nodesWithDimension": [Function],
           "revisions": [Function],
           "sql": [Function],
           "sqls": [Function],

--- a/datajunction-ui/src/app/pages/NodePage/NodesWithDimension.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodesWithDimension.jsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import * as React from 'react';
+
+export default function NodesWithDimension({ node, djClient }) {
+  const [availableNodes, setAvailableNodes] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await djClient.nodesWithDimension(node.name);
+      setAvailableNodes(data);
+    };
+    fetchData().catch(console.error);
+  }, [djClient, node]);
+  return (
+    <div className="table-responsive">
+      <table className="card-inner-table table">
+        <thead className="fs-7 fw-bold text-gray-400 border-bottom-0">
+          <th className="text-start">Name</th>
+          <th>Type</th>
+        </thead>
+        {availableNodes.map(node => (
+          <tr>
+            <td>
+              <a href={`/nodes/${node.name}`}>{node.display_name}</a>
+            </td>
+            <td>
+              <span className={'node_type__' + node.type + ' badge node_type'}>
+                {node.type}
+              </span>
+            </td>
+          </tr>
+        ))}
+      </table>
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/pages/NodePage/NodesWithDimension.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodesWithDimension.jsx
@@ -18,18 +18,22 @@ export default function NodesWithDimension({ node, djClient }) {
           <th className="text-start">Name</th>
           <th>Type</th>
         </thead>
-        {availableNodes.map(node => (
-          <tr>
-            <td>
-              <a href={`/nodes/${node.name}`}>{node.display_name}</a>
-            </td>
-            <td>
-              <span className={'node_type__' + node.type + ' badge node_type'}>
-                {node.type}
-              </span>
-            </td>
-          </tr>
-        ))}
+        <tbody>
+          {availableNodes.map(node => (
+            <tr>
+              <td>
+                <a href={`/nodes/${node.name}`}>{node.display_name}</a>
+              </td>
+              <td>
+                <span
+                  className={'node_type__' + node.type + ' badge node_type'}
+                >
+                  {node.type}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
       </table>
     </div>
   );

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -11,6 +11,7 @@ import DJClientContext from '../../providers/djclient';
 import NodeSQLTab from './NodeSQLTab';
 import NodeMaterializationTab from './NodeMaterializationTab';
 import ClientCodePopover from './ClientCodePopover';
+import NodesWithDimension from './NodesWithDimension';
 
 export function NodePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
@@ -25,7 +26,7 @@ export function NodePage() {
   };
 
   const buildTabs = tab => {
-    return (
+    return tab.display ? (
       <Tab
         key={tab.id}
         id={tab.id}
@@ -33,7 +34,7 @@ export function NodePage() {
         onClick={onClickTab(tab.id)}
         selectedTab={state.selectedTab}
       />
-    );
+    ) : null;
   };
 
   const { name } = useParams();
@@ -57,32 +58,46 @@ export function NodePage() {
     fetchData().catch(console.error);
   }, [djClient, name]);
 
-  const TabsJson = [
-    {
-      id: 0,
-      name: 'Info',
-    },
-    {
-      id: 1,
-      name: 'Columns',
-    },
-    {
-      id: 2,
-      name: 'Graph',
-    },
-    {
-      id: 3,
-      name: 'History',
-    },
-    {
-      id: 4,
-      name: 'SQL',
-    },
-    {
-      id: 5,
-      name: 'Materializations',
-    },
-  ];
+  const tabsList = node => {
+    return [
+      {
+        id: 0,
+        name: 'Info',
+        display: true,
+      },
+      {
+        id: 1,
+        name: 'Columns',
+        display: true,
+      },
+      {
+        id: 2,
+        name: 'Graph',
+        display: true,
+      },
+      {
+        id: 3,
+        name: 'History',
+        display: true,
+      },
+      {
+        id: 4,
+        name: 'SQL',
+        display: node?.type !== 'dimension' && node?.type !== 'source',
+      },
+      {
+        id: 5,
+        name: 'Materializations',
+        display: node?.type !== 'source',
+      },
+      {
+        id: 6,
+        name: 'Available Nodes',
+        display: node?.type === 'dimension',
+      },
+    ];
+  };
+
   //
   //
   let tabToDisplay = null;
@@ -106,6 +121,9 @@ export function NodePage() {
     case 5:
       tabToDisplay = <NodeMaterializationTab node={node} djClient={djClient} />;
       break;
+    case 6:
+      tabToDisplay = <NodesWithDimension node={node} djClient={djClient} />;
+      break;
     default:
       tabToDisplay = <NodeInfoTab node={node} />;
   }
@@ -126,7 +144,7 @@ export function NodePage() {
           </h3>
           <ClientCodePopover code={node?.createNodeClientCode} />
           <div className="align-items-center row">
-            {TabsJson.map(buildTabs)}
+            {tabsList(node).map(buildTabs)}
           </div>
           {tabToDisplay}
         </div>

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -92,7 +92,7 @@ export function NodePage() {
       },
       {
         id: 6,
-        name: 'Available Nodes',
+        name: 'Available',
         display: node?.type === 'dimension',
       },
     ];

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -92,7 +92,7 @@ export function NodePage() {
       },
       {
         id: 6,
-        name: 'Available',
+        name: 'Linked Nodes',
         display: node?.type === 'dimension',
       },
     ];
@@ -139,7 +139,10 @@ export function NodePage() {
             style={{ display: 'inline-block' }}
           >
             <span className="card-label fw-bold text-gray-800">
-              {node?.display_name}
+              {node?.display_name}{' '}
+              <span className={'node_type__' + node?.type + ' badge node_type'}>
+                {node?.type}
+              </span>
             </span>
           </h3>
           <ClientCodePopover code={node?.createNodeClientCode} />

--- a/datajunction-ui/src/app/pages/SQLBuilderPage/index.jsx
+++ b/datajunction-ui/src/app/pages/SQLBuilderPage/index.jsx
@@ -175,7 +175,7 @@ export function SQLBuilderPage() {
               onChange={handleMetricSelect}
               onMenuClose={handleMetricSelectorClose}
             />
-            <h4>Shared Dimensions</h4>
+            <h4>Group By</h4>
             <Select
               name="dimensions"
               formatOptionLabel={formatOptionLabel}

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -108,6 +108,13 @@ export const DataJunctionAPI = {
     return data;
   },
 
+  nodesWithDimension: async function (name) {
+    const data = await (
+      await fetch(DJ_URL + '/dimensions/' + name + '/nodes/')
+    ).json();
+    return data;
+  },
+
   materializations: async function (node) {
     const data = await (
       await fetch(DJ_URL + `/nodes/${node}/materializations/`)


### PR DESCRIPTION
### Summary

This PR adds endpoint that will find all nodes that share a given dimension:
```
GET /dimensions/{name}/nodes/
```

The same functionality that underlies that endpoint can be used to find and invalidate cube nodes after a relevant dimension link is removed (that was started in #623). 

Also added a tab to display these nodes in the dimension node tab UI. I changed the tabs setup in the UI to hide certain tabs (SQL, materializations) from nodes where the tab isn't relevant (i.e., source nodes).

<img width="949" alt="Screenshot 2023-07-13 at 11 00 49 PM" src="https://github.com/DataJunction/dj/assets/9524628/179b1e20-26bc-4d83-9b07-c28320446e41">

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #321 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
