### PR TITLE
Release datajunction-server==0.0.1a21

### DIFF
--- a/datajunction-server/datajunction_server/__about__.py
+++ b/datajunction-server/datajunction_server/__about__.py
@@ -1,4 +1,4 @@
 """
 Version for Hatch
 """
-__version__ = "0.0.1a20"
+__version__ = "0.0.1a21"


### PR DESCRIPTION
### Summary

Release `datajunction-server` version `0.0.1a21`: https://pypi.org/project/datajunction-server/0.0.1a21/

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

The main configurable feature in this release is the SQL transpilation library
