### PR TITLE
Fix trailing slashes in FastAPI endpoints by adding custom APIRouter

### DIFF
--- a/datajunction-server/tests/api/routers_test.py
+++ b/datajunction-server/tests/api/routers_test.py
@@ -1,0 +1,32 @@
+"""
+Tests for the custom API routers.
+"""
+from fastapi.testclient import TestClient
+
+
+def test_api_router_trailing_slashes(
+    client_with_examples: TestClient,
+) -> None:
+    """
+    Test that the API router used by our endpoints will send both routes without
+    trailing slashes and those with trailing slashes to right place.
+    """
+    response = client_with_examples.get("/attributes/")
+    assert response.ok
+    assert len(response.json()) > 0
+
+    response = client_with_examples.get("/attributes")
+    assert response.ok
+    assert len(response.json()) > 0
+
+    response = client_with_examples.get("/namespaces/")
+    assert response.ok
+    assert len(response.json()) > 0
+
+    response = client_with_examples.get("/namespaces")
+    assert response.ok
+    assert len(response.json()) > 0
+
+    response = client_with_examples.get("/namespaces/basic?type_=source")
+    assert response.ok
+    assert len(response.json()) > 0


### PR DESCRIPTION
### Summary

This PR fixes the issue where using any endpoints without the trailing slash will yield an unhelpful 307 Temporary Redirect when run with uvicorn. The change adds a custom `APIRouter` with the trailing slashes handler fix from https://github.com/tiangolo/fastapi/discussions/7298. 

All endpoints will show up in the Swagger docs without the trailing slash, but the same endpoint can be used with or without the slash.

### Test Plan

Tested locally. Added a unit test for the new router class.

- [x] PR has an associated issue: #751 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
