### PR TITLE
Skip transpilation for unsupported SQL dialects (i.e., Druid)

### DIFF
--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -65,7 +65,12 @@ class SQLGlotTranspilationPlugin(SQLTranspilationPlugin):
         """
         import sqlglot  # pylint: disable=import-outside-toplevel,import-error
 
-        if input_dialect and output_dialect:
+        # Check to make sure that the output dialect is supported by sqlglot before transpiling
+        if (
+            input_dialect
+            and output_dialect
+            and output_dialect.name in dir(sqlglot.dialects.Dialects)
+        ):
             value = sqlglot.transpile(
                 query,
                 read=str(input_dialect.name.lower()),  # type: ignore

--- a/datajunction-server/tests/transpilation_test.py
+++ b/datajunction-server/tests/transpilation_test.py
@@ -55,3 +55,18 @@ def test_translated_sql(mocker: MockerFixture) -> None:
         dialect=Dialect.SPARK,
     )
     assert translated_sql.sql == "1"
+
+
+def test_druid_sql(mocker: MockerFixture) -> None:
+    """
+    Verify that the TranslatedSQL object will call the configured transpilation plugin
+    """
+    mock_settings = mocker.MagicMock()
+    mock_settings.return_value = MockSettings()
+    mocker.patch("datajunction_server.models.metric.get_settings", mock_settings)
+    translated_sql = TranslatedSQL(
+        sql="SELECT 1",
+        columns=[],
+        dialect=Dialect.DRUID,
+    )
+    assert translated_sql.sql == "SELECT 1"


### PR DESCRIPTION
### Summary

Adds a check to make sure that the output dialect is in the list of supported sqlglot dialects before transpiling the query. This fixes the issue of druid queries failing to be transpiled.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
