### PR TITLE
A ton of Spark SQL functions ⛱️ 

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2034,6 +2034,52 @@ def infer_type(arg: Union[ct.IntegerType, ct.StringType]) -> ct.ColumnType:
     return ct.StringType()
 
 
+class HistogramNumeric(Function):
+    """
+    histogram_numeric(col, numBins) - Generates a histogram using a series of buckets
+    defined by equally spaced width intervals.
+    """
+
+
+@HistogramNumeric.register  # type: ignore
+def infer_type(arg1: ct.ColumnType, arg2: ct.IntegerType) -> ct.ColumnType:
+    # assuming that there's a StructType for the bin and frequency
+    from datajunction_server.sql.parsing import (  # pylint: disable=import-outside-toplevel
+        ast,
+    )
+
+    return ct.ListType(
+        element_type=ct.StructType(
+            ct.NestedField(ast.Name("x"), ct.FloatType()),
+            ct.NestedField(ast.Name("y"), ct.FloatType()),
+        ),
+    )
+
+
+class Hour(Function):
+    """
+    hour(timestamp) - Extracts the hour from a timestamp.
+    """
+
+
+@Hour.register  # type: ignore
+def infer_type(
+    arg: Union[ct.TimestampType, ct.StringType],
+) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Hypot(Function):
+    """
+    hypot(a, b) - Returns sqrt(a^2 + b^2) without intermediate overflow or underflow.
+    """
+
+
+@Hypot.register  # type: ignore
+def infer_type(arg1: ct.NumberType, arg2: ct.NumberType) -> ct.ColumnType:
+    return ct.FloatType()
+
+
 class If(Function):
     """
     If statement

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3063,6 +3063,75 @@ def infer_type(
     return ct.FloatType()
 
 
+class NamedStruct(Function):
+    """
+    named_struct(name, val, ...) - Creates a new struct with the given field names and values.
+    """
+
+
+@NamedStruct.register  # type: ignore
+def infer_type(*args: ct.ColumnType) -> ct.ColumnType:
+    from itertools import pairwise  # pylint: disable=import-outside-toplevel
+
+    nested_fields = [
+        ct.NestedField(
+            name=field_name.value.replace("'", ""),
+            field_type=field_value.type,
+        )
+        for field_name, field_value in pairwise(args)
+    ][::2]
+    return ct.StructType(*nested_fields)
+
+
+class Nanvl(Function):
+    """
+    nanvl(expr1, expr2) - Returns the first argument if it is not NaN,
+    or the second argument if the first argument is NaN.
+    """
+
+
+@Nanvl.register  # type: ignore
+def infer_type(expr1: ct.NumberType, expr2: ct.NumberType) -> ct.NumberType:
+    return expr1.type
+
+
+class Negative(Function):
+    """
+    negative(expr) - Returns the negated value of the input expression.
+    """
+
+
+@Negative.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.NumberType:
+    return arg.type
+
+
+class NextDay(Function):
+    """
+    next_day(start_date, day_of_week) - Returns the first date which is
+    later than start_date and named as indicated.
+    """
+
+
+@NextDay.register  # type: ignore
+def infer_type(
+    date: Union[ct.DateType, ct.StringType],
+    day_of_week: ct.StringType,
+) -> ct.ColumnType:
+    return ct.DateType()
+
+
+class Not(Function):
+    """
+    not(expr) - Returns the logical NOT of the Boolean expression.
+    """
+
+
+@Not.register  # type: ignore
+def infer_type(arg: ct.BooleanType) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
 class Now(Function):
     """
     Returns the current timestamp.

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1551,6 +1551,49 @@ def infer_type(
     return ct.DoubleType()
 
 
+class Explode(Function):
+    """
+    explode(expr) - Returns a new row for each element in the given array or map.
+    """
+
+
+@Explode.register  # type: ignore
+def infer_type(arg: ct.ListType) -> ct.ColumnType:
+    return arg.type.element.type
+
+
+@Explode.register  # type: ignore
+def infer_type(arg: ct.MapType) -> ct.ColumnType:
+    return arg.type.value.type
+
+
+class ExplodeOuter(Function):
+    """
+    explode_outer(expr) - Similar to explode, but returns null if the array/map is null or empty.
+    """
+
+
+@ExplodeOuter.register  # type: ignore
+def infer_type(arg: ct.ListType) -> ct.ColumnType:
+    return arg.type.element.type
+
+
+@ExplodeOuter.register  # type: ignore
+def infer_type(arg: ct.MapType) -> ct.ColumnType:
+    return arg.type.value.type
+
+
+class Expm1(Function):
+    """
+    expm1(expr) - Calculates e^x - 1.
+    """
+
+
+@Expm1.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
+    return ct.FloatType()
+
+
 class Extract(Function):
     """
     Returns a specified component of a timestamp, such as year, month or day.
@@ -2434,29 +2477,6 @@ def infer_type(
 # Table Functions                                                                #
 # https://spark.apache.org/docs/3.3.2/sql-ref-syntax-qry-select-tvf.html#content #
 ##################################################################################
-
-
-class Explode(TableFunction):
-    """
-    The Explode function is used to explode the specified array,
-    nested array, or map column into multiple rows.
-    The explode function will generate a new row for each
-    element in the specified column.
-    """
-
-
-@Explode.register
-def infer_type(
-    arg: ct.ListType,
-) -> List[ct.NestedField]:
-    return [arg.element]
-
-
-@Explode.register
-def infer_type(
-    arg: ct.MapType,
-) -> List[ct.NestedField]:
-    return [arg.key, arg.value]
 
 
 class Unnest(TableFunction):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1224,6 +1224,17 @@ def infer_type(
     return ct.IntegerType()
 
 
+class DateFromUnixDate(Function):
+    """
+    date_from_unix_date(expr) - Converts the number of days from epoch (1970-01-01) to a date.
+    """
+
+
+@DateFromUnixDate.register  # type: ignore
+def infer_type(arg: ct.IntegerType) -> ct.ColumnType:
+    return ct.DateType()
+
+
 class DateFormat(Function):
     """
     date_format(timestamp, fmt) - Converts timestamp to a value of string
@@ -1237,6 +1248,21 @@ def infer_type(
     fmt: ct.StringType,
 ) -> ct.StringType:
     return ct.StringType()
+
+
+class DatePart(Function):
+    """
+    date_part(field, source) - Extracts a part of the date or time given.
+    """
+
+
+@DatePart.register  # type: ignore
+def infer_type(
+    arg1: ct.StringType, arg2: Union[ct.DateType, ct.TimestampType],
+) -> ct.ColumnType:
+    # The output can be integer, float, or string depending on the part extracted.
+    # Here we assume the output is an integer for simplicity. Adjust as needed.
+    return ct.IntegerType()
 
 
 class DateSub(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1609,6 +1609,17 @@ class Extract(Function):
         return ct.IntegerType()
 
 
+class Factorial(Function):
+    """
+    factorial(expr) - Returns the factorial of the number.
+    """
+
+
+@Factorial.register  # type: ignore
+def infer_type(arg: ct.IntegerType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
 class Filter(Function):
     """
     Filter an array.
@@ -1650,6 +1661,17 @@ def infer_type(
     func: ct.PrimitiveType,
 ) -> ct.ListType:
     return arg.type  # type: ignore
+
+
+class FindInSet(Function):
+    """
+    find_in_set(str, str_list) - Returns the index of the first occurrence of str in str_list.
+    """
+
+
+@FindInSet.register  # type: ignore
+def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
+    return ct.IntegerType()
 
 
 class First(Function):
@@ -1711,6 +1733,17 @@ def infer_type(
     array: ct.ListType,
 ) -> ct.ListType:
     return array.type.element.type  # type: ignore
+
+
+class Float(Function):
+    """
+    float(expr) - Casts the value expr to the target data type float.
+    """
+
+
+@Float.register  # type: ignore
+def infer_type(arg: Union[ct.NumberType, ct.StringType]) -> ct.FloatType:
+    return ct.FloatType()
 
 
 class Floor(Function):
@@ -2477,6 +2510,29 @@ def infer_type(
 # Table Functions                                                                #
 # https://spark.apache.org/docs/3.3.2/sql-ref-syntax-qry-select-tvf.html#content #
 ##################################################################################
+
+
+class Explode(TableFunction):
+    """
+    The Explode function is used to explode the specified array,
+    nested array, or map column into multiple rows.
+    The explode function will generate a new row for each
+    element in the specified column.
+    """
+
+
+@Explode.register
+def infer_type(
+    arg: ct.ListType,
+) -> List[ct.NestedField]:
+    return [arg.element]
+
+
+@Explode.register
+def infer_type(
+    arg: ct.MapType,
+) -> List[ct.NestedField]:
+    return [arg.key, arg.value]
 
 
 class Unnest(TableFunction):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1951,19 +1951,16 @@ def infer_type(arg1: ct.ListType, arg2: ct.IntegerType) -> ct.ColumnType:
     return arg1.type.element.type
 
 
-# TODO: Extract the actual output schema  # pylint: disable=fixme
-# class GetJsonObject(Function):
-#     """
-#     get_json_object(jsonString, path) - Extracts a JSON object from a JSON
-#     string based on the JSON path specified.
-#     """
-#
-#
-# @GetJsonObject.register  # type: ignore
-# def infer_type(
-#     arg1: ct.StringType, arg2: ct.StringType
-# ) -> ct.ColumnType:
-#     return ct.StringType()
+class GetJsonObject(Function):
+    """
+    get_json_object(jsonString, path) - Extracts a JSON object from a JSON
+    string based on the JSON path specified.
+    """
+
+
+@GetJsonObject.register  # type: ignore
+def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
+    return ct.StringType()
 
 
 class GetBit(Function):
@@ -2218,6 +2215,73 @@ def infer_type(
     arg: ct.ColumnType,
 ) -> ct.ColumnType:
     return ct.IntegerType()
+
+
+class Isnan(Function):
+    """
+    isnan(expr) - Tests if a value is NaN.
+    """
+
+
+@Isnan.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
+class Isnotnull(Function):
+    """
+    isnotnull(expr) - Tests if a value is not null.
+    """
+
+
+@Isnotnull.register  # type: ignore
+def infer_type(arg: ct.ColumnType) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
+class Isnull(Function):
+    """
+    isnull(expr) - Tests if a value is null.
+    """
+
+
+@Isnull.register  # type: ignore
+def infer_type(arg: ct.ColumnType) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
+class JsonArrayLength(Function):
+    """
+    json_array_length(jsonArray) - Returns the length of the JSON array.
+    """
+
+
+@JsonArrayLength.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class JsonObjectKeys(Function):
+    """
+    json_object_keys(jsonObject) - Returns all the keys of the JSON object.
+    """
+
+
+@JsonObjectKeys.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
+    return ct.ListType(element_type=ct.StringType())
+
+
+class JsonTuple(Function):
+    """
+    json_tuple(json_str, path1, path2, ...) - Extracts multiple values from a JSON object.
+    """
+
+
+@JsonTuple.register  # type: ignore
+def infer_type(json_str: ct.StringType, *paths: ct.StringType) -> ct.ColumnType:
+    # assuming that there's a TupleType for the extracted values
+    return ct.ListType(element_type=ct.StringType())
 
 
 class Length(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2848,6 +2848,41 @@ def infer_type(map_: ct.MapType) -> ct.ColumnType:
     return ct.ListType(element_type=map_.type.value.type)
 
 
+# TODO  # pylint: disable=fixme
+# class MapZipWith(Function):
+#     """
+#     map_zip_with(map1, map2, function) - Returns a merged map of two given maps by
+#     applying function to the pair of values with the same key.
+#     """
+#
+#
+# @MapZipWith.register  # type: ignore
+# def infer_type(
+#     map1: ct.MapType, map2: ct.MapType, function: ct.ColumnType
+# ) -> ct.ColumnType:
+#     return ct.MapType()
+
+
+class Mask(Function):
+    """
+    mask(input[, upperChar, lowerChar, digitChar, otherChar]) - masks the
+    given string value. The function replaces characters with 'X' or 'x',
+    and numbers with 'n'. This can be useful for creating copies of tables
+    with sensitive information removed.
+    """
+
+
+@Mask.register  # type: ignore
+def infer_type(
+    input_: ct.StringType,
+    upper: Optional[ct.StringType] = None,
+    lower: Optional[ct.StringType] = None,
+    digit: Optional[ct.StringType] = None,
+    other: Optional[ct.StringType] = None,
+) -> ct.StringType:
+    return ct.StringType()
+
+
 class Max(Function):
     """
     Computes the maximum value of the input column or expression.
@@ -2870,6 +2905,59 @@ def infer_type(
     return arg.type
 
 
+class MaxBy(Function):
+    """
+    max_by(val, key) - Returns the value of val corresponding to the maximum value of key.
+    """
+
+
+@MaxBy.register  # type: ignore
+def infer_type(val: ct.ColumnType, key: ct.ColumnType) -> ct.ColumnType:
+    return val.type
+
+
+class Md5(Function):
+    """
+    md5(expr) - Calculates the MD5 hash of the given value.
+    """
+
+
+@Md5.register  # type: ignore
+def infer_type(arg: ct.ColumnType) -> ct.ColumnType:
+    return ct.StringType()
+
+
+class Mean(Function):
+    """
+    mean(expr) - Returns the average of the values in the group.
+    """
+
+
+@Mean.register  # type: ignore
+def infer_type(arg: ct.ColumnType) -> ct.ColumnType:
+    return ct.DoubleType()
+
+
+class Median(Function):
+    """
+    median(expr) - Returns the median of the values in the group.
+    """
+
+
+@Median.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
+    return ct.DoubleType()
+
+
+# TODO: fix parsing of:  # pylint: disable=fixme
+#   SELECT median(col) FROM VALUES (INTERVAL '0' MONTH),
+#   (INTERVAL '10' MONTH) AS tab(col)
+#   in order to test this
+@Median.register  # type: ignore
+def infer_type(arg: ct.IntervalTypeBase) -> ct.IntervalTypeBase:  # pragma: no cover
+    return arg.type
+
+
 class Min(Function):
     """
     Computes the minimum value of the input column or expression.
@@ -2883,6 +2971,17 @@ def infer_type(
     arg: ct.NumberType,
 ) -> ct.NumberType:
     return arg.type
+
+
+class MinBy(Function):
+    """
+    min_by(val, key) - Returns the value of val corresponding to the minimum value of key.
+    """
+
+
+@MinBy.register  # type: ignore
+def infer_type(val: ct.ColumnType, key: ct.ColumnType) -> ct.ColumnType:
+    return val.type
 
 
 class Month(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -731,9 +731,7 @@ class Ceiling(Function):
 
 
 @Ceiling.register  # type: ignore
-def infer_type(
-    arg: ct.NumberType
-) -> ct.ColumnType:
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
     return ct.BigIntType()
 
 
@@ -757,9 +755,7 @@ class CharLength(Function):
 
 
 @CharLength.register  # type: ignore
-def infer_type(
-    arg: ct.StringType
-) -> ct.ColumnType:
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
     return ct.IntegerType()
 
 
@@ -770,9 +766,7 @@ class CharacterLength(Function):
 
 
 @CharacterLength.register  # type: ignore
-def infer_type(
-    arg: ct.StringType
-) -> ct.ColumnType:
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
     return ct.IntegerType()
 
 
@@ -783,9 +777,7 @@ class Chr(Function):
 
 
 @Chr.register  # type: ignore
-def infer_type(
-    arg: ct.IntegerType
-) -> ct.ColumnType:
+def infer_type(arg: ct.IntegerType) -> ct.ColumnType:
     return ct.StringType()
 
 
@@ -849,7 +841,8 @@ def infer_type(
 
 class ConcatWs(Function):
     """
-    concat_ws(separator, [str | array(str)]+) - Returns the concatenation of the strings separated by separator.
+    concat_ws(separator, [str | array(str)]+) - Returns the concatenation of the
+    strings separated by separator.
     """
 
 
@@ -870,15 +863,14 @@ class Contains(Function):
 
 
 @Contains.register  # type: ignore
-def infer_type(
-    arg1: ct.StringType, arg2: ct.StringType
-) -> ct.ColumnType:
+def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
     return ct.BooleanType()
 
 
 @Contains.register  # type: ignore
 def infer_type(  # pragma: no cover
-    arg1: ct.BinaryType, arg2: ct.BinaryType
+    arg1: ct.BinaryType,
+    arg2: ct.BinaryType,
 ) -> ct.ColumnType:
     return ct.BooleanType()
 
@@ -891,14 +883,18 @@ class Conv(Function):
 
 @Conv.register  # type: ignore
 def infer_type(
-    arg1: ct.NumberType, arg2: ct.IntegerType, arg3: ct.IntegerType
+    arg1: ct.NumberType,
+    arg2: ct.IntegerType,
+    arg3: ct.IntegerType,
 ) -> ct.ColumnType:
     return ct.StringType()
 
 
 @Conv.register  # type: ignore
 def infer_type(
-    arg1: ct.StringType, arg2: ct.IntegerType, arg3: ct.IntegerType
+    arg1: ct.StringType,
+    arg2: ct.IntegerType,
+    arg3: ct.IntegerType,
 ) -> ct.ColumnType:
     return ct.StringType()
 
@@ -912,7 +908,9 @@ class ConvertTimezone(Function):
 
 @ConvertTimezone.register  # type: ignore
 def infer_type(
-    arg1: ct.StringType, arg2: ct.StringType, arg3: ct.TimestampType
+    arg1: ct.StringType,
+    arg2: ct.StringType,
+    arg3: ct.TimestampType,
 ) -> ct.ColumnType:
     return ct.TimestampType()
 
@@ -925,7 +923,8 @@ class Corr(Function):
 
 @Corr.register  # type: ignore
 def infer_type(
-    arg1: ct.NumberType, arg2: ct.NumberType,
+    arg1: ct.NumberType,
+    arg2: ct.NumberType,
 ) -> ct.ColumnType:
     return ct.FloatType()
 
@@ -937,9 +936,7 @@ class Cos(Function):
 
 
 @Cos.register  # type: ignore
-def infer_type(
-    arg: ct.NumberType
-) -> ct.ColumnType:
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
     return ct.FloatType()
 
 
@@ -950,9 +947,7 @@ class Cosh(Function):
 
 
 @Cosh.register  # type: ignore
-def infer_type(
-    arg: ct.NumberType
-) -> ct.ColumnType:
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
     return ct.FloatType()
 
 
@@ -963,9 +958,7 @@ class Cot(Function):
 
 
 @Cot.register  # type: ignore
-def infer_type(
-    arg: ct.NumberType
-) -> ct.ColumnType:
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
     return ct.FloatType()
 
 
@@ -984,6 +977,124 @@ def infer_type(
     return ct.BigIntType()
 
 
+class CountIf(Function):
+    """
+    count_if(expr) - Returns the number of true values in expr.
+    """
+
+
+@CountIf.register  # type: ignore
+def infer_type(arg: ct.BooleanType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class CountMinSketch(Function):
+    """
+    count_min_sketch(col, eps, confidence, seed) - Creates a Count-Min sketch of col.
+    """
+
+
+@CountMinSketch.register  # type: ignore
+def infer_type(
+    arg1: ct.ColumnType,
+    arg2: ct.FloatType,
+    arg3: ct.FloatType,
+    arg4: ct.IntegerType,
+) -> ct.ColumnType:
+    return ct.BinaryType()
+
+
+class CovarPop(Function):
+    """
+    covar_pop(expr1, expr2) - Returns the population covariance of expr1 and expr2.
+    """
+
+
+@CovarPop.register  # type: ignore
+def infer_type(
+    arg1: ct.NumberType,
+    arg2: ct.NumberType,
+) -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class CovarSamp(Function):
+    """
+    covar_samp(expr1, expr2) - Returns the sample covariance of expr1 and expr2.
+    """
+
+
+@CovarSamp.register  # type: ignore
+def infer_type(arg1: ct.NumberType, arg2: ct.NumberType) -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class Crc32(Function):
+    """
+    crc32(expr) - Computes a cyclic redundancy check value and returns the result as a bigint.
+    """
+
+
+@Crc32.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
+    return ct.BigIntType()
+
+
+class Csc(Function):
+    """
+    csc(expr) - Computes the cosecant of expr.
+    """
+
+
+@Csc.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class CumeDist(Function):
+    """
+    cume_dist() - Computes the cumulative distribution of a value within a group of values.
+    """
+
+
+@CumeDist.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class Curdate(Function):
+    """
+    curdate() - Returns the current date.
+    """
+
+
+@Curdate.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.DateType()
+
+
+class CurrentCatalog(Function):
+    """
+    current_catalog() - Returns the current catalog.
+    """
+
+
+@CurrentCatalog.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.StringType()
+
+
+class CurrentDatabase(Function):
+    """
+    current_database() - Returns the current database.
+    """
+
+
+@CurrentDatabase.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.StringType()
+
+
 class CurrentDate(Function):
     """
     Returns the current date.
@@ -993,6 +1104,17 @@ class CurrentDate(Function):
 @CurrentDate.register  # type: ignore
 def infer_type() -> ct.DateType:
     return ct.DateType()
+
+
+class CurrentSchema(Function):
+    """
+    current_schema() - Returns the current schema.
+    """
+
+
+@CurrentSchema.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.StringType()
 
 
 class CurrentTime(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -655,6 +655,19 @@ def infer_type(
     return ct.IntegerType()
 
 
+class Cbrt(Function):
+    """
+    cbrt(expr) - Computes the cube root of the value expr.
+    """
+
+
+@Cbrt.register  # type: ignore
+def infer_type(
+    arg: ct.NumberType,
+) -> ct.ColumnType:
+    return ct.FloatType()
+
+
 class Ceil(Function):
     """
     Computes the smallest integer greater than or equal to the input value.
@@ -709,6 +722,71 @@ def infer_type(
     args: ct.NumberType,
 ) -> ct.BigIntType:
     return ct.BigIntType()
+
+
+class Ceiling(Function):
+    """
+    ceiling(expr) - Returns the smallest integer greater than or equal to the value expr.
+    """
+
+
+@Ceiling.register  # type: ignore
+def infer_type(
+    arg: ct.NumberType
+) -> ct.ColumnType:
+    return ct.BigIntType()
+
+
+class Char(Function):
+    """
+    char(expr) - Returns the ASCII character having the binary equivalent to expr.
+    """
+
+
+@Char.register  # type: ignore
+def infer_type(
+    arg: ct.IntegerType,
+) -> ct.ColumnType:
+    return ct.StringType()
+
+
+class CharLength(Function):
+    """
+    char_length(expr) - Returns the length of the value expr.
+    """
+
+
+@CharLength.register  # type: ignore
+def infer_type(
+    arg: ct.StringType
+) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class CharacterLength(Function):
+    """
+    character_length(expr) - Returns the length of the value expr.
+    """
+
+
+@CharacterLength.register  # type: ignore
+def infer_type(
+    arg: ct.StringType
+) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Chr(Function):
+    """
+    chr(expr) - Returns the ASCII character having the binary equivalent to expr.
+    """
+
+
+@Chr.register  # type: ignore
+def infer_type(
+    arg: ct.IntegerType
+) -> ct.ColumnType:
+    return ct.StringType()
 
 
 class Coalesce(Function):
@@ -767,6 +845,128 @@ def infer_type(
     arg: ct.ColumnType,
 ) -> ct.ColumnType:
     return ct.ListType(element_type=arg.type)
+
+
+class ConcatWs(Function):
+    """
+    concat_ws(separator, [str | array(str)]+) - Returns the concatenation of the strings separated by separator.
+    """
+
+
+@ConcatWs.register  # type: ignore
+def infer_type(
+    sep: ct.StringType,
+    *strings: ct.StringType,
+) -> ct.ColumnType:
+    return ct.StringType()
+
+
+class Contains(Function):
+    """
+    contains(left, right) - Returns a boolean. The value is True if right is found inside left.
+    Returns NULL if either input expression is NULL. Otherwise, returns False. Both left or
+    right must be of STRING or BINARY type.
+    """
+
+
+@Contains.register  # type: ignore
+def infer_type(
+    arg1: ct.StringType, arg2: ct.StringType
+) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
+@Contains.register  # type: ignore
+def infer_type(  # pragma: no cover
+    arg1: ct.BinaryType, arg2: ct.BinaryType
+) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
+class Conv(Function):
+    """
+    conv(expr, from_base, to_base) - Convert the number expr from from_base to to_base.
+    """
+
+
+@Conv.register  # type: ignore
+def infer_type(
+    arg1: ct.NumberType, arg2: ct.IntegerType, arg3: ct.IntegerType
+) -> ct.ColumnType:
+    return ct.StringType()
+
+
+@Conv.register  # type: ignore
+def infer_type(
+    arg1: ct.StringType, arg2: ct.IntegerType, arg3: ct.IntegerType
+) -> ct.ColumnType:
+    return ct.StringType()
+
+
+class ConvertTimezone(Function):
+    """
+    convert_timezone(from_tz, to_tz, timestamp) - Convert timestamp from from_tz to to_tz.
+    Spark 3.4+
+    """
+
+
+@ConvertTimezone.register  # type: ignore
+def infer_type(
+    arg1: ct.StringType, arg2: ct.StringType, arg3: ct.TimestampType
+) -> ct.ColumnType:
+    return ct.TimestampType()
+
+
+class Corr(Function):
+    """
+    corr(expr1, expr2) - Compute the correlation of expr1 and expr2.
+    """
+
+
+@Corr.register  # type: ignore
+def infer_type(
+    arg1: ct.NumberType, arg2: ct.NumberType,
+) -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class Cos(Function):
+    """
+    cos(expr) - Compute the cosine of expr.
+    """
+
+
+@Cos.register  # type: ignore
+def infer_type(
+    arg: ct.NumberType
+) -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class Cosh(Function):
+    """
+    cosh(expr) - Compute the hyperbolic cosine of expr.
+    """
+
+
+@Cosh.register  # type: ignore
+def infer_type(
+    arg: ct.NumberType
+) -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class Cot(Function):
+    """
+    cot(expr) - Compute the cotangent of expr.
+    """
+
+
+@Cot.register  # type: ignore
+def infer_type(
+    arg: ct.NumberType
+) -> ct.ColumnType:
+    return ct.FloatType()
 
 
 class Count(Function):
@@ -857,6 +1057,14 @@ def infer_type(
 def infer_type(
     start_date: ct.StringType,
     end_date: ct.StringType,
+) -> ct.IntegerType:
+    return ct.IntegerType()
+
+
+@DateDiff.register  # type: ignore
+def infer_type(
+    start_date: ct.IntegerType,
+    end_date: ct.IntegerType,
 ) -> ct.IntegerType:
     return ct.IntegerType()
 
@@ -1191,6 +1399,19 @@ class IfNull(Function):
 @IfNull.register
 def infer_type(*args: ct.ColumnType) -> ct.ColumnType:
     return args[0].type if args[1].type == ct.NullType() else args[1].type
+
+
+class Int(Function):
+    """
+    int(expr) - Casts the value expr to the target data type int.
+    """
+
+
+@Int.register  # type: ignore
+def infer_type(
+    arg: ct.ColumnType,
+) -> ct.ColumnType:
+    return ct.IntegerType()
 
 
 class Length(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2527,6 +2527,17 @@ def infer_type(
     return ct.DoubleType()
 
 
+class Log1p(Function):
+    """
+    log1p(expr) - Returns the natural logarithm of the given value plus one.
+    """
+
+
+@Log1p.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.DoubleType:
+    return ct.DoubleType()
+
+
 class Log2(Function):
     """
     Returns the base-2 logarithm of a number.
@@ -2548,6 +2559,51 @@ class Lower(Function):
     @staticmethod
     def infer_type(arg: "Expression") -> ct.StringType:  # type: ignore
         return ct.StringType()
+
+
+class Lpad(Function):
+    """
+    lpad(str, len[, pad]) - Left-pads the string with pad to a length of len.
+    If str is longer than len, the return value is shortened to len characters.
+    """
+
+
+@Lpad.register  # type: ignore
+def infer_type(
+    arg1: ct.StringType,
+    arg2: ct.IntegerType,
+    pad: Optional[ct.StringType] = None,
+) -> ct.StringType:
+    return ct.StringType()
+
+
+class Ltrim(Function):
+    """
+    ltrim(str[, trimStr]) - Trims the spaces from left end of the string.
+    """
+
+
+@Ltrim.register  # type: ignore
+def infer_type(
+    arg1: ct.StringType,
+    trim_str: Optional[ct.StringType] = None,
+) -> ct.StringType:
+    return ct.StringType()
+
+
+class MakeDate(Function):
+    """
+    make_date(year, month, day) - Creates a date from the given year, month, and day.
+    """
+
+
+@MakeDate.register  # type: ignore
+def infer_type(
+    year: ct.IntegerType,
+    month: ct.IntegerType,
+    day: ct.IntegerType,
+) -> ct.ColumnType:
+    return ct.DateType()
 
 
 class Map(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2984,6 +2984,50 @@ def infer_type(val: ct.ColumnType, key: ct.ColumnType) -> ct.ColumnType:
     return val.type
 
 
+class Minute(Function):
+    """
+    minute(timestamp) - Returns the minute component of the string/timestamp
+    """
+
+
+@Minute.register  # type: ignore
+def infer_type(val: Union[ct.StringType, ct.TimestampType]) -> ct.IntegerType:
+    return ct.IntegerType()
+
+
+class Mod(Function):
+    """
+    mod(expr1, expr2) - Returns the remainder after expr1/expr2.
+    """
+
+
+@Mod.register  # type: ignore
+def infer_type(expr1: ct.NumberType, expr2: ct.NumberType) -> ct.FloatType:
+    return ct.FloatType()
+
+
+class Mode(Function):
+    """
+    mode(col) - Returns the most frequent value for the values within col.
+    """
+
+
+@Mode.register  # type: ignore
+def infer_type(arg: ct.ColumnType) -> ct.ColumnType:
+    return arg.type
+
+
+class MonotonicallyIncreasingId(Function):
+    """
+    monotonically_increasing_id() - Returns monotonically increasing 64-bit integers
+    """
+
+
+@MonotonicallyIncreasingId.register  # type: ignore
+def infer_type() -> ct.BigIntType:
+    return ct.BigIntType()
+
+
 class Month(Function):
     """
     Extracts the month of a date or timestamp.
@@ -2993,6 +3037,30 @@ class Month(Function):
 @Month.register
 def infer_type(arg: Union[ct.StringType, ct.DateTimeBase]) -> ct.BigIntType:
     return ct.BigIntType()
+
+
+class MonthsBetween(Function):
+    """
+    months_between(timestamp1, timestamp2[, roundOff])
+    """
+
+
+@MonthsBetween.register
+def infer_type(
+    arg: ct.StringType,
+    arg2: ct.StringType,
+    arg3: Optional[ct.BooleanType] = None,
+) -> ct.BigIntType:
+    return ct.FloatType()
+
+
+@MonthsBetween.register
+def infer_type(
+    arg: ct.TimestampType,
+    arg2: ct.TimestampType,
+    arg3: Optional[ct.BooleanType] = None,
+) -> ct.BigIntType:
+    return ct.FloatType()
 
 
 class Now(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3071,15 +3071,14 @@ class NamedStruct(Function):
 
 @NamedStruct.register  # type: ignore
 def infer_type(*args: ct.ColumnType) -> ct.ColumnType:
-    from itertools import pairwise  # pylint: disable=import-outside-toplevel
-
+    args_iter = iter(args)
     nested_fields = [
         ct.NestedField(
             name=field_name.value.replace("'", ""),
             field_type=field_value.type,
         )
-        for field_name, field_value in pairwise(args)
-    ][::2]
+        for field_name, field_value in zip(args_iter, args_iter)
+    ]
     return ct.StructType(*nested_fields)
 
 

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2115,6 +2115,98 @@ def infer_type(*args: ct.ColumnType) -> ct.ColumnType:
     return args[0].type if args[1].type == ct.NullType() else args[1].type
 
 
+class ILike(Function):
+    """
+    ilike(str, pattern) - Performs case-insensitive LIKE match.
+    """
+
+
+@ILike.register  # type: ignore
+def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
+class InitCap(Function):
+    """
+    initcap(str) - Converts the first letter of each word in the string to uppercase
+    and the rest to lowercase.
+    """
+
+
+@InitCap.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
+    return ct.StringType()
+
+
+class Inline(Function):
+    """
+    inline(array_of_struct) - Explodes an array of structs into a table.
+    """
+
+
+@Inline.register  # type: ignore
+def infer_type(arg: ct.ListType) -> ct.ColumnType:
+    # The output type is the type of the struct's fields
+    return arg.type.element.type
+
+
+class InlineOuter(Function):
+    """
+    inline_outer(array_of_struct) - Similar to inline, but includes nulls if the size
+    of the array is less than the size of the outer array.
+    """
+
+
+@InlineOuter.register  # type: ignore
+def infer_type(arg: ct.ListType) -> ct.ColumnType:
+    # The output type is the type of the struct's fields
+    return arg.type.element.type
+
+
+class InputFileBlockLength(Function):
+    """
+    input_file_block_length() - Returns the length of the current block being read from HDFS.
+    """
+
+
+@InputFileBlockLength.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.LongType()
+
+
+class InputFileBlockStart(Function):
+    """
+    input_file_block_start() - Returns the start offset of the current block being read from HDFS.
+    """
+
+
+@InputFileBlockStart.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.LongType()
+
+
+class InputFileName(Function):
+    """
+    input_file_name() - Returns the name of the current file being read from HDFS.
+    """
+
+
+@InputFileName.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.StringType()
+
+
+class Instr(Function):
+    """
+    instr(str, substring) - Returns the position of the first occurrence of substring in string.
+    """
+
+
+@Instr.register  # type: ignore
+def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
 class Int(Function):
     """
     int(expr) - Casts the value expr to the target data type int.

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2284,6 +2284,90 @@ def infer_type(json_str: ct.StringType, *paths: ct.StringType) -> ct.ColumnType:
     return ct.ListType(element_type=ct.StringType())
 
 
+class Kurtosis(Function):
+    """
+    kurtosis(expr) - Returns the kurtosis of the values in a group.
+    """
+
+
+@Kurtosis.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.DoubleType:
+    return ct.DoubleType()
+
+
+class Lag(Function):
+    """
+    lag(expr[, offset[, default]]) - Returns the value that is `offset` rows
+    before the current row in a window partition.
+    """
+
+
+@Lag.register  # type: ignore
+def infer_type(
+    arg: ct.ColumnType,
+    offset: Optional[ct.IntegerType] = None,
+    default: Optional[ct.ColumnType] = None,
+) -> ct.ColumnType:
+    # The output type is the same as the input expression's type
+    return arg.type
+
+
+class Last(Function):
+    """
+    last(expr[, ignoreNulls]) - Returns the last value of `expr` for a group of rows.
+    """
+
+    is_aggregation = True
+
+
+@Last.register  # type: ignore
+def infer_type(
+    arg: ct.ColumnType,
+    ignore_nulls: Optional[ct.BooleanType] = None,
+) -> ct.ColumnType:
+    # The output type is the same as the input expression's type
+    return arg.type
+
+
+class LastDay(Function):
+    """
+    last_day(date) - Returns the last day of the month which the date belongs to.
+    """
+
+
+@LastDay.register  # type: ignore
+def infer_type(arg: Union[ct.DateType, ct.StringType]) -> ct.ColumnType:
+    return ct.DateType()
+
+
+class LastValue(Function):
+    """
+    last_value(expr[, ignoreNulls]) - Returns the last value in an ordered set of values.
+    """
+
+    is_aggregation = True
+
+
+@LastValue.register  # type: ignore
+def infer_type(
+    arg: ct.ColumnType,
+    ignore_nulls: Optional[ct.BooleanType] = None,
+) -> ct.ColumnType:
+    # The output type is the same as the input expression's type
+    return arg.type
+
+
+class Lcase(Function):
+    """
+    lcase(str) - Converts the string to lowercase.
+    """
+
+
+@Lcase.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
+    return ct.StringType()
+
+
 class Length(Function):
     """
     Returns the length of a string.

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -125,6 +125,7 @@ class Dispatch(metaclass=DispatchMeta):
             spread_types = temp
         for types in spread_types:
             cls.registry[cls][func_name][tuple(types)] = func  # type: ignore
+        return func
 
     @classmethod
     def dispatch(  # pylint: disable=redefined-outer-name
@@ -675,7 +676,15 @@ class Ceil(Function):
     """
 
 
+class Ceiling(Function):
+    """
+    ceiling(expr[, scale]) - Returns the smallest number after rounding up that is not smaller
+    than expr. An optional scale parameter can be specified to control the rounding behavior.
+    """
+
+
 @Ceil.register
+@Ceiling.register
 def infer_type(
     args: ct.NumberType,
     _target_scale: ct.IntegerType,
@@ -712,6 +721,7 @@ def infer_type(
 
 
 @Ceil.register
+@Ceiling.register
 def infer_type(
     args: ct.DecimalType,
 ) -> ct.DecimalType:
@@ -719,20 +729,10 @@ def infer_type(
 
 
 @Ceil.register
+@Ceiling.register
 def infer_type(
     args: ct.NumberType,
 ) -> ct.BigIntType:
-    return ct.BigIntType()
-
-
-class Ceiling(Function):
-    """
-    ceiling(expr) - Returns the smallest integer greater than or equal to the value expr.
-    """
-
-
-@Ceiling.register  # type: ignore
-def infer_type(arg: ct.NumberType) -> ct.ColumnType:
     return ct.BigIntType()
 
 
@@ -869,10 +869,10 @@ def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
 
 
 @Contains.register  # type: ignore
-def infer_type(  # pragma: no cover
+def infer_type(
     arg1: ct.BinaryType,
     arg2: ct.BinaryType,
-) -> ct.ColumnType:
+) -> ct.ColumnType:  # pragma: no cover
     return ct.BooleanType()
 
 
@@ -985,8 +985,8 @@ class CountIf(Function):
 
 
 @CountIf.register  # type: ignore
-def infer_type(arg: ct.BooleanType) -> ct.ColumnType:
-    return ct.IntegerType()
+def infer_type(arg: ct.BooleanType) -> ct.IntegerType:
+    return ct.IntegerType()  # pragma: no cover
 
 
 class CountMinSketch(Function):
@@ -1222,7 +1222,7 @@ def infer_type(
     start_date: ct.IntegerType,
     end_date: ct.IntegerType,
 ) -> ct.IntegerType:
-    return ct.IntegerType()
+    return ct.IntegerType()  # pragma: no cover
 
 
 class DateFromUnixDate(Function):
@@ -1519,7 +1519,7 @@ class Exists(Function):
 
         expr, func = args
         if len(func.identifiers) != 1:
-            raise DJParseException(
+            raise DJParseException(  # pragma: no cover
                 message="The function `exists` takes a lambda function that takes at "
                 "most one argument.",
             )
@@ -1560,12 +1560,12 @@ class Explode(Function):
 
 @Explode.register  # type: ignore
 def infer_type(arg: ct.ListType) -> ct.ColumnType:
-    return arg.type.element.type
+    return arg.type.element.type  # pragma: no cover
 
 
 @Explode.register  # type: ignore
 def infer_type(arg: ct.MapType) -> ct.ColumnType:
-    return arg.type.value.type
+    return arg.type.value.type  # pragma: no cover
 
 
 class ExplodeOuter(Function):
@@ -1820,7 +1820,7 @@ class Forall(Function):
 
         expr, func = args
         if len(func.identifiers) != 1:
-            raise DJParseException(
+            raise DJParseException(  # pragma: no cover
                 message="The function `forall` takes a lambda function that takes at "
                 "most one argument.",
             )
@@ -2406,11 +2406,11 @@ class Left(Function):
 
 
 @Left.register  # type: ignore
-def infer_type(  # pragma: no cover  # see test_left_func
+def infer_type(
     arg1: ct.StringType,
     arg2: ct.IntegerType,
 ) -> ct.StringType:
-    return ct.StringType()
+    return ct.StringType()  # pragma: no cover  # see test_left_func
 
 
 class Len(Function):
@@ -2778,7 +2778,7 @@ class MapFilter(Function):
 
         expr, func = args
         if len(func.identifiers) != 2:
-            raise DJParseException(
+            raise DJParseException(  # pragma: no cover
                 message="The function `map_filter` takes a lambda function that takes "
                 "exactly two arguments.",
             )
@@ -3047,17 +3047,8 @@ class MonthsBetween(Function):
 
 @MonthsBetween.register
 def infer_type(
-    arg: ct.StringType,
-    arg2: ct.StringType,
-    arg3: Optional[ct.BooleanType] = None,
-) -> ct.BigIntType:
-    return ct.FloatType()
-
-
-@MonthsBetween.register
-def infer_type(
-    arg: ct.TimestampType,
-    arg2: ct.TimestampType,
+    arg: Union[ct.StringType, ct.TimestampType],
+    arg2: Union[ct.StringType, ct.TimestampType],
     arg3: Optional[ct.BooleanType] = None,
 ) -> ct.BigIntType:
     return ct.FloatType()
@@ -3128,7 +3119,7 @@ class Not(Function):
 
 @Not.register  # type: ignore
 def infer_type(arg: ct.BooleanType) -> ct.ColumnType:
-    return ct.BooleanType()
+    return ct.BooleanType()  # pragma: no cover
 
 
 class Now(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1258,7 +1258,8 @@ class DatePart(Function):
 
 @DatePart.register  # type: ignore
 def infer_type(
-    arg1: ct.StringType, arg2: Union[ct.DateType, ct.TimestampType],
+    arg1: ct.StringType,
+    arg2: Union[ct.DateType, ct.TimestampType],
 ) -> ct.ColumnType:
     # The output can be integer, float, or string depending on the part extracted.
     # Here we assume the output is an integer for simplicity. Adjust as needed.
@@ -1298,6 +1299,125 @@ def infer_type(
     arg: Union[ct.StringType, ct.DateType, ct.TimestampType],
 ) -> ct.IntegerType:  # type: ignore
     return ct.IntegerType()
+
+
+class Dayofmonth(Function):
+    """
+    dayofmonth(date) - Extracts the day of the month of a given date.
+    """
+
+
+@Dayofmonth.register  # type: ignore
+def infer_type(
+    arg: Union[ct.DateType, ct.StringType],
+) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Dayofweek(Function):
+    """
+    dayofweek(date) - Extracts the day of the week of a given date.
+    """
+
+
+@Dayofweek.register  # type: ignore
+def infer_type(
+    arg: Union[ct.DateType, ct.StringType],
+) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Dayofyear(Function):
+    """
+    dayofyear(date) - Extracts the day of the year of a given date.
+    """
+
+
+@Dayofyear.register  # type: ignore
+def infer_type(
+    arg: Union[ct.DateType, ct.StringType],
+) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Decimal(Function):
+    """
+    decimal(expr, precision, scale) - Converts expr to a decimal number.
+    """
+
+
+@Decimal.register  # type: ignore
+def infer_type(
+    arg1: Union[ct.IntegerType, ct.FloatType, ct.StringType],
+) -> ct.ColumnType:
+    return ct.DecimalType(8, 6)
+
+
+class Decode(Function):
+    """
+    decode(bin, charset) - Decodes the first argument using the second argument
+    character set.
+
+    TODO: decode(expr, search, result [, search, result ] ... [, default]) - Compares
+    expr to each search value in order. If expr is equal to a search value, decode
+    returns the corresponding result. If no match is found, then it returns default.
+    If default is omitted, it returns null.
+    """
+
+
+@Decode.register  # type: ignore
+def infer_type(arg1: ct.BinaryType, arg2: ct.StringType) -> ct.ColumnType:
+    return ct.StringType()
+
+
+class Degrees(Function):
+    """
+    degrees(expr) - Converts radians to degrees.
+    """
+
+
+@Degrees.register  # type: ignore
+def infer_type(arg: ct.NumberType) -> ct.ColumnType:
+    return ct.FloatType()
+
+
+class DenseRank(Function):  # pragma: no cover
+    """
+    TODO
+    dense_rank() - Computes the dense rank of a value in a group of values.
+    """
+
+
+class Div(Function):
+    """
+    TODO
+    expr1 div expr2 - Divide expr1 by expr2. It returns NULL if an operand is NULL or
+    expr2 is 0. The result is casted to long.
+    """
+
+
+class Double(Function):
+    """
+    double(expr) - Converts expr to a double precision floating-point number.
+    """
+
+
+@Double.register  # type: ignore
+def infer_type(
+    arg: Union[ct.IntegerType, ct.FloatType, ct.StringType],
+) -> ct.ColumnType:
+    return ct.DoubleType()
+
+
+class E(Function):  # pylint: disable=invalid-name
+    """
+    e() - Returns the mathematical constant e.
+    """
+
+
+@E.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.FloatType()
 
 
 class ElementAt(Function):
@@ -2138,6 +2258,19 @@ class Trim(Function):
 @Trim.register
 def infer_type(arg: ct.StringType) -> ct.StringType:
     return ct.StringType()
+
+
+class Unhex(Function):
+    """
+    unhex(str) - Interprets each pair of characters in the input string as a
+    hexadecimal number and converts it to the byte that number represents.
+    The output is a binary string.
+    """
+
+
+@Unhex.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.ColumnType:
+    return ct.BinaryType()
 
 
 class Upper(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2606,6 +2606,108 @@ def infer_type(
     return ct.DateType()
 
 
+class MakeDtInterval(Function):
+    """
+    make_dt_interval(days, hours, mins, secs) - Returns a day-time interval.
+    """
+
+
+@MakeDtInterval.register  # type: ignore
+def infer_type(
+    days: ct.IntegerType,
+    hours: ct.IntegerType,
+    mins: ct.IntegerType,
+    secs: ct.IntegerType,
+) -> ct.DayTimeIntervalType:
+    return ct.DayTimeIntervalType()
+
+
+class MakeInterval(Function):
+    """
+    make_interval(years, months) - Returns a year-month interval.
+    """
+
+
+@MakeInterval.register  # type: ignore
+def infer_type(
+    years: ct.IntegerType,
+    months: ct.IntegerType,
+) -> ct.YearMonthIntervalType:
+    return ct.YearMonthIntervalType()
+
+
+class MakeTimestamp(Function):
+    """
+    make_timestamp(year, month, day, hour, min, sec) - Returns a timestamp
+    made from the arguments.
+    """
+
+
+@MakeTimestamp.register  # type: ignore
+def infer_type(  # pylint: disable=too-many-arguments
+    year: ct.IntegerType,
+    month: ct.IntegerType,
+    day: ct.IntegerType,
+    hour: ct.IntegerType,
+    min_: ct.IntegerType,
+    sec: ct.IntegerType,
+) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
+class MakeTimestampLtz(Function):
+    """
+    make_timestamp_ltz(year, month, day, hour, min, sec, timezone)
+    Returns a timestamp with local time zone.
+    """
+
+
+@MakeTimestampLtz.register  # type: ignore
+def infer_type(  # pylint: disable=too-many-arguments
+    year: ct.IntegerType,
+    month: ct.IntegerType,
+    day: ct.IntegerType,
+    hour: ct.IntegerType,
+    min_: ct.IntegerType,
+    sec: ct.IntegerType,
+    timezone: Optional[ct.StringType] = None,
+) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
+class MakeTimestampNtz(Function):
+    """
+    make_timestamp_ntz(year, month, day, hour, min, sec)
+    Returns a timestamp without time zone.
+    """
+
+
+@MakeTimestampNtz.register  # type: ignore
+def infer_type(  # pylint: disable=too-many-arguments
+    year: ct.IntegerType,
+    month: ct.IntegerType,
+    day: ct.IntegerType,
+    hour: ct.IntegerType,
+    min_: ct.IntegerType,
+    sec: ct.IntegerType,
+) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
+class MakeYmInterval(Function):
+    """
+    make_ym_interval(years, months) - Returns a year-month interval.
+    """
+
+
+@MakeYmInterval.register  # type: ignore
+def infer_type(
+    years: ct.IntegerType,
+    months: ct.IntegerType,
+) -> ct.YearMonthIntervalType:
+    return ct.YearMonthIntervalType()
+
+
 class Map(Function):
     """
     Returns a map of constants

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2368,6 +2368,61 @@ def infer_type(arg: ct.StringType) -> ct.ColumnType:
     return ct.StringType()
 
 
+class Lead(Function):
+    """
+    lead(expr[, offset[, default]]) - Returns the value that is `offset`
+    rows after the current row in a window partition.
+    """
+
+
+@Lead.register  # type: ignore
+def infer_type(
+    arg: ct.ColumnType,
+    offset: Optional[ct.IntegerType] = None,
+    default: Optional[ct.ColumnType] = None,
+) -> ct.ColumnType:
+    # The output type is the same as the input expression's type
+    return arg.type
+
+
+class Least(Function):
+    """
+    least(expr1, expr2, ...) - Returns the smallest value of the list of values.
+    """
+
+
+@Least.register  # type: ignore
+def infer_type(*args: ct.ColumnType) -> ct.ColumnType:
+    # The output type is the same as the input expressions' type
+    # Assuming all input expressions have the same type
+    return args[0].type
+
+
+class Left(Function):
+    """
+    left(str, len) - Returns the leftmost `len` characters from the string.
+    """
+
+
+@Left.register  # type: ignore
+def infer_type(  # pragma: no cover  # see test_left_func
+    arg1: ct.StringType,
+    arg2: ct.IntegerType,
+) -> ct.StringType:
+    return ct.StringType()
+
+
+class Len(Function):
+    """
+    len(str) - Returns the length of the string.
+    """
+
+
+@Len.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.IntegerType:
+    return ct.IntegerType()
+
+
 class Length(Function):
     """
     Returns the length of a string.

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1139,6 +1139,39 @@ def infer_type() -> ct.TimestampType:
     return ct.TimestampType()
 
 
+class CurrentTimezone(Function):
+    """
+    current_timezone() - Returns the current timezone.
+    """
+
+
+@CurrentTimezone.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.StringType()
+
+
+class CurrentUser(Function):
+    """
+    current_user() - Returns the current user.
+    """
+
+
+@CurrentUser.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.StringType()
+
+
+class Date(Function):
+    """
+    date(expr) - Converts expr to date.
+    """
+
+
+@Date.register  # type: ignore
+def infer_type(arg: Union[ct.StringType, ct.TimestampType]) -> ct.ColumnType:
+    return ct.DateType()
+
+
 class DateAdd(Function):
     """
     Adds a specified number of days to a date.

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3143,6 +3143,96 @@ def infer_type() -> ct.TimestampType:
     return ct.TimestampType()
 
 
+class NthValue(Function):
+    """
+    nth_value(input[, offset]) - Returns the value of input at the row
+    that is the offset-th row from beginning of the window frame
+    """
+
+
+@NthValue.register  # type: ignore
+def infer_type(expr: ct.ColumnType, offset: ct.IntegerType) -> ct.ColumnType:
+    return expr.type
+
+
+class Ntile(Function):
+    """
+    ntile(n) - Divides the rows for each window partition into n buckets
+    ranging from 1 to at most n.
+    """
+
+
+@Ntile.register  # type: ignore
+def infer_type(n_buckets: ct.IntegerType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Nullif(Function):
+    """
+    nullif(expr1, expr2) - Returns null if expr1 equals expr2, or expr1 otherwise.
+    """
+
+
+@Nullif.register  # type: ignore
+def infer_type(expr1: ct.ColumnType, expr2: ct.ColumnType) -> ct.ColumnType:
+    return expr1.type
+
+
+class Nvl(Function):
+    """
+    nvl(expr1, expr2) - Returns the first argument if it is not null, or the
+    second argument if the first argument is null.
+    """
+
+
+@Nvl.register  # type: ignore
+def infer_type(expr1: ct.ColumnType, expr2: ct.ColumnType) -> ct.ColumnType:
+    return expr1.type
+
+
+class Nvl2(Function):
+    """
+    nvl2(expr1, expr2, expr3) - Returns expr3 if expr1 is null, or expr2 otherwise.
+    """
+
+
+@Nvl2.register  # type: ignore
+def infer_type(
+    expr1: ct.ColumnType,
+    expr2: ct.ColumnType,
+    expr3: ct.ColumnType,
+) -> ct.ColumnType:
+    return expr1.type
+
+
+class OctetLength(Function):
+    """
+    octet_length(expr) - Returns the number of bytes in the input string.
+    """
+
+
+@OctetLength.register  # type: ignore
+def infer_type(expr: ct.StringType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Overlay(Function):
+    """
+    overlay(expr1, expr2, start[, length]) - Replaces the substring of expr1
+    specified by start (and optionally length) with expr2.
+    """
+
+
+@Overlay.register  # type: ignore
+def infer_type(
+    input_: ct.StringType,
+    replace: ct.StringType,
+    pos: ct.IntegerType,
+    length: Optional[ct.IntegerType] = None,
+) -> ct.ColumnType:
+    return ct.StringType()
+
+
 class PercentRank(Function):
     """
     percent_rank() - Computes the percentage ranking of a value in a group of values.

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1939,6 +1939,17 @@ def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
     return ct.TimestampType()
 
 
+class Get(Function):
+    """
+    get(expr, index) - Retrieves an element from an array at the specified index or retrieves a value from a map for the given key.
+    """
+
+
+@Get.register  # type: ignore
+def infer_type(arg1: ct.ListType, arg2: ct.IntegerType) -> ct.ColumnType:
+    return arg1.type.element.type
+
+
 class Greatest(Function):
     """
     greatest(expr, ...) - Returns the greatest value of all parameters, skipping null values.

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1941,13 +1941,40 @@ def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
 
 class Get(Function):
     """
-    get(expr, index) - Retrieves an element from an array at the specified index or retrieves a value from a map for the given key.
+    get(expr, index) - Retrieves an element from an array at the specified
+    index or retrieves a value from a map for the given key.
     """
 
 
 @Get.register  # type: ignore
 def infer_type(arg1: ct.ListType, arg2: ct.IntegerType) -> ct.ColumnType:
     return arg1.type.element.type
+
+
+# TODO: Extract the actual output schema  # pylint: disable=fixme
+# class GetJsonObject(Function):
+#     """
+#     get_json_object(jsonString, path) - Extracts a JSON object from a JSON
+#     string based on the JSON path specified.
+#     """
+#
+#
+# @GetJsonObject.register  # type: ignore
+# def infer_type(
+#     arg1: ct.StringType, arg2: ct.StringType
+# ) -> ct.ColumnType:
+#     return ct.StringType()
+
+
+class GetBit(Function):
+    """
+    getbit(expr, pos) - Returns the value of the bit (0 or 1) at the specified position.
+    """
+
+
+@GetBit.register  # type: ignore
+def infer_type(arg1: ct.IntegerType, arg2: ct.IntegerType) -> ct.ColumnType:
+    return ct.IntegerType()
 
 
 class Greatest(Function):
@@ -1961,6 +1988,50 @@ def infer_type(
     *values: ct.NumberType,
 ) -> ct.ColumnType:
     return values[0].type
+
+
+class Grouping(Function):
+    """
+    grouping(col) - Returns 1 if the specified column is aggregated, and 0 otherwise.
+    """
+
+
+@Grouping.register  # type: ignore
+def infer_type(arg: ct.ColumnType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class GroupingId(Function):
+    """
+    grouping_id(cols) - Returns a bit vector with a bit for each grouping column.
+    """
+
+
+@GroupingId.register  # type: ignore
+def infer_type(*args: ct.ColumnType) -> ct.ColumnType:
+    return ct.BigIntType()
+
+
+class Hash(Function):
+    """
+    hash(args) - Returns a hash value of the arguments.
+    """
+
+
+@Hash.register  # type: ignore
+def infer_type(*args: ct.ColumnType) -> ct.ColumnType:
+    return ct.IntegerType()
+
+
+class Hex(Function):
+    """
+    hex(expr) - Converts a number or a string to a hexadecimal string.
+    """
+
+
+@Hex.register  # type: ignore
+def infer_type(arg: Union[ct.IntegerType, ct.StringType]) -> ct.ColumnType:
+    return ct.StringType()
 
 
 class If(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2450,6 +2450,17 @@ def infer_type(
     return ct.IntegerType()
 
 
+class Like(Function):
+    """
+    like(str, pattern) - Performs pattern matching using SQL's LIKE operator.
+    """
+
+
+@Like.register  # type: ignore
+def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
 class Ln(Function):
     """
     Returns the natural logarithm of a number.
@@ -2461,6 +2472,32 @@ def infer_type(
     args: ct.ColumnType,
 ) -> ct.DoubleType:
     return ct.DoubleType()
+
+
+class Localtimestamp(Function):
+    """
+    localtimestamp() - Returns the current timestamp at the system's local time zone.
+    """
+
+
+@Localtimestamp.register  # type: ignore
+def infer_type() -> ct.ColumnType:
+    return ct.TimestampType()
+
+
+class Locate(Function):
+    """
+    locate(substr, str[, pos]) - Returns the position of the first occurrence of substr in str.
+    """
+
+
+@Locate.register  # type: ignore
+def infer_type(
+    arg1: ct.StringType,
+    arg2: ct.StringType,
+    pos: Optional[ct.IntegerType] = None,
+) -> ct.ColumnType:
+    return ct.IntegerType()
 
 
 class Log(Function):

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -597,7 +597,7 @@ def _(ctx: sbp.FunctionCallContext):
     name = visit(ctx.functionName())
     quantifier = visit(ctx.setQuantifier()) if ctx.setQuantifier() else ""
     over = visit(ctx.windowSpec()) if ctx.windowSpec() else None
-    args = visit((ctx.argument))
+    args = visit(ctx.argument)
     return ast.Function(name, args, quantifier=quantifier, over=over)
 
 
@@ -967,8 +967,11 @@ def _(ctx: sbp.SubqueryContext):
 
 
 @visit.register
-def _(ctx: sbp.StructContext) -> ast.Struct:
-    return ast.Struct(visit(ctx.argument))
+def _(ctx: sbp.StructContext) -> ast.Function:
+    return ast.Function(
+        ast.Name("struct"),
+        args=visit(ctx.argument),
+    )
 
 
 @visit.register

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -477,9 +477,10 @@ def test_infer_types_array_map(construction_session: Session):
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
     query.compile(ctx)
-    with pytest.raises(DJParseException) as exc_info:
-        query.select.projection[0].type  # type: ignore  # pylint: disable=pointless-statement
-    assert "Different number of keys and values for MAP" in str(exc_info)
+    assert query.select.projection[0].type == MapType(  # type: ignore
+        key_type=IntegerType(),
+        value_type=StringType(),
+    )
 
     query = parse(
         """

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -811,11 +811,13 @@ def test_count_if_func(session: Session):
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_count_if_func(session: Session):
+def test_count_min_sketch(session: Session):
     """
-    Test the `count_if` function
+    Test the `count_min_sketch` function
     """
-    query = parse("SELECT count_min_sketch(col, 0.5, 0.5, 1) FROM (SELECT (1), (2), (1) AS col)")
+    query = parse(
+        "SELECT count_min_sketch(col, 0.5, 0.5, 1) FROM (SELECT (1), (2), (1) AS col)",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -1414,7 +1416,9 @@ def test_format_number_func(session: Session):
     """
     Test the `format_number` function
     """
-    query = parse("SELECT format_number(12345.6789, 2), format_number(98765.4321, '###.##')")
+    query = parse(
+        "SELECT format_number(12345.6789, 2), format_number(98765.4321, '###.##')",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -1684,8 +1688,10 @@ def test_inline_func(session: Session):
     Test the `inline` function
     """
     # This test assumes there's a table with a column of type ARRAY<STRUCT<a: INT, b: STRING>>
-    query = parse("SELECT inline(col1), inline_outer(array(struct(1, 'a'), struct(2, 'b')))"
-                  " FROM (SELECT (array(struct('a', 1, 'b', '222'))) AS col1)")
+    query = parse(
+        "SELECT inline(col1), inline_outer(array(struct(1, 'a'), struct(2, 'b')))"
+        " FROM (SELECT (array(struct('a', 1, 'b', '222'))) AS col1)",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1844,6 +1844,59 @@ def test_lcase_func(session: Session):
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
+def test_lead_func(session: Session):
+    """
+    Test the `lead` function
+    """
+    query = parse("SELECT lead(col, 1, 'N/A') OVER (ORDER BY col) FROM table")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    # The output type depends on the type of `col`
+    # Assuming `col` is of type StringType for this test
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
+def test_least_func(session: Session):
+    """
+    Test the `least` function
+    """
+    query = parse("SELECT least(10, 20, 30, 40)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+# TODO: figure out why antlr parser fails
+# def test_left_func(session: Session):
+#     """
+#     Test the `left` function
+#     """
+#     query = parse("SELECT left('hello world', 5)")
+#     exc = DJException()
+#     ctx = ast.CompileContext(session=session, exception=exc)
+#     query.compile(ctx)
+#     assert not exc.errors
+#     assert query.select.projection[0].type == ct.StringType()  # type: ignore
+#     assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_len_func(session: Session):
+    """
+    Test the `len` function
+    """
+    query = parse("SELECT len('hello'), len('world')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
 def test_max() -> None:
     """
     Test ``Max`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2379,6 +2379,69 @@ def test_months_between(session: Session):
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
 
+def test_named_struct_func(session: Session):
+    """
+    Test the `named_struct` function
+    """
+    query = parse("SELECT named_struct('name', 'cactus', 'age', 30)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StructType(  # type: ignore
+        ct.NestedField(name="name", field_type=ct.StringType()),  # type: ignore
+        ct.NestedField(name="age", field_type=ct.IntegerType()),  # type: ignore
+    )
+
+
+def test_nanvl_func(session: Session):
+    """
+    Test the `nanvl` function
+    """
+    query = parse("SELECT nanvl(cast('NaN' as double), 123)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
+
+
+def test_negative_func(session: Session):
+    """
+    Test the `negative` function
+    """
+    query = parse("SELECT negative(1)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_next_day_func(session: Session):
+    """
+    Test the `next_day` function
+    """
+    query = parse("SELECT next_day('2015-01-14', 'TU')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+
+
+def test_not_func(session: Session):
+    """
+    Test the `not` function
+    """
+    query = parse("SELECT not(true)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
 def test_now() -> None:
     """
     Test ``Now`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2307,6 +2307,78 @@ def test_min() -> None:
         ) == StringType()
 
 
+def test_minute(session: Session):
+    """
+    Test the `minute` function
+    """
+    query = parse(
+        "SELECT minute('2009-07-30 12:58:59'), minute(cast('2009-07-30 12:58:59' as timestamp))",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_mod(session: Session):
+    """
+    Test the `mod` function
+    """
+    query = parse(
+        "SELECT MOD(2, 1.8)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+
+
+def test_mode(session: Session):
+    """
+    Test the `mode` function
+    """
+    query = parse(
+        "SELECT mode(col) FROM (SELECT (0), (10), (10) AS col)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_monotonically_increasing_id(session: Session):
+    """
+    Test the `monotonically_increasing_id` function
+    """
+    query = parse(
+        "SELECT monotonically_increasing_id()",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+
+
+def test_months_between(session: Session):
+    """
+    Test the `months_between` function
+    """
+    query = parse(
+        "SELECT months_between('1997-02-28 10:30:00', '1996-10-30'), "
+        "months_between('1997-02-28 10:30:00', '1996-10-30', false)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+
+
 def test_now() -> None:
     """
     Test ``Now`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1897,6 +1897,47 @@ def test_len_func(session: Session):
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
+def test_like_func(session: Session):
+    """
+    Test the `like` function
+    """
+    query = parse(
+        "SELECT col like '%pattern%' FROM (SELECT ('a'), ('b'), ('c') AS col)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+def test_localtimestamp_func(session: Session):
+    """
+    Test the `localtimestamp` function
+    """
+    query = parse("SELECT localtimestamp()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+def test_locate_func(session: Session):
+    """
+    Test the `locate` function
+    """
+    query = parse(
+        "SELECT locate('world', 'hello world'), locate('SQL', 'hello world', 2)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
 def test_max() -> None:
     """
     Test ``Max`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1129,6 +1129,82 @@ def test_element_at(session: Session):
     assert query_with_map.select.projection[0].type == StringType()  # type: ignore
 
 
+def test_elt_func(session: Session):
+    """
+    Test the `elt` function
+    """
+    query = parse("SELECT elt(1, 'a', 'b', 'c'), elt(3, 'd', 'e', 'f')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_encode_func(session: Session):
+    """
+    Test the `encode` function
+    """
+    query = parse("SELECT encode('hello', 'UTF-8'), encode('world', 'UTF-8')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_endswith_func(session: Session):
+    """
+    Test the `endswith` function
+    """
+    query = parse("SELECT endswith('hello', 'lo'), endswith('world', 'ld')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+    assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
+
+
+def test_equal_null_func(session: Session):
+    """
+    Test the `equal_null` function
+    """
+    query = parse("SELECT equal_null('hello', 'hello'), equal_null(NULL, NULL)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+    assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
+
+
+def test_every_func(session: Session):
+    """
+    Test the `every` function
+    """
+    query = parse("SELECT every(col), every(col) FROM (SELECT (true), (false) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+    assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
+
+
+def test_exists_func(session: Session):
+    """
+    Test the `exists` function
+    """
+    query = parse("SELECT exists(array(1, 2, 3), x -> x % 2 > 0)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
 def test_filter(session: Session):
     """
     Test the `filter` function

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -489,6 +489,7 @@ def test_cardinality(session: Session):
     assert not exc.errors
     assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore
 
+
 def test_cbrt_func(session: Session):
     """
     Test the `cbrt` function
@@ -645,7 +646,9 @@ def test_concat_ws_func(session: Session):
     """
     Test the `concat_ws` function
     """
-    query = parse("SELECT concat_ws(',', 'hello', 'world'), concat_ws('-', 'spark', 'sql', 'function')")
+    query = parse(
+        "SELECT concat_ws(',', 'hello', 'world'), concat_ws('-', 'spark', 'sql', 'function')",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -686,7 +689,9 @@ def test_contains_func(session: Session):
     """
     Test the `contains` function
     """
-    query = parse("SELECT contains('hello world', 'world'), contains('hello world', 'spark')")
+    query = parse(
+        "SELECT contains('hello world', 'world'), contains('hello world', 'spark')",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -712,7 +717,9 @@ def test_convert_timezone_func(session: Session):
     """
     Test the `convert_timezone` function
     """
-    query = parse("SELECT convert_timezone('PST', 'EST', cast('2023-07-30 12:34:56' as timestamp))")
+    query = parse(
+        "SELECT convert_timezone('PST', 'EST', cast('2023-07-30 12:34:56' as timestamp))",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -781,6 +788,136 @@ def test_count() -> None:
         == BigIntType()
     )
     assert Count.is_aggregation is True
+
+
+def test_count_if_func(session: Session):
+    """
+    Test the `count_if` function
+    """
+    query = parse("SELECT count_if(true), count_if(false)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_covar_pop_func(session: Session):
+    """
+    Test the `covar_pop` function
+    """
+    query = parse("SELECT covar_pop(1.0, 2.0), covar_pop(3, 4)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_covar_samp_func(session: Session):
+    """
+    Test the `covar_samp` function
+    """
+    query = parse("SELECT covar_samp(1.0, 2.0), covar_samp(3, 4)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_crc32_func(session: Session):
+    """
+    Test the `crc32` function
+    """
+    query = parse("SELECT crc32('hello'), crc32('world')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+    assert query.select.projection[1].type == ct.BigIntType()  # type: ignore
+
+
+def test_csc_func(session: Session):
+    """
+    Test the `csc` function
+    """
+    query = parse("SELECT csc(1), csc(0.7854)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_cume_dist_func(session: Session):
+    """
+    Test the `cume_dist` function
+    """
+    query = parse("SELECT cume_dist(), cume_dist()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_curdate_func(session: Session):
+    """
+    Test the `curdate` function
+    """
+    query = parse("SELECT curdate(), curdate()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+    assert query.select.projection[1].type == ct.DateType()  # type: ignore
+
+
+def test_current_catalog_func(session: Session):
+    """
+    Test the `current_catalog` function
+    """
+    query = parse("SELECT current_catalog(), current_catalog()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_current_database_func(session: Session):
+    """
+    Test the `current_database` function
+    """
+    query = parse("SELECT current_database(), current_database()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_current_schema_func(session: Session):
+    """
+    Test the `current_schema` function
+    """
+    query = parse("SELECT current_schema(), current_schema()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
 def test_date_format(session: Session) -> None:

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1848,7 +1848,9 @@ def test_lead_func(session: Session):
     """
     Test the `lead` function
     """
-    query = parse("SELECT lead(col, 1, 'N/A') OVER (ORDER BY col) FROM table")
+    query = parse(
+        "SELECT lead(col, 1, 'N/A') OVER (ORDER BY col) FROM (SELECT ('1'), ('a'), ('x') AS col)",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
@@ -1936,6 +1938,61 @@ def test_locate_func(session: Session):
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_log_functions(session: Session):
+    """
+    Test the `log1p`, `log10` and `log2` functions
+    """
+    query = parse(
+        "SELECT log1p(col), log10(col), log2(col) FROM (SELECT (1), (2), (3) as col)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
+    assert query.select.projection[1].type == ct.DoubleType()  # type: ignore
+    assert query.select.projection[2].type == ct.DoubleType()  # type: ignore
+
+
+def test_lpad_func(session: Session):
+    """
+    Test the `lpad` function
+    """
+    query = parse("SELECT lpad('hello', 10, ' '), lpad('SQL', 5, '0')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_ltrim_func(session: Session):
+    """
+    Test the `ltrim` function
+    """
+    query = parse("SELECT ltrim('   hello'), ltrim('-----world-', '-')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_make_date_func(session: Session):
+    """
+    Test the `make_date` function
+    """
+    query = parse("SELECT make_date(2023, 7, 30), make_date(2023, 12, 31)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+    assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
 def test_max() -> None:

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2200,6 +2200,95 @@ def test_max() -> None:
     )
 
 
+# TODO
+# def test_map_zip_with_func(session: Session):
+#     """
+#     Test the `map_zip_with` function
+#     """
+#     # The third argument to map_zip_with is a function, which needs special handling
+#     # Assuming that we have a function "func" defined elsewhere in the code
+#     query = parse("SELECT map_zip_with(map_col1, map_col2, func) FROM table")
+#     exc = DJException()
+#     ctx = ast.CompileContext(session=session, exception=exc)
+#     query.compile(ctx)
+#     assert not exc.errors
+#     assert isinstance(query.select.projection[0].type, ct.MapType)  # type: ignore
+
+
+def test_mask_func(session: Session):
+    """
+    Test the `mask` function
+    """
+    query = parse(
+        "SELECT mask('abcd-EFGH-8765-4321'), "
+        "mask('abcd-EFGH-8765-4321', 'Q'), "
+        "mask('AbCD123-@$#', 'Q', 'q'), "
+        "mask('AbCD123-@$#', 'Q', 'q', 'd'), "
+        "mask('AbCD123-@$#', 'Q', 'q', 'd', 'o')",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+    assert query.select.projection[2].type == ct.StringType()  # type: ignore
+    assert query.select.projection[3].type == ct.StringType()  # type: ignore
+    assert query.select.projection[4].type == ct.StringType()  # type: ignore
+
+
+def test_max_by_min_by_funcs(session: Session):
+    """
+    Test the `max_by` function
+    """
+    query = parse(
+        "SELECT max_by(x, y), min_by(x, y) "
+        "FROM (SELECT ('a'), ('b'), ('c') AS x, (10), (50), (20) AS y)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_md5_func(session: Session):
+    """
+    Test the `md5` function
+    """
+    query = parse("SELECT md5('Spark')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
+def test_mean_func(session: Session):
+    """
+    Test the `mean` function
+    """
+    query = parse("SELECT mean(col) FROM (SELECT (1), (2), (3) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
+
+
+def test_median_func(session: Session):
+    """
+    Test the `median` function
+    """
+    query = parse("SELECT median(col) FROM (SELECT (1), (2), (3) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
+
+
 def test_min() -> None:
     """
     Test ``Min`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1628,6 +1628,96 @@ def test_hypot_func(session: Session):
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
+def test_ilike_func(session: Session):
+    """
+    Test the `ilike` function
+    """
+    query = parse(
+        "SELECT col1 ilike '%pattern%' FROM (SELECT ('aee'), ('bee') AS col1)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+def test_initcap_func(session: Session):
+    """
+    Test the `initcap` function
+    """
+    query = parse("SELECT initcap('hello world'), initcap('SQL function')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+# TODO: fix struct  # pylint: disable=fixme
+# def test_inline_func(session: Session):
+#     """
+#     Test the `inline` function
+#     """
+#     # This test assumes there's a table with a column of type ARRAY<STRUCT<a: INT, b: STRING>>
+#     query = parse("SELECT inline(array_col) FROM (SELECT (array(struct('a', 1, 'b', '222'))) AS col1)")
+#     exc = DJException()
+#     ctx = ast.CompileContext(session=session, exception=exc)
+#     query.compile(ctx)
+#     assert not exc.errors
+#     assert isinstance(query.select.projection[0].type, ct.StructType)  # type: ignore
+
+
+def test_input_file_block_length_func(session: Session):
+    """
+    Test the `input_file_block_length` function
+    """
+    query = parse("SELECT input_file_block_length()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.LongType()  # type: ignore
+
+
+def test_input_file_block_start_func(session: Session):
+    """
+    Test the `input_file_block_start` function
+    """
+    query = parse("SELECT input_file_block_start()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.LongType()  # type: ignore
+
+
+def test_input_file_name_func(session: Session):
+    """
+    Test the `input_file_name` function
+    """
+    query = parse("SELECT input_file_name()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
+def test_instr_func(session: Session):
+    """
+    Test the `instr` function
+    """
+    query = parse("SELECT instr('hello world', 'world'), instr('hello world', 'SQL')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
 def test_max() -> None:
     """
     Test ``Max`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1001,6 +1001,115 @@ def test_dj_logical_timestamp(session: Session) -> None:
     assert query_with_array.select.projection[0].type == StringType()  # type: ignore
 
 
+def test_dayofmonth_func(session: Session):
+    """
+    Test the `dayofmonth` function
+    """
+    query = parse(
+        "SELECT dayofmonth(cast('2023-07-30' as date)), dayofmonth('2023-01-01')",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_dayofweek_func(session: Session):
+    """
+    Test the `dayofweek` function
+    """
+    query = parse(
+        "SELECT dayofweek(cast('2023-07-30' as date)), dayofweek('2023-01-01')",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_dayofyear_func(session: Session):
+    """
+    Test the `dayofyear` function
+    """
+    query = parse(
+        "SELECT dayofyear(cast('2023-07-30' as date)), dayofyear('2023-01-01')",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_decimal_func(session: Session):
+    """
+    Test the `decimal` function
+    """
+    query = parse("SELECT decimal(123), decimal('456.78')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DecimalType(8, 6)  # type: ignore
+    assert query.select.projection[1].type == ct.DecimalType(8, 6)  # type: ignore
+
+
+def test_decode_func(session: Session):
+    """
+    Test the `decode` function
+    """
+    query = parse("SELECT decode(unhex('4D7953514C'), 'UTF-8')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
+def test_degrees_func(session: Session):
+    """
+    Test the `degrees` function
+    """
+    query = parse("SELECT degrees(1), degrees(3.141592653589793)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_double_func(session: Session):
+    """
+    Test the `double` function
+    """
+    query = parse("SELECT double('123.45'), double(67890)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
+    assert query.select.projection[1].type == ct.DoubleType()  # type: ignore
+
+
+def test_e_func(session: Session):
+    """
+    Test the `e` function
+    """
+    query = parse("SELECT e(), e()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
 def test_element_at(session: Session):
     """
     Test the `element_at` Spark function
@@ -1357,6 +1466,19 @@ def test_trim(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
+def test_unhex_func(session: Session):
+    """
+    Test the `unhex` function
+    """
+    query = parse("SELECT unhex('4D'), unhex('7953514C')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BinaryType()  # type: ignore
+    assert query.select.projection[1].type == ct.BinaryType()  # type: ignore
 
 
 def test_upper(session: Session):

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1491,18 +1491,20 @@ def test_get_func(session: Session):
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-# TODO: Fix GetJsonObject to extract output schema
-# def test_get_json_object_func(session: Session):
-#     """
-#     Test the `get_json_object` function
-#     """
-#     query = parse("SELECT get_json_object('{\"key\": \"value\"}', '$.key'), get_json_object('{\"key1\": \"value1\", \"key2\": \"value2\"}', '$.key2')")
-#     exc = DJException()
-#     ctx = ast.CompileContext(session=session, exception=exc)
-#     query.compile(ctx)
-#     assert not exc.errors
-#     assert query.select.projection[0].type == ct.StringType()  # type: ignore
-#     assert query.select.projection[1].type == ct.StringType()  # type: ignore
+def test_get_json_object_func(session: Session):
+    """
+    Test the `get_json_object` function
+    """
+    query = parse(
+        "SELECT get_json_object('{\"key\": \"value\"}', '$.key'), "
+        'get_json_object(\'{"key1": "value1", "key2": "value2"}\', \'$.key2\')',
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
 def test_getbit_func(session: Session):
@@ -1716,6 +1718,58 @@ def test_instr_func(session: Session):
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_isnan_func(session: Session):
+    """
+    Test the `isnan` function
+    """
+    query = parse("SELECT isnan(1/0), isnan(0.0/0.0)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+    assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
+
+
+def test_json_array_length_func(session: Session):
+    """
+    Test the `json_array_length` function
+    """
+    query = parse("SELECT json_array_length('[1, 2, 3]')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_json_object_keys_func(session: Session):
+    """
+    Test the `json_object_keys` function
+    """
+    query = parse('SELECT json_object_keys(\'{"key1": "value1", "key2": "value2"}\')')
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert isinstance(query.select.projection[0].type, ct.ListType)  # type: ignore
+    assert query.select.projection[0].type.element.type == ct.StringType()  # type: ignore
+
+
+def test_json_tuple_func(session: Session):
+    """
+    Test the `json_tuple` function
+    """
+    query = parse(
+        'SELECT json_tuple(\'{"key1": "value1", "key2": "value2"}\', \'key1\', \'key2\')',
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert isinstance(query.select.projection[0].type, ct.ListType)  # type: ignore
 
 
 def test_max() -> None:

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1995,6 +1995,82 @@ def test_make_date_func(session: Session):
     assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
+def test_make_dt_interval_func(session: Session):
+    """
+    Test the `make_dt_interval` function
+    """
+    query = parse("SELECT make_dt_interval(1, 2, 30, 45)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DayTimeIntervalType()  # type: ignore
+
+
+def test_make_interval_func(session: Session):
+    """
+    Test the `make_interval` function
+    """
+    query = parse("SELECT make_interval(1, 6)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.YearMonthIntervalType()  # type: ignore
+
+
+def test_make_timestamp_func(session: Session):
+    """
+    Test the `make_timestamp` function
+    """
+    query = parse("SELECT make_timestamp(2023, 7, 30, 14, 45, 30)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+def test_make_timestamp_ltz_func(session: Session):
+    """
+    Test the `make_timestamp_ltz` function
+    """
+    query = parse(
+        "SELECT make_timestamp_ltz(2023, 7, 30, 14, 45, 30, 'UTC'), "
+        "make_timestamp_ltz(2023, 7, 30, 14, 45, 30)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+    assert query.select.projection[1].type == ct.TimestampType()  # type: ignore
+
+
+def test_make_timestamp_ntz_func(session: Session):
+    """
+    Test the `make_timestamp_ntz` function
+    """
+    query = parse("SELECT make_timestamp_ntz(2023, 7, 30, 14, 45, 30)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+def test_make_ym_interval_func(session: Session):
+    """
+    Test the `make_ym_interval` function
+    """
+    query = parse("SELECT make_ym_interval(1, 6)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.YearMonthIntervalType()  # type: ignore
+
+
 def test_max() -> None:
     """
     Test ``Max`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1205,21 +1205,6 @@ def test_exists_func(session: Session):
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_explode_func(session: Session):
-    """
-    Test the `explode` function
-    """
-    query = parse(
-        "SELECT explode(array(1, 2, 3)), explode(map('key1', 'value1', 'key2', 'value2'))",
-    )
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
-    assert not exc.errors
-    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
-    assert query.select.projection[1].type == ct.StringType()  # type: ignore
-
-
 def test_explode_outer_func(session: Session):
     """
     Test the `explode_outer` function
@@ -1246,6 +1231,19 @@ def test_expm1_func(session: Session):
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_factorial_func(session: Session):
+    """
+    Test the `factorial` function
+    """
+    query = parse("SELECT factorial(0), factorial(5)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
 def test_filter(session: Session):
@@ -1279,6 +1277,19 @@ def test_filter(session: Session):
         query.compile(ctx)
 
 
+def test_find_in_set_func(session: Session):
+    """
+    Test the `find_in_set` function
+    """
+    query = parse("SELECT find_in_set('b', 'a,b,c,d'), find_in_set('e', 'a,b,c,d')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
 def test_first_and_first_value(session: Session):
     """
     Test `first` and `first_value`
@@ -1309,6 +1320,19 @@ def test_flatten(session: Session):
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.IntegerType(),
     )
+
+
+def test_float_func(session: Session):
+    """
+    Test the `float` function
+    """
+    query = parse("SELECT float(123), float('456.78')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2449,6 +2449,98 @@ def test_now() -> None:
     assert Now.infer_type() == ct.TimestampType()
 
 
+def test_nth_value_func(session: Session):
+    """
+    Test the `nth_value` function
+    """
+    query = parse(
+        "SELECT a, b, nth_value(b, 2) OVER (PARTITION BY a ORDER BY b) FROM "
+        "(SELECT ('A1'), ('A2'), ('A1') AS a, (2), (1), (3) AS b)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[2].type == ct.IntegerType()  # type: ignore
+
+
+def test_ntile_func(session: Session):
+    """
+    Test the `ntile` function
+    """
+    query = parse(
+        "SELECT a, b, ntile(2) OVER (PARTITION BY a ORDER BY b) FROM"
+        "(SELECT ('A1'), ('A2'), ('A1') AS a, (2), (1), (3) AS b)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[2].type == ct.IntegerType()  # type: ignore
+
+
+def test_nullif_func(session: Session):
+    """
+    Test the `nullif` function
+    """
+    query = parse("SELECT nullif(2, 2)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_nvl_func(session: Session):
+    """
+    Test the `nvl` function
+    """
+    query = parse("SELECT nvl(array('1'), array('2'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
+
+
+def test_nvl2_func(session: Session):
+    """
+    Test the `nvl2` function
+    """
+    query = parse("SELECT nvl2(3, NULL, 1)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_octet_length_func(session: Session):
+    """
+    Test the `octet_length` function
+    """
+    query = parse("SELECT octet_length('Spark SQL')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_overlay_func(session: Session):
+    """
+    Test the `overlay` function
+    TODO: support syntax like:  # pylint: disable=fixme
+        SELECT overlay(encode('Spark SQL', 'utf-8') PLACING encode('_', 'utf-8') FROM 6);
+    """
+    query = parse("SELECT overlay('Hello World', 'J', 7)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
 def test_rank(session: Session):
     """
     Test `rank`

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -489,6 +489,70 @@ def test_cardinality(session: Session):
     assert not exc.errors
     assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore
 
+def test_cbrt_func(session: Session):
+    """
+    Test the `cbrt` function
+    """
+    query = parse("SELECT cbrt(27), cbrt(64.0)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == FloatType()  # type: ignore
+    assert query.select.projection[1].type == FloatType()  # type: ignore
+
+
+def test_char_func(session: Session):
+    """
+    Test the `char` function
+    """
+    query = parse("SELECT char(65), char(97)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == StringType()  # type: ignore
+    assert query.select.projection[1].type == StringType()  # type: ignore
+
+
+def test_char_length_func(session: Session):
+    """
+    Test the `char_length` function
+    """
+    query = parse("SELECT char_length('hello'), char_length('world')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == IntegerType()  # type: ignore
+    assert query.select.projection[1].type == IntegerType()  # type: ignore
+
+
+def test_character_length_func(session: Session):
+    """
+    Test the `character_length` function
+    """
+    query = parse("SELECT character_length('hello'), character_length('world')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == IntegerType()  # type: ignore
+    assert query.select.projection[1].type == IntegerType()  # type: ignore
+
+
+def test_chr_func(session: Session):
+    """
+    Test the `chr` function
+    """
+    query = parse("SELECT chr(65), chr(97)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == StringType()  # type: ignore
+    assert query.select.projection[1].type == StringType()  # type: ignore
+
 
 @pytest.mark.parametrize(
     "types, expected",
@@ -577,6 +641,19 @@ def test_coalesce_infer_type() -> None:
     )
 
 
+def test_concat_ws_func(session: Session):
+    """
+    Test the `concat_ws` function
+    """
+    query = parse("SELECT concat_ws(',', 'hello', 'world'), concat_ws('-', 'spark', 'sql', 'function')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == StringType()  # type: ignore
+    assert query.select.projection[1].type == StringType()  # type: ignore
+
+
 def test_collect_list(session: Session):
     """
     Test the `collect_list` function
@@ -603,6 +680,96 @@ def test_collect_set(session: Session):
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.IntegerType(),
     )
+
+
+def test_contains_func(session: Session):
+    """
+    Test the `contains` function
+    """
+    query = parse("SELECT contains('hello world', 'world'), contains('hello world', 'spark')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+    assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
+
+
+def test_conv_func(session: Session):
+    """
+    Test the `conv` function
+    """
+    query = parse("SELECT conv('10', 10, 2), conv(15, 10, 16)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_convert_timezone_func(session: Session):
+    """
+    Test the `convert_timezone` function
+    """
+    query = parse("SELECT convert_timezone('PST', 'EST', cast('2023-07-30 12:34:56' as timestamp))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+def test_corr_func(session: Session):
+    """
+    Test the `corr` function
+    """
+    query = parse("SELECT corr(2.0, 3.0), corr(5, 10)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_cos_func(session: Session):
+    """
+    Test the `cos` function
+    """
+    query = parse("SELECT cos(0), cos(3.1416)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_cosh_func(session: Session):
+    """
+    Test the `cosh` function
+    """
+    query = parse("SELECT cosh(0), cosh(1.0)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
+def test_cot_func(session: Session):
+    """
+    Test the `cot` function
+    """
+    query = parse("SELECT cot(1), cot(0.7854)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
 def test_count() -> None:

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1205,6 +1205,49 @@ def test_exists_func(session: Session):
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
+def test_explode_func(session: Session):
+    """
+    Test the `explode` function
+    """
+    query = parse(
+        "SELECT explode(array(1, 2, 3)), explode(map('key1', 'value1', 'key2', 'value2'))",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_explode_outer_func(session: Session):
+    """
+    Test the `explode_outer` function
+    """
+    query = parse(
+        "SELECT explode_outer(array(1, 2, 3)), explode_outer(map('key1', 'value1', 'key2', 'value2'))",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_expm1_func(session: Session):
+    """
+    Test the `expm1` function
+    """
+    query = parse("SELECT expm1(1), expm1(0.5)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
 def test_filter(session: Session):
     """
     Test the `filter` function

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -949,6 +949,19 @@ def test_date_func(session: Session):
     assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
+def test_date_from_unix_date_func(session: Session):
+    """
+    Test the `date_from_unix_date` function
+    """
+    query = parse("SELECT date_from_unix_date(0), date_from_unix_date(18500)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+    assert query.select.projection[1].type == ct.DateType()  # type: ignore
+
+
 def test_date_format(session: Session) -> None:
     """
     Test ``date_format`` function.
@@ -959,6 +972,21 @@ def test_date_format(session: Session) -> None:
     query_with_array.compile(ctx)
     assert not exc.errors
     assert query_with_array.select.projection[0].type == StringType()  # type: ignore
+
+
+def test_date_part_func(session: Session):
+    """
+    Test the `date_part` function
+    """
+    query = parse(
+        "SELECT date_part('year', cast('2023-07-30' as date)), date_part('hour', cast('2023-07-30 12:34:56' as timestamp))",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
 def test_dj_logical_timestamp(session: Session) -> None:

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1478,6 +1478,19 @@ def test_from_utc_timestamp_func(session: Session):
     assert query.select.projection[1].type == ct.TimestampType()  # type: ignore
 
 
+def test_get_func(session: Session):
+    """
+    Test the `get` function
+    """
+    query = parse("SELECT get(array(1, 2, 3), 0), get(array('a', 'b', 'c'), 1)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
 def test_greatest(session: Session):
     """
     Test `greatest`

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -920,6 +920,35 @@ def test_current_schema_func(session: Session):
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
+def test_current_timezone_current_user_funcs(session: Session):
+    """
+    Test the `current_timezone` function
+    Test the `current_user` function
+    """
+    query = parse("SELECT current_timezone(), current_user()")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_date_func(session: Session):
+    """
+    Test the `date` function
+    """
+    query = parse(
+        "SELECT date('2023-07-30'), date(cast('2023-07-30 12:34:56' as timestamp))",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+    assert query.select.projection[1].type == ct.DateType()  # type: ignore
+
+
 def test_date_format(session: Session) -> None:
     """
     Test ``date_format`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1587,6 +1587,47 @@ def test_hex_func(session: Session):
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
+def test_histogram_numeric_func(session: Session):
+    """
+    Test the `histogram_numeric` function
+    """
+    query = parse("SELECT histogram_numeric(col, 5) FROM (SELECT (1), (2) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert isinstance(query.select.projection[0].type, ct.ListType)  # type: ignore
+    assert isinstance(query.select.projection[0].type.element.type, ct.StructType)  # type: ignore
+
+
+def test_hour_func(session: Session):
+    """
+    Test the `hour` function
+    """
+    query = parse(
+        "SELECT hour(cast('2023-01-01 12:34:56' as timestamp)), hour('2023-01-01 23:45:56')",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_hypot_func(session: Session):
+    """
+    Test the `hypot` function
+    """
+    query = parse("SELECT hypot(3, 4), hypot(5.0, 12.0)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.FloatType()  # type: ignore
+    assert query.select.projection[1].type == ct.FloatType()  # type: ignore
+
+
 def test_max() -> None:
     """
     Test ``Max`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1491,6 +1491,33 @@ def test_get_func(session: Session):
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
+# TODO: Fix GetJsonObject to extract output schema
+# def test_get_json_object_func(session: Session):
+#     """
+#     Test the `get_json_object` function
+#     """
+#     query = parse("SELECT get_json_object('{\"key\": \"value\"}', '$.key'), get_json_object('{\"key1\": \"value1\", \"key2\": \"value2\"}', '$.key2')")
+#     exc = DJException()
+#     ctx = ast.CompileContext(session=session, exception=exc)
+#     query.compile(ctx)
+#     assert not exc.errors
+#     assert query.select.projection[0].type == ct.StringType()  # type: ignore
+#     assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
+def test_getbit_func(session: Session):
+    """
+    Test the `getbit` function
+    """
+    query = parse("SELECT getbit(1010, 0), getbit(1010, 1)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
 def test_greatest(session: Session):
     """
     Test `greatest`
@@ -1501,6 +1528,63 @@ def test_greatest(session: Session):
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_grouping_func(session: Session):
+    """
+    Test the `grouping` function
+    """
+    query = parse(
+        "SELECT grouping(col1), grouping(col2) FROM "
+        "(SELECT (1), (2) AS col1, (3), (4) AS col2) GROUP BY col1",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_grouping_id_func(session: Session):
+    """
+    Test the `grouping_id` function
+    """
+    query = parse(
+        "SELECT grouping_id(col1, col2) FROM "
+        "(SELECT (1), (2) AS col1, (3), (4) AS col2) GROUP BY col1",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+
+
+def test_hash_func(session: Session):
+    """
+    Test the `hash` function
+    """
+    query = parse("SELECT hash('hello'), hash(123)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_hex_func(session: Session):
+    """
+    Test the `hex` function
+    """
+    query = parse("SELECT hex('hello'), hex(123)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
 def test_max() -> None:

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1772,6 +1772,78 @@ def test_json_tuple_func(session: Session):
     assert isinstance(query.select.projection[0].type, ct.ListType)  # type: ignore
 
 
+def test_kurtosis_func(session: Session):
+    """
+    Test the `kurtosis` function
+    """
+    query = parse("SELECT kurtosis(col) FROM (SELECT (1), (2), (3) AS col)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
+
+
+def test_lag_func(session: Session):
+    """
+    Test the `lag` function
+    """
+    query = parse(
+        "SELECT lag(col) OVER (ORDER BY col) FROM (SELECT (1), (2), (3) AS col)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    # The output type depends on the type of `col`
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+def test_last_and_last_value(session: Session):
+    """
+    Test the `last` function
+    """
+    query = parse(
+        "SELECT last(col) OVER (PARTITION BY col2 ORDER BY col3), "
+        "last_value(col) OVER (PARTITION BY col2 ORDER BY col3) "
+        "FROM (SELECT (1), (2), (3) AS col, (1), (2), (3) AS col2, "
+        "(3), (4), (5) as col3)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    # The output type depends on the type of `col`
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+
+
+def test_last_day_func(session: Session):
+    """
+    Test the `last_day` function
+    """
+    query = parse("SELECT last_day('2023-01-01'), last_day(cast('2023-02-15' as date))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+    assert query.select.projection[1].type == ct.DateType()  # type: ignore
+
+
+def test_lcase_func(session: Session):
+    """
+    Test the `lcase` function
+    """
+    query = parse("SELECT lcase('HELLO'), lcase('WORLD')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    assert query.select.projection[1].type == ct.StringType()  # type: ignore
+
+
 def test_max() -> None:
     """
     Test ``Max`` function.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2071,6 +2071,115 @@ def test_make_ym_interval_func(session: Session):
     assert query.select.projection[0].type == ct.YearMonthIntervalType()  # type: ignore
 
 
+def test_map_concat_func(session: Session):
+    """
+    Test the `map_concat` function
+    """
+    query = parse("SELECT map_concat(map(1, 'a', 2, 'b'), map(1, 'c'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.MapType(key_type=ct.IntegerType(), value_type=ct.StringType())  # type: ignore
+
+
+def test_map_contains_key_func(session: Session):
+    """
+    Test the `map_contains_key` function
+    """
+    query = parse("SELECT map_contains_key(map(1, 'a', 2, 'b'), 1)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+def test_map_entries_func(session: Session):
+    """
+    Test the `map_entries` function
+    """
+    query = parse("SELECT map_entries(map(1, 'a', 2, 'b'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(  # type: ignore
+        element_type=ct.StructType(
+            ct.NestedField(name="key", field_type=ct.IntegerType()),  # type: ignore
+            ct.NestedField(name="value", field_type=ct.StringType()),  # type: ignore
+        ),
+    )  # type: ignore
+
+
+def test_map_filter_func(session: Session):
+    """
+    Test the `map_filter` function
+    """
+    query = parse("SELECT map_filter(map(1, 0, 2, 2, 3, -1), (k, v) -> k > v)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert query.select.projection[0].type == ct.MapType(  # type: ignore
+        key_type=ct.IntegerType(),
+        value_type=ct.IntegerType(),
+    )
+
+
+def test_map_from_arrays_func(session: Session):
+    """
+    Test the `map_from_arrays` function
+    """
+    query = parse("SELECT map_from_arrays(array(1.0, 3.0), array('2', '4'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.MapType(  # type: ignore
+        key_type=ct.FloatType(),
+        value_type=ct.StringType(),
+    )
+
+
+def test_map_from_entries_func(session: Session):
+    """
+    Test the `map_from_entries` function
+    """
+    query = parse("SELECT map_from_entries(array(struct(1, 'a'), struct(2, 'b')))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.MapType(  # type: ignore
+        key_type=ct.IntegerType(),
+        value_type=ct.StringType(),
+    )
+
+
+def test_map_keys_func(session: Session):
+    """
+    Test the `map_keys` function
+    """
+    query = parse("SELECT map_keys(map(1, 'a', 2, 'b'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
+
+
+def test_map_values_func(session: Session):
+    """
+    Test the `map_values` function
+    """
+    query = parse("SELECT map_values(map(1, 'a', 2, 'b'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
+
+
 def test_max() -> None:
     """
     Test ``Max`` function.


### PR DESCRIPTION
### Summary

(fyi going down this list in alphabetical order: https://spark.apache.org/docs/latest/api/sql/index.html)

Added the following SparkSQL functions:

- cbrt
- ceiling
- char
- char_length
- character_length
- chr
- concat_ws
- contains
- conv
- convert_timezone
- corr
- cos
- cot
- cosh
- datediff
- int
- count_if
- count_min_sketch
- covar_pop
- covar_samp
- crc32
- csc
- cume_dist
- curdate
- current_catalog
- current_database
- current_schema
- current_timezone
- current_user
- date
- date_from_unix_date
- date_part
- dayofmonth
- dayofweek
- dayofyear
- decimal
- decode
- degrees
- double
- e
- unhex
- elt
- encode
- endswith
- equal_null
- every
- exists
- explode
- explode_outer
- expm1
- factorial
- find_in_set
- float
- forall
- format_number
- format_string
- from_csv
- from_json
- from_unixtime
- from_utc_timestamp
- get
- grouping
- grouping_id
- hash
- hex
- histogram_numeric
- hour
- hypot
- ilike
- initcap
- inline (needs more work)
- inline_outer (needs more work)
- input_file_block_length
- input_file_block_start
- input_file_name
- instr
- isnan
- isnotnull
- isnull
- json_array_length
- json_object_keys
- json_tuple
- kurtosis
- lag
- last
- last_day
- last_value
- lcase
- lead
- least
- left
- len
- like
- localtimestamp
- locate
- log1p
- lpad
- ltrim
- make_date
- make_dt_interval
- make_interval
- make_timestamp
- make_timestamp_ltz
- make_timestamp_ntz
- make_ym_interval
- map_concat
- map_contains_key
- map_entries
- map_filter
- map_from_arrays
- map_from_entries
- map_keys
- map_values
- struct
- mask
- max_by
- md5
- mean
- median
- min_by
- minute
- mod
- mode
- monotonically_increasing_id
- months_between
- named_struct
- nanvl
- negative
- next_day
- not
- nth_value
- ntile
- nullif
- nvl
- nvl2
- octet_length
- overlay

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #544 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
