### PR TITLE
Fix node access control check 

### DIFF
--- a/datajunction-clients/python/datajunction/__about__.py
+++ b/datajunction-clients/python/datajunction/__about__.py
@@ -1,4 +1,4 @@
 """
 Version for Hatch
 """
-__version__ = "0.0.1a20"
+__version__ = "0.0.1a22"

--- a/datajunction-server/datajunction_server/__about__.py
+++ b/datajunction-server/datajunction_server/__about__.py
@@ -1,4 +1,4 @@
 """
 Version for Hatch
 """
-__version__ = "0.0.1a26"
+__version__ = "0.0.1a29"

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -354,16 +354,23 @@ def validate_access_nodes(
     validation_results = access_control.validate()
     if raise_:
         access_control.raise_if_invalid_requests()  # pragma: no cover
-
+    approved_node_ids = {
+        request.access_object.id for request in validation_results if request.approved
+    }
+    approved_node_revision_ids = {
+        request.access_object.revision_id
+        for request in validation_results
+        if request.approved
+    }
     return [
         node
         for node in nodes
-        if node.id
-        in {
-            request.access_object.revision_id
-            for request in validation_results
-            if request.approved
-        }
+        if (
+            (isinstance(node, Node) and node.id in approved_node_ids)
+            or (
+                isinstance(node, NodeRevision) and node.id in approved_node_revision_ids
+            )
+        )
     ]
 
 

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-rc.21",
+  "version": "0.0.1-rc.25",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {


### PR DESCRIPTION
### Summary

This fixes a bug in `validate_access_nodes` so that during the resource access validation check, we distinguish between node revision ids and node ids. It was previously just using node revision ids, which then fails validation if we get passed a list of nodes.

### Test Plan

Locally and beyond. Discovered upon deployment

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A