### PR TITLE
More context for type inference failure

### DIFF
--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -463,7 +463,12 @@ class TestDJReader:
         )
         assert (
             result["message"]
-            == "Cannot resolve type of column dimension_that_does_not_exist."
+            == "Cannot resolve type of column dimension_that_does_not_exist in SELECT  "
+            "dimension_that_does_not_exist,\n"
+            "\tavg(foo_DOT_bar_DOT_repair_order_details.price) "
+            "foo_DOT_bar_DOT_avg_repair_price \n"
+            " FROM roads.repair_order_details AS foo_DOT_bar_DOT_repair_order_details \n"
+            " GROUP BY  dimension_that_does_not_exist\n"
         )
 
         # Retrieve SQL for multiple metrics using the client object

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -684,7 +684,7 @@ class Column(Aliasable, Named, Expression):
             self.add_type(self.expression.type)
             return self.expression.type
 
-        raise DJParseException(f"Cannot resolve type of column {self}.")
+        raise DJParseException(f"Cannot resolve type of column {self} in {self.parent}")
 
     def add_type(self, type_: ColumnType) -> "Column":
         """

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -683,8 +683,8 @@ class Column(Aliasable, Named, Expression):
         if self.expression:
             self.add_type(self.expression.type)
             return self.expression.type
-
-        raise DJParseException(f"Cannot resolve type of column {self} in {self.parent}")
+        parent_expr = f"in {self.parent}" if self.parent else "that has no parent"
+        raise DJParseException(f"Cannot resolve type of column {self} {parent_expr}")
 
     def add_type(self, type_: ColumnType) -> "Column":
         """

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -168,7 +168,7 @@ def test_raising_when_expression_has_no_parent():
     with pytest.raises(DJParseException) as exc_info:
         col.type  # pylint: disable=pointless-statement
 
-    assert "Cannot resolve type of column status." in str(exc_info.value)
+    assert "Cannot resolve type of column status in None" in str(exc_info.value)
 
 
 def test_infer_map_subscripts(construction_session: Session):

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -168,7 +168,9 @@ def test_raising_when_expression_has_no_parent():
     with pytest.raises(DJParseException) as exc_info:
         col.type  # pylint: disable=pointless-statement
 
-    assert "Cannot resolve type of column status in None" in str(exc_info.value)
+    assert "Cannot resolve type of column status that has no parent" in str(
+        exc_info.value,
+    )
 
 
 def test_infer_map_subscripts(construction_session: Session):


### PR DESCRIPTION
### Summary

Adds more context around a column's type inference failure by pulling the parent node's expression.

### Test Plan

<!-- How did you test your change? -->

- [X] PR has an associated issue: #652 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
