### PR TITLE
When hard deleting a node, completely remove its revisions and relations

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -1064,6 +1064,9 @@ def hard_delete_node(name: str, session: Session):
         linked_nodes = get_nodes_with_dimension(session=session, dimension_node=node)
 
     session.delete(node)
+    for revision in node.revisions:
+        session.delete(revision)
+
     session.commit()
     impact = []  # Aggregate all impact of this deletion to include in response
 

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -636,7 +636,12 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         },
     )
 
-    parent_links: List[NodeRelationship] = Relationship()
+    parent_links: List[NodeRelationship] = Relationship(
+        sa_relationship_kwargs={
+            "primaryjoin": "NodeRevision.id==NodeRelationship.child_id",
+            "cascade": "all, delete",
+        },
+    )
 
     missing_parents: List[MissingParent] = Relationship(
         link_model=NodeMissingParents,


### PR DESCRIPTION
### Summary

When we hard delete a node, we should also completely remove its associated node revisions, and for each node revision, all of the associated node relations entries. The current logic doesn't do this, leaving these orphaned node revisions to cause issues later, especially if a node by the same name is later recreated.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #725 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
