### PR TITLE
Include the current user when storing history events

### DIFF
--- a/datajunction-server/datajunction_server/api/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/authentication/whoami.py
@@ -4,24 +4,24 @@ Router for getting the current active user
 from datetime import timedelta
 from http import HTTPStatus
 
-from fastapi import Request
+from fastapi import Depends, Request
 from fastapi.responses import JSONResponse
 
 from datajunction_server.internal.authentication.http import SecureAPIRouter
 from datajunction_server.internal.authentication.tokens import create_token
-from datajunction_server.models.user import UserOutput
-from datajunction_server.utils import get_settings
+from datajunction_server.models.user import User, UserOutput
+from datajunction_server.utils import get_current_user, get_settings
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["Who am I?"])
 
 
 @router.get("/whoami/", response_model=UserOutput)
-async def get_current_user(request: Request) -> UserOutput:
+async def get_user(current_user: User = Depends(get_current_user)) -> UserOutput:
     """
     Returns the current authenticated user
     """
-    return request.state.user
+    return UserOutput.parse_obj(current_user)
 
 
 @router.get("/token/")

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -23,7 +23,7 @@ from datajunction_server.errors import (
     DJQueryServiceClientException,
 )
 from datajunction_server.internal.authentication.http import SecureAPIRouter
-from datajunction_server.models import History
+from datajunction_server.models import History, User
 from datajunction_server.models.history import ActivityType, EntityType
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node import (
@@ -38,6 +38,7 @@ from datajunction_server.models.query import (
 )
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import (
+    get_current_user,
     get_query_service_client,
     get_session,
     get_settings,
@@ -53,6 +54,7 @@ def add_availability_state(
     data: AvailabilityStateBase,
     *,
     session: Session = Depends(get_session),
+    current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Add an availability state to a node
@@ -106,6 +108,7 @@ def add_availability_state(
             if old_availability
             else {},
             post=AvailabilityStateBase.parse_obj(node_revision.availability).dict(),
+            user=current_user.username if current_user else None,
         ),
     )
     session.commit()

--- a/datajunction-server/datajunction_server/api/history.py
+++ b/datajunction-server/datajunction_server/api/history.py
@@ -52,6 +52,10 @@ def list_history_by_node_context(
     List all activity history for a node context
     """
     hist = session.exec(
-        select(History).where(History.node == node).offset(offset).limit(limit),
+        select(History)
+        .where(History.node == node)
+        .order_by(History.created_at)
+        .offset(offset)
+        .limit(limit),
     ).all()
     return hist

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -10,11 +10,11 @@ from sqlmodel import Session, select
 
 from datajunction_server.errors import DJException
 from datajunction_server.internal.authentication.http import SecureAPIRouter
-from datajunction_server.models import History
+from datajunction_server.models import History, User
 from datajunction_server.models.history import ActivityType, EntityType
 from datajunction_server.models.node import NodeType
 from datajunction_server.models.tag import CreateTag, Tag, TagOutput, UpdateTag
-from datajunction_server.utils import get_session, get_settings
+from datajunction_server.utils import get_current_user, get_session, get_settings
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["tags"])
@@ -69,6 +69,7 @@ def get_a_tag(name: str, *, session: Session = Depends(get_session)) -> Tag:
 def create_a_tag(
     data: CreateTag,
     session: Session = Depends(get_session),
+    current_user: Optional[User] = Depends(get_current_user),
 ) -> Tag:
     """
     Create a tag.
@@ -86,6 +87,7 @@ def create_a_tag(
             entity_type=EntityType.TAG,
             entity_name=tag.name,
             activity_type=ActivityType.CREATE,
+            user=current_user.username if current_user else None,
         ),
     )
     session.commit()
@@ -98,6 +100,7 @@ def update_a_tag(
     name: str,
     data: UpdateTag,
     session: Session = Depends(get_session),
+    current_user: Optional[User] = Depends(get_current_user),
 ) -> Tag:
     """
     Update a tag.
@@ -115,6 +118,7 @@ def update_a_tag(
             entity_name=tag.name,
             activity_type=ActivityType.UPDATE,
             details=data,
+            user=current_user.username if current_user else None,
         ),
     )
     session.commit()

--- a/datajunction-server/datajunction_server/internal/authentication/basic.py
+++ b/datajunction-server/datajunction_server/internal/authentication/basic.py
@@ -8,7 +8,7 @@ from passlib.context import CryptContext
 from sqlmodel import Session, select
 
 from datajunction_server.errors import DJError, DJException, ErrorCode
-from datajunction_server.models import User
+from datajunction_server.models.user import User
 
 _logger = logging.getLogger(__name__)
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/datajunction-server/datajunction_server/internal/authentication/http.py
+++ b/datajunction-server/datajunction_server/internal/authentication/http.py
@@ -4,12 +4,13 @@ A secure API router for routes that require authentication
 from http import HTTPStatus
 from typing import Any, Callable
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 from fastapi.security import HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
 from fastapi.types import DecoratedCallable
 from jose.exceptions import JWEError, JWTError
 from sqlmodel import Session
+from starlette.requests import Request
 
 from datajunction_server.constants import DJ_AUTH_COOKIE
 from datajunction_server.errors import DJError, DJException, ErrorCode

--- a/datajunction-server/datajunction_server/models/history.py
+++ b/datajunction-server/datajunction_server/models/history.py
@@ -11,6 +11,7 @@ from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlmodel import JSON, Field, SQLModel
 
 from datajunction_server.models.node import NodeRevision, NodeStatus
+from datajunction_server.models.user import User
 from datajunction_server.typing import UTCDatetime
 
 
@@ -76,6 +77,7 @@ def status_change_history(
     start_status: NodeStatus,
     end_status: NodeStatus,
     parent_node: str = None,
+    current_user: Optional[User] = None,
 ) -> History:
     """
     Returns a status change history activity entry
@@ -88,4 +90,5 @@ def status_change_history(
         pre={"status": start_status},
         post={"status": end_status},
         details={"upstream_node": parent_node if parent_node else None},
+        user=current_user.username if current_user else None,
     )

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -15,10 +15,12 @@ from dotenv import load_dotenv
 from rich.logging import RichHandler
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
+from starlette.requests import Request
 from yarl import URL
 
 from datajunction_server.config import Settings
 from datajunction_server.errors import DJException
+from datajunction_server.models.user import User
 from datajunction_server.service_clients import QueryServiceClient
 
 
@@ -203,3 +205,12 @@ def amenable_name(name: str) -> str:
             cont = []
 
     return ("_".join(ret) + "_" + "".join(cont)).strip("_")
+
+
+async def get_current_user(request: Request) -> Optional[User]:
+    """
+    Returns the current authenticated user
+    """
+    if hasattr(request.state, "user"):
+        return request.state.user
+    return None  # pragma: no cover

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -393,7 +393,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "valid_through_ts": 20230125,
                 },
                 "pre": {},
-                "user": None,
+                "user": "dj",
             },
         ]
 
@@ -526,7 +526,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "valid_through_ts": 20230125,
                 },
                 "pre": {},
-                "user": None,
+                "user": "dj",
             },
             {
                 "activity_type": "create",
@@ -558,7 +558,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                 },
-                "user": None,
+                "user": "dj",
             },
             {
                 "activity_type": "create",
@@ -590,7 +590,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                 },
-                "user": None,
+                "user": "dj",
             },
         ]
 

--- a/datajunction-server/tests/api/history_test.py
+++ b/datajunction-server/tests/api/history_test.py
@@ -46,7 +46,7 @@ def test_get_history_entity(client_with_roads: TestClient):
             "entity_type": "node",
             "entity_name": "default.repair_orders",
             "activity_type": "create",
-            "user": None,
+            "user": "dj",
             "details": {},
         },
     ]
@@ -72,7 +72,7 @@ def test_get_history_node(client_with_roads: TestClient):
             "id": mock.ANY,
             "post": {},
             "pre": {},
-            "user": None,
+            "user": "dj",
         },
         {
             "activity_type": "set_attribute",
@@ -92,7 +92,7 @@ def test_get_history_node(client_with_roads: TestClient):
             "id": mock.ANY,
             "post": {},
             "pre": {},
-            "user": None,
+            "user": "dj",
         },
         {
             "activity_type": "create",
@@ -108,7 +108,7 @@ def test_get_history_node(client_with_roads: TestClient):
             "id": mock.ANY,
             "post": {},
             "pre": {},
-            "user": None,
+            "user": "dj",
         },
         {
             "activity_type": "create",
@@ -124,7 +124,7 @@ def test_get_history_node(client_with_roads: TestClient):
             "id": mock.ANY,
             "post": {},
             "pre": {},
-            "user": None,
+            "user": "dj",
         },
         {
             "activity_type": "create",
@@ -140,7 +140,7 @@ def test_get_history_node(client_with_roads: TestClient):
             "id": mock.ANY,
             "post": {},
             "pre": {},
-            "user": None,
+            "user": "dj",
         },
     ]
 
@@ -165,6 +165,6 @@ def test_get_history_namespace(client_with_service_setup: TestClient):
             "id": mock.ANY,
             "post": {},
             "pre": {},
-            "user": None,
+            "user": "dj",
         },
     ]

--- a/datajunction-server/tests/api/node_update_test.py
+++ b/datajunction-server/tests/api/node_update_test.py
@@ -73,7 +73,7 @@ def test_update_source_node(
                 "node": "default.national_level_agg",
                 "post": {"status": "invalid"},
                 "pre": {"status": "valid"},
-                "user": None,
+                "user": "dj",
             },
         ],
         "default.regional_level_agg": [
@@ -111,7 +111,7 @@ def test_update_source_node(
                 "node": "default.regional_level_agg",
                 "post": {"status": "invalid"},
                 "pre": {"status": "valid"},
-                "user": None,
+                "user": "dj",
             },
         ],
         "default.avg_repair_price": [
@@ -121,7 +121,7 @@ def test_update_source_node(
                 "entity_name": "default.avg_repair_price",
                 "node": "default.avg_repair_price",
                 "activity_type": "status_change",
-                "user": None,
+                "user": "dj",
                 "pre": {"status": "valid"},
                 "post": {"status": "invalid"},
                 "details": {
@@ -155,7 +155,7 @@ def test_update_source_node(
                 "entity_name": "default.regional_repair_efficiency",
                 "node": "default.regional_repair_efficiency",
                 "activity_type": "status_change",
-                "user": None,
+                "user": "dj",
                 "pre": {"status": "valid"},
                 "post": {"status": "invalid"},
                 "details": {

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -363,7 +363,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "id": mock.ANY,
                 "post": {},
                 "pre": {},
-                "user": None,
+                "user": "dj",
             },
             {
                 "activity_type": "delete",
@@ -375,7 +375,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "id": mock.ANY,
                 "post": {},
                 "pre": {},
-                "user": None,
+                "user": "dj",
             },
             {
                 "id": mock.ANY,
@@ -383,7 +383,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "entity_name": "basic.source.users",
                 "node": "basic.source.users",
                 "activity_type": "update",
-                "user": None,
+                "user": "dj",
                 "pre": {},
                 "post": {},
                 "details": {"version": "v2.0"},
@@ -395,7 +395,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "entity_name": "basic.source.users",
                 "node": "basic.source.users",
                 "activity_type": "restore",
-                "user": None,
+                "user": "dj",
                 "pre": {},
                 "post": {},
                 "details": {},
@@ -3144,7 +3144,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         """
         Test validating a valid node
         """
-        response = client_with_account_revenue.post(
+        response = client_with_account_revenue.get(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3179,7 +3179,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         Test validating an invalid node
         """
 
-        response = client.post(
+        response = client.get(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3207,7 +3207,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         Test validating an invalid node with invalid SQL
         """
 
-        response = client.post(
+        response = client.get(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3244,7 +3244,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         Test validating a node with a query that has missing parents
         """
 
-        response = client.post(
+        response = client.get(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3287,7 +3287,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         Test validating a draft node that's allowed to have missing parents
         """
 
-        response = client.post(
+        response = client.get(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3331,7 +3331,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         Test validating a source node which is not possible
         """
 
-        response = client.post(
+        response = client.get(
             "/nodes/validate/",
             json={
                 "name": "foo",

--- a/datajunction-server/tests/api/tags_test.py
+++ b/datajunction-server/tests/api/tags_test.py
@@ -60,7 +60,7 @@ class TestTags:
                 "id": mock.ANY,
                 "post": {},
                 "pre": {},
-                "user": None,
+                "user": "dj",
             },
         ]
 


### PR DESCRIPTION
### Summary

This PR adds functionality to store the current user every time we create a history event, allowing us to track which user is associated with a particular action. We use the `user` field on the `History` model, and we store the user's username.

### Test Plan

Locally + unit tests

- [x] PR has an associated issue: #790 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A since we can't find users for previously saved history events