### PR TITLE
UI bugfix + optimization

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -2,7 +2,6 @@ import { useState, useContext, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
-import { format } from 'sql-formatter';
 import NodeStatus from './NodeStatus';
 import ListGroupItem from '../../components/ListGroupItem';
 import ToggleSwitch from '../../components/ToggleSwitch';
@@ -50,23 +49,7 @@ export default function NodeInfoTab({ node }) {
             <></>
           )}
           <SyntaxHighlighter language="sql" style={foundation}>
-            {checked
-              ? format(compiledSQL, {
-                  language: 'spark',
-                  tabWidth: 2,
-                  keywordCase: 'upper',
-                  denseOperators: true,
-                  logicalOperatorNewline: 'before',
-                  expressionWidth: 10,
-                })
-              : format(node?.query, {
-                  language: 'spark',
-                  tabWidth: 2,
-                  keywordCase: 'upper',
-                  denseOperators: true,
-                  logicalOperatorNewline: 'before',
-                  expressionWidth: 10,
-                })}
+            {checked ? compiledSQL : node?.query}
           </SyntaxHighlighter>
         </div>
       </div>

--- a/datajunction-ui/src/app/pages/NodePage/NodeSQLTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeSQLTab.jsx
@@ -82,14 +82,7 @@ const NodeSQLTab = djNode => {
         >
           <h6 className="mb-0 w-100">Query</h6>
           <SyntaxHighlighter language="sql" style={foundation}>
-            {format(query, {
-              language: 'spark',
-              tabWidth: 2,
-              keywordCase: 'upper',
-              denseOperators: true,
-              logicalOperatorNewline: 'before',
-              expressionWidth: 10,
-            })}
+            {query}
           </SyntaxHighlighter>
         </div>
       </div>

--- a/datajunction-ui/src/app/pages/SQLBuilderPage/index.jsx
+++ b/datajunction-ui/src/app/pages/SQLBuilderPage/index.jsx
@@ -293,14 +293,7 @@ export function SQLBuilderPage() {
             <div>
               {query && !viewData ? (
                 <SyntaxHighlighter language="sql" style={foundation}>
-                  {format(query, {
-                    language: 'spark',
-                    tabWidth: 2,
-                    keywordCase: 'upper',
-                    denseOperators: true,
-                    logicalOperatorNewline: 'before',
-                    expressionWidth: 10,
-                  })}
+                  {query}
                 </SyntaxHighlighter>
               ) : (
                 ''

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -134,12 +134,14 @@ export const DataJunctionAPI = {
   columns: async function (node) {
     return await Promise.all(
       node.columns.map(async col => {
-        col.clientCode = await (
-          await fetch(
-            DJ_URL +
-              `/datajunction-clients/python/link_dimension/${node.name}/${col.name}/${col.dimension?.name}`,
-          )
-        ).json();
+        if (col.dimension !== null) {
+          col.clientCode = await (
+            await fetch(
+              DJ_URL +
+                `/datajunction-clients/python/link_dimension/${node.name}/${col.name}/${col.dimension?.name}`,
+            )
+          ).json();
+        }
         return col;
       }),
     );
@@ -167,7 +169,9 @@ export const DataJunctionAPI = {
     const params = new URLSearchParams();
     metricSelection.map(metric => params.append('metrics', metric));
     dimensionSelection.map(dimension => params.append('dimensions', dimension));
-    return new EventSource(DJ_URL + '/stream/?' + params + '&limit=10000&async_=true');
+    return new EventSource(
+      DJ_URL + '/stream/?' + params + '&limit=10000&async_=true',
+    );
   },
 
   lineage: async function (node) {},


### PR DESCRIPTION
### Summary

* Bugfix: Don't use the sql-formatter library to format the query for display, as it can't parse `BETWEEN` in queries
* Optimization: Only call the client code for dimensions linking a column if the column actually has a dimension defined on it. Otherwise the client code endpoint will return nothing but it takes a long time for the node columns page to load

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
