### PR TITLE
Fix namespace display in UI after changing namespaces endpoint

### DIFF
--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -20,7 +20,7 @@ export function NamespacePage() {
     const hierarchy = [];
 
     for (const item of namespaceList) {
-      const namespaces = item.namespace.split('.');
+      const namespaces = item.split('.');
       let currentLevel = hierarchy;
 
       let path = '';


### PR DESCRIPTION
### Summary

Minor change to fix displaying namespaces in the UI after the endpoint changed from {"namespace": "..."} to just a list of namespaces.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
