### PR TITLE
SQL for non-metric nodes should not include dimension attributes in group by

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -197,12 +197,6 @@ def get_query(  # pylint: disable=too-many-arguments
     """
     node = get_node_by_name(session=session, name=node_name)
 
-    if node.type in (NodeType.DIMENSION, NodeType.SOURCE):
-        if dimensions:
-            raise DJInvalidInputException(
-                message=f"Cannot set dimensions for node type {node.type}!",
-            )
-
     # Builds the node for the engine's dialect if one is set or defaults to Spark
     if (
         not engine

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -368,6 +368,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
     dimensions: Optional[List[str]] = None,
     orderby: Optional[List[str]] = None,
     limit: Optional[int] = None,
+    include_dimensions_in_groupby: bool = True,
 ):
     """
     Add filters and dimensions to a query ast
@@ -379,7 +380,8 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             temp_select = parse(
                 f"select * group by {agg}",
             ).select
-            query.select.group_by += temp_select.group_by  # type:ignore
+            if include_dimensions_in_groupby:
+                query.select.group_by += temp_select.group_by  # type:ignore
             for col in temp_select.find_all(ast.Column):
                 projection_addition[col.identifier(False)] = col
 
@@ -530,6 +532,7 @@ def build_node(  # pylint: disable=too-many-arguments
         dimensions,
         orderby,
         limit,
+        include_dimensions_in_groupby=(node.type == NodeType.METRIC),
     )
     memoized_queries: Dict[int, ast.Query] = {}
     _logger.info("Calling build_ast on %s", node.name)

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -33,8 +33,15 @@ class TestDataForNode:
             },
         )
         data = response.json()
-        assert response.status_code == 422
-        assert data["message"] == "Cannot set dimensions for node type dimension!"
+        assert response.status_code == 500
+        assert data["message"] == (
+            "Cannot resolve type of column something in SELECT  "
+            "default_DOT_payment_type_table.id,\n"
+            "\tdefault_DOT_payment_type_table.payment_type_classification,\n"
+            "\tdefault_DOT_payment_type_table.payment_type_name,\n"
+            "\tsomething \n"
+            " FROM accounting.payment_type_table AS default_DOT_payment_type_table\n"
+        )
 
     def test_get_dimension_data(
         self,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2193,8 +2193,7 @@ FROM (
       EXTRACT(YEAR, default_DOT_repair_orders.order_date),
       EXTRACT(MONTH, default_DOT_repair_orders.order_date),
       EXTRACT(DAY, default_DOT_repair_orders.order_date)
-  ) AS default_DOT_regional_level_agg_structs
-GROUP BY default_DOT_regional_level_agg_structs.location_hierarchy""",
+  ) AS default_DOT_regional_level_agg_structs""",
         )
 
     def test_node_with_incremental_materialization(


### PR DESCRIPTION
### Summary

When requesting SQL for a non-metric node (i.e., transform, dimension, or source nodes), the generated SQL should not include requested dimension attributes in the `GROUP BY` clause. Instead, it should just join the appropriate nodes to bring in the dimension attribute and include it in the `SELECT` clause. This PR adds a small check based on node type to determine whether or not to include the dimension attribute in the `GROUP BY`.

### Test Plan

Locally. Added a unit test for requesting dimension attributes on a source (`default.repair_orders`, which can access `default.hard_hat` after two hops away on the dimensions graph).

- [x] PR has an associated issue: #787 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
