### PR TITLE
Separate measures db migration from initial migration

### DIFF
--- a/datajunction-server/alembic/versions/2023_07_07_2006-4e1ff36c27c6_initial_migration.py
+++ b/datajunction-server/alembic/versions/2023_07_07_2006-4e1ff36c27c6_initial_migration.py
@@ -177,23 +177,6 @@ def upgrade():
         ),
     )
     op.create_table(
-        "measures",
-        sa.Column(
-            "additive",
-            sa.Enum(
-                "ADDITIVE",
-                "NON_ADDITIVE",
-                "SEMI_ADDITIVE",
-                name="aggregationrule",
-            ),
-            nullable=True,
-        ),
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.PrimaryKeyConstraint("id", name=op.f("pk_measures")),
-        sa.UniqueConstraint("name", name=op.f("uq_measures_name")),
-    )
-    op.create_table(
         "column",
         sa.Column("type", sa.String(), nullable=False),
         sa.Column("id", sa.Integer(), nullable=False),
@@ -208,12 +191,6 @@ def upgrade():
             ["dimension_id"],
             ["node.id"],
             name=op.f("fk_column_dimension_id_node"),
-        ),
-        sa.Column("measure_id", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["measure_id"],
-            ["measures.id"],
-            name=op.f("fk_column_measure_id_measures"),
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_column")),
     )
@@ -473,4 +450,3 @@ def downgrade():
     op.drop_table("catalog")
     op.drop_table("availabilitystate")
     op.drop_table("attributetype")
-    op.drop_table("measures")

--- a/datajunction-server/alembic/versions/2023_09_18_1346-f2e9ef937daf_add_measures.py
+++ b/datajunction-server/alembic/versions/2023_09_18_1346-f2e9ef937daf_add_measures.py
@@ -1,0 +1,58 @@
+"""Add measures
+
+Revision ID: f2e9ef937daf
+Revises: fe8d3dbe512a
+Create Date: 2023-09-18 13:46:17.700118+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2e9ef937daf"
+down_revision = "fe8d3dbe512a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "measures",
+        sa.Column(
+            "additive",
+            sa.Enum(
+                "ADDITIVE",
+                "NON_ADDITIVE",
+                "SEMI_ADDITIVE",
+                name="aggregationrule",
+            ),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_measures")),
+        sa.UniqueConstraint("name", name=op.f("uq_measures_name")),
+    )
+    with op.batch_alter_table("column", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("measure_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            batch_op.f("fk_column_measure_id_measures"),
+            "measures",
+            ["measure_id"],
+            ["id"],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("column", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            batch_op.f("fk_column_measure_id_measures"),
+            type_="foreignkey",
+        )
+        batch_op.drop_column("measure_id")
+
+    op.drop_table("measures")


### PR DESCRIPTION
### Summary

Separate the measures db migration from the initial migration. This allows us to apply the revision that has the measures changes, as previously these changes were buried in the initial migration, which would not get reapplied by alembic when running a standard database migration. 

Another option is to squash all the database migrations into a single "initial" migration, which we did before, but that was prior to us having deployed DJ.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

When migrating the database, running `alembic upgrade head` should create the tables associated with measures.