### PR TITLE
Measures CRUD API

### DIFF
--- a/datajunction-server/alembic/versions/2023_09_21_0033-b75e5163b09d_add_description_and_display_name_to_.py
+++ b/datajunction-server/alembic/versions/2023_09_21_0033-b75e5163b09d_add_description_and_display_name_to_.py
@@ -1,0 +1,33 @@
+"""Add description and display_name to measures
+
+Revision ID: b75e5163b09d
+Revises: 879128f3e778
+Create Date: 2023-09-21 00:33:52.761619+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b75e5163b09d"
+down_revision = "879128f3e778"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("measures", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("display_name", sa.String(), nullable=True))
+        batch_op.add_column(
+            sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("measures", schema=None) as batch_op:
+        batch_op.drop_column("description")
+        batch_op.drop_column("display_name")

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -33,6 +33,7 @@ from datajunction_server.api import (
     health,
     history,
     materializations,
+    measures,
     metrics,
     namespaces,
     nodes,
@@ -90,6 +91,7 @@ app.include_router(djsql.router)
 app.include_router(nodes.router)
 app.include_router(namespaces.router)
 app.include_router(materializations.router)
+app.include_router(measures.router)
 app.include_router(data.router)
 app.include_router(health.router)
 app.include_router(history.router)

--- a/datajunction-server/datajunction_server/api/measures.py
+++ b/datajunction-server/datajunction_server/api/measures.py
@@ -1,0 +1,145 @@
+"""
+Measures related APIs.
+"""
+
+import logging
+from typing import List, Optional
+
+from fastapi import Depends
+from sqlmodel import Session, select
+
+from datajunction_server.api.helpers import get_node_by_name
+from datajunction_server.errors import DJAlreadyExistsException, DJDoesNotExistException
+from datajunction_server.internal.authentication.http import SecureAPIRouter
+from datajunction_server.models.measure import (
+    CreateMeasure,
+    EditMeasure,
+    Measure,
+    MeasureOutput,
+)
+from datajunction_server.utils import get_session, get_settings
+
+_logger = logging.getLogger(__name__)
+settings = get_settings()
+router = SecureAPIRouter(tags=["measures"])
+
+
+def get_measure_by_name(session: Session, measure_name: str) -> Optional[Measure]:
+    """Retrieve a measure by name"""
+    return (
+        session.exec(select(Measure).where(Measure.name == measure_name))
+        .unique()
+        .one_or_none()
+    )
+
+
+@router.get("/measures/", response_model=List[str])
+def list_measures(*, session: Session = Depends(get_session)) -> List[str]:
+    """
+    List all measures.
+    """
+    measures = session.exec(select(Measure.name)).all()
+    return measures
+
+
+@router.get("/measures/{measure_name}", response_model=MeasureOutput)
+def get_measure(
+    measure_name: str, *, session: Session = Depends(get_session)
+) -> MeasureOutput:
+    """
+    Get info on a measure.
+    """
+    measure = get_measure_by_name(session, measure_name)
+    if not measure:
+        raise DJDoesNotExistException(
+            message=f"Measure with name `{measure_name}` does not exist",
+        )
+    return measure
+
+
+@router.post(
+    "/measures/",
+    response_model=MeasureOutput,
+    status_code=201,
+    name="Add a Measure",
+)
+def add_measure(
+    data: CreateMeasure, *, session: Session = Depends(get_session)
+) -> MeasureOutput:
+    """
+    Add a measure
+    """
+    measure = get_measure_by_name(session, data.name)
+    if measure:
+        raise DJAlreadyExistsException(message=f"Measure `{data.name}` already exists!")
+    measure_columns = []
+    for node_column in data.columns:
+        node = get_node_by_name(session, node_column.node)
+        available = [
+            col for col in node.current.columns if col.name == node_column.column
+        ]
+        if len(available) != 1:
+            raise DJDoesNotExistException(
+                message=f"Column `{node_column.column}` does not exist on "
+                f"node `{node_column.node}`",
+            )
+        measure_columns.extend(available)
+    measure = Measure(
+        name=data.name,
+        display_name=data.display_name,
+        description=data.description,
+        columns=measure_columns,
+        additive=data.additive,
+    )
+    session.add(measure)
+    session.commit()
+    session.refresh(measure)
+    return measure
+
+
+@router.patch(
+    "/measures/{measure_name}",
+    response_model=MeasureOutput,
+    status_code=201,
+    name="Edit a Measure",
+)
+def edit_measure(
+    measure_name: str, data: EditMeasure, *, session: Session = Depends(get_session)
+) -> MeasureOutput:
+    """
+    Edit a measure
+    """
+    measure = get_measure_by_name(session, measure_name)
+    if not measure:
+        raise DJDoesNotExistException(
+            message=f"Measure with name `{measure_name}` does not exist",
+        )
+
+    if data.description:
+        measure.description = data.description
+
+    if data.columns is not None:
+        measure_columns = []
+        for node_column in data.columns:
+            node = get_node_by_name(session, node_column.node)
+            available = [
+                col for col in node.current.columns if col.name == node_column.column
+            ]
+            if len(available) != 1:
+                raise DJDoesNotExistException(
+                    message=f"Column `{node_column.column}` does not "
+                    f"exist on node `{node_column.node}`",
+                )
+            measure_columns.extend(available)
+        measure.columns = measure_columns
+
+    if data.additive:
+        measure.additive = data.additive
+
+    if data.display_name:
+        measure.display_name = data.display_name
+
+    session.add(measure)
+    session.commit()
+    session.refresh(measure)
+    return measure

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -66,7 +66,7 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         sa_column=SqlaColumn(
             "display_name",
             String,
-            default=generate_display_name,
+            default=generate_display_name("name"),
         ),
     )
     type: ColumnType = Field(sa_column=SqlaColumn(ColumnTypeDecorator, nullable=False))

--- a/datajunction-server/datajunction_server/models/measure.py
+++ b/datajunction-server/datajunction_server/models/measure.py
@@ -4,11 +4,12 @@ Models for measures.
 import enum
 from typing import TYPE_CHECKING, List, Optional
 
+from pydantic.class_validators import root_validator
 from sqlalchemy.sql.schema import Column as SqlaColumn
-from sqlalchemy.types import Enum
+from sqlalchemy.types import Enum, String
 from sqlmodel import Field, Relationship
 
-from datajunction_server.models.base import BaseSQLModel
+from datajunction_server.models.base import BaseSQLModel, generate_display_name
 
 if TYPE_CHECKING:
     from datajunction_server.models import Column
@@ -22,6 +23,38 @@ class AggregationRule(str, enum.Enum):
     ADDITIVE = "additive"
     NON_ADDITIVE = "non-additive"
     SEMI_ADDITIVE = "semi-additive"
+
+
+class NodeColumn(BaseSQLModel):
+    """
+    Defines a column on a node
+    """
+
+    node: str
+    column: str
+
+
+class CreateMeasure(BaseSQLModel):
+    """
+    Input for creating a measure
+    """
+
+    name: str
+    display_name: Optional[str]
+    description: Optional[str]
+    columns: List[NodeColumn]
+    additive: AggregationRule = AggregationRule.NON_ADDITIVE
+
+
+class EditMeasure(BaseSQLModel):
+    """
+    Editable fields on a measure
+    """
+
+    display_name: Optional[str]
+    description: Optional[str]
+    columns: Optional[List[NodeColumn]]
+    additive: Optional[AggregationRule]
 
 
 class Measure(BaseSQLModel, table=True):  # type: ignore
@@ -39,8 +72,54 @@ class Measure(BaseSQLModel, table=True):  # type: ignore
 
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(unique=True)
-    columns: List["Column"] = Relationship(back_populates="measure")
+    display_name: Optional[str] = Field(
+        sa_column=SqlaColumn(
+            "display_name",
+            String,
+            default=generate_display_name("name"),
+        ),
+    )
+    description: Optional[str]
+    columns: List["Column"] = Relationship(
+        back_populates="measure",
+        sa_relationship_kwargs={
+            "lazy": "joined",
+        },
+    )
     additive: AggregationRule = Field(
         default=AggregationRule.NON_ADDITIVE,
         sa_column=SqlaColumn(Enum(AggregationRule)),
     )
+
+
+class ColumnOutput(BaseSQLModel):
+    """
+    A simplified column schema, without ID or dimensions.
+    """
+
+    name: str
+    type: str
+    node: str
+
+    @root_validator(pre=True)
+    def transform(cls, values):  # pylint: disable=no-self-argument
+        """
+        Transforms the values for output
+        """
+        return {
+            "name": values.get("name"),
+            "type": str(values.get("type")),
+            "node": values.get("node_revisions")[0].name,
+        }
+
+
+class MeasureOutput(BaseSQLModel):
+    """
+    Output model for measures
+    """
+
+    name: str
+    display_name: Optional[str]
+    description: Optional[str]
+    columns: List[ColumnOutput]
+    additive: AggregationRule

--- a/datajunction-server/tests/api/measures_test.py
+++ b/datajunction-server/tests/api/measures_test.py
@@ -62,6 +62,14 @@ def test_list_all_measures(
     assert response.ok
     assert response.json() == ["completed_repairs"]
 
+    response = client_with_roads.get("/measures/?prefix=comp")
+    assert response.ok
+    assert response.json() == ["completed_repairs"]
+
+    response = client_with_roads.get("/measures/?prefix=xyz")
+    assert response.ok
+    assert response.json() == []
+
     response = client_with_roads.get("/measures/completed_repairs")
     assert response.ok
     assert response.json() == {

--- a/datajunction-server/tests/api/measures_test.py
+++ b/datajunction-server/tests/api/measures_test.py
@@ -78,6 +78,13 @@ def test_list_all_measures(
         "name": "completed_repairs",
     }
 
+    response = client_with_roads.get("/measures/random_measure")
+    assert not response.ok
+    assert (
+        response.json()["message"]
+        == "Measure with name `random_measure` does not exist"
+    )
+
 
 def test_create_measure(
     client_with_roads: TestClient,

--- a/datajunction-server/tests/api/measures_test.py
+++ b/datajunction-server/tests/api/measures_test.py
@@ -1,0 +1,223 @@
+"""
+Tests for the namespaces API.
+"""
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def completed_repairs_measure() -> Dict:
+    """
+    Test ``GET /measures/``.
+    """
+    return {
+        "name": "completed_repairs",
+        "description": "Number of completed repairs",
+        "columns": [
+            {
+                "node": "default.regional_level_agg",
+                "column": "completed_repairs",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def failed_measure() -> Dict:
+    """
+    Measure that will fail due to one of the columns not existing
+    """
+    return {
+        "name": "completed_repairs2",
+        "description": "Number of completed repairs",
+        "columns": [
+            {
+                "node": "default.regional_level_agg",
+                "column": "completed_repairs",
+            },
+            {
+                "node": "default.national_level_agg",
+                "column": "completed_repairs",
+            },
+        ],
+    }
+
+
+def test_list_all_measures(
+    client_with_roads: TestClient,
+    completed_repairs_measure: Dict,  # pylint: disable=redefined-outer-name
+) -> None:
+    """
+    Test ``GET /measures/``.
+    """
+    response = client_with_roads.get("/measures/")
+    assert response.ok
+    assert response.json() == []
+
+    client_with_roads.post("/measures/", json=completed_repairs_measure)
+
+    response = client_with_roads.get("/measures/")
+    assert response.ok
+    assert response.json() == ["completed_repairs"]
+
+    response = client_with_roads.get("/measures/completed_repairs")
+    assert response.ok
+    assert response.json() == {
+        "additive": "non-additive",
+        "columns": [
+            {
+                "name": "completed_repairs",
+                "node": "default.regional_level_agg",
+                "type": "bigint",
+            },
+        ],
+        "description": "Number of completed repairs",
+        "display_name": "Completed Repairs",
+        "name": "completed_repairs",
+    }
+
+
+def test_create_measure(
+    client_with_roads: TestClient,
+    completed_repairs_measure: Dict,  # pylint: disable=redefined-outer-name
+    failed_measure: Dict,  # pylint: disable=redefined-outer-name
+) -> None:
+    """
+    Test ``POST /measures/``.
+    """
+    # Successful measure creation
+    response = client_with_roads.post("/measures/", json=completed_repairs_measure)
+    assert response.ok
+    assert response.json() == {
+        "additive": "non-additive",
+        "columns": [
+            {
+                "name": "completed_repairs",
+                "node": "default.regional_level_agg",
+                "type": "bigint",
+            },
+        ],
+        "description": "Number of completed repairs",
+        "display_name": "Completed Repairs",
+        "name": "completed_repairs",
+    }
+
+    # Creating the same measure again will fail
+    response = client_with_roads.post("/measures/", json=completed_repairs_measure)
+    assert not response.ok
+    assert response.json()["message"] == "Measure `completed_repairs` already exists!"
+
+    # Failed measure creation
+    response = client_with_roads.post("/measures/", json=failed_measure)
+    assert not response.ok
+    assert response.json()["message"] == (
+        "Column `completed_repairs` does not exist on node `default.national_level_agg`"
+    )
+
+
+def test_edit_measure(
+    client_with_roads: TestClient,
+    completed_repairs_measure: Dict,  # pylint: disable=redefined-outer-name
+) -> None:
+    """
+    Test ``PATCH /measures/{name}``.
+    """
+    client_with_roads.post("/measures", json=completed_repairs_measure)
+
+    # Successfully edit measure
+    response = client_with_roads.patch(
+        "/measures/completed_repairs",
+        json={
+            "additive": "additive",
+            "display_name": "blah",
+            "description": "random description",
+        },
+    )
+    assert response.ok
+    assert response.json() == {
+        "additive": "additive",
+        "columns": [
+            {
+                "name": "completed_repairs",
+                "node": "default.regional_level_agg",
+                "type": "bigint",
+            },
+        ],
+        "description": "random description",
+        "display_name": "blah",
+        "name": "completed_repairs",
+    }
+
+    response = client_with_roads.patch(
+        "/measures/completed_repairs",
+        json={
+            "additive": "non-additive",
+            "columns": [],
+        },
+    )
+    assert response.ok
+    assert response.json() == {
+        "additive": "non-additive",
+        "columns": [],
+        "description": "random description",
+        "display_name": "blah",
+        "name": "completed_repairs",
+    }
+
+    response = client_with_roads.patch(
+        "/measures/completed_repairs",
+        json={
+            "columns": [
+                {
+                    "node": "default.regional_level_agg",
+                    "column": "completed_repairs",
+                },
+                {
+                    "node": "default.national_level_agg",
+                    "column": "total_amount_nationwide",
+                },
+            ],
+        },
+    )
+    assert response.ok
+    assert response.json() == {
+        "additive": "non-additive",
+        "columns": [
+            {
+                "name": "completed_repairs",
+                "node": "default.regional_level_agg",
+                "type": "bigint",
+            },
+            {
+                "name": "total_amount_nationwide",
+                "node": "default.national_level_agg",
+                "type": "double",
+            },
+        ],
+        "description": "random description",
+        "display_name": "blah",
+        "name": "completed_repairs",
+    }
+
+    # Failed edit
+    response = client_with_roads.patch(
+        "/measures/completed_repairs",
+        json={
+            "columns": [
+                {
+                    "node": "default.regional_level_agg",
+                    "column": "completed_repairs",
+                },
+                {
+                    "node": "default.national_level_agg",
+                    "column": "non_existent_column",
+                },
+            ],
+        },
+    )
+    assert not response.ok
+    assert response.json()["message"] == (
+        "Column `non_existent_column` does not exist on node `default.national_level_agg`"
+    )


### PR DESCRIPTION
### Summary

This PR adds API endpoints for:
* `POST /measures`: creating measures
* `PATCH /measures/{name}`: editing measures
* `GET /measures`: listing measures (only shows the measure name)
* `GET /measures/{name}`: shows detailed info for the measure, including the column(s)

I'll punt the delete measures endpoint to a different PR, after we implement the functionality to reference them in metrics.

### Test Plan

Added a series of unit tests. Will add some example measures to the demo db as well.

- [x] PR has an associated issue: #733 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
