### PR TITLE
Fix bug with building queries with struct-type columns

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from http import HTTPStatus
 from typing import List, Optional
 
-from cachetools import TTLCache, cached  # type: ignore
+from cachetools import cached, LRUCache  # type: ignore
 from cachetools.keys import hashkey  # type: ignore
 from fastapi import Depends
 from sqlmodel import Session, select
@@ -693,7 +693,7 @@ def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-ma
 
 
 @cached(
-    cache=TTLCache(maxsize=200, ttl=300),
+    cache=LRUCache(maxsize=1000),
     key=lambda session, node_rev, column_name: hashkey(node_rev, column_name),
 )
 def column_level_lineage(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from http import HTTPStatus
 from typing import List, Optional
 
-from cachetools import cached, LRUCache  # type: ignore
+from cachetools import LRUCache, cached  # type: ignore
 from cachetools.keys import hashkey  # type: ignore
 from fastapi import Depends
 from sqlmodel import Session, select

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -751,7 +751,9 @@ def column_level_lineage(
                 column_level_lineage(
                     session,
                     current.table.dj_node,
-                    current.name.name,
+                    current.name.name
+                    if not current.is_struct_ref
+                    else current.struct_column_name,
                 ),
             )
         else:

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -701,7 +701,7 @@ class Column(Aliasable, Named, Expression):
         repr=False,
         default=None,
     )
-    _struct_subscript: Optional["Name"] = field(repr=False, default=None)
+    _is_struct_ref: bool = False
     _type: Optional["ColumnType"] = field(repr=False, default=None)
     _expression: Optional[Expression] = field(repr=False, default=None)
     _is_compiled: bool = False
@@ -749,8 +749,12 @@ class Column(Aliasable, Named, Expression):
         self._expression = expression
         return self
 
-    def add_struct_subscript(self, struct_subscript: "Name"):
-        self._struct_subscript = struct_subscript
+    def set_struct_ref(self):
+        """
+        Marks this column as a struct dereference. This implies that we treat the name
+        and namespace values on this object as struct column and struct subscript values.
+        """
+        self._is_struct_ref = True
 
     def add_table(self, table: "TableExpression"):
         self._table = table
@@ -930,13 +934,23 @@ class Column(Aliasable, Named, Expression):
             source_table.add_ref_column(self, ctx)
         self._is_compiled = True
 
+    @property
+    def struct_column_name(self) -> str:
+        """If this is a struct reference, the struct type's column name"""
+        return self.namespace[0].name
+
+    @property
+    def struct_subscript(self) -> str:
+        """If this is a struct reference, the struct type's field name"""
+        return self.name.name
+
     def __str__(self) -> str:
         as_ = " AS " if self.as_ else " "
         alias = "" if not self.alias else f"{as_}{self.alias}"
         if self.table is not None and not isinstance(self.table, FunctionTable):
             name = (
-                self._struct_subscript.name
-                if self._struct_subscript
+                self.struct_column_name + "." + self.struct_subscript
+                if self._is_struct_ref
                 else self.name.name
             )
             ret = f"{self.name.quote_style}{name}{self.name.quote_style}"
@@ -947,6 +961,10 @@ class Column(Aliasable, Named, Expression):
         if self.parenthesized:
             ret = f"({ret})"
         return ret + alias
+
+    @property
+    def is_struct_ref(self):
+        return self._is_struct_ref
 
 
 @dataclass(eq=False)
@@ -1052,7 +1070,7 @@ class TableExpression(Aliasable, Expression):
                         column.add_type(col.type)
                         return True
 
-        for col in self._columns:
+        for col in self.columns:
             if isinstance(col, (Aliasable, Named)):
                 if column.name.name == col.alias_or_name.name:
                     self._ref_columns.append(column)
@@ -1073,7 +1091,7 @@ class TableExpression(Aliasable, Expression):
                         for type_field in col.type.fields:
                             if type_field.name.name == column.name.name:
                                 self._ref_columns.append(column)
-                                column.add_struct_subscript(Name(str(column.name)))
+                                column.set_struct_ref()
                                 column.add_table(self)
                                 column.add_expression(col)
                                 column.add_type(type_field.type)


### PR DESCRIPTION
### Summary

When we build SQL that accesses struct types, the built SQL (a) doesn't have the right aliased table name for the struct-type column and (b) doesn't include both the name of the column and the subscript. There were a couple of causes:
* We don't add a reference to the struct-type column onto the table
* We don't indicate that the `add_ref_column` call was successful
* We need a way to track the name for columns that reference a subscript on a `StructType` (see `_struct_subscript` variable on `ast.Column`)

### Test Plan

Added a test for the particular struct reference within a metric that was failing.

- [ ] PR has an associated issue: #718 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
