### PR TITLE
Add history for node status changes and dimension link removal

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -27,7 +27,11 @@ from datajunction_server.errors import (
 from datajunction_server.models import AttributeType, Catalog, Column, Engine
 from datajunction_server.models.attribute import RESERVED_ATTRIBUTE_NAMESPACE
 from datajunction_server.models.engine import Dialect
-from datajunction_server.models.history import EntityType, History
+from datajunction_server.models.history import (
+    EntityType,
+    History,
+    status_change_history,
+)
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node import (
     BuildCriteria,
@@ -566,6 +570,13 @@ def propagate_valid_status(
                     node.current.columns = validated_node.columns or []
                     node.current.status = NodeStatus.VALID
                     node.current.catalog_id = catalog_id
+                    session.add(
+                        status_change_history(
+                            node.current,
+                            NodeStatus.INVALID,
+                            NodeStatus.VALID,
+                        ),
+                    )
                     session.add(node.current)
                     session.commit()
                     newly_valid_nodes.append(node.current)

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -380,6 +380,7 @@ def deactivate_a_node(name: str, *, session: Session = Depends(get_session)):
                     downstream.current,
                     NodeStatus.VALID,
                     NodeStatus.INVALID,
+                    parent_node=node.name,
                 ),
             )
             session.add(downstream)
@@ -450,6 +451,7 @@ def activate_a_node(name: str, *, session: Session = Depends(get_session)):
                     downstream.current,
                     old_status,
                     downstream.current.status,
+                    parent_node=node.name,
                 ),
             )
 

--- a/datajunction-server/datajunction_server/models/history.py
+++ b/datajunction-server/datajunction_server/models/history.py
@@ -10,6 +10,7 @@ from sqlalchemy import DateTime
 from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlmodel import JSON, Field, SQLModel
 
+from datajunction_server.models.node import NodeRevision, NodeStatus
 from datajunction_server.typing import UTCDatetime
 
 
@@ -24,6 +25,7 @@ class ActivityType(str, Enum):
     UPDATE = "update"
     TAG = "tag"
     SET_ATTRIBUTE = "set_attribute"
+    STATUS_CHANGE = "status_change"
 
 
 class EntityType(str, Enum):
@@ -65,3 +67,21 @@ class History(SQLModel, table=True):  # type: ignore
 
     def __hash__(self) -> int:
         return hash(self.id)
+
+
+def status_change_history(
+    node_revision: NodeRevision,
+    start_status: NodeStatus,
+    end_status: NodeStatus,
+) -> History:
+    """
+    Returns a status change history activity entry
+    """
+    return History(
+        entity_type=EntityType.NODE,
+        entity_name=node_revision.name,
+        node=node_revision.name,
+        activity_type=ActivityType.STATUS_CHANGE,
+        pre={"status": start_status},
+        post={"status": end_status},
+    )

--- a/datajunction-server/datajunction_server/models/history.py
+++ b/datajunction-server/datajunction_server/models/history.py
@@ -73,6 +73,7 @@ def status_change_history(
     node_revision: NodeRevision,
     start_status: NodeStatus,
     end_status: NodeStatus,
+    parent_node: str = None,
 ) -> History:
     """
     Returns a status change history activity entry
@@ -84,4 +85,5 @@ def status_change_history(
         activity_type=ActivityType.STATUS_CHANGE,
         pre={"status": start_status},
         post={"status": end_status},
+        details={"upstream_node": parent_node if parent_node else None},
     )

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -269,10 +269,16 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             # The downstreams' status change should be recorded in their histories
             response = client_with_examples.get(f"/history?node={downstream}")
             assert [
-                (activity["pre"], activity["post"])
+                (activity["pre"], activity["post"], activity["details"])
                 for activity in response.json()
                 if activity["activity_type"] == "status_change"
-            ] == [({"status": "valid"}, {"status": "invalid"})]
+            ] == [
+                (
+                    {"status": "valid"},
+                    {"status": "invalid"},
+                    {"upstream_node": "basic.source.users"},
+                ),
+            ]
 
         # Trying to create the node again should reveal that the node exists but is deactivated
         response = client_with_examples.post(
@@ -387,10 +393,16 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         )
         response = client.get("/history?node=default.num_users")
         assert [
-            (activity["pre"], activity["post"])
+            (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
             if activity["activity_type"] == "status_change"
-        ] == [({"status": "valid"}, {"status": "invalid"})]
+        ] == [
+            (
+                {"status": "valid"},
+                {"status": "invalid"},
+                {"upstream_node": "basic.source.users"},
+            ),
+        ]
 
         # Reactivate the source node
         response = client.post("/nodes/default.users/activate/")
@@ -404,12 +416,20 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         # Check activity history of downstream metric
         response = client.get("/history?node=default.num_users")
         assert [
-            (activity["pre"], activity["post"])
+            (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
             if activity["activity_type"] == "status_change"
         ] == [
-            ({"status": "valid"}, {"status": "invalid"}),
-            ({"status": "invalid"}, {"status": "valid"}),
+            (
+                {"status": "valid"},
+                {"status": "invalid"},
+                {"upstream_node": "basic.source.users"},
+            ),
+            (
+                {"status": "invalid"},
+                {"status": "valid"},
+                {"upstream_node": "basic.source.users"},
+            ),
         ]
 
     def test_deactivating_transform_upstream_from_metric(
@@ -515,10 +535,16 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         # Check history of downstream metrics
         response = client.get("/history?node=default.num_us_users")
         assert [
-            (activity["pre"], activity["post"])
+            (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
             if activity["activity_type"] == "status_change"
-        ] == [({"status": "valid"}, {"status": "invalid"})]
+        ] == [
+            (
+                {"status": "valid"},
+                {"status": "invalid"},
+                {"upstream_node": "default.us_users"},
+            ),
+        ]
         # No change recorded here because the metric was already invalid
         response = client.get("/history?node=default.invalid_metric")
         assert [
@@ -546,12 +572,20 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         # Check history of downstream metric
         response = client.get("/history?node=default.num_us_users")
         assert [
-            (activity["pre"], activity["post"])
+            (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
             if activity["activity_type"] == "status_change"
         ] == [
-            ({"status": "valid"}, {"status": "invalid"}),
-            ({"status": "invalid"}, {"status": "valid"}),
+            (
+                {"status": "valid"},
+                {"status": "invalid"},
+                {"upstream_node": "default.us_users"},
+            ),
+            (
+                {"status": "invalid"},
+                {"status": "valid"},
+                {"upstream_node": "default.us_users"},
+            ),
         ]
 
         # The other downstream metric should have remained invalid

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2517,6 +2517,11 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         response = client_with_examples.get("/nodes/default.revenue")
         data = response.json()
         assert all(col["dimension"] is None for col in data["columns"])
+        response = client_with_examples.get("/history?node=default.revenue")
+        assert [
+            (activity["activity_type"], activity["entity_type"])
+            for activity in response.json()
+        ] == [("create", "node"), ("create", "link"), ("delete", "link")]
 
         # Removing the dimension link again will result in no change
         response = client_with_examples.delete(
@@ -2528,6 +2533,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "message": "No change was made to payment_type on node default.revenue as the"
             " specified dimension link to default.payment_type on None was not found.",
         }
+        # Check history again, no change
+        response = client_with_examples.get("/history?node=default.revenue")
+        assert [
+            (activity["activity_type"], activity["entity_type"])
+            for activity in response.json()
+        ] == [("create", "node"), ("create", "link"), ("delete", "link")]
 
         # Check that the proper error is raised when the column doesn't exist
         response = client_with_examples.post(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -400,7 +400,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             (
                 {"status": "valid"},
                 {"status": "invalid"},
-                {"upstream_node": "basic.source.users"},
+                {"upstream_node": "default.users"},
             ),
         ]
 
@@ -423,12 +423,12 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             (
                 {"status": "valid"},
                 {"status": "invalid"},
-                {"upstream_node": "basic.source.users"},
+                {"upstream_node": "default.users"},
             ),
             (
                 {"status": "invalid"},
                 {"status": "valid"},
-                {"upstream_node": "basic.source.users"},
+                {"upstream_node": "default.users"},
             ),
         ]
 

--- a/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
@@ -85,6 +85,32 @@ export default function NodeHistory({ node, djClient }) {
         </div>
       );
     }
+    if (
+      event.activity_type === 'status_change' &&
+      event.entity_type === 'node'
+    ) {
+      const expr = (
+        <div>
+          Caused by a change in upstream{' '}
+          <a href={`/nodes/${event.details['upstream_node']}`}>
+            {event.details['upstream_node']}
+          </a>
+        </div>
+      );
+      return (
+        <div>
+          Status changed from{' '}
+          <span className={`status__${event.pre['status']}`}>
+            {event.pre['status']}
+          </span>{' '}
+          to{' '}
+          <span className={`status__${event.post['status']}`}>
+            {event.post['status']}
+          </span>{' '}
+          {event.details['upstream_node'] !== undefined ? expr : ''}
+        </div>
+      );
+    }
     return '';
   };
 

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -433,12 +433,12 @@ tbody th {
   color: #00b368;
 }
 
-.history_type__deactvate {
-  background-color: #a8a8a8 !important;
-  color: #855e5e;
+.history_type__delete {
+  background-color: #ffc8c8 !important;
+  color: #9b5a5a;
 }
 
-.history_type__activate {
+.history_type__restore {
   background-color: #ccf7e5 !important;
   color: #00b368;
 }
@@ -459,8 +459,13 @@ tbody th {
 }
 
 .history_type__set_attribute {
-  background-color: #ffe6e6 !important;
-  color: #855e5e;
+  background-color: #e6f5ff !important;
+  color: #487c8c;
+}
+
+.history_type__status_change {
+  background-color: #ffe9db !important;
+  color: #573d3d;
 }
 
 .partition_value {


### PR DESCRIPTION
### Summary

More history tracking:
* Node status switched to valid/invalid by the system (there are quite a few of these, but hopefully with this we'll be able to track where some of the node invalidation is occurring)
* Dimension link removed

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #624
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
