### PR TITLE
Python Client cleanup part 2

### DIFF
--- a/client/python/datajunction/__init__.py
+++ b/client/python/datajunction/__init__.py
@@ -3,7 +3,15 @@ A DataJunction client for connecting to a DataJunction server
 """
 from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
-from datajunction._internal import (
+from datajunction.client import DJBuilder, DJClient
+from datajunction.models import (
+    AvailabilityState,
+    ColumnAttribute,
+    Engine,
+    MaterializationConfig,
+    NodeMode,
+)
+from datajunction.nodes import (
     Cube,
     Dimension,
     Metric,
@@ -11,14 +19,6 @@ from datajunction._internal import (
     Node,
     Source,
     Transform,
-)
-from datajunction.client import DJReader, DJWriter
-from datajunction.models import (
-    AvailabilityState,
-    ColumnAttribute,
-    Engine,
-    MaterializationConfig,
-    NodeMode,
 )
 
 try:
@@ -32,8 +32,8 @@ finally:
 
 
 __all__ = [
-    "DJReader",
-    "DJWriter",
+    "DJClient",
+    "DJBuilder",
     "AvailabilityState",
     "ColumnAttribute",
     "Source",

--- a/client/python/datajunction/_internal.py
+++ b/client/python/datajunction/_internal.py
@@ -1,11 +1,10 @@
 """DataJunction base client setup."""
-import abc
 
 # pylint: disable=redefined-outer-name, import-outside-toplevel, too-many-lines
 import logging
 import platform
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict
 from urllib.parse import urljoin
 
 try:
@@ -19,23 +18,29 @@ except ImportError:  # pragma: no cover
         ImportWarning,
     )
 import requests
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 from requests.adapters import CaseInsensitiveDict, HTTPAdapter
 
 from datajunction import models
-from datajunction.exceptions import DJClientException, DJNamespaceAlreadyExists
+from datajunction.exceptions import DJClientException
+
+if TYPE_CHECKING:
+    from datajunction.nodes import Node  # pragma: no cover
 
 DEFAULT_NAMESPACE = "default"
 _logger = logging.getLogger(__name__)
 
 
+#
+# Helpers
+#
 class Results(TypedDict):
     """
     Results in a completed DJ Query
     """
 
-    data: Tuple[Tuple]
     columns: Tuple[str]
+    data: Tuple[Tuple]
 
 
 class RequestsSessionWithEndpoint(requests.Session):  # pragma: no cover
@@ -100,9 +105,12 @@ class RequestsSessionWithEndpoint(requests.Session):  # pragma: no cover
         return urljoin(self.endpoint, url)
 
 
-class DJClient:  # pylint: disable=too-many-public-methods
+#
+# Main DJClient (internal)
+#
+class DJClient:
     """
-    Client for access to the DJ core service
+    Internal client class with non-user facing methods.
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -126,150 +134,8 @@ class DJClient:  # pylint: disable=too-many-public-methods
             self._session = requests_session
         self._timeout = timeout
 
-    def source(self, node_name: str) -> "Source":
-        """
-        Retrieves a source node with that name if one exists.
-        """
-        node_dict = self.verify_node_exists(node_name, "source")
-        node = Source(
-            **node_dict,
-            dj_client=self,
-        )
-        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
-        return node
-
-    def new_source(  # pylint: disable=too-many-arguments
-        self,
-        name: str,
-        catalog: str,
-        schema_: str,
-        table: str,
-        description: Optional[str] = None,
-        display_name: Optional[str] = None,
-        columns: Optional[List[models.Column]] = None,
-        primary_key: Optional[List[str]] = None,
-        tags: Optional[List[models.Tag]] = None,
-    ) -> "Source":
-        """
-        Instantiates a new Source object with the given parameters.
-        """
-        return Source(
-            dj_client=self,
-            name=name,
-            description=description,
-            display_name=display_name,
-            tags=tags,
-            primary_key=primary_key,
-            catalog=catalog,
-            schema_=schema_,
-            table=table,
-            columns=columns,
-        )
-
-    def transform(self, node_name: str) -> "Transform":
-        """
-        Retrieves a transform node with that name if one exists.
-        """
-        node_dict = self.verify_node_exists(node_name, "transform")
-        node = Transform(
-            **node_dict,
-            dj_client=self,
-        )
-        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
-        return node
-
-    def new_transform(  # pylint: disable=too-many-arguments
-        self,
-        name: str,
-        query: str,
-        description: Optional[str] = None,
-        display_name: Optional[str] = None,
-        primary_key: Optional[List[str]] = None,
-        tags: Optional[List[models.Tag]] = None,
-    ) -> "Transform":
-        """
-        Instantiates a new Transform object with the given parameters.
-        """
-        return Transform(
-            dj_client=self,
-            name=name,
-            description=description,
-            display_name=display_name,
-            tags=tags,
-            primary_key=primary_key,
-            query=query,
-        )
-
-    def dimension(self, node_name: str) -> "Dimension":
-        """
-        Retrieves a dimension node with that name if one exists.
-        """
-        node_dict = self.verify_node_exists(node_name, "dimension")
-        node = Dimension(
-            **node_dict,
-            dj_client=self,
-        )
-        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
-        return node
-
-    def new_dimension(  # pylint: disable=too-many-arguments
-        self,
-        name: str,
-        query: str,
-        primary_key: Optional[List[str]],
-        description: Optional[str] = None,
-        display_name: Optional[str] = None,
-        tags: Optional[List[models.Tag]] = None,
-    ) -> "Dimension":
-        """
-        Instantiates a new Dimension object with the given parameters.
-        """
-        return Dimension(
-            dj_client=self,
-            name=name,
-            description=description,
-            display_name=display_name,
-            tags=tags,
-            primary_key=primary_key,
-            query=query,
-        )
-
-    def metric(self, node_name: str) -> "Metric":
-        """
-        Retrieves a metric node with that name if one exists.
-        """
-        node_dict = self.verify_node_exists(node_name, "metric")
-        node = Metric(
-            **node_dict,
-            dj_client=self,
-        )
-        node.primary_key = self.primary_key_from_columns(node_dict["columns"])
-        return node
-
-    def new_metric(  # pylint: disable=too-many-arguments
-        self,
-        name: str,
-        query: str,
-        description: Optional[str] = None,
-        display_name: Optional[str] = None,
-        primary_key: Optional[List[str]] = None,
-        tags: Optional[List[models.Tag]] = None,
-    ) -> "Metric":
-        """
-        Instantiates a new Metric object with the given parameters.
-        """
-        return Metric(
-            dj_client=self,
-            name=name,
-            description=description,
-            display_name=display_name,
-            tags=tags,
-            primary_key=primary_key,
-            query=query,
-        )
-
     @staticmethod
-    def primary_key_from_columns(columns) -> List[str]:
+    def _primary_key_from_columns(columns) -> List[str]:
         """
         Extracts the primary key from the columns
         """
@@ -283,157 +149,30 @@ class DJClient:  # pylint: disable=too-many-public-methods
             )
         ]
 
-    def cube(self, node_name: str) -> "Cube":  # pragma: no cover
+    @staticmethod
+    def process_results(results) -> "pd.DataFrame":
         """
-        Retrieves a cube node with that name if one exists.
+        Return a pandas dataframe of the results if pandas is installed
         """
-        node_dict = self.get_cube(node_name)
-        if "name" not in node_dict:
-            raise DJClientException(f"Cube `{node_name}` does not exist")
-        dimensions = [
-            f'{col["node_name"]}.{col["name"]}'
-            for col in node_dict["cube_elements"]
-            if col["type"] != "metric"
-        ]
-        metrics = [
-            f'{col["node_name"]}.{col["name"]}'
-            for col in node_dict["cube_elements"]
-            if col["type"] == "metric"
-        ]
-        return Cube(
-            **node_dict,
-            metrics=metrics,
-            dimensions=dimensions,
-            dj_client=self,
-        )
+        if "results" in results and results["results"]:
+            columns = results["results"][0]["columns"]
+            rows = results["results"][0]["rows"]
+            try:
+                return pd.DataFrame(
+                    rows,
+                    columns=[col["name"] for col in columns],
+                )
+            except NameError:  # pragma: no cover
+                return Results(
+                    data=rows,
+                    columns=tuple(col["name"] for col in columns),  # type: ignore
+                )
+        raise DJClientException("No data for query!")
 
-    def new_cube(  # pylint: disable=too-many-arguments
-        self,
-        name: str,
-        metrics: List[str],
-        dimensions: List[str],
-        filters: Optional[List[str]] = None,
-        description: Optional[str] = None,
-        display_name: Optional[str] = None,
-        # materialization_configs: Optional[List[MaterializationConfig]] = None,
-    ) -> "Cube":
-        """
-        Instantiates a new cube with the given parameters.
-        """
-        return Cube(  # pragma: no cover
-            dj_client=self,
-            name=name,
-            metrics=metrics,
-            dimensions=dimensions,
-            filters=filters,
-            description=description,
-            display_name=display_name,
-        )
-
-    def new_namespace(
-        self,
-        namespace: str,
-    ) -> "Namespace":
-        """
-        Creates a new namespace on the server
-        """
-        _namespace = Namespace(dj_client=self, namespace=namespace)
-        self.create_namespace(_namespace)
-        return _namespace
-
-    def verify_node_exists(self, node_name: str, type_: str) -> Dict[str, Any]:
-        """
-        Retrieves a node and verifies that it exists and has the expected node type.
-        """
-        node = self.get_node(node_name)
-        if "name" not in node:
-            raise DJClientException(f"No node with name {node_name} exists!")
-        if "name" in node and node["type"] != type_:
-            raise DJClientException(
-                f"A node with name {node_name} exists, but it is not a {type_} node!",
-            )
-        return node
-
-    def catalogs(self):
-        """
-        Gets all catalogs.
-        """
-        response = self._session.get("/catalogs/", timeout=self._timeout)
-        return response.json()
-
-    def engines(self):
-        """
-        Gets all engines.
-        """
-        response = self._session.get("/engines/", timeout=self._timeout)
-        return response.json()
-
-    def namespace(self, _namespace):
-        """
-        Returns the specified node namespace.
-        TODO: delete
-        """
-        return Namespace(namespace=_namespace, dj_client=self)
-
-    def create_namespace(self, namespace: "Namespace"):
-        """
-        Helper function to create a namespace.
-        """
-        response = self._session.post(
-            f"/namespaces/{namespace.namespace}/",
-            timeout=self._timeout,
-        )
-        json_response = response.json()
-        if response.status_code == 409:
-            raise DJNamespaceAlreadyExists(json_response["message"])
-        return json_response
-
-    def deactivate_node(self, node: "Node"):
-        """
-        Deactivate this node
-        """
-        response = self._session.post(
-            f"/nodes/{node.name}/deactivate/",
-            timeout=self._timeout,
-        )
-        return response
-
-    def activate_node(self, node: "Node"):
-        """
-        Activate this node
-        """
-        response = self._session.post(
-            f"/nodes/{node.name}/activate/",
-            timeout=self._timeout,
-        )
-        return response
-
-    def validate_node(self, node: "Node"):
-        """
-        Check if a locally defined node is valid
-        """
-        node_copy = node.dict().copy()
-        node_copy["mode"] = models.NodeMode.PUBLISHED
-        response = self._session.post(
-            "/nodes/validate/",
-            json=node_copy,
-            timeout=self._timeout,
-        )
-        return response.json()
-
-    def create_node(self, node: "Node", mode: models.NodeMode):
-        """
-        Helper function to create a node.
-        """
-        node.mode = mode
-        response = self._session.post(
-            f"/nodes/{node.type}/",
-            timeout=self._timeout,
-            json=node.dict(exclude_none=True, exclude={"type"}),
-        )
-        return response.json()
-
-    def get_nodes_in_namespace(
+    #
+    # Node methods
+    #
+    def _get_nodes_in_namespace(
         self,
         namespace: str,
         type_: Optional[str] = None,
@@ -446,21 +185,82 @@ class DJClient:  # pylint: disable=too-many-public-methods
         )
         return response.json()
 
-    def update_node(self, node_name: str, update_input: models.UpdateNode):
+    def _verify_node_exists(self, node_name: str, type_: str) -> Dict[str, Any]:
+        """
+        Retrieves a node and verifies that it exists and has the expected node type.
+        """
+        node = self._get_node(node_name)
+        if "name" not in node:
+            raise DJClientException(f"No node with name {node_name} exists!")
+        if "name" in node and node["type"] != type_:
+            raise DJClientException(
+                f"A node with name {node_name} exists, but it is not a {type_} node!",
+            )
+        return node
+
+    def _deactivate_node(self, node: "Node"):
+        """
+        Deactivate this node
+        """
+        response = self._session.post(
+            f"/nodes/{node.name}/deactivate/",
+            timeout=self._timeout,
+        )
+        return response
+
+    def _activate_node(self, node: "Node"):
+        """
+        Activate this node
+        """
+        response = self._session.post(
+            f"/nodes/{node.name}/activate/",
+            timeout=self._timeout,
+        )
+        return response
+
+    def _validate_node(self, node: "Node"):
+        """
+        Check if a locally defined node is valid
+        """
+        node_copy = node.dict().copy()
+        node_copy["mode"] = models.NodeMode.PUBLISHED
+        response = self._session.post(
+            "/nodes/validate/",
+            json=node_copy,
+            timeout=self._timeout,
+        )
+        return response.json()
+
+    def _create_node(
+        self,
+        node: "Node",
+        mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+    ):
+        """
+        Helper function to create a node.
+        """
+        node.mode = mode
+        response = self._session.post(
+            f"/nodes/{node.type}/",
+            timeout=self._timeout,
+            json=node.dict(exclude_none=True, exclude={"type"}),
+        )
+        return response
+
+    def _update_node(self, node_name: str, update_input: models.UpdateNode):
+        """
+        Call node update API with attributes to update.
+        """
+        return self._session.patch(f"/nodes/{node_name}/", json=update_input.dict())
+
+    def _publish_node(self, node_name: str, update_input: models.UpdateNode):
         """
         Retrieves a node.
         """
         response = self._session.patch(f"/nodes/{node_name}/", json=update_input.dict())
         return response.json()
 
-    def publish_node(self, node_name: str, update_input: models.UpdateNode):
-        """
-        Retrieves a node.
-        """
-        response = self._session.patch(f"/nodes/{node_name}/", json=update_input.dict())
-        return response.json()
-
-    def get_node(self, node_name: str):
+    def _get_node(self, node_name: str):
         """
         Retrieves a node.
         """
@@ -470,21 +270,28 @@ class DJClient:  # pylint: disable=too-many-public-methods
         except DJClientException as exc:  # pragma: no cover
             return exc.__dict__
 
-    def get_cube(self, node_name: str):
+    def _get_cube(self, node_name: str):
         """
-        Retrieves a node.
+        Retrieves a Cube node.
         """
         response = self._session.get(f"/cubes/{node_name}/")
         return response.json()
 
-    def get_node_revisions(self, node_name: str):
+    def get_metric(self, node_name: str):
+        """
+        Helper function to retrieve metadata for the given metric node.
+        """
+        response = self._session.get(f"/metrics/{node_name}/")
+        return response.json()
+
+    def _get_node_revisions(self, node_name: str):
         """
         Retrieve all revisions of the node
         """
         response = self._session.get(f"/nodes/{node_name}/revisions")
         return response.json()
 
-    def link_dimension_to_node(
+    def _link_dimension_to_node(
         self,
         node_name: str,
         column_name: str,
@@ -509,7 +316,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
         dimension_column: Optional[str] = None,
     ):
         """
-        Helper function to link a dimension to the node.
+        Helper function to un-link a dimension to the node.
         """
         response = self._session.delete(
             f"/nodes/{node_name}/columns/{column_name}/"
@@ -518,35 +325,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
         )
         return response.json()
 
-    def get_metric(self, node_name: str):
-        """
-        Helper function to retrieve metadata for the given metric node.
-        """
-        response = self._session.get(f"/metrics/{node_name}/")
-        return response.json()
-
-    @staticmethod
-    def process_results(results) -> "pd.DataFrame":
-        """
-        Return a pandas dataframe of the results if pandas is installed
-        """
-        if "results" in results and results["results"]:
-            columns = results["results"][0]["columns"]
-            rows = results["results"][0]["rows"]
-            try:
-                return pd.DataFrame(
-                    rows,
-                    columns=[col["name"] for col in columns],
-                )
-            except NameError:  # pragma: no cover
-                return Results(
-                    data=rows,
-                    columns=tuple(col["name"] for col in columns),  # type: ignore
-                )
-
-        raise DJClientException("No data for query!")
-
-    def upsert_materialization(
+    def _upsert_materialization(
         self,
         node_name: str,
         config: models.MaterializationConfig,
@@ -560,7 +339,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
         )
         return response.json()
 
-    def add_availability_state(
+    def _add_availability_state(
         self,
         node_name: str,
         availability: models.AvailabilityState,
@@ -574,7 +353,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
         )
         return response.json()
 
-    def set_column_attributes(
+    def _set_column_attributes(
         self,
         node_name,
         attributes: List[models.ColumnAttribute],
@@ -591,7 +370,7 @@ class DJClient:  # pylint: disable=too-many-public-methods
 
 class ClientEntity(BaseModel):
     """
-    Any entity that uses the DJ client
+    Any entity that uses the DJ client.
     """
 
     dj_client: DJClient = Field(exclude=True)
@@ -604,313 +383,3 @@ class ClientEntity(BaseModel):
 
         arbitrary_types_allowed = True
         exclude = {"dj_client"}
-
-
-class Node(ClientEntity):
-    """
-    Represents a DJ node object
-    """
-
-    name: str
-    description: Optional[str]
-    type: str
-    mode: Optional[models.NodeMode]
-    status: Optional[str] = None
-    display_name: Optional[str]
-    availability: Optional[models.AvailabilityState]
-    tags: Optional[List[models.Tag]]
-    primary_key: Optional[List[str]]
-    materializations: Optional[List[Dict[str, Any]]]
-    version: Optional[str]
-    deactivated_at: Optional[int]
-
-    def save(self, mode: models.NodeMode = models.NodeMode.PUBLISHED):
-        """
-        Sets the node's mode to PUBLISHED and pushes it to the server.
-        """
-        existing_node = self.dj_client.get_node(node_name=self.name)
-        if "name" in existing_node:
-            response = self.update()
-        else:
-            response = self.dj_client.create_node(self, mode)
-        self.sync()
-        return response
-
-    @abc.abstractmethod
-    def update(self) -> Dict:
-        """
-        Update the node for fields that have changed
-        """
-
-    def sync(self):
-        """
-        Refreshes a node with its latest version from the database.
-        """
-        refreshed_node = self.dj_client.get_node(self.name)
-        for key, value in refreshed_node.items():
-            if hasattr(self, key):
-                setattr(self, key, value)
-        return self
-
-    def link_dimension(
-        self,
-        column: str,
-        dimension: str,
-        dimension_column: Optional[str],
-    ):
-        """
-        Links the dimension to this node via the node's `column` and the dimension's
-        `dimension_column`. If no `dimension_column` is provided, the dimension's
-        primary key will be used automatically.
-        """
-        link_response = self.dj_client.link_dimension_to_node(
-            self.name,
-            column,
-            dimension,
-            dimension_column,
-        )
-        self.sync()
-        return link_response
-
-    def unlink_dimension(
-        self,
-        column: str,
-        dimension: str,
-        dimension_column: Optional[str],
-    ):
-        """
-        Removes the dimension link on the node's `column` to the dimension.
-        """
-        link_response = self.dj_client._unlink_dimension_from_node(  # pylint: disable=protected-access
-            self.name,
-            column,
-            dimension,
-            dimension_column,
-        )
-        self.sync()
-        return link_response
-
-    def add_materialization(self, config: models.MaterializationConfig):
-        """
-        Adds a materialization for the node. This will not work for source nodes
-        as they don't need to be materialized.
-        """
-        upsert_response = self.dj_client.upsert_materialization(
-            self.name,
-            config,
-        )
-        self.sync()
-        return upsert_response
-
-    def deactivate(self) -> str:
-        """
-        Deactivates the node
-        """
-        response = self.dj_client.deactivate_node(self)
-        if not response.ok:  # pragma: no cover
-            raise DJClientException(
-                f"Error deactivating node `{self.name}`: {response.text}",
-            )
-        return f"Successfully deactivated `{self.name}`"
-
-    def activate(self) -> str:
-        """
-        Activates the node
-        """
-        response = self.dj_client.activate_node(self)
-        if not response.ok:  # pragma: no cover
-            raise DJClientException(
-                f"Error activating node `{self.name}`: {response.text}",
-            )
-        return f"Successfully activated `{self.name}`"
-
-    def revisions(self):
-        """
-        List all revisions of this node
-        """
-        return self.dj_client.get_node_revisions(self.name)
-
-    def add_availability(self, availability: models.AvailabilityState):
-        """
-        Adds an availability state to the node
-        """
-        return self.dj_client.add_availability_state(self.name, availability)
-
-    def set_column_attributes(self, attributes: List[models.ColumnAttribute]):
-        """
-        Sets attributes for columns on the node
-        """
-        return self.dj_client.set_column_attributes(self.name, attributes)
-
-
-class Source(Node):
-    """
-    DJ source node
-    """
-
-    type: str = "source"
-    catalog: str
-    schema_: str
-    table: str
-    columns: Optional[List[models.Column]]
-
-    @validator("catalog", pre=True)
-    def parse_cls(  # pylint: disable=no-self-argument
-        cls,
-        value: Union[str, Dict[str, Any]],
-    ) -> str:
-        """
-        When `catalog` is a dictionary, parse out the catalog's
-        name, otherwise just return the string.
-        """
-        if isinstance(value, str):
-            return value
-        return value["name"]
-
-    def update(self) -> Dict:
-        """
-        Update the node for fields that have changed
-        """
-        update_node = models.UpdateNode(
-            display_name=self.display_name,
-            description=self.description,
-            mode=self.mode,
-            primary_key=self.primary_key,
-            catalog=self.catalog,
-            schema_=self.schema_,
-            table=self.table,
-            columns=self.columns,
-        )
-        return self.dj_client.update_node(self.name, update_node)
-
-
-class NodeWithQuery(Node):
-    """
-    Nodes with query attribute
-    """
-
-    query: str
-
-    def update(self) -> Dict:
-        """
-        Update the node for fields that have changed
-        """
-        update_node = models.UpdateNode(
-            display_name=self.display_name,
-            description=self.description,
-            mode=self.mode,
-            primary_key=self.primary_key,
-            query=self.query,
-        )
-        return self.dj_client.update_node(self.name, update_node)
-
-    def check(self) -> str:
-        """
-        Check if the node is valid by calling the /validate endpoint
-        """
-        validation = self.dj_client.validate_node(self)
-        return validation["status"]
-
-    def publish(self) -> bool:
-        """
-        Change a node's mode to published
-        """
-        self.dj_client.publish_node(
-            self.name,
-            models.UpdateNode(mode=models.NodeMode.PUBLISHED),
-        )
-        return True
-
-
-class Transform(NodeWithQuery):
-    """
-    DJ transform node
-    """
-
-    type: str = "transform"
-    columns: Optional[List[models.Column]]
-
-
-class Metric(NodeWithQuery):
-    """
-    DJ metric node
-    """
-
-    type: str = "metric"
-    columns: Optional[List[models.Column]]
-
-    def dimensions(self):
-        """
-        Returns the available dimensions for this metric.
-        """
-        metric = self.dj_client.get_metric(self.name)
-        return metric["dimensions"]
-
-
-class Dimension(NodeWithQuery):
-    """
-    DJ dimension node
-    """
-
-    type: str = "dimension"
-    query: str
-    columns: Optional[List[models.Column]]
-
-
-class Cube(Node):  # pylint: disable=abstract-method
-    """
-    DJ cube node
-    """
-
-    type: str = "cube"
-    query: Optional[str] = None
-    metrics: List[str]
-    dimensions: List[str]
-    filters: Optional[List[str]]
-    columns: Optional[List[models.Column]]
-
-    def update(self):  # pragma: no cover
-        pass
-
-
-class Namespace(ClientEntity):
-    """
-    Represents a namespace
-    """
-
-    namespace: str
-
-    def nodes(self):
-        """
-        Retrieves all nodes under this namespace.
-        """
-        return self.dj_client.get_nodes_in_namespace(
-            self.namespace,
-        )
-
-    def sources(self):
-        """
-        Retrieves source nodes under this namespace.
-        """
-        return self.dj_client.get_nodes_in_namespace(
-            self.namespace,
-            type_="source",
-        )
-
-    def transforms(self):
-        """
-        Retrieves transform nodes under this namespace.
-        """
-        return self.dj_client.get_nodes_in_namespace(
-            self.namespace,
-            type_="transform",
-        )
-
-    def cubes(self):
-        """
-        Retrieves cubes under this namespace.
-        """
-        return self.dj_client.get_nodes_in_namespace(
-            self.namespace,
-            type_="cube",
-        )

--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -7,16 +7,17 @@ from urllib.parse import urlencode
 from alive_progress import alive_bar
 
 from datajunction import _internal, models
-from datajunction.exceptions import DJClientException
+from datajunction.exceptions import DJClientException, DJNamespaceAlreadyExists
+from datajunction.nodes import Cube, Dimension, Metric, Namespace, Source, Transform
 
 
-class DJReader(_internal.DJClient):
+class DJClient(_internal.DJClient):
     """
-    Client class to consume basic DJ services: metrics and dimensions.
+    Client class for basic DJ dag and data access.
     """
 
     #
-    # List namespace, metrics and dimensions
+    # List
     #
     def list_namespaces(self, prefix: Optional[str] = None) -> List[str]:
         """
@@ -32,7 +33,7 @@ class DJReader(_internal.DJClient):
         List dimension nodes under given namespace.
         TODO: make namespace optional and return all dimension nodes, similar to get("/metrics/").
         """
-        return self.get_nodes_in_namespace(
+        return self._get_nodes_in_namespace(
             namespace=namespace,
             type_=models.NodeType.DIMENSION.value,
         )
@@ -42,7 +43,7 @@ class DJReader(_internal.DJClient):
         List metric nodes for given namespace or all.
         """
         if namespace:
-            return self.get_nodes_in_namespace(
+            return self._get_nodes_in_namespace(
                 namespace=namespace,
                 type_=models.NodeType.METRIC.value,
             )
@@ -215,7 +216,281 @@ class DJReader(_internal.DJClient):
             )
 
 
-class DJWriter(DJReader):
+class DJBuilder(DJClient):
     """
-    Client class to manage all your DJ dag: nodes, attributes, namespaces, tags.
+    Client class for DJ node manipulation.
     """
+
+    #
+    # Catalogs and Engines
+    #
+    def list_catalogs(self):
+        """
+        Gets all catalogs.
+        """
+        response = self._session.get("/catalogs/", timeout=self._timeout)
+        return response.json()
+
+    def list_engines(self):
+        """
+        Gets all engines.
+        """
+        response = self._session.get("/engines/", timeout=self._timeout)
+        return response.json()
+
+    #
+    # Namespace
+    #
+    # TODO: add delete namespace (with warnings) # pylint: disable=fixme
+    def namespace(self, namespace: str) -> "Namespace":
+        """
+        Returns the specified node namespace.
+        """
+        try:
+            return self.create_namespace(namespace=namespace)
+        except DJNamespaceAlreadyExists:
+            pass
+        return Namespace(namespace=namespace, dj_client=self)
+
+    def create_namespace(self, namespace: str) -> "Namespace":
+        """
+        Helper function to create a namespace.
+        """
+        response = self._session.post(
+            f"/namespaces/{namespace}/",
+            timeout=self._timeout,
+        )
+        json_response = response.json()
+        if response.status_code == 409:
+            raise DJNamespaceAlreadyExists(json_response["message"])
+        return Namespace(namespace=namespace, dj_client=self)
+
+    #
+    # Nodes: SOURCE
+    #
+    def source(self, node_name: str) -> "Source":
+        """
+        Retrieves a source node with that name if one exists.
+        """
+        node_dict = self._verify_node_exists(
+            node_name,
+            type_=models.NodeType.SOURCE.value,
+        )
+        node = Source(
+            **node_dict,
+            dj_client=self,
+        )
+        node.primary_key = self._primary_key_from_columns(node_dict["columns"])
+        return node
+
+    def create_source(  # pylint: disable=too-many-arguments
+        self,
+        name: str,
+        catalog: str,
+        schema_: str,
+        table: str,
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        columns: Optional[List[models.Column]] = None,
+        primary_key: Optional[List[str]] = None,
+        tags: Optional[List[models.Tag]] = None,
+        mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+    ) -> "Source":
+        """
+        Creates a new Source node with given parameters.
+        """
+        new_source = Source(
+            dj_client=self,
+            name=name,
+            description=description,
+            display_name=display_name,
+            tags=tags,
+            primary_key=primary_key,
+            catalog=catalog,
+            schema_=schema_,
+            table=table,
+            columns=columns,
+        )
+        new_source.save(mode=mode)
+        return new_source
+
+    #
+    # Nodes: TRANSFORM
+    #
+    def transform(self, node_name: str) -> "Transform":
+        """
+        Retrieves a transform node with that name if one exists.
+        """
+        node_dict = self._verify_node_exists(
+            node_name,
+            type_=models.NodeType.TRANSFORM.value,
+        )
+        node = Transform(
+            **node_dict,
+            dj_client=self,
+        )
+        node.primary_key = self._primary_key_from_columns(node_dict["columns"])
+        return node
+
+    def create_transform(  # pylint: disable=too-many-arguments
+        self,
+        name: str,
+        query: str,
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        primary_key: Optional[List[str]] = None,
+        tags: Optional[List[models.Tag]] = None,
+        mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+    ) -> "Transform":
+        """
+        Creates a new Transform node with given parameters.
+        """
+        new_node = Transform(
+            dj_client=self,
+            name=name,
+            description=description,
+            display_name=display_name,
+            tags=tags,
+            primary_key=primary_key,
+            query=query,
+        )
+        new_node.save(mode=mode)
+        return new_node
+
+    #
+    # Nodes: DIMENSION
+    #
+    def dimension(self, node_name: str) -> "Dimension":
+        """
+        Retrieves a Dimension node with that name if one exists.
+        """
+        node_dict = self._verify_node_exists(
+            node_name,
+            type_=models.NodeType.DIMENSION.value,
+        )
+        node = Dimension(
+            **node_dict,
+            dj_client=self,
+        )
+        node.primary_key = self._primary_key_from_columns(node_dict["columns"])
+        return node
+
+    def create_dimension(  # pylint: disable=too-many-arguments
+        self,
+        name: str,
+        query: str,
+        primary_key: Optional[List[str]],
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        tags: Optional[List[models.Tag]] = None,
+        mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+    ) -> "Transform":
+        """
+        Creates a new Dimension node with given parameters.
+        """
+        new_node = Dimension(
+            dj_client=self,
+            name=name,
+            description=description,
+            display_name=display_name,
+            tags=tags,
+            primary_key=primary_key,
+            query=query,
+        )
+        new_node.save(mode=mode)
+        return new_node
+
+    #
+    # Nodes: METRIC
+    #
+    def metric(self, node_name: str) -> "Metric":
+        """
+        Retrieves a Metric node with that name if one exists.
+        """
+        node_dict = self._verify_node_exists(
+            node_name,
+            type_=models.NodeType.METRIC.value,
+        )
+        node = Metric(
+            **node_dict,
+            dj_client=self,
+        )
+        node.primary_key = self._primary_key_from_columns(node_dict["columns"])
+        return node
+
+    def create_metric(  # pylint: disable=too-many-arguments
+        self,
+        name: str,
+        query: str,
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        primary_key: Optional[List[str]] = None,
+        tags: Optional[List[models.Tag]] = None,
+        mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+    ) -> "Transform":
+        """
+        Creates a new Metric node with given parameters.
+        """
+        new_node = Metric(
+            dj_client=self,
+            name=name,
+            description=description,
+            display_name=display_name,
+            tags=tags,
+            primary_key=primary_key,
+            query=query,
+        )
+        new_node.save(mode=mode)
+        return new_node
+
+    #
+    # Nodes: CUBE
+    #
+    def cube(self, node_name: str) -> "Cube":  # pragma: no cover
+        """
+        Retrieves a Cube node with that name if one exists.
+        """
+        node_dict = self._get_cube(node_name)
+        if "name" not in node_dict:
+            raise DJClientException(f"Cube `{node_name}` does not exist")
+        dimensions = [
+            f'{col["node_name"]}.{col["name"]}'
+            for col in node_dict["cube_elements"]
+            if col["type"] != "metric"
+        ]
+        metrics = [
+            f'{col["node_name"]}.{col["name"]}'
+            for col in node_dict["cube_elements"]
+            if col["type"] == "metric"
+        ]
+        return Cube(
+            **node_dict,
+            metrics=metrics,
+            dimensions=dimensions,
+            dj_client=self,
+        )
+
+    def create_cube(  # pylint: disable=too-many-arguments
+        self,
+        name: str,
+        metrics: List[str],
+        dimensions: List[str],
+        filters: Optional[List[str]] = None,
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+    ) -> "Cube":
+        """
+        Instantiates a new cube with the given parameters.
+        """
+        new_node = Cube(  # pragma: no cover
+            dj_client=self,
+            name=name,
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=filters,
+            description=description,
+            display_name=display_name,
+        )
+        new_node.save(mode=mode)  # pragma: no cover
+        return new_node  # pragma: no cover

--- a/client/python/datajunction/nodes.py
+++ b/client/python/datajunction/nodes.py
@@ -1,0 +1,331 @@
+"""DataJunction base client setup."""
+import abc
+
+# pylint: disable=redefined-outer-name, import-outside-toplevel, too-many-lines, protected-access
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import validator
+
+from datajunction import models
+from datajunction._internal import ClientEntity
+from datajunction.exceptions import DJClientException
+
+
+class Namespace(ClientEntity):  # pylint: disable=protected-access
+    """
+    Represents a namespace
+    """
+
+    namespace: str
+
+    def nodes(self):
+        """
+        Retrieves all nodes under this namespace.
+        """
+        return self.dj_client._get_nodes_in_namespace(
+            self.namespace,
+        )
+
+    def sources(self):
+        """
+        Retrieves source nodes under this namespace.
+        """
+        return self.dj_client._get_nodes_in_namespace(
+            self.namespace,
+            type_=models.NodeType.SOURCE.value,
+        )
+
+    def transforms(self):
+        """
+        Retrieves transform nodes under this namespace.
+        """
+        return self.dj_client._get_nodes_in_namespace(
+            self.namespace,
+            type_=models.NodeType.TRANSFORM.value,
+        )
+
+    def cubes(self):
+        """
+        Retrieves cubes under this namespace.
+        """
+        return self.dj_client._get_nodes_in_namespace(
+            self.namespace,
+            type_=models.NodeType.CUBE.value,
+        )
+
+
+class Node(ClientEntity):  # pylint: disable=protected-access
+    """
+    Represents a DJ node object
+    """
+
+    name: str
+    description: Optional[str]
+    type: str
+    mode: Optional[models.NodeMode]
+    status: Optional[str] = None
+    display_name: Optional[str]
+    availability: Optional[models.AvailabilityState]
+    tags: Optional[List[models.Tag]]
+    primary_key: Optional[List[str]]
+    materializations: Optional[List[Dict[str, Any]]]
+    version: Optional[str]
+    deactivated_at: Optional[int]
+
+    @abc.abstractmethod
+    def _update(self) -> "Node":
+        """
+        Update the node for fields that have changed.
+        """
+
+    def save(self, mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED) -> dict:
+        """
+        Sets the node's mode to PUBLISHED and pushes it to the server.
+        """
+        existing_node = self.dj_client._get_node(node_name=self.name)
+        if "name" in existing_node:
+            # update
+            response = self._update()
+            if not response.ok:  # pragma: no cover
+                raise DJClientException(
+                    f"Error updating node `{self.name}`: {response.text}",
+                )
+            self.refresh()
+        else:
+            # create
+            response = self.dj_client._create_node(node=self, mode=mode)
+            if not response.ok:  # pragma: no cover
+                raise DJClientException(
+                    f"Error creating new node `{self.name}`: {response.text}",
+                )
+        return response.json()
+
+    def refresh(self):
+        """
+        Refreshes a node with its latest version from the database.
+        """
+        refreshed_node = self.dj_client._get_node(self.name)
+        for key, value in refreshed_node.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+        return self
+
+    def link_dimension(
+        self,
+        column: str,
+        dimension: str,
+        dimension_column: Optional[str],
+    ):
+        """
+        Links the dimension to this node via the node's `column` and the dimension's
+        `dimension_column`. If no `dimension_column` is provided, the dimension's
+        primary key will be used automatically.
+        """
+        link_response = self.dj_client._link_dimension_to_node(
+            self.name,
+            column,
+            dimension,
+            dimension_column,
+        )
+        self.refresh()
+        return link_response
+
+    def unlink_dimension(
+        self,
+        column: str,
+        dimension: str,
+        dimension_column: Optional[str],
+    ):
+        """
+        Removes the dimension link on the node's `column` to the dimension.
+        """
+        link_response = self.dj_client._unlink_dimension_from_node(  # pylint: disable=protected-access
+            self.name,
+            column,
+            dimension,
+            dimension_column,
+        )
+        self.refresh()
+        return link_response
+
+    def add_materialization(self, config: models.MaterializationConfig):
+        """
+        Adds a materialization for the node. This will not work for source nodes
+        as they don't need to be materialized.
+        """
+        upsert_response = self.dj_client._upsert_materialization(
+            self.name,
+            config,
+        )
+        self.refresh()
+        return upsert_response
+
+    def deactivate(self) -> str:
+        """
+        Deactivates the node
+        """
+        response = self.dj_client._deactivate_node(self)
+        if not response.ok:  # pragma: no cover
+            raise DJClientException(
+                f"Error deactivating node `{self.name}`: {response.text}",
+            )
+        return f"Successfully deactivated `{self.name}`"
+
+    def activate(self) -> str:
+        """
+        Activates the node
+        """
+        response = self.dj_client._activate_node(self)
+        if not response.ok:  # pragma: no cover
+            raise DJClientException(
+                f"Error activating node `{self.name}`: {response.text}",
+            )
+        return f"Successfully activated `{self.name}`"
+
+    def list_revisions(self):
+        """
+        List all revisions of this node
+        """
+        return self.dj_client._get_node_revisions(self.name)
+
+    def add_availability(self, availability: models.AvailabilityState):
+        """
+        Adds an availability state to the node
+        """
+        return self.dj_client._add_availability_state(self.name, availability)
+
+    def set_column_attributes(self, attributes: List[models.ColumnAttribute]):
+        """
+        Sets attributes for columns on the node
+        """
+        return self.dj_client._set_column_attributes(self.name, attributes)
+
+
+class Source(Node):
+    """
+    DJ source node
+    """
+
+    type: str = "source"
+    catalog: str
+    schema_: str
+    table: str
+    columns: Optional[List[models.Column]]
+
+    @validator("catalog", pre=True)
+    def parse_cls(  # pylint: disable=no-self-argument
+        cls,
+        value: Union[str, Dict[str, Any]],
+    ) -> str:
+        """
+        When `catalog` is a dictionary, parse out the catalog's
+        name, otherwise just return the string.
+        """
+        if isinstance(value, str):
+            return value
+        return value["name"]
+
+    def _update(self) -> "Node":
+        """
+        Update the node for fields that have changed
+        """
+        update_node = models.UpdateNode(
+            display_name=self.display_name,
+            description=self.description,
+            mode=self.mode,
+            primary_key=self.primary_key,
+            catalog=self.catalog,
+            schema_=self.schema_,
+            table=self.table,
+            columns=self.columns,
+        )
+        return self.dj_client._update_node(self.name, update_node)
+
+
+class NodeWithQuery(Node):
+    """
+    Nodes with query attribute
+    """
+
+    query: str
+
+    def _update(self) -> "Node":
+        """
+        Update the node for fields that have changed.
+        """
+        update_node = models.UpdateNode(
+            display_name=self.display_name,
+            description=self.description,
+            mode=self.mode,
+            primary_key=self.primary_key,
+            query=self.query,
+        )
+        return self.dj_client._update_node(self.name, update_node)
+
+    def _validate(self) -> str:
+        """
+        Check if the node is valid by calling the /validate endpoint.
+        """
+        validation = self.dj_client._validate_node(self)
+        return validation["status"]
+
+    def publish(self) -> bool:
+        """
+        Change a node's mode to published
+        """
+        self.dj_client._publish_node(
+            self.name,
+            models.UpdateNode(mode=models.NodeMode.PUBLISHED),
+        )
+        return True
+
+
+class Transform(NodeWithQuery):
+    """
+    DJ transform node
+    """
+
+    type: str = "transform"
+    columns: Optional[List[models.Column]]
+
+
+class Metric(NodeWithQuery):
+    """
+    DJ metric node
+    """
+
+    type: str = "metric"
+    columns: Optional[List[models.Column]]
+
+    def dimensions(self):
+        """
+        Returns the available dimensions for this metric.
+        """
+        metric = self.dj_client.get_metric(self.name)
+        return metric["dimensions"]
+
+
+class Dimension(NodeWithQuery):
+    """
+    DJ dimension node
+    """
+
+    type: str = "dimension"
+    query: str
+    columns: Optional[List[models.Column]]
+
+
+class Cube(Node):  # pylint: disable=abstract-method
+    """
+    DJ cube node
+    """
+
+    type: str = "cube"
+    query: Optional[str] = None
+    metrics: List[str]
+    dimensions: List[str]
+    filters: Optional[List[str]]
+    columns: Optional[List[models.Column]]
+
+    def _update(self):  # pragma: no cover
+        pass


### PR DESCRIPTION
### Summary

I know we have been going back and forth on the DJ Client class name but after spending some time in this I would liek to re-suggest this picture and chat about it if needed:

- **_internal.py** - all the stuff that users should never see
- **exceptions.py, models.py** - self-explanatory
- **client.py**
    - DJClient class (basic DJ access)
        - list_[namespaces | dimensions | metrics]
        - common_[dimensions | metrics]
        - sql() | data()
    - DJBuilder class (building DJ dag)
        - list|create|delete : engine|catalogs (some TODO)
        - list|create|delete namespace (some TODO)
        - source|transform|metric|dimension|cube --> returns an existing Node
        - create_[source|...] --> create a new Node (in DJ) and returns it
- **node.py**
    - Namespace
        - nodes|sources|transforms|cubes --> get nodes from a namespace, not sure if we need this
    - Node
        - save() --> creates or updates an existing Node
        - refresh() --> refreshes current object from DJ
        - [un]link_dimensions()
        - [de]activate() -- ?
        - add_materialization(), add_availability(), set_column_attributes()
        - list_revisions(), 
    - some other classes

Some open questions:
1. Is there a reason our `client` directory does not follow the `datajunction-<service>` pattern?
2. What is node activate/deactivate for?

TODO (maybe follow-up PRs):
1. Complete all TODOs in the code. Few methods are missing.
2. Adjust client README to the new code.
3. Adjust Demo notebook the the new code.
4. Hide all-the-protected-methods in _internal.DJClient better, cause now they are still visible in the user client classes.

### Test Plan

make check + make test

### Deployment Plan

n/a