### PR TITLE
Version bump for server, clients/python and ui.

### DIFF
--- a/datajunction-clients/python/datajunction/__about__.py
+++ b/datajunction-clients/python/datajunction/__about__.py
@@ -1,4 +1,4 @@
 """
 Version for Hatch
 """
-__version__ = "0.0.1a18"
+__version__ = "0.0.1a20"

--- a/datajunction-server/datajunction_server/__about__.py
+++ b/datajunction-server/datajunction_server/__about__.py
@@ -1,4 +1,4 @@
 """
 Version for Hatch
 """
-__version__ = "0.0.1a19"
+__version__ = "0.0.1a20"

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.16",
+  "version": "0.0.1-rc.18",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.15",
+  "version": "0.0.1-rc.16",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {


### PR DESCRIPTION
### Summary

Version bump for `datajunction-server` and `datajunction-clients/python` . We should add all these steps to https://github.com/DataJunction/dj/actions/workflows/bump-version.yml... I'll look into that.

I still need to run `npm publish` after I get permissions to https://www.npmjs.com/package/datajunction-ui.

### Test Plan

Made sure pypi has both:
- https://github.com/DataJunction/dj/actions/workflows/bump-version.yml
- https://pypi.org/project/datajunction/

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a