### PR TITLE
Pass column metadata to GenericMaterializationConfig.

### DIFF
--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -237,6 +237,10 @@ def create_new_materialization(
                 f"{current_revision.catalog.name}.{tbl.identifier()}"
                 for tbl in materialization_ast.find_all(ast.Table)
             ],
+            columns=[
+                ColumnMetadata(name=col.name, type=str(col.type))
+                for col in current_revision.columns
+            ],
         )
 
     if current_revision.type == NodeType.CUBE:

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2398,7 +2398,11 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                     "dialect": "spark",
                 },
                 "config": {
-                    "columns": None,
+                    "columns": [
+                        {"name": "country", "type": "string"},
+                        {"name": "num_users", "type": "bigint"},
+                        {"name": "languages", "type": "bigint"},
+                    ],
                     "partitions": [
                         {
                             "name": "country",
@@ -2593,7 +2597,10 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                         "dialect": "spark",
                     },
                     "config": {
-                        "columns": None,
+                        "columns": [
+                            {"name": "country", "type": "string"},
+                            {"name": "num_users", "type": "bigint"},
+                        ],
                         "query": "SELECT  basic_DOT_source_DOT_users.country,\n\tCOUNT( "
                         "DISTINCT basic_DOT_source_DOT_users.id) AS num_users \n "
                         "FROM basic.dim_users AS basic_DOT_source_DOT_users \n WHERE"
@@ -2616,7 +2623,10 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                 },
                 {
                     "config": {
-                        "columns": None,
+                        "columns": [
+                            {"name": "country", "type": "string"},
+                            {"name": "num_users", "type": "bigint"},
+                        ],
                         "partitions": [],
                         "query": "SELECT  basic_DOT_source_DOT_users.country,\n"
                         "\tCOUNT( DISTINCT basic_DOT_source_DOT_users.id) AS "
@@ -2692,7 +2702,21 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                         "dialect": "spark",
                     },
                     "config": {
-                        "columns": None,
+                        "columns": [
+                            {"name": "hard_hat_id", "type": "int"},
+                            {"name": "last_name", "type": "string"},
+                            {"name": "first_name", "type": "string"},
+                            {"name": "title", "type": "string"},
+                            {"name": "birth_date", "type": "timestamp"},
+                            {"name": "hire_date", "type": "timestamp"},
+                            {"name": "address", "type": "string"},
+                            {"name": "city", "type": "string"},
+                            {"name": "state", "type": "string"},
+                            {"name": "postal_code", "type": "string"},
+                            {"name": "country", "type": "string"},
+                            {"name": "manager", "type": "int"},
+                            {"name": "contractor_id", "type": "int"},
+                        ],
                         "query": "SELECT  default_DOT_hard_hats.address,\n\tdefault_DOT_hard_hats."
                         "birth_date,\n\tdefault_DOT_hard_hats.city,\n\tdefault_DOT_hard_hats."
                         "contractor_id,\n\tdefault_DOT_hard_hats.country,\n\tdefault_DOT_hard"
@@ -2744,7 +2768,21 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             [
                 {
                     "config": {
-                        "columns": None,
+                        "columns": [
+                            {"name": "hard_hat_id", "type": "int"},
+                            {"name": "last_name", "type": "string"},
+                            {"name": "first_name", "type": "string"},
+                            {"name": "title", "type": "string"},
+                            {"name": "birth_date", "type": "timestamp"},
+                            {"name": "hire_date", "type": "timestamp"},
+                            {"name": "address", "type": "string"},
+                            {"name": "city", "type": "string"},
+                            {"name": "state", "type": "string"},
+                            {"name": "postal_code", "type": "string"},
+                            {"name": "country", "type": "string"},
+                            {"name": "manager", "type": "int"},
+                            {"name": "contractor_id", "type": "int"},
+                        ],
                         "partitions": [
                             {
                                 "expression": None,


### PR DESCRIPTION
### Summary

We had an attribute for them already but we did not pass the values in. We need them for efficient table creation.

Piggyback: rename `nodes/{name}/materialization` to `nodes/{node_name}/materialization` for consistency.

### Test Plan

unit tests

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a