### PR TITLE
Sign Up page to create a basic auth user

### DIFF
--- a/datajunction-server/datajunction_server/api/authentication/basic.py
+++ b/datajunction-server/datajunction_server/api/authentication/basic.py
@@ -24,6 +24,7 @@ router = APIRouter(tags=["Basic OAuth2"])
 
 @router.post("/basic/user/")
 async def create_a_user(
+    email: str = Form(),
     username: str = Form(),
     password: str = Form(),
     session: Session = Depends(get_session),
@@ -42,6 +43,7 @@ async def create_a_user(
             ],
         )
     new_user = User(
+        email=email,
         username=username,
         password=get_password_hash(password),
         oauth_provider=OAuthProvider.BASIC,

--- a/datajunction-server/tests/internal/authentication/basic_test.py
+++ b/datajunction-server/tests/internal/authentication/basic_test.py
@@ -14,7 +14,10 @@ def test_login_with_username_and_password(client: TestClient):
     """
     Test validating a username and a password
     """
-    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
+    client.post(
+        "/basic/user/",
+        data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"},
+    )
     response = client.post("/basic/login/", data={"username": "dj", "password": "dj"})
     assert response.ok
     assert response.cookies.get(AUTH_COOKIE)
@@ -42,7 +45,10 @@ def test_validate_username_and_password(client: TestClient, session: Session):
     """
     Test validating a username and a password
     """
-    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
+    client.post(
+        "/basic/user/",
+        data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"},
+    )
     user = basic.validate_user_password(username="dj", password="dj", session=session)
     assert user.username == "dj"
 
@@ -51,7 +57,10 @@ def test_get_user(client: TestClient, session: Session):
     """
     Test getting a user
     """
-    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
+    client.post(
+        "/basic/user/",
+        data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"},
+    )
     user = basic.get_user(username="dj", session=session)
     assert user.username == "dj"
 
@@ -77,7 +86,10 @@ def test_fail_invalid_credentials(client: TestClient, session: Session):
     """
     Test failing on invalid user credentials
     """
-    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "incorrect"})
+    client.post(
+        "/basic/user/",
+        data={"email": "dj@datajunction.io", "username": "dj", "password": "incorrect"},
+    )
     with pytest.raises(DJException) as exc_info:
         basic.validate_user_password(username="dj", password="dj", session=session)
     assert "Invalid password for user dj" in str(exc_info.value)
@@ -87,8 +99,14 @@ def test_fail_on_user_already_exists(client: TestClient):
     """
     Test failing when creating a user that already exists
     """
-    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
-    response = client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
+    client.post(
+        "/basic/user/",
+        data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"},
+    )
+    response = client.post(
+        "/basic/user/",
+        data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"},
+    )
     assert response.status_code == 409
     assert response.json() == {
         "message": "User dj already exists.",

--- a/datajunction-server/tests/internal/authentication/basic_test.py
+++ b/datajunction-server/tests/internal/authentication/basic_test.py
@@ -14,7 +14,7 @@ def test_login_with_username_and_password(client: TestClient):
     """
     Test validating a username and a password
     """
-    client.post("/basic/user/", data={"username": "dj", "password": "dj"})
+    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
     response = client.post("/basic/login/", data={"username": "dj", "password": "dj"})
     assert response.ok
     assert response.cookies.get(AUTH_COOKIE)
@@ -42,7 +42,7 @@ def test_validate_username_and_password(client: TestClient, session: Session):
     """
     Test validating a username and a password
     """
-    client.post("/basic/user/", data={"username": "dj", "password": "dj"})
+    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
     user = basic.validate_user_password(username="dj", password="dj", session=session)
     assert user.username == "dj"
 
@@ -51,7 +51,7 @@ def test_get_user(client: TestClient, session: Session):
     """
     Test getting a user
     """
-    client.post("/basic/user/", data={"username": "dj", "password": "dj"})
+    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
     user = basic.get_user(username="dj", session=session)
     assert user.username == "dj"
 
@@ -77,7 +77,7 @@ def test_fail_invalid_credentials(client: TestClient, session: Session):
     """
     Test failing on invalid user credentials
     """
-    client.post("/basic/user/", data={"username": "dj", "password": "incorrect"})
+    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "incorrect"})
     with pytest.raises(DJException) as exc_info:
         basic.validate_user_password(username="dj", password="dj", session=session)
     assert "Invalid password for user dj" in str(exc_info.value)
@@ -87,8 +87,8 @@ def test_fail_on_user_already_exists(client: TestClient):
     """
     Test failing when creating a user that already exists
     """
-    client.post("/basic/user/", data={"username": "dj", "password": "dj"})
-    response = client.post("/basic/user/", data={"username": "dj", "password": "dj"})
+    client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
+    response = client.post("/basic/user/", data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"})
     assert response.status_code == 409
     assert response.json() == {
         "message": "User dj already exists.",

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -98,7 +98,8 @@
     "web-vitals": "2.1.4",
     "webpack": "5.81.0",
     "webpack-cli": "5.0.2",
-    "webpack-dev-server": "4.13.3"
+    "webpack-dev-server": "4.13.3",
+    "yup": "1.3.2"
   },
   "scripts": {
     "webpack-start": "webpack-dev-server --open",

--- a/datajunction-ui/src/app/icons/LoadingIcon.jsx
+++ b/datajunction-ui/src/app/icons/LoadingIcon.jsx
@@ -3,12 +3,12 @@ import '../../styles/loading.css';
 export default function LoadingIcon() {
   return (
     <center>
-    <div class="lds-ring">
-      <div></div>
-      <div></div>
-      <div></div>
-      <div></div>
-    </div>
+      <div class="lds-ring">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
     </center>
   );
 }

--- a/datajunction-ui/src/app/icons/LoadingIcon.jsx
+++ b/datajunction-ui/src/app/icons/LoadingIcon.jsx
@@ -1,0 +1,14 @@
+import '../../styles/loading.css';
+
+export default function LoadingIcon() {
+  return (
+    <center>
+    <div class="lds-ring">
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
+    </center>
+  );
+}

--- a/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
@@ -18,7 +18,7 @@ const LoginSchema = Yup.object().shape({
   password: Yup.string().required('Password is required'),
 });
 
-export default function LoginForm({setShowSignup}) {
+export default function LoginForm({ setShowSignup }) {
   const [, setError] = useState('');
 
   // Add the path that the user was trying to access in order to properly redirect after auth
@@ -79,7 +79,7 @@ export default function LoginForm({setShowSignup}) {
             </p>
           </div>
           <button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? <LoadingIcon/> : "Login"}
+            {isSubmitting ? <LoadingIcon /> : 'Login'}
           </button>
           <div>
             <p>Or</p>

--- a/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
@@ -12,8 +12,7 @@ const googleLoginURL = new URL('/google/login/', process.env.REACT_APP_DJ_URL);
 
 const LoginSchema = Yup.object().shape({
   username: Yup.string()
-    .min(2, 'Too Short')
-    .max(20, 'Too Long')
+    .min(2, 'Must be at least 2 characters')
     .required('Username is required'),
   password: Yup.string().required('Password is required'),
 });

--- a/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { Formik, Form, Field, ErrorMessage } from 'formik';
+import '../../../styles/login.css';
+import LoadingIcon from '../../icons/LoadingIcon';
+import logo from '../Root/assets/dj-logo.png';
+import GitHubLoginButton from './assets/sign-in-with-github.png';
+import GoogleLoginButton from './assets/sign-in-with-google.png';
+import * as Yup from 'yup';
+
+const githubLoginURL = new URL('/github/login/', process.env.REACT_APP_DJ_URL);
+const googleLoginURL = new URL('/google/login/', process.env.REACT_APP_DJ_URL);
+
+const LoginSchema = Yup.object().shape({
+  username: Yup.string()
+    .min(2, 'Too Short')
+    .max(20, 'Too Long')
+    .required('Username is required'),
+  password: Yup.string().required('Password is required'),
+});
+
+export default function LoginForm({setShowSignup}) {
+  const [, setError] = useState('');
+
+  // Add the path that the user was trying to access in order to properly redirect after auth
+  githubLoginURL.searchParams.append('target', window.location.pathname);
+  googleLoginURL.searchParams.append('target', window.location.pathname);
+
+  const handleBasicLogin = async ({ username, password }) => {
+    const data = new FormData();
+    data.append('username', username);
+    data.append('password', password);
+    await fetch(`${process.env.REACT_APP_DJ_URL}/basic/login/`, {
+      method: 'POST',
+      body: data,
+      credentials: 'include',
+    }).catch(error => {
+      setError(error ? JSON.stringify(error) : '');
+    });
+    window.location.reload();
+  };
+
+  return (
+    <Formik
+      initialValues={{
+        username: '',
+        password: '',
+        target: window.location.pathname,
+      }}
+      validationSchema={LoginSchema}
+      onSubmit={(values, { setSubmitting }) => {
+        setTimeout(() => {
+          handleBasicLogin(values);
+          setSubmitting(false);
+        }, 400);
+      }}
+    >
+      {({ isSubmitting }) => (
+        <Form>
+          <div className="logo-title">
+            <img src={logo} alt="DJ Logo" width="75px" height="75px" />
+            <h2>DataJunction</h2>
+          </div>
+          <div>
+            <Field type="text" name="username" placeholder="Username" />
+          </div>
+          <div>
+            <ErrorMessage name="username" component="span" />
+          </div>
+          <div>
+            <Field type="password" name="password" placeholder="Password" />
+          </div>
+          <div>
+            <ErrorMessage name="password" component="span" />
+          </div>
+          <div>
+            <p>
+              Don't have an account yet?{' '}
+              <a onClick={() => setShowSignup(true)}>Sign Up</a>
+            </p>
+          </div>
+          <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? <LoadingIcon/> : "Login"}
+          </button>
+          <div>
+            <p>Or</p>
+          </div>
+          {process.env.REACT_ENABLE_GITHUB_OAUTH === 'true' ? (
+            <div>
+              <a href={githubLoginURL.href}>
+                <img
+                  src={GitHubLoginButton}
+                  alt="Sign in with GitHub"
+                  width="200px"
+                />
+              </a>
+            </div>
+          ) : (
+            ''
+          )}
+          {process.env.REACT_ENABLE_GOOGLE_OAUTH === 'true' ? (
+            <div>
+              <a href={googleLoginURL.href}>
+                <img
+                  src={GoogleLoginButton}
+                  alt="Sign in with Google"
+                  width="200px"
+                />
+              </a>
+            </div>
+          ) : (
+            ''
+          )}
+        </Form>
+      )}
+    </Formik>
+  );
+}

--- a/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/LoginForm.jsx
@@ -63,13 +63,13 @@ export default function LoginForm({ setShowSignup }) {
             <Field type="text" name="username" placeholder="Username" />
           </div>
           <div>
-            <ErrorMessage name="username" component="span" />
+            <ErrorMessage className="form-error" name="username" component="span" />
           </div>
           <div>
             <Field type="password" name="password" placeholder="Password" />
           </div>
           <div>
-            <ErrorMessage name="password" component="span" />
+            <ErrorMessage className="form-error" name="password" component="span" />
           </div>
           <div>
             <p>

--- a/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
@@ -13,8 +13,8 @@ const googleLoginURL = new URL('/google/login/', process.env.REACT_APP_DJ_URL);
 const SignupSchema = Yup.object().shape({
   email: Yup.string().email('Invalid email').required('Email is required'),
   signupUsername: Yup.string()
-    .min(3, 'Too Short')
-    .max(20, 'Too Long')
+    .min(3, 'Must be at least 2 characters')
+    .max(20, 'Must be less than 20 characters')
     .required('Username is required'),
   signupPassword: Yup.string().required('Password is required'),
 });

--- a/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { Formik, Form, Field, ErrorMessage } from 'formik';
+import '../../../styles/login.css';
+import logo from '../Root/assets/dj-logo.png';
+import LoadingIcon from '../../icons/LoadingIcon';
+import GitHubLoginButton from './assets/sign-in-with-github.png';
+import GoogleLoginButton from './assets/sign-in-with-google.png';
+import * as Yup from 'yup';
+
+const githubLoginURL = new URL('/github/login/', process.env.REACT_APP_DJ_URL);
+const googleLoginURL = new URL('/google/login/', process.env.REACT_APP_DJ_URL);
+
+const SignupSchema = Yup.object().shape({
+  email: Yup.string().email('Invalid email').required('Email is required'),
+  signupUsername: Yup.string()
+    .min(3, 'Too Short')
+    .max(20, 'Too Long')
+    .required('Username is required'),
+  signupPassword: Yup.string().required('Password is required'),
+});
+
+export default function SignupForm({ setShowSignup }) {
+  const [, setError] = useState('');
+
+  // Add the path that the user was trying to access in order to properly redirect after auth
+  githubLoginURL.searchParams.append('target', window.location.pathname);
+  googleLoginURL.searchParams.append('target', window.location.pathname);
+
+  const handleBasicSignup = async ({
+    email,
+    signupUsername,
+    signupPassword,
+  }) => {
+    const data = new FormData();
+    data.append('email', email);
+    data.append('username', signupUsername);
+    data.append('password', signupPassword);
+    await fetch(`${process.env.REACT_APP_DJ_URL}/basic/user/`, {
+      method: 'POST',
+      body: data,
+      credentials: 'include',
+    }).catch(error => {
+      setError(error ? JSON.stringify(error) : '');
+    });
+    const loginData = new FormData();
+    loginData.append('username', signupUsername);
+    loginData.append('password', signupPassword);
+    await fetch(`${process.env.REACT_APP_DJ_URL}/basic/login/`, {
+      method: 'POST',
+      body: data,
+      credentials: 'include',
+    }).catch(error => {
+      setError(error ? JSON.stringify(error) : '');
+    });
+    window.location.reload();
+  };
+
+  return (
+    <Formik
+      initialValues={{
+        email: '',
+        signupUsername: '',
+        signupPassword: '',
+        target: window.location.pathname,
+      }}
+      validationSchema={SignupSchema}
+      onSubmit={(values, { setSubmitting }) => {
+        setTimeout(() => {
+          handleBasicSignup(values);
+          setSubmitting(false);
+        }, 400);
+      }}
+    >
+      {({ isSubmitting }) => (
+        <Form>
+          <div className="logo-title">
+            <img src={logo} alt="DJ Logo" width="75px" height="75px" />
+            <h2>DataJunction</h2>
+          </div>
+          <div>
+            <Field type="text" name="email" placeholder="Email" />
+          </div>
+          <div>
+            <ErrorMessage name="email" component="span" />
+          </div>
+          <div>
+            <Field type="text" name="signupUsername" placeholder="Username" />
+          </div>
+          <div>
+            <ErrorMessage name="signupUsername" component="span" />
+          </div>
+          <div>
+            <Field
+              type="password"
+              name="signupPassword"
+              placeholder="Password"
+            />
+          </div>
+          <div>
+            <ErrorMessage name="signupPassword" component="span" />
+          </div>
+          <div>
+            <p>
+              Have an account already?{' '}
+              <a onClick={() => setShowSignup(false)}>Login</a>
+            </p>
+          </div>
+          <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? <LoadingIcon/> : "Sign Up"}
+          </button>
+          <div>
+            <p>Or</p>
+          </div>
+          {process.env.REACT_ENABLE_GITHUB_OAUTH === 'true' ? (
+            <div>
+              <a href={githubLoginURL.href}>
+                <img
+                  src={GitHubLoginButton}
+                  alt="Sign in with GitHub"
+                  width="200px"
+                />
+              </a>
+            </div>
+          ) : (
+            ''
+          )}
+          {process.env.REACT_ENABLE_GOOGLE_OAUTH === 'true' ? (
+            <div>
+              <a href={googleLoginURL.href}>
+                <img
+                  src={GoogleLoginButton}
+                  alt="Sign in with Google"
+                  width="200px"
+                />
+              </a>
+            </div>
+          ) : (
+            ''
+          )}
+        </Form>
+      )}
+    </Formik>
+  );
+}

--- a/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
@@ -106,7 +106,7 @@ export default function SignupForm({ setShowSignup }) {
             </p>
           </div>
           <button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? <LoadingIcon/> : "Sign Up"}
+            {isSubmitting ? <LoadingIcon /> : 'Sign Up'}
           </button>
           <div>
             <p>Or</p>

--- a/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/SignupForm.jsx
@@ -81,13 +81,13 @@ export default function SignupForm({ setShowSignup }) {
             <Field type="text" name="email" placeholder="Email" />
           </div>
           <div>
-            <ErrorMessage name="email" component="span" />
+            <ErrorMessage className="form-error" name="email" component="span" />
           </div>
           <div>
             <Field type="text" name="signupUsername" placeholder="Username" />
           </div>
           <div>
-            <ErrorMessage name="signupUsername" component="span" />
+            <ErrorMessage className="form-error" name="signupUsername" component="span" />
           </div>
           <div>
             <Field
@@ -97,7 +97,7 @@ export default function SignupForm({ setShowSignup }) {
             />
           </div>
           <div>
-            <ErrorMessage name="signupPassword" component="span" />
+            <ErrorMessage className="form-error" name="signupPassword" component="span" />
           </div>
           <div>
             <p>

--- a/datajunction-ui/src/app/pages/LoginPage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/__tests__/index.test.jsx
@@ -33,7 +33,8 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(getByText('DataJunction')).toBeInTheDocument();
-      expect(queryAllByText('Required').length).toEqual(2);
+      expect(getByText('Username is required')).toBeInTheDocument();
+      expect(getByText('Password is required')).toBeInTheDocument();
     });
   });
 

--- a/datajunction-ui/src/app/pages/LoginPage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/__tests__/index.test.jsx
@@ -38,7 +38,7 @@ describe('LoginPage', () => {
     });
   });
 
-  it('calls fetch with correct data on submit', async () => {
+  it('calls fetch with correct data on login', async () => {
     const username = 'testUser';
     const password = 'testPassword';
 
@@ -54,6 +54,37 @@ describe('LoginPage', () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         `${process.env.REACT_APP_DJ_URL}/basic/login/`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(FormData),
+          credentials: 'include',
+        }),
+      );
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+  });
+
+  it('calls fetch with correct data on signup', async () => {
+    const email = 'testEmail@testEmail.com';
+    const username = 'testUser';
+    const password = 'testPassword';
+
+    const { getByText, getByPlaceholderText } = render(<LoginPage />);
+    fireEvent.click(getByText('Sign Up'));
+    fireEvent.change(getByPlaceholderText('Email'), {
+      target: { value: email },
+    });
+    fireEvent.change(getByPlaceholderText('Username'), {
+      target: { value: username },
+    });
+    fireEvent.change(getByPlaceholderText('Password'), {
+      target: { value: password },
+    });
+    fireEvent.click(getByText('Sign Up'));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        `${process.env.REACT_APP_DJ_URL}/basic/user/`,
         expect.objectContaining({
           method: 'POST',
           body: expect.any(FormData),

--- a/datajunction-ui/src/app/pages/LoginPage/index.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/index.jsx
@@ -4,124 +4,19 @@ import '../../../styles/login.css';
 import logo from '../Root/assets/dj-logo.png';
 import GitHubLoginButton from './assets/sign-in-with-github.png';
 import GoogleLoginButton from './assets/sign-in-with-google.png';
+import * as Yup from 'yup';
+import SignupForm from './SignupForm';
+import LoginForm from './LoginForm';
 
 export function LoginPage() {
-  const [, setError] = useState('');
-  const githubLoginURL = new URL(
-    '/github/login/',
-    process.env.REACT_APP_DJ_URL,
-  );
-  const googleLoginURL = new URL(
-    '/google/login/',
-    process.env.REACT_APP_DJ_URL,
-  );
-
-  // Add the path that the user was trying to access in order to properly redirect after auth
-  githubLoginURL.searchParams.append('target', window.location.pathname);
-  googleLoginURL.searchParams.append('target', window.location.pathname);
-
-  const handleBasicLogin = async ({ username, password }) => {
-    const data = new FormData();
-    data.append('username', username);
-    data.append('password', password);
-    await fetch(`${process.env.REACT_APP_DJ_URL}/basic/login/`, {
-      method: 'POST',
-      body: data,
-      credentials: 'include',
-    }).catch(error => {
-      setError(error ? JSON.stringify(error) : '');
-    });
-    window.location.reload();
-  };
-
+  const [showSignup, setShowSignup] = useState(false);
   return (
-    <div className="container">
-      <div className="login">
-        <center>
-          <Formik
-            initialValues={{
-              username: '',
-              password: '',
-              target: window.location.pathname,
-            }}
-            validate={values => {
-              const errors = {};
-              if (!values.username) {
-                errors.username = 'Required';
-              }
-              if (!values.password) {
-                errors.password = 'Required';
-              }
-              return errors;
-            }}
-            onSubmit={(values, { setSubmitting }) => {
-              setTimeout(() => {
-                handleBasicLogin(values);
-                setSubmitting(false);
-              }, 400);
-            }}
-          >
-            {({ isSubmitting }) => (
-              <Form>
-                <div className="logo-title">
-                  <img src={logo} alt="DJ Logo" width="75px" height="75px" />
-                  <h2>DataJunction</h2>
-                </div>
-                <center>
-                  <div className="inputContainer">
-                    <ErrorMessage name="username" component="span" />
-                    <Field type="text" name="username" placeholder="Username" />
-                  </div>
-                </center>
-                <center>
-                  <div>
-                    <ErrorMessage name="password" component="span" />
-                    <Field
-                      type="password"
-                      name="password"
-                      placeholder="Password"
-                    />
-                  </div>
-                </center>
-                <button type="submit" disabled={isSubmitting}>
-                  Login
-                </button>
-                <center>{'Or'}</center>
-                <center>
-                  {process.env.REACT_ENABLE_GITHUB_OAUTH === 'true' ? (
-                    <div>
-                      <a href={githubLoginURL.href}>
-                        <img
-                          src={GitHubLoginButton}
-                          alt="Sign in with GitHub"
-                          width="200px"
-                        />
-                      </a>
-                    </div>
-                  ) : (
-                    ''
-                  )}
-                </center>
-                <center>
-                  {process.env.REACT_ENABLE_GOOGLE_OAUTH === 'true' ? (
-                    <div>
-                      <a href={googleLoginURL.href}>
-                        <img
-                          src={GoogleLoginButton}
-                          alt="Sign in with Google"
-                          width="200px"
-                        />
-                      </a>
-                    </div>
-                  ) : (
-                    ''
-                  )}
-                </center>
-              </Form>
-            )}
-          </Formik>
-        </center>
-      </div>
+    <div className="container login">
+      {showSignup ? (
+        <SignupForm setShowSignup={setShowSignup} />
+      ) : (
+        <LoginForm setShowSignup={setShowSignup} />
+      )}
     </div>
   );
 }

--- a/datajunction-ui/src/app/pages/LoginPage/index.jsx
+++ b/datajunction-ui/src/app/pages/LoginPage/index.jsx
@@ -1,10 +1,5 @@
 import { useState } from 'react';
-import { Formik, Form, Field, ErrorMessage } from 'formik';
 import '../../../styles/login.css';
-import logo from '../Root/assets/dj-logo.png';
-import GitHubLoginButton from './assets/sign-in-with-github.png';
-import GoogleLoginButton from './assets/sign-in-with-google.png';
-import * as Yup from 'yup';
 import SignupForm from './SignupForm';
 import LoginForm from './LoginForm';
 

--- a/datajunction-ui/src/app/pages/Root/index.tsx
+++ b/datajunction-ui/src/app/pages/Root/index.tsx
@@ -59,7 +59,7 @@ export function Root() {
         ) : (
           <span className="menu-link">
             <span className="menu-title">
-              <button onClick={handleLogout}>Logout</button>
+              <a onClick={handleLogout}>Logout</a>
             </span>
           </span>
         )}

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -710,9 +710,11 @@ pre {
 }
 .menu-title a {
   color: #7e8299;
+  cursor: pointer;
 }
 .menu-title a:hover {
   color: #3f4254;
+  cursor: pointer;
 }
 
 .node__header,

--- a/datajunction-ui/src/styles/loading.css
+++ b/datajunction-ui/src/styles/loading.css
@@ -1,0 +1,35 @@
+.lds-ring {
+    display: inline-block;
+    position: relative;
+    width: 25px;
+    height: 25px;
+  }
+  .lds-ring div {
+    box-sizing: border-box;
+    display: block;
+    position: absolute;
+    width: 25px;
+    height: 25px;
+    border: 8px solid #fff;
+    border-radius: 50%;
+    animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+    border-color: #fff transparent transparent transparent;
+  }
+  .lds-ring div:nth-child(1) {
+    animation-delay: -0.45s;
+  }
+  .lds-ring div:nth-child(2) {
+    animation-delay: -0.3s;
+  }
+  .lds-ring div:nth-child(3) {
+    animation-delay: -0.15s;
+  }
+  @keyframes lds-ring {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+  

--- a/datajunction-ui/src/styles/login.css
+++ b/datajunction-ui/src/styles/login.css
@@ -3,18 +3,24 @@
   border: 2px solid #000000;
   background: linear-gradient(120deg, #ffed7c, #fef7c8);
   width: 40vw;
-  height: 30rem;
+  height: 45rem;
   box-sizing: border-box;
   padding: 2rem;
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
   margin: auto;
   position: absolute;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
+  cursor: pointer;
+  grid-row-gap: 0;
+}
+
+.login form div {
+  display: block;
+  text-align: center;
 }
 
 .login form button {
@@ -49,7 +55,7 @@
 
 .login button[type='submit'] {
   width: 10vw;
-  background-color: #01b268;
+  background-color: #5D2E85;
   border: 2px solid #000000;
   color: white;
   padding: 14px 20px;
@@ -64,4 +70,8 @@
 
 .login .logo-title img {
   padding: 0.5rem;
+}
+
+.signup form {
+  height: 50rem;
 }

--- a/datajunction-ui/src/styles/login.css
+++ b/datajunction-ui/src/styles/login.css
@@ -75,3 +75,7 @@
 .signup form {
   height: 50rem;
 }
+
+.form-error {
+  color: red;
+}

--- a/datajunction-ui/yarn.lock
+++ b/datajunction-ui/yarn.lock
@@ -11614,6 +11614,11 @@ prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 property-information@^5.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
@@ -13669,6 +13674,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
@@ -13757,6 +13767,11 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tough-cookie@^4.0.0:
   version "4.1.3"
@@ -13900,7 +13915,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-fest@^2.13.0:
+type-fest@^2.13.0, type-fest@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
@@ -15032,6 +15047,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.3.2.tgz#afffc458f1513ed386e6aaf4bcaa4e67a9e270dc"
+  integrity sha512-6KCM971iQtJ+/KUaHdrhVr2LDkfhBtFPRnsG1P8F4q3uUVQ2RfEM9xekpha9aA4GXWJevjM10eDcPQ1FfWlmaQ==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"
 
 zustand@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
### Summary

This adds a signup form to the login screen that can be used to create a basic auth user (not using google oauth or github oauth). This gets us one step closer to always requiring auth and is worth serious consideration on if we want to do that in the OSS project as an alternative to what we recently agreed on in a recent sync--setting the user as "unknown" when auth is globally disabled.

In other words, creating a basic auth user through the signup page is such a low bar that maybe we can make it the lowest bar :)

https://github.com/DataJunction/dj/assets/43911210/018be113-b227-4582-8663-df0cda207e52

### Test Plan

Added UI tests for the signup page and tested signing up in the local docker demo environment.

- [x] PR has an associated issue: #697 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
