### PR TITLE
During cube materialization, pass columns of the intermediate table to query service

### DIFF
--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -258,6 +258,7 @@ def create_new_materialization(
                 druid=DruidConf.parse_obj(upsert.config.druid),
                 partitions=upsert.config.partitions,
                 upstream_tables=default_job_config.upstream_tables,
+                columns=default_job_config.columns,
             )
         except (KeyError, ValidationError, AttributeError) as exc:
             raise DJInvalidInputException(

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -152,5 +152,6 @@ class DruidCubeMaterializationJob(MaterializationJob):
                 druid_spec=druid_spec,
                 partitions=cube_config.partitions,
                 upstream_tables=cube_config.upstream_tables or [],
+                intermediate_columns=cube_config.columns,
             ),
         )

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -152,6 +152,8 @@ class DruidCubeMaterializationJob(MaterializationJob):
                 druid_spec=druid_spec,
                 partitions=cube_config.partitions,
                 upstream_tables=cube_config.upstream_tables or [],
+                # Cube materialization involves creating an intermediate dataset,
+                # which will have measures columns for all metrics in the cube
                 intermediate_columns=cube_config.columns,
             ),
         )

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -42,6 +42,7 @@ class DruidMaterializationInput(GenericMaterializationInput):
     """
 
     druid_spec: Dict
+    intermediate_columns: List[ColumnMetadata]
 
 
 class MaterializationInfo(BaseModel):

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 from fastapi.testclient import TestClient
 
+from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.service_clients import QueryServiceClient
 from tests.sql.utils import compare_query_strings
 
@@ -1116,6 +1117,49 @@ def test_add_materialization_config_to_cube(
         called_kwargs.druid_spec["dataSchema"]["metricsSpec"],
         key=lambda x: x["fieldName"],
     )
+    assert sorted(called_kwargs.intermediate_columns, key=lambda x: x.name) == sorted(
+        [
+            ColumnMetadata(
+                name="m0_default_DOT_discounted_orders_rate_discount3789599758_sum",
+                type="bigint",
+            ),
+            ColumnMetadata(
+                name="m0_default_DOT_discounted_orders_rate_placeholder_count",
+                type="bigint",
+            ),
+            ColumnMetadata(
+                name="m1_default_DOT_num_repair_orders_repair_order_id3825669267_count",
+                type="bigint",
+            ),
+            ColumnMetadata(
+                name="m2_default_DOT_avg_repair_price_price3402113753_sum",
+                type="double",
+            ),
+            ColumnMetadata(
+                name="m2_default_DOT_avg_repair_price_price3402113753_count",
+                type="bigint",
+            ),
+            ColumnMetadata(
+                name="m3_default_DOT_total_repair_cost_price3402113753_sum",
+                type="double",
+            ),
+            ColumnMetadata(
+                name="m4_default_DOT_total_repair_order_discounts_price_discount2203488025_sum",
+                type="double",
+            ),
+            ColumnMetadata(
+                name="m5_default_DOT_double_total_repair_cost_price3402113753_sum",
+                type="double",
+            ),
+            ColumnMetadata(name="company_name", type="string"),
+            ColumnMetadata(name="country", type="string"),
+            ColumnMetadata(name="city", type="string"),
+            ColumnMetadata(name="state", type="string"),
+            ColumnMetadata(name="local_region", type="string"),
+            ColumnMetadata(name="postal_code", type="string"),
+        ],
+        key=lambda x: x.name,
+    )
     assert called_kwargs.druid_spec == {
         "dataSchema": {
             "dataSource": "default_DOT_repairs_cube",
@@ -1487,7 +1531,11 @@ def test_updating_cube_with_existing_materialization(
     # Check that the existing materialization was updated
     assert data["materializations"][1] == {
         "config": {
-            "columns": None,
+            "columns": [
+                {"name": mock.ANY, "type": mock.ANY},
+                {"name": mock.ANY, "type": mock.ANY},
+                {"name": mock.ANY, "type": mock.ANY},
+            ],
             "dimensions": ["city"],
             "druid": {
                 "granularity": "DAY",


### PR DESCRIPTION
### Summary

During cube materialization, pass columns of the intermediate table over to the call to the query service. This enables us to create the table with the columns first.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
