### PR TITLE
Allow deleting (aka deactivating) materializations

### DIFF
--- a/datajunction-server/alembic/versions/2023_07_30_1608-4147da2ac841_add_deactivated_to_materialization.py
+++ b/datajunction-server/alembic/versions/2023_07_30_1608-4147da2ac841_add_deactivated_to_materialization.py
@@ -1,0 +1,27 @@
+"""Add deactivated to materialization
+
+Revision ID: 4147da2ac841
+Revises: 5c3d0c958c3c
+Create Date: 2023-07-30 16:08:40.416585+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '4147da2ac841'
+down_revision = '5c3d0c958c3c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('materialization', sa.Column('deactivated_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade():
+    op.drop_column('materialization', 'deactivated_at')

--- a/datajunction-server/alembic/versions/2023_07_30_1608-4147da2ac841_add_deactivated_to_materialization.py
+++ b/datajunction-server/alembic/versions/2023_07_30_1608-4147da2ac841_add_deactivated_to_materialization.py
@@ -9,19 +9,22 @@ Create Date: 2023-07-30 16:08:40.416585+00:00
 
 import sqlalchemy as sa
 import sqlmodel
+
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
-revision = '4147da2ac841'
-down_revision = '5c3d0c958c3c'
+revision = "4147da2ac841"
+down_revision = "5c3d0c958c3c"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('materialization', sa.Column('deactivated_at', sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "materialization",
+        sa.Column("deactivated_at", sa.DateTime(timezone=True), nullable=True),
+    )
 
 
 def downgrade():
-    op.drop_column('materialization', 'deactivated_at')
+    op.drop_column("materialization", "deactivated_at")

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -856,6 +856,16 @@ def deactivate_node_materializations(
                 second=now.second,
             )
             session.add(materialization)
+
+    session.add(
+        History(
+            entity_type=EntityType.MATERIALIZATION,
+            entity_name=materialization_name,
+            node=node.name,
+            activity_type=ActivityType.DELETE,
+            details={},
+        ),
+    )
     session.commit()
     session.refresh(node.current)
     return JSONResponse(

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -812,7 +812,7 @@ def list_node_materializations(
     node = get_node_by_name(session, node_name, with_current=True)
     materializations = []
     for materialization in node.current.materializations:
-        if not materialization.deactivated_at or show_deleted:
+        if not materialization.deactivated_at or show_deleted:  # pragma: no cover
             info = query_service_client.get_materialization_info(
                 node_name,
                 node.current.version,  # type: ignore
@@ -845,7 +845,7 @@ def deactivate_node_materializations(
     node = get_node_by_name(session, node_name, with_current=True)
     query_service_client.deactivate_materialization(node_name, materialization_name)
     for materialization in node.current.materializations:
-        if materialization.name == materialization_name:
+        if materialization.name == materialization_name:  # pragma: no cover
             now = datetime.utcnow()
             materialization.deactivated_at = UTCDatetime(
                 year=now.year,
@@ -858,7 +858,13 @@ def deactivate_node_materializations(
             session.add(materialization)
     session.commit()
     session.refresh(node.current)
-    return node.current.materializations
+    return JSONResponse(
+        status_code=HTTPStatus.NO_CONTENT,
+        content={
+            "message": f"The materialization named `{materialization_name}` on node `{node_name}` "
+            "has been successfully deactivated",
+        },
+    )
 
 
 @router.get("/nodes/{name}/revisions/", response_model=List[NodeRevisionOutput])

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -729,6 +729,15 @@ def upsert_a_materialization(  # pylint: disable=too-many-locals
         if existing_materialization.deactivated_at is not None:
             deactivated_before = True
             existing_materialization.deactivated_at = None  # type: ignore
+            session.add(
+                History(
+                    entity_type=EntityType.MATERIALIZATION,
+                    entity_name=existing_materialization.name,
+                    node=node.name,
+                    activity_type=ActivityType.RESTORE,
+                    details={},
+                ),
+            )
             session.commit()
             session.refresh(existing_materialization)
         existing_materialization_info = query_service_client.get_materialization_info(

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from pydantic import AnyHttpUrl, BaseModel, validator
 from sqlalchemy import JSON
 from sqlalchemy import Column as SqlaColumn
-from sqlalchemy import String
+from sqlalchemy import DateTime, String
 from sqlmodel import Field, Relationship, SQLModel
 
 from datajunction_server.models.base import BaseSQLModel
 from datajunction_server.models.engine import Engine, EngineInfo, EngineRef
+from datajunction_server.typing import UTCDatetime
 
 if TYPE_CHECKING:
     from datajunction_server.models import NodeRevision
@@ -265,6 +266,12 @@ class Materialization(BaseSQLModel, table=True):  # type: ignore
     job: str = Field(
         default="MaterializationJob",
         sa_column=SqlaColumn("job", String),
+    )
+
+    deactivated_at: UTCDatetime = Field(
+        nullable=True,
+        sa_column=SqlaColumn(DateTime(timezone=True)),
+        default=None,
     )
 
     @validator("config")

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -157,6 +157,26 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         result = response.json()
         return MaterializationInfo(**result)
 
+    def deactivate_materialization(
+        self,
+        node_name: str,
+        materialization_name: str,
+    ) -> MaterializationInfo:
+        """
+        Deactivates the specified node materialization
+        """
+        response = self.requests_session.delete(
+            "/materialization/",
+            params={
+                "node_name": node_name,
+                "materialization_name": materialization_name,
+            },
+        )
+        if not response.ok:  # pragma: no cover
+            return MaterializationInfo(urls=[], output_tables=[])
+        result = response.json()
+        return MaterializationInfo(**result)
+
     def get_materialization_info(
         self,
         node_name: str,

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -1,7 +1,7 @@
+# pylint: disable=too-many-lines
 """
 Tests for the data API.
 """
-# pylint: disable=too-many-lines
 from typing import Dict, List, Optional
 from unittest import mock
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1941,7 +1941,7 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
                 "urls": ["http://fake.url/job"],
             },
             "message": "The same materialization config with name "
-            "`country_3491792861`already exists for node "
+            "`country_3491792861` already exists for node "
             "`basic.transform.country_agg` so no update was performed.",
         }
 
@@ -1953,6 +1953,32 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             "message": "The materialization named `country_3491792861` on node "
             "`basic.transform.country_agg` has been successfully deactivated",
         }
+
+        # Setting it again should inform that it already exists but was reactivated
+        response = client_with_query_service.post(
+            "/nodes/basic.transform.country_agg/materialization/",
+            json={
+                "engine": {
+                    "name": "spark",
+                    "version": "2.4.4",
+                },
+                "config": {
+                    "partitions": [
+                        {
+                            "name": "country",
+                            "values": ["DE", "MY"],
+                            "type_": "categorical",
+                        },
+                    ],
+                },
+                "schedule": "0 * * * *",
+            },
+        )
+        assert response.json()["message"] == (
+            "The same materialization config with name `country_3491792861` already "
+            "exists for node `basic.transform.country_agg` but was deactivated. It has "
+            "now been restored."
+        )
 
         # Setting the materialization config without partitions should succeed
         response = client_with_query_service.post(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1945,6 +1945,15 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             "`basic.transform.country_agg` so no update was performed.",
         }
 
+        response = client_with_query_service.delete(
+            "/nodes/basic.transform.country_agg/materializations/"
+            "?materialization_name=country_3491792861",
+        )
+        assert response.json() == {
+            "message": "The materialization named `country_3491792861` on node "
+            "`basic.transform.country_agg` has been successfully deactivated",
+        }
+
         # Setting the materialization config without partitions should succeed
         response = client_with_query_service.post(
             "/nodes/basic.transform.country_agg/materialization/",

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1979,6 +1979,22 @@ class TestCreateOrUpdateNodes:  # pylint: disable=too-many-public-methods
             "exists for node `basic.transform.country_agg` but was deactivated. It has "
             "now been restored."
         )
+        response = client_with_query_service.get(
+            "/history?node=basic.transform.country_agg",
+        )
+        assert [
+            (
+                activity["activity_type"],
+                activity["entity_type"],
+                activity["entity_name"],
+            )
+            for activity in response.json()
+        ] == [
+            ("create", "node", "basic.transform.country_agg"),
+            ("create", "materialization", "country_3491792861"),
+            ("delete", "materialization", "country_3491792861"),
+            ("restore", "materialization", "country_3491792861"),
+        ]
 
         # Setting the materialization config without partitions should succeed
         response = client_with_query_service.post(

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -124,13 +124,6 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         "get_query",
         mock_get_query,
     )
-    #
-    # def mock_materialize(
-    #     materialization_input: Union[GenericMaterializationInput, DruidMaterializationInput],
-    # ) -> MaterializationOutput:
-    #     return MaterializationOutput(
-    #         urls=["http://fake.url/job"],
-    #     )
 
     mock_materialize = MagicMock()
     mock_materialize.return_value = MaterializationInfo(
@@ -141,6 +134,17 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         qs_client,
         "materialize",
         mock_materialize,
+    )
+
+    mock_deactivate_materialization = MagicMock()
+    mock_deactivate_materialization.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=[],
+    )
+    mocker.patch.object(
+        qs_client,
+        "deactivate_materialization",
+        mock_deactivate_materialization,
     )
 
     mock_get_materialization_info = MagicMock()

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -260,6 +260,39 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             },
         )
 
+    def test_query_service_client_deactivate_materialization(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """
+        Test deactivate materialization from a query service client.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "urls": ["http://fake.url/job"],
+            "output_tables": ["common.a", "common.b"],
+        }
+
+        mock_request = mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.delete",
+            return_value=mock_response,
+        )
+
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        query_service_client.deactivate_materialization(
+            node_name="default.hard_hat",
+            materialization_name="default",
+        )
+
+        mock_request.assert_called_with(
+            "/materialization/",
+            params={
+                "node_name": "default.hard_hat",
+                "materialization_name": "default",
+            },
+        )
+
     def test_query_service_client_raising_error(self, mocker: MockerFixture) -> None:
         """
         Test handling an error response from the query service client


### PR DESCRIPTION
### Summary

Add some functionality that lets users delete (or from the internal perspective, deactivate) a materialization by its name. This endpoint will also make a call out to the query service client to deactivate the materialization's associated scheduled jobs.

### Test Plan

- [x] PR has an associated issue: #528 #624 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
