### PR TITLE
Add functionality to get nodes with a set of common dimensions

### DIFF
--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -2,14 +2,17 @@
 Dimensions related APIs.
 """
 import logging
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
 from datajunction_server.api.helpers import get_node_by_name
 from datajunction_server.models.node import NodeRevisionOutput, NodeType
-from datajunction_server.sql.dag import get_nodes_with_dimension
+from datajunction_server.sql.dag import (
+    get_nodes_with_common_dimensions,
+    get_nodes_with_dimension,
+)
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
@@ -28,4 +31,22 @@ def find_nodes_with_dimension(
     """
     dimension_node = get_node_by_name(session, name)
     nodes = get_nodes_with_dimension(session, dimension_node, node_types)
+    return nodes
+
+
+@router.get("/dimensions/common/", response_model=List[NodeRevisionOutput])
+def find_nodes_with_common_dimensions(
+    dimension: Annotated[list[str] | None, Query()] = Query(None),
+    *,
+    node_types: Optional[List[NodeType]] = None,
+    session: Session = Depends(get_session),
+) -> List[NodeRevisionOutput]:
+    """
+    List all nodes that have the specified dimension
+    """
+    nodes = get_nodes_with_common_dimensions(
+        session,
+        [get_node_by_name(session, dim) for dim in dimension],  # type: ignore
+        node_types,
+    )
     return nodes

--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -2,10 +2,11 @@
 Dimensions related APIs.
 """
 import logging
-from typing import Annotated, List
+from typing import List, Union
 
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
+from typing_extensions import Annotated
 
 from datajunction_server.api.helpers import get_node_by_name
 from datajunction_server.models.node import NodeRevisionOutput, NodeType
@@ -23,7 +24,7 @@ router = APIRouter()
 def find_nodes_with_dimension(
     name: str,
     *,
-    node_type: Annotated[List[NodeType] | None, Query()] = Query(None),
+    node_type: Annotated[Union[List[NodeType], None], Query()] = Query(None),
     session: Session = Depends(get_session),
 ) -> List[NodeRevisionOutput]:
     """
@@ -36,8 +37,8 @@ def find_nodes_with_dimension(
 
 @router.get("/dimensions/common/", response_model=List[NodeRevisionOutput])
 def find_nodes_with_common_dimensions(
-    dimension: Annotated[List[str] | None, Query()] = Query(None),
-    node_type: Annotated[List[NodeType] | None, Query()] = Query(None),
+    dimension: Annotated[Union[List[str], None], Query()] = Query(None),
+    node_type: Annotated[Union[List[NodeType], None], Query()] = Query(None),
     *,
     session: Session = Depends(get_session),
 ) -> List[NodeRevisionOutput]:

--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -2,7 +2,7 @@
 Dimensions related APIs.
 """
 import logging
-from typing import Annotated, List, Optional
+from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
@@ -23,30 +23,30 @@ router = APIRouter()
 def find_nodes_with_dimension(
     name: str,
     *,
-    node_types: Optional[List[NodeType]] = None,
+    node_type: Annotated[List[NodeType] | None, Query()] = Query(None),
     session: Session = Depends(get_session),
 ) -> List[NodeRevisionOutput]:
     """
     List all nodes that have the specified dimension
     """
     dimension_node = get_node_by_name(session, name)
-    nodes = get_nodes_with_dimension(session, dimension_node, node_types)
+    nodes = get_nodes_with_dimension(session, dimension_node, node_type)
     return nodes
 
 
 @router.get("/dimensions/common/", response_model=List[NodeRevisionOutput])
 def find_nodes_with_common_dimensions(
-    dimension: Annotated[list[str] | None, Query()] = Query(None),
+    dimension: Annotated[List[str] | None, Query()] = Query(None),
+    node_type: Annotated[List[NodeType] | None, Query()] = Query(None),
     *,
-    node_types: Optional[List[NodeType]] = None,
     session: Session = Depends(get_session),
 ) -> List[NodeRevisionOutput]:
     """
-    List all nodes that have the specified dimension
+    Find all nodes that have the list of common dimensions
     """
     nodes = get_nodes_with_common_dimensions(
         session,
         [get_node_by_name(session, dim) for dim in dimension],  # type: ignore
-        node_types,
+        node_type,
     )
     return nodes

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -134,6 +134,8 @@ def get_shared_dimensions(
         # Merge each set of dimensions based on the name and path
         to_delete = set()
         common_dim_keys = common.keys() & list(node_dimensions.keys())
+        if not common_dim_keys:
+            return []
         for common_dim in common_dim_keys:
             for existing_attr in common[common_dim]:
                 for new_attr in node_dimensions[common_dim]:
@@ -228,4 +230,6 @@ def get_nodes_with_common_dimensions(
             nodes_that_share_dimensions = nodes_that_share_dimensions.intersection(
                 set(new_nodes),
             )
+            if not nodes_that_share_dimensions:
+                break
     return list(nodes_that_share_dimensions)

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -207,3 +207,25 @@ def get_nodes_with_dimension(
     if node_types:
         return [node for node in final_set if node.type in node_types]
     return list(final_set)
+
+
+def get_nodes_with_common_dimensions(
+    session: Session,
+    common_dimensions: List[Node],
+    node_types: Optional[List[NodeType]] = None,
+) -> List[NodeRevision]:
+    """
+    Find all nodes that share a list of common dimensions
+    """
+    nodes_that_share_dimensions = set()
+    first = True
+    for dimension in common_dimensions:
+        new_nodes = get_nodes_with_dimension(session, dimension, node_types)
+        if first:
+            nodes_that_share_dimensions = set(new_nodes)
+            first = False
+        else:
+            nodes_that_share_dimensions = nodes_that_share_dimensions.intersection(
+                set(new_nodes),
+            )
+    return list(nodes_that_share_dimensions)

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -41,6 +41,20 @@ def test_list_nodes_with_dimension(client_with_examples: TestClient) -> None:
         "default.repair_type",
     ]
 
+    response = client_with_examples.get(
+        "/dimensions/default.municipality_dim/nodes/?node_type=metric",
+    )
+    data = response.json()
+    assert [node["name"] for node in data] == [
+        "default.num_repair_orders",
+        "default.avg_repair_price",
+        "default.total_repair_cost",
+        "default.discounted_orders_rate",
+        "default.total_repair_order_discounts",
+        "default.avg_repair_order_discounts",
+        "default.avg_time_to_dispatch",
+    ]
+
 
 def test_list_nodes_with_common_dimension(client_with_examples: TestClient) -> None:
     """
@@ -76,3 +90,18 @@ def test_list_nodes_with_common_dimension(client_with_examples: TestClient) -> N
     )
     data = response.json()
     assert [node["name"] for node in data] == []
+
+    response = client_with_examples.get(
+        "/dimensions/common/?dimension=default.hard_hat&dimension=default.us_state"
+        "&dimension=default.dispatcher&node_type=metric",
+    )
+    data = response.json()
+    assert [node["name"] for node in data] == [
+        "default.num_repair_orders",
+        "default.avg_repair_price",
+        "default.total_repair_cost",
+        "default.discounted_orders_rate",
+        "default.total_repair_order_discounts",
+        "default.avg_repair_order_discounts",
+        "default.avg_time_to_dispatch",
+    ]

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -40,3 +40,39 @@ def test_list_nodes_with_dimension(client_with_examples: TestClient) -> None:
     assert [node["name"] for node in data] == [
         "default.repair_type",
     ]
+
+
+def test_list_nodes_with_common_dimension(client_with_examples: TestClient) -> None:
+    """
+    Test ``GET /dimensions/common/``.
+    """
+    response = client_with_examples.get(
+        "/dimensions/common/?dimension=default.hard_hat",
+    )
+    data = response.json()
+    roads_nodes = [
+        "default.repair_orders",
+        "default.repair_order_details",
+        "default.num_repair_orders",
+        "default.avg_repair_price",
+        "default.total_repair_cost",
+        "default.discounted_orders_rate",
+        "default.total_repair_order_discounts",
+        "default.avg_repair_order_discounts",
+        "default.avg_time_to_dispatch",
+    ]
+    assert [node["name"] for node in data] == roads_nodes
+
+    response = client_with_examples.get(
+        "/dimensions/common/?dimension=default.hard_hat&dimension=default.us_state"
+        "&dimension=default.dispatcher&dimension=default.municipality_dim",
+    )
+    data = response.json()
+    assert [node["name"] for node in data] == roads_nodes
+
+    response = client_with_examples.get(
+        "/dimensions/common/?dimension=default.hard_hat&dimension=default.us_state"
+        "&dimension=default.dispatcher&dimension=default.payment_type",
+    )
+    data = response.json()
+    assert [node["name"] for node in data] == []

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -421,6 +421,21 @@ def test_common_dimensions(
     ]
 
 
+def test_no_common_dimensions(
+    client_with_examples: TestClient,
+) -> None:
+    """
+    Test getting common dimensions for metrics that have none in common
+    """
+    response = client_with_examples.get(
+        "/metrics/common/dimensions?"
+        "metric=basic.num_comments&metric=default.total_repair_order_discounts"
+        "&metric=default.total_repair_cost",
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
 def test_raise_common_dimensions_not_a_metric_node(
     client_with_examples: TestClient,
 ) -> None:


### PR DESCRIPTION
### Summary

This adds functionality to get all nodes that have a set of common dimensions, which was referenced recently in https://github.com/DataJunction/dj/pull/635#discussion_r1269497074. It expands on the `get_nodes_with_dimension` function, which works for a single dimension, to a set of dimensions. I added a new endpoint at `GET /dimensions/common` to expose this feature.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #321 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
