### PR TITLE
Updating node should update child dependencies based on column changes

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -435,6 +435,8 @@ def validate_node_data(  # pylint: disable=too-many-locals
     query_ast.select.add_aliases_to_unnamed_columns()
 
     # Invalid parents will invalidate this node
+    # Note: we include source nodes here because they sometimes appear to be invalid, but
+    # this is a bug that needs to be fixed
     invalid_parents = {
         parent.name
         for parent in node_validator.dependencies_map

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -73,15 +73,17 @@ def _join_path(
             full_join_path = (joinable_dim, next_join_path)
             if joinable_dim == dimension_node:
                 for col in join_cols:
-                    if col.dimension_column is None and not any(
-                        dim_col.name == "id" for dim_col in dimension_node.columns
-                    ):
-                        raise DJException(
-                            f"Node {current_node.name} specifying dimension "
-                            f"{joinable_dim.name} on column {col.name} does not"
-                            f" specify a dimension column, but {dimension_node.name} "
-                            f"does not have the default key `id`.",
-                        )
+                    dim_pk = dimension_node.primary_key()
+                    if not col.dimension_column:
+                        if len(dim_pk) != 1:
+                            raise DJException(
+                                f"Node {current_node.name} specifying dimension "
+                                f"{joinable_dim.name} on column {col.name} does not"
+                                f" specify a dimension column, and {dimension_node.name} "
+                                f"has a compound primary key.",
+                            )
+                        col.dimension_column = dim_pk[0].name
+
                 possible_join_paths.append(full_join_path)  # type: ignore
             if joinable_dim not in processed:  # pragma: no cover
                 to_process.append(full_join_path)

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -504,7 +504,7 @@ def propagate_update_downstream(
 
     # Each entry being processed is a list that represents the changelog of affected nodes
     # The last entry in the list is the current node that's being processed
-    to_process = deque([[node.current, child] for child in node.children])
+    to_process = deque([[node.current, child.node.current] for child in node.children])
 
     while to_process:
         changelog = to_process.popleft()
@@ -580,10 +580,8 @@ def copy_existing_node_revision(old_revision: NodeRevision):
     """
     Create an exact copy of the node revision
     """
-    node = old_revision.node
     return NodeRevision(
         name=old_revision.name,
-        node_id=node.id,
         version=old_revision.version,
         display_name=old_revision.display_name,
         description=old_revision.description,

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -1142,10 +1142,10 @@ class NodeValidation(SQLModel):
 
     message: str
     status: NodeStatus
-    node_revision: NodeRevision
     dependencies: List[NodeRevisionOutput]
     columns: List[Column]
     errors: List[DJError]
+    missing_parents: List[str]
 
 
 class LineageColumn(BaseModel):

--- a/datajunction-server/tests/api/node_update_test.py
+++ b/datajunction-server/tests/api/node_update_test.py
@@ -1,0 +1,211 @@
+"""Tests for node updates"""
+from unittest import mock
+
+from fastapi.testclient import TestClient
+
+from datajunction_server.models.node import NodeStatus
+
+
+def test_update_source_node(
+    client_with_roads: TestClient,
+) -> None:
+    """
+    Test updating a source node that has multiple layers of downstream effects
+    non-immediate children should be revalidated:
+    - default.regional_repair_efficiency should be affected (invalidated)
+    column changes should affect validity:
+    - any metric selecting from `quantity` should be invalid (now quantity_v2)
+    - any metric selecting from `price` should have updated types (now string)
+    """
+    client_with_roads.patch(
+        "/nodes/default.repair_order_details/",
+        json={
+            "columns": [
+                {"name": "repair_order_id", "type": "string"},
+                {"name": "repair_type_id", "type": "int"},
+                {"name": "price", "type": "string"},
+                {"name": "quantity_v2", "type": "int"},
+                {"name": "discount", "type": "float"},
+            ],
+        },
+    )
+    affected_nodes = {
+        "default.regional_level_agg": NodeStatus.INVALID,  # NodeStatus.INVALID
+        "default.national_level_agg": NodeStatus.INVALID,
+        "default.avg_repair_price": NodeStatus.INVALID,
+        "default.total_repair_cost": NodeStatus.INVALID,
+        "default.discounted_orders_rate": NodeStatus.VALID,
+        "default.total_repair_order_discounts": NodeStatus.INVALID,
+        "default.avg_repair_order_discounts": NodeStatus.INVALID,
+        "default.regional_repair_efficiency": NodeStatus.INVALID,
+    }
+
+    node_history_events = {
+        "default.national_level_agg": [
+            {
+                "activity_type": "status_change",
+                "created_at": mock.ANY,
+                "details": {
+                    "reason": "Caused by update of `default.repair_order_details` to "
+                    "v2.0",
+                    "upstreams": [
+                        {
+                            "current_version": "v2.0",
+                            "name": "default.repair_order_details",
+                            "previous_version": "v1.0",
+                            "updated_columns": [
+                                "repair_order_id",
+                                "price",
+                                "quantity_v2",
+                            ],
+                        },
+                        {
+                            "current_version": "v2.0",
+                            "name": "default.national_level_agg",
+                            "previous_version": "v1.0",
+                            "updated_columns": ["total_amount_nationwide"],
+                        },
+                    ],
+                },
+                "entity_name": "default.national_level_agg",
+                "entity_type": "node",
+                "id": mock.ANY,
+                "node": "default.national_level_agg",
+                "post": {"status": "invalid"},
+                "pre": {"status": "valid"},
+                "user": None,
+            },
+        ],
+        "default.regional_level_agg": [
+            {
+                "activity_type": "status_change",
+                "created_at": mock.ANY,
+                "details": {
+                    "reason": "Caused by update of `default.repair_order_details` to "
+                    "v2.0",
+                    "upstreams": [
+                        {
+                            "current_version": "v2.0",
+                            "name": "default.repair_order_details",
+                            "previous_version": "v1.0",
+                            "updated_columns": [
+                                "repair_order_id",
+                                "price",
+                                "quantity_v2",
+                            ],
+                        },
+                        {
+                            "current_version": "v2.0",
+                            "name": "default.regional_level_agg",
+                            "previous_version": "v1.0",
+                            "updated_columns": [
+                                "avg_repair_amount_in_region",
+                                "total_amount_in_region",
+                            ],
+                        },
+                    ],
+                },
+                "entity_name": "default.regional_level_agg",
+                "entity_type": "node",
+                "id": mock.ANY,
+                "node": "default.regional_level_agg",
+                "post": {"status": "invalid"},
+                "pre": {"status": "valid"},
+                "user": None,
+            },
+        ],
+        "default.avg_repair_price": [
+            {
+                "id": mock.ANY,
+                "entity_type": "node",
+                "entity_name": "default.avg_repair_price",
+                "node": "default.avg_repair_price",
+                "activity_type": "status_change",
+                "user": None,
+                "pre": {"status": "valid"},
+                "post": {"status": "invalid"},
+                "details": {
+                    "upstreams": [
+                        {
+                            "name": "default.repair_order_details",
+                            "current_version": "v2.0",
+                            "previous_version": "v1.0",
+                            "updated_columns": [
+                                "repair_order_id",
+                                "price",
+                                "quantity_v2",
+                            ],
+                        },
+                        {
+                            "name": "default.avg_repair_price",
+                            "current_version": "v2.0",
+                            "previous_version": "v1.0",
+                            "updated_columns": ["default_DOT_avg_repair_price"],
+                        },
+                    ],
+                    "reason": "Caused by update of `default.repair_order_details` to v2.0",
+                },
+                "created_at": mock.ANY,
+            },
+        ],
+        "default.regional_repair_efficiency": [
+            {
+                "id": mock.ANY,
+                "entity_type": "node",
+                "entity_name": "default.regional_repair_efficiency",
+                "node": "default.regional_repair_efficiency",
+                "activity_type": "status_change",
+                "user": None,
+                "pre": {"status": "valid"},
+                "post": {"status": "invalid"},
+                "details": {
+                    "upstreams": [
+                        {
+                            "name": "default.repair_order_details",
+                            "current_version": "v2.0",
+                            "previous_version": "v1.0",
+                            "updated_columns": [
+                                "repair_order_id",
+                                "price",
+                                "quantity_v2",
+                            ],
+                        },
+                        {
+                            "name": "default.regional_level_agg",
+                            "current_version": "v2.0",
+                            "previous_version": "v1.0",
+                            "updated_columns": [
+                                "avg_repair_amount_in_region",
+                                "total_amount_in_region",
+                            ],
+                        },
+                        {
+                            "name": "default.regional_repair_efficiency",
+                            "current_version": "v2.0",
+                            "previous_version": "v1.0",
+                            "updated_columns": [
+                                "default_DOT_regional_repair_efficiency",
+                            ],
+                        },
+                    ],
+                    "reason": "Caused by update of `default.repair_order_details` to v2.0",
+                },
+                "created_at": mock.ANY,
+            },
+        ],
+    }
+
+    # check all affected nodes and verify that their statuses have been updated
+    for affected, expected_status in affected_nodes.items():
+        response = client_with_roads.get(f"/nodes/{affected}")
+        assert response.json()["status"] == expected_status
+
+        # only nodes with a status change will have a history record
+        if expected_status == NodeStatus.INVALID:
+            response = client_with_roads.get(f"/history?node={affected}")
+            if node_history_events.get(affected):
+                assert [
+                    event
+                    for event in response.json()
+                    if event["activity_type"] == "status_change"
+                ] == node_history_events.get(affected)

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1128,7 +1128,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 {
                     "effect": "downstream node is now invalid",
                     "name": "default.regional_repair_efficiency",
-                    "status": "valid",
+                    "status": "invalid",
                 },
                 {
                     "name": "default.num_repair_orders",
@@ -1167,7 +1167,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 {
                     "effect": "broken link",
                     "name": "default.regional_repair_efficiency",
-                    "status": "valid",
+                    "status": "invalid",
                 },
                 {
                     "name": "default.avg_repair_price",
@@ -1586,6 +1586,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             json=create_transform_node_payload,
         )
         data = response.json()
+        print("data", data)
         assert data["name"] == "default.country_agg"
         assert data["display_name"] == "Default: Country Agg"
         assert data["type"] == "transform"
@@ -4094,7 +4095,6 @@ def test_resolving_downstream_status(client_with_service_setup: TestClient) -> N
         data = response.json()
         assert data["name"] == node["name"]
         assert data["mode"] == node["mode"]
-        print(data["name"], data["status"])
         assert data["status"] == "invalid"
 
     # Add the missing parent
@@ -4128,7 +4128,6 @@ def test_resolving_downstream_status(client_with_service_setup: TestClient) -> N
         response = client_with_service_setup.get(f"/nodes/{node['name']}/")
         assert response.status_code == 200
         data = response.json()
-        print("assertions", data["name"], data["status"])
         assert data["name"] == node["name"]
         assert data["mode"] == node["mode"]  # make sure the mode hasn't been changed
         assert (


### PR DESCRIPTION
### Summary

There are two main parts to this PR:
* Refactor node validation function `validate_node_data` to have no side effects by returning a `NodeValidator` object instead of directly changing the original node revision.
* After a node gets updated, we should revalidate all downstream nodes and take into account column changes (name changes and type changes) as well as status changes

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #769 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
