### PR TITLE
Remove import from examples

### DIFF
--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -76,9 +76,7 @@ def client_code_for_creating_node(
         [f"    {k}={params[k]}" for k in sorted(params.keys())] + cube_params,
     )
 
-    client_code = f"""from datajunction import DJClient, NodeMode
-
-dj = DJClient(DJ_URL)
+    client_code = f"""dj = DJClient(DJ_URL)
 
 {node_short_name} = dj.new_{node.type}(
 {formatted_params}
@@ -118,9 +116,7 @@ def client_code_for_adding_materialization(
             for line in json.dumps(user_modified_config, indent=4).split("\n")
         ],
     )
-    client_code = f"""from datajunction import DJClient, MaterializationConfig
-
-dj = DJClient(DJ_URL)
+    client_code = f"""dj = DJClient(DJ_URL)
 
 {node_short_name} = dj.{node.type}(
     "{node.name}"
@@ -155,9 +151,7 @@ def client_code_for_linking_dimension_to_node(
     """
     node_short_name = node_name.split(".")[-1]
     node = get_node_by_name(session, node_name)
-    client_code = f"""from datajunction import DJClient, MaterializationConfig
-
-dj = DJClient(DJ_URL)
+    client_code = f"""dj = DJClient(DJ_URL)
 {node_short_name} = dj.{node.type}(
     "{node.name}"
 )

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -14,9 +14,7 @@ def test_generated_python_client_code_new_metric(client_with_examples: TestClien
     )
     assert (
         response.json()
-        == """from datajunction import DJClient, NodeMode
-
-dj = DJClient(DJ_URL)
+        == """dj = DJClient(DJ_URL)
 
 num_repair_orders = dj.new_metric(
     description="Number of repair orders",
@@ -42,9 +40,7 @@ def test_generated_python_client_code_new_source(client_with_examples: TestClien
     )
     assert (
         response.json()
-        == """from datajunction import DJClient, NodeMode
-
-dj = DJClient(DJ_URL)
+        == """dj = DJClient(DJ_URL)
 
 repair_order_details = dj.new_source(
     description="Details on repair orders",
@@ -65,9 +61,7 @@ def test_generated_python_client_code_new_dimension(client_with_examples: TestCl
     response = client_with_examples.get("/client/python/new_node/default.repair_order")
     assert (
         response.json()
-        == """from datajunction import DJClient, NodeMode
-
-dj = DJClient(DJ_URL)
+        == """dj = DJClient(DJ_URL)
 
 repair_order = dj.new_dimension(
     description="Repair order dimension",
@@ -110,9 +104,7 @@ def test_generated_python_client_code_new_cube(client_with_examples: TestClient)
     response = client_with_examples.get("/client/python/new_node/default.repairs_cube")
     assert (
         response.json()
-        == """from datajunction import DJClient, NodeMode
-
-dj = DJClient(DJ_URL)
+        == """dj = DJClient(DJ_URL)
 
 repairs_cube = dj.new_cube(
     description="Cube of various metrics related to repairs",
@@ -164,9 +156,7 @@ def test_generated_python_client_code_adding_materialization(
     )
     assert (
         response.json()
-        == """from datajunction import DJClient, MaterializationConfig
-
-dj = DJClient(DJ_URL)
+        == """dj = DJClient(DJ_URL)
 
 country_agg = dj.transform(
     "basic.transform.country_agg"
@@ -209,9 +199,7 @@ def test_generated_python_client_code_link_dimension(client_with_examples: TestC
     )
     assert (
         response.json()
-        == """from datajunction import DJClient, MaterializationConfig
-
-dj = DJClient(DJ_URL)
+        == """dj = DJClient(DJ_URL)
 repair_orders = dj.source(
     "foo.bar.repair_orders"
 )


### PR DESCRIPTION
### Summary

This removes the imports from the UI example code snippets.

### Test Plan

Ran the UI locally and took a look at the rendered snippets.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
