### PR TITLE
Add register_table functionality to the DJ python client

### DIFF
--- a/client/python/datajunction/client.py
+++ b/client/python/datajunction/client.py
@@ -314,6 +314,18 @@ class DJBuilder(DJClient):
         new_source.save(mode=mode)
         return new_source
 
+    def register_table(self, catalog: str, schema: str, table: str):
+        """
+        Register a table as a source node. This will create a source node under the configured
+        `source_node_namespace` (a server-side setting), which defaults to the `source` namespace.
+        """
+        response = self._session.post(f"/register/table/{catalog}/{schema}/{table}/")
+        new_source = Source(
+            **response.json(),
+            dj_client=self,
+        )
+        return new_source
+
     #
     # Nodes: TRANSFORM
     #

--- a/client/python/tests/examples.py
+++ b/client/python/tests/examples.py
@@ -5,7 +5,9 @@ import uuid
 from typing import Dict, Union
 
 from datajunction_server.errors import DJException, DJQueryServiceClientException
+from datajunction_server.models import Column
 from datajunction_server.models.query import QueryWithResults
+from datajunction_server.sql.parsing.types import IntegerType, StringType, TimestampType
 from datajunction_server.typing import QueryState
 
 # pylint: disable=too-many-lines
@@ -1076,6 +1078,15 @@ EXAMPLES = (  # type: ignore
         {},
     ),
 )
+
+COLUMN_MAPPINGS = {
+    "default.store.comments": [
+        Column(name="id", type=IntegerType()),
+        Column(name="user_id", type=IntegerType()),
+        Column(name="timestamp", type=TimestampType()),
+        Column(name="text", type=StringType()),
+    ],
+}
 
 QUERY_DATA_MAPPINGS: Dict[str, Union[DJException, QueryWithResults]] = {
     """

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -14,7 +14,7 @@ from datajunction.models import (
 )
 
 
-class TestDJClient:
+class TestDJClient:  # pylint: disable=too-many-public-methods
     """
     Tests for DJ client functionality.
     """
@@ -271,6 +271,18 @@ class TestDJClient:
         assert "default.avg_length_of_employment" in client.list_metrics(
             namespace="default",
         )
+
+    def test_register_table(self, client):  # pylint: disable=unused-argument
+        """
+        Verifies that registering a table works.
+        """
+        store_comments = client.register_table(
+            catalog="default",
+            schema="store",
+            table="comments",
+        )
+        assert store_comments.name == "source.default.store.comments"
+        assert "source.default.store.comments" in client.namespace("source").sources()
 
     def test_create_nodes(self, client):  # pylint: disable=unused-argument
         """

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1357,6 +1357,7 @@ def register_a_table(  # pylint: disable=too-many-arguments
         )
     namespace = f"{settings.source_node_namespace}.{catalog}.{schema_}"
     name = f"{namespace}.{table}"
+    raise_if_node_exists(session, name)
 
     # Create the namespace if required (idempotent)
     create_a_node_namespace(namespace=namespace, session=session)


### PR DESCRIPTION
### Summary

This PR adds `register_table` to the client. It can be used with `dj.register_table(<catalog>, <schema>, <table>)`. 

Also adds a small check to table registration endpoint to abort if a source node with the same name already exists. This saves us a good chunk of time since we don't have to go out to the query service and pull columns if there's already a source registered.

Additionally adds a `debug` mode to the client, where setting it to False (default) hides the traceback when using the client from a jupyter notebook.

### Test Plan

Tested locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
