### PR TITLE
Add tags to endpoints + restructure api/nodes.py

### DIFF
--- a/datajunction-server/datajunction_server/api/attributes.py
+++ b/datajunction-server/datajunction_server/api/attributes.py
@@ -33,7 +33,7 @@ def list_attributes(*, session: Session = Depends(get_session)) -> List[Attribut
     "/attributes/",
     response_model=AttributeType,
     status_code=201,
-    name="Add An Attribute Type",
+    name="Add an Attribute Type",
 )
 def add_attribute_type(
     data: MutableAttributeTypeFields, *, session: Session = Depends(get_session)

--- a/datajunction-server/datajunction_server/api/attributes.py
+++ b/datajunction-server/datajunction_server/api/attributes.py
@@ -18,7 +18,7 @@ from datajunction_server.models.node import NodeType
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(tags=["attributes"])
 
 
 @router.get("/attributes/", response_model=List[AttributeType])
@@ -29,8 +29,13 @@ def list_attributes(*, session: Session = Depends(get_session)) -> List[Attribut
     return session.exec(select(AttributeType)).all()
 
 
-@router.post("/attributes/", response_model=AttributeType, status_code=201)
-def add_an_attribute_type(
+@router.post(
+    "/attributes/",
+    response_model=AttributeType,
+    status_code=201,
+    name="Add An Attribute Type",
+)
+def add_attribute_type(
     data: MutableAttributeTypeFields, *, session: Session = Depends(get_session)
 ) -> AttributeType:
     """

--- a/datajunction-server/datajunction_server/api/catalogs.py
+++ b/datajunction-server/datajunction_server/api/catalogs.py
@@ -27,7 +27,7 @@ def list_catalogs(*, session: Session = Depends(get_session)) -> List[CatalogInf
     return list(session.exec(select(Catalog)))
 
 
-@router.get("/catalogs/{name}/", response_model=CatalogInfo, name="Get A Catalog")
+@router.get("/catalogs/{name}/", response_model=CatalogInfo, name="Get a Catalog")
 def get_catalog(name: str, *, session: Session = Depends(get_session)) -> CatalogInfo:
     """
     Return a catalog by name

--- a/datajunction-server/datajunction_server/api/catalogs.py
+++ b/datajunction-server/datajunction_server/api/catalogs.py
@@ -10,13 +10,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
 from datajunction_server.api.engines import EngineInfo, get_engine
-from datajunction_server.api.helpers import get_catalog
+from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.errors import DJException
 from datajunction_server.models.catalog import Catalog, CatalogInfo
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(tags=["catalogs"])
 
 
 @router.get("/catalogs/", response_model=List[CatalogInfo])
@@ -27,16 +27,21 @@ def list_catalogs(*, session: Session = Depends(get_session)) -> List[CatalogInf
     return list(session.exec(select(Catalog)))
 
 
-@router.get("/catalogs/{name}/", response_model=CatalogInfo)
-def get_a_catalog(name: str, *, session: Session = Depends(get_session)) -> CatalogInfo:
+@router.get("/catalogs/{name}/", response_model=CatalogInfo, name="Get A Catalog")
+def get_catalog(name: str, *, session: Session = Depends(get_session)) -> CatalogInfo:
     """
     Return a catalog by name
     """
-    return get_catalog(session, name)
+    return get_catalog_by_name(session, name)
 
 
-@router.post("/catalogs/", response_model=CatalogInfo, status_code=201)
-def add_a_catalog(
+@router.post(
+    "/catalogs/",
+    response_model=CatalogInfo,
+    status_code=201,
+    name="Add A Catalog",
+)
+def add_catalog(
     data: CatalogInfo,
     *,
     session: Session = Depends(get_session),
@@ -45,7 +50,7 @@ def add_a_catalog(
     Add a Catalog
     """
     try:
-        get_catalog(session, data.name)
+        get_catalog_by_name(session, data.name)
     except DJException:
         pass
     else:
@@ -69,8 +74,13 @@ def add_a_catalog(
     return catalog
 
 
-@router.post("/catalogs/{name}/engines/", response_model=CatalogInfo, status_code=201)
-def add_engines_to_a_catalog(
+@router.post(
+    "/catalogs/{name}/engines/",
+    response_model=CatalogInfo,
+    status_code=201,
+    name="Add Engines to a Catalog",
+)
+def add_engines_to_catalog(
     name: str,
     data: List[EngineInfo],
     *,
@@ -79,7 +89,7 @@ def add_engines_to_a_catalog(
     """
     Attach one or more engines to a catalog
     """
-    catalog = get_catalog(session, name)
+    catalog = get_catalog_by_name(session, name)
     catalog.engines.extend(
         list_new_engines(session=session, catalog=catalog, create_engines=data),
     )

--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -13,7 +13,7 @@ from datajunction_server.models.node import NodeType
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(tags=["client"])
 
 
 @router.get("/datajunction-clients/python/new_node/{node_name}", response_model=str)

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 router = APIRouter(tags=["cubes"])
 
 
-@router.get("/cubes/{name}/", response_model=CubeRevisionMetadata, name="Get A Cube")
+@router.get("/cubes/{name}/", response_model=CubeRevisionMetadata, name="Get a Cube")
 def get_cube(
     name: str, *, session: Session = Depends(get_session)
 ) -> CubeRevisionMetadata:

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -12,11 +12,11 @@ from datajunction_server.models.node import NodeType
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(tags=["cubes"])
 
 
-@router.get("/cubes/{name}/", response_model=CubeRevisionMetadata)
-def get_a_cube(
+@router.get("/cubes/{name}/", response_model=CubeRevisionMetadata, name="Get A Cube")
+def get_cube(
     name: str, *, session: Session = Depends(get_session)
 ) -> CubeRevisionMetadata:
     """

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -37,7 +37,7 @@ from datajunction_server.utils import get_query_service_client, get_session
 router = APIRouter(tags=["data"])
 
 
-@router.post("/data/{node_name}/availability/", name="Add Availability State To Node")
+@router.post("/data/{node_name}/availability/", name="Add Availability State to Node")
 def add_availability_state(
     node_name: str,
     data: AvailabilityStateBase,

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -34,11 +34,11 @@ from datajunction_server.models.query import (
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import get_query_service_client, get_session
 
-router = APIRouter()
+router = APIRouter(tags=["data"])
 
 
-@router.post("/data/{node_name}/availability/")
-def add_an_availability_state(
+@router.post("/data/{node_name}/availability/", name="Add Availability State To Node")
+def add_availability_state(
     node_name: str,
     data: AvailabilityStateBase,
     *,
@@ -105,15 +105,21 @@ def add_an_availability_state(
     )
 
 
-@router.get("/data/{node_name}/")
+@router.get("/data/{node_name}/", name="Get Data for a Node")
 def get_data(  # pylint: disable=too-many-locals
     node_name: str,
     *,
-    dimensions: List[str] = Query([]),
-    filters: List[str] = Query([]),
-    orderby: List[str] = Query([]),
-    limit: Optional[int] = None,
-    async_: bool = False,
+    dimensions: List[str] = Query([], description="Dimensional attributes to group by"),
+    filters: List[str] = Query([], description="Filters on dimensional attributes"),
+    orderby: List[str] = Query([], description="Expression to order by"),
+    limit: Optional[int] = Query(
+        None,
+        description="Number of rows to limit the data retrieved to",
+    ),
+    async_: bool = Query(
+        default=False,
+        description="Whether to run the query async or wait for results from the query engine",
+    ),
     session: Session = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
@@ -168,7 +174,7 @@ def get_data(  # pylint: disable=too-many-locals
     return result
 
 
-@router.get("/data/", response_model=QueryWithResults)
+@router.get("/data/", response_model=QueryWithResults, name="Get Data For Metrics")
 def get_data_for_metrics(  # pylint: disable=R0914, R0913
     metrics: List[str] = Query([]),
     dimensions: List[str] = Query([]),

--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -18,7 +18,7 @@ from datajunction_server.sql.dag import (
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(tags=["dimensions"])
 
 
 @router.get("/dimensions/", response_model=List[str])

--- a/datajunction-server/datajunction_server/api/engines.py
+++ b/datajunction-server/datajunction_server/api/engines.py
@@ -12,7 +12,7 @@ from datajunction_server.api.helpers import get_engine
 from datajunction_server.models.engine import Engine, EngineInfo
 from datajunction_server.utils import get_session
 
-router = APIRouter()
+router = APIRouter(tags=["engines"])
 
 
 @router.get("/engines/", response_model=List[EngineInfo])
@@ -33,14 +33,19 @@ def get_an_engine(
     return get_engine(session, name, version)
 
 
-@router.post("/engines/", response_model=EngineInfo, status_code=201)
-def add_an_engine(
+@router.post(
+    "/engines/",
+    response_model=EngineInfo,
+    status_code=201,
+    name="Add An Engine",
+)
+def add_engine(
     data: EngineInfo,
     *,
     session: Session = Depends(get_session),
 ) -> EngineInfo:
     """
-    Add an Engine
+    Add a new engine
     """
     try:
         get_engine(session, data.name, data.version)

--- a/datajunction-server/datajunction_server/api/health.py
+++ b/datajunction-server/datajunction_server/api/health.py
@@ -11,7 +11,7 @@ from sqlmodel import Session, SQLModel
 
 from datajunction_server.utils import get_session
 
-router = APIRouter()
+router = APIRouter(tags=["health"])
 
 
 class HealthcheckStatus(str, enum.Enum):

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -161,7 +161,7 @@ def get_attribute_type(
     return session.exec(statement).one_or_none()
 
 
-def get_catalog(session: Session, name: str) -> Catalog:
+def get_catalog_by_name(session: Session, name: str) -> Catalog:
     """
     Get a catalog by name
     """
@@ -750,7 +750,7 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
         materialized=True,
     )
     if cube:
-        catalog = get_catalog(session, cube.availability.catalog)  # type: ignore
+        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
         available_engines = catalog.engines + available_engines
 
     # Check if selected engine is available, or if none is provided, select the fastest

--- a/datajunction-server/datajunction_server/api/history.py
+++ b/datajunction-server/datajunction_server/api/history.py
@@ -13,7 +13,7 @@ from datajunction_server.models.history import EntityType, History
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(tags=["history"])
 
 
 @router.get("/history/{entity_type}/{entity_name}/", response_model=List[History])

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -28,6 +28,7 @@ from datajunction_server.api import (
     engines,
     health,
     history,
+    materializations,
     metrics,
     namespaces,
     nodes,
@@ -85,6 +86,7 @@ def get_dj_app(
     application.include_router(query.router)
     application.include_router(nodes.router)
     application.include_router(namespaces.router)
+    application.include_router(materializations.router)
     application.include_router(data.router)
     application.include_router(health.router)
     application.include_router(history.router)

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -1,0 +1,240 @@
+# pylint: disable=too-many-lines
+"""
+Node materialization related APIs.
+"""
+import logging
+from datetime import datetime
+from http import HTTPStatus
+from typing import List
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlmodel import Session
+
+from datajunction_server.api.helpers import get_node_by_name
+from datajunction_server.errors import DJException
+from datajunction_server.internal.materializations import (
+    create_new_materialization,
+    schedule_materialization_jobs,
+)
+from datajunction_server.models.history import ActivityType, EntityType, History
+from datajunction_server.models.materialization import (
+    MaterializationConfigInfoUnified,
+    UpsertMaterialization,
+)
+from datajunction_server.models.node import NodeType
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.typing import UTCDatetime
+from datajunction_server.utils import get_query_service_client, get_session
+
+_logger = logging.getLogger(__name__)
+router = APIRouter(tags=["materializations"])
+
+
+@router.post(
+    "/nodes/{name}/materialization/",
+    status_code=201,
+    name="Insert Or Update A Materialization For A Node",
+)
+def upsert_materialization(  # pylint: disable=too-many-locals
+    name: str,
+    data: UpsertMaterialization,
+    *,
+    session: Session = Depends(get_session),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+) -> JSONResponse:
+    """
+    Add or update a materialization of the specified node. If a name is specified
+    for the materialization config, it will always update that named config.
+    """
+    node = get_node_by_name(session, name, with_current=True)
+    if node.type == NodeType.SOURCE:
+        raise DJException(
+            http_status_code=HTTPStatus.BAD_REQUEST,
+            message=f"Cannot set materialization config for source node `{name}`!",
+        )
+    current_revision = node.current
+    old_materializations = {mat.name: mat for mat in current_revision.materializations}
+
+    # Create a new materialization
+    new_materialization = create_new_materialization(session, current_revision, data)
+
+    # Check to see if a materialization for this engine already exists with the exact same config
+    existing_materialization = old_materializations.get(new_materialization.name)
+    deactivated_before = False
+    if (
+        existing_materialization
+        and existing_materialization.config == new_materialization.config
+    ):
+        new_materialization.node_revision = None  # type: ignore
+        # if the materialization was deactivated before, restore it
+        if existing_materialization.deactivated_at is not None:
+            deactivated_before = True
+            existing_materialization.deactivated_at = None  # type: ignore
+            session.add(
+                History(
+                    entity_type=EntityType.MATERIALIZATION,
+                    entity_name=existing_materialization.name,
+                    node=node.name,
+                    activity_type=ActivityType.RESTORE,
+                    details={},
+                ),
+            )
+            session.commit()
+            session.refresh(existing_materialization)
+        existing_materialization_info = query_service_client.get_materialization_info(
+            name,
+            current_revision.version,  # type: ignore
+            new_materialization.name,  # type: ignore
+        )
+        return JSONResponse(
+            status_code=HTTPStatus.CREATED,
+            content={
+                "message": (
+                    f"The same materialization config with name `{new_materialization.name}` "
+                    f"already exists for node `{name}` so no update was performed."
+                    if not deactivated_before
+                    else f"The same materialization config with name `{new_materialization.name}` "
+                    f"already exists for node `{name}` but was deactivated. It has now been "
+                    f"restored."
+                ),
+                "info": existing_materialization_info.dict(),
+            },
+        )
+    # If changes are detected, save the new materialization
+    existing_materialization_names = {
+        mat.name for mat in current_revision.materializations
+    }
+    unchanged_existing_materializations = [
+        config
+        for config in current_revision.materializations
+        if config.name != new_materialization.name
+    ]
+    current_revision.materializations = unchanged_existing_materializations + [  # type: ignore
+        new_materialization,
+    ]
+
+    # This will add the materialization config, the new node rev, and update the node's version.
+    session.add(current_revision)
+    session.add(node)
+
+    session.add(
+        History(
+            entity_type=EntityType.MATERIALIZATION,
+            node=node.name,
+            entity_name=new_materialization.name,
+            activity_type=(
+                ActivityType.CREATE
+                if new_materialization.name in existing_materialization_names
+                else ActivityType.UPDATE
+            ),
+            details={
+                "node": node.name,
+                "materialization": new_materialization.name,
+            },
+        ),
+    )
+    session.commit()
+
+    materialization_response = schedule_materialization_jobs(
+        [new_materialization],
+        query_service_client,
+    )
+    return JSONResponse(
+        status_code=200,
+        content={
+            "message": (
+                f"Successfully updated materialization config named `{new_materialization.name}` "
+                f"for node `{name}`"
+            ),
+            "urls": [output.urls for output in materialization_response.values()],
+        },
+    )
+
+
+@router.get(
+    "/nodes/{node_name}/materializations/",
+    response_model=List[MaterializationConfigInfoUnified],
+    name="List Materializations For A Node",
+)
+def list_node_materializations(
+    node_name: str,
+    show_deleted: bool = False,
+    *,
+    session: Session = Depends(get_session),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+) -> List[MaterializationConfigInfoUnified]:
+    """
+    Show all materializations configured for the node, with any associated metadata
+    like urls from the materialization service, if available.
+    """
+    node = get_node_by_name(session, node_name, with_current=True)
+    materializations = []
+    for materialization in node.current.materializations:
+        if not materialization.deactivated_at or show_deleted:  # pragma: no cover
+            info = query_service_client.get_materialization_info(
+                node_name,
+                node.current.version,  # type: ignore
+                materialization.name,  # type: ignore
+            )
+            materialization = MaterializationConfigInfoUnified(
+                **materialization.dict(),
+                **{"engine": materialization.engine.dict()},
+                **info.dict(),
+            )
+            materializations.append(materialization)
+    return materializations
+
+
+@router.delete(
+    "/nodes/{node_name}/materializations/",
+    response_model=List[MaterializationConfigInfoUnified],
+    name="Deactivate A Materialization For A Node",
+)
+def deactivate_node_materializations(
+    node_name: str,
+    materialization_name: str,
+    *,
+    session: Session = Depends(get_session),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+) -> List[MaterializationConfigInfoUnified]:
+    """
+    Deactivate the node materialization with the provided name.
+    Also calls the query service to deactivate the associated scheduled jobs.
+    """
+    node = get_node_by_name(session, node_name, with_current=True)
+    query_service_client.deactivate_materialization(node_name, materialization_name)
+    for materialization in node.current.materializations:
+        if (
+            materialization.name == materialization_name
+            and not materialization.deactivated_at
+        ):  # pragma: no cover
+            now = datetime.utcnow()
+            materialization.deactivated_at = UTCDatetime(
+                year=now.year,
+                month=now.month,
+                day=now.day,
+                hour=now.hour,
+                minute=now.minute,
+                second=now.second,
+            )
+            session.add(materialization)
+
+    session.add(
+        History(
+            entity_type=EntityType.MATERIALIZATION,
+            entity_name=materialization_name,
+            node=node.name,
+            activity_type=ActivityType.DELETE,
+            details={},
+        ),
+    )
+    session.commit()
+    session.refresh(node.current)
+    return JSONResponse(
+        status_code=HTTPStatus.OK,
+        content={
+            "message": f"The materialization named `{materialization_name}` on node `{node_name}` "
+            "has been successfully deactivated",
+        },
+    )

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -34,7 +34,7 @@ router = APIRouter(tags=["materializations"])
 @router.post(
     "/nodes/{name}/materialization/",
     status_code=201,
-    name="Insert Or Update A Materialization For A Node",
+    name="Insert or Update a Materialization for a Node",
 )
 def upsert_materialization(  # pylint: disable=too-many-locals
     name: str,
@@ -155,7 +155,7 @@ def upsert_materialization(  # pylint: disable=too-many-locals
 @router.get(
     "/nodes/{node_name}/materializations/",
     response_model=List[MaterializationConfigInfoUnified],
-    name="List Materializations For A Node",
+    name="List Materializations for a Node",
 )
 def list_node_materializations(
     node_name: str,
@@ -189,7 +189,7 @@ def list_node_materializations(
 @router.delete(
     "/nodes/{node_name}/materializations/",
     response_model=List[MaterializationConfigInfoUnified],
-    name="Deactivate A Materialization For A Node",
+    name="Deactivate a Materialization for a Node",
 )
 def deactivate_node_materializations(
     node_name: str,

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -17,7 +17,7 @@ from datajunction_server.models.node import DimensionAttributeOutput, Node, Node
 from datajunction_server.sql.dag import get_shared_dimensions
 from datajunction_server.utils import get_session
 
-router = APIRouter()
+router = APIRouter(tags=["metrics"])
 
 
 def get_metric(session: Session, name: str) -> Node:

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -4,14 +4,11 @@ Node related APIs.
 """
 import logging
 import os
-from collections import defaultdict
-from datetime import datetime
 from http import HTTPStatus
-from typing import Dict, List, Optional, Set, Tuple, Union, cast
+from typing import List, Optional, Union, cast
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from pydantic import ValidationError
 from sqlalchemy.sql.operators import is_
 from sqlmodel import Session, select
 from starlette.requests import Request
@@ -19,69 +16,41 @@ from starlette.requests import Request
 from datajunction_server.api.helpers import (
     activate_node,
     deactivate_node,
-    get_attribute_type,
-    get_catalog,
+    get_catalog_by_name,
     get_column,
     get_downstream_nodes,
-    get_engine,
     get_node_by_name,
     get_node_namespace,
     get_upstream_nodes,
-    propagate_valid_status,
     raise_if_node_exists,
-    resolve_downstream_references,
-    validate_cube,
     validate_node_data,
 )
 from datajunction_server.api.namespaces import create_node_namespace
 from datajunction_server.api.tags import get_tag_by_name
 from datajunction_server.config import Settings
-from datajunction_server.construction.build import build_metric_nodes, build_node
-from datajunction_server.errors import (
-    DJDoesNotExistException,
-    DJException,
-    DJInvalidInputException,
+from datajunction_server.errors import DJException, DJInvalidInputException
+from datajunction_server.internal.materializations import schedule_materialization_jobs
+from datajunction_server.internal.nodes import (
+    _create_node_from_inactive,
+    _update_node,
+    create_cube_node_revision,
+    create_node_revision,
+    save_node,
+    set_column_attributes_on_node,
 )
-from datajunction_server.materialization.jobs import (
-    DefaultCubeMaterialization,
-    DruidCubeMaterializationJob,
-    MaterializationJob,
-    SparkSqlMaterializationJob,
-    TrinoMaterializationJob,
-)
-from datajunction_server.models import ColumnAttribute
-from datajunction_server.models.attribute import AttributeType, UniquenessScope
 from datajunction_server.models.base import generate_display_name
 from datajunction_server.models.column import Column, ColumnAttributeInput
-from datajunction_server.models.engine import Dialect, Engine
 from datajunction_server.models.history import (
     ActivityType,
     EntityType,
     History,
     status_change_history,
 )
-from datajunction_server.models.materialization import (
-    DruidConf,
-    DruidCubeConfig,
-    GenericCubeConfig,
-    GenericMaterializationConfig,
-    Materialization,
-    MaterializationConfigInfoUnified,
-    MaterializationInfo,
-    Measure,
-    MetricMeasures,
-    Partition,
-    PartitionType,
-    UpsertMaterialization,
-)
 from datajunction_server.models.node import (
-    DEFAULT_DRAFT_VERSION,
-    DEFAULT_PUBLISHED_VERSION,
     ColumnOutput,
     CreateCubeNode,
     CreateNode,
     CreateSourceNode,
-    MissingParent,
     Node,
     NodeMode,
     NodeOutput,
@@ -95,13 +64,9 @@ from datajunction_server.models.node import (
 )
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import get_dimensions, get_nodes_with_dimension
-from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
-from datajunction_server.sql.parsing.backends.exceptions import DJParseException
-from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import (
     Version,
-    VersionUpgrade,
     get_namespace_from_name,
     get_query_service_client,
     get_session,
@@ -200,118 +165,6 @@ def revalidate_node(
     )
 
 
-def validate_and_build_attribute(
-    session: Session,
-    attribute_input: ColumnAttributeInput,
-    node: Node,
-) -> ColumnAttribute:
-    """
-    Run some validation and build column attribute.
-    """
-    column_map = {column.name: column for column in node.current.columns}
-    if attribute_input.column_name not in column_map:
-        raise DJDoesNotExistException(
-            message=f"Column `{attribute_input.column_name}` "
-            f"does not exist on node `{node.name}`!",
-        )
-    column = column_map[attribute_input.column_name]
-    existing_attributes = {attr.attribute_type.name: attr for attr in column.attributes}
-    if attribute_input.attribute_type_name in existing_attributes:
-        return existing_attributes[attribute_input.attribute_type_name]
-
-    # Verify attribute type exists
-    attribute_type = get_attribute_type(
-        session,
-        attribute_input.attribute_type_name,
-        attribute_input.attribute_type_namespace,
-    )
-    if not attribute_type:
-        raise DJDoesNotExistException(
-            message=f"Attribute type `{attribute_input.attribute_type_namespace}"
-            f".{attribute_input.attribute_type_name}` "
-            f"does not exist!",
-        )
-
-    # Verify that the attribute type is allowed for this node
-    if node.type not in attribute_type.allowed_node_types:
-        raise DJException(
-            message=f"Attribute type `{attribute_input.attribute_type_namespace}."
-            f"{attribute_type.name}` not allowed on node "
-            f"type `{node.type}`!",
-        )
-
-    return ColumnAttribute(
-        attribute_type=attribute_type,
-        column=column,
-    )
-
-
-def set_column_attributes_on_node(
-    session: Session,
-    attributes: List[ColumnAttributeInput],
-    node: Node,
-) -> List[Column]:
-    """
-    Sets the column attributes on the node if allowed.
-    """
-    modified_columns_map = {}
-    for attribute_input in attributes:
-        new_attribute = validate_and_build_attribute(session, attribute_input, node)
-        # pylint: disable=no-member
-        modified_columns_map[new_attribute.column.name] = new_attribute.column
-
-    # Validate column attributes by building mapping between
-    # attribute scope and columns
-    attributes_columns_map = defaultdict(set)
-    modified_columns = modified_columns_map.values()
-
-    for column in modified_columns:
-        for attribute in column.attributes:
-            scopes_map = {
-                UniquenessScope.NODE: attribute.attribute_type,
-                UniquenessScope.COLUMN_TYPE: column.type,
-            }
-            attributes_columns_map[
-                (  # type: ignore
-                    attribute.attribute_type,
-                    tuple(
-                        scopes_map[item]
-                        for item in attribute.attribute_type.uniqueness_scope
-                    ),
-                )
-            ].add(column.name)
-
-    for (attribute, _), columns in attributes_columns_map.items():
-        if len(columns) > 1 and attribute.uniqueness_scope:
-            for col in columns:
-                modified_columns_map[col].attributes = []
-            raise DJException(
-                message=f"The column attribute `{attribute.name}` is scoped to be "
-                f"unique to the `{attribute.uniqueness_scope}` level, but there "
-                "is more than one column tagged with it: "
-                f"`{', '.join(sorted(list(columns)))}`",
-            )
-
-    session.add_all(modified_columns)
-    session.add(
-        History(
-            entity_type=EntityType.COLUMN_ATTRIBUTE,
-            node=node.name,
-            activity_type=ActivityType.SET_ATTRIBUTE,
-            details={
-                "attributes": [attr.dict() for attr in attributes],
-            },
-        ),
-    )
-    session.commit()
-    for col in modified_columns:
-        session.refresh(col)
-
-    session.refresh(node)
-    session.refresh(node.current)
-    return list(modified_columns)
-
-
 @router.post(
     "/nodes/{node_name}/attributes/",
     response_model=List[ColumnOutput],
@@ -380,436 +233,6 @@ def restore_node(name: str, *, session: Session = Depends(get_session)):
     )
 
 
-def build_cube_config(  # pylint: disable=too-many-locals
-    cube_node: NodeRevision,
-    combined_ast: ast.Query,
-) -> Union[DruidCubeConfig, GenericCubeConfig]:
-    """
-    Builds the materialization config for a cube. This includes two parts:
-    (a) building a query that decomposes each of the cube's metrics into their
-    constituent measures that have simple aggregations
-    (b) adding a metric to measures mapping that tells us which measures
-    in the query map to each selected metric
-
-    The query in the materialization config is different from the one stored
-    on the cube node itself in that this one is meant to create a temporary
-    table in preparation for ingestion into an OLAP database like Druid. The
-    metric to measures mapping then provides information on how to assemble
-    metrics from measures based on this query's output.
-
-    The query directly on the cube node is meant for direct querying of the cube
-    without materialization to an OLAP database.
-    """
-    dimensions_set = {
-        dim.name for dim in cube_node.columns if dim.has_dimension_attribute()
-    }
-    metrics_to_measures = {}
-    measures_tracker = {}
-    for cte in combined_ast.ctes:
-        metrics_to_measures.update(decompose_metrics(cte, dimensions_set))
-        new_select_projection: Set[Union[ast.Aliasable, ast.Expression]] = set()
-        for expr in cte.select.projection:
-            if expr in metrics_to_measures:
-                combiner, measures = metrics_to_measures[expr]  # type: ignore
-                new_select_projection = set(new_select_projection).union(
-                    measures,
-                )
-                metric_key = expr.alias_or_name.name  # type: ignore
-                if metric_key not in measures_tracker:  # pragma: no cover
-                    measures_tracker[metric_key] = MetricMeasures(
-                        metric=metric_key,
-                        measures=[],
-                        combiner=str(combiner),
-                    )
-                for measure in measures:
-                    measures_tracker[metric_key].measures.append(  # type: ignore
-                        Measure(
-                            name=measure.alias_or_name.name,
-                            field_name=str(
-                                f"{cte.alias_or_name}_{measure.alias_or_name}",
-                            ),
-                            agg=str(measure.child.name),
-                            type=str(measure.type),
-                        ),
-                    )
-            else:
-                new_select_projection.add(expr)
-        cte.select.projection = list(new_select_projection)
-    for _, metric_measures in measures_tracker.items():
-        metric_measures.measures = sorted(
-            metric_measures.measures,
-            key=lambda x: x.name,
-        )
-    combined_ast.select.projection = [
-        (
-            ast.Column(name=col.alias_or_name, _table=cte).set_alias(  # type: ignore
-                ast.Name(f"{cte.alias_or_name}_{col.alias_or_name}"),  # type: ignore
-            )
-        )
-        for cte in combined_ast.ctes
-        for col in cte.select.projection
-        if col.alias_or_name.name not in dimensions_set  # type: ignore
-    ]
-    dimension_grouping: Dict[str, List[ast.Column]] = {}
-    for col in [
-        ast.Column(name=col.alias_or_name, _table=cte)  # type: ignore
-        for cte in combined_ast.ctes
-        for col in cte.select.projection
-        if col.alias_or_name.name in dimensions_set  # type: ignore
-    ]:
-        dimension_grouping.setdefault(str(col.alias_or_name.name), []).append(col)
-
-    for col_name, columns in dimension_grouping.items():
-        combined_ast.select.projection.append(
-            ast.Function(name=ast.Name("COALESCE"), args=list(columns)).set_alias(
-                ast.Name(col_name),
-            ),
-        )
-
-    upstream_tables = sorted(
-        list(
-            {
-                f"{tbl.dj_node.catalog.name}.{tbl.identifier()}"
-                for tbl in combined_ast.find_all(ast.Table)
-                if tbl.dj_node
-            },
-        ),
-    )
-    return GenericCubeConfig(
-        query=str(combined_ast),
-        dimensions=sorted(list(dimensions_set)),
-        measures=measures_tracker,
-        partitions=[],
-        upstream_tables=upstream_tables,
-    )
-
-
-def materialization_job_from_engine(engine: Engine) -> MaterializationJob:
-    """
-    Finds the appropriate materialization job based on the choice of engine.
-    """
-    engine_to_job_mapping = {
-        Dialect.SPARK: SparkSqlMaterializationJob,
-        Dialect.TRINO: TrinoMaterializationJob,
-        Dialect.DRUID: DruidCubeMaterializationJob,
-        None: SparkSqlMaterializationJob,
-    }
-    if engine.dialect not in engine_to_job_mapping:
-        raise DJInvalidInputException(  # pragma: no cover
-            f"The engine used for materialization ({engine.name}) "
-            "must have a dialect configured.",
-        )
-    return engine_to_job_mapping[engine.dialect]  # type: ignore
-
-
-def filters_from_partitions(partitions: List[Partition]):
-    """
-    Derive filters needed from partitions spec.
-    """
-    filters = []
-    for partition in partitions:
-        if partition.type_ != PartitionType.TEMPORAL:  # pragma: no cover
-            if partition.values:  # pragma: no cover
-                quoted_values = [f"'{value}'" for value in partition.values]
-                filters.append(f"{partition.name} IN ({','.join(quoted_values)})")
-            if partition.range and len(partition.range) == 2:
-                filters.append(  # pragma: no cover
-                    f"{partition.name} BETWEEN {partition.range[0]} "
-                    f"AND {partition.range[1]}",
-                )
-    return filters
-
-
-def create_new_materialization(
-    session: Session,
-    current_revision: NodeRevision,
-    upsert: UpsertMaterialization,
-) -> Materialization:
-    """
-    Create a new materialization based on the input values.
-    """
-    generic_config = None
-    engine = get_engine(session, upsert.engine.name, upsert.engine.version)
-    if current_revision.type in (
-        NodeType.DIMENSION,
-        NodeType.TRANSFORM,
-        NodeType.METRIC,
-    ):
-        materialization_ast = build_node(
-            session=session,
-            node=current_revision,
-            filters=(
-                filters_from_partitions(
-                    [
-                        Partition.parse_obj(partition)
-                        for partition in upsert.config.partitions
-                    ],
-                )
-                if upsert.config.partitions
-                else []
-            ),
-            dimensions=[],
-            orderby=[],
-        )
-        generic_config = GenericMaterializationConfig(
-            query=str(materialization_ast),
-            spark=upsert.config.spark if upsert.config.spark else {},
-            partitions=upsert.config.partitions if upsert.config.partitions else [],
-            upstream_tables=[
-                f"{current_revision.catalog.name}.{tbl.identifier()}"
-                for tbl in materialization_ast.find_all(ast.Table)
-            ],
-        )
-
-    if current_revision.type == NodeType.CUBE:
-        # Check to see if a default materialization was already configured, so that we
-        # can copy over the default cube setup and layer on specific config as needed
-        default_job = [
-            conf
-            for conf in current_revision.materializations
-            if conf.job == DefaultCubeMaterialization.__name__
-        ][0]
-        default_job_config = GenericCubeConfig.parse_obj(default_job.config)
-        try:
-            generic_config = DruidCubeConfig(
-                node_name=current_revision.name,
-                query=default_job_config.query,
-                dimensions=default_job_config.dimensions,
-                measures=default_job_config.measures,
-                spark=upsert.config.spark,
-                druid=DruidConf.parse_obj(upsert.config.druid),
-                partitions=upsert.config.partitions,
-                upstream_tables=default_job_config.upstream_tables,
-            )
-        except (KeyError, ValidationError, AttributeError) as exc:
-            raise DJInvalidInputException(
-                message=(
-                    "No change has been made to the materialization config for "
-                    f"node `{current_revision.name}` and engine `{engine.name}` as"
-                    " the config does not have valid configuration for "
-                    f"engine `{engine.name}`."
-                ),
-            ) from exc
-    materialization_name = generic_config.identifier()  # type: ignore
-    return Materialization(
-        name=materialization_name,
-        node_revision=current_revision,
-        engine=engine,
-        config=generic_config,
-        schedule=upsert.schedule or "@daily",
-        job=materialization_job_from_engine(engine).__name__,  # type: ignore
-    )
-
-
-@router.post(
-    "/nodes/{name}/materialization/",
-    status_code=201,
-    tags=["materializations"],
-)
-def upsert_materialization(  # pylint: disable=too-many-locals
-    name: str,
-    data: UpsertMaterialization,
-    *,
-    session: Session = Depends(get_session),
-    query_service_client: QueryServiceClient = Depends(get_query_service_client),
-) -> JSONResponse:
-    """
-    Add or update a materialization of the specified node. If a name is specified
-    for the materialization config, it will always update that named config.
-    """
-    node = get_node_by_name(session, name, with_current=True)
-    if node.type == NodeType.SOURCE:
-        raise DJException(
-            http_status_code=HTTPStatus.BAD_REQUEST,
-            message=f"Cannot set materialization config for source node `{name}`!",
-        )
-    current_revision = node.current
-    old_materializations = {mat.name: mat for mat in current_revision.materializations}
-
-    # Create a new materialization
-    new_materialization = create_new_materialization(session, current_revision, data)
-
-    # Check to see if a materialization for this engine already exists with the exact same config
-    existing_materialization = old_materializations.get(new_materialization.name)
-    deactivated_before = False
-    if (
-        existing_materialization
-        and existing_materialization.config == new_materialization.config
-    ):
-        new_materialization.node_revision = None  # type: ignore
-        # if the materialization was deactivated before, restore it
-        if existing_materialization.deactivated_at is not None:
-            deactivated_before = True
-            existing_materialization.deactivated_at = None  # type: ignore
-            session.add(
-                History(
-                    entity_type=EntityType.MATERIALIZATION,
-                    entity_name=existing_materialization.name,
-                    node=node.name,
-                    activity_type=ActivityType.RESTORE,
-                    details={},
-                ),
-            )
-            session.commit()
-            session.refresh(existing_materialization)
-        existing_materialization_info = query_service_client.get_materialization_info(
-            name,
-            current_revision.version,  # type: ignore
-            new_materialization.name,  # type: ignore
-        )
-        return JSONResponse(
-            status_code=HTTPStatus.CREATED,
-            content={
-                "message": (
-                    f"The same materialization config with name `{new_materialization.name}` "
-                    f"already exists for node `{name}` so no update was performed."
-                    if not deactivated_before
-                    else f"The same materialization config with name `{new_materialization.name}` "
-                    f"already exists for node `{name}` but was deactivated. It has now been "
-                    f"restored."
-                ),
-                "info": existing_materialization_info.dict(),
-            },
-        )
-    # If changes are detected, save the new materialization
-    existing_materialization_names = {
-        mat.name for mat in current_revision.materializations
-    }
-    unchanged_existing_materializations = [
-        config
-        for config in current_revision.materializations
-        if config.name != new_materialization.name
-    ]
-    current_revision.materializations = unchanged_existing_materializations + [  # type: ignore
-        new_materialization,
-    ]
-
-    # This will add the materialization config, the new node rev, and update the node's version.
-    session.add(current_revision)
-    session.add(node)
-
-    session.add(
-        History(
-            entity_type=EntityType.MATERIALIZATION,
-            node=node.name,
-            entity_name=new_materialization.name,
-            activity_type=(
-                ActivityType.CREATE
-                if new_materialization.name in existing_materialization_names
-                else ActivityType.UPDATE
-            ),
-            details={
-                "node": node.name,
-                "materialization": new_materialization.name,
-            },
-        ),
-    )
-    session.commit()
-
-    materialization_response = schedule_materialization_jobs(
-        [new_materialization],
-        query_service_client,
-    )
-    return JSONResponse(
-        status_code=200,
-        content={
-            "message": (
-                f"Successfully updated materialization config named `{new_materialization.name}` "
-                f"for node `{name}`"
-            ),
-            "urls": [output.urls for output in materialization_response.values()],
-        },
-    )
-
-
-@router.get(
-    "/nodes/{node_name}/materializations/",
-    response_model=List[MaterializationConfigInfoUnified],
-    tags=["materializations"],
-)
-def list_node_materializations(
-    node_name: str,
-    show_deleted: bool = False,
-    *,
-    session: Session = Depends(get_session),
-    query_service_client: QueryServiceClient = Depends(get_query_service_client),
-) -> List[MaterializationConfigInfoUnified]:
-    """
-    Show all materializations configured for the node, with any associated metadata
-    like urls from the materialization service, if available.
-    """
-    node = get_node_by_name(session, node_name, with_current=True)
-    materializations = []
-    for materialization in node.current.materializations:
-        if not materialization.deactivated_at or show_deleted:  # pragma: no cover
-            info = query_service_client.get_materialization_info(
-                node_name,
-                node.current.version,  # type: ignore
-                materialization.name,  # type: ignore
-            )
-            materialization = MaterializationConfigInfoUnified(
-                **materialization.dict(),
-                **{"engine": materialization.engine.dict()},
-                **info.dict(),
-            )
-            materializations.append(materialization)
-    return materializations
-
-
-@router.delete(
-    "/nodes/{node_name}/materializations/",
-    response_model=List[MaterializationConfigInfoUnified],
-    tags=["materializations"],
-)
-def deactivate_node_materializations(
-    node_name: str,
-    materialization_name: str,
-    *,
-    session: Session = Depends(get_session),
-    query_service_client: QueryServiceClient = Depends(get_query_service_client),
-) -> List[MaterializationConfigInfoUnified]:
-    """
-    Deactivate the node materialization with the provided name.
-    Also calls the query service to deactivate the associated scheduled jobs.
-    """
-    node = get_node_by_name(session, node_name, with_current=True)
-    query_service_client.deactivate_materialization(node_name, materialization_name)
-    for materialization in node.current.materializations:
-        if (
-            materialization.name == materialization_name
-            and not materialization.deactivated_at
-        ):  # pragma: no cover
-            now = datetime.utcnow()
-            materialization.deactivated_at = UTCDatetime(
-                year=now.year,
-                month=now.month,
-                day=now.day,
-                hour=now.hour,
-                minute=now.minute,
-                second=now.second,
-            )
-            session.add(materialization)
-
-    session.add(
-        History(
-            entity_type=EntityType.MATERIALIZATION,
-            entity_name=materialization_name,
-            node=node.name,
-            activity_type=ActivityType.DELETE,
-            details={},
-        ),
-    )
-    session.commit()
-    session.refresh(node.current)
-    return JSONResponse(
-        status_code=HTTPStatus.NO_CONTENT,
-        content={
-            "message": f"The materialization named `{materialization_name}` on node `{node_name}` "
-            "has been successfully deactivated",
-        },
-    )
-
-
 @router.get("/nodes/{name}/revisions/", response_model=List[NodeRevisionOutput])
 def list_node_revisions(
     name: str, *, session: Session = Depends(get_session)
@@ -821,395 +244,7 @@ def list_node_revisions(
     return node.revisions  # type: ignore
 
 
-def create_node_revision(
-    data: CreateNode,
-    node_type: NodeType,
-    session: Session,
-) -> NodeRevision:
-    """
-    Create a non-source node revision.
-    """
-    node_revision = NodeRevision(
-        name=data.name,
-        namespace=data.namespace,
-        display_name=data.display_name
-        if data.display_name
-        else generate_display_name(data.name),
-        description=data.description,
-        type=node_type,
-        status=NodeStatus.VALID,
-        query=data.query,
-        mode=data.mode,
-        required_dimensions=data.required_dimensions or [],
-    )
-    (
-        validated_node,
-        dependencies_map,
-        missing_parents_map,
-        _,
-        errors,
-    ) = validate_node_data(node_revision, session)
-    if errors:
-        if node_revision.mode == NodeMode.DRAFT:
-            node_revision.status = NodeStatus.INVALID
-        else:
-            raise DJException(
-                http_status_code=HTTPStatus.BAD_REQUEST,
-                errors=errors,
-            )
-    else:
-        node_revision.status = NodeStatus.VALID
-    node_revision.missing_parents = [
-        MissingParent(name=missing_parent) for missing_parent in missing_parents_map
-    ]
-    new_parents = [node.name for node in dependencies_map]
-    catalog_ids = [node.catalog_id for node in dependencies_map]
-    if node_revision.mode == NodeMode.PUBLISHED and not len(set(catalog_ids)) == 1:
-        raise DJException(
-            f"Cannot create nodes with multi-catalog dependencies: {set(catalog_ids)}",
-        )
-    catalog_id = next(iter(catalog_ids), 0)
-    parent_refs = session.exec(
-        select(Node).where(
-            # pylint: disable=no-member
-            Node.name.in_(  # type: ignore
-                new_parents,
-            ),
-        ),
-    ).all()
-    node_revision.parents = parent_refs
-
-    _logger.info(
-        "Parent nodes for %s (%s): %s",
-        data.name,
-        node_revision.version,
-        [p.name for p in node_revision.parents],
-    )
-    node_revision.columns = validated_node.columns or []
-    node_revision.catalog_id = catalog_id
-    return node_revision
-
-
-def _get_readable_name(expr):
-    """
-    Returns a readable name based on the columns in the expression. This is used
-    if we want to represent the expression as a single measure, which needs a name
-    """
-    columns = [col for arg in expr.args for col in arg.find_all(ast.Column)]
-    return (
-        "_".join(str(col.alias_or_name).rsplit(".", maxsplit=1)[-1] for col in columns)
-        if columns
-        else "placeholder"
-    )
-
-
-def decompose_expression(  # pylint: disable=too-many-return-statements
-    expr: Union[ast.Aliasable, ast.Expression],
-) -> Tuple[ast.Expression, List[ast.Alias]]:
-    """
-    Takes a metric expression and (a) determines the measures needed to evaluate
-    the metric and (b) includes the query expression needed to recombine these
-    measures into the metric, given a materialized cube.
-
-    Simple aggregations are operations that can be computed incrementally as new
-    data is ingested, without relying on the results of other aggregations.
-    Examples include SUM, COUNT, MIN, MAX.
-
-    Some complex aggregations can be decomposed to simple aggregations: i.e., AVG(x) can
-    be decomposed to SUM(x)/COUNT(x).
-    """
-    if isinstance(expr, ast.Alias):
-        expr = expr.child
-
-    if isinstance(expr, ast.Number):
-        return expr, []  # type: ignore
-
-    if not expr.is_aggregation():  # type: ignore  # pragma: no cover
-        return expr, [expr]  # type: ignore
-
-    simple_aggregations = {"sum", "count", "min", "max"}
-    if isinstance(expr, ast.Function):
-        function_name = expr.alias_or_name.name.lower()
-        readable_name = _get_readable_name(expr)
-
-        if function_name in simple_aggregations:
-            measure_name = ast.Name(f"{readable_name}_{function_name}")
-            if not expr.args[0].is_aggregation():
-                combiner: ast.Expression = ast.Function(
-                    name=ast.Name(function_name),
-                    args=[ast.Column(name=measure_name)],
-                )
-                return combiner, [expr.set_alias(measure_name)]
-
-            combiner, measures = decompose_expression(expr.args[0])
-            return (
-                ast.Function(
-                    name=ast.Name(function_name),
-                    args=[combiner],
-                ),
-                measures,
-            )
-
-        if function_name == "avg":  # pragma: no cover
-            numerator_measure_name = ast.Name(f"{readable_name}_sum")
-            denominator_measure_name = ast.Name(f"{readable_name}_count")
-            combiner = ast.BinaryOp(
-                left=ast.Function(
-                    ast.Name("sum"),
-                    args=[ast.Column(name=numerator_measure_name)],
-                ),
-                right=ast.Function(
-                    ast.Name("count"),
-                    args=[ast.Column(name=denominator_measure_name)],
-                ),
-                op=ast.BinaryOpKind.Divide,
-            )
-            return combiner, [
-                (
-                    ast.Function(ast.Name("sum"), args=expr.args).set_alias(
-                        numerator_measure_name,
-                    )
-                ),
-                (
-                    ast.Function(ast.Name("count"), args=expr.args).set_alias(
-                        denominator_measure_name,
-                    )
-                ),
-            ]
-    acceptable_binary_ops = {
-        ast.BinaryOpKind.Plus,
-        ast.BinaryOpKind.Minus,
-        ast.BinaryOpKind.Multiply,
-        ast.BinaryOpKind.Divide,
-    }
-    if isinstance(expr, ast.BinaryOp):
-        if expr.op in acceptable_binary_ops:  # pragma: no cover
-            measures_combiner_left, measures_left = decompose_expression(expr.left)
-            measures_combiner_right, measures_right = decompose_expression(expr.right)
-            combiner = ast.BinaryOp(
-                left=measures_combiner_left,
-                right=measures_combiner_right,
-                op=expr.op,
-            )
-            return combiner, measures_left + measures_right
-
-    if isinstance(expr, ast.Cast):
-        return decompose_expression(expr.expression)
-
-    raise DJInvalidInputException(  # pragma: no cover
-        f"Metric expression {expr} cannot be decomposed into its constituent measures",
-    )
-
-
-def decompose_metrics(
-    combined_ast: ast.Query,
-    dimensions_set: Set[str],
-) -> Dict[Union[ast.Aliasable, ast.Expression], Tuple[ast.Expression, List[ast.Alias]]]:
-    """
-    Decompose each metric into simple constituent measures and return a dict
-    that maps each metric to its measures.
-    """
-    metrics_to_measures = {}
-    for expr in combined_ast.select.projection:
-        if expr.alias_or_name.name not in dimensions_set:  # type: ignore
-            metrics_to_measures[expr] = decompose_expression(expr)
-    return metrics_to_measures
-
-
-def create_cube_node_revision(  # pylint: disable=too-many-locals
-    session: Session,
-    data: CreateCubeNode,
-) -> NodeRevision:
-    """
-    Create a cube node revision.
-    """
-    (
-        metric_columns,
-        metric_nodes,
-        dimension_nodes,
-        dimension_columns,
-        catalog,
-    ) = validate_cube(
-        session,
-        data.metrics,
-        data.dimensions,
-    )
-
-    combined_ast = build_metric_nodes(
-        session,
-        metric_nodes,
-        filters=data.filters or [],
-        dimensions=data.dimensions or [],
-        orderby=data.orderby or [],
-        limit=data.limit or None,
-    )
-    dimension_attribute = session.exec(
-        select(AttributeType).where(AttributeType.name == "dimension"),
-    ).one()
-    dimensions_set = {dim.rsplit(".", 1)[1] for dim in data.dimensions}
-
-    node_columns = []
-    status = NodeStatus.VALID
-    type_inference_failed_columns = []
-    for col in combined_ast.select.projection:
-        try:
-            column_type = col.type  # type: ignore
-            column_attributes = (
-                [ColumnAttribute(attribute_type=dimension_attribute)]
-                if col.alias_or_name.name in dimensions_set
-                else []
-            )
-            node_columns.append(
-                Column(
-                    name=col.alias_or_name.name,
-                    type=column_type,
-                    attributes=column_attributes,
-                ),
-            )
-        except DJParseException:  # pragma: no cover
-            type_inference_failed_columns.append(col.alias_or_name.name)  # type: ignore
-            status = NodeStatus.INVALID
-
-    node_revision = NodeRevision(
-        name=data.name,
-        namespace=data.namespace,
-        description=data.description,
-        type=NodeType.CUBE,
-        query=str(combined_ast),
-        columns=node_columns,
-        cube_elements=metric_columns + dimension_columns,
-        parents=list(set(dimension_nodes + metric_nodes)),
-        status=status,
-        catalog=catalog,
-    )
-
-    # Set up a default materialization for the cube. Note that this does not get used
-    # for any actual materialization, but is for storing info needed for materialization
-    node_revision.materializations = []
-    default_materialization = UpsertMaterialization(
-        name="placeholder",
-        engine=node_revision.catalog.engines[0],  # pylint: disable=no-member
-        schedule="@daily",
-        config={},
-        job="CubeMaterializationJob",
-    )
-    engine = get_engine(
-        session,
-        name=default_materialization.engine.name,
-        version=default_materialization.engine.version,
-    )
-    cube_custom_config = build_cube_config(
-        node_revision,
-        combined_ast,
-    )
-    new_materialization = Materialization(
-        name=cube_custom_config.identifier(),
-        node_revision=node_revision,
-        engine=engine,
-        config=cube_custom_config,
-        schedule=default_materialization.schedule,
-        job=(
-            DefaultCubeMaterialization.__name__
-            if not isinstance(cube_custom_config, DruidCubeConfig)
-            else DruidCubeMaterializationJob.__name__
-        ),
-    )
-    node_revision.materializations.append(new_materialization)
-    return node_revision
-
-
-def save_node(
-    session: Session,
-    node_revision: NodeRevision,
-    node: Node,
-    node_mode: NodeMode,
-):
-    """
-    Links the node and node revision together and saves them
-    """
-    node_revision.node = node
-    node_revision.version = (
-        str(DEFAULT_DRAFT_VERSION)
-        if node_mode == NodeMode.DRAFT
-        else str(DEFAULT_PUBLISHED_VERSION)
-    )
-    node.current_version = node_revision.version
-    node_revision.extra_validation()
-
-    session.add(node)
-    session.add(
-        History(
-            node=node.name,
-            entity_type=EntityType.NODE,
-            entity_name=node.name,
-            activity_type=ActivityType.CREATE,
-        ),
-    )
-    session.commit()
-
-    newly_valid_nodes = resolve_downstream_references(
-        session=session,
-        node_revision=node_revision,
-    )
-    propagate_valid_status(
-        session=session,
-        valid_nodes=newly_valid_nodes,
-        catalog_id=node.current.catalog_id,  # pylint: disable=no-member
-    )
-    session.refresh(node.current)
-
-
-def _create_node_from_inactive(
-    new_node_type: NodeType,
-    data: CreateSourceNode,
-    session: Session = Depends(get_session),
-) -> Optional[Node]:
-    """
-    If the node existed and is inactive the re-creation takes different steps than
-    creating it from scratch.
-    """
-    previous_inactive_node = get_node_by_name(
-        session,
-        name=data.name,
-        raise_if_not_exists=False,
-        include_inactive=True,
-    )
-    if previous_inactive_node and previous_inactive_node.deactivated_at:
-        if previous_inactive_node.type != new_node_type:
-            raise DJException(  # pragma: no cover
-                message=f"A node with name `{data.name}` of a `{previous_inactive_node.type.value}` "  # pylint: disable=line-too-long
-                "type existed before. If you want to re-created with a different type now, "
-                "you need to remove all the traces of the previous node with a <TODO> command.",
-                http_status_code=HTTPStatus.CONFLICT,
-            )
-        update_node(
-            name=data.name,
-            data=UpdateNode(
-                # MutableNodeFields
-                display_name=data.display_name,
-                description=data.description,
-                mode=data.mode,
-                # SourceNodeFields
-                catalog=data.catalog,
-                schema_=data.schema_,
-                table=data.table,
-                columns=data.columns,
-            ),
-            session=session,
-        )
-        response = restore_node(name=data.name, session=session)
-
-        if response.status_code == HTTPStatus.OK:
-            return get_node_by_name(session, data.name, with_current=True)
-
-        raise DJException(
-            f"Restoring node `{data.name}` failed: {response.body}",
-        )  # pragma: no cover
-
-    return None
-
-
-@router.post("/nodes/source/", response_model=NodeOutput)
+@router.post("/nodes/source/", response_model=NodeOutput, name="Create A Source Node")
 def create_source(
     data: CreateSourceNode,
     session: Session = Depends(get_session),
@@ -1241,7 +276,7 @@ def create_source(
         type=NodeType.SOURCE,
         current_version=0,
     )
-    catalog = get_catalog(session=session, name=data.catalog)
+    catalog = get_catalog_by_name(session=session, name=data.catalog)
 
     columns = [
         Column(
@@ -1281,9 +316,24 @@ def create_source(
     return node  # type: ignore
 
 
-@router.post("/nodes/transform/", response_model=NodeOutput, status_code=201)
-@router.post("/nodes/dimension/", response_model=NodeOutput, status_code=201)
-@router.post("/nodes/metric/", response_model=NodeOutput, status_code=201)
+@router.post(
+    "/nodes/transform/",
+    response_model=NodeOutput,
+    status_code=201,
+    name="Create A Transform Node",
+)
+@router.post(
+    "/nodes/dimension/",
+    response_model=NodeOutput,
+    status_code=201,
+    name="Create A Dimension Node",
+)
+@router.post(
+    "/nodes/metric/",
+    response_model=NodeOutput,
+    status_code=201,
+    name="Create A Metric Node",
+)
 def create_node(
     data: CreateNode,
     request: Request,
@@ -1352,7 +402,12 @@ def create_node(
     return node  # type: ignore
 
 
-@router.post("/nodes/cube/", response_model=NodeOutput, status_code=201)
+@router.post(
+    "/nodes/cube/",
+    response_model=NodeOutput,
+    status_code=201,
+    name="Create A Cube",
+)
 def create_cube(
     data: CreateCubeNode,
     *,
@@ -1426,7 +481,7 @@ def register_table(  # pylint: disable=too-many-arguments
     create_node_namespace(namespace=namespace, session=session)
 
     # Use reflection to get column names and types
-    _catalog = get_catalog(session=session, name=catalog)
+    _catalog = get_catalog_by_name(session=session, name=catalog)
     columns = query_service_client.get_columns_for_table(
         _catalog,
         schema_,
@@ -1447,27 +502,6 @@ def register_table(  # pylint: disable=too-many-arguments
         ),
         session=session,
     )
-
-
-def schedule_materialization_jobs(
-    materializations: List[Materialization],
-    query_service_client: QueryServiceClient,
-) -> Dict[str, MaterializationInfo]:
-    """
-    Schedule recurring materialization jobs
-    """
-    materialization_jobs = {
-        cls.__name__: cls for cls in MaterializationJob.__subclasses__()
-    }
-    materialization_to_output = {}
-    for materialization in materializations:
-        clazz = materialization_jobs.get(materialization.job)
-        if clazz and materialization.name:  # pragma: no cover
-            materialization_to_output[materialization.name] = clazz().schedule(  # type: ignore
-                materialization,
-                query_service_client,
-            )
-    return materialization_to_output
 
 
 @router.post("/nodes/{name}/columns/{column}/", status_code=201)
@@ -1618,7 +652,7 @@ def delete_dimension_link(
     )
 
 
-@router.post("/nodes/{name}/tag/", status_code=201, tags=["tags"])
+@router.post("/nodes/{name}/tag/", status_code=201, tags=["tags"], name="Tag A Node")
 def tag_node(
     name: str, tag_name: str, *, session: Session = Depends(get_session)
 ) -> JSONResponse:
@@ -1653,179 +687,6 @@ def tag_node(
             ),
         },
     )
-
-
-def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-many-arguments,too-many-branches
-    session: Session,
-    query_service_client: QueryServiceClient,
-    old_revision: NodeRevision,
-    node: Node,
-    data: UpdateNode = None,
-    version_upgrade: VersionUpgrade = None,
-) -> Optional[NodeRevision]:
-    """
-    Creates a new revision from an existing node revision.
-    """
-    minor_changes = (
-        (data and data.description and old_revision.description != data.description)
-        or (data and data.mode and old_revision.mode != data.mode)
-        or (
-            data
-            and data.display_name
-            and old_revision.display_name != data.display_name
-        )
-    )
-    query_changes = (
-        old_revision.type != NodeType.SOURCE
-        and data
-        and data.query
-        and old_revision.query != data.query
-    )
-    column_changes = (
-        old_revision.type == NodeType.SOURCE
-        and data is not None
-        and data.columns is not None
-        and ({col.identifier() for col in old_revision.columns} != data.columns)
-    )
-    pk_changes = (
-        data is not None
-        and data.primary_key
-        and {col.name for col in old_revision.primary_key()} != set(data.primary_key)
-    )
-    major_changes = query_changes or column_changes or pk_changes
-
-    # If nothing has changed, do not create the new node revision
-    if not minor_changes and not major_changes and not version_upgrade:
-        return None
-
-    old_version = Version.parse(node.current_version)
-    new_mode = data.mode if data and data.mode else old_revision.mode
-    new_revision = NodeRevision(
-        name=old_revision.name,
-        node_id=node.id,
-        version=str(
-            old_version.next_major_version()
-            if major_changes or version_upgrade == VersionUpgrade.MAJOR
-            else old_version.next_minor_version(),
-        ),
-        display_name=(
-            data.display_name
-            if data and data.display_name
-            else old_revision.display_name
-        ),
-        description=(
-            data.description if data and data.description else old_revision.description
-        ),
-        query=(data.query if data and data.query else old_revision.query),
-        type=old_revision.type,
-        columns=[
-            Column(
-                name=column_data.name,
-                type=column_data.type,
-                dimension_column=column_data.dimension,
-                attributes=column_data.attributes or [],
-            )
-            for column_data in data.columns
-        ]
-        if data and data.columns
-        else old_revision.columns,
-        catalog=old_revision.catalog,
-        schema_=old_revision.schema_,
-        table=old_revision.table,
-        parents=[],
-        mode=new_mode,
-        materializations=[],
-        status=old_revision.status,
-    )
-
-    # Link the new revision to its parents if the query has changed and update its status
-    if new_revision.type != NodeType.SOURCE and (query_changes or pk_changes):
-        (
-            validated_node,
-            dependencies_map,
-            missing_parents_map,
-            _,
-            errors,
-        ) = validate_node_data(new_revision, session)
-
-        if errors:
-            if new_mode == NodeMode.DRAFT:
-                new_revision.status = NodeStatus.INVALID
-            else:
-                raise DJException(
-                    http_status_code=HTTPStatus.BAD_REQUEST,
-                    errors=errors,
-                )
-
-        # Keep the dimension links and attributes on the columns from the node's
-        # last revision if any existed
-        old_columns_mapping = {col.name: col for col in old_revision.columns}
-        for col in validated_node.columns:
-            if col.name in old_columns_mapping:
-                col.dimension_id = old_columns_mapping[col.name].dimension_id
-                col.attributes = old_columns_mapping[col.name].attributes or []
-
-        new_parents = [n.name for n in dependencies_map]
-        parent_refs = session.exec(
-            select(Node).where(
-                # pylint: disable=no-member
-                Node.name.in_(  # type: ignore
-                    new_parents,
-                ),
-            ),
-        ).all()
-        new_revision.parents = list(parent_refs)
-        new_revision.columns = validated_node.columns or []
-
-        # Update the primary key if one was set in the input
-        if data is not None and data.primary_key:
-            pk_attribute = session.exec(
-                select(AttributeType).where(AttributeType.name == "primary_key"),
-            ).one()
-            for col in new_revision.columns:
-                if col.name in data.primary_key and not col.has_primary_key_attribute():
-                    col.attributes.append(
-                        ColumnAttribute(column=col, attribute_type=pk_attribute),
-                    )
-
-        # Set the node's validity status
-        invalid_primary_key = (
-            new_revision.type == NodeType.DIMENSION and not new_revision.primary_key()
-        )
-        if invalid_primary_key:
-            new_revision.status = NodeStatus.INVALID
-
-        new_revision.missing_parents = [
-            MissingParent(name=missing_parent) for missing_parent in missing_parents_map
-        ]
-        _logger.info(
-            "Parent nodes for %s (v%s): %s",
-            new_revision.name,
-            new_revision.version,
-            [p.name for p in new_revision.parents],
-        )
-        new_revision.columns = validated_node.columns or []
-
-    # Handle materializations
-    active_materializations = [
-        mat for mat in old_revision.materializations if not mat.deactivated_at
-    ]
-    if active_materializations and query_changes:
-        for old in active_materializations:
-            new_revision.materializations.append(
-                create_new_materialization(
-                    session,
-                    new_revision,
-                    UpsertMaterialization(
-                        **old.dict(), **{"engine": old.engine.dict()}
-                    ),
-                ),
-            )
-        schedule_materialization_jobs(
-            new_revision.materializations,
-            query_service_client,
-        )
-    return new_revision
 
 
 @router.post(
@@ -1909,61 +770,12 @@ def update_node(
     """
     Update a node.
     """
-
-    query = (
-        select(Node)
-        .where(Node.name == name)
-        .with_for_update()
-        .execution_options(populate_existing=True)
-    )
-    node = session.exec(query).one_or_none()
-    if not node:
-        raise DJException(
-            message=f"A node with name `{name}` does not exist.",
-            http_status_code=404,
-        )
-
-    old_revision = node.current
-    new_revision = create_new_revision_from_existing(
-        session,
-        query_service_client,
-        old_revision,
-        node,
+    node = _update_node(
+        name,
         data,
+        session=session,
+        query_service_client=query_service_client,
     )
-
-    if not new_revision:
-        return node  # type: ignore
-
-    node.current_version = new_revision.version
-
-    new_revision.extra_validation()
-
-    session.add(new_revision)
-    session.add(node)
-
-    session.add(
-        History(
-            entity_type=EntityType.NODE,
-            entity_name=node.name,
-            node=node.name,
-            activity_type=ActivityType.UPDATE,
-            details={
-                "version": new_revision.version,
-            },
-        ),
-    )
-
-    if new_revision.status != old_revision.status:
-        session.add(
-            status_change_history(
-                new_revision,
-                old_revision.status,
-                new_revision.status,
-            ),
-        )
-    session.commit()
-    session.refresh(node.current)
     return node  # type: ignore
 
 
@@ -1987,7 +799,11 @@ def calculate_node_similarity(
     return JSONResponse(status_code=200, content={"similarity": similarity})
 
 
-@router.get("/nodes/{name}/downstream/", response_model=List[NodeOutput])
+@router.get(
+    "/nodes/{name}/downstream/",
+    response_model=List[NodeOutput],
+    name="List Downstream Nodes For A Node",
+)
 def list_downstream_nodes(
     name: str, *, node_type: NodeType = None, session: Session = Depends(get_session)
 ) -> List[NodeOutput]:
@@ -1997,7 +813,11 @@ def list_downstream_nodes(
     return get_downstream_nodes(session, name, node_type)  # type: ignore
 
 
-@router.get("/nodes/{name}/upstream/", response_model=List[NodeOutput])
+@router.get(
+    "/nodes/{name}/upstream/",
+    response_model=List[NodeOutput],
+    name="List Upstream Nodes For A Node",
+)
 def list_upstream_nodes(
     name: str, *, node_type: NodeType = None, session: Session = Depends(get_session)
 ) -> List[NodeOutput]:
@@ -2007,7 +827,11 @@ def list_upstream_nodes(
     return get_upstream_nodes(session, name, node_type)  # type: ignore
 
 
-@router.get("/nodes/{name}/dag/", response_model=List[NodeOutput])
+@router.get(
+    "/nodes/{name}/dag/",
+    response_model=List[NodeOutput],
+    name="List All Connected Nodes (Upstreams + Downstreams)",
+)
 def list_node_dag(
     name: str, *, session: Session = Depends(get_session)
 ) -> List[NodeOutput]:

--- a/datajunction-server/datajunction_server/api/query.py
+++ b/datajunction-server/datajunction_server/api/query.py
@@ -10,7 +10,7 @@ from datajunction_server.api.helpers import get_dj_query
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.utils import get_session
 
-router = APIRouter()
+router = APIRouter(tags=["query"])
 
 
 @router.get("/query/{sql}", response_model=TranslatedSQL)

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -18,10 +18,14 @@ from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.utils import get_session
 
 _logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(tags=["sql"])
 
 
-@router.get("/sql/{node_name}/", response_model=TranslatedSQL)
+@router.get(
+    "/sql/{node_name}/",
+    response_model=TranslatedSQL,
+    name="Get SQL For A Node",
+)
 def get_sql(
     node_name: str,
     dimensions: List[str] = Query([]),
@@ -62,7 +66,7 @@ def get_sql(
     )
 
 
-@router.get("/sql/", response_model=TranslatedSQL)
+@router.get("/sql/", response_model=TranslatedSQL, name="Get SQL For Metrics")
 def get_sql_for_metrics(
     metrics: List[str] = Query([]),
     dimensions: List[str] = Query([]),

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -15,7 +15,7 @@ from datajunction_server.models.node import NodeType
 from datajunction_server.models.tag import CreateTag, Tag, TagOutput, UpdateTag
 from datajunction_server.utils import get_session
 
-router = APIRouter()
+router = APIRouter(tags=["tags"])
 
 
 def get_tag_by_name(

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -1,0 +1,402 @@
+"""Node materialization helper functions"""
+from typing import Dict, List, Set, Tuple, Union
+
+from pydantic import ValidationError
+from sqlmodel import Session
+
+from datajunction_server.api.helpers import get_engine
+from datajunction_server.construction.build import build_node
+from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.materialization.jobs import (
+    DefaultCubeMaterialization,
+    DruidCubeMaterializationJob,
+    MaterializationJob,
+    SparkSqlMaterializationJob,
+    TrinoMaterializationJob,
+)
+from datajunction_server.models import Engine, NodeRevision
+from datajunction_server.models.engine import Dialect
+from datajunction_server.models.materialization import (
+    DruidConf,
+    DruidCubeConfig,
+    GenericCubeConfig,
+    GenericMaterializationConfig,
+    Materialization,
+    MaterializationInfo,
+    Measure,
+    MetricMeasures,
+    Partition,
+    PartitionType,
+    UpsertMaterialization,
+)
+from datajunction_server.models.node import NodeType
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.sql.parsing import ast
+
+
+def build_cube_config(  # pylint: disable=too-many-locals
+    cube_node: NodeRevision,
+    combined_ast: ast.Query,
+) -> Union[DruidCubeConfig, GenericCubeConfig]:
+    """
+    Builds the materialization config for a cube. This includes two parts:
+    (a) building a query that decomposes each of the cube's metrics into their
+    constituent measures that have simple aggregations
+    (b) adding a metric to measures mapping that tells us which measures
+    in the query map to each selected metric
+
+    The query in the materialization config is different from the one stored
+    on the cube node itself in that this one is meant to create a temporary
+    table in preparation for ingestion into an OLAP database like Druid. The
+    metric to measures mapping then provides information on how to assemble
+    metrics from measures based on this query's output.
+
+    The query directly on the cube node is meant for direct querying of the cube
+    without materialization to an OLAP database.
+    """
+    dimensions_set = {
+        dim.name for dim in cube_node.columns if dim.has_dimension_attribute()
+    }
+    metrics_to_measures = {}
+    measures_tracker = {}
+    for cte in combined_ast.ctes:
+        metrics_to_measures.update(decompose_metrics(cte, dimensions_set))
+        new_select_projection: Set[Union[ast.Aliasable, ast.Expression]] = set()
+        for expr in cte.select.projection:
+            if expr in metrics_to_measures:
+                combiner, measures = metrics_to_measures[expr]  # type: ignore
+                new_select_projection = set(new_select_projection).union(
+                    measures,
+                )
+                metric_key = expr.alias_or_name.name  # type: ignore
+                if metric_key not in measures_tracker:  # pragma: no cover
+                    measures_tracker[metric_key] = MetricMeasures(
+                        metric=metric_key,
+                        measures=[],
+                        combiner=str(combiner),
+                    )
+                for measure in measures:
+                    measures_tracker[metric_key].measures.append(  # type: ignore
+                        Measure(
+                            name=measure.alias_or_name.name,
+                            field_name=str(
+                                f"{cte.alias_or_name}_{measure.alias_or_name}",
+                            ),
+                            agg=str(measure.child.name),
+                            type=str(measure.type),
+                        ),
+                    )
+            else:
+                new_select_projection.add(expr)
+        cte.select.projection = list(new_select_projection)
+    for _, metric_measures in measures_tracker.items():
+        metric_measures.measures = sorted(
+            metric_measures.measures,
+            key=lambda x: x.name,
+        )
+    combined_ast.select.projection = [
+        (
+            ast.Column(name=col.alias_or_name, _table=cte).set_alias(  # type: ignore
+                ast.Name(f"{cte.alias_or_name}_{col.alias_or_name}"),  # type: ignore
+            )
+        )
+        for cte in combined_ast.ctes
+        for col in cte.select.projection
+        if col.alias_or_name.name not in dimensions_set  # type: ignore
+    ]
+    dimension_grouping: Dict[str, List[ast.Column]] = {}
+    for col in [
+        ast.Column(name=col.alias_or_name, _table=cte)  # type: ignore
+        for cte in combined_ast.ctes
+        for col in cte.select.projection
+        if col.alias_or_name.name in dimensions_set  # type: ignore
+    ]:
+        dimension_grouping.setdefault(str(col.alias_or_name.name), []).append(col)
+
+    for col_name, columns in dimension_grouping.items():
+        combined_ast.select.projection.append(
+            ast.Function(name=ast.Name("COALESCE"), args=list(columns)).set_alias(
+                ast.Name(col_name),
+            ),
+        )
+
+    upstream_tables = sorted(
+        list(
+            {
+                f"{tbl.dj_node.catalog.name}.{tbl.identifier()}"
+                for tbl in combined_ast.find_all(ast.Table)
+                if tbl.dj_node
+            },
+        ),
+    )
+    return GenericCubeConfig(
+        query=str(combined_ast),
+        dimensions=sorted(list(dimensions_set)),
+        measures=measures_tracker,
+        partitions=[],
+        upstream_tables=upstream_tables,
+    )
+
+
+def materialization_job_from_engine(engine: Engine) -> MaterializationJob:
+    """
+    Finds the appropriate materialization job based on the choice of engine.
+    """
+    engine_to_job_mapping = {
+        Dialect.SPARK: SparkSqlMaterializationJob,
+        Dialect.TRINO: TrinoMaterializationJob,
+        Dialect.DRUID: DruidCubeMaterializationJob,
+        None: SparkSqlMaterializationJob,
+    }
+    if engine.dialect not in engine_to_job_mapping:
+        raise DJInvalidInputException(  # pragma: no cover
+            f"The engine used for materialization ({engine.name}) "
+            "must have a dialect configured.",
+        )
+    return engine_to_job_mapping[engine.dialect]  # type: ignore
+
+
+def filters_from_partitions(partitions: List[Partition]):
+    """
+    Derive filters needed from partitions spec.
+    """
+    filters = []
+    for partition in partitions:
+        if partition.type_ != PartitionType.TEMPORAL:  # pragma: no cover
+            if partition.values:  # pragma: no cover
+                quoted_values = [f"'{value}'" for value in partition.values]
+                filters.append(f"{partition.name} IN ({','.join(quoted_values)})")
+            if partition.range and len(partition.range) == 2:
+                filters.append(  # pragma: no cover
+                    f"{partition.name} BETWEEN {partition.range[0]} "
+                    f"AND {partition.range[1]}",
+                )
+    return filters
+
+
+def create_new_materialization(
+    session: Session,
+    current_revision: NodeRevision,
+    upsert: UpsertMaterialization,
+) -> Materialization:
+    """
+    Create a new materialization based on the input values.
+    """
+    generic_config = None
+    engine = get_engine(session, upsert.engine.name, upsert.engine.version)
+    if current_revision.type in (
+        NodeType.DIMENSION,
+        NodeType.TRANSFORM,
+        NodeType.METRIC,
+    ):
+        materialization_ast = build_node(
+            session=session,
+            node=current_revision,
+            filters=(
+                filters_from_partitions(
+                    [
+                        Partition.parse_obj(partition)
+                        for partition in upsert.config.partitions
+                    ],
+                )
+                if upsert.config.partitions
+                else []
+            ),
+            dimensions=[],
+            orderby=[],
+        )
+        generic_config = GenericMaterializationConfig(
+            query=str(materialization_ast),
+            spark=upsert.config.spark if upsert.config.spark else {},
+            partitions=upsert.config.partitions if upsert.config.partitions else [],
+            upstream_tables=[
+                f"{current_revision.catalog.name}.{tbl.identifier()}"
+                for tbl in materialization_ast.find_all(ast.Table)
+            ],
+        )
+
+    if current_revision.type == NodeType.CUBE:
+        # Check to see if a default materialization was already configured, so that we
+        # can copy over the default cube setup and layer on specific config as needed
+        default_job = [
+            conf
+            for conf in current_revision.materializations
+            if conf.job == DefaultCubeMaterialization.__name__
+        ][0]
+        default_job_config = GenericCubeConfig.parse_obj(default_job.config)
+        try:
+            generic_config = DruidCubeConfig(
+                node_name=current_revision.name,
+                query=default_job_config.query,
+                dimensions=default_job_config.dimensions,
+                measures=default_job_config.measures,
+                spark=upsert.config.spark,
+                druid=DruidConf.parse_obj(upsert.config.druid),
+                partitions=upsert.config.partitions,
+                upstream_tables=default_job_config.upstream_tables,
+            )
+        except (KeyError, ValidationError, AttributeError) as exc:
+            raise DJInvalidInputException(
+                message=(
+                    "No change has been made to the materialization config for "
+                    f"node `{current_revision.name}` and engine `{engine.name}` as"
+                    " the config does not have valid configuration for "
+                    f"engine `{engine.name}`."
+                ),
+            ) from exc
+    materialization_name = generic_config.identifier()  # type: ignore
+    return Materialization(
+        name=materialization_name,
+        node_revision=current_revision,
+        engine=engine,
+        config=generic_config,
+        schedule=upsert.schedule or "@daily",
+        job=materialization_job_from_engine(engine).__name__,  # type: ignore
+    )
+
+
+def schedule_materialization_jobs(
+    materializations: List[Materialization],
+    query_service_client: QueryServiceClient,
+) -> Dict[str, MaterializationInfo]:
+    """
+    Schedule recurring materialization jobs
+    """
+    materialization_jobs = {
+        cls.__name__: cls for cls in MaterializationJob.__subclasses__()
+    }
+    materialization_to_output = {}
+    for materialization in materializations:
+        clazz = materialization_jobs.get(materialization.job)
+        if clazz and materialization.name:  # pragma: no cover
+            materialization_to_output[materialization.name] = clazz().schedule(  # type: ignore
+                materialization,
+                query_service_client,
+            )
+    return materialization_to_output
+
+
+def _get_readable_name(expr):
+    """
+    Returns a readable name based on the columns in the expression. This is used
+    if we want to represent the expression as a single measure, which needs a name
+    """
+    columns = [col for arg in expr.args for col in arg.find_all(ast.Column)]
+    return (
+        "_".join(str(col.alias_or_name).rsplit(".", maxsplit=1)[-1] for col in columns)
+        if columns
+        else "placeholder"
+    )
+
+
+def decompose_expression(  # pylint: disable=too-many-return-statements
+    expr: Union[ast.Aliasable, ast.Expression],
+) -> Tuple[ast.Expression, List[ast.Alias]]:
+    """
+    Takes a metric expression and (a) determines the measures needed to evaluate
+    the metric and (b) includes the query expression needed to recombine these
+    measures into the metric, given a materialized cube.
+
+    Simple aggregations are operations that can be computed incrementally as new
+    data is ingested, without relying on the results of other aggregations.
+    Examples include SUM, COUNT, MIN, MAX.
+
+    Some complex aggregations can be decomposed to simple aggregations: i.e., AVG(x) can
+    be decomposed to SUM(x)/COUNT(x).
+    """
+    if isinstance(expr, ast.Alias):
+        expr = expr.child
+
+    if isinstance(expr, ast.Number):
+        return expr, []  # type: ignore
+
+    if not expr.is_aggregation():  # type: ignore  # pragma: no cover
+        return expr, [expr]  # type: ignore
+
+    simple_aggregations = {"sum", "count", "min", "max"}
+    if isinstance(expr, ast.Function):
+        function_name = expr.alias_or_name.name.lower()
+        readable_name = _get_readable_name(expr)
+
+        if function_name in simple_aggregations:
+            measure_name = ast.Name(f"{readable_name}_{function_name}")
+            if not expr.args[0].is_aggregation():
+                combiner: ast.Expression = ast.Function(
+                    name=ast.Name(function_name),
+                    args=[ast.Column(name=measure_name)],
+                )
+                return combiner, [expr.set_alias(measure_name)]
+
+            combiner, measures = decompose_expression(expr.args[0])
+            return (
+                ast.Function(
+                    name=ast.Name(function_name),
+                    args=[combiner],
+                ),
+                measures,
+            )
+
+        if function_name == "avg":  # pragma: no cover
+            numerator_measure_name = ast.Name(f"{readable_name}_sum")
+            denominator_measure_name = ast.Name(f"{readable_name}_count")
+            combiner = ast.BinaryOp(
+                left=ast.Function(
+                    ast.Name("sum"),
+                    args=[ast.Column(name=numerator_measure_name)],
+                ),
+                right=ast.Function(
+                    ast.Name("count"),
+                    args=[ast.Column(name=denominator_measure_name)],
+                ),
+                op=ast.BinaryOpKind.Divide,
+            )
+            return combiner, [
+                (
+                    ast.Function(ast.Name("sum"), args=expr.args).set_alias(
+                        numerator_measure_name,
+                    )
+                ),
+                (
+                    ast.Function(ast.Name("count"), args=expr.args).set_alias(
+                        denominator_measure_name,
+                    )
+                ),
+            ]
+    acceptable_binary_ops = {
+        ast.BinaryOpKind.Plus,
+        ast.BinaryOpKind.Minus,
+        ast.BinaryOpKind.Multiply,
+        ast.BinaryOpKind.Divide,
+    }
+    if isinstance(expr, ast.BinaryOp):
+        if expr.op in acceptable_binary_ops:  # pragma: no cover
+            measures_combiner_left, measures_left = decompose_expression(expr.left)
+            measures_combiner_right, measures_right = decompose_expression(expr.right)
+            combiner = ast.BinaryOp(
+                left=measures_combiner_left,
+                right=measures_combiner_right,
+                op=expr.op,
+            )
+            return combiner, measures_left + measures_right
+
+    if isinstance(expr, ast.Cast):
+        return decompose_expression(expr.expression)
+
+    raise DJInvalidInputException(  # pragma: no cover
+        f"Metric expression {expr} cannot be decomposed into its constituent measures",
+    )
+
+
+def decompose_metrics(
+    combined_ast: ast.Query,
+    dimensions_set: Set[str],
+) -> Dict[Union[ast.Aliasable, ast.Expression], Tuple[ast.Expression, List[ast.Alias]]]:
+    """
+    Decompose each metric into simple constituent measures and return a dict
+    that maps each metric to its measures.
+    """
+    metrics_to_measures = {}
+    for expr in combined_ast.select.projection:
+        if expr.alias_or_name.name not in dimensions_set:  # type: ignore
+            metrics_to_measures[expr] = decompose_expression(expr)
+    return metrics_to_measures

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -501,10 +501,10 @@ def _create_node_from_inactive(
         try:
             activate_node(name=data.name, session=session)
             return get_node_by_name(session, data.name, with_current=True)
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover
             raise DJException(
                 f"Restoring node `{data.name}` failed: {exc}",
-            ) from exc  # pragma: no cover
+            ) from exc
 
     return None
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1,0 +1,682 @@
+"""Nodes endpoint helper functions"""
+import logging
+from collections import defaultdict
+from http import HTTPStatus
+from typing import List, Optional
+
+from fastapi import Depends
+from sqlmodel import Session, select
+
+from datajunction_server.api.helpers import (
+    activate_node,
+    get_attribute_type,
+    get_engine,
+    get_node_by_name,
+    propagate_valid_status,
+    resolve_downstream_references,
+    validate_cube,
+    validate_node_data,
+)
+from datajunction_server.construction.build import build_metric_nodes
+from datajunction_server.errors import DJDoesNotExistException, DJException
+from datajunction_server.internal.materializations import (
+    build_cube_config,
+    create_new_materialization,
+    schedule_materialization_jobs,
+)
+from datajunction_server.materialization.jobs import (
+    DefaultCubeMaterialization,
+    DruidCubeMaterializationJob,
+)
+from datajunction_server.models import (
+    AttributeType,
+    Column,
+    ColumnAttribute,
+    History,
+    Node,
+    NodeRevision,
+)
+from datajunction_server.models.attribute import UniquenessScope
+from datajunction_server.models.base import generate_display_name
+from datajunction_server.models.column import ColumnAttributeInput
+from datajunction_server.models.history import (
+    ActivityType,
+    EntityType,
+    status_change_history,
+)
+from datajunction_server.models.materialization import (
+    DruidCubeConfig,
+    Materialization,
+    UpsertMaterialization,
+)
+from datajunction_server.models.node import (
+    DEFAULT_DRAFT_VERSION,
+    DEFAULT_PUBLISHED_VERSION,
+    CreateCubeNode,
+    CreateNode,
+    CreateSourceNode,
+    MissingParent,
+    NodeMode,
+    NodeStatus,
+    NodeType,
+    UpdateNode,
+)
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
+from datajunction_server.utils import (
+    Version,
+    VersionUpgrade,
+    get_query_service_client,
+    get_session,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def validate_and_build_attribute(
+    session: Session,
+    attribute_input: ColumnAttributeInput,
+    node: Node,
+) -> ColumnAttribute:
+    """
+    Run some validation and build column attribute.
+    """
+    column_map = {column.name: column for column in node.current.columns}
+    if attribute_input.column_name not in column_map:
+        raise DJDoesNotExistException(
+            message=f"Column `{attribute_input.column_name}` "
+            f"does not exist on node `{node.name}`!",
+        )
+    column = column_map[attribute_input.column_name]
+    existing_attributes = {attr.attribute_type.name: attr for attr in column.attributes}
+    if attribute_input.attribute_type_name in existing_attributes:
+        return existing_attributes[attribute_input.attribute_type_name]
+
+    # Verify attribute type exists
+    attribute_type = get_attribute_type(
+        session,
+        attribute_input.attribute_type_name,
+        attribute_input.attribute_type_namespace,
+    )
+    if not attribute_type:
+        raise DJDoesNotExistException(
+            message=f"Attribute type `{attribute_input.attribute_type_namespace}"
+            f".{attribute_input.attribute_type_name}` "
+            f"does not exist!",
+        )
+
+    # Verify that the attribute type is allowed for this node
+    if node.type not in attribute_type.allowed_node_types:
+        raise DJException(
+            message=f"Attribute type `{attribute_input.attribute_type_namespace}."
+            f"{attribute_type.name}` not allowed on node "
+            f"type `{node.type}`!",
+        )
+
+    return ColumnAttribute(
+        attribute_type=attribute_type,
+        column=column,
+    )
+
+
+def set_column_attributes_on_node(
+    session: Session,
+    attributes: List[ColumnAttributeInput],
+    node: Node,
+) -> List[Column]:
+    """
+    Sets the column attributes on the node if allowed.
+    """
+    modified_columns_map = {}
+    for attribute_input in attributes:
+        new_attribute = validate_and_build_attribute(session, attribute_input, node)
+        # pylint: disable=no-member
+        modified_columns_map[new_attribute.column.name] = new_attribute.column
+
+    # Validate column attributes by building mapping between
+    # attribute scope and columns
+    attributes_columns_map = defaultdict(set)
+    modified_columns = modified_columns_map.values()
+
+    for column in modified_columns:
+        for attribute in column.attributes:
+            scopes_map = {
+                UniquenessScope.NODE: attribute.attribute_type,
+                UniquenessScope.COLUMN_TYPE: column.type,
+            }
+            attributes_columns_map[
+                (  # type: ignore
+                    attribute.attribute_type,
+                    tuple(
+                        scopes_map[item]
+                        for item in attribute.attribute_type.uniqueness_scope
+                    ),
+                )
+            ].add(column.name)
+
+    for (attribute, _), columns in attributes_columns_map.items():
+        if len(columns) > 1 and attribute.uniqueness_scope:
+            for col in columns:
+                modified_columns_map[col].attributes = []
+            raise DJException(
+                message=f"The column attribute `{attribute.name}` is scoped to be "
+                f"unique to the `{attribute.uniqueness_scope}` level, but there "
+                "is more than one column tagged with it: "
+                f"`{', '.join(sorted(list(columns)))}`",
+            )
+
+    session.add_all(modified_columns)
+    session.add(
+        History(
+            entity_type=EntityType.COLUMN_ATTRIBUTE,
+            node=node.name,
+            activity_type=ActivityType.SET_ATTRIBUTE,
+            details={
+                "attributes": [attr.dict() for attr in attributes],
+            },
+        ),
+    )
+    session.commit()
+    for col in modified_columns:
+        session.refresh(col)
+
+    session.refresh(node)
+    session.refresh(node.current)
+    return list(modified_columns)
+
+
+def create_node_revision(
+    data: CreateNode,
+    node_type: NodeType,
+    session: Session,
+) -> NodeRevision:
+    """
+    Create a non-source node revision.
+    """
+    node_revision = NodeRevision(
+        name=data.name,
+        namespace=data.namespace,
+        display_name=data.display_name
+        if data.display_name
+        else generate_display_name(data.name),
+        description=data.description,
+        type=node_type,
+        status=NodeStatus.VALID,
+        query=data.query,
+        mode=data.mode,
+        required_dimensions=data.required_dimensions or [],
+    )
+    (
+        validated_node,
+        dependencies_map,
+        missing_parents_map,
+        _,
+        errors,
+    ) = validate_node_data(node_revision, session)
+    if errors:
+        if node_revision.mode == NodeMode.DRAFT:
+            node_revision.status = NodeStatus.INVALID
+        else:
+            raise DJException(
+                http_status_code=HTTPStatus.BAD_REQUEST,
+                errors=errors,
+            )
+    else:
+        node_revision.status = NodeStatus.VALID
+    node_revision.missing_parents = [
+        MissingParent(name=missing_parent) for missing_parent in missing_parents_map
+    ]
+    new_parents = [node.name for node in dependencies_map]
+    catalog_ids = [node.catalog_id for node in dependencies_map]
+    if node_revision.mode == NodeMode.PUBLISHED and not len(set(catalog_ids)) == 1:
+        raise DJException(
+            f"Cannot create nodes with multi-catalog dependencies: {set(catalog_ids)}",
+        )
+    catalog_id = next(iter(catalog_ids), 0)
+    parent_refs = session.exec(
+        select(Node).where(
+            # pylint: disable=no-member
+            Node.name.in_(  # type: ignore
+                new_parents,
+            ),
+        ),
+    ).all()
+    node_revision.parents = parent_refs
+
+    _logger.info(
+        "Parent nodes for %s (%s): %s",
+        data.name,
+        node_revision.version,
+        [p.name for p in node_revision.parents],
+    )
+    node_revision.columns = validated_node.columns or []
+    node_revision.catalog_id = catalog_id
+    return node_revision
+
+
+def create_cube_node_revision(  # pylint: disable=too-many-locals
+    session: Session,
+    data: CreateCubeNode,
+) -> NodeRevision:
+    """
+    Create a cube node revision.
+    """
+    (
+        metric_columns,
+        metric_nodes,
+        dimension_nodes,
+        dimension_columns,
+        catalog,
+    ) = validate_cube(
+        session,
+        data.metrics,
+        data.dimensions,
+    )
+
+    combined_ast = build_metric_nodes(
+        session,
+        metric_nodes,
+        filters=data.filters or [],
+        dimensions=data.dimensions or [],
+        orderby=data.orderby or [],
+        limit=data.limit or None,
+    )
+    dimension_attribute = session.exec(
+        select(AttributeType).where(AttributeType.name == "dimension"),
+    ).one()
+    dimensions_set = {dim.rsplit(".", 1)[1] for dim in data.dimensions}
+
+    node_columns = []
+    status = NodeStatus.VALID
+    type_inference_failed_columns = []
+    for col in combined_ast.select.projection:
+        try:
+            column_type = col.type  # type: ignore
+            column_attributes = (
+                [ColumnAttribute(attribute_type=dimension_attribute)]
+                if col.alias_or_name.name in dimensions_set
+                else []
+            )
+            node_columns.append(
+                Column(
+                    name=col.alias_or_name.name,
+                    type=column_type,
+                    attributes=column_attributes,
+                ),
+            )
+        except DJParseException:  # pragma: no cover
+            type_inference_failed_columns.append(col.alias_or_name.name)  # type: ignore
+            status = NodeStatus.INVALID
+
+    node_revision = NodeRevision(
+        name=data.name,
+        namespace=data.namespace,
+        description=data.description,
+        type=NodeType.CUBE,
+        query=str(combined_ast),
+        columns=node_columns,
+        cube_elements=metric_columns + dimension_columns,
+        parents=list(set(dimension_nodes + metric_nodes)),
+        status=status,
+        catalog=catalog,
+    )
+
+    # Set up a default materialization for the cube. Note that this does not get used
+    # for any actual materialization, but is for storing info needed for materialization
+    node_revision.materializations = []
+    default_materialization = UpsertMaterialization(
+        name="placeholder",
+        engine=node_revision.catalog.engines[0],  # pylint: disable=no-member
+        schedule="@daily",
+        config={},
+        job="CubeMaterializationJob",
+    )
+    engine = get_engine(
+        session,
+        name=default_materialization.engine.name,
+        version=default_materialization.engine.version,
+    )
+    cube_custom_config = build_cube_config(
+        node_revision,
+        combined_ast,
+    )
+    new_materialization = Materialization(
+        name=cube_custom_config.identifier(),
+        node_revision=node_revision,
+        engine=engine,
+        config=cube_custom_config,
+        schedule=default_materialization.schedule,
+        job=(
+            DefaultCubeMaterialization.__name__
+            if not isinstance(cube_custom_config, DruidCubeConfig)
+            else DruidCubeMaterializationJob.__name__
+        ),
+    )
+    node_revision.materializations.append(new_materialization)
+    return node_revision
+
+
+def save_node(
+    session: Session,
+    node_revision: NodeRevision,
+    node: Node,
+    node_mode: NodeMode,
+):
+    """
+    Links the node and node revision together and saves them
+    """
+    node_revision.node = node
+    node_revision.version = (
+        str(DEFAULT_DRAFT_VERSION)
+        if node_mode == NodeMode.DRAFT
+        else str(DEFAULT_PUBLISHED_VERSION)
+    )
+    node.current_version = node_revision.version
+    node_revision.extra_validation()
+
+    session.add(node)
+    session.add(
+        History(
+            node=node.name,
+            entity_type=EntityType.NODE,
+            entity_name=node.name,
+            activity_type=ActivityType.CREATE,
+        ),
+    )
+    session.commit()
+
+    newly_valid_nodes = resolve_downstream_references(
+        session=session,
+        node_revision=node_revision,
+    )
+    propagate_valid_status(
+        session=session,
+        valid_nodes=newly_valid_nodes,
+        catalog_id=node.current.catalog_id,  # pylint: disable=no-member
+    )
+    session.refresh(node.current)
+
+
+def _update_node(
+    name: str,
+    data: UpdateNode,
+    session: Session,
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+):
+    query = (
+        select(Node)
+        .where(Node.name == name)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    node = session.exec(query).one_or_none()
+    if not node:
+        raise DJException(
+            message=f"A node with name `{name}` does not exist.",
+            http_status_code=404,
+        )
+
+    old_revision = node.current
+    new_revision = create_new_revision_from_existing(
+        session,
+        query_service_client,
+        old_revision,
+        node,
+        data,
+    )
+
+    if not new_revision:
+        return node  # type: ignore
+
+    node.current_version = new_revision.version
+
+    new_revision.extra_validation()
+
+    session.add(new_revision)
+    session.add(node)
+
+    session.add(
+        History(
+            entity_type=EntityType.NODE,
+            entity_name=node.name,
+            node=node.name,
+            activity_type=ActivityType.UPDATE,
+            details={
+                "version": new_revision.version,
+            },
+        ),
+    )
+
+    if new_revision.status != old_revision.status:
+        session.add(
+            status_change_history(
+                new_revision,
+                old_revision.status,
+                new_revision.status,
+            ),
+        )
+    session.commit()
+    session.refresh(node.current)
+    return node
+
+
+def _create_node_from_inactive(
+    new_node_type: NodeType,
+    data: CreateSourceNode,
+    session: Session = Depends(get_session),
+) -> Optional[Node]:
+    """
+    If the node existed and is inactive the re-creation takes different steps than
+    creating it from scratch.
+    """
+    previous_inactive_node = get_node_by_name(
+        session,
+        name=data.name,
+        raise_if_not_exists=False,
+        include_inactive=True,
+    )
+    if previous_inactive_node and previous_inactive_node.deactivated_at:
+        if previous_inactive_node.type != new_node_type:
+            raise DJException(  # pragma: no cover
+                message=f"A node with name `{data.name}` of a `{previous_inactive_node.type.value}` "  # pylint: disable=line-too-long
+                "type existed before. If you want to re-created with a different type now, "
+                "you need to remove all the traces of the previous node with a <TODO> command.",
+                http_status_code=HTTPStatus.CONFLICT,
+            )
+        _update_node(
+            name=data.name,
+            data=UpdateNode(
+                # MutableNodeFields
+                display_name=data.display_name,
+                description=data.description,
+                mode=data.mode,
+                # SourceNodeFields
+                catalog=data.catalog,
+                schema_=data.schema_,
+                table=data.table,
+                columns=data.columns,
+            ),
+            session=session,
+        )
+        try:
+            activate_node(name=data.name, session=session)
+            return get_node_by_name(session, data.name, with_current=True)
+        except Exception as exc:
+            raise DJException(
+                f"Restoring node `{data.name}` failed: {exc}",
+            ) from exc  # pragma: no cover
+
+    return None
+
+
+def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-many-arguments,too-many-branches
+    session: Session,
+    query_service_client: QueryServiceClient,
+    old_revision: NodeRevision,
+    node: Node,
+    data: UpdateNode = None,
+    version_upgrade: VersionUpgrade = None,
+) -> Optional[NodeRevision]:
+    """
+    Creates a new revision from an existing node revision.
+    """
+    minor_changes = (
+        (data and data.description and old_revision.description != data.description)
+        or (data and data.mode and old_revision.mode != data.mode)
+        or (
+            data
+            and data.display_name
+            and old_revision.display_name != data.display_name
+        )
+    )
+    query_changes = (
+        old_revision.type != NodeType.SOURCE
+        and data
+        and data.query
+        and old_revision.query != data.query
+    )
+    column_changes = (
+        old_revision.type == NodeType.SOURCE
+        and data is not None
+        and data.columns is not None
+        and ({col.identifier() for col in old_revision.columns} != data.columns)
+    )
+    pk_changes = (
+        data is not None
+        and data.primary_key
+        and {col.name for col in old_revision.primary_key()} != set(data.primary_key)
+    )
+    major_changes = query_changes or column_changes or pk_changes
+
+    # If nothing has changed, do not create the new node revision
+    if not minor_changes and not major_changes and not version_upgrade:
+        return None
+
+    old_version = Version.parse(node.current_version)
+    new_mode = data.mode if data and data.mode else old_revision.mode
+    new_revision = NodeRevision(
+        name=old_revision.name,
+        node_id=node.id,
+        version=str(
+            old_version.next_major_version()
+            if major_changes or version_upgrade == VersionUpgrade.MAJOR
+            else old_version.next_minor_version(),
+        ),
+        display_name=(
+            data.display_name
+            if data and data.display_name
+            else old_revision.display_name
+        ),
+        description=(
+            data.description if data and data.description else old_revision.description
+        ),
+        query=(data.query if data and data.query else old_revision.query),
+        type=old_revision.type,
+        columns=[
+            Column(
+                name=column_data.name,
+                type=column_data.type,
+                dimension_column=column_data.dimension,
+                attributes=column_data.attributes or [],
+            )
+            for column_data in data.columns
+        ]
+        if data and data.columns
+        else old_revision.columns,
+        catalog=old_revision.catalog,
+        schema_=old_revision.schema_,
+        table=old_revision.table,
+        parents=[],
+        mode=new_mode,
+        materializations=[],
+        status=old_revision.status,
+    )
+
+    # Link the new revision to its parents if the query has changed and update its status
+    if new_revision.type != NodeType.SOURCE and (query_changes or pk_changes):
+        (
+            validated_node,
+            dependencies_map,
+            missing_parents_map,
+            _,
+            errors,
+        ) = validate_node_data(new_revision, session)
+
+        if errors:
+            if new_mode == NodeMode.DRAFT:
+                new_revision.status = NodeStatus.INVALID
+            else:
+                raise DJException(
+                    http_status_code=HTTPStatus.BAD_REQUEST,
+                    errors=errors,
+                )
+
+        # Keep the dimension links and attributes on the columns from the node's
+        # last revision if any existed
+        old_columns_mapping = {col.name: col for col in old_revision.columns}
+        for col in validated_node.columns:
+            if col.name in old_columns_mapping:
+                col.dimension_id = old_columns_mapping[col.name].dimension_id
+                col.attributes = old_columns_mapping[col.name].attributes or []
+
+        new_parents = [n.name for n in dependencies_map]
+        parent_refs = session.exec(
+            select(Node).where(
+                # pylint: disable=no-member
+                Node.name.in_(  # type: ignore
+                    new_parents,
+                ),
+            ),
+        ).all()
+        new_revision.parents = list(parent_refs)
+        new_revision.columns = validated_node.columns or []
+
+        # Update the primary key if one was set in the input
+        if data is not None and data.primary_key:
+            pk_attribute = session.exec(
+                select(AttributeType).where(AttributeType.name == "primary_key"),
+            ).one()
+            for col in new_revision.columns:
+                if col.name in data.primary_key and not col.has_primary_key_attribute():
+                    col.attributes.append(
+                        ColumnAttribute(column=col, attribute_type=pk_attribute),
+                    )
+
+        # Set the node's validity status
+        invalid_primary_key = (
+            new_revision.type == NodeType.DIMENSION and not new_revision.primary_key()
+        )
+        if invalid_primary_key:
+            new_revision.status = NodeStatus.INVALID
+
+        new_revision.missing_parents = [
+            MissingParent(name=missing_parent) for missing_parent in missing_parents_map
+        ]
+        _logger.info(
+            "Parent nodes for %s (v%s): %s",
+            new_revision.name,
+            new_revision.version,
+            [p.name for p in new_revision.parents],
+        )
+        new_revision.columns = validated_node.columns or []
+
+    # Handle materializations
+    active_materializations = [
+        mat for mat in old_revision.materializations if not mat.deactivated_at
+    ]
+    if active_materializations and query_changes:
+        for old in active_materializations:
+            new_revision.materializations.append(
+                create_new_materialization(
+                    session,
+                    new_revision,
+                    UpsertMaterialization(
+                        **old.dict(), **{"engine": old.engine.dict()}
+                    ),
+                ),
+            )
+        schedule_materialization_jobs(
+            new_revision.materializations,
+            query_service_client,
+        )
+    return new_revision

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
-from datajunction_server.api.nodes import decompose_expression
+from datajunction_server.internal.materializations import decompose_expression
 from datajunction_server.models import Database, Table
 from datajunction_server.models.column import Column
 from datajunction_server.models.node import Node, NodeRevision, NodeStatus, NodeType

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long,too-many-lines
 """
 Tests for ``datajunction_server.sql.functions``.
 """
@@ -33,8 +34,6 @@ from datajunction_server.sql.parsing.types import (
     StringType,
     WildcardType,
 )
-
-# pylint: disable=line-too-long,too-many-lines
 
 
 def test_missing_functions() -> None:


### PR DESCRIPTION
### Summary

Two main changes:

(1) Add tags to API endpoints so that they're nicely grouped in the Swagger docs UI
<img width="880" alt="Screenshot 2023-08-02 at 12 27 11 PM" src="https://github.com/DataJunction/dj/assets/9524628/3c5298ec-45d0-41c4-ac90-664586732c93">

<br/>

(2) Restructure `datajunction_server/api/nodes.py` so that:
   - `api/nodes.py` just has the nodes-related API routes
   - `api/materializations.py` has the node materialization-related API routes
   - Any helper functions that are used by either of those routes now live in `datajunction_server/internal/nodes.py` and `datajunction_server/internal/materializations.py` 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
