### PR TITLE
Fix node reactivation bug (where downstream is a cube)

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -327,7 +327,7 @@ def get_upstream_nodes(
     ]
 
 
-def validate_node_data(  # pylint: disable=too-many-locals,too-many-branches
+def validate_node_data(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     data: Union[NodeRevisionBase, NodeRevision],
     session: Session,
 ) -> Tuple[

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1193,3 +1193,69 @@ def test_unlink_node_column_dimension(
     response = client_with_repairs_cube.get("/nodes/default.repairs_cube")
     data = response.json()
     assert data["status"] == "invalid"
+
+
+def test_deactivating_node_upstream_from_cube(
+    client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
+):
+    """
+    Verify deactivating and activating a node upstream from a cube
+    """
+    client_with_repairs_cube.post("/nodes/default.repair_orders/deactivate/")
+    response = client_with_repairs_cube.get("/nodes/default.repairs_cube/")
+    data = response.json()
+    assert data["status"] == "invalid"
+
+    client_with_repairs_cube.post("/nodes/default.repair_orders/activate/")
+    response = client_with_repairs_cube.get("/nodes/default.repairs_cube/")
+    data = response.json()
+    assert data["status"] == "valid"
+
+    response = client_with_repairs_cube.get("/cubes/default.repairs_cube/")
+    data = response.json()
+    assert data["cube_elements"] == [
+        {
+            "name": "default_DOT_discounted_orders_rate",
+            "node_name": "default.discounted_orders_rate",
+            "type": "metric",
+        },
+        {
+            "name": "default_DOT_num_repair_orders",
+            "node_name": "default.num_repair_orders",
+            "type": "metric",
+        },
+        {
+            "name": "default_DOT_avg_repair_price",
+            "node_name": "default.avg_repair_price",
+            "type": "metric",
+        },
+        {
+            "name": "default_DOT_total_repair_cost",
+            "node_name": "default.total_repair_cost",
+            "type": "metric",
+        },
+        {
+            "name": "default_DOT_total_repair_order_discounts",
+            "node_name": "default.total_repair_order_discounts",
+            "type": "metric",
+        },
+        {
+            "name": "default_DOT_double_total_repair_cost",
+            "node_name": "default.double_total_repair_cost",
+            "type": "metric",
+        },
+        {"name": "country", "node_name": "default.hard_hat", "type": "dimension"},
+        {"name": "postal_code", "node_name": "default.hard_hat", "type": "dimension"},
+        {"name": "city", "node_name": "default.hard_hat", "type": "dimension"},
+        {"name": "state", "node_name": "default.hard_hat", "type": "dimension"},
+        {
+            "name": "company_name",
+            "node_name": "default.dispatcher",
+            "type": "dimension",
+        },
+        {
+            "name": "local_region",
+            "node_name": "default.municipality_dim",
+            "type": "dimension",
+        },
+    ]


### PR DESCRIPTION
### Summary

* Let's say a metric node that gets referenced by a cube is deactivated. When the node is reactivated, we call `validate_node_data`, which creates a new column (for the metric's single column reference) and saves the node referencing that new column. However, the way that cubes keep track of metrics and dimensions is through the `Column` reference, and now this old column reference will no longer exist, which breaks the cube.
* A cube node should be considered valid when the nodes referenced by its cube elements (all metrics and dimensions) are valid. This modifies the revalidation of cubes to do that.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #643 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
