### PR TITLE
Allow for dimensions and transforms to be created without a catalog

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -505,7 +505,10 @@ def link_dimension(
         name=dimension,
         node_type=NodeType.DIMENSION,
     )
-    if node.current.catalog.name != dimension_node.current.catalog.name:
+    if (
+        dimension_node.current.catalog is not None
+        and node.current.catalog.name != dimension_node.current.catalog.name
+    ):
         raise DJException(
             message=(
                 "Cannot add dimension to column, because catalogs do not match: "

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -234,7 +234,7 @@ def create_node_revision(
     ]
     new_parents = [node.name for node in dependencies_map]
     catalog_ids = [node.catalog_id for node in dependencies_map]
-    if node_revision.mode == NodeMode.PUBLISHED and not len(set(catalog_ids)) == 1:
+    if node_revision.mode == NodeMode.PUBLISHED and not len(set(catalog_ids)) <= 1:
         raise DJException(
             f"Cannot create nodes with multi-catalog dependencies: {set(catalog_ids)}",
         )


### PR DESCRIPTION
### Summary

We should allow users to create dimensions and transforms that don't have a catalog. This makes it easier to create a dimension on-the-fly, without having to create source table that underlies the dimension. This is often useful if the dimension is just a simple enum-like mapping that can be maintained as a query in DJ rather than as a fully materialized table. An example such dimension might be:
```
name: default.title_dimension
primary_key: title_code
description: Title to title code mapping
query: 
  SELECT 0 AS title_code, 'Agha' AS title 
  UNION ALL SELECT 1, 'Abbot' 
  UNION ALL SELECT 2, 'Akhoond' 
  UNION ALL SELECT 3, 'Apostle'
```

### Test Plan

Added a unit test with the above example. Also tested with some cases locally that needed this feature.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
