### PR TITLE
global setting for source_node_namespace and /register/table/... endpoint

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -33,7 +33,9 @@ from datajunction_server.api.helpers import (
     validate_cube,
     validate_node_data,
 )
+from datajunction_server.api.namespaces import create_a_node_namespace
 from datajunction_server.api.tags import get_tag_by_name
+from datajunction_server.config import Settings
 from datajunction_server.construction.build import build_metric_nodes, build_node
 from datajunction_server.errors import (
     DJDoesNotExistException,
@@ -98,6 +100,7 @@ from datajunction_server.utils import (
     get_namespace_from_name,
     get_query_service_client,
     get_session,
+    get_settings,
 )
 
 _logger = logging.getLogger(__name__)
@@ -1169,7 +1172,7 @@ def create_a_source(
         if not query_service_client:
             raise DJException(
                 message="No table columns were provided and no query "
-                "service is configured for table columns inference!",
+                "service is configured for table columns inference",
             )
         columns = query_service_client.get_columns_for_table(
             data.catalog,
@@ -1299,6 +1302,45 @@ def create_a_cube(
         query_service_client,
     )
     return node  # type: ignore
+
+
+@router.post(
+    "/register/table/{catalog}/{schema_}/{table}/",
+    response_model=NodeOutput,
+    status_code=201,
+)
+def register_a_table(  # pylint: disable=too-many-arguments
+    catalog: str,
+    schema_: str,
+    table: str,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+) -> NodeOutput:
+    """
+    Register a table. This creates a source node in the SOURCE_NODE_NAMESPACE and
+    the source node's schema will be inferred using the configured query service.
+    """
+    if not query_service_client:
+        raise DJException(
+            message="Registering tables requires that a query "
+            "service is configured for table columns inference",
+        )
+    namespace = f"{settings.source_node_namespace}.{catalog}.{schema_}"
+    name = f"{namespace}.{table}"
+    create_a_node_namespace(namespace=namespace, session=session)
+    return create_a_source(
+        data=CreateSourceNode(
+            catalog=catalog,
+            schema_=schema_,
+            table=table,
+            name=name,
+            description="This source node was automatically created as a registered table.",
+            mode=NodeMode.PUBLISHED,
+        ),
+        session=session,
+        query_service_client=query_service_client,
+    )
 
 
 def schedule_materialization_jobs(

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -51,6 +51,9 @@ class Settings(
     # Query service
     query_service: Optional[str] = None
 
+    # The namespace where source nodes for registered tables should exist
+    source_node_namespace: Optional[str] = "sources"
+
     @property
     def celery(self) -> Celery:
         """

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -52,7 +52,7 @@ class Settings(
     query_service: Optional[str] = None
 
     # The namespace where source nodes for registered tables should exist
-    source_node_namespace: Optional[str] = "sources"
+    source_node_namespace: Optional[str] = "source"
 
     @property
     def celery(self) -> Celery:

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -942,7 +942,7 @@ class SourceNodeFields(BaseSQLModel):
     catalog: str
     schema_: str
     table: str
-    columns: Optional[List["SourceColumnOutput"]] = []
+    columns: List["SourceColumnOutput"]
 
 
 class CubeNodeFields(BaseSQLModel):

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -843,11 +843,9 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         """
         response = client.post("/register/table/foo/bar/baz/")
         data = response.json()
-        assert (
-            data["message"] == (
-                "Registering tables requires that a query "
-                "service is configured for table columns inference"
-            )
+        assert data["message"] == (
+            "Registering tables requires that a query "
+            "service is configured for table columns inference"
         )
         assert response.status_code == 500
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -834,34 +834,20 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             "warnings": [],
         }
 
-    def test_create_source_node_without_cols_or_query_service(
+    def test_register_table_without_query_service(
         self,
-        client_with_examples: TestClient,
+        client: TestClient,
     ):
         """
-        Trying to create a source node without columns and without
-        a query service set up should fail.
+        Trying to register a table without a query service set up should fail.
         """
-        basic_source_comments = {
-            "name": "default.comments",
-            "description": "A fact table with comments",
-            "columns": [],
-            "mode": "published",
-            "catalog": "public",
-            "schema_": "basic",
-            "table": "comments",
-        }
-
-        # Trying to create a source node without columns and without
-        # a query service set up should fail
-        response = client_with_examples.post(
-            "/nodes/source/",
-            json=basic_source_comments,
-        )
+        response = client.post("/register/table/foo/bar/baz/")
         data = response.json()
         assert (
-            data["message"] == "No table columns were provided and no query "
-            "service is configured for table columns inference!"
+            data["message"] == (
+                "Registering tables requires that a query "
+                "service is configured for table columns inference"
+            )
         )
         assert response.status_code == 500
 
@@ -873,26 +859,13 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         Creating a source node without columns but with a query service set should
         result in the source node columns being inferred via the query service.
         """
-        basic_source_comments = {
-            "name": "default.comments",
-            "description": "A fact table with comments",
-            "columns": [],
-            "mode": "published",
-            "catalog": "public",
-            "schema_": "basic",
-            "table": "comments",
-        }
-
-        # Trying to create a source node without columns and without
-        # a query service set up should fail
         response = client_with_query_service.post(
-            "/nodes/source/",
-            json=basic_source_comments,
+            "/register/table/public/basic/comments/",
         )
         data = response.json()
-        assert data["name"] == "default.comments"
+        assert data["name"] == "source.public.basic.comments"
         assert data["type"] == "source"
-        assert data["display_name"] == "Default: Comments"
+        assert data["display_name"] == "source.public.basic.comments"
         assert data["version"] == "v1.0"
         assert data["status"] == "valid"
         assert data["mode"] == "published"


### PR DESCRIPTION
### Summary

It's been pretty confusing to differentiate between manually created source nodes (i.e., user may be manually modeling a table that hasn't been created in the warehouse yet) and source nodes that should be under constant monitoring from the query service. This adds two things to make this a bit easier.

#### `SOURCE_NODE_NAMESPACE` server setting
This setting defaults to `"sources"` and determines the namespace where all reflection managed source nodes will be created. Users can still manually create source nodes in any other namespace in the system, but those won't be monitored via reflection.

#### `POST /register/table/{catalog}/{schema_}/{table}/` endpoint
This endpoint is meant to be an alternative to manually creating a source node through `POST /nodes/source/`. Unlike the manual endpoint, this endpoint does not allow you to choose the node name, namespace, description or provide the columns. It will instead create a source node named `f"{settings.source_node_namespace}.{catalog}.{schema_}.{table}"` and the schema will automatically be set through reflection and only works when a query service is configured.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
