### PR TITLE
Make "Compile SQL" button only call backend when requested

### DIFF
--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.14",
+  "version": "0.0.1-rc.15",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.13",
+  "version": "0.0.1-rc.14",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -11,21 +11,8 @@ SyntaxHighlighter.registerLanguage('sql', sql);
 foundation.hljs['padding'] = '2rem';
 
 export default function NodeInfoTab({ node }) {
-  const [compiledSQL, setCompiledSQL] = useState('');
   const [checked, setChecked] = useState(false);
   const nodeTags = node?.tags.map(tag => <div>{tag}</div>);
-  const djClient = useContext(DJClientContext).DataJunctionAPI;
-  useEffect(() => {
-    const fetchData = async () => {
-      const data = djClient.compiledSql(node.name);
-      if (data.sql) {
-        setCompiledSQL(data.sql);
-      } else {
-        setCompiledSQL('/* Ran into an issue while generating compiled SQL */');
-      }
-    };
-    fetchData().catch(console.error);
-  }, [node, djClient]);
   function toggle(value) {
     return !value;
   }
@@ -38,18 +25,8 @@ export default function NodeInfoTab({ node }) {
           }}
         >
           <h6 className="mb-0 w-100">Query</h6>
-          {['metric', 'dimension', 'transform'].indexOf(node?.type) > -1 ? (
-            <ToggleSwitch
-              id="toggleSwitch"
-              checked={checked}
-              onChange={() => setChecked(toggle)}
-              toggleName="Show Compiled SQL"
-            />
-          ) : (
-            <></>
-          )}
           <SyntaxHighlighter language="sql" style={foundation}>
-            {checked ? compiledSQL : node?.query}
+            {node?.query}
           </SyntaxHighlighter>
         </div>
       </div>

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -11,8 +11,25 @@ SyntaxHighlighter.registerLanguage('sql', sql);
 foundation.hljs['padding'] = '2rem';
 
 export default function NodeInfoTab({ node }) {
+  const [compiledSQL, setCompiledSQL] = useState('');
   const [checked, setChecked] = useState(false);
   const nodeTags = node?.tags.map(tag => <div>{tag}</div>);
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  useEffect(() => {
+    const fetchData = async () => {
+      if (checked === true) {
+        const data = await djClient.compiledSql(node.name);
+        if (data.sql) {
+          setCompiledSQL(data.sql);
+        } else {
+          setCompiledSQL(
+            '/* Ran into an issue while generating compiled SQL */',
+          );
+        }
+      }
+    };
+    fetchData().catch(console.error);
+  }, [node, djClient, checked]);
   function toggle(value) {
     return !value;
   }
@@ -25,8 +42,18 @@ export default function NodeInfoTab({ node }) {
           }}
         >
           <h6 className="mb-0 w-100">Query</h6>
+          {['metric', 'dimension', 'transform'].indexOf(node?.type) > -1 ? (
+            <ToggleSwitch
+              id="toggleSwitch"
+              checked={checked}
+              onChange={() => setChecked(toggle)}
+              toggleName="Show Compiled SQL"
+            />
+          ) : (
+            <></>
+          )}
           <SyntaxHighlighter language="sql" style={foundation}>
-            {node?.query}
+            {checked ? compiledSQL : node?.query}
           </SyntaxHighlighter>
         </div>
       </div>


### PR DESCRIPTION
### Summary

The "Show Compiled SQL" toggle in the UI should only call the backend when a user actually requests it. Alternatively we should just make the compilation faster and/or cache the compiled node.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
