### PR TITLE
Validate that a metric only selects from a single source/transform

### DIFF
--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -764,8 +764,8 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         ):
             raise DJInvalidInputException(
                 http_status_code=HTTPStatus.BAD_REQUEST,
-                message=f"Metric {self.name} selects from more than one table, "
-                "should only select from a single table",
+                message=f"Metric {self.name} selects from more than one node, "
+                "should only select from a single node",
             )
 
     def extra_validation(self) -> None:

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -7,6 +7,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import partial
+from http import HTTPStatus
 from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Extra
@@ -739,18 +740,32 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         tree = parse(self.query)
         if len(tree.select.projection) != 1:
             raise DJInvalidInputException(
-                "Metric queries can only have a single "
+                http_status_code=HTTPStatus.BAD_REQUEST,
+                message="Metric queries can only have a single "
                 f"expression, found {len(tree.select.projection)}",
             )
         projection_0 = tree.select.projection[0]
 
+        # must have an aggregation
         if (
             not hasattr(projection_0, "is_aggregation")
             or not projection_0.is_aggregation()  # type: ignore
         ):
             raise DJInvalidInputException(
-                f"Metric {self.name} has an invalid query, "
+                http_status_code=HTTPStatus.BAD_REQUEST,
+                message=f"Metric {self.name} has an invalid query, "
                 "should have a single aggregation",
+            )
+
+        # must query from a single table
+        if (
+            len(tree.select.from_.relations) != 1
+            or tree.select.from_.relations[0].extensions
+        ):
+            raise DJInvalidInputException(
+                http_status_code=HTTPStatus.BAD_REQUEST,
+                message=f"Metric {self.name} selects from more than one table, "
+                "should only select from a single table",
             )
 
     def extra_validation(self) -> None:

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1073,7 +1073,7 @@ def test_raise_on_multiple_expressions(client_with_examples: TestClient):
             "name": "basic.dream_count",
         },
     )
-    assert response.status_code == 422
+    assert response.status_code == 400
     assert (
         "Metric queries can only have a single expression, found 2"
     ) in response.json()["message"]

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1077,3 +1077,65 @@ def test_raise_on_multiple_expressions(client_with_examples: TestClient):
     assert (
         "Metric queries can only have a single expression, found 2"
     ) in response.json()["message"]
+
+
+def test_raise_on_joins(client_with_examples: TestClient):
+    """
+    Testing raising when a metric selects from more than a single table
+    """
+    response = client_with_examples.post(
+        "/nodes/source/",
+        json={
+            "columns": [
+                {
+                    "name": "counts",
+                    "type": "struct<a string, b bigint>",
+                },
+            ],
+            "description": "Collection of dreams",
+            "mode": "published",
+            "name": "basic.dreams",
+            "catalog": "public",
+            "schema_": "basic",
+            "table": "dreams",
+        },
+    )
+    assert response.ok
+
+    response = client_with_examples.post(
+        "/nodes/source/",
+        json={
+            "columns": [
+                {
+                    "name": "counts",
+                    "type": "struct<a string, b bigint>",
+                },
+            ],
+            "description": "Collection of day dreams",
+            "mode": "published",
+            "name": "basic.daydreams",
+            "catalog": "public",
+            "schema_": "basic",
+            "table": "daydreams",
+        },
+    )
+    assert response.ok
+
+    response = client_with_examples.post(
+        "/nodes/metric/",
+        json={
+            "query": "SELECT SUM(counts.b) FROM basic.dreams LEFT JOIN basic.daydreams on id",
+            "description": "Day Dream Counts",
+            "mode": "published",
+            "name": "basic.day_dreams",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "message": (
+            "Metric basic.day_dreams selects from more than one table, "
+            "should only select from a single table"
+        ),
+        "errors": [],
+        "warnings": [],
+    }

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1133,8 +1133,8 @@ def test_raise_on_joins(client_with_examples: TestClient):
     assert response.status_code == 400
     assert response.json() == {
         "message": (
-            "Metric basic.day_dreams selects from more than one table, "
-            "should only select from a single table"
+            "Metric basic.day_dreams selects from more than one node, "
+            "should only select from a single node"
         ),
         "errors": [],
         "warnings": [],


### PR DESCRIPTION
### Summary

Although we validate that a metric has a single expression that includes an aggregation, we don't validate that it only selects from a single table (no joins). This adds that validation.

### Test Plan

Added a metric test `test_raise_on_joins`.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
