### PR TITLE
Various functions

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -3,6 +3,7 @@ Helpers for API endpoints
 """
 import collections
 import http.client
+import logging
 from http import HTTPStatus
 from typing import Dict, List, Optional, Set, Tuple, Union
 
@@ -50,6 +51,8 @@ from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import SqlSyntaxError, parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
+
+logger = logging.getLogger(__name__)
 
 
 def get_node_namespace(  # pylint: disable=too-many-arguments
@@ -392,6 +395,11 @@ def validate_node_data(  # pylint: disable=too-many-locals
 
     # Only raise on missing parents if the node mode is set to published
     if missing_parents_map and validated_node.mode != NodeMode.DRAFT:
+        logger.error(
+            "Node %s missing parents %s",
+            validated_node.name,
+            list(missing_parents_map.keys()),
+        )
         raise DJException(
             http_status_code=HTTPStatus.BAD_REQUEST,
             errors=[

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -44,7 +44,7 @@ from datajunction_server.errors import (
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 
 if TYPE_CHECKING:
-    from datajunction_server.sql.parsing.ast import Expression, Lambda
+    from datajunction_server.sql.parsing.ast import Expression
 
 
 def compare_registers(types, register) -> bool:
@@ -293,6 +293,11 @@ def infer_type(
         )
     element_type = elements[0].type if elements else ct.NullType()
     return ct.ListType(element_type=element_type)
+
+
+@Array.register  # type: ignore
+def infer_type() -> ct.ListType:
+    return ct.ListType(element_type=ct.NullType())
 
 
 class ArrayAgg(Function):
@@ -715,6 +720,21 @@ def infer_type(
     return ct.ListType(element_type=arg.type)
 
 
+class CollectSet(Function):
+    """
+    Collects and returns a list of unique elements.
+    """
+
+    is_aggregation = True
+
+
+@CollectSet.register
+def infer_type(
+    arg: ct.ColumnType,
+) -> ct.ColumnType:
+    return ct.ListType(element_type=arg.type)
+
+
 class Count(Function):
     """
     Counts the number of non-null values in the input column or expression.
@@ -849,6 +869,17 @@ class ElementAt(Function):
     """
 
 
+class DjCurrentDate(Function):
+    """
+    A special function that returns the current date, used for incrementally materializing nodes.
+    """
+
+
+@DjCurrentDate.register  # type: ignore
+def infer_type() -> ct.IntegerType:
+    return ct.IntegerType()
+
+
 @ElementAt.register
 def infer_type(
     array: ct.ListType,
@@ -893,6 +924,45 @@ class Extract(Function):
         return ct.IntegerType()
 
 
+class Filter(Function):
+    """
+    Filter an array.
+    """
+
+    @staticmethod
+    def compile_lambda(*args):
+        """
+        Compiles the lambda function used by the `filter` Spark function so that
+        the lambda's expression can be evaluated to determine the result's type.
+        """
+        from datajunction_server.sql.parsing import (  # pylint: disable=import-outside-toplevel
+            ast,
+        )
+
+        expr, func = args
+        available_identifiers = {
+            identifier.name: idx for idx, identifier in enumerate(func.identifiers)
+        }
+        columns = list(
+            func.expr.filter(lambda x: isinstance(x, ast.Column)),
+        )
+        for col in columns:
+            if (
+                col.alias_or_name.namespace
+                and col.alias_or_name.namespace.name
+                and available_identifiers.get(col.alias_or_name.namespace.name) == 0
+            ) or available_identifiers.get(col.alias_or_name.name) == 0:
+                col.add_type(expr.type)
+
+
+@Filter.register  # type: ignore
+def infer_type(
+    arg: Union[ct.ListType, ct.PrimitiveType],
+    func: ct.PrimitiveType,
+) -> ct.ListType:
+    return arg.type  # type: ignore
+
+
 class First(Function):
     """
     Returns the first value of expr for a group of rows. If isIgnoreNull is
@@ -915,6 +985,43 @@ def infer_type(
     is_ignore_null: ct.BooleanType,
 ) -> ct.ColumnType:
     return arg.type
+
+
+class FirstValue(Function):
+    """
+    Returns the first value of expr for a group of rows. If isIgnoreNull is
+    true, returns only non-null values.
+    """
+
+    is_aggregation = True
+
+
+@FirstValue.register
+def infer_type(
+    arg: ct.ColumnType,
+) -> ct.ColumnType:
+    return arg.type
+
+
+@FirstValue.register
+def infer_type(
+    arg: ct.ColumnType,
+    is_ignore_null: ct.BooleanType,
+) -> ct.ColumnType:
+    return arg.type
+
+
+class Flatten(Function):
+    """
+    Flatten an array.
+    """
+
+
+@Flatten.register  # type: ignore
+def infer_type(
+    array: ct.ListType,
+) -> ct.ListType:
+    return array.type.element.type  # type: ignore
 
 
 class Floor(Function):
@@ -994,6 +1101,19 @@ def infer_type(  # pragma: no cover
     return ct.StructType(
         *parse_rule(schema.value, "complexColTypeList")
     )  # pragma: no cover
+
+
+class Greatest(Function):
+    """
+    greatest(expr, ...) - Returns the greatest value of all parameters, skipping null values.
+    """
+
+
+@Greatest.register  # type: ignore
+def infer_type(
+    *values: ct.NumberType,
+) -> ct.ColumnType:
+    return values[0].type
 
 
 class If(Function):
@@ -1254,6 +1374,19 @@ def infer_type(
     return ct.DoubleType()
 
 
+class Rank(Function):
+    """
+    rank() - Computes the rank of a value in a group of values. The result is
+    one plus the number of rows preceding or equal to the current row in the
+    ordering of the partition. The values will produce gaps in the sequence.
+    """
+
+
+@Rank.register
+def infer_type() -> ct.IntegerType:
+    return ct.IntegerType()
+
+
 class RegexpLike(Function):
     """
     regexp_like(str, regexp) - Returns true if str matches regexp, or false otherwise
@@ -1266,6 +1399,18 @@ def infer_type(  # type: ignore
     arg2: ct.StringType,
 ) -> ct.BooleanType:
     return ct.BooleanType()
+
+
+class RowNumber(Function):
+    """
+    row_number() - Assigns a unique, sequential number to each row, starting with
+    one, according to the ordering of rows within the window partition.
+    """
+
+
+@RowNumber.register
+def infer_type() -> ct.IntegerType:
+    return ct.IntegerType()
 
 
 class Round(Function):
@@ -1296,7 +1441,40 @@ def infer_type(  # type: ignore
     child: ct.NumberType,
     scale: ct.IntegerBase,
 ) -> ct.NumberType:
+    if scale.value == 0:
+        return ct.IntegerType()
     return child.type
+
+
+@Round.register
+def infer_type(  # type: ignore
+    child: ct.NumberType,
+) -> ct.NumberType:
+    return ct.IntegerType()
+
+
+class Size(Function):
+    """
+    size(expr) - Returns the size of an array or a map. The function returns
+    null for null input if spark.sql.legacy.sizeOfNull is set to false or
+    spark.sql.ansi.enabled is set to true. Otherwise, the function returns -1
+    for null input. With the default settings, the function returns -1 for null
+    input.
+    """
+
+
+@Size.register  # type: ignore
+def infer_type(
+    arg: ct.ListType,
+) -> ct.IntegerType:
+    return ct.IntegerType()
+
+
+@Size.register  # type: ignore
+def infer_type(
+    arg: ct.MapType,
+) -> ct.IntegerType:
+    return ct.IntegerType()
 
 
 class Split(Function):
@@ -1574,7 +1752,9 @@ class Year(Function):
 
 
 @Year.register
-def infer_type(arg: Union[ct.StringType, ct.DateTimeBase]) -> ct.BigIntType:
+def infer_type(
+    arg: Union[ct.StringType, ct.DateTimeBase, ct.IntegerType],
+) -> ct.BigIntType:
     return ct.BigIntType()
 
 

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -936,7 +936,7 @@ class Filter(Function):
             func.expr.filter(lambda x: isinstance(x, ast.Column)),
         )
         for col in columns:
-            if (
+            if (  # pragma: no cover
                 col.alias_or_name.namespace
                 and col.alias_or_name.namespace.name
                 and available_identifiers.get(col.alias_or_name.namespace.name) == 0

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -869,17 +869,6 @@ class ElementAt(Function):
     """
 
 
-class DjCurrentDate(Function):
-    """
-    A special function that returns the current date, used for incrementally materializing nodes.
-    """
-
-
-@DjCurrentDate.register  # type: ignore
-def infer_type() -> ct.IntegerType:
-    return ct.IntegerType()
-
-
 @ElementAt.register
 def infer_type(
     array: ct.ListType,

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -684,7 +684,7 @@ class Column(Aliasable, Named, Expression):
             self.add_type(self.expression.type)
             return self.expression.type
 
-        raise DJParseException(f"Cannot resolve type of column {self} in {self.parent}")
+        raise DJParseException(f"Cannot resolve type of column {self}.")
 
     def add_type(self, type_: ColumnType) -> "Column":
         """
@@ -856,7 +856,7 @@ class Column(Aliasable, Named, Expression):
         Compile a column.
         Determines the table from which a column is from.
         """
-        print("col", self.name, self._type)
+
         if self.is_compiled():
             return
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -684,7 +684,7 @@ class Column(Aliasable, Named, Expression):
             self.add_type(self.expression.type)
             return self.expression.type
 
-        raise DJParseException(f"Cannot resolve type of column {self}.")
+        raise DJParseException(f"Cannot resolve type of column {self} in {self.parent}")
 
     def add_type(self, type_: ColumnType) -> "Column":
         """
@@ -856,7 +856,7 @@ class Column(Aliasable, Named, Expression):
         Compile a column.
         Determines the table from which a column is from.
         """
-
+        print("col", self.name, self._type)
         if self.is_compiled():
             return
 

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -560,7 +560,7 @@ def test_infer_types_exp(construction_session: Session):
         DoubleType(),
         DoubleType(),
         DoubleType(),
-        FloatType(),
+        IntegerType(),
         FloatType(),
         DoubleType(),
         DecimalType(precision=9, scale=6),

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -662,6 +662,7 @@ def test_first_and_first_value(session: Session):
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[2].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[3].type == ct.IntegerType()  # type: ignore
 
 
 def test_flatten(session: Session):

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -128,6 +128,33 @@ def test_approx_percentile(session: Session):
     assert query_with_list.select.projection[0].type == ct.FloatType()  # type: ignore
 
 
+def test_array(session: Session):
+    """
+    Test the `array` Spark function
+    """
+    query = parse(
+        """
+    SELECT array() FROM (select 1 as col)
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.NullType())  # type: ignore
+
+    query = parse(
+        """
+    SELECT array(1, 2, 3) FROM (select 1 as col)
+    """,
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
+
+
 def test_array_agg(session: Session):
     """
     Test the `array_agg` Spark function
@@ -563,6 +590,20 @@ def test_collect_list(session: Session):
     )
 
 
+def test_collect_set(session: Session):
+    """
+    Test the `collect_set` function
+    """
+    query = parse("SELECT collect_set(col) FROM (SELECT (1), (2) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(  # type: ignore
+        element_type=ct.IntegerType(),
+    )
+
+
 def test_count() -> None:
     """
     Test ``Count`` function.
@@ -593,17 +634,48 @@ def test_element_at(session: Session):
     assert query_with_map.select.projection[0].type == StringType()  # type: ignore
 
 
-def test_first(session: Session):
+def test_filter(session: Session):
     """
-    Test `first`
+    Test the `filter` function
     """
-    query = parse("SELECT first(col), first(col, true) FROM (SELECT (1), (2) AS col)")
+    query = parse("SELECT filter(col, s -> s != 3) FROM (SELECT array(1, 2, 3) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert query.select.projection[0].type == ct.ListType(  # type: ignore
+        element_type=ct.IntegerType(),
+    )
+
+
+def test_first_and_first_value(session: Session):
+    """
+    Test `first` and `first_value`
+    """
+    query = parse(
+        "SELECT first(col), first(col, true), first_value(col), "
+        "first_value(col, true) FROM (SELECT (1), (2) AS col)",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[2].type == ct.IntegerType()  # type: ignore
+
+
+def test_flatten(session: Session):
+    """
+    Test `flatten`
+    """
+    query = parse("SELECT flatten(array(array(1, 2), array(3, 4)))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(  # type: ignore
+        element_type=ct.IntegerType(),
+    )
 
 
 @pytest.mark.parametrize(
@@ -644,6 +716,18 @@ def test_floor(types, expected) -> None:
             )
             == expected
         )
+
+
+def test_greatest(session: Session):
+    """
+    Test `greatest`
+    """
+    query = parse("SELECT greatest(10, 9, 2, 4, 3)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
 def test_max() -> None:
@@ -691,6 +775,20 @@ def test_now() -> None:
     assert Now.infer_type() == ct.TimestampType()
 
 
+def test_rank(session: Session):
+    """
+    Test `rank`
+    """
+    query = parse(
+        "SELECT rank() OVER (PARTITION BY col ORDER BY col) FROM (SELECT (1), (2) AS col)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
 def test_regexp_like(session: Session):
     """
     Test `regexp_like`
@@ -703,6 +801,62 @@ def test_regexp_like(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+def test_row_number(session: Session):
+    """
+    Test `row_number`
+    """
+    query = parse(
+        "SELECT row_number() OVER (PARTITION BY col ORDER BY col) FROM (SELECT (1), (2) AS col)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_round(session: Session):
+    """
+    Test `round`
+    """
+    query = parse(
+        "SELECT round(2.5, 0)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+    query = parse(
+        "SELECT round(2.5)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_size(session: Session):
+    """
+    Test the `size` Spark function
+    """
+    query = parse("SELECT size(array('b', 'd', 'c', 'a'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+    query = parse("SELECT size(map('a', 1, 'b', 2))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
 def test_split(session: Session):


### PR DESCRIPTION
### Summary

Added support for several functions:
* `array()` without any args
* `collect_set`
* `filter`
* `first_value`
* `flatten`
* `greatest`
* `rank`
* `row_number`
* `round(x)` without default scale=0
* `size` for both arrays and maps

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #544 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
