### PR TITLE
Fix two bugs around namespaces

### DIFF
--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -27,6 +27,7 @@ from datajunction_server.models.node import (
     NamespaceOutput,
     Node,
     NodeMinimumDetail,
+    NodeNamespace,
     NodeType,
 )
 from datajunction_server.utils import get_session, get_settings
@@ -76,11 +77,12 @@ def list_namespaces(
     List namespaces with the number of nodes contained in them
     """
     return session.exec(
-        select(Node.namespace, func.count(Node.id).label("num_nodes"))
+        select(NodeNamespace.namespace, func.count(Node.id).label("num_nodes"))
+        .join(Node, onclause=NodeNamespace.namespace == Node.namespace, isouter=True)
         .where(
-            is_(Node.deactivated_at, None),
+            is_(NodeNamespace.deactivated_at, None),
         )
-        .group_by(Node.namespace),
+        .group_by(NodeNamespace.namespace),
     ).all()
 
 

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -26,6 +26,9 @@ def get_nodes_in_namespace(
         Node.name,
         Node.display_name,
         Node.type,
+        Node.current_version.label(  # type: ignore # pylint: disable=no-member
+            "version",
+        ),
         NodeRevision.status,
         NodeRevision.mode,
         NodeRevision.updated_at,

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -871,6 +871,7 @@ class NodeMinimumDetail(SQLModel):
 
     name: str
     display_name: str
+    version: str
     type: NodeType
     status: NodeStatus
     mode: NodeMode

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -16,6 +16,7 @@ def test_list_all_namespaces(client_with_examples: TestClient) -> None:
         {"namespace": "basic.source", "num_nodes": 2},
         {"namespace": "basic.transform", "num_nodes": 1},
         {"namespace": "dbt.dimension", "num_nodes": 1},
+        {'namespace': 'dbt.source', 'num_nodes': 0},
         {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
         {"namespace": "dbt.source.stripe", "num_nodes": 1},
         {"namespace": "dbt.transform", "num_nodes": 1},
@@ -107,6 +108,7 @@ def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
         "basic.source",
         "basic.transform",
         "basic.dimension",
+        "dbt.source",
         "dbt.source.jaffle_shop",
         "dbt.transform",
         "dbt.dimension",
@@ -131,10 +133,12 @@ def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
         "basic.source",
         "basic.transform",
         "dbt.dimension",
+        "dbt.source",
         "dbt.source.jaffle_shop",
         "dbt.source.stripe",
         "dbt.transform",
         "default",
+        "foo.bar",
     }
 
     # Check that nodes in the namespace remain deactivated

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -16,7 +16,7 @@ def test_list_all_namespaces(client_with_examples: TestClient) -> None:
         {"namespace": "basic.source", "num_nodes": 2},
         {"namespace": "basic.transform", "num_nodes": 1},
         {"namespace": "dbt.dimension", "num_nodes": 1},
-        {'namespace': 'dbt.source', 'num_nodes': 0},
+        {"namespace": "dbt.source", "num_nodes": 0},
         {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
         {"namespace": "dbt.source.stripe", "num_nodes": 1},
         {"namespace": "dbt.transform", "num_nodes": 1},


### PR DESCRIPTION
### Summary

1. One of the API endpoints for listing nodes in a namespace includes some node details for surfacing the node list with a single call in the UI. This list of fields is missing the node's latest version. Fixing this yields the versions next to the node names again:
<img width="435" alt="Screenshot 2023-08-21 at 10 29 41 AM" src="https://github.com/DataJunction/dj/assets/9524628/47cb9c64-6d55-4fcb-8536-46051a7d5e70">

2. Also fixes an issue where if a namespace has 0 nodes in it, it won't be included in the list of available namespaces. Listing namespaces should include all namespaces that are in the `nodenamespace` table.

### Test Plan

Local testing. Unit tests

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
