### PR TITLE
UI for registering tables, deleting nodes, adding namespaces

### DIFF
--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.22",
+  "version": "0.0.1-rc.21",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.19",
+  "version": "0.0.1-rc.20",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.20",
+  "version": "0.0.1-rc.22",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/src/app/components/DeleteNode.jsx
+++ b/datajunction-ui/src/app/components/DeleteNode.jsx
@@ -1,0 +1,79 @@
+import DJClientContext from '../providers/djclient';
+import ValidIcon from '../icons/ValidIcon';
+import AlertIcon from '../icons/AlertIcon';
+import * as React from 'react';
+import DeleteIcon from '../icons/DeleteIcon';
+import { Form, Formik } from 'formik';
+import { useContext } from 'react';
+
+export default function DeleteNode({ nodeName }) {
+  console.log('nodeName', nodeName);
+
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const deleteNode = async (values, { setSubmitting, setStatus }) => {
+    const { status, json } = await djClient.deactivate(values.nodeName);
+    if (status === 200 || status === 201 || status === 204) {
+      setStatus({
+        success: <>Successfully deleted node {values.nodeName}</>,
+      });
+    } else {
+      setStatus({
+        failure: `${json.message}`,
+      });
+    }
+    setSubmitting(false);
+  };
+
+  const displayMessageAfterSubmit = status => {
+    return status?.success !== undefined ? (
+      <div className="message success">
+        <ValidIcon />
+        {status?.success}
+      </div>
+    ) : status?.failure !== undefined ? (
+      alertMessage(status?.failure)
+    ) : (
+      ''
+    );
+  };
+
+  const alertMessage = message => {
+    return (
+      <div className="message alert">
+        <AlertIcon />
+        {message}
+      </div>
+    );
+  };
+  const initialValues = {
+    nodeName: nodeName,
+  };
+
+  return (
+    <Formik initialValues={initialValues} onSubmit={deleteNode}>
+      {function Render({ isSubmitting, status, setFieldValue }) {
+        return (
+          <Form className="deleteNode">
+            {displayMessageAfterSubmit(status)}
+            {
+              <>
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  style={{
+                    marginLeft: 0,
+                    all: 'unset',
+                    color: '#005c72',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <DeleteIcon />
+                </button>
+              </>
+            }
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+}

--- a/datajunction-ui/src/app/components/DeleteNode.jsx
+++ b/datajunction-ui/src/app/components/DeleteNode.jsx
@@ -1,14 +1,11 @@
 import DJClientContext from '../providers/djclient';
-import ValidIcon from '../icons/ValidIcon';
-import AlertIcon from '../icons/AlertIcon';
 import * as React from 'react';
 import DeleteIcon from '../icons/DeleteIcon';
 import { Form, Formik } from 'formik';
 import { useContext } from 'react';
+import { displayMessageAfterSubmit } from '../../utils/form';
 
 export default function DeleteNode({ nodeName }) {
-  console.log('nodeName', nodeName);
-
   const djClient = useContext(DJClientContext).DataJunctionAPI;
   const deleteNode = async (values, { setSubmitting, setStatus }) => {
     const { status, json } = await djClient.deactivate(values.nodeName);
@@ -24,27 +21,6 @@ export default function DeleteNode({ nodeName }) {
     setSubmitting(false);
   };
 
-  const displayMessageAfterSubmit = status => {
-    return status?.success !== undefined ? (
-      <div className="message success">
-        <ValidIcon />
-        {status?.success}
-      </div>
-    ) : status?.failure !== undefined ? (
-      alertMessage(status?.failure)
-    ) : (
-      ''
-    );
-  };
-
-  const alertMessage = message => {
-    return (
-      <div className="message alert">
-        <AlertIcon />
-        {message}
-      </div>
-    );
-  };
   const initialValues = {
     nodeName: nodeName,
   };

--- a/datajunction-ui/src/app/components/__tests__/DeleteNode.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/DeleteNode.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../setupTests';
+import DJClientContext from '../../providers/djclient';
+import DeleteNode from '../DeleteNode';
+
+describe('<DeleteNode />', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    jest.clearAllMocks();
+    window.scrollTo = jest.fn();
+  });
+
+  const renderElement = djClient => {
+    return render(
+      <DJClientContext.Provider value={djClient}>
+        <DeleteNode nodeName="default.hard_hat" />
+      </DJClientContext.Provider>,
+    );
+  };
+
+  const initializeMockDJClient = () => {
+    return {
+      DataJunctionAPI: {
+        deactivate: jest.fn(),
+      },
+    };
+  };
+
+  it('deletes a node when clicked', async () => {
+    const mockDjClient = initializeMockDJClient();
+    mockDjClient.DataJunctionAPI.deactivate.mockReturnValue({
+      status: 204,
+      json: { name: 'source.warehouse.schema.some_table' },
+    });
+
+    renderElement(mockDjClient);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(mockDjClient.DataJunctionAPI.deactivate).toBeCalled();
+      expect(mockDjClient.DataJunctionAPI.deactivate).toBeCalledWith(
+        'default.hard_hat',
+      );
+    });
+    expect(
+      screen.getByText('Successfully deleted node default.hard_hat'),
+    ).toBeInTheDocument();
+  }, 60000);
+});

--- a/datajunction-ui/src/app/index.tsx
+++ b/datajunction-ui/src/app/index.tsx
@@ -13,6 +13,7 @@ import { SQLBuilderPage } from './pages/SQLBuilderPage/Loadable';
 import { AddEditNodePage } from './pages/AddEditNodePage/Loadable';
 import { NotFoundPage } from './pages/NotFoundPage/Loadable';
 import { LoginPage } from './pages/LoginPage';
+import { RegisterTablePage } from './pages/RegisterTablePage';
 import { Root } from './pages/Root/Loadable';
 import DJClientContext from './providers/djclient';
 import { DataJunctionAPI } from './services/DJService';
@@ -59,6 +60,11 @@ export function App() {
                           key="namespaces"
                         />
                       </Route>
+                      <Route
+                        path="create/source"
+                        key="register"
+                        element={<RegisterTablePage />}
+                      ></Route>
                       <Route path="create/:nodeType">
                         <Route
                           path=":initialNamespace"

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -9,6 +9,10 @@ import {
   testElement,
 } from './index.test';
 import { mocks } from '../../../../mocks/mockNodes';
+import { render } from '../../../../setupTests';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import DJClientContext from '../../../providers/djclient';
+import { AddEditNodePage } from '../index';
 
 describe('AddEditNodePage submission succeeded', () => {
   beforeEach(() => {

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -15,6 +15,7 @@ import { useParams } from 'react-router-dom';
 import { FullNameField } from './FullNameField';
 import { FormikSelect } from './FormikSelect';
 import { NodeQueryField } from './NodeQueryField';
+import { displayMessageAfterSubmit } from '../../../utils/form';
 
 class Action {
   static Add = new Action('add');
@@ -68,22 +69,6 @@ export function AddEditNodePage() {
       }, 400);
     }
     window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-  };
-
-  const displayMessageAfterSubmit = status => {
-    return status?.success !== undefined ? (
-      <div className="message success">
-        <ValidIcon />
-        {status?.success}
-      </div>
-    ) : status?.failure !== undefined ? (
-      <div className="message alert">
-        <AlertIcon />
-        {status?.failure}
-      </div>
-    ) : (
-      ''
-    );
   };
 
   const pageTitle =

--- a/datajunction-ui/src/app/pages/LoginPage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/__tests__/index.test.jsx
@@ -5,10 +5,6 @@ import { LoginPage } from '../index';
 describe('LoginPage', () => {
   const original = window.location;
 
-  const reloadFn = () => {
-    window.location.reload();
-  };
-
   beforeAll(() => {
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -44,7 +40,6 @@ describe('LoginPage', () => {
   it('calls fetch with correct data on submit', async () => {
     const username = 'testUser';
     const password = 'testPassword';
-    reloadFn();
 
     const { getByText, getByPlaceholderText } = render(<LoginPage />);
     fireEvent.change(getByPlaceholderText('Username'), {

--- a/datajunction-ui/src/app/pages/NamespacePage/AddNamespacePopover.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/AddNamespacePopover.jsx
@@ -1,0 +1,86 @@
+import { useContext, useState } from 'react';
+import * as React from 'react';
+import DJClientContext from '../../providers/djclient';
+import { ErrorMessage, Field, Form, Formik } from 'formik';
+import { FormikSelect } from '../AddEditNodePage/FormikSelect';
+import EditIcon from '../../icons/EditIcon';
+import { displayMessageAfterSubmit, labelize } from '../../../utils/form';
+
+export default function AddNamespacePopover({ namespace, onSubmit }) {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const [popoverAnchor, setPopoverAnchor] = useState(false);
+
+  const addNamespace = async ({ namespace }, { setSubmitting, setStatus }) => {
+    setSubmitting(false);
+    const response = await djClient.addNamespace(namespace);
+    if (response.status === 200 || response.status === 201) {
+      setStatus({ success: 'Saved' });
+    } else {
+      setStatus({
+        failure: `${response.json.message}`,
+      });
+    }
+    onSubmit();
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <button
+        className="edit_button"
+        aria-label="AddNamespaceTogglePopover"
+        tabIndex="0"
+        onClick={() => {
+          setPopoverAnchor(!popoverAnchor);
+        }}
+      >
+        <EditIcon />
+      </button>
+      <div
+        className="popover"
+        role="dialog"
+        aria-label="AddNamespacePopover"
+        style={{
+          display: popoverAnchor === false ? 'none' : 'block',
+          width: '200px !important',
+          textTransform: 'none',
+          fontWeight: 'normal',
+        }}
+      >
+        <Formik
+          initialValues={{
+            namespace: '',
+          }}
+          onSubmit={addNamespace}
+        >
+          {function Render({ isSubmitting, status, setFieldValue }) {
+            return (
+              <Form>
+                {displayMessageAfterSubmit(status)}
+                <span data-testid="add-namespace">
+                  <ErrorMessage name="namespace" component="span" />
+                  <label htmlFor="namespace">Namespace</label>
+                  <Field
+                    type="text"
+                    name="namespace"
+                    id="namespace"
+                    placeholder="New namespace"
+                  />
+                </span>
+                <button
+                  className="add_node"
+                  type="submit"
+                  aria-label="SaveNamespace"
+                  aria-hidden="false"
+                  style={{ marginTop: '1rem' }}
+                >
+                  Save
+                </button>
+              </Form>
+            );
+          }}
+        </Formik>
+      </div>
+    </>
+  );
+}

--- a/datajunction-ui/src/app/pages/NamespacePage/AddNamespacePopover.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/AddNamespacePopover.jsx
@@ -6,7 +6,7 @@ import { FormikSelect } from '../AddEditNodePage/FormikSelect';
 import EditIcon from '../../icons/EditIcon';
 import { displayMessageAfterSubmit, labelize } from '../../../utils/form';
 
-export default function AddNamespacePopover({ namespace, onSubmit }) {
+export default function AddNamespacePopover({ namespace }) {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
   const [popoverAnchor, setPopoverAnchor] = useState(false);
 
@@ -20,7 +20,6 @@ export default function AddNamespacePopover({ namespace, onSubmit }) {
         failure: `${response.json.message}`,
       });
     }
-    onSubmit();
     window.location.reload();
   };
 

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -59,7 +59,7 @@ export function NamespacePage() {
   useEffect(() => {
     const fetchData = async () => {
       if (namespace === undefined && namespaceHierarchy !== undefined) {
-        namespace = namespaceHierarchy.children[0].path;
+        namespace = namespaceHierarchy[0].namespace;
       }
       const nodes = await djClient.namespace(namespace);
       const foundNodes = await Promise.all(nodes);

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -6,6 +6,7 @@ import DJClientContext from '../../providers/djclient';
 import Explorer from '../NamespacePage/Explorer';
 import EditIcon from '../../icons/EditIcon';
 import DeleteNode from '../../components/DeleteNode';
+import AddNamespacePopover from './AddNamespacePopover';
 
 export function NamespacePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
@@ -159,7 +160,7 @@ export function NamespacePage() {
                   padding: '1rem 1rem 1rem 0',
                 }}
               >
-                Namespaces
+                Namespaces <AddNamespacePopover />
               </span>
               {namespaceHierarchy
                 ? namespaceHierarchy.map(child => (

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -5,7 +5,7 @@ import NodeStatus from '../NodePage/NodeStatus';
 import DJClientContext from '../../providers/djclient';
 import Explorer from '../NamespacePage/Explorer';
 import EditIcon from '../../icons/EditIcon';
-import DeleteIcon from '../../icons/DeleteIcon';
+import DeleteNode from '../../components/DeleteNode';
 
 export function NamespacePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
@@ -108,9 +108,7 @@ export function NamespacePage() {
         <a href={`/nodes/${node?.name}/edit`} style={{ marginLeft: '0.5rem' }}>
           <EditIcon />
         </a>
-        <a href="#" style={{ marginLeft: '0.5rem' }}>
-          <DeleteIcon />
-        </a>
+        <DeleteNode nodeName={node?.name} />
       </td>
     </tr>
   ));

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -85,7 +85,7 @@ export function NamespacePage() {
       </td>
       <td>
         <a href={'/nodes/' + node.name} className="link-table">
-          {node.display_name}
+          {node.type !== 'source' ? node.display_name : ''}
         </a>
       </td>
       <td>
@@ -126,6 +126,11 @@ export function NamespacePage() {
               <div className="dropdown">
                 <span className="add_node">+ Add Node</span>
                 <div className="dropdown-content">
+                  <a href={`/create/source`}>
+                    <div className="node_type__source node_type_creation_heading">
+                      Register Table
+                    </div>
+                  </a>
                   <a href={`/create/transform/${namespace}`}>
                     <div className="node_type__transform node_type_creation_heading">
                       Transform

--- a/datajunction-ui/src/app/pages/RegisterTablePage/Loadable.jsx
+++ b/datajunction-ui/src/app/pages/RegisterTablePage/Loadable.jsx
@@ -1,0 +1,16 @@
+/**
+ * Asynchronously loads the component for the Node page
+ */
+
+import * as React from 'react';
+import { lazyLoad } from '../../../utils/loadable';
+
+export const RegisterTablePage = () => {
+  return lazyLoad(
+    () => import('./index'),
+    module => module.RegisterTablePage,
+    {
+      fallback: <div></div>,
+    },
+  )();
+};

--- a/datajunction-ui/src/app/pages/RegisterTablePage/__tests__/RegisterTablePage.test.jsx
+++ b/datajunction-ui/src/app/pages/RegisterTablePage/__tests__/RegisterTablePage.test.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../../setupTests';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import DJClientContext from '../../../providers/djclient';
+import { RegisterTablePage } from '../index';
+
+describe('<RegisterTablePage />', () => {
+  const initializeMockDJClient = () => {
+    return {
+      DataJunctionAPI: {
+        catalogs: jest.fn(),
+        registerTable: jest.fn(),
+      },
+    };
+  };
+
+  const mockDjClient = initializeMockDJClient();
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    jest.clearAllMocks();
+    window.scrollTo = jest.fn();
+
+    mockDjClient.DataJunctionAPI.catalogs.mockReturnValue([
+      {
+        name: 'warehouse',
+        engines: [
+          {
+            name: 'duckdb',
+            version: '0.7.1',
+            uri: null,
+            dialect: null,
+          },
+        ],
+      },
+    ]);
+  });
+
+  const renderRegisterTable = element => {
+    return render(
+      <MemoryRouter initialEntries={['/create/source']}>
+        <Routes>
+          <Route path="create/source" element={element} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  };
+
+  const testElement = djClient => {
+    return (
+      <DJClientContext.Provider value={djClient}>
+        <RegisterTablePage />
+      </DJClientContext.Provider>
+    );
+  };
+
+  it('registers a table correctly', async () => {
+    mockDjClient.DataJunctionAPI.registerTable.mockReturnValue({
+      status: 201,
+      json: { name: 'source.warehouse.schema.some_table' },
+    });
+
+    const element = testElement(mockDjClient);
+    const { container, getByTestId } = renderRegisterTable(element);
+
+    const catalog = getByTestId('choose-catalog');
+    await waitFor(async () => {
+      fireEvent.keyDown(catalog.firstChild, { key: 'ArrowDown' });
+      fireEvent.click(screen.getByText('warehouse'));
+    });
+
+    await userEvent.type(screen.getByLabelText('Schema'), 'schema');
+    await userEvent.type(screen.getByLabelText('Table'), 'some_table');
+    await userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(mockDjClient.DataJunctionAPI.registerTable).toBeCalled();
+      expect(mockDjClient.DataJunctionAPI.registerTable).toBeCalledWith(
+        'warehouse',
+        'schema',
+        'some_table',
+      );
+    });
+    expect(container.getElementsByClassName('message')).toMatchSnapshot();
+  }, 60000);
+
+  it('fails to register a table', async () => {
+    mockDjClient.DataJunctionAPI.registerTable.mockReturnValue({
+      status: 500,
+      json: { message: 'table not found' },
+    });
+
+    const element = testElement(mockDjClient);
+    const { getByTestId } = renderRegisterTable(element);
+
+    const catalog = getByTestId('choose-catalog');
+    await waitFor(async () => {
+      fireEvent.keyDown(catalog.firstChild, { key: 'ArrowDown' });
+      fireEvent.click(screen.getByText('warehouse'));
+    });
+
+    await userEvent.type(screen.getByLabelText('Schema'), 'schema');
+    await userEvent.type(screen.getByLabelText('Table'), 'some_table');
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('table not found')).toBeInTheDocument();
+  }, 60000);
+});

--- a/datajunction-ui/src/app/pages/RegisterTablePage/__tests__/__snapshots__/RegisterTablePage.test.jsx.snap
+++ b/datajunction-ui/src/app/pages/RegisterTablePage/__tests__/__snapshots__/RegisterTablePage.test.jsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RegisterTablePage /> registers a table correctly 1`] = `
+HTMLCollection [
+  <div
+    class="message success"
+  >
+    <svg
+      class="bi bi-check-circle-fill"
+      fill="currentColor"
+      height="25"
+      viewBox="0 0 16 16"
+      width="25"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"
+      />
+    </svg>
+    Successfully registered source node
+     
+    <a
+      href="/nodes/source.warehouse.schema.some_table"
+    >
+      source.warehouse.schema.some_table
+    </a>
+    , which references table 
+    warehouse
+    .
+    schema
+    .
+    some_table
+    .
+  </div>,
+]
+`;

--- a/datajunction-ui/src/app/pages/RegisterTablePage/index.jsx
+++ b/datajunction-ui/src/app/pages/RegisterTablePage/index.jsx
@@ -1,0 +1,163 @@
+/**
+ * Node add + edit page for transforms, metrics, and dimensions. The creation and edit flow for these
+ * node types is largely the same, with minor differences handled server-side. For the `query`
+ * field, this page will render a CodeMirror SQL editor with autocompletion and syntax highlighting.
+ */
+import { ErrorMessage, Field, Form, Formik } from 'formik';
+
+import NamespaceHeader from '../../components/NamespaceHeader';
+import React, { useContext, useEffect, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+import 'styles/node-creation.scss';
+import AlertIcon from '../../icons/AlertIcon';
+import ValidIcon from '../../icons/ValidIcon';
+import { FormikSelect } from '../AddEditNodePage/FormikSelect';
+
+export function RegisterTablePage() {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const [catalogs, setCatalogs] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const catalogs = await djClient.catalogs();
+      setCatalogs(
+        catalogs.map(catalog => {
+          return { value: catalog.name, label: catalog.name };
+        }),
+      );
+    };
+    fetchData().catch(console.error);
+  }, [djClient, djClient.namespaces]);
+
+  const initialValues = {
+    catalog: '',
+    schema: '',
+    table: '',
+  };
+
+  const validator = values => {
+    const errors = {};
+    if (!values.table) {
+      errors.table = 'Required';
+    }
+    if (!values.schema) {
+      errors.schema = 'Required';
+    }
+    return errors;
+  };
+
+  const handleSubmit = async (values, { setSubmitting, setStatus }) => {
+    const { status, json } = await djClient.registerTable(
+      values.catalog,
+      values.schema,
+      values.table,
+    );
+    if (status === 200 || status === 201) {
+      setStatus({
+        success: (
+          <>
+            Successfully registered source node{' '}
+            <a href={`/nodes/${json.name}`}>{json.name}</a>, which references
+            table {values.catalog}.{values.schema}.{values.table}.
+          </>
+        ),
+      });
+    } else {
+      setStatus({
+        failure: `${json.message}`,
+      });
+    }
+    setSubmitting(false);
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  };
+
+  const displayMessageAfterSubmit = status => {
+    return status?.success !== undefined ? (
+      <div className="message success">
+        <ValidIcon />
+        {status?.success}
+      </div>
+    ) : status?.failure !== undefined ? (
+      alertMessage(status?.failure)
+    ) : (
+      ''
+    );
+  };
+
+  const alertMessage = message => {
+    return (
+      <div className="message alert">
+        <AlertIcon />
+        {message}
+      </div>
+    );
+  };
+
+  return (
+    <div className="mid">
+      <NamespaceHeader namespace="" />
+      <div className="card">
+        <div className="card-header">
+          <h2>
+            Register{' '}
+            <span className={`node_type__source node_type_creation_heading`}>
+              Source
+            </span>
+          </h2>
+          <center>
+            <Formik
+              initialValues={initialValues}
+              validate={validator}
+              onSubmit={handleSubmit}
+            >
+              {function Render({ isSubmitting, status, setFieldValue }) {
+                return (
+                  <Form>
+                    {displayMessageAfterSubmit(status)}
+                    {
+                      <>
+                        <div className="SourceCreationInput">
+                          <ErrorMessage name="catalog" component="span" />
+                          <label htmlFor="catalog">Catalog</label>
+                          <FormikSelect
+                            selectOptions={catalogs}
+                            formikFieldName="catalog"
+                            placeholder="Choose Catalog"
+                            defaultValue={catalogs[0]}
+                          />
+                        </div>
+                        <div className="SourceCreationInput">
+                          <ErrorMessage name="schema" component="span" />
+                          <label htmlFor="schema">Schema</label>
+                          <Field
+                            type="text"
+                            name="schema"
+                            id="schema"
+                            placeholder="Schema"
+                          />
+                        </div>
+                        <div className="SourceCreationInput NodeCreationInput">
+                          <ErrorMessage name="table" component="span" />
+                          <label htmlFor="table">Table</label>
+                          <Field
+                            type="text"
+                            name="table"
+                            id="table"
+                            placeholder="Table"
+                          />
+                        </div>
+                        <button type="submit" disabled={isSubmitting}>
+                          Register
+                        </button>
+                      </>
+                    }
+                  </Form>
+                );
+              }}
+            </Formik>
+          </center>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/pages/RegisterTablePage/index.jsx
+++ b/datajunction-ui/src/app/pages/RegisterTablePage/index.jsx
@@ -9,9 +9,8 @@ import NamespaceHeader from '../../components/NamespaceHeader';
 import React, { useContext, useEffect, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
 import 'styles/node-creation.scss';
-import AlertIcon from '../../icons/AlertIcon';
-import ValidIcon from '../../icons/ValidIcon';
 import { FormikSelect } from '../AddEditNodePage/FormikSelect';
+import { displayMessageAfterSubmit } from '../../../utils/form';
 
 export function RegisterTablePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
@@ -71,28 +70,6 @@ export function RegisterTablePage() {
     window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
   };
 
-  const displayMessageAfterSubmit = status => {
-    return status?.success !== undefined ? (
-      <div className="message success">
-        <ValidIcon />
-        {status?.success}
-      </div>
-    ) : status?.failure !== undefined ? (
-      alertMessage(status?.failure)
-    ) : (
-      ''
-    );
-  };
-
-  const alertMessage = message => {
-    return (
-      <div className="message alert">
-        <AlertIcon />
-        {message}
-      </div>
-    );
-  };
-
   return (
     <div className="mid">
       <NamespaceHeader namespace="" />
@@ -110,7 +87,7 @@ export function RegisterTablePage() {
               validate={validator}
               onSubmit={handleSubmit}
             >
-              {function Render({ isSubmitting, status, setFieldValue }) {
+              {function Render({ isSubmitting, status }) {
                 return (
                   <Form>
                     {displayMessageAfterSubmit(status)}
@@ -119,12 +96,14 @@ export function RegisterTablePage() {
                         <div className="SourceCreationInput">
                           <ErrorMessage name="catalog" component="span" />
                           <label htmlFor="catalog">Catalog</label>
-                          <FormikSelect
-                            selectOptions={catalogs}
-                            formikFieldName="catalog"
-                            placeholder="Choose Catalog"
-                            defaultValue={catalogs[0]}
-                          />
+                          <span data-testid="choose-catalog">
+                            <FormikSelect
+                              selectOptions={catalogs}
+                              formikFieldName="catalog"
+                              placeholder="Choose Catalog"
+                              defaultValue={catalogs[0]}
+                            />
+                          </span>
                         </div>
                         <div className="SourceCreationInput">
                           <ErrorMessage name="schema" component="span" />

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -18,6 +18,14 @@ export const DataJunctionAPI = {
     });
   },
 
+  catalogs: async function () {
+    return await (
+      await fetch(`${DJ_URL}/catalogs`, {
+        credentials: 'include',
+      })
+    ).json();
+  },
+
   node: async function (name) {
     const data = await (
       await fetch(`${DJ_URL}/nodes/${name}/`, {
@@ -99,6 +107,20 @@ export const DataJunctionAPI = {
     } catch (error) {
       return { status: 500, json: { message: 'Update failed' } };
     }
+  },
+
+  registerTable: async function (catalog, schema, table) {
+    const response = await fetch(
+      `${DJ_URL}/register/table/${catalog}/${schema}/${table}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      },
+    );
+    return { status: response.status, json: await response.json() };
   },
 
   upstreams: async function (name) {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -487,4 +487,14 @@ export const DataJunctionAPI = {
     });
     return { status: response.status, json: await response.json() };
   },
+  addNamespace: async function (namespace) {
+    const response = await fetch(`${DJ_URL}/namespaces/${namespace}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+    return { status: response.status, json: await response.json() };
+  },
 };

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -989,3 +989,7 @@ pre {
   outline: inherit;
   margin-left: 1rem;
 }
+
+.deleteNode {
+  display: inline-block;
+}

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -890,7 +890,7 @@ pre {
   border-radius: 10px;
   text-align: left;
   position: absolute;
-  min-width: 200px;
+  min-width: 210px;
   max-width: 100%;
   z-index: 1;
 }

--- a/datajunction-ui/src/styles/node-creation.scss
+++ b/datajunction-ui/src/styles/node-creation.scss
@@ -188,3 +188,10 @@ form {
       brightness(96%) contrast(100%);
   }
 }
+
+.SourceCreationInput {
+  margin: 0.5rem 0;
+  display: inline-grid;
+  width: 20%;
+  padding: 0 20px;
+}


### PR DESCRIPTION
### Summary

#### Added page to register tables:

<img width="149" alt="Screenshot 2023-09-20 at 12 03 42 AM" src="https://github.com/DataJunction/dj/assets/9524628/feea9ba5-01f9-4b23-a2b0-39f1c79e7f89">

<img width="1146" alt="Screenshot 2023-09-20 at 12 10 42 AM" src="https://github.com/DataJunction/dj/assets/9524628/71906fae-99c4-4a6d-9065-1c8647300156">

#### Node deletion

The delete node icon was added previously to the list nodes page, but clicking it wasn't wired up to actually deactivate nodes. This change wires it up with the right API call. Note that the current setup is prone to fat-fingering node deletions, but this can be fixed later.

#### Add namespace popover

Provides a small popover in the hierarchical namespaces sidebar to add a new namespace

https://github.com/DataJunction/dj/assets/9524628/228e7171-82f3-471d-aa6a-1986d30d317c

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #749 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
