### PR TITLE
Improve error message when node creation fails due to type inference

### DIFF
--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1229,14 +1229,18 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
         assert data == {
             "message": (
                 "Unable to infer type for some columns on node "
-                "`default.avg_length_of_employment_plus_one`"
+                "`default.avg_length_of_employment_plus_one`.\n\n"
+                "\t* Incompatible types in binary operation NOW() - "
+                "foo.bar.hard_hats.hire_date + 1. Got left timestamp, rig"
             ),
             "errors": [
                 {
                     "code": 302,
                     "message": (
                         "Unable to infer type for some columns on node "
-                        "`default.avg_length_of_employment_plus_one`"
+                        "`default.avg_length_of_employment_plus_one`.\n\n"
+                        "\t* Incompatible types in binary operation NOW() - "
+                        "foo.bar.hard_hats.hire_date + 1. Got left timestamp, rig"
                     ),
                     "debug": {
                         "columns": {


### PR DESCRIPTION
### Summary

When node creation fails from a type inference error, the current server-side error message just returns `Unable to infer type for some columns on node <name>`. This doesn't tell users what part of the query they should fix.

Since we already have a `type_inference_failures` object that contains a map of all the columns to their failures, this PR exposes all of that directly in the error message as a list.

An example error message would look like:
```
Unable to infer type for some columns on node `example.node_name`.

	* Cannot resolve type of column x.first_name in SELECT  x.name
	* Cannot resolve type of column last_name in x.last_name
```

### Test Plan

I'll add a better test shortly

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
