### PR TITLE
update tests with smaller fixtures to increase efficiency

### DIFF
--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -20,12 +20,12 @@ class TestDataForNode:
 
     def test_get_dimension_data_failed(
         self,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test trying to get dimensions data while setting dimensions
         """
-        response = client_with_examples.get(
+        response = client_with_account_revenue.get(
             "/data/default.payment_type/",
             params={
                 "dimensions": ["something"],
@@ -38,12 +38,13 @@ class TestDataForNode:
 
     def test_get_dimension_data(
         self,
-        client_with_query_service: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test trying to get dimensions data while setting dimensions
         """
-        response = client_with_query_service.get(
+        custom_client = client_with_query_service_example_loader(["ACCOUNT_REVENUE"])
+        response = custom_client.get(
             "/data/default.payment_type/",
         )
         data = response.json()
@@ -86,12 +87,13 @@ class TestDataForNode:
 
     def test_get_source_data(
         self,
-        client_with_query_service: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test retrieving data for a source node
         """
-        response = client_with_query_service.get("/data/default.revenue/")
+        custom_client = client_with_query_service_example_loader(["ACCOUNT_REVENUE"])
+        response = custom_client.get("/data/default.revenue/")
         data = response.json()
         assert response.status_code == 200
         assert data == {
@@ -122,12 +124,13 @@ class TestDataForNode:
 
     def test_get_transform_data(
         self,
-        client_with_query_service: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test retrieving data for a transform node
         """
-        response = client_with_query_service.get(
+        custom_client = client_with_query_service_example_loader(["ACCOUNT_REVENUE"])
+        response = custom_client.get(
             "/data/default.large_revenue_payments_only/",
         )
         data = response.json()
@@ -174,12 +177,14 @@ class TestDataForNode:
 
     def test_get_metric_data(
         self,
-        client_with_query_service: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test retrieving data for a metric
         """
-        response = client_with_query_service.get("/data/basic.num_comments/")
+        custom_client = client_with_query_service_example_loader(["BASIC"])
+
+        response = custom_client.get("/data/basic.num_comments/")
         data = response.json()
         assert response.status_code == 200
         assert data == {
@@ -213,12 +218,13 @@ class TestDataForNode:
 
     def test_get_multiple_metrics_and_dimensions_data(
         self,
-        client_with_query_service: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test getting multiple metrics and dimensions
         """
-        response = client_with_query_service.get(
+        custom_client = client_with_query_service_example_loader(["ROADS"])
+        response = custom_client.get(
             "/data?metrics=default.num_repair_orders&metrics="
             "default.avg_repair_price&dimensions=default.dispatcher.company_name&limit=10",
         )
@@ -272,12 +278,13 @@ class TestDataForNode:
 
     def test_stream_multiple_metrics_and_dimensions_data(
         self,
-        client_with_query_service: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test streaming query status for multiple metrics and dimensions
         """
-        response = client_with_query_service.get(
+        custom_client = client_with_query_service_example_loader(["ROADS"])
+        response = custom_client.get(
             "/stream?metrics=default.num_repair_orders&metrics="
             "default.avg_repair_price&dimensions=default.dispatcher.company_name&limit=10",
             headers={
@@ -289,19 +296,20 @@ class TestDataForNode:
 
     def test_get_data_for_query_id(
         self,
-        client_with_query_service: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test retrieving data for a query ID
         """
         # run some query
-        response = client_with_query_service.get("/data/basic.num_comments/")
+        custom_client = client_with_query_service_example_loader(["BASIC"])
+        response = custom_client.get("/data/basic.num_comments/")
         data = response.json()
         assert response.status_code == 200
         assert data["id"] == "ee41ea6c-2303-4fe1-8bf0-f0ce3d6a35ca"
 
         # and try to get the results by the query id only
-        new_response = client_with_query_service.get(f"/data/query/{data['id']}/")
+        new_response = custom_client.get(f"/data/query/{data['id']}/")
         new_data = response.json()
         assert new_response.status_code == 200
         assert new_data["results"] == [
@@ -314,7 +322,7 @@ class TestDataForNode:
         ]
 
         # and repeat for a bogus query id
-        yet_another_response = client_with_query_service.get("/data/query/foo-bar-baz/")
+        yet_another_response = custom_client.get("/data/query/foo-bar-baz/")
         assert yet_another_response.status_code == 404
         assert "Query foo-bar-baz not found." in yet_another_response.text
 
@@ -327,12 +335,13 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     def test_setting_availability_state(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_query_service_example_loader: TestClient,
     ) -> None:
         """
         Test adding an availability state
         """
-        response = client_with_examples.post(
+        custom_client = client_with_query_service_example_loader(["ACCOUNT_REVENUE"])
+        response = custom_client.post(
             "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
@@ -349,7 +358,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         # Check that the history tracker has been updated
-        response = client_with_examples.get(
+        response = custom_client.get(
             "/history?node=default.large_revenue_payments_and_business_only",
         )
         data = response.json()
@@ -402,12 +411,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_availability_catalog_mismatch(
         self,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test that setting availability works even when the catalogs do not match
         """
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "public",
@@ -426,12 +435,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     def test_setting_availability_state_multiple_times(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test adding multiple availability states
         """
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
@@ -447,7 +456,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert response.status_code == 200
         assert data == {"message": "Availability state successfully posted"}
 
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
@@ -463,7 +472,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert response.status_code == 200
         assert data == {"message": "Availability state successfully posted"}
 
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
@@ -482,7 +491,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert data == {"message": "Availability state successfully posted"}
 
         # Check that the history tracker has been updated
-        response = client_with_examples.get(
+        response = client_with_account_revenue.get(
             "/history/?node=default.large_revenue_payments_and_business_only",
         )
         data = response.json()
@@ -600,12 +609,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     def test_that_update_at_timestamp_is_being_updated(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test that the `updated_at` attribute is being updated
         """
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
@@ -627,7 +636,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             ]
         )
 
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_and_business_only/availability/",
             json={
                 "catalog": "default",
@@ -651,12 +660,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_raising_when_node_does_not_exist(
         self,
-        client_with_examples: TestClient,
+        client_with_service_setup: TestClient,
     ) -> None:
         """
         Test raising when setting availability state on non-existent node
         """
-        response = client_with_examples.post(
+        response = client_with_service_setup.post(
             "/data/default.nonexistentnode/availability/",
             json={
                 "catalog": "default",
@@ -679,12 +688,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     def test_merging_in_a_higher_max_partition(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test that the higher max_partition value is used when merging in an availability state
         """
-        client_with_examples.post(
+        client_with_account_revenue.post(
             "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
@@ -695,7 +704,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "min_temporal_partition": ["2022", "01", "01"],
             },
         )
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
@@ -739,7 +748,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         }
 
     @pytest.fixture
-    def post_local_hard_hats_availability(self, client_with_examples: TestClient):
+    def post_local_hard_hats_availability(self, client_with_roads: TestClient):
         """
         Fixture for posting availability for local_hard_hats
         """
@@ -752,7 +761,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         ):
             if categorical_partitions is None:
                 categorical_partitions = ["country", "postal_code"]
-            return client_with_examples.post(
+            return client_with_roads.post(
                 "/data/default.local_hard_hats/availability/",
                 json={
                     "catalog": "default",
@@ -771,7 +780,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_temporal_only_availability(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -791,7 +800,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             categorical_partitions=[],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         assert response.json()["availability"] == {
@@ -810,7 +819,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_node_level_availability_wider_time_range(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -837,7 +846,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             partitions=[],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         assert response.json()["availability"] == {
@@ -856,7 +865,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_node_level_availability_smaller_time_range(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -875,7 +884,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             partitions=[],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         availability = response.json()["availability"]
@@ -885,7 +894,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_partition_level_availability_smaller_time_range(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -910,7 +919,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             ],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         availability = response.json()["availability"]
@@ -920,7 +929,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_partition_level_availability_larger_time_range(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -945,7 +954,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             ],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         availability = response.json()["availability"]
@@ -962,7 +971,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_orthogonal_partition_level_availability(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -992,7 +1001,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             ],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         availability = response.json()["availability"]
@@ -1015,7 +1024,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_overlap_partition_level_availability(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -1045,7 +1054,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             ],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         availability = response.json()["availability"]
@@ -1062,7 +1071,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_set_semioverlap_partition_level_availability(
         self,
-        client_with_examples: TestClient,
+        client_with_roads: TestClient,
         post_local_hard_hats_availability,
     ):
         """
@@ -1104,7 +1113,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             ],
         )
 
-        response = client_with_examples.get(
+        response = client_with_roads.get(
             "/nodes/default.local_hard_hats/",
         )
         availability = response.json()["availability"]
@@ -1128,12 +1137,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     def test_merging_in_a_lower_min_partition(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test that the lower min_partition value is used when merging in an availability state
         """
-        client_with_examples.post(
+        client_with_account_revenue.post(
             "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
@@ -1144,7 +1153,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "min_temporal_partition": ["2022", "01", "01"],
             },
         )
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
@@ -1190,12 +1199,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     def test_moving_back_valid_through_ts(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test that the valid through timestamp can be moved backwards
         """
-        client_with_examples.post(
+        client_with_account_revenue.post(
             "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
@@ -1206,7 +1215,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                 "min_temporal_partition": ["2022", "01", "01"],
             },
         )
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.large_revenue_payments_only/availability/",
             json={
                 "catalog": "default",
@@ -1252,12 +1261,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
     def test_setting_availablity_state_on_a_source_node(
         self,
         session: Session,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test setting the availability state on a source node
         """
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.revenue/availability/",
             json={
                 "catalog": "default",
@@ -1294,12 +1303,12 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
 
     def test_raise_on_setting_invalid_availability_state_on_a_source_node(
         self,
-        client_with_examples: TestClient,
+        client_with_account_revenue: TestClient,
     ) -> None:
         """
         Test raising availability state doesn't match existing source node table
         """
-        response = client_with_examples.post(
+        response = client_with_account_revenue.post(
             "/data/default.revenue/availability/",
             json={
                 "catalog": "default",

--- a/datajunction-server/tests/api/history_test.py
+++ b/datajunction-server/tests/api/history_test.py
@@ -27,11 +27,11 @@ def test_history_hash():
     assert hash(foo1) == hash(foo2)
 
 
-def test_get_history_entity(client_with_examples: TestClient):
+def test_get_history_entity(client_with_roads: TestClient):
     """
     Test getting history for an entity
     """
-    response = client_with_examples.get("/history/node/default.repair_orders/")
+    response = client_with_roads.get("/history/node/default.repair_orders/")
     assert response.ok
     history = response.json()
     assert len(history) == 1
@@ -52,12 +52,12 @@ def test_get_history_entity(client_with_examples: TestClient):
     ]
 
 
-def test_get_history_node(client_with_examples: TestClient):
+def test_get_history_node(client_with_roads: TestClient):
     """
     Test getting history for a node
     """
 
-    response = client_with_examples.get("/history?node=default.repair_order")
+    response = client_with_roads.get("/history?node=default.repair_order")
     assert response.ok
     history = response.json()
     assert len(history) == 5
@@ -145,12 +145,12 @@ def test_get_history_node(client_with_examples: TestClient):
     ]
 
 
-def test_get_history_namespace(client_with_examples: TestClient):
+def test_get_history_namespace(client_with_service_setup: TestClient):
     """
     Test getting history for a node context
     """
 
-    response = client_with_examples.get("/history/namespace/default")
+    response = client_with_service_setup.get("/history/namespace/default")
     assert response.ok
     history = response.json()
     assert len(history) == 1

--- a/datajunction-server/tests/api/routers_test.py
+++ b/datajunction-server/tests/api/routers_test.py
@@ -5,28 +5,28 @@ from fastapi.testclient import TestClient
 
 
 def test_api_router_trailing_slashes(
-    client_with_examples: TestClient,
+    client_with_basic: TestClient,
 ) -> None:
     """
     Test that the API router used by our endpoints will send both routes without
     trailing slashes and those with trailing slashes to right place.
     """
-    response = client_with_examples.get("/attributes/")
+    response = client_with_basic.get("/attributes/")
     assert response.ok
     assert len(response.json()) > 0
 
-    response = client_with_examples.get("/attributes")
+    response = client_with_basic.get("/attributes")
     assert response.ok
     assert len(response.json()) > 0
 
-    response = client_with_examples.get("/namespaces/")
+    response = client_with_basic.get("/namespaces/")
     assert response.ok
     assert len(response.json()) > 0
 
-    response = client_with_examples.get("/namespaces")
+    response = client_with_basic.get("/namespaces")
     assert response.ok
     assert len(response.json()) > 0
 
-    response = client_with_examples.get("/namespaces/basic?type_=source")
+    response = client_with_basic.get("/namespaces/basic?type_=source")
     assert response.ok
     assert len(response.json()) > 0

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -49,6 +49,10 @@ SERVICE_SETUP = (  # type: ignore
         "/namespaces/default/",
         {},
     ),
+    (
+        "/namespaces/basic/",
+        {},
+    ),
 )
 
 ROADS = (  # type: ignore
@@ -1284,10 +1288,6 @@ ACCOUNT_REVENUE = (  # type: ignore
 )
 
 BASIC = (  # type: ignore
-    (
-        "/namespaces/basic/",
-        {},
-    ),
     (
         "/namespaces/basic.source/",
         {},

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -11,21 +11,21 @@ from datajunction_server.sql.parsing.backends.antlr4 import parse
 
 
 def test_ast_compile_table(
-    session,
-    client_with_examples,  # pylint: disable=unused-argument
+    session: Session,
+    client_with_roads: TestClient,  # pylint: disable=unused-argument
 ):
     """
     Test compiling the primary table from a query
 
-    Includes client_with_examples fixture so that examples are loaded into session
+    Includes client_with_roads fixture so that roads examples are loaded into session
     """
     query = parse("SELECT hard_hat_id, last_name, first_name FROM default.hard_hats")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.select.from_.relations[0].primary.compile(ctx)
+    query.select.from_.relations[0].primary.compile(ctx)  # type: ignore
     assert not exc.errors
 
-    node = query.select.from_.relations[  # pylint: disable=protected-access
+    node = query.select.from_.relations[  # type: ignore  # pylint: disable=protected-access
         0
     ].primary._dj_node
     assert node
@@ -72,8 +72,8 @@ def test_ast_compile_table_missing_node(session):
 
 
 def test_ast_compile_query(
-    session,
-    client_with_examples,  # pylint: disable=unused-argument
+    session: Session,
+    client_with_roads: TestClient,  # pylint: disable=unused-argument
 ):
     """
     Test compiling an entire query
@@ -84,7 +84,7 @@ def test_ast_compile_query(
     query.compile(ctx)
     assert not exc.errors
 
-    node = query.select.from_.relations[  # pylint: disable=protected-access
+    node = query.select.from_.relations[  # type: ignore  # pylint: disable=protected-access
         0
     ].primary._dj_node
     assert node
@@ -92,8 +92,8 @@ def test_ast_compile_query(
 
 
 def test_ast_compile_query_missing_columns(
-    session,
-    client_with_examples,  # pylint: disable=unused-argument
+    session: Session,
+    client_with_roads: TestClient,  # pylint: disable=unused-argument
 ):
     """
     Test compiling a query with missing columns
@@ -111,7 +111,7 @@ def test_ast_compile_query_missing_columns(
         in exc.errors[1].message
     )
 
-    node = query.select.from_.relations[  # pylint: disable=protected-access
+    node = query.select.from_.relations[  # type: ignore  # pylint: disable=protected-access
         0
     ].primary._dj_node
     assert node
@@ -132,7 +132,7 @@ def test_ast_compile_missing_references(session: Session):
 
 def test_ast_compile_raise_on_ambiguous_column(
     session: Session,
-    client_with_examples,  # pylint: disable=unused-argument
+    client_with_basic: TestClient,  # pylint: disable=unused-argument
 ):
     """
     Test raising on ambiguous column
@@ -152,7 +152,7 @@ def test_ast_compile_raise_on_ambiguous_column(
 
 def test_ast_compile_having(
     session: Session,
-    client_with_examples,  # pylint: disable=unused-argument
+    client_with_dbt: TestClient,  # pylint: disable=unused-argument
 ):
     """
     Test using having


### PR DESCRIPTION
### Summary

Continues the work started in #753 

Updates a few more unit tests to use the less expensive fixtures.

Tests are now back down to ~30min!

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #753 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
