### PR TITLE
pass columns to query service for druid materialization

### DIFF
--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -154,6 +154,6 @@ class DruidCubeMaterializationJob(MaterializationJob):
                 upstream_tables=cube_config.upstream_tables or [],
                 # Cube materialization involves creating an intermediate dataset,
                 # which will have measures columns for all metrics in the cube
-                intermediate_columns=cube_config.columns,
+                columns=cube_config.columns,
             ),
         )

--- a/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
@@ -86,6 +86,7 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
                 partitions=[
                     partition.dict() for partition in generic_config.partitions
                 ],
+                columns=generic_config.columns,
             ),
         )
         return result

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -33,6 +33,7 @@ class GenericMaterializationInput(BaseModel):
     upstream_tables: List[str]
     spark_conf: Optional[Dict] = None
     partitions: Optional[List[Dict]] = None
+    columns: List[ColumnMetadata]
 
 
 class DruidMaterializationInput(GenericMaterializationInput):
@@ -42,7 +43,6 @@ class DruidMaterializationInput(GenericMaterializationInput):
     """
 
     druid_spec: Dict
-    intermediate_columns: List[ColumnMetadata]
 
 
 class MaterializationInfo(BaseModel):

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1105,6 +1105,7 @@ def test_add_materialization_config_to_cube(
     assert called_kwargs.node_type == "cube"
     assert called_kwargs.schedule == "@daily"
     assert called_kwargs.spark_conf == {}
+    assert len(called_kwargs.columns) > 0
     dimensions_sorted = sorted(
         called_kwargs.druid_spec["dataSchema"]["parser"]["parseSpec"]["dimensionsSpec"][
             "dimensions"
@@ -1117,7 +1118,7 @@ def test_add_materialization_config_to_cube(
         called_kwargs.druid_spec["dataSchema"]["metricsSpec"],
         key=lambda x: x["fieldName"],
     )
-    assert sorted(called_kwargs.intermediate_columns, key=lambda x: x.name) == sorted(
+    assert sorted(called_kwargs.columns, key=lambda x: x.name) == sorted(
         [
             ColumnMetadata(
                 name="m0_default_DOT_discounted_orders_rate_discount3789599758_sum",

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -244,6 +244,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 spark_conf={},
                 upstream_tables=["default.hard_hats"],
                 partitions=[],
+                columns=[],
             ),
         )
 
@@ -259,6 +260,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 "schedule": "0 * * * *",
                 "spark_conf": {},
                 "upstream_tables": ["default.hard_hats"],
+                "columns": [],
             },
         )
 
@@ -358,6 +360,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 spark_conf={},
                 upstream_tables=["default.hard_hats"],
                 partitions=[],
+                columns=[],
             ),
         )
         mock_request.assert_called_with(
@@ -372,6 +375,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 "upstream_tables": ["default.hard_hats"],
                 "spark_conf": {},
                 "partitions": [],
+                "columns": [],
             },
         )
         assert response == {


### PR DESCRIPTION
### Summary

Instead of calling the query service with `intermediate_columns` for Druid materialization, use `columns`, which is also used by generic materialization.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
