### PR TITLE
Add gradle validation and build github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,3 +105,23 @@ jobs:
         run: yarn test
       - name: Build Project
         run: yarn webpack-build
+
+  build-java:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./client/java
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Official Gradle Wrapper Validation Action
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          build-root-directory: ./client/java


### PR DESCRIPTION
### Summary

This adds a step to our workflow that runs on PRs to also ensure that the java project builds successfully. It runs [gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action), which makes sure that an official gradle wrapper is being used, and the [gradle/gradle-build-action](https://github.com/gradle/gradle-build-action), which makes sure gradle build completes successfully.

cc: @Geo881

### Test Plan

GitHub CI

- [x] PR has an associated issue: #502 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
