### PR TITLE
Add hard deletion for namespaces + bugfixes

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -356,6 +356,7 @@ def _build_select_ast(
     dimension_columns = dimension_columns_mapping(select)
     join_tables_for_dimensions(session, dimension_columns, tables, build_criteria)
     _build_tables_on_select(session, select, tables, memoized_queries, build_criteria)
+    print("select", select.projection)
 
 
 # pylint: disable=R0915

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -356,7 +356,6 @@ def _build_select_ast(
     dimension_columns = dimension_columns_mapping(select)
     join_tables_for_dimensions(session, dimension_columns, tables, build_criteria)
     _build_tables_on_select(session, select, tables, memoized_queries, build_criteria)
-    print("select", select.projection)
 
 
 # pylint: disable=R0915

--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -266,3 +266,9 @@ class DJQueryServiceClientException(DJException):
 
     dbapi_exception: DBAPIExceptions = "InterfaceError"
     http_status_code: int = 500
+
+
+class DJActionNotAllowedException(DJException):
+    """
+    Exception raised when an action is not allowed.
+    """

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -4,9 +4,12 @@ Helper methods for namespaces endpoints.
 from datetime import datetime
 from typing import Dict, List
 
+from sqlalchemy import or_
 from sqlalchemy.sql.operators import is_
 from sqlmodel import Session, col, select
 
+from datajunction_server.api.helpers import get_node_namespace, hard_delete_node
+from datajunction_server.errors import DJActionNotAllowedException
 from datajunction_server.models import History
 from datajunction_server.models.history import ActivityType, EntityType
 from datajunction_server.models.node import Node, NodeNamespace, NodeRevision, NodeType
@@ -22,6 +25,7 @@ def get_nodes_in_namespace(
     """
     Gets a list of node names in the namespace
     """
+    get_node_namespace(session, namespace)
     list_nodes_query = select(
         Node.name,
         Node.display_name,
@@ -33,7 +37,10 @@ def get_nodes_in_namespace(
         NodeRevision.mode,
         NodeRevision.updated_at,
     ).where(
-        col(Node.namespace).contains(namespace),  # pylint: disable=no-member
+        or_(
+            col(Node.namespace).like(f"{namespace}.%"),  # pylint: disable=no-member
+            Node.namespace == namespace,
+        ),
         Node.current_version == NodeRevision.version,
         Node.name == NodeRevision.name,
         Node.type == node_type if node_type else True,
@@ -108,3 +115,35 @@ def create_namespace(session: Session, namespace: str):
         ),
     )
     session.commit()
+
+
+def hard_delete_namespace(session: Session, namespace: str, cascade: bool = False):
+    """
+    Hard delete a node namespace.
+    """
+    node_names = session.exec(
+        select(Node.name).where(
+            or_(
+                col(Node.namespace).like(f"{namespace}.%"),  # pylint: disable=no-member
+                Node.namespace == namespace,
+            ),
+        ),
+    ).all()
+
+    if not cascade and node_names:
+        raise DJActionNotAllowedException(
+            message=(
+                f"Cannot hard delete namespace `{namespace}` as there are still the "
+                f"following nodes under it: `{node_names}`. Set `cascade` to true to "
+                "additionally hard delete the above nodes in this namespace. WARNING:"
+                " this action cannot be undone."
+            ),
+        )
+
+    impacts = {}
+    for node_name in node_names:
+        impacts[node_name] = hard_delete_node(node_name, session)
+
+    node_namespace = get_node_namespace(session, namespace)
+    session.delete(node_namespace)
+    return impacts

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -283,12 +283,20 @@ def test_hard_delete_namespace(client_with_examples: TestClient):
     )
 
     client_with_examples.post("/namespaces/foo/")
+    client_with_examples.post("/namespaces/foo.bar.baz/")
+    client_with_examples.post("/namespaces/foo.bar.baf/")
+    client_with_examples.post("/namespaces/foo.bar.bif.d/")
+
     hard_delete_response = client_with_examples.delete(
         "/namespaces/foo.bar/hard/?cascade=true",
     )
     assert hard_delete_response.json() == {
         "message": "The namespace `foo.bar` has been completely removed.",
         "impact": {
+            "foo.bar": {"namespace": "foo.bar", "status": "deleted"},
+            "foo.bar.baz": {"namespace": "foo.bar.baz", "status": "deleted"},
+            "foo.bar.baf": {"namespace": "foo.bar.baf", "status": "deleted"},
+            "foo.bar.bif.d": {"namespace": "foo.bar.bif.d", "status": "deleted"},
             "foo.bar.avg_length_of_employment": [],
             "foo.bar.avg_repair_order_discounts": [],
             "foo.bar.avg_repair_price": [],
@@ -475,6 +483,6 @@ def test_hard_delete_namespace(client_with_examples: TestClient):
     response = client_with_examples.delete("/namespaces/jaffle_shop/hard/?cascade=true")
     assert response.json() == {
         "errors": [],
-        "message": "node namespace `jaffle_shop` does not exist.",
+        "message": "Namespace `jaffle_shop` does not exist.",
         "warnings": [],
     }

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -257,3 +257,224 @@ def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
         ("status_change", {"upstream_node": "foo.bar.hard_hats"}),
         ("restore", {"message": "Cascaded from restoring namespace `foo.bar`"}),
     ]
+
+
+def test_hard_delete_namespace(client_with_examples: TestClient):
+    """
+    Test hard deleting a namespace
+    """
+    response = client_with_examples.delete("/namespaces/foo/hard/")
+    assert response.json()["message"] == (
+        "Cannot hard delete namespace `foo` as there are still the following nodes "
+        "under it: `['foo.bar.avg_length_of_employment', "
+        "'foo.bar.avg_repair_order_discounts', 'foo.bar.avg_repair_price', "
+        "'foo.bar.avg_time_to_dispatch', 'foo.bar.contractor', 'foo.bar.contractors', "
+        "'foo.bar.dispatcher', 'foo.bar.dispatchers', 'foo.bar.hard_hat', "
+        "'foo.bar.hard_hat_state', 'foo.bar.hard_hats', 'foo.bar.local_hard_hats', "
+        "'foo.bar.municipality', 'foo.bar.municipality_dim', "
+        "'foo.bar.municipality_municipality_type', 'foo.bar.municipality_type', "
+        "'foo.bar.num_repair_orders', 'foo.bar.repair_order', "
+        "'foo.bar.repair_order_details', 'foo.bar.repair_orders', "
+        "'foo.bar.repair_type', 'foo.bar.total_repair_cost', "
+        "'foo.bar.total_repair_order_discounts', 'foo.bar.us_region', "
+        "'foo.bar.us_state', 'foo.bar.us_states']`. Set `cascade` to true to "
+        "additionally hard delete the above nodes in this namespace. WARNING: this "
+        "action cannot be undone."
+    )
+
+    client_with_examples.post("/namespaces/foo/")
+    hard_delete_response = client_with_examples.delete(
+        "/namespaces/foo.bar/hard/?cascade=true",
+    )
+    assert hard_delete_response.json() == {
+        "message": "The namespace `foo.bar` has been completely removed.",
+        "impact": {
+            "foo.bar.avg_length_of_employment": [],
+            "foo.bar.avg_repair_order_discounts": [],
+            "foo.bar.avg_repair_price": [],
+            "foo.bar.avg_time_to_dispatch": [],
+            "foo.bar.contractor": [
+                {
+                    "name": "foo.bar.repair_type",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+            ],
+            "foo.bar.contractors": [],
+            "foo.bar.dispatcher": [
+                {
+                    "name": "foo.bar.repair_order_details",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.num_repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_cost",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_order_discounts",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+            ],
+            "foo.bar.dispatchers": [],
+            "foo.bar.hard_hat": [
+                {
+                    "name": "foo.bar.repair_order_details",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.num_repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_cost",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_order_discounts",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+            ],
+            "foo.bar.hard_hat_state": [
+                {
+                    "name": "foo.bar.local_hard_hats",
+                    "status": "invalid",
+                    "effect": "downstream node is now invalid",
+                },
+            ],
+            "foo.bar.hard_hats": [
+                {
+                    "name": "foo.bar.local_hard_hats",
+                    "status": "invalid",
+                    "effect": "downstream node is now invalid",
+                },
+            ],
+            "foo.bar.local_hard_hats": [],
+            "foo.bar.municipality": [
+                {
+                    "name": "foo.bar.municipality_dim",
+                    "status": "invalid",
+                    "effect": "downstream node is now invalid",
+                },
+            ],
+            "foo.bar.municipality_dim": [
+                {
+                    "name": "foo.bar.repair_order_details",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.num_repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_cost",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_order_discounts",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+            ],
+            "foo.bar.municipality_municipality_type": [],
+            "foo.bar.municipality_type": [],
+            "foo.bar.num_repair_orders": [],
+            "foo.bar.repair_order": [
+                {
+                    "name": "foo.bar.repair_order_details",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_cost",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.total_repair_order_discounts",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+            ],
+            "foo.bar.repair_order_details": [
+                {
+                    "name": "foo.bar.total_repair_cost",
+                    "status": "invalid",
+                    "effect": "downstream node is now invalid",
+                },
+                {
+                    "name": "foo.bar.total_repair_order_discounts",
+                    "status": "invalid",
+                    "effect": "downstream node is now invalid",
+                },
+            ],
+            "foo.bar.repair_orders": [],
+            "foo.bar.repair_type": [],
+            "foo.bar.total_repair_cost": [],
+            "foo.bar.total_repair_order_discounts": [],
+            "foo.bar.us_region": [
+                {
+                    "name": "foo.bar.us_state",
+                    "status": "invalid",
+                    "effect": "downstream node is now invalid",
+                },
+            ],
+            "foo.bar.us_state": [],
+            "foo.bar.us_states": [],
+        },
+    }
+    list_namespaces_response = client_with_examples.get("/namespaces/")
+    assert list_namespaces_response.json() == [
+        {"namespace": "basic", "num_nodes": 8},
+        {"namespace": "basic.dimension", "num_nodes": 2},
+        {"namespace": "basic.source", "num_nodes": 2},
+        {"namespace": "basic.transform", "num_nodes": 1},
+        {"namespace": "dbt.dimension", "num_nodes": 1},
+        {"namespace": "dbt.source", "num_nodes": 0},
+        {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
+        {"namespace": "dbt.source.stripe", "num_nodes": 1},
+        {"namespace": "dbt.transform", "num_nodes": 1},
+        {"namespace": "default", "num_nodes": 54},
+        {"namespace": "foo", "num_nodes": 0},
+    ]
+
+    response = client_with_examples.delete("/namespaces/jaffle_shop/hard/?cascade=true")
+    assert response.json() == {
+        "errors": [],
+        "message": "node namespace `jaffle_shop` does not exist.",
+        "warnings": [],
+    }


### PR DESCRIPTION
### Summary

This adds "hard" deletion for namespaces, including an option to cascade the hard delete to nodes within the namespace. This opens up an option to completely remove namespaces (and the nodes within them) from the DJ database, which is useful in certain contexts, where namespace deactivation will just litter the database with unnecessary state. We should eventually put this behind an admin gate. 

This PR also fixes two bugs around namespace functions:
* When we try to list nodes under a namespace, we should first check to make sure the namespace exists and raise an error if it doesn't.
* When listing nodes under a namespace, we shouldn't match on any namespace that contains the search string, as trying to search for namespace `foo.bar` will also (erroneously) match on `default.foo.bar`. Instead, we need to match on the search namespace being the prefix.

### Test Plan

Locally + added unit test

- [x] PR has an associated issue: #744
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
