### PR TITLE
Mark `Query` as compiled after compilation finishes to reduce compile speed 

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -446,6 +446,7 @@ class Node(ABC):
             if not child.is_compiled():
                 child.compile(ctx)
                 child._is_compiled = True
+        self._is_compiled = True
 
     def is_compiled(self) -> bool:
         """
@@ -869,7 +870,7 @@ class Column(Aliasable, Named, Expression):
                 ctx.exception.errors.append(
                     DJError(
                         code=ErrorCode.INVALID_COLUMN,
-                        message=f"Column`{self}` does not exist on any valid table.",
+                        message=f"Column `{self}` does not exist on any valid table.",
                     ),
                 )
                 return
@@ -2243,6 +2244,7 @@ class Query(TableExpression):
         )
         for expr in self.select.projection:
             self._columns += expr.columns
+        self._is_compiled = True
 
     def bake_ctes(self) -> "Query":
         """

--- a/datajunction-server/tests/construction/compile_test.py
+++ b/datajunction-server/tests/construction/compile_test.py
@@ -158,7 +158,7 @@ def test_raise_on_unjoinable_automatic_dimension_groupby(construction_session: S
     query_ast.compile(ctx)
 
     assert (
-        "Column`basic.dimension.countries.country` does not exist on any valid table."
+        "Column `basic.dimension.countries.country` does not exist on any valid table."
         in str(
             ctx.exception.errors,
         )

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -103,10 +103,12 @@ def test_ast_compile_query_missing_columns(
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
     assert (
-        "Column `column_foo` does not exist on any valid table." in exc.errors[0].message
+        "Column `column_foo` does not exist on any valid table."
+        in exc.errors[0].message
     )
     assert (
-        "Column `column_bar` does not exist on any valid table." in exc.errors[1].message
+        "Column `column_bar` does not exist on any valid table."
+        in exc.errors[1].message
     )
 
     node = query.select.from_.relations[  # pylint: disable=protected-access

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -103,10 +103,10 @@ def test_ast_compile_query_missing_columns(
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
     assert (
-        "Column`column_foo` does not exist on any valid table." in exc.errors[0].message
+        "Column `column_foo` does not exist on any valid table." in exc.errors[0].message
     )
     assert (
-        "Column`column_bar` does not exist on any valid table." in exc.errors[1].message
+        "Column `column_bar` does not exist on any valid table." in exc.errors[1].message
     )
 
     node = query.select.from_.relations[  # pylint: disable=protected-access


### PR DESCRIPTION
### Summary

On large queries with many columns and subqueries, table compilation takes a long time (>5min). Did some digging and noticed that part of the time sink is from us not marking a `Query` object that's already gone through the compilation process as compiled.

This means that if we're working with a query that has many subqueries, those subqueries will get reprocessed over and over when we want to assign table sources to columns in the outer query. This issue doesn't manifest if we have a simple query without subqueries.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
