### PR TITLE
feat:allow queryservice be hosted at non-root path

### DIFF
--- a/datajunction-server/datajunction_server/api/authentication/basic.py
+++ b/datajunction-server/datajunction_server/api/authentication/basic.py
@@ -72,11 +72,17 @@ async def login(
     response.set_cookie(
         DJ_AUTH_COOKIE,
         create_token({"username": user.username}, expires_delta=timedelta(days=365)),
+        domain="djui.fly.dev",
+        secure=True,
+        samesite="none",
         httponly=True,
     )
     response.set_cookie(
         DJ_LOGGED_IN_FLAG_COOKIE,
         "true",
+        domain="djui.fly.dev",
+        secure=True,
+        samesite="none",
     )
     return response
 

--- a/datajunction-server/datajunction_server/api/authentication/github.py
+++ b/datajunction-server/datajunction_server/api/authentication/github.py
@@ -99,10 +99,16 @@ async def get_access_token(
     response.set_cookie(
         DJ_AUTH_COOKIE,
         create_token({"username": user.username}, expires_delta=timedelta(days=365)),
+        domain="djui.fly.dev",
+        secure=True,
+        samesite="none",
         httponly=True,
     )
     response.set_cookie(
         DJ_LOGGED_IN_FLAG_COOKIE,
         "true",
+        domain="djui.fly.dev",
+        secure=True,
+        samesite="none",
     )
     return response

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -86,7 +86,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         Retrieves columns for a table.
         """
         response = self.requests_session.get(
-            f"/table/{catalog}.{schema}.{table}/columns/",
+            f"table/{catalog}.{schema}.{table}/columns/",
             params={
                 "engine": engine.name,
                 "engine_version": engine.version,
@@ -108,7 +108,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         Submit a query to the query service
         """
         response = self.requests_session.post(
-            "/queries/",
+            "queries/",
             json=query_create.dict(),
         )
         response_data = response.json()
@@ -126,7 +126,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         """
         Get a previously submitted query
         """
-        response = self.requests_session.get(f"/queries/{query_id}/")
+        response = self.requests_session.get(f"queries/{query_id}/")
         if not response.ok:
             raise DJQueryServiceClientException(
                 message=f"Error response from query service: {response.text}",
@@ -147,7 +147,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         that this functionality may be moved to the materialization service at a later point.
         """
         response = self.requests_session.post(
-            "/materialization/",
+            "materialization/",
             json=materialization_input.dict(),
         )
         if not response.ok:  # pragma: no cover
@@ -185,7 +185,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         Gets materialization info for the node and materialization config name.
         """
         response = self.requests_session.get(
-            f"/materialization/{node_name}/{node_version}/{materialization_name}/",
+            f"materialization/{node_name}/{node_version}/{materialization_name}/",
             timeout=3,
         )
         if not response.ok:


### PR DESCRIPTION
The RequestsSessionWithEndpoint builds a URI from a base URL + a path.

Currently in all cases of the RequestsSessionWithEndpoint being used in
the QueryServiceClient, the paths that are being passed in are all
absolute paths.

By passing in absolute paths, it makes it impossible to use a base URL
that also includes a path (e.g. http://localhost:8000/qs/), because
urllib.parse.urljoin will create the new full URI by substituting the
path of the base URL (e.g. /qs/) with the full absolute path that is
passed in to the RequestsSessionWithEndpoint constructor.

By passing in relative paths to the RequestsSessionWithEndpoint
constructor, the ability to host the query service on a base URL with a
path is now possible.
