### PR TITLE
Add listing of dimension attributes for any node

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -54,6 +54,7 @@ from datajunction_server.models.node import (
     CreateCubeNode,
     CreateNode,
     CreateSourceNode,
+    DimensionAttributeOutput,
     LineageColumn,
     Node,
     NodeMode,
@@ -831,6 +832,21 @@ def list_node_dag(
     downstreams = get_downstream_nodes(session, name)
     upstreams = get_upstream_nodes(session, name)
     return list(set(cast(List[Node], dimension_nodes) + downstreams + upstreams))  # type: ignore
+
+
+@router.get(
+    "/nodes/{name}/dimensions/",
+    response_model=List[DimensionAttributeOutput],
+    name="List All Dimension Attributes",
+)
+def list_all_dimension_attributes(
+    name: str, *, session: Session = Depends(get_session)
+) -> List[DimensionAttributeOutput]:
+    """
+    List all available dimension attributes for the given node.
+    """
+    node = get_node_by_name(session, name)
+    return get_dimensions(node, attributes=True)
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -85,6 +85,16 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         """
         return self.name, self.type
 
+    def is_dimensional(self) -> bool:
+        """
+        Whether this column is considered dimensional
+        """
+        return (
+            self.has_dimension_attribute()
+            or self.has_primary_key_attribute()
+            or self.dimension
+        )
+
     def has_dimension_attribute(self) -> bool:
         """
         Whether the dimension attribute is set on this column.

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -54,14 +54,7 @@ def get_dimensions(
         for column in current_node.current.columns:
             # Include the dimension if it's a column belonging to a dimension node
             # or if it's tagged with the dimension column attribute
-            if (
-                current_node.type == NodeType.DIMENSION
-                or any(
-                    attr.attribute_type.name == "dimension"
-                    for attr in column.attributes
-                )
-                or column.dimension
-            ):
+            if current_node.type == NodeType.DIMENSION or column.is_dimensional():
                 join_path_str = [
                     (
                         (

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -4158,3 +4158,18 @@ def test_decompose_expression():
         "has_ordered_sum",
         "total_sum",
     ]
+
+
+def test_list_dimension_attributes(client_with_examples: TestClient) -> None:
+    """
+    Test that listing dimension attributes for any node works.
+    """
+    response = client_with_examples.get("/nodes/default.regional_level_agg/dimensions/")
+    assert response.ok
+    assert response.json() == [
+        {"name": "default.regional_level_agg.order_day", "path": [], "type": "int"},
+        {"name": "default.regional_level_agg.order_month", "path": [], "type": "int"},
+        {"name": "default.regional_level_agg.order_year", "path": [], "type": "int"},
+        {"name": "default.regional_level_agg.state_name", "path": [], "type": "string"},
+        {"name": "default.regional_level_agg.us_region_id", "path": [], "type": "int"},
+    ]


### PR DESCRIPTION
### Summary

Adds an endpoint to list dimension attributes for any node. This opens up exploring the dimensions graph from any node, not just from metric nodes.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #746 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
