### PR TITLE
Cube Node Fixes

### DIFF
--- a/datajunction-server/datajunction_server/__about__.py
+++ b/datajunction-server/datajunction_server/__about__.py
@@ -1,4 +1,4 @@
 """
 Version for Hatch
 """
-__version__ = "0.0.1a25"
+__version__ = "0.0.1a26"

--- a/datajunction-server/datajunction_server/__about__.py
+++ b/datajunction-server/datajunction_server/__about__.py
@@ -1,4 +1,4 @@
 """
 Version for Hatch
 """
-__version__ = "0.0.1a21"
+__version__ = "0.0.1a25"

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -34,12 +34,12 @@ from datajunction_server.internal.authentication.http import SecureAPIRouter
 from datajunction_server.internal.materializations import schedule_materialization_jobs
 from datajunction_server.internal.nodes import (
     _create_node_from_inactive,
-    update_node_with_query,
     create_cube_node_revision,
     create_node_revision,
     get_column_level_lineage,
     save_node,
-    set_node_column_attributes, update_any_node,
+    set_node_column_attributes,
+    update_any_node,
 )
 from datajunction_server.models import User
 from datajunction_server.models.attribute import AttributeTypeIdentifier

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -34,12 +34,12 @@ from datajunction_server.internal.authentication.http import SecureAPIRouter
 from datajunction_server.internal.materializations import schedule_materialization_jobs
 from datajunction_server.internal.nodes import (
     _create_node_from_inactive,
-    _update_node,
+    update_node_with_query,
     create_cube_node_revision,
     create_node_revision,
     get_column_level_lineage,
     save_node,
-    set_node_column_attributes,
+    set_node_column_attributes, update_any_node,
 )
 from datajunction_server.models import User
 from datajunction_server.models.attribute import AttributeTypeIdentifier
@@ -808,7 +808,7 @@ def update_node(
     """
     Update a node.
     """
-    node = _update_node(
+    node = update_any_node(
         name,
         data,
         session=session,

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -28,7 +28,7 @@ class Settings(
     cors_origin_whitelist: List[str] = ["http://localhost:3000"]
 
     # SQLAlchemy URI for the metadata database.
-    index: str = "sqlite:///dj.db?check_same_thread=False"
+    index: str = "cockroachdb://netflix_user@localhost:8196/dj?sslmode=disable"
 
     # Directory where the repository lives. This should have 2 subdirectories, "nodes" and
     # "databases".

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -28,7 +28,7 @@ class Settings(
     cors_origin_whitelist: List[str] = ["http://localhost:3000"]
 
     # SQLAlchemy URI for the metadata database.
-    index: str = "cockroachdb://netflix_user@localhost:8196/dj?sslmode=disable"
+    index: str = "sqlite:///dj.db?check_same_thread=False"
 
     # Directory where the repository lives. This should have 2 subdirectories, "nodes" and
     # "databases".

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -18,8 +18,7 @@ from datajunction_server.models import History, User
 from datajunction_server.models.history import ActivityType, EntityType
 from datajunction_server.models.node import Node, NodeNamespace, NodeRevision, NodeType
 from datajunction_server.typing import UTCDatetime
-
-SEPARATOR = "."
+from datajunction_server.utils import SEPARATOR
 
 
 def get_nodes_in_namespace(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -583,7 +583,7 @@ def update_cube_node(
     old_version = Version.parse(node_revision.version)
     if major_changes:
         new_cube_revision.version = str(old_version.next_major_version())
-    elif minor_changes:
+    elif minor_changes:  # pragma: no cover
         new_cube_revision.version = str(old_version.next_minor_version())
     new_cube_revision.node = node_revision.node
     new_cube_revision.node.current_version = new_cube_revision.version  # type: ignore

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -454,6 +454,9 @@ def update_node_with_query(
     """
     Update the named node with the changes defined in the UpdateNode object.
     Propagate these changes to all of the node's downstream children.
+
+    Note: this function works for both source nodes and nodes with query (transforms,
+    dimensions, metrics). We should update it to separate out the logic for source nodes
     """
     node = get_node_by_name(session, name, for_update=True, include_inactive=True)
     old_revision = node.current

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -155,6 +155,13 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         values["type"] = str(values.get("type"))
         return values
 
+    def node_revision(self) -> "NodeRevision":
+        """
+        Returns the most recent node revision associated with this columns
+        """
+        available_revisions = sorted(self.node_revisions, key=lambda n: n.updated_at)
+        return available_revisions[-1] if available_revisions else None
+
 
 class ColumnAttributeInput(BaseSQLModel):
     """

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -155,9 +155,9 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         values["type"] = str(values.get("type"))
         return values
 
-    def node_revision(self) -> "NodeRevision":
+    def node_revision(self) -> Optional["NodeRevision"]:
         """
-        Returns the most recent node revision associated with this columns
+        Returns the most recent node revision associated with this column
         """
         available_revisions = sorted(self.node_revisions, key=lambda n: n.updated_at)
         return available_revisions[-1] if available_revisions else None

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -11,6 +11,7 @@ from sqlmodel import Field, Relationship, SQLModel
 
 from datajunction_server.models.base import BaseSQLModel
 from datajunction_server.models.engine import Engine, EngineInfo, EngineRef
+from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.typing import UTCDatetime
 
 if TYPE_CHECKING:
@@ -142,6 +143,7 @@ class GenericMaterializationConfig(GenericMaterializationConfigInput):
     """
 
     query: Optional[str]
+    columns: Optional[List[ColumnMetadata]]
     upstream_tables: Optional[List[str]]
 
     def identifier(self) -> str:

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -1085,7 +1085,7 @@ class UpdateNode(MutableNodeFields, SourceNodeFields):
             **SourceNodeFields.__annotations__,  # pylint: disable=E1101
             **MutableNodeFields.__annotations__,  # pylint: disable=E1101
             **MutableNodeQueryField.__annotations__,  # pylint: disable=E1101
-            **CubeNodeFields.__annotations__,
+            **CubeNodeFields.__annotations__,  # pylint: disable=E1101
         }.items()
     }
 

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -843,7 +843,7 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         Cube node's metrics
         """
         if self.type != NodeType.CUBE:
-            raise DJInvalidInputException(
+            raise DJInvalidInputException(  # pragma: no cover
                 message="Cannot retrieve metrics for a non-cube node!",
             )
 
@@ -858,7 +858,7 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         Cube node's dimension attributes
         """
         if self.type != NodeType.CUBE:
-            raise DJInvalidInputException(
+            raise DJInvalidInputException(  # pragma: no cover
                 "Cannot retrieve dimensions for a non-cube node!",
             )
         return [

--- a/datajunction-server/datajunction_server/models/query.py
+++ b/datajunction-server/datajunction_server/models/query.py
@@ -47,6 +47,9 @@ class ColumnMetadata(BaseSQLModel):
     name: str
     type: str
 
+    def __hash__(self):
+        return hash((self.name, self.type))
+
 
 class StatementResults(BaseSQLModel):
     """

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -214,3 +214,6 @@ async def get_current_user(request: Request) -> Optional[User]:
     if hasattr(request.state, "user"):
         return request.state.user
     return None  # pragma: no cover
+
+
+SEPARATOR = "."

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -254,6 +254,7 @@ def client_with_repairs_cube(
         },
     )
     assert response.status_code == 201
+    assert response.json()["version"] == "v1.0"
     return custom_client
 
 
@@ -1331,6 +1332,18 @@ def test_updating_cube(
     """
     Verify updating a cube
     """
+    # Check a minor update to the cube
+    response = client_with_repairs_cube.patch(
+        "/nodes/default.repairs_cube",
+        json={
+            "description": "This cube has a new description",
+        },
+    )
+    data = response.json()
+    assert data["version"] == "v1.1"
+    assert data["description"] == "This cube has a new description"
+
+    # Check a major update to the cube
     response = client_with_repairs_cube.patch(
         "/nodes/default.repairs_cube",
         json={

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1377,6 +1377,36 @@ def test_updating_cube(
     data = response.json()
     assert_updated_repairs_cube(data)
 
+    response = client_with_repairs_cube.get("/history?node=default.repairs_cube")
+    assert [
+        event for event in response.json() if event["activity_type"] == "update"
+    ] == [
+        {
+            "activity_type": "update",
+            "created_at": mock.ANY,
+            "details": {"version": "v1.1"},
+            "entity_name": "default.repairs_cube",
+            "entity_type": "node",
+            "id": mock.ANY,
+            "node": "default.repairs_cube",
+            "post": {},
+            "pre": {},
+            "user": "dj",
+        },
+        {
+            "activity_type": "update",
+            "created_at": mock.ANY,
+            "details": {"version": "v2.0"},
+            "entity_name": "default.repairs_cube",
+            "entity_type": "node",
+            "id": mock.ANY,
+            "node": "default.repairs_cube",
+            "post": {},
+            "pre": {},
+            "user": "dj",
+        },
+    ]
+
 
 def test_updating_cube_with_existing_materialization(
     client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
@@ -1467,3 +1497,33 @@ def test_updating_cube_with_existing_materialization(
         "name": "date_int_0",
         "schedule": "@daily",
     }
+
+    response = client_with_repairs_cube.get("/history?node=default.repairs_cube")
+    assert [
+        event for event in response.json() if event["activity_type"] == "update"
+    ] == [
+        {
+            "activity_type": "update",
+            "created_at": "2023-09-26T15:01:41.888399+00:00",
+            "details": {"version": "v2.0"},
+            "entity_name": "default.repairs_cube",
+            "entity_type": "node",
+            "id": 56,
+            "node": "default.repairs_cube",
+            "post": {},
+            "pre": {},
+            "user": "dj",
+        },
+        {
+            "activity_type": "update",
+            "created_at": "2023-09-26T15:01:41.890344+00:00",
+            "details": {},
+            "entity_name": "date_int_0",
+            "entity_type": "materialization",
+            "id": 57,
+            "node": "default.repairs_cube",
+            "post": {},
+            "pre": {},
+            "user": "dj",
+        },
+    ]

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -467,6 +467,52 @@ def test_create_cube(  # pylint: disable=redefined-outer-name
     assert default_materialization["job"] == "DefaultCubeMaterialization"
     assert default_materialization["name"] == "default"
     assert default_materialization["schedule"] == "@daily"
+    assert sorted(
+        default_materialization["config"]["columns"],
+        key=lambda x: x["name"],
+    ) == sorted(
+        [
+            {
+                "name": "m0_default_DOT_discounted_orders_rate_placeholder_count",
+                "type": "bigint",
+            },
+            {
+                "name": "m0_default_DOT_discounted_orders_rate_discount3789599758_sum",
+                "type": "bigint",
+            },
+            {
+                "name": "m1_default_DOT_num_repair_orders_repair_order_id3825669267_count",
+                "type": "bigint",
+            },
+            {
+                "name": "m2_default_DOT_avg_repair_price_price3402113753_count",
+                "type": "bigint",
+            },
+            {
+                "name": "m2_default_DOT_avg_repair_price_price3402113753_sum",
+                "type": "double",
+            },
+            {
+                "name": "m3_default_DOT_total_repair_cost_price3402113753_sum",
+                "type": "double",
+            },
+            {
+                "name": "m4_default_DOT_total_repair_order_discounts_price_discount2203488025_sum",
+                "type": "double",
+            },
+            {
+                "name": "m5_default_DOT_double_total_repair_cost_price3402113753_sum",
+                "type": "double",
+            },
+            {"name": "local_region", "type": "string"},
+            {"name": "country", "type": "string"},
+            {"name": "postal_code", "type": "string"},
+            {"name": "city", "type": "string"},
+            {"name": "company_name", "type": "string"},
+            {"name": "state", "type": "string"},
+        ],
+        key=lambda x: x["name"],
+    )
     assert default_materialization["config"]["partitions"] == []
     assert default_materialization["config"]["upstream_tables"] == [
         "default.roads.dispatchers",
@@ -1441,6 +1487,7 @@ def test_updating_cube_with_existing_materialization(
     # Check that the existing materialization was updated
     assert data["materializations"][1] == {
         "config": {
+            "columns": None,
             "dimensions": ["city"],
             "druid": {
                 "granularity": "DAY",
@@ -1504,11 +1551,11 @@ def test_updating_cube_with_existing_materialization(
     ] == [
         {
             "activity_type": "update",
-            "created_at": "2023-09-26T15:01:41.888399+00:00",
+            "created_at": mock.ANY,
             "details": {"version": "v2.0"},
             "entity_name": "default.repairs_cube",
             "entity_type": "node",
-            "id": 56,
+            "id": mock.ANY,
             "node": "default.repairs_cube",
             "post": {},
             "pre": {},
@@ -1516,11 +1563,11 @@ def test_updating_cube_with_existing_materialization(
         },
         {
             "activity_type": "update",
-            "created_at": "2023-09-26T15:01:41.890344+00:00",
+            "created_at": mock.ANY,
             "details": {},
             "entity_name": "date_int_0",
             "entity_type": "materialization",
-            "id": 57,
+            "id": mock.ANY,
             "node": "default.repairs_cube",
             "post": {},
             "pre": {},

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -3,8 +3,10 @@
 Tests for the cubes API.
 """
 from typing import Callable, Dict, Iterator, List, Optional
+from unittest import mock
 
 import pytest
+import requests
 from fastapi.testclient import TestClient
 
 from datajunction_server.service_clients import QueryServiceClient
@@ -262,30 +264,30 @@ def repair_orders_cube_measures() -> Dict:
     """
     return {
         "default_DOT_avg_repair_price": {
-            "combiner": "sum(price_sum) / count(price_count)",
+            "combiner": "sum(price3402113753_sum) / " "count(price3402113753_count)",
             "measures": [
                 {
                     "agg": "count",
-                    "field_name": "m2_default_DOT_avg_repair_price_price_count",
-                    "name": "price_count",
+                    "field_name": "m2_default_DOT_avg_repair_price_price3402113753_count",
+                    "name": "price3402113753_count",
                     "type": "bigint",
                 },
                 {
                     "agg": "sum",
-                    "field_name": "m2_default_DOT_avg_repair_price_price_sum",
-                    "name": "price_sum",
+                    "field_name": "m2_default_DOT_avg_repair_price_price3402113753_sum",
+                    "name": "price3402113753_sum",
                     "type": "double",
                 },
             ],
             "metric": "default_DOT_avg_repair_price",
         },
         "default_DOT_discounted_orders_rate": {
-            "combiner": "sum(discount_sum) / " "count(placeholder_count)",
+            "combiner": "sum(discount3789599758_sum) " "/ " "count(placeholder_count)",
             "measures": [
                 {
                     "agg": "sum",
-                    "field_name": "m0_default_DOT_discounted_orders_rate_discount_sum",
-                    "name": "discount_sum",
+                    "field_name": "m0_default_DOT_discounted_orders_rate_discount3789599758_sum",
+                    "name": "discount3789599758_sum",
                     "type": "bigint",
                 },
                 {
@@ -298,54 +300,56 @@ def repair_orders_cube_measures() -> Dict:
             "metric": "default_DOT_discounted_orders_rate",
         },
         "default_DOT_double_total_repair_cost": {
-            "combiner": "sum(price_sum) + " "sum(price_sum)",
+            "combiner": "sum(price3402113753_sum) " "+ " "sum(price3402113753_sum)",
             "measures": [
                 {
                     "agg": "sum",
-                    "field_name": "m5_default_DOT_double_total_repair_cost_price_sum",
-                    "name": "price_sum",
+                    "field_name": "m5_default_DOT_double_total_repair_cost_price3402113753_sum",
+                    "name": "price3402113753_sum",
                     "type": "double",
                 },
                 {
                     "agg": "sum",
-                    "field_name": "m5_default_DOT_double_total_repair_cost_price_sum",
-                    "name": "price_sum",
+                    "field_name": "m5_default_DOT_double_total_repair_cost_price3402113753_sum",
+                    "name": "price3402113753_sum",
                     "type": "double",
                 },
             ],
             "metric": "default_DOT_double_total_repair_cost",
         },
         "default_DOT_num_repair_orders": {
-            "combiner": "count(repair_order_id_count)",
+            "combiner": "count(repair_order_id3825669267_count)",
             "measures": [
                 {
                     "agg": "count",
-                    "field_name": "m1_default_DOT_num_repair_orders_repair_order_id_count",
-                    "name": "repair_order_id_count",
+                    "field_name": "m1_default_DOT_num_repair_orders_"
+                    "repair_order_id3825669267_count",
+                    "name": "repair_order_id3825669267_count",
                     "type": "bigint",
                 },
             ],
             "metric": "default_DOT_num_repair_orders",
         },
         "default_DOT_total_repair_cost": {
-            "combiner": "sum(price_sum)",
+            "combiner": "sum(price3402113753_sum)",
             "measures": [
                 {
                     "agg": "sum",
-                    "field_name": "m3_default_DOT_total_repair_cost_price_sum",
-                    "name": "price_sum",
+                    "field_name": "m3_default_DOT_total_repair_cost_price3402113753_sum",
+                    "name": "price3402113753_sum",
                     "type": "double",
                 },
             ],
             "metric": "default_DOT_total_repair_cost",
         },
         "default_DOT_total_repair_order_discounts": {
-            "combiner": "sum(price_discount_sum)",
+            "combiner": "sum(price_discount2203488025_sum)",
             "measures": [
                 {
                     "agg": "sum",
-                    "field_name": "m4_default_DOT_total_repair_order_discounts_price_discount_sum",
-                    "name": "price_discount_sum",
+                    "field_name": "m4_default_DOT_total_repair_order_discounts_"
+                    "price_discount2203488025_sum",
+                    "name": "price_discount2203488025_sum",
                     "type": "double",
                 },
             ],
@@ -356,52 +360,62 @@ def repair_orders_cube_measures() -> Dict:
 
 @pytest.fixture
 def repairs_cube_elements():
-    return sorted([
-        {
-            "name": "default_DOT_discounted_orders_rate",
-            "node_name": "default.discounted_orders_rate",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_num_repair_orders",
-            "node_name": "default.num_repair_orders",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_avg_repair_price",
-            "node_name": "default.avg_repair_price",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_total_repair_cost",
-            "node_name": "default.total_repair_cost",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_total_repair_order_discounts",
-            "node_name": "default.total_repair_order_discounts",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_double_total_repair_cost",
-            "node_name": "default.double_total_repair_cost",
-            "type": "metric",
-        },
-        {"name": "country", "node_name": "default.hard_hat", "type": "dimension"},
-        {"name": "postal_code", "node_name": "default.hard_hat", "type": "dimension"},
-        {"name": "city", "node_name": "default.hard_hat", "type": "dimension"},
-        {"name": "state", "node_name": "default.hard_hat", "type": "dimension"},
-        {
-            "name": "company_name",
-            "node_name": "default.dispatcher",
-            "type": "dimension",
-        },
-        {
-            "name": "local_region",
-            "node_name": "default.municipality_dim",
-            "type": "dimension",
-        },
-    ], key=lambda x: x["name"])
+    """
+    Fixture of repairs cube elements
+    """
+    return sorted(
+        [
+            {
+                "name": "default_DOT_discounted_orders_rate",
+                "node_name": "default.discounted_orders_rate",
+                "type": "metric",
+            },
+            {
+                "name": "default_DOT_num_repair_orders",
+                "node_name": "default.num_repair_orders",
+                "type": "metric",
+            },
+            {
+                "name": "default_DOT_avg_repair_price",
+                "node_name": "default.avg_repair_price",
+                "type": "metric",
+            },
+            {
+                "name": "default_DOT_total_repair_cost",
+                "node_name": "default.total_repair_cost",
+                "type": "metric",
+            },
+            {
+                "name": "default_DOT_total_repair_order_discounts",
+                "node_name": "default.total_repair_order_discounts",
+                "type": "metric",
+            },
+            {
+                "name": "default_DOT_double_total_repair_cost",
+                "node_name": "default.double_total_repair_cost",
+                "type": "metric",
+            },
+            {"name": "country", "node_name": "default.hard_hat", "type": "dimension"},
+            {
+                "name": "postal_code",
+                "node_name": "default.hard_hat",
+                "type": "dimension",
+            },
+            {"name": "city", "node_name": "default.hard_hat", "type": "dimension"},
+            {"name": "state", "node_name": "default.hard_hat", "type": "dimension"},
+            {
+                "name": "company_name",
+                "node_name": "default.dispatcher",
+                "type": "dimension",
+            },
+            {
+                "name": "local_region",
+                "node_name": "default.municipality_dim",
+                "type": "dimension",
+            },
+        ],
+        key=lambda x: x["name"],
+    )
 
 
 def test_invalid_cube(client_with_roads: TestClient):
@@ -689,58 +703,16 @@ def test_create_cube(  # pylint: disable=redefined-outer-name
 def test_cube_materialization_sql_and_measures(
     client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
     repair_orders_cube_measures,  # pylint: disable=redefined-outer-name
+    repairs_cube_elements,  # pylint: disable=redefined-outer-name
 ):
     """
     Verifies a cube's materialization SQL + measures
     """
     response = client_with_repairs_cube.get("/cubes/default.repairs_cube/")
     data = response.json()
-    assert data["cube_elements"] == [
-        {
-            "name": "default_DOT_discounted_orders_rate",
-            "node_name": "default.discounted_orders_rate",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_num_repair_orders",
-            "node_name": "default.num_repair_orders",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_avg_repair_price",
-            "node_name": "default.avg_repair_price",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_total_repair_cost",
-            "node_name": "default.total_repair_cost",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_total_repair_order_discounts",
-            "node_name": "default.total_repair_order_discounts",
-            "type": "metric",
-        },
-        {
-            "name": "default_DOT_double_total_repair_cost",
-            "node_name": "default.double_total_repair_cost",
-            "type": "metric",
-        },
-        {"name": "country", "node_name": "default.hard_hat", "type": "dimension"},
-        {"name": "postal_code", "node_name": "default.hard_hat", "type": "dimension"},
-        {"name": "city", "node_name": "default.hard_hat", "type": "dimension"},
-        {"name": "state", "node_name": "default.hard_hat", "type": "dimension"},
-        {
-            "name": "company_name",
-            "node_name": "default.dispatcher",
-            "type": "dimension",
-        },
-        {
-            "name": "local_region",
-            "node_name": "default.municipality_dim",
-            "type": "dimension",
-        },
-    ]
+    assert (
+        sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
+    )
     expected_materialization_query = """
     WITH
         m0_default_DOT_discounted_orders_rate AS (SELECT  default_DOT_hard_hat.city,
@@ -749,7 +721,7 @@ def test_cube_materialization_sql_and_measures(
             count(*) placeholder_count,
             default_DOT_municipality_dim.local_region,
             default_DOT_hard_hat.postal_code,
-            sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount_sum,
+            sum(if(default_DOT_repair_order_details.discount > 0.0, 1, 0)) discount3789599758_sum,
             default_DOT_hard_hat.country
     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
             default_DOT_repair_orders.hard_hat_id,
@@ -782,7 +754,7 @@ def test_cube_materialization_sql_and_measures(
         default_DOT_municipality_dim.local_region,
         default_DOT_hard_hat.postal_code,
         default_DOT_hard_hat.country,
-        count(default_DOT_repair_orders.repair_order_id) repair_order_id_count
+        count(default_DOT_repair_orders.repair_order_id) repair_order_id3825669267_count
     FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
         default_DOT_repair_orders.hard_hat_id,
         default_DOT_repair_orders.municipality_id,
@@ -811,9 +783,9 @@ def test_cube_materialization_sql_and_measures(
         m2_default_DOT_avg_repair_price AS (SELECT  default_DOT_hard_hat.city,
             default_DOT_dispatcher.company_name,
             default_DOT_hard_hat.state,
-            sum(default_DOT_repair_order_details.price) price_sum,
+            sum(default_DOT_repair_order_details.price) price3402113753_sum,
             default_DOT_municipality_dim.local_region,
-            count(default_DOT_repair_order_details.price) price_count,
+            count(default_DOT_repair_order_details.price) price3402113753_count,
             default_DOT_hard_hat.postal_code,
             default_DOT_hard_hat.country
     FROM roads.repair_order_details AS default_DOT_repair_order_details LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatcher_id,
@@ -844,7 +816,7 @@ def test_cube_materialization_sql_and_measures(
         m3_default_DOT_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
             default_DOT_dispatcher.company_name,
             default_DOT_hard_hat.state,
-            sum(default_DOT_repair_order_details.price) price_sum,
+            sum(default_DOT_repair_order_details.price) price3402113753_sum,
             default_DOT_municipality_dim.local_region,
             default_DOT_hard_hat.postal_code,
             default_DOT_hard_hat.country
@@ -876,7 +848,7 @@ def test_cube_materialization_sql_and_measures(
         m4_default_DOT_total_repair_order_discounts AS (SELECT  default_DOT_hard_hat.city,
             default_DOT_dispatcher.company_name,
             default_DOT_hard_hat.state,
-            sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount_sum,
+            sum(default_DOT_repair_order_details.price * default_DOT_repair_order_details.discount) price_discount2203488025_sum,
             default_DOT_municipality_dim.local_region,
             default_DOT_hard_hat.postal_code,
             default_DOT_hard_hat.country
@@ -908,7 +880,7 @@ def test_cube_materialization_sql_and_measures(
         m5_default_DOT_double_total_repair_cost AS (SELECT  default_DOT_hard_hat.city,
             default_DOT_dispatcher.company_name,
             default_DOT_hard_hat.state,
-            sum(default_DOT_repair_order_details.price) price_sum,
+            sum(default_DOT_repair_order_details.price) price3402113753_sum,
             default_DOT_municipality_dim.local_region,
             default_DOT_hard_hat.postal_code,
             default_DOT_hard_hat.country
@@ -936,26 +908,27 @@ def test_cube_materialization_sql_and_measures(
     AS default_DOT_municipality_dim ON default_DOT_repair_order.municipality_id = default_DOT_municipality_dim.municipality_id
     WHERE  default_DOT_hard_hat.state = 'AZ'
     GROUP BY  default_DOT_hard_hat.country, default_DOT_hard_hat.postal_code, default_DOT_hard_hat.city, default_DOT_hard_hat.state, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
-    )SELECT  m0_default_DOT_discounted_orders_rate.placeholder_count m0_default_DOT_discounted_orders_rate_placeholder_count,
-            m0_default_DOT_discounted_orders_rate.discount_sum m0_default_DOT_discounted_orders_rate_discount_sum,
-            m1_default_DOT_num_repair_orders.repair_order_id_count m1_default_DOT_num_repair_orders_repair_order_id_count,
-            m2_default_DOT_avg_repair_price.price_sum m2_default_DOT_avg_repair_price_price_sum,
-            m2_default_DOT_avg_repair_price.price_count m2_default_DOT_avg_repair_price_price_count,
-            m3_default_DOT_total_repair_cost.price_sum m3_default_DOT_total_repair_cost_price_sum,
-            m4_default_DOT_total_repair_order_discounts.price_discount_sum m4_default_DOT_total_repair_order_discounts_price_discount_sum,
-            m5_default_DOT_double_total_repair_cost.price_sum m5_default_DOT_double_total_repair_cost_price_sum,
-            COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city,
+    )SELECT m0_default_DOT_discounted_orders_rate.placeholder_count m0_default_DOT_discounted_orders_rate_placeholder_count,
+            m0_default_DOT_discounted_orders_rate.discount3789599758_sum m0_default_DOT_discounted_orders_rate_discount3789599758_sum,
+            m1_default_DOT_num_repair_orders.repair_order_id3825669267_count m1_default_DOT_num_repair_orders_repair_order_id3825669267_count,
+            m2_default_DOT_avg_repair_price.price3402113753_count m2_default_DOT_avg_repair_price_price3402113753_count,
+            m2_default_DOT_avg_repair_price.price3402113753_sum m2_default_DOT_avg_repair_price_price3402113753_sum,
+            m3_default_DOT_total_repair_cost.price3402113753_sum m3_default_DOT_total_repair_cost_price3402113753_sum,
+            m4_default_DOT_total_repair_order_discounts.price_discount2203488025_sum m4_default_DOT_total_repair_order_discounts_price_discount2203488025_sum,
+            m5_default_DOT_double_total_repair_cost.price3402113753_sum m5_default_DOT_double_total_repair_cost_price3402113753_sum,
+            COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country,
             COALESCE(m0_default_DOT_discounted_orders_rate.company_name, m1_default_DOT_num_repair_orders.company_name, m2_default_DOT_avg_repair_price.company_name, m3_default_DOT_total_repair_cost.company_name, m4_default_DOT_total_repair_order_discounts.company_name, m5_default_DOT_double_total_repair_cost.company_name) company_name,
             COALESCE(m0_default_DOT_discounted_orders_rate.state, m1_default_DOT_num_repair_orders.state, m2_default_DOT_avg_repair_price.state, m3_default_DOT_total_repair_cost.state, m4_default_DOT_total_repair_order_discounts.state, m5_default_DOT_double_total_repair_cost.state) state,
             COALESCE(m0_default_DOT_discounted_orders_rate.local_region, m1_default_DOT_num_repair_orders.local_region, m2_default_DOT_avg_repair_price.local_region, m3_default_DOT_total_repair_cost.local_region, m4_default_DOT_total_repair_order_discounts.local_region, m5_default_DOT_double_total_repair_cost.local_region) local_region,
             COALESCE(m0_default_DOT_discounted_orders_rate.postal_code, m1_default_DOT_num_repair_orders.postal_code, m2_default_DOT_avg_repair_price.postal_code, m3_default_DOT_total_repair_cost.postal_code, m4_default_DOT_total_repair_order_discounts.postal_code, m5_default_DOT_double_total_repair_cost.postal_code) postal_code,
-            COALESCE(m0_default_DOT_discounted_orders_rate.country, m1_default_DOT_num_repair_orders.country, m2_default_DOT_avg_repair_price.country, m3_default_DOT_total_repair_cost.country, m4_default_DOT_total_repair_order_discounts.country, m5_default_DOT_double_total_repair_cost.country) country
+            COALESCE(m0_default_DOT_discounted_orders_rate.city, m1_default_DOT_num_repair_orders.city, m2_default_DOT_avg_repair_price.city, m3_default_DOT_total_repair_cost.city, m4_default_DOT_total_repair_order_discounts.city, m5_default_DOT_double_total_repair_cost.city) city
          FROM m0_default_DOT_discounted_orders_rate FULL OUTER JOIN m1_default_DOT_num_repair_orders ON m0_default_DOT_discounted_orders_rate.company_name = m1_default_DOT_num_repair_orders.company_name AND m0_default_DOT_discounted_orders_rate.city = m1_default_DOT_num_repair_orders.city AND m0_default_DOT_discounted_orders_rate.country = m1_default_DOT_num_repair_orders.country AND m0_default_DOT_discounted_orders_rate.postal_code = m1_default_DOT_num_repair_orders.postal_code AND m0_default_DOT_discounted_orders_rate.state = m1_default_DOT_num_repair_orders.state AND m0_default_DOT_discounted_orders_rate.local_region = m1_default_DOT_num_repair_orders.local_region
         FULL OUTER JOIN m2_default_DOT_avg_repair_price ON m0_default_DOT_discounted_orders_rate.company_name = m2_default_DOT_avg_repair_price.company_name AND m0_default_DOT_discounted_orders_rate.city = m2_default_DOT_avg_repair_price.city AND m0_default_DOT_discounted_orders_rate.country = m2_default_DOT_avg_repair_price.country AND m0_default_DOT_discounted_orders_rate.postal_code = m2_default_DOT_avg_repair_price.postal_code AND m0_default_DOT_discounted_orders_rate.state = m2_default_DOT_avg_repair_price.state AND m0_default_DOT_discounted_orders_rate.local_region = m2_default_DOT_avg_repair_price.local_region
         FULL OUTER JOIN m3_default_DOT_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m3_default_DOT_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m3_default_DOT_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m3_default_DOT_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m3_default_DOT_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m3_default_DOT_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m3_default_DOT_total_repair_cost.local_region
         FULL OUTER JOIN m4_default_DOT_total_repair_order_discounts ON m0_default_DOT_discounted_orders_rate.company_name = m4_default_DOT_total_repair_order_discounts.company_name AND m0_default_DOT_discounted_orders_rate.city = m4_default_DOT_total_repair_order_discounts.city AND m0_default_DOT_discounted_orders_rate.country = m4_default_DOT_total_repair_order_discounts.country AND m0_default_DOT_discounted_orders_rate.postal_code = m4_default_DOT_total_repair_order_discounts.postal_code AND m0_default_DOT_discounted_orders_rate.state = m4_default_DOT_total_repair_order_discounts.state AND m0_default_DOT_discounted_orders_rate.local_region = m4_default_DOT_total_repair_order_discounts.local_region
         FULL OUTER JOIN m5_default_DOT_double_total_repair_cost ON m0_default_DOT_discounted_orders_rate.company_name = m5_default_DOT_double_total_repair_cost.company_name AND m0_default_DOT_discounted_orders_rate.city = m5_default_DOT_double_total_repair_cost.city AND m0_default_DOT_discounted_orders_rate.country = m5_default_DOT_double_total_repair_cost.country AND m0_default_DOT_discounted_orders_rate.postal_code = m5_default_DOT_double_total_repair_cost.postal_code AND m0_default_DOT_discounted_orders_rate.state = m5_default_DOT_double_total_repair_cost.state AND m0_default_DOT_discounted_orders_rate.local_region = m5_default_DOT_double_total_repair_cost.local_region
     """
+    print("QUERY", data["materializations"][0]["config"]["query"])
     assert compare_query_strings(
         data["materializations"][0]["config"]["query"],
         expected_materialization_query,
@@ -1030,14 +1003,14 @@ def test_add_materialization_cube_failures(
     )
 
 
-def test_add_materialization_config_to_cube(
+@pytest.fixture
+def repairs_cube_with_materialization(
     client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
-    query_service_client: Iterator[QueryServiceClient],
 ):
     """
-    Verifies adding materialization config to a cube
+    Repairs cube with a configured materialization
     """
-    response = client_with_repairs_cube.post(
+    return client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization/",
         json={
             "engine": {"name": "druid", "version": ""},
@@ -1060,7 +1033,17 @@ def test_add_materialization_config_to_cube(
             "schedule": "",
         },
     )
-    assert response.json() == {
+
+
+def test_add_materialization_config_to_cube(
+    client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
+    repairs_cube_with_materialization: requests.Response,  # pylint: disable=redefined-outer-name
+    query_service_client: Iterator[QueryServiceClient],
+):
+    """
+    Verifies adding materialization config to a cube
+    """
+    assert repairs_cube_with_materialization.json() == {
         "message": "Successfully updated materialization config named `date_int_0` "
         "for node `default.repairs_cube`",
         "urls": [["http://fake.url/job"]],
@@ -1096,8 +1079,8 @@ def test_add_materialization_config_to_cube(
             },
             "metricsSpec": [
                 {
-                    "fieldName": "m0_default_DOT_discounted_orders_rate_discount_sum",
-                    "name": "discount_sum",
+                    "fieldName": "m0_default_DOT_discounted_orders_rate_discount3789599758_sum",
+                    "name": "discount3789599758_sum",
                     "type": "longSum",
                 },
                 {
@@ -1106,23 +1089,25 @@ def test_add_materialization_config_to_cube(
                     "type": "longSum",
                 },
                 {
-                    "fieldName": "m1_default_DOT_num_repair_orders_repair_order_id_count",
-                    "name": "repair_order_id_count",
+                    "fieldName": "m1_default_DOT_num_repair_orders_repair_"
+                    "order_id3825669267_count",
+                    "name": "repair_order_id3825669267_count",
                     "type": "longSum",
                 },
                 {
-                    "fieldName": "m2_default_DOT_avg_repair_price_price_count",
-                    "name": "price_count",
+                    "fieldName": "m2_default_DOT_avg_repair_price_price3402113753_count",
+                    "name": "price3402113753_count",
                     "type": "longSum",
                 },
                 {
-                    "fieldName": "m4_default_DOT_total_repair_order_discounts_price_discount_sum",
-                    "name": "price_discount_sum",
+                    "fieldName": "m4_default_DOT_total_repair_order_discounts_"
+                    "price_discount2203488025_sum",
+                    "name": "price_discount2203488025_sum",
                     "type": "doubleSum",
                 },
                 {
-                    "fieldName": "m5_default_DOT_double_total_repair_cost_price_sum",
-                    "name": "price_sum",
+                    "fieldName": "m5_default_DOT_double_total_repair_cost_price3402113753_sum",
+                    "name": "price3402113753_sum",
                     "type": "doubleSum",
                 },
             ],
@@ -1219,10 +1204,12 @@ def test_add_availability_to_cube(
             {"name": "postal_code", "type": "string"},
         ],
         "dialect": "spark",
-        "sql": "SELECT  sum(discount_sum) / count(placeholder_count) "
+        "sql": "SELECT  sum(discount3789599758_sum) / count(placeholder_count) "
         "default_DOT_discounted_orders_rate,\n"
-        "\tcount(repair_order_id_count) default_DOT_num_repair_orders,\n"
-        "\tsum(price_sum) / count(price_count) default_DOT_avg_repair_price,\n"
+        "\tcount(repair_order_id3825669267_count) "
+        "default_DOT_num_repair_orders,\n"
+        "\tsum(price3402113753_sum) / count(price3402113753_count) "
+        "default_DOT_avg_repair_price,\n"
         "\tcountry,\n"
         "\tpostal_code \n"
         " FROM repairs_cube \n"
@@ -1251,7 +1238,7 @@ def test_unlink_node_column_dimension(
 
 def test_changing_node_upstream_from_cube(
     client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
-    repairs_cube_elements: List[Dict],
+    repairs_cube_elements: List[Dict],  # pylint: disable=redefined-outer-name
 ):
     """
     Verify changing nodes upstream from a cube
@@ -1270,42 +1257,200 @@ def test_changing_node_upstream_from_cube(
 
     response = client_with_repairs_cube.get("/cubes/default.repairs_cube/")
     data = response.json()
-    assert sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
+    assert (
+        sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
+    )
 
     # Verify effects on cube after updating a node upstream from the cube
-    client_with_repairs_cube.patch("/nodes/default.discounted_orders_rate/", json={
-        "query": """SELECT
+    client_with_repairs_cube.patch(
+        "/nodes/default.discounted_orders_rate/",
+        json={
+            "query": """SELECT
   cast(sum(if(discount > 0.0, 1, 0)) as double)
-FROM default.repair_order_details"""
-    })
+FROM default.repair_order_details""",
+        },
+    )
     response = client_with_repairs_cube.get("/nodes/default.repairs_cube/")
     data = response.json()
     assert data["status"] == "valid"
 
     response = client_with_repairs_cube.get("/cubes/default.repairs_cube/")
     data = response.json()
-    assert sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
+    assert (
+        sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
+    )
+
+
+def assert_updated_repairs_cube(data):
+    """
+    Asserts that the updated repairs cube has the right cube elements and default materialization
+    """
+    assert sorted(data["cube_elements"], key=lambda x: x["name"]) == [
+        {"name": "city", "node_name": "default.hard_hat", "type": "dimension"},
+        {
+            "name": "default_DOT_discounted_orders_rate",
+            "node_name": "default.discounted_orders_rate",
+            "type": "metric",
+        },
+    ]
+    assert data["materializations"][0]["config"]["dimensions"] == ["city"]
+    assert data["materializations"][0]["config"]["measures"] == {
+        "default_DOT_discounted_orders_rate": {
+            "combiner": "sum(discount3789599758_sum) " "/ " "count(placeholder_count)",
+            "measures": [
+                {
+                    "agg": "sum",
+                    "field_name": "m0_default_DOT_discounted_orders_rate_discount3789599758_sum",
+                    "name": "discount3789599758_sum",
+                    "type": "bigint",
+                },
+                {
+                    "agg": "count",
+                    "field_name": "m0_default_DOT_discounted_orders_rate_placeholder_count",
+                    "name": "placeholder_count",
+                    "type": "bigint",
+                },
+            ],
+            "metric": "default_DOT_discounted_orders_rate",
+        },
+    }
+    assert data["materializations"][0]["config"]["partitions"] == []
+    assert "discount3789599758_sum" in data["materializations"][0]["config"]["query"]
+    assert data["materializations"][0]["config"]["upstream_tables"] == [
+        "default.roads.hard_hats",
+        "default.roads.repair_order_details",
+        "default.roads.repair_orders",
+    ]
+    assert data["materializations"][0]["job"] == "DefaultCubeMaterialization"
+    assert data["materializations"][0]["name"] == "default"
 
 
 def test_updating_cube(
     client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
-    repairs_cube_elements: List[Dict],
 ):
     """
     Verify updating a cube
     """
-    response = client_with_repairs_cube.patch("/nodes/default.repairs_cube", json={
-        "metrics": ["default.discounted_orders_rate"],
-        "dimensions": ["default.hard_hat.city"],
-    })
+    response = client_with_repairs_cube.patch(
+        "/nodes/default.repairs_cube",
+        json={
+            "metrics": ["default.discounted_orders_rate"],
+            "dimensions": ["default.hard_hat.city"],
+        },
+    )
     result = response.json()
     assert result["version"] == "v2.0"
-    assert result["columns"] == [{'attributes': [],
-              'dimension': None,
-              'name': 'default_DOT_discounted_orders_rate',
-              'type': 'double'},
-             {'attributes': [{'attribute_type': {'name': 'dimension',
-                                                 'namespace': 'system'}}],
-              'dimension': None,
-              'name': 'city',
-              'type': 'string'}]
+    assert sorted(result["columns"], key=lambda x: x["name"]) == sorted(
+        [
+            {
+                "attributes": [],
+                "dimension": None,
+                "name": "default_DOT_discounted_orders_rate",
+                "type": "double",
+            },
+            {
+                "attributes": [
+                    {"attribute_type": {"name": "dimension", "namespace": "system"}},
+                ],
+                "dimension": None,
+                "name": "city",
+                "type": "string",
+            },
+        ],
+        key=lambda x: x["name"],  # type: ignore
+    )
+
+    response = client_with_repairs_cube.get("/cubes/default.repairs_cube/")
+    data = response.json()
+    assert_updated_repairs_cube(data)
+
+
+def test_updating_cube_with_existing_materialization(
+    client_with_repairs_cube: TestClient,  # pylint: disable=redefined-outer-name
+    repairs_cube_with_materialization: requests.Response,  # pylint: disable=redefined-outer-name
+):
+    """
+    Verify updating a cube with existing materialization
+    """
+    assert repairs_cube_with_materialization.ok
+
+    # Make sure that the cube already has an additional materialization configured
+    response = client_with_repairs_cube.get("/cubes/default.repairs_cube/")
+    data = response.json()
+    assert len(data["materializations"]) == 2
+
+    # Update the cube
+    response = client_with_repairs_cube.patch(
+        "/nodes/default.repairs_cube",
+        json={
+            "metrics": ["default.discounted_orders_rate"],
+            "dimensions": ["default.hard_hat.city"],
+        },
+    )
+    result = response.json()
+    assert result["version"] == "v2.0"
+
+    # Check that the cube was updated
+    response = client_with_repairs_cube.get("/cubes/default.repairs_cube/")
+    data = response.json()
+    assert_updated_repairs_cube(data)
+
+    # Check that the existing materialization was updated
+    assert data["materializations"][1] == {
+        "config": {
+            "dimensions": ["city"],
+            "druid": {
+                "granularity": "DAY",
+                "intervals": ["2021-01-01/2022-01-01"],
+                "parse_spec_format": None,
+                "timestamp_column": "date_int",
+                "timestamp_format": None,
+            },
+            "measures": {
+                "default_DOT_discounted_orders_rate": {
+                    "combiner": "sum(discount3789599758_sum) "
+                    "/ "
+                    "count(placeholder_count)",
+                    "measures": [
+                        {
+                            "agg": "sum",
+                            "field_name": "m0_default_DOT_discounted_orders_"
+                            "rate_discount3789599758_sum",
+                            "name": "discount3789599758_sum",
+                            "type": "bigint",
+                        },
+                        {
+                            "agg": "count",
+                            "field_name": "m0_default_DOT_discounted_orders_rate_"
+                            "placeholder_count",
+                            "name": "placeholder_count",
+                            "type": "bigint",
+                        },
+                    ],
+                    "metric": "default_DOT_discounted_orders_rate",
+                },
+            },
+            "partitions": [
+                {
+                    "expression": None,
+                    "name": "date_int",
+                    "range": [20210101, 20220101],
+                    "type_": "temporal",
+                    "values": [],
+                },
+            ],
+            "prefix": "",
+            "query": mock.ANY,
+            "spark": {},
+            "suffix": "",
+            "upstream_tables": [
+                "default.roads.hard_hats",
+                "default.roads.repair_order_details",
+                "default.roads.repair_orders",
+            ],
+        },
+        "engine": {"dialect": "druid", "name": "druid", "uri": None, "version": ""},
+        "job": "DruidCubeMaterializationJob",
+        "name": "date_int_0",
+        "schedule": "@daily",
+    }

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -4157,10 +4157,10 @@ def test_decompose_expression():
     res = decompose_expression(
         ast.Function(ast.Name("avg"), args=[ast.Column(ast.Name("orders"))]),
     )
-    assert str(res[0]) == "sum(orders_sum) / count(orders_count)"
+    assert str(res[0]) == "sum(orders3845127662_sum) / count(orders3845127662_count)"
     assert [measure.alias_or_name.name for measure in res[1]] == [
-        "orders_sum",
-        "orders_count",
+        "orders3845127662_sum",
+        "orders3845127662_count",
     ]
 
     # Decompose `avg(orders) + 5.5`
@@ -4171,10 +4171,12 @@ def test_decompose_expression():
             op=ast.BinaryOpKind.Plus,
         ),
     )
-    assert str(res[0]) == "sum(orders_sum) / count(orders_count) + 5.5"
+    assert (
+        str(res[0]) == "sum(orders3845127662_sum) / count(orders3845127662_count) + 5.5"
+    )
     assert [measure.alias_or_name.name for measure in res[1]] == [
-        "orders_sum",
-        "orders_count",
+        "orders3845127662_sum",
+        "orders3845127662_count",
     ]
 
     # Decompose `max(avg(orders_a) + avg(orders_b))`
@@ -4197,8 +4199,9 @@ def test_decompose_expression():
         ),
     )
     assert (
-        str(res[0]) == "max(sum(orders_a_sum) / count(orders_a_count) "
-        "+ sum(orders_b_sum) / count(orders_b_count))"
+        str(res[0])
+        == "max(sum(orders_a1170126662_sum) / count(orders_a1170126662_count) "
+        "+ sum(orders_b3703039740_sum) / count(orders_b3703039740_count))"
     )
 
     # Decompose `sum(max(orders))`
@@ -4213,8 +4216,10 @@ def test_decompose_expression():
             ],
         ),
     )
-    assert str(res[0]) == "sum(max(orders_max))"
-    assert [measure.alias_or_name.name for measure in res[1]] == ["orders_max"]
+    assert str(res[0]) == "sum(max(orders3845127662_max))"
+    assert [measure.alias_or_name.name for measure in res[1]] == [
+        "orders3845127662_max",
+    ]
 
     # Decompose `(max(orders) + min(validations))/sum(total)`
     res = decompose_expression(
@@ -4234,11 +4239,14 @@ def test_decompose_expression():
             op=ast.BinaryOpKind.Divide,
         ),
     )
-    assert str(res[0]) == "max(orders_max) + min(validations_min) / sum(total_sum)"
+    assert (
+        str(res[0])
+        == "max(orders3845127662_max) + min(validations2970758927_min) / sum(total3257917790_sum)"
+    )
     assert [measure.alias_or_name.name for measure in res[1]] == [
-        "orders_max",
-        "validations_min",
-        "total_sum",
+        "orders3845127662_max",
+        "validations2970758927_min",
+        "total3257917790_sum",
     ]
 
     # Decompose `cast(sum(coalesce(has_ordered, 0.0)) as double)/count(total)`
@@ -4263,10 +4271,10 @@ def test_decompose_expression():
             op=ast.BinaryOpKind.Divide,
         ),
     )
-    assert str(res[0]) == "sum(has_ordered_sum) / sum(total_sum)"
+    assert str(res[0]) == "sum(has_ordered2766370626_sum) / sum(total3257917790_sum)"
     assert [measure.alias_or_name.name for measure in res[1]] == [
-        "has_ordered_sum",
-        "total_sum",
+        "has_ordered2766370626_sum",
+        "total3257917790_sum",
     ]
 
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2398,6 +2398,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                     "dialect": "spark",
                 },
                 "config": {
+                    "columns": None,
                     "partitions": [
                         {
                             "name": "country",
@@ -2592,6 +2593,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                         "dialect": "spark",
                     },
                     "config": {
+                        "columns": None,
                         "query": "SELECT  basic_DOT_source_DOT_users.country,\n\tCOUNT( "
                         "DISTINCT basic_DOT_source_DOT_users.id) AS num_users \n "
                         "FROM basic.dim_users AS basic_DOT_source_DOT_users \n WHERE"
@@ -2614,6 +2616,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                 },
                 {
                     "config": {
+                        "columns": None,
                         "partitions": [],
                         "query": "SELECT  basic_DOT_source_DOT_users.country,\n"
                         "\tCOUNT( DISTINCT basic_DOT_source_DOT_users.id) AS "
@@ -2689,6 +2692,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                         "dialect": "spark",
                     },
                     "config": {
+                        "columns": None,
                         "query": "SELECT  default_DOT_hard_hats.address,\n\tdefault_DOT_hard_hats."
                         "birth_date,\n\tdefault_DOT_hard_hats.city,\n\tdefault_DOT_hard_hats."
                         "contractor_id,\n\tdefault_DOT_hard_hats.country,\n\tdefault_DOT_hard"
@@ -2740,6 +2744,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             [
                 {
                     "config": {
+                        "columns": None,
                         "partitions": [
                             {
                                 "expression": None,


### PR DESCRIPTION
### Summary

This PR has a number of cube-related fixes:

#### Cube Updates

Cube updates weren't working before. If someone tried to update a cube using the existing update-node endpoint, they would fail out because we didn't allow for specifying metrics and dimensions in the input. Furthermore, the generic node update sequence doesn't actually update the metrics and dimensions in a cube. 

This change separates out the cube node update into a separate path to handle updates correctly, including:
* Minor updates like changes to `display_name` and `description`
* Major updates like changes to the metrics and dimensions in the cube
* Updates and reschedules all materializations if there are major updates
* Propagates upstream node updates to cubes

#### Druid Materialization Fix

Druid materialization for cube nodes were generating measures columns (ingested to Druid) with column names that were too long to be queried via Druid SQL. This means that we create Druid datasources that are unqueryable later. 

This PR limits the measure column names to be 128 characters max. We use a readable name, generated via the same method as before, but truncate it so that we have enough space to append a crc32 hash (8 characters). This yields measure column names like `orders3845127662_sum`.

#### Druid Materialization Columns

In order to materialize cubes to a Druid datasource, we first materialize it to a table in the data warehouse. This change will save the column names and types on that table to the default cube materialization config, which will be returned every time we ask for the cube.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #792
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
