### PR TITLE
Just show text for status (small pr)

### DIFF
--- a/datajunction-ui/src/app/components/QueryInfo.jsx
+++ b/datajunction-ui/src/app/components/QueryInfo.jsx
@@ -10,38 +10,6 @@ export default function QueryInfo({
   started,
   numRows,
 }) {
-  const stateIcon =
-    state === 'FINISHED' ? (
-      <span className="status__valid status" style={{ alignContent: 'center' }}>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="25"
-          height="25"
-          fill="currentColor"
-          className="bi bi-check-circle-fill"
-          viewBox="0 0 16 16"
-        >
-          <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z" />
-        </svg>
-      </span>
-    ) : (
-      <span
-        className="status__invalid status"
-        style={{ alignContent: 'center' }}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          fill="currentColor"
-          className="bi bi-x-circle-fill"
-          viewBox="0 0 16 16"
-        >
-          <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z" />
-        </svg>
-      </span>
-    );
-
   return (
     <div className="table-responsive">
       <table className="card-inner-table table">
@@ -70,7 +38,7 @@ export default function QueryInfo({
                 {engine_version}
               </span>
             </td>
-            <td>{stateIcon}</td>
+            <td>{state}</td>
             <td>{scheduled}</td>
             <td>{started}</td>
             <td>


### PR DESCRIPTION
### Summary

Another small PR. I used the same icon for node status for query status but I'm realizing it doesn't make much sense since query status is not binary. Since there are various states (`FINISHED`, `ACCEPTED`, `FAILED`, etc), this simplifies the query info box to just show the status value.

<img width="1921" alt="Screenshot 2023-07-16 at 1 38 13 PM" src="https://github.com/DataJunction/dj/assets/43911210/d06c33b6-286a-4701-a31b-73cd3f90caeb">



### Test Plan

`docker compose --profile demo up` and checked the UI.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
