### PR TITLE
When updating metrics, automatically assign an alias to the metric's column

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -529,6 +529,10 @@ def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-ma
             and old_revision.display_name != data.display_name
         )
     )
+
+    if node.type == NodeType.METRIC:
+        data.query = NodeRevision.format_metric_alias(data.query, node.name)  # type: ignore
+
     query_changes = (
         old_revision.type != NodeType.SOURCE
         and data


### PR DESCRIPTION
### Summary

This PR fixes a bug where we don't automatically assign an appropriate alias to the metric's column in the query, which we do upon creating a metric node. Not doing this causes problems later when building queries for the metric. 

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #706 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
