### PR TITLE
Streamline unit tests

### DIFF
--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -119,12 +119,12 @@ repairs_cube = dj.create_cube(
 
 
 def test_generated_python_client_code_adding_materialization(
-    _client_with_query_service: TestClient,
+    client_with_query_service_example_loader,
 ):
     """
     Test that generating python client code for adding materialization works
     """
-    custom_client = _client_with_query_service(["BASIC"])
+    custom_client = client_with_query_service_example_loader(["BASIC"])
     custom_client.post(
         "/engines/",
         json={

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -5,11 +5,11 @@ Tests for client code generator.
 from fastapi.testclient import TestClient
 
 
-def test_generated_python_client_code_new_metric(client_with_examples: TestClient):
+def test_generated_python_client_code_new_metric(client_with_roads: TestClient):
     """
     Test generating Python client code for creating a new metric
     """
-    response = client_with_examples.get(
+    response = client_with_roads.get(
         "/datajunction-clients/python/new_node/default.num_repair_orders",
     )
     assert (
@@ -30,11 +30,11 @@ num_repair_orders = dj.create_metric(
     )
 
 
-def test_generated_python_client_code_new_source(client_with_examples: TestClient):
+def test_generated_python_client_code_new_source(client_with_roads: TestClient):
     """
     Test generating Python client code for creating a new source
     """
-    response = client_with_examples.get(
+    response = client_with_roads.get(
         "/datajunction-clients/python/new_node/default.repair_order_details",
     )
     assert (
@@ -52,11 +52,11 @@ repair_order_details = dj.create_source(
     )
 
 
-def test_generated_python_client_code_new_dimension(client_with_examples: TestClient):
+def test_generated_python_client_code_new_dimension(client_with_roads: TestClient):
     """
     Test generating Python client code for creating a new dimension
     """
-    response = client_with_examples.get(
+    response = client_with_roads.get(
         "/datajunction-clients/python/new_node/default.repair_order",
     )
     assert (
@@ -83,11 +83,11 @@ repair_order = dj.create_dimension(
     )
 
 
-def test_generated_python_client_code_new_cube(client_with_examples: TestClient):
+def test_generated_python_client_code_new_cube(client_with_roads: TestClient):
     """
     Test generating Python client code for creating a new dimension
     """
-    client_with_examples.post(
+    client_with_roads.post(
         "/nodes/cube/",
         json={
             "metrics": ["default.num_repair_orders", "default.total_repair_cost"],
@@ -100,7 +100,7 @@ def test_generated_python_client_code_new_cube(client_with_examples: TestClient)
             "name": "default.repairs_cube",
         },
     )
-    response = client_with_examples.get(
+    response = client_with_roads.get(
         "/datajunction-clients/python/new_node/default.repairs_cube",
     )
     assert (
@@ -119,12 +119,13 @@ repairs_cube = dj.create_cube(
 
 
 def test_generated_python_client_code_adding_materialization(
-    client_with_query_service: TestClient,
+    _client_with_query_service: TestClient,
 ):
     """
     Test that generating python client code for adding materialization works
     """
-    client_with_query_service.post(
+    custom_client = _client_with_query_service(["BASIC"])
+    custom_client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -132,7 +133,7 @@ def test_generated_python_client_code_adding_materialization(
             "dialect": "spark",
         },
     )
-    client_with_query_service.post(
+    custom_client.post(
         "/nodes/basic.transform.country_agg/materialization/",
         json={
             "engine": {
@@ -151,7 +152,7 @@ def test_generated_python_client_code_adding_materialization(
             "schedule": "0 * * * *",
         },
     )
-    response = client_with_query_service.get(
+    response = custom_client.get(
         "/datajunction-clients/python/add_materialization/basic.transform.country_agg/country_3491792861",  # pylint: disable=line-too-long
     )
     assert (
@@ -189,11 +190,11 @@ country_agg.add_materialization(
     )
 
 
-def test_generated_python_client_code_link_dimension(client_with_examples: TestClient):
+def test_generated_python_client_code_link_dimension(client_with_namespaced_roads: TestClient):
     """
     Test generating Python client code for creating a new dimension
     """
-    response = client_with_examples.get(
+    response = client_with_namespaced_roads.get(
         "/datajunction-clients/python/link_dimension/foo.bar.repair_orders/"
         "municipality_id/foo.bar.municipality_dim/",
     )

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -190,7 +190,9 @@ country_agg.add_materialization(
     )
 
 
-def test_generated_python_client_code_link_dimension(client_with_namespaced_roads: TestClient):
+def test_generated_python_client_code_link_dimension(
+    client_with_namespaced_roads: TestClient,
+):
     """
     Test generating Python client code for creating a new dimension
     """

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -205,12 +205,12 @@ def test_raise_on_cube_with_multiple_catalogs(
 
 @pytest.fixture
 def client_with_repairs_cube(
-    _client_with_query_service: Callable[[List[str]], TestClient],
+    client_with_query_service_example_loader,
 ):
     """
     Adds a repairs cube with a new double total repair cost metric to the test client
     """
-    custom_client = _client_with_query_service(["ROADS"])
+    custom_client = client_with_query_service_example_loader(["ROADS"])
     metrics_list = [
         "default.discounted_orders_rate",
         "default.num_repair_orders",

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -46,12 +46,6 @@ def test_list_nodes_by_namespace(client_with_basic: TestClient) -> None:
         "basic.transform.country_agg",
         "basic.num_comments",
         "basic.num_users",
-        "basic.murals",
-        "basic.patches",
-        "basic.corrected_patches",
-        "basic.paint_colors_trino",
-        "basic.paint_colors_spark",
-        "basic.avg_luminosity_patches",
     }
 
     response = client_with_basic.get("/namespaces/basic/?type_=dimension")
@@ -59,17 +53,13 @@ def test_list_nodes_by_namespace(client_with_basic: TestClient) -> None:
     assert {n["name"] for n in response.json()} == {
         "basic.dimension.users",
         "basic.dimension.countries",
-        "basic.paint_colors_spark",
-        "basic.paint_colors_trino",
     }
 
     response = client_with_basic.get("/namespaces/basic/?type_=source")
     assert response.ok
     assert {n["name"] for n in response.json()} == {
         "basic.source.comments",
-        "basic.murals",
         "basic.source.users",
-        "basic.patches",
     }
 
 

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -25,18 +25,18 @@ def test_list_all_namespaces(client_with_examples: TestClient) -> None:
     ]
 
 
-def test_list_nodes_by_namespace(client_with_examples: TestClient) -> None:
+def test_list_nodes_by_namespace(client_with_basic: TestClient) -> None:
     """
     Test ``GET /namespaces/{namespace}/``.
     """
-    response = client_with_examples.get("/namespaces/basic.source/")
+    response = client_with_basic.get("/namespaces/basic.source/")
     assert response.ok
     assert {n["name"] for n in response.json()} == {
         "basic.source.users",
         "basic.source.comments",
     }
 
-    response = client_with_examples.get("/namespaces/basic/")
+    response = client_with_basic.get("/namespaces/basic/")
     assert response.ok
     assert {n["name"] for n in response.json()} == {
         "basic.source.users",
@@ -54,7 +54,7 @@ def test_list_nodes_by_namespace(client_with_examples: TestClient) -> None:
         "basic.avg_luminosity_patches",
     }
 
-    response = client_with_examples.get("/namespaces/basic/?type_=dimension")
+    response = client_with_basic.get("/namespaces/basic/?type_=dimension")
     assert response.ok
     assert {n["name"] for n in response.json()} == {
         "basic.dimension.users",
@@ -63,7 +63,7 @@ def test_list_nodes_by_namespace(client_with_examples: TestClient) -> None:
         "basic.paint_colors_trino",
     }
 
-    response = client_with_examples.get("/namespaces/basic/?type_=source")
+    response = client_with_basic.get("/namespaces/basic/?type_=source")
     assert response.ok
     assert {n["name"] for n in response.json()} == {
         "basic.source.comments",
@@ -73,19 +73,19 @@ def test_list_nodes_by_namespace(client_with_examples: TestClient) -> None:
     }
 
 
-def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
+def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None:
     """
     Test ``DELETE /namespaces/{namespace}``.
     """
     # Cannot deactivate if there are nodes under the namespace
-    response = client_with_examples.delete("/namespaces/foo.bar/?cascade=false")
+    response = client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=false")
     assert response.json() == {
         "message": "Cannot deactivate node namespace `foo.bar` as there are still "
         "active nodes under that namespace.",
     }
 
     # Can deactivate with cascade
-    response = client_with_examples.delete("/namespaces/foo.bar/?cascade=true")
+    response = client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=true")
     assert response.json() == {
         "message": "Namespace `foo.bar` has been deactivated. The following nodes "
         "have also been deactivated: foo.bar.repair_orders,foo.bar.repair_order_details,"
@@ -100,55 +100,34 @@ def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
     }
 
     # Check that the namespace is no longer listed
-    response = client_with_examples.get("/namespaces/")
+    response = client_with_namespaced_roads.get("/namespaces/")
     assert response.ok
-    assert {n["namespace"] for n in response.json()} == {
-        "default",
-        "basic",
-        "basic.source",
-        "basic.transform",
-        "basic.dimension",
-        "dbt.source",
-        "dbt.source.jaffle_shop",
-        "dbt.transform",
-        "dbt.dimension",
-        "dbt.source.stripe",
-    }
+    assert "foo.bar" not in {n["namespace"] for n in response.json()}
 
-    response = client_with_examples.delete("/namespaces/foo.bar/?cascade=false")
+    response = client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=false")
     assert response.json()["message"] == "Namespace `foo.bar` is already deactivated."
 
     # Try restoring
-    response = client_with_examples.post("/namespaces/foo.bar/restore/")
+    response = client_with_namespaced_roads.post("/namespaces/foo.bar/restore/")
     assert response.json() == {
         "message": "Namespace `foo.bar` has been restored.",
     }
 
     # Check that the namespace is back
-    response = client_with_examples.get("/namespaces/")
+    response = client_with_namespaced_roads.get("/namespaces/")
     assert response.ok
-    assert {n["namespace"] for n in response.json()} == {
-        "basic",
-        "basic.dimension",
-        "basic.source",
-        "basic.transform",
-        "dbt.dimension",
-        "dbt.source",
-        "dbt.source.jaffle_shop",
-        "dbt.source.stripe",
-        "dbt.transform",
-        "default",
-        "foo.bar",
-    }
+    assert "foo.bar" in {n["namespace"] for n in response.json()}
 
     # Check that nodes in the namespace remain deactivated
-    response = client_with_examples.get("/namespaces/foo.bar/")
+    response = client_with_namespaced_roads.get("/namespaces/foo.bar/")
     assert response.ok
     assert response.json() == []
 
     # Restore with cascade=true should also restore all the nodes
-    client_with_examples.delete("/namespaces/foo.bar/?cascade=false")
-    response = client_with_examples.post("/namespaces/foo.bar/restore/?cascade=true")
+    client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=false")
+    response = client_with_namespaced_roads.post(
+        "/namespaces/foo.bar/restore/?cascade=true",
+    )
     assert response.json() == {
         "message": "Namespace `foo.bar` has been restored. The following nodes have "
         "also been restored: foo.bar.repair_orders,foo.bar.repair_order_details,foo."
@@ -162,14 +141,16 @@ def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
         "r_order_discounts,foo.bar.avg_time_to_dispatch",
     }
     # Calling restore again will raise
-    response = client_with_examples.post("/namespaces/foo.bar/restore/?cascade=true")
+    response = client_with_namespaced_roads.post(
+        "/namespaces/foo.bar/restore/?cascade=true",
+    )
     assert (
         response.json()["message"]
         == "Node namespace `foo.bar` already exists and is active."
     )
 
     # Check that nodes in the namespace are restored
-    response = client_with_examples.get("/namespaces/foo.bar/")
+    response = client_with_namespaced_roads.get("/namespaces/foo.bar/")
     assert response.ok
     assert {n["name"] for n in response.json()} == {
         "foo.bar.repair_orders",
@@ -200,7 +181,7 @@ def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
         "foo.bar.avg_time_to_dispatch",
     }
 
-    response = client_with_examples.get("/history/namespace/foo.bar/")
+    response = client_with_namespaced_roads.get("/history/namespace/foo.bar/")
     assert [
         (activity["activity_type"], activity["details"]) for activity in response.json()
     ] == [
@@ -245,7 +226,7 @@ def test_deactivate_namespaces(client_with_examples: TestClient) -> None:
         ),
     ]
 
-    response = client_with_examples.get(
+    response = client_with_namespaced_roads.get(
         "/history?node=foo.bar.avg_length_of_employment",
     )
     assert [

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -39,11 +39,11 @@ def materialization_compare(response, expected):
         assert materialization_response == materialization_expected
 
 
-def test_read_node(client_with_examples: TestClient) -> None:
+def test_read_node(client_with_roads: TestClient) -> None:
     """
     Test ``GET /nodes/{node_id}``.
     """
-    response = client_with_examples.get("/nodes/default.repair_orders/")
+    response = client_with_roads.get("/nodes/default.repair_orders/")
     data = response.json()
 
     assert response.status_code == 200
@@ -52,7 +52,7 @@ def test_read_node(client_with_examples: TestClient) -> None:
     assert data["node_revision_id"] == 1
     assert data["type"] == "source"
 
-    response = client_with_examples.get("/nodes/default.nothing/")
+    response = client_with_roads.get("/nodes/default.nothing/")
     data = response.json()
 
     assert response.status_code == 404
@@ -225,13 +225,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_create_dimension_without_catalog(
         self,
-        client_with_examples: TestClient,
+        client_with_roads,
     ):
         """
         Test that creating a dimension that's purely query-based and therefore
         doesn't reference a catalog works.
         """
-        response = client_with_examples.post(
+        response = client_with_roads.post(
             "/nodes/dimension/",
             json={
                 "description": "Title",
@@ -259,12 +259,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # Link the dimension to a column on the source node
-        response = client_with_examples.post(
+        response = client_with_roads.post(
             "/nodes/default.hard_hats/columns/title/"
             "?dimension=default.title&dimension_column=title",
         )
         assert response.ok
-        response = client_with_examples.get("/nodes/default.hard_hats/")
+        response = client_with_roads.get("/nodes/default.hard_hats/")
         assert {
             "attributes": [],
             "dimension": {"name": "default.title"},
@@ -274,16 +274,16 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_deleting_node(
         self,
-        client_with_examples: TestClient,
+        client_with_basic: TestClient,
     ):
         """
         Test deleting a node
         """
         # Delete a node
-        response = client_with_examples.delete("/nodes/basic.source.users/")
+        response = client_with_basic.delete("/nodes/basic.source.users/")
         assert response.status_code == 200
         # Check that then retrieving the node returns an error
-        response = client_with_examples.get("/nodes/basic.source.users/")
+        response = client_with_basic.get("/nodes/basic.source.users/")
         assert not response.ok
         assert response.json() == {
             "message": "A node with name `basic.source.users` does not exist.",
@@ -298,11 +298,11 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "basic.num_users",
         ]
         for downstream in expected_downstreams:
-            response = client_with_examples.get(f"/nodes/{downstream}/")
+            response = client_with_basic.get(f"/nodes/{downstream}/")
             assert response.json()["status"] == NodeStatus.INVALID
 
             # The downstreams' status change should be recorded in their histories
-            response = client_with_examples.get(f"/history?node={downstream}")
+            response = client_with_basic.get(f"/history?node={downstream}")
             assert [
                 (activity["pre"], activity["post"], activity["details"])
                 for activity in response.json()
@@ -316,7 +316,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ]
 
         # Trying to create the node again should work.
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/source/",
             json={
                 "name": "basic.source.users",
@@ -341,7 +341,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert response.ok
 
         # The deletion action should be recorded in the node's history
-        response = client_with_examples.get("/history?node=basic.source.users")
+        response = client_with_basic.get("/history?node=basic.source.users")
         history = response.json()
         assert history == [
             {
@@ -985,7 +985,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
     def verify_complete_hard_delete(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         node_name: str,
     ):
         """
@@ -998,7 +998,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # Hard delete the node
-        response = client_with_examples.delete(f"/nodes/{node_name}/hard/")
+        response = client_with_roads.delete(f"/nodes/{node_name}/hard/")
         assert response.ok
 
         # Check that all revisions (and their relations) for the node have been deleted
@@ -1039,18 +1039,18 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_hard_deleting_node_with_versions(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         session: Session,
     ):
         """
         Test that hard deleting a node will remove all previous node revisions.
         """
         # Create a few revisions for the `default.repair_order` dimension
-        client_with_examples.patch(
+        client_with_roads.patch(
             "/nodes/default.repair_order/",
             json={"query": """SELECT repair_order_id FROM default.repair_orders"""},
         )
-        client_with_examples.patch(
+        client_with_roads.patch(
             "/nodes/default.repair_order/",
             json={
                 "query": """SELECT
@@ -1064,15 +1064,15 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                         FROM default.repair_orders""",
             },
         )
-        response = client_with_examples.get("/nodes/default.repair_order")
+        response = client_with_roads.get("/nodes/default.repair_order")
         assert response.json()["version"] == "v3.0"
 
         # Hard delete all nodes and verify after each delete
-        default_nodes = client_with_examples.get("/namespaces/default/").json()
+        default_nodes = client_with_roads.get("/namespaces/default/").json()
         for node_name in default_nodes:
             self.verify_complete_hard_delete(
                 session,
-                client_with_examples,
+                client_with_roads,
                 node_name["name"],
             )
 
@@ -1095,13 +1095,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_hard_deleting_a_node(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
     ):
         """
         Test raising when restoring an already active node
         """
         # Hard deleting a node causes downstream nodes to become invalid
-        response = client_with_examples.delete("/nodes/default.repair_orders/hard/")
+        response = client_with_roads.delete("/nodes/default.repair_orders/hard/")
         assert response.ok
         assert response.json() == {
             "message": "The node `default.repair_orders` has been completely removed.",
@@ -1135,7 +1135,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Hard deleting a dimension creates broken links
-        response = client_with_examples.delete("/nodes/default.repair_order/hard/")
+        response = client_with_roads.delete("/nodes/default.repair_order/hard/")
         assert response.ok
         assert response.json() == {
             "message": "The node `default.repair_order` has been completely removed.",
@@ -1189,7 +1189,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Hard deleting an unlinked dimension has no impact
-        response = client_with_examples.delete("/nodes/default.municipality_dim/hard/")
+        response = client_with_roads.delete("/nodes/default.municipality_dim/hard/")
         assert response.ok
         assert response.json() == {
             "message": "The node `default.municipality_dim` has been completely removed.",
@@ -1197,7 +1197,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Hard delete a metric
-        response = client_with_examples.delete(
+        response = client_with_roads.delete(
             "/nodes/default.avg_repair_order_discounts/hard/",
         )
         assert response.ok
@@ -1223,13 +1223,14 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_create_source_node_with_query_service(
         self,
-        client_with_query_service: TestClient,
+        _client_with_query_service: TestClient,
     ):
         """
         Creating a source node without columns but with a query service set should
         result in the source node columns being inferred via the query service.
         """
-        response = client_with_query_service.post(
+        custom_client = _client_with_query_service(["BASIC"])
+        response = custom_client.post(
             "/register/table/public/basic/comments/",
         )
         data = response.json()
@@ -1257,12 +1258,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_refresh_source_node(
         self,
-        client_with_query_service: TestClient,
+        _client_with_query_service: TestClient,
     ):
         """
         Refresh a source node with a query service
         """
-        response = client_with_query_service.post(
+        custom_client = _client_with_query_service(["ROADS"])
+        response = custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data = response.json()
@@ -1313,7 +1315,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["columns"] == new_columns
         assert response.status_code == 201
 
-        response = client_with_query_service.get("/history?node=default.repair_orders")
+        response = custom_client.get("/history?node=default.repair_orders")
         history = response.json()
         assert [
             (activity["activity_type"], activity["entity_type"]) for activity in history
@@ -1321,7 +1323,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Refresh it again, but this time no columns will have changed so
         # verify that the node revision stays the same
-        response = client_with_query_service.post(
+        response = custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_second = response.json()
@@ -1331,7 +1333,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_create_update_source_node(
         self,
-        client_with_examples: TestClient,
+        client_with_basic: TestClient,
     ) -> None:
         """
         Test creating and updating a source node
@@ -1356,7 +1358,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Trying to create it again should fail
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/source/",
             json=basic_source_comments,
         )
@@ -1368,7 +1370,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert response.status_code == 409
 
         # Update node with a new description should create a new revision
-        response = client_with_examples.patch(
+        response = client_with_basic.patch(
             f"/nodes/{basic_source_comments['name']}/",
             json={
                 "description": "New description",
@@ -1384,7 +1386,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["description"] == "New description"
 
         # Try to update node with no changes
-        response = client_with_examples.patch(
+        response = client_with_basic.patch(
             f"/nodes/{basic_source_comments['name']}/",
             json={"description": "New description", "display_name": "Comments facts"},
         )
@@ -1392,7 +1394,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data == new_data
 
         # Try to update a node with a table that has different columns
-        response = client_with_examples.patch(
+        response = client_with_basic.patch(
             f"/nodes/{basic_source_comments['name']}/",
             json={
                 "columns": [
@@ -1506,13 +1508,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_create_node_with_type_inference_failure(
         self,
-        client_with_examples: TestClient,
+        client_with_namespaced_roads: TestClient,
     ):
         """
         Attempting to create a published metric where type inference fails should raise
         an appropriate error and fail.
         """
-        response = client_with_examples.post(
+        response = client_with_namespaced_roads.post(
             "/nodes/metric/",
             json={
                 "description": "Average length of employment",
@@ -1723,13 +1725,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ],
         }
 
-    def test_update_metric_node(self, client_with_examples: TestClient):
+    def test_update_metric_node(self, client_with_roads: TestClient):
         """
         Verify that during metric node updates, if the query changes, DJ will automatically
         alias the metric column. If this aliased query is the same as the current revision's
         query, DJ won't promote the version.
         """
-        response = client_with_examples.patch(
+        response = client_with_roads.patch(
             "/nodes/default.total_repair_cost/",
             json={"query": "SELECT sum(price) FROM default.repair_order_details"},
         )
@@ -1738,10 +1740,10 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "SELECT  sum(price) default_DOT_total_repair_cost \n"
             " FROM default.repair_order_details\n\n"
         )
-        response = client_with_examples.get("/nodes/default.total_repair_cost")
+        response = client_with_roads.get("/nodes/default.total_repair_cost")
         assert response.json()["version"] == "v1.0"
 
-        response = client_with_examples.patch(
+        response = client_with_roads.patch(
             "/nodes/default.total_repair_cost/",
             json={"query": "SELECT count(price) FROM default.repair_order_details"},
         )
@@ -1750,7 +1752,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "SELECT  count(price) default_DOT_total_repair_cost \n"
             " FROM default.repair_order_details\n\n"
         )
-        response = client_with_examples.get("/nodes/default.total_repair_cost")
+        response = client_with_roads.get("/nodes/default.total_repair_cost")
         assert response.json()["version"] == "v2.0"
 
     def test_create_dimension_node_fails(
@@ -1854,11 +1856,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_raise_on_multi_catalog_node(self, client_with_examples: TestClient):
+    def test_raise_on_multi_catalog_node(self, _client_with_examples: TestClient):
         """
         Test raising when trying to select from multiple catalogs
         """
-        response = client_with_examples.post(
+        custom_client = _client_with_examples(["BASIC", "ACCOUNT_REVENUE"])
+        response = custom_client.post(
             "/nodes/transform/",
             json={
                 "query": (
@@ -1936,13 +1939,14 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_upsert_materialization_config(  # pylint: disable=too-many-arguments
         self,
-        client_with_query_service: TestClient,
+        _client_with_query_service: TestClient,
     ) -> None:
         """
         Test creating & updating materialization config for a node.
         """
+        custom_client = _client_with_query_service(["BASIC"])
         # Setting the materialization config for a source node should fail
-        response = client_with_query_service.post(
+        response = custom_client.post(
             "/nodes/basic.source.comments/materialization/",
             json={
                 "engine": {
@@ -1960,7 +1964,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
 
         # Setting the materialization config for an engine that doesn't exist should fail
-        response = client_with_query_service.post(
+        response = custom_client.post(
             "/nodes/basic.transform.country_agg/materialization/",
             json={
                 "engine": {
@@ -1975,12 +1979,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data["detail"] == "Engine not found: `spark` version `2.4.4`"
 
-    def test_node_with_struct(self, client_with_examples: TestClient):
+    def test_node_with_struct(self, client_with_roads: TestClient):
         """
         Test that building a query string with structs yields a correctly formatted struct
         reference.
         """
-        response = client_with_examples.post(
+        response = client_with_roads.post(
             "/nodes/transform/",
             json={
                 "description": "Regional level agg with structs",
@@ -2042,7 +2046,7 @@ GROUP BY
             "bigint>",
         } in response.json()["columns"]
 
-        client_with_examples.post(
+        client_with_roads.post(
             "/nodes/transform/",
             json={
                 "description": "Total Repair Amounts during the COVID-19 Pandemic",
@@ -2052,7 +2056,7 @@ GROUP BY
                 "mode": "published",
             },
         )
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/sql/default.total_amount_in_region_from_struct_transform?filters="
             "&dimensions=default.regional_level_agg_structs.location_hierarchy",
         )
@@ -2128,7 +2132,7 @@ GROUP BY default_DOT_regional_level_agg_structs.location_hierarchy""",
 
     def test_node_with_incremental_materialization(
         self,
-        client_with_query_service: TestClient,
+        _client_with_query_service: TestClient,
     ) -> None:
         """
         1. Create a transform node that uses dj_logical_timestamp (i.e., it is
@@ -2137,7 +2141,8 @@ GROUP BY default_DOT_regional_level_agg_structs.location_hierarchy""",
         3. When SQL for the metric is requested without the transform having been materialized,
            the request will fail.
         """
-        client_with_query_service.post(
+        custom_client = _client_with_query_service(["ROADS"])
+        custom_client.post(
             "/nodes/transform/",
             json={
                 "description": "Repair orders transform (partitioned)",
@@ -2159,12 +2164,12 @@ GROUP BY default_DOT_regional_level_agg_structs.location_hierarchy""",
                 "primary_key": ["repair_order_id"],
             },
         )
-        client_with_query_service.post(
+        custom_client.post(
             "/nodes/default.repair_orders_partitioned/columns/hard_hat_id/"
             "?dimension=default.hard_hat&dimension_column=hard_hat_id",
         )
 
-        client_with_query_service.post(
+        custom_client.post(
             "/nodes/metric/",
             json={
                 "description": "Number of repair orders",
@@ -2173,7 +2178,7 @@ GROUP BY default_DOT_regional_level_agg_structs.location_hierarchy""",
                 "name": "default.num_repair_orders_partitioned",
             },
         )
-        response = client_with_query_service.get(
+        response = custom_client.get(
             "/sql?metrics=default.num_repair_orders_partitioned"
             "&dimensions=default.hard_hat.last_name",
         )
@@ -2215,7 +2220,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
  FROM m0_default_DOT_num_repair_orders_partitioned""",
         )
 
-        client_with_query_service.post(
+        custom_client.post(
             "/engines/",
             json={
                 "name": "spark",
@@ -2225,7 +2230,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
         )
 
         # Setting the materialization config should succeed
-        response = client_with_query_service.post(
+        response = custom_client.post(
             "/nodes/default.repair_orders_partitioned/materialization/",
             json={
                 "engine": {
@@ -2244,7 +2249,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             "`default` for node `default.repair_orders_partitioned`"
         )
 
-        response = client_with_query_service.get(
+        response = custom_client.get(
             "/nodes/default.repair_orders_partitioned",
         )
         result_sql = response.json()["materializations"][0]["config"]["query"]
@@ -2270,13 +2275,14 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
 
     def test_update_node_query_with_materializations(
         self,
-        client_with_query_service: TestClient,
+        _client_with_query_service: TestClient,
     ):
         """
         Testing updating a node's query when the node already has materializations. The node's
         materializations should be updated based on the new query and rescheduled.
         """
-        client_with_query_service.post(
+        custom_client = _client_with_query_service(["BASIC"])
+        custom_client.post(
             "/engines/",
             json={
                 "name": "spark",
@@ -2285,7 +2291,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             },
         )
 
-        client_with_query_service.post(
+        custom_client.post(
             "/nodes/basic.transform.country_agg/materialization/",
             json={
                 "engine": {
@@ -2304,7 +2310,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                 "schedule": "0 * * * *",
             },
         )
-        client_with_query_service.patch(
+        custom_client.patch(
             "/nodes/basic.transform.country_agg/",
             json={
                 "query": (
@@ -2314,7 +2320,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                 ),
             },
         )
-        response = client_with_query_service.get("/nodes/basic.transform.country_agg/")
+        response = custom_client.get("/nodes/basic.transform.country_agg/")
         node_output = response.json()
         assert node_output["materializations"] == [
             {
@@ -2808,12 +2814,12 @@ class TestNodeColumnsAttributes:
 
     def test_set_columns_attributes(
         self,
-        client_with_examples: TestClient,
+        client_with_basic: TestClient,
     ):
         """
         Validate that setting column attributes on the node works.
         """
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/basic.source.comments/attributes/",
             json=[
                 {
@@ -2836,7 +2842,7 @@ class TestNodeColumnsAttributes:
         ]
 
         # Set columns attributes
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/basic.dimension.users/attributes/",
             json=[
                 {
@@ -2875,11 +2881,11 @@ class TestNodeColumnsAttributes:
             },
         ]
 
-    def test_set_columns_attributes_failed(self, client_with_examples: TestClient):
+    def test_set_columns_attributes_failed(self, client_with_basic: TestClient):
         """
         Test setting column attributes with different failure modes.
         """
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/basic.source.comments/attributes/",
             json=[
                 {
@@ -2895,11 +2901,11 @@ class TestNodeColumnsAttributes:
             == "Attribute type `system.effective_time` not allowed on node type `source`!"
         )
 
-        response = client_with_examples.get(
+        response = client_with_basic.get(
             "/nodes/basic.source.comments/",
         )
 
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/basic.source.comments/attributes/",
             json=[
                 {
@@ -2916,7 +2922,7 @@ class TestNodeColumnsAttributes:
             "warnings": [],
         }
 
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/basic.source.comments/attributes/",
             json=[
                 {
@@ -2933,7 +2939,7 @@ class TestNodeColumnsAttributes:
             "warnings": [],
         }
 
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/basic.source.comments/attributes/",
             json=[
                 {
@@ -2955,7 +2961,7 @@ class TestNodeColumnsAttributes:
             },
         ]
 
-        response = client_with_examples.post(
+        response = client_with_basic.post(
             "/nodes/basic.source.comments/attributes/",
             json=[
                 {
@@ -2977,7 +2983,7 @@ class TestNodeColumnsAttributes:
             "warnings": [],
         }
 
-        response = client_with_examples.get("/nodes/basic.source.comments/")
+        response = client_with_basic.get("/nodes/basic.source.comments/")
         data = response.json()
         assert data["columns"] == [
             {
@@ -3027,11 +3033,11 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
     Test ``POST /nodes/validate/``.
     """
 
-    def test_validating_a_valid_node(self, client_with_examples: TestClient) -> None:
+    def test_validating_a_valid_node(self, client_with_account_revenue: TestClient) -> None:
         """
         Test validating a valid node
         """
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3258,12 +3264,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "warnings": [],
         }
 
-    def test_adding_dimensions_to_node_columns(self, client_with_examples: TestClient):
+    def test_adding_dimensions_to_node_columns(self, client_with_account_revenue: TestClient):
         """
         Test linking dimensions to node columns
         """
         # Attach the payment_type dimension to the payment_type column on the revenue node
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
         )
         data = response.json()
@@ -3273,14 +3279,14 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "linked to column payment_type on node default.revenue"
             ),
         }
-        response = client_with_examples.get("/nodes/default.revenue")
+        response = client_with_account_revenue.get("/nodes/default.revenue")
         data = response.json()
         assert [
             col["dimension"]["name"] for col in data["columns"] if col["dimension"]
         ] == ["default.payment_type"]
 
         # Check that after deleting the dimension link, none of the columns have links
-        response = client_with_examples.delete(
+        response = client_with_account_revenue.delete(
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
         )
         data = response.json()
@@ -3290,17 +3296,17 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "default.payment_type has been successfully removed."
             ),
         }
-        response = client_with_examples.get("/nodes/default.revenue")
+        response = client_with_account_revenue.get("/nodes/default.revenue")
         data = response.json()
         assert all(col["dimension"] is None for col in data["columns"])
-        response = client_with_examples.get("/history?node=default.revenue")
+        response = client_with_account_revenue.get("/history?node=default.revenue")
         assert [
             (activity["activity_type"], activity["entity_type"])
             for activity in response.json()
         ] == [("create", "node"), ("create", "link"), ("delete", "link")]
 
         # Removing the dimension link again will result in no change
-        response = client_with_examples.delete(
+        response = client_with_account_revenue.delete(
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
         )
         data = response.json()
@@ -3310,14 +3316,14 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             " specified dimension link to default.payment_type on None was not found.",
         }
         # Check history again, no change
-        response = client_with_examples.get("/history?node=default.revenue")
+        response = client_with_account_revenue.get("/history?node=default.revenue")
         assert [
             (activity["activity_type"], activity["entity_type"])
             for activity in response.json()
         ] == [("create", "node"), ("create", "link"), ("delete", "link")]
 
         # Check that the proper error is raised when the column doesn't exist
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/nodes/default.revenue/columns/non_existent_column/?dimension=default.payment_type",
         )
         assert response.status_code == 404
@@ -3327,7 +3333,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         )
 
         # Add a dimension including a specific dimension column name
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/nodes/default.revenue/columns/payment_type/"
             "?dimension=default.payment_type"
             "&dimension_column=payment_type_name",
@@ -3341,7 +3347,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "types are incompatible and the dimension cannot be linked"
         )
 
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/nodes/default.revenue/columns/payment_type/?dimension=basic.dimension.users",
         )
         data = response.json()
@@ -3349,13 +3355,13 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "Cannot add dimension to column, because catalogs do not match: default, public"
         )
 
-    def test_update_node_with_dimension_links(self, client_with_examples: TestClient):
+    def test_update_node_with_dimension_links(self, client_with_roads: TestClient):
         """
         When a node is updated with a new query, the original dimension links and attributes
         on its columns should be preserved where possible (that is, where the new and old
         columns have the same names).
         """
-        client_with_examples.patch(
+        client_with_roads.patch(
             "/nodes/default.hard_hat/",
             json={
                 "query": """
@@ -3367,7 +3373,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 """,
             },
         )
-        response = client_with_examples.get("/history?node=default.hard_hat")
+        response = client_with_roads.get("/history?node=default.hard_hat")
         history = response.json()
         assert [
             (activity["activity_type"], activity["entity_type"]) for activity in history
@@ -3378,7 +3384,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             ("update", "node"),
         ]
 
-        response = client_with_examples.get("/nodes/default.hard_hat").json()
+        response = client_with_roads.get("/nodes/default.hard_hat").json()
         assert response["columns"] == [
             {
                 "name": "hard_hat_id",
@@ -3398,7 +3404,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         ]
 
         # Check history of the node with column attribute set
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/history?node=default.hard_hat",
         )
         history = response.json()
@@ -3411,12 +3417,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             ("update", "node"),
         ]
 
-    def test_update_dimension_remove_pk_column(self, client_with_examples: TestClient):
+    def test_update_dimension_remove_pk_column(self, client_with_roads: TestClient):
         """
         When a dimension node is updated with a new query that removes the original primary key
         column, either a new primary key must be set or the node will be set to invalid.
         """
-        response = client_with_examples.patch(
+        response = client_with_roads.patch(
             "/nodes/default.hard_hat/",
             json={
                 "query": """
@@ -3429,7 +3435,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.json()["status"] == "invalid"
-        response = client_with_examples.patch(
+        response = client_with_roads.patch(
             "/nodes/default.hard_hat/",
             json={
                 "query": """
@@ -3443,11 +3449,11 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         )
         assert response.json()["status"] == "valid"
 
-    def test_node_downstreams(self, client_with_examples: TestClient):
+    def test_node_downstreams(self, client_with_event: TestClient):
         """
         Test getting downstream nodes of different node types.
         """
-        response = client_with_examples.get(
+        response = client_with_event.get(
             "/nodes/default.event_source/downstream/?node_type=metric",
         )
         data = response.json()
@@ -3456,19 +3462,19 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.device_ids_count",
         }
 
-        response = client_with_examples.get(
+        response = client_with_event.get(
             "/nodes/default.event_source/downstream/?node_type=transform",
         )
         data = response.json()
         assert {node["name"] for node in data} == {"default.long_events"}
 
-        response = client_with_examples.get(
+        response = client_with_event.get(
             "/nodes/default.event_source/downstream/?node_type=dimension",
         )
         data = response.json()
         assert {node["name"] for node in data} == {"default.country_dim"}
 
-        response = client_with_examples.get("/nodes/default.event_source/downstream/")
+        response = client_with_event.get("/nodes/default.event_source/downstream/")
         data = response.json()
         assert {node["name"] for node in data} == {
             "default.long_events_distinct_countries",
@@ -3477,23 +3483,23 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.country_dim",
         }
 
-        response = client_with_examples.get(
+        response = client_with_event.get(
             "/nodes/default.device_ids_count/downstream/",
         )
         data = response.json()
         assert data == []
 
-        response = client_with_examples.get("/nodes/default.long_events/downstream/")
+        response = client_with_event.get("/nodes/default.long_events/downstream/")
         data = response.json()
         assert {node["name"] for node in data} == {
             "default.long_events_distinct_countries",
         }
 
-    def test_node_upstreams(self, client_with_examples: TestClient):
+    def test_node_upstreams(self, client_with_event: TestClient):
         """
         Test getting upstream nodes of different node types.
         """
-        response = client_with_examples.get(
+        response = client_with_event.get(
             "/nodes/default.long_events_distinct_countries/upstream/",
         )
         data = response.json()
@@ -3502,11 +3508,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.long_events",
         }
 
-    def test_list_node_dag(self, client_with_examples: TestClient):
+    def test_list_node_dag(self, _client_with_examples: TestClient):
         """
         Test getting the DAG for a node
         """
-        response = client_with_examples.get(
+        custom_client = _client_with_examples(["EVENTS", "ROADS"])
+        response = custom_client.get(
             "/nodes/default.long_events_distinct_countries/dag",
         )
         data = response.json()
@@ -3516,7 +3523,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.long_events_distinct_countries",
         }
 
-        response = client_with_examples.get("/nodes/default.num_repair_orders/dag")
+        response = custom_client.get("/nodes/default.num_repair_orders/dag")
         data = response.json()
         assert {node["name"] for node in data} == {
             "default.dispatcher",
@@ -3528,11 +3535,11 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.us_state",
         }
 
-    def test_node_column_lineage(self, client_with_examples: TestClient):
+    def test_node_column_lineage(self, client_with_roads: TestClient):
         """
         Test endpoint to retrieve a node's column-level lineage
         """
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.num_repair_orders/lineage/",
         )
         assert response.json() == [
@@ -3553,7 +3560,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-        client_with_examples.post(
+        client_with_roads.post(
             "/nodes/metric/",
             json={
                 "name": "default.discounted_repair_orders",
@@ -3568,7 +3575,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "description": "Discounted Repair Orders",
             },
         )
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.discounted_repair_orders/lineage/",
         )
         assert response.json() == [
@@ -3596,25 +3603,25 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_revalidating_existing_nodes(self, client_with_examples: TestClient):
+    def test_revalidating_existing_nodes(self, client_with_roads: TestClient):
         """
         Test revalidating all example nodes and confirm that they are set to valid
         """
-        for node in client_with_examples.get("/nodes/").json():
-            status = client_with_examples.post(
+        for node in client_with_roads.get("/nodes/").json():
+            status = client_with_roads.post(
                 f"/nodes/{node}/validate/",
             ).json()["status"]
             assert status == "valid"
         # Confirm that they still show as valid server-side
-        for node in client_with_examples.get("/nodes/").json():
-            node = client_with_examples.get(f"/nodes/{node}").json()
+        for node in client_with_roads.get("/nodes/").json():
+            node = client_with_roads.get(f"/nodes/{node}").json()
             assert node["status"] == "valid"
 
-    def test_lineage_on_complex_transforms(self, client_with_examples: TestClient):
+    def test_lineage_on_complex_transforms(self, client_with_roads: TestClient):
         """
         Test metric lineage on more complex transforms and metrics
         """
-        response = client_with_examples.get("/nodes/default.regional_level_agg/").json()
+        response = client_with_roads.get("/nodes/default.regional_level_agg/").json()
         assert response["columns"] == [
             {
                 "name": "us_region_id",
@@ -3700,7 +3707,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.regional_repair_efficiency/",
         ).json()
         assert response["columns"] == [
@@ -3711,7 +3718,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "type": "double",
             },
         ]
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.regional_repair_efficiency/lineage/",
         ).json()
         assert response == [
@@ -3899,7 +3906,7 @@ def test_node_similarity(session: Session, client: TestClient):
     }
 
 
-def test_resolving_downstream_status(client_with_examples: TestClient) -> None:
+def test_resolving_downstream_status(client_with_service_setup: TestClient) -> None:
     """
     Test creating and updating a source node
     """
@@ -3980,7 +3987,7 @@ def test_resolving_downstream_status(client_with_examples: TestClient) -> None:
         (metric2, NodeType.METRIC),
         (metric3, NodeType.METRIC),
     ]:
-        response = client_with_examples.post(
+        response = client_with_service_setup.post(
             f"/nodes/{node_type.value}/",
             json=node,
         )
@@ -4006,7 +4013,7 @@ def test_resolving_downstream_status(client_with_examples: TestClient) -> None:
         "table": "comments",
     }
 
-    response = client_with_examples.post(
+    response = client_with_service_setup.post(
         "/nodes/source/",
         json=missing_parent_node,
     )
@@ -4017,7 +4024,7 @@ def test_resolving_downstream_status(client_with_examples: TestClient) -> None:
 
     # Check that downstream nodes have now been switched to a "valid" status
     for node in [transform1, transform2, transform3, metric1, metric2, metric3]:
-        response = client_with_examples.get(f"/nodes/{node['name']}/")
+        response = client_with_service_setup.get(f"/nodes/{node['name']}/")
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == node["name"]
@@ -4028,7 +4035,7 @@ def test_resolving_downstream_status(client_with_examples: TestClient) -> None:
 
     # Check that nodes still not valid have an invalid status
     for node in [transform4, transform5]:
-        response = client_with_examples.get(f"/nodes/{node['name']}/")
+        response = client_with_service_setup.get(f"/nodes/{node['name']}/")
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == node["name"]
@@ -4160,11 +4167,11 @@ def test_decompose_expression():
     ]
 
 
-def test_list_dimension_attributes(client_with_examples: TestClient) -> None:
+def test_list_dimension_attributes(client_with_roads: TestClient) -> None:
     """
     Test that listing dimension attributes for any node works.
     """
-    response = client_with_examples.get("/nodes/default.regional_level_agg/dimensions/")
+    response = client_with_roads.get("/nodes/default.regional_level_agg/dimensions/")
     assert response.ok
     assert response.json() == [
         {"name": "default.regional_level_agg.order_day", "path": [], "type": "int"},

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1223,13 +1223,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_create_source_node_with_query_service(
         self,
-        _client_with_query_service: TestClient,
+        client_with_query_service_example_loader,
     ):
         """
         Creating a source node without columns but with a query service set should
         result in the source node columns being inferred via the query service.
         """
-        custom_client = _client_with_query_service(["BASIC"])
+        custom_client = client_with_query_service_example_loader(["BASIC"])
         response = custom_client.post(
             "/register/table/public/basic/comments/",
         )
@@ -1258,12 +1258,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_refresh_source_node(
         self,
-        _client_with_query_service: TestClient,
+        client_with_query_service_example_loader,
     ):
         """
         Refresh a source node with a query service
         """
-        custom_client = _client_with_query_service(["ROADS"])
+        custom_client = client_with_query_service_example_loader(["ROADS"])
         response = custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
@@ -1939,12 +1939,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
     def test_upsert_materialization_config(  # pylint: disable=too-many-arguments
         self,
-        _client_with_query_service: TestClient,
+        client_with_query_service_example_loader,
     ) -> None:
         """
         Test creating & updating materialization config for a node.
         """
-        custom_client = _client_with_query_service(["BASIC"])
+        custom_client = client_with_query_service_example_loader(["BASIC"])
         # Setting the materialization config for a source node should fail
         response = custom_client.post(
             "/nodes/basic.source.comments/materialization/",
@@ -2132,7 +2132,7 @@ GROUP BY default_DOT_regional_level_agg_structs.location_hierarchy""",
 
     def test_node_with_incremental_materialization(
         self,
-        _client_with_query_service: TestClient,
+        client_with_query_service_example_loader,
     ) -> None:
         """
         1. Create a transform node that uses dj_logical_timestamp (i.e., it is
@@ -2141,7 +2141,7 @@ GROUP BY default_DOT_regional_level_agg_structs.location_hierarchy""",
         3. When SQL for the metric is requested without the transform having been materialized,
            the request will fail.
         """
-        custom_client = _client_with_query_service(["ROADS"])
+        custom_client = client_with_query_service_example_loader(["ROADS"])
         custom_client.post(
             "/nodes/transform/",
             json={
@@ -2275,13 +2275,13 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
 
     def test_update_node_query_with_materializations(
         self,
-        _client_with_query_service: TestClient,
+        client_with_query_service_example_loader,
     ):
         """
         Testing updating a node's query when the node already has materializations. The node's
         materializations should be updated based on the new query and rescheduled.
         """
-        custom_client = _client_with_query_service(["BASIC"])
+        custom_client = client_with_query_service_example_loader(["BASIC"])
         custom_client.post(
             "/engines/",
             json={

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1856,11 +1856,11 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_raise_on_multi_catalog_node(self, _client_with_examples: TestClient):
+    def test_raise_on_multi_catalog_node(self, client_example_loader):
         """
         Test raising when trying to select from multiple catalogs
         """
-        custom_client = _client_with_examples(["BASIC", "ACCOUNT_REVENUE"])
+        custom_client = client_example_loader(["BASIC", "ACCOUNT_REVENUE"])
         response = custom_client.post(
             "/nodes/transform/",
             json={
@@ -3269,12 +3269,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
 
     def test_adding_dimensions_to_node_columns(
         self,
-        _client_with_examples: TestClient,
+        client_example_loader,
     ):
         """
         Test linking dimensions to node columns
         """
-        custom_client = _client_with_examples(["ACCOUNT_REVENUE", "BASIC"])
+        custom_client = client_example_loader(["ACCOUNT_REVENUE", "BASIC"])
         # Attach the payment_type dimension to the payment_type column on the revenue node
         response = custom_client.post(
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
@@ -3515,11 +3515,11 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.long_events",
         }
 
-    def test_list_node_dag(self, _client_with_examples: TestClient):
+    def test_list_node_dag(self, client_example_loader):
         """
         Test getting the DAG for a node
         """
-        custom_client = _client_with_examples(["EVENT", "ROADS"])
+        custom_client = client_example_loader(["EVENT", "ROADS"])
         response = custom_client.get(
             "/nodes/default.long_events_distinct_countries/dag",
         )

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -300,6 +300,14 @@ def client_with_event(client_example_loader) -> TestClient:
     return client_example_loader(["EVENT"])
 
 
+@pytest.fixture
+def client_with_dbt(client_example_loader) -> TestClient:
+    """
+    Provides a DJ client fixture with dbt examples
+    """
+    return client_example_loader(["DBT"])
+
+
 def compare_parse_trees(tree1, tree2):
     """
     Recursively compare two ANTLR parse trees for equality.

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -231,11 +231,11 @@ def load_examples_in_client(
 
 
 @pytest.fixture
-def _client_with_examples(
+def client_example_loader(
     client: TestClient,
 ) -> Callable[[Optional[List[str]]], TestClient]:
     """
-    Provide a DJ test client fixture loaded with a specified set of examples.
+    Provides a callable fixture for loading examples into a DJ client.
     """
 
     def _load_examples(examples_to_load: Optional[List[str]] = None):
@@ -245,59 +245,59 @@ def _client_with_examples(
 
 
 @pytest.fixture
-def client_with_examples(_client_with_examples: TestClient) -> TestClient:
+def client_with_examples(client_example_loader) -> TestClient:
     """
-    load examples
+    Provides a DJ client fixture with all examples
     """
-    return _client_with_examples()
+    return client_example_loader()
 
 
 @pytest.fixture
-def client_with_roads(_client_with_examples: TestClient) -> TestClient:
+def client_with_service_setup(client_example_loader) -> TestClient:
     """
-    load examples
+    Provides a DJ client fixture with just the service setup
     """
-    return _client_with_examples(["ROADS"])
+    return client_example_loader([])
 
 
 @pytest.fixture
-def client_with_account_revenue(_client_with_examples: TestClient) -> TestClient:
+def client_with_roads(client_example_loader) -> TestClient:
     """
-    load examples
+    Provides a DJ client fixture with roads examples
     """
-    return _client_with_examples(["ACCOUNT_REVENUE"])
+    return client_example_loader(["ROADS"])
 
 
 @pytest.fixture
-def client_with_event(_client_with_examples: TestClient) -> TestClient:
+def client_with_namespaced_roads(client_example_loader) -> TestClient:
     """
-    load examples
+    Provides a DJ client fixture with namespaced roads examples
     """
-    return _client_with_examples(["EVENT"])
+    return client_example_loader(["NAMESPACED_ROADS"])
 
 
 @pytest.fixture
-def client_with_namespaced_roads(_client_with_examples: TestClient) -> TestClient:
+def client_with_basic(client_example_loader) -> TestClient:
     """
-    load examples
+    Provides a DJ client fixture with basic examples
     """
-    return _client_with_examples(["NAMESPACED_ROADS"])
+    return client_example_loader(["BASIC"])
 
 
 @pytest.fixture
-def client_with_service_setup(_client_with_examples: TestClient) -> TestClient:
+def client_with_account_revenue(client_example_loader) -> TestClient:
     """
-    load examples
+    Provides a DJ client fixture with account revenue examples
     """
-    return _client_with_examples([])
+    return client_example_loader(["ACCOUNT_REVENUE"])
 
 
 @pytest.fixture
-def client_with_basic(_client_with_examples: TestClient) -> TestClient:
+def client_with_event(client_example_loader) -> TestClient:
     """
-    load examples
+    Provides a DJ client fixture with event examples
     """
-    return _client_with_examples(["BASIC"])
+    return client_example_loader(["EVENT"])
 
 
 def compare_parse_trees(tree1, tree2):

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -5,7 +5,7 @@ Fixtures for testing.
 
 import re
 from http.client import HTTPException
-from typing import Callable, Collection, Iterator, List, Optional
+from typing import Callable, Collection, Generator, Iterator, List, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -376,13 +376,14 @@ def compare_query_strings_fixture():
 
 
 @pytest.fixture
-def _client_with_query_service(  # pylint: disable=too-many-statements
+def client_with_query_service_example_loader(  # pylint: disable=too-many-statements
     session: Session,
     settings: Settings,
     query_service_client: QueryServiceClient,
-) -> TestClient:
+) -> Generator[Callable[[Optional[List[str]]], TestClient], None, None]:
     """
-    Add a mock query service to the test client.
+    Provides a callable fixture for loading examples into a test client
+    fixture that additionally has a mocked query service.
     """
 
     def get_query_service_client_override() -> QueryServiceClient:
@@ -420,12 +421,15 @@ def _client_with_query_service(  # pylint: disable=too-many-statements
 
 @pytest.fixture
 def client_with_query_service(  # pylint: disable=too-many-statements
-    _client_with_query_service: TestClient,
+    client_with_query_service_example_loader: Callable[
+        [Optional[List[str]]],
+        TestClient,
+    ],
 ) -> TestClient:
     """
     Client with query service and all examples loaded.
     """
-    return _client_with_query_service()
+    return client_with_query_service_example_loader(None)
 
 
 def pytest_addoption(parser):

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -1,12 +1,11 @@
 """
 Fixtures for testing.
 """
-import copy
 # pylint: disable=redefined-outer-name, invalid-name, W0611
 
 import re
 from http.client import HTTPException
-from typing import Collection, Iterator, List, Optional, Callable
+from typing import Callable, Collection, Iterator, List, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -206,7 +205,10 @@ def post_and_raise_if_error(client: TestClient, endpoint: str, json: dict):
         raise HTTPException(response.text)
 
 
-def load_examples_in_client(client: TestClient, examples_to_load: Optional[List[str]] = None):
+def load_examples_in_client(
+    client: TestClient,
+    examples_to_load: Optional[List[str]] = None,
+):
     """
     Load the DJ client with examples
     """
@@ -217,24 +219,28 @@ def load_examples_in_client(client: TestClient, examples_to_load: Optional[List[
     # Load only the selected examples if any are specified
     if examples_to_load is not None:
         for example_name in examples_to_load:
-            for endpoint, json in EXAMPLES[example_name]:
+            for endpoint, json in EXAMPLES[example_name]:  # type: ignore
                 post_and_raise_if_error(client=client, endpoint=endpoint, json=json)  # type: ignore
         return client
 
     # Load all examples if none are specified
     for example_name, examples in EXAMPLES.items():
-        for endpoint, json in examples:
+        for endpoint, json in examples:  # type: ignore
             post_and_raise_if_error(client=client, endpoint=endpoint, json=json)  # type: ignore
     return client
 
 
 @pytest.fixture
-def _client_with_examples(client: TestClient) -> Callable[[Optional[List[str]]], TestClient]:
+def _client_with_examples(
+    client: TestClient,
+) -> Callable[[Optional[List[str]]], TestClient]:
     """
     Provide a DJ test client fixture loaded with a specified set of examples.
     """
+
     def _load_examples(examples_to_load: Optional[List[str]] = None):
         return load_examples_in_client(client, examples_to_load)
+
     return _load_examples
 
 
@@ -294,7 +300,6 @@ def client_with_basic(_client_with_examples: TestClient) -> TestClient:
     return _client_with_examples(["BASIC"])
 
 
-
 def compare_parse_trees(tree1, tree2):
     """
     Recursively compare two ANTLR parse trees for equality.
@@ -351,7 +356,6 @@ def _client_with_query_service(  # pylint: disable=too-many-statements
     session: Session,
     settings: Settings,
     query_service_client: QueryServiceClient,
-    examples_to_load: Optional[List[str]] = None,
 ) -> TestClient:
     """
     Add a mock query service to the test client.
@@ -394,6 +398,9 @@ def _client_with_query_service(  # pylint: disable=too-many-statements
 def client_with_query_service(  # pylint: disable=too-many-statements
     _client_with_query_service: TestClient,
 ) -> TestClient:
+    """
+    Client with query service and all examples loaded.
+    """
     return _client_with_query_service()
 
 

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -245,15 +245,19 @@ def client_example_loader(
 
 
 @pytest.fixture
-def client_with_examples(client_example_loader) -> TestClient:
+def client_with_examples(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with all examples
     """
-    return client_example_loader()
+    return client_example_loader(None)
 
 
 @pytest.fixture
-def client_with_service_setup(client_example_loader) -> TestClient:
+def client_with_service_setup(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with just the service setup
     """
@@ -261,7 +265,9 @@ def client_with_service_setup(client_example_loader) -> TestClient:
 
 
 @pytest.fixture
-def client_with_roads(client_example_loader) -> TestClient:
+def client_with_roads(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with roads examples
     """
@@ -269,7 +275,9 @@ def client_with_roads(client_example_loader) -> TestClient:
 
 
 @pytest.fixture
-def client_with_namespaced_roads(client_example_loader) -> TestClient:
+def client_with_namespaced_roads(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with namespaced roads examples
     """
@@ -277,7 +285,9 @@ def client_with_namespaced_roads(client_example_loader) -> TestClient:
 
 
 @pytest.fixture
-def client_with_basic(client_example_loader) -> TestClient:
+def client_with_basic(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with basic examples
     """
@@ -285,7 +295,9 @@ def client_with_basic(client_example_loader) -> TestClient:
 
 
 @pytest.fixture
-def client_with_account_revenue(client_example_loader) -> TestClient:
+def client_with_account_revenue(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with account revenue examples
     """
@@ -293,7 +305,9 @@ def client_with_account_revenue(client_example_loader) -> TestClient:
 
 
 @pytest.fixture
-def client_with_event(client_example_loader) -> TestClient:
+def client_with_event(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with event examples
     """
@@ -301,7 +315,9 @@ def client_with_event(client_example_loader) -> TestClient:
 
 
 @pytest.fixture
-def client_with_dbt(client_example_loader) -> TestClient:
+def client_with_dbt(
+    client_example_loader: Callable[[Optional[List[str]]], TestClient],
+) -> TestClient:
     """
     Provides a DJ client fixture with dbt examples
     """

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -910,19 +910,19 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Contractor dimension",
             "query": """
-                    SELECT
-                    contractor_id,
-                    company_name,
-                    contact_name,
-                    contact_title,
-                    address,
-                    city,
-                    state,
-                    postal_code,
-                    country,
-                    phone
-                    FROM foo.bar.contractors
-                """,
+                SELECT
+                contractor_id,
+                company_name,
+                contact_name,
+                contact_title,
+                address,
+                city,
+                state,
+                postal_code,
+                country,
+                phone
+                FROM foo.bar.contractors
+            """,
             "mode": "published",
             "name": "foo.bar.contractor",
             "primary_key": ["contractor_id"],
@@ -933,22 +933,22 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Hard hat dimension",
             "query": """
-                    SELECT
-                    hard_hat_id,
-                    last_name,
-                    first_name,
-                    title,
-                    birth_date,
-                    hire_date,
-                    address,
-                    city,
-                    state,
-                    postal_code,
-                    country,
-                    manager,
-                    contractor_id
-                    FROM foo.bar.hard_hats
-                """,
+                SELECT
+                hard_hat_id,
+                last_name,
+                first_name,
+                title,
+                birth_date,
+                hire_date,
+                address,
+                city,
+                state,
+                postal_code,
+                country,
+                manager,
+                contractor_id
+                FROM foo.bar.hard_hats
+            """,
             "mode": "published",
             "name": "foo.bar.hard_hat",
             "primary_key": ["hard_hat_id"],
@@ -959,26 +959,26 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Hard hat dimension",
             "query": """
-                    SELECT
-                    hh.hard_hat_id,
-                    last_name,
-                    first_name,
-                    title,
-                    birth_date,
-                    hire_date,
-                    address,
-                    city,
-                    state,
-                    postal_code,
-                    country,
-                    manager,
-                    contractor_id,
-                    hhs.state_id AS state_id
-                    FROM foo.bar.hard_hats hh
-                    LEFT JOIN foo.bar.hard_hat_state hhs
-                    ON hh.hard_hat_id = hhs.hard_hat_id
-                    WHERE hh.state_id = 'NY'
-                """,
+                SELECT
+                hh.hard_hat_id,
+                last_name,
+                first_name,
+                title,
+                birth_date,
+                hire_date,
+                address,
+                city,
+                state,
+                postal_code,
+                country,
+                manager,
+                contractor_id,
+                hhs.state_id AS state_id
+                FROM foo.bar.hard_hats hh
+                LEFT JOIN foo.bar.hard_hat_state hhs
+                ON hh.hard_hat_id = hhs.hard_hat_id
+                WHERE hh.state_id = 'NY'
+            """,
             "mode": "published",
             "name": "foo.bar.local_hard_hats",
             "primary_key": ["hard_hat_id"],
@@ -989,16 +989,16 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "US state dimension",
             "query": """
-                    SELECT
-                    state_id,
-                    state_name,
-                    state_abbr,
-                    state_region,
-                    r.us_region_description AS state_region_description
-                    FROM foo.bar.us_states s
-                    LEFT JOIN foo.bar.us_region r
-                    ON s.state_region = r.us_region_id
-                """,
+                SELECT
+                state_id,
+                state_name,
+                state_abbr,
+                state_region,
+                r.us_region_description AS state_region_description
+                FROM foo.bar.us_states s
+                LEFT JOIN foo.bar.us_region r
+                ON s.state_region = r.us_region_id
+            """,
             "mode": "published",
             "name": "foo.bar.us_state",
             "primary_key": ["state_id"],
@@ -1009,12 +1009,12 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Dispatcher dimension",
             "query": """
-                    SELECT
-                    dispatcher_id,
-                    company_name,
-                    phone
-                    FROM foo.bar.dispatchers
-                """,
+                SELECT
+                dispatcher_id,
+                company_name,
+                phone
+                FROM foo.bar.dispatchers
+            """,
             "mode": "published",
             "name": "foo.bar.dispatcher",
             "primary_key": ["dispatcher_id"],
@@ -1025,20 +1025,20 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Municipality dimension",
             "query": """
-                    SELECT
-                    m.municipality_id AS municipality_id,
-                    contact_name,
-                    contact_title,
-                    local_region,
-                    state_id,
-                    mmt.municipality_type_id AS municipality_type_id,
-                    mt.municipality_type_desc AS municipality_type_desc
-                    FROM foo.bar.municipality AS m
-                    LEFT JOIN foo.bar.municipality_municipality_type AS mmt
-                    ON m.municipality_id = mmt.municipality_id
-                    LEFT JOIN foo.bar.municipality_type AS mt
-                    ON mmt.municipality_type_id = mt.municipality_type_desc
-                """,
+                SELECT
+                m.municipality_id AS municipality_id,
+                contact_name,
+                contact_title,
+                local_region,
+                state_id,
+                mmt.municipality_type_id AS municipality_type_id,
+                mt.municipality_type_desc AS municipality_type_desc
+                FROM foo.bar.municipality AS m
+                LEFT JOIN foo.bar.municipality_municipality_type AS mmt
+                ON m.municipality_id = mmt.municipality_id
+                LEFT JOIN foo.bar.municipality_type AS mt
+                ON mmt.municipality_type_id = mt.municipality_type_desc
+            """,
             "mode": "published",
             "name": "foo.bar.municipality_dim",
             "primary_key": ["municipality_id"],

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -8,7 +8,6 @@ from datajunction_server.models.query import QueryWithResults
 from datajunction_server.sql.parsing.types import IntegerType, StringType, TimestampType
 from datajunction_server.typing import QueryState
 
-
 SERVICE_SETUP = (  # type: ignore
     (
         "/catalogs/",
@@ -52,8 +51,8 @@ SERVICE_SETUP = (  # type: ignore
     ),
 )
 
-ROADS = (
-(
+ROADS = (  # type: ignore
+    (
         "/nodes/source/",
         {
             "columns": [
@@ -666,7 +665,7 @@ CROSS JOIN
     ),
 )
 
-NAMESPACED_ROADS = (
+NAMESPACED_ROADS = (  # type: ignore
     (  # foo.bar Namespaced copy of roads database example
         "/namespaces/foo.bar/",
         {},
@@ -1168,8 +1167,7 @@ NAMESPACED_ROADS = (
     ),
 )
 
-ACCOUNT_REVENUE = (
-
+ACCOUNT_REVENUE = (  # type: ignore
     (  # Accounts/Revenue examples begin
         "/nodes/source/",
         {
@@ -1285,8 +1283,8 @@ ACCOUNT_REVENUE = (
     ),
 )
 
-BASIC = (
-(
+BASIC = (  # type: ignore
+    (
         "/namespaces/basic/",
         {},
     ),
@@ -1406,7 +1404,7 @@ BASIC = (
     ),
 )
 
-EVENT = (
+EVENT = (  # type: ignore
     (  # Event examples
         "/nodes/source/",
         {
@@ -1430,7 +1428,7 @@ EVENT = (
             "name": "default.long_events",
             "description": "High-Latency Events",
             "query": "SELECT event_id, event_latency, device_id, country "
-                     "FROM default.event_source WHERE event_latency > 1000000",
+            "FROM default.event_source WHERE event_latency > 1000000",
             "mode": "published",
         },
     ),
@@ -1440,7 +1438,7 @@ EVENT = (
             "name": "default.country_dim",
             "description": "Country Dimension",
             "query": "SELECT country, COUNT(DISTINCT event_id) AS events_cnt "
-                     "FROM default.event_source GROUP BY country",
+            "FROM default.event_source GROUP BY country",
             "mode": "published",
             "primary_key": ["country"],
         },
@@ -1472,8 +1470,8 @@ EVENT = (
     ),
 )
 
-DBT = (
-(
+DBT = (  # type: ignore
+    (
         "/namespaces/dbt.source/",
         {},
     ),
@@ -1634,8 +1632,8 @@ DBT = (
 )
 
 # lateral view explode/cross join unnest examples
-LATERAL_VIEW = (
-(
+LATERAL_VIEW = (  # type: ignore
+    (
         "/nodes/source/",
         {
             "columns": [
@@ -1757,8 +1755,8 @@ LATERAL_VIEW = (
     ),
 )
 
-DIMENSION_LINK = (
-(
+DIMENSION_LINK = (  # type: ignore
+    (
         "/nodes/source/",
         {
             "columns": [

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -8,7 +8,8 @@ from datajunction_server.models.query import QueryWithResults
 from datajunction_server.sql.parsing.types import IntegerType, StringType, TimestampType
 from datajunction_server.typing import QueryState
 
-EXAMPLES = (  # type: ignore
+
+SERVICE_SETUP = (  # type: ignore
     (
         "/catalogs/",
         {"name": "draft"},
@@ -49,7 +50,10 @@ EXAMPLES = (  # type: ignore
         "/namespaces/default/",
         {},
     ),
-    (
+)
+
+ROADS = (
+(
         "/nodes/source/",
         {
             "columns": [
@@ -660,6 +664,9 @@ CROSS JOIN
         ),
         {},
     ),
+)
+
+NAMESPACED_ROADS = (
     (  # foo.bar Namespaced copy of roads database example
         "/namespaces/foo.bar/",
         {},
@@ -904,19 +911,19 @@ CROSS JOIN
         {
             "description": "Contractor dimension",
             "query": """
-                        SELECT
-                        contractor_id,
-                        company_name,
-                        contact_name,
-                        contact_title,
-                        address,
-                        city,
-                        state,
-                        postal_code,
-                        country,
-                        phone
-                        FROM foo.bar.contractors
-                    """,
+                    SELECT
+                    contractor_id,
+                    company_name,
+                    contact_name,
+                    contact_title,
+                    address,
+                    city,
+                    state,
+                    postal_code,
+                    country,
+                    phone
+                    FROM foo.bar.contractors
+                """,
             "mode": "published",
             "name": "foo.bar.contractor",
             "primary_key": ["contractor_id"],
@@ -927,22 +934,22 @@ CROSS JOIN
         {
             "description": "Hard hat dimension",
             "query": """
-                        SELECT
-                        hard_hat_id,
-                        last_name,
-                        first_name,
-                        title,
-                        birth_date,
-                        hire_date,
-                        address,
-                        city,
-                        state,
-                        postal_code,
-                        country,
-                        manager,
-                        contractor_id
-                        FROM foo.bar.hard_hats
-                    """,
+                    SELECT
+                    hard_hat_id,
+                    last_name,
+                    first_name,
+                    title,
+                    birth_date,
+                    hire_date,
+                    address,
+                    city,
+                    state,
+                    postal_code,
+                    country,
+                    manager,
+                    contractor_id
+                    FROM foo.bar.hard_hats
+                """,
             "mode": "published",
             "name": "foo.bar.hard_hat",
             "primary_key": ["hard_hat_id"],
@@ -953,26 +960,26 @@ CROSS JOIN
         {
             "description": "Hard hat dimension",
             "query": """
-                        SELECT
-                        hh.hard_hat_id,
-                        last_name,
-                        first_name,
-                        title,
-                        birth_date,
-                        hire_date,
-                        address,
-                        city,
-                        state,
-                        postal_code,
-                        country,
-                        manager,
-                        contractor_id,
-                        hhs.state_id AS state_id
-                        FROM foo.bar.hard_hats hh
-                        LEFT JOIN foo.bar.hard_hat_state hhs
-                        ON hh.hard_hat_id = hhs.hard_hat_id
-                        WHERE hh.state_id = 'NY'
-                    """,
+                    SELECT
+                    hh.hard_hat_id,
+                    last_name,
+                    first_name,
+                    title,
+                    birth_date,
+                    hire_date,
+                    address,
+                    city,
+                    state,
+                    postal_code,
+                    country,
+                    manager,
+                    contractor_id,
+                    hhs.state_id AS state_id
+                    FROM foo.bar.hard_hats hh
+                    LEFT JOIN foo.bar.hard_hat_state hhs
+                    ON hh.hard_hat_id = hhs.hard_hat_id
+                    WHERE hh.state_id = 'NY'
+                """,
             "mode": "published",
             "name": "foo.bar.local_hard_hats",
             "primary_key": ["hard_hat_id"],
@@ -983,16 +990,16 @@ CROSS JOIN
         {
             "description": "US state dimension",
             "query": """
-                        SELECT
-                        state_id,
-                        state_name,
-                        state_abbr,
-                        state_region,
-                        r.us_region_description AS state_region_description
-                        FROM foo.bar.us_states s
-                        LEFT JOIN foo.bar.us_region r
-                        ON s.state_region = r.us_region_id
-                    """,
+                    SELECT
+                    state_id,
+                    state_name,
+                    state_abbr,
+                    state_region,
+                    r.us_region_description AS state_region_description
+                    FROM foo.bar.us_states s
+                    LEFT JOIN foo.bar.us_region r
+                    ON s.state_region = r.us_region_id
+                """,
             "mode": "published",
             "name": "foo.bar.us_state",
             "primary_key": ["state_id"],
@@ -1003,12 +1010,12 @@ CROSS JOIN
         {
             "description": "Dispatcher dimension",
             "query": """
-                        SELECT
-                        dispatcher_id,
-                        company_name,
-                        phone
-                        FROM foo.bar.dispatchers
-                    """,
+                    SELECT
+                    dispatcher_id,
+                    company_name,
+                    phone
+                    FROM foo.bar.dispatchers
+                """,
             "mode": "published",
             "name": "foo.bar.dispatcher",
             "primary_key": ["dispatcher_id"],
@@ -1019,20 +1026,20 @@ CROSS JOIN
         {
             "description": "Municipality dimension",
             "query": """
-                        SELECT
-                        m.municipality_id AS municipality_id,
-                        contact_name,
-                        contact_title,
-                        local_region,
-                        state_id,
-                        mmt.municipality_type_id AS municipality_type_id,
-                        mt.municipality_type_desc AS municipality_type_desc
-                        FROM foo.bar.municipality AS m
-                        LEFT JOIN foo.bar.municipality_municipality_type AS mmt
-                        ON m.municipality_id = mmt.municipality_id
-                        LEFT JOIN foo.bar.municipality_type AS mt
-                        ON mmt.municipality_type_id = mt.municipality_type_desc
-                    """,
+                    SELECT
+                    m.municipality_id AS municipality_id,
+                    contact_name,
+                    contact_title,
+                    local_region,
+                    state_id,
+                    mmt.municipality_type_id AS municipality_type_id,
+                    mt.municipality_type_desc AS municipality_type_desc
+                    FROM foo.bar.municipality AS m
+                    LEFT JOIN foo.bar.municipality_municipality_type AS mmt
+                    ON m.municipality_id = mmt.municipality_id
+                    LEFT JOIN foo.bar.municipality_type AS mt
+                    ON mmt.municipality_type_id = mt.municipality_type_desc
+                """,
             "mode": "published",
             "name": "foo.bar.municipality_dim",
             "primary_key": ["municipality_id"],
@@ -1159,6 +1166,10 @@ CROSS JOIN
         ),
         {},
     ),
+)
+
+ACCOUNT_REVENUE = (
+
     (  # Accounts/Revenue examples begin
         "/nodes/source/",
         {
@@ -1272,7 +1283,10 @@ CROSS JOIN
             "name": "default.number_of_account_types",
         },
     ),
-    (
+)
+
+BASIC = (
+(
         "/namespaces/basic/",
         {},
     ),
@@ -1390,6 +1404,9 @@ CROSS JOIN
             "name": "basic.num_users",
         },
     ),
+)
+
+EVENT = (
     (  # Event examples
         "/nodes/source/",
         {
@@ -1413,7 +1430,7 @@ CROSS JOIN
             "name": "default.long_events",
             "description": "High-Latency Events",
             "query": "SELECT event_id, event_latency, device_id, country "
-            "FROM default.event_source WHERE event_latency > 1000000",
+                     "FROM default.event_source WHERE event_latency > 1000000",
             "mode": "published",
         },
     ),
@@ -1423,7 +1440,7 @@ CROSS JOIN
             "name": "default.country_dim",
             "description": "Country Dimension",
             "query": "SELECT country, COUNT(DISTINCT event_id) AS events_cnt "
-            "FROM default.event_source GROUP BY country",
+                     "FROM default.event_source GROUP BY country",
             "mode": "published",
             "primary_key": ["country"],
         },
@@ -1453,7 +1470,10 @@ CROSS JOIN
             "mode": "published",
         },
     ),
-    (
+)
+
+DBT = (
+(
         "/namespaces/dbt.source/",
         {},
     ),
@@ -1611,8 +1631,11 @@ CROSS JOIN
             "name": "default.total_profit",
         },
     ),
-    # lateral view explode/cross join unnest examples
-    (
+)
+
+# lateral view explode/cross join unnest examples
+LATERAL_VIEW = (
+(
         "/nodes/source/",
         {
             "columns": [
@@ -1732,7 +1755,10 @@ CROSS JOIN
             "name": "basic.avg_luminosity_patches",
         },
     ),
-    (
+)
+
+DIMENSION_LINK = (
+(
         "/nodes/source/",
         {
             "columns": [
@@ -1868,6 +1894,17 @@ CROSS JOIN
         {},
     ),
 )
+
+EXAMPLES = {  # type: ignore
+    "ROADS": ROADS,
+    "NAMESPACED_ROADS": NAMESPACED_ROADS,
+    "ACCOUNT_REVENUE": ACCOUNT_REVENUE,
+    "BASIC": BASIC,
+    "EVENT": EVENT,
+    "DBT": DBT,
+    "LATERAL_VIEW": LATERAL_VIEW,
+    "DIMENSION_LINK": DIMENSION_LINK,
+}
 
 
 COLUMN_MAPPINGS = {

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -910,19 +910,19 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Contractor dimension",
             "query": """
-                SELECT
-                contractor_id,
-                company_name,
-                contact_name,
-                contact_title,
-                address,
-                city,
-                state,
-                postal_code,
-                country,
-                phone
-                FROM foo.bar.contractors
-            """,
+                        SELECT
+                        contractor_id,
+                        company_name,
+                        contact_name,
+                        contact_title,
+                        address,
+                        city,
+                        state,
+                        postal_code,
+                        country,
+                        phone
+                        FROM foo.bar.contractors
+                    """,
             "mode": "published",
             "name": "foo.bar.contractor",
             "primary_key": ["contractor_id"],
@@ -933,22 +933,22 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Hard hat dimension",
             "query": """
-                SELECT
-                hard_hat_id,
-                last_name,
-                first_name,
-                title,
-                birth_date,
-                hire_date,
-                address,
-                city,
-                state,
-                postal_code,
-                country,
-                manager,
-                contractor_id
-                FROM foo.bar.hard_hats
-            """,
+                        SELECT
+                        hard_hat_id,
+                        last_name,
+                        first_name,
+                        title,
+                        birth_date,
+                        hire_date,
+                        address,
+                        city,
+                        state,
+                        postal_code,
+                        country,
+                        manager,
+                        contractor_id
+                        FROM foo.bar.hard_hats
+                    """,
             "mode": "published",
             "name": "foo.bar.hard_hat",
             "primary_key": ["hard_hat_id"],
@@ -959,26 +959,26 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Hard hat dimension",
             "query": """
-                SELECT
-                hh.hard_hat_id,
-                last_name,
-                first_name,
-                title,
-                birth_date,
-                hire_date,
-                address,
-                city,
-                state,
-                postal_code,
-                country,
-                manager,
-                contractor_id,
-                hhs.state_id AS state_id
-                FROM foo.bar.hard_hats hh
-                LEFT JOIN foo.bar.hard_hat_state hhs
-                ON hh.hard_hat_id = hhs.hard_hat_id
-                WHERE hh.state_id = 'NY'
-            """,
+                        SELECT
+                        hh.hard_hat_id,
+                        last_name,
+                        first_name,
+                        title,
+                        birth_date,
+                        hire_date,
+                        address,
+                        city,
+                        state,
+                        postal_code,
+                        country,
+                        manager,
+                        contractor_id,
+                        hhs.state_id AS state_id
+                        FROM foo.bar.hard_hats hh
+                        LEFT JOIN foo.bar.hard_hat_state hhs
+                        ON hh.hard_hat_id = hhs.hard_hat_id
+                        WHERE hh.state_id = 'NY'
+                    """,
             "mode": "published",
             "name": "foo.bar.local_hard_hats",
             "primary_key": ["hard_hat_id"],
@@ -989,16 +989,16 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "US state dimension",
             "query": """
-                SELECT
-                state_id,
-                state_name,
-                state_abbr,
-                state_region,
-                r.us_region_description AS state_region_description
-                FROM foo.bar.us_states s
-                LEFT JOIN foo.bar.us_region r
-                ON s.state_region = r.us_region_id
-            """,
+                        SELECT
+                        state_id,
+                        state_name,
+                        state_abbr,
+                        state_region,
+                        r.us_region_description AS state_region_description
+                        FROM foo.bar.us_states s
+                        LEFT JOIN foo.bar.us_region r
+                        ON s.state_region = r.us_region_id
+                    """,
             "mode": "published",
             "name": "foo.bar.us_state",
             "primary_key": ["state_id"],
@@ -1009,12 +1009,12 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Dispatcher dimension",
             "query": """
-                SELECT
-                dispatcher_id,
-                company_name,
-                phone
-                FROM foo.bar.dispatchers
-            """,
+                        SELECT
+                        dispatcher_id,
+                        company_name,
+                        phone
+                        FROM foo.bar.dispatchers
+                    """,
             "mode": "published",
             "name": "foo.bar.dispatcher",
             "primary_key": ["dispatcher_id"],
@@ -1025,20 +1025,20 @@ NAMESPACED_ROADS = (  # type: ignore
         {
             "description": "Municipality dimension",
             "query": """
-                SELECT
-                m.municipality_id AS municipality_id,
-                contact_name,
-                contact_title,
-                local_region,
-                state_id,
-                mmt.municipality_type_id AS municipality_type_id,
-                mt.municipality_type_desc AS municipality_type_desc
-                FROM foo.bar.municipality AS m
-                LEFT JOIN foo.bar.municipality_municipality_type AS mmt
-                ON m.municipality_id = mmt.municipality_id
-                LEFT JOIN foo.bar.municipality_type AS mt
-                ON mmt.municipality_type_id = mt.municipality_type_desc
-            """,
+                        SELECT
+                        m.municipality_id AS municipality_id,
+                        contact_name,
+                        contact_title,
+                        local_region,
+                        state_id,
+                        mmt.municipality_type_id AS municipality_type_id,
+                        mt.municipality_type_desc AS municipality_type_desc
+                        FROM foo.bar.municipality AS m
+                        LEFT JOIN foo.bar.municipality_municipality_type AS mmt
+                        ON m.municipality_id = mmt.municipality_id
+                        LEFT JOIN foo.bar.municipality_type AS mt
+                        ON mmt.municipality_type_id = mt.municipality_type_desc
+                    """,
             "mode": "published",
             "name": "foo.bar.municipality_dim",
             "primary_key": ["municipality_id"],


### PR DESCRIPTION
### Summary

This PR kicks off some changes to the unit test examples setup so that we can start cleaning up our unit tests to only load the examples that are relevant for that test. In the existing setup, we load all examples, which has become quite large over time. This repeated loading of all examples has caused unit tests to take >1h to run (especially after #735).

* Splits up the `EXAMPLES` list into different groups: `ROADS`, `NAMESPACED_ROADS`, `EVENT`, `BASIC`, `DBT` etc. This list is now a dictionary that maps the group name to a list of requests. Most tests will just want to load one of these groups, but some will load more than one.
* Adds a `client_example_loader` fixture that provides a callable for loading examples into a `TestClient` session
* The existing `client_with_examples` fixture stays the same so that we can remain backwards compatible. As we clean up the unit tests, I would expect only a few tests to use this fixture, as most only operate in one of the groups above.
* Added several convenience fixtures for the different groups like `client_with_roads` and `client_with_service_setup`. These might be able to be generated automatically based on the keys to `EXAMPLES`, but I haven't investigated.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
