### PR TITLE
Add deactivating materialization to the Python client

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -377,6 +377,22 @@ class DJClient:
         )
         return response.json()
 
+    def _deactivate_materialization(
+        self,
+        node_name: str,
+        materialization_name: str,
+    ):
+        """
+        Upserts a materialization config for the node.
+        """
+        response = self._session.delete(
+            f"/nodes/{node_name}/materializations/",
+            params={
+                "materialization_name": materialization_name,
+            },
+        )
+        return response.json()
+
     def _add_availability_state(
         self,
         node_name: str,

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -191,6 +191,17 @@ class Node(ClientEntity):  # pylint: disable=protected-access
         self.refresh()
         return upsert_response
 
+    def deactivate_materialization(self, materialization_name: str):
+        """
+        Deactivate a materialization for the node.
+        """
+        response = self.dj_client._deactivate_materialization(
+            self.name,
+            materialization_name,
+        )
+        self.refresh()
+        return response
+
     def add_availability(self, availability: models.AvailabilityState):
         """
         Adds an availability state to the node

--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -124,6 +124,17 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         mock_materialize,
     )
 
+    mock_deactivate_materialization = MagicMock()
+    mock_deactivate_materialization.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=[],
+    )
+    mocker.patch.object(
+        qs_client,
+        "deactivate_materialization",
+        mock_deactivate_materialization,
+    )
+
     mock_get_materialization_info = MagicMock()
     mock_get_materialization_info.return_value = MaterializationInfo(
         urls=["http://fake.url/job"],

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -425,6 +425,14 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             "urls": [["http://fake.url/job"]],
         }
 
+        result = large_revenue_payments_only.deactivate_materialization(
+            materialization_name="default",
+        )
+        assert result == {
+            "message": "The materialization named `default` on node "
+            "`default.large_revenue_payments_only` has been successfully deactivated",
+        }
+
         large_revenue_payments_and_business_only = client.create_transform(
             name="default.large_revenue_payments_and_business_only",
             description="Only large revenue payments from business accounts",


### PR DESCRIPTION
### Summary

This adds the ability to deactivate node materializations from the Python client. @agorajek let me know if you think this should be called `delete` rather than `deactivate`, but I figure the latter actually makes more sense in the materialization context. 

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #528 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
