### PR TITLE
Add support for CTEs and fix bug with struct types + aliased tables

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -435,7 +435,10 @@ def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
             else validated_node.query
         )
         query_ast = parse(formatted_query)  # type: ignore
-        dependencies_map, missing_parents_map = query_ast.extract_dependencies(ctx)
+        (
+            dependencies_map,
+            missing_parents_map,
+        ) = query_ast.bake_ctes().extract_dependencies(ctx)
         node_validator.dependencies_map = dependencies_map
         node_validator.missing_parents_map = missing_parents_map
     except (DJParseException, ValueError, SqlSyntaxError) as raised_exceptions:

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -285,6 +285,7 @@ def create_source(
     data: CreateSourceNode,
     session: Session = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
 ) -> NodeOutput:
     """
     Create a source node. If columns are not provided, the source node's schema
@@ -298,6 +299,7 @@ def create_source(
         data=data,
         session=session,
         current_user=current_user,
+        query_service_client=query_service_client,
     ):
         return recreated_node
 
@@ -378,6 +380,7 @@ def create_node(
     *,
     session: Session = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
 ) -> NodeOutput:
     """
     Create a node.
@@ -395,6 +398,7 @@ def create_node(
         data=data,
         session=session,
         current_user=current_user,
+        query_service_client=query_service_client,
     ):
         return recreated_node  # pragma: no cover
 
@@ -463,6 +467,7 @@ def create_cube(
         data=data,
         session=session,
         current_user=current_user,
+        query_service_client=query_service_client,
     ):
         return recreated_node  # pragma: no cover
 

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -314,7 +314,6 @@ def _build_tables_on_select(
                     if col in set(tbl.child.select.projection)
                 ]
             node_ast.compile(context)
-
             select.replace(
                 tbl,
                 node_ast,
@@ -552,6 +551,8 @@ def build_node(  # pylint: disable=too-many-arguments
         query = parse(NodeRevision.format_metric_alias(node.query, node.name))
     elif node.query and node.type != NodeType.METRIC:
         node_query = parse(node.query)
+        if node_query.ctes:
+            node_query = node_query.bake_ctes()
         node_query.select.add_aliases_to_unnamed_columns()
         query = parse(f"select * from {node.name}")
         query.select.projection = []

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -552,7 +552,7 @@ def build_node(  # pylint: disable=too-many-arguments
     elif node.query and node.type != NodeType.METRIC:
         node_query = parse(node.query)
         if node_query.ctes:
-            node_query = node_query.bake_ctes()
+            node_query = node_query.bake_ctes()  # pragma: no cover
         node_query.select.add_aliases_to_unnamed_columns()
         query = parse(f"select * from {node.name}")
         query.select.projection = []

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -443,7 +443,17 @@ ROADS = (  # type: ignore
                 "order_month",
                 "order_day",
             ],
-            "query": """SELECT
+            "query": """
+WITH ro as (SELECT
+        repair_order_id,
+        municipality_id,
+        hard_hat_id,
+        order_date,
+        required_date,
+        dispatched_date,
+        dispatcher_id
+    FROM default.repair_orders)
+            SELECT
     usr.us_region_id,
     us.state_name,
     CONCAT(us.state_name, '-', usr.us_region_description) AS location_hierarchy,
@@ -457,16 +467,7 @@ ROADS = (  # type: ignore
     -- ELEMENT_AT(ARRAY_SORT(COLLECT_LIST(STRUCT(COUNT(*) AS cnt, rt.repair_type_name AS repair_type_name)), (left, right) -> case when left.cnt < right.cnt then 1 when left.cnt > right.cnt then -1 else 0 end), 0).repair_type_name AS most_common_repair_type,
     AVG(DATEDIFF(ro.dispatched_date, ro.order_date)) AS avg_dispatch_delay,
     COUNT(DISTINCT c.contractor_id) AS unique_contractors
-FROM
-    (SELECT
-        repair_order_id,
-        municipality_id,
-        hard_hat_id,
-        order_date,
-        required_date,
-        dispatched_date,
-        dispatcher_id
-    FROM default.repair_orders) ro
+FROM ro
 JOIN
     default.municipality m ON ro.municipality_id = m.municipality_id
 JOIN


### PR DESCRIPTION
### Summary

This change adds support for CTEs in node queries, so users can author transform nodes like:
```sql
WITH ro as (
  SELECT
    repair_order_id,
    STRUCT(
      required_date as required_dt,
      order_date as order_dt,
      dispatched_date as dispatched_dt
    ) relevant_dates
  FROM default.repair_orders
)
SELECT
  SUM(DATEDIFF(ro.relevant_dates.dispatched_dt, ro.relevant_dates.order_dt)) AS dispatch_delay_sum,
  COUNT(ro.repair_order_id) AS repair_orders_cnt
FROM ro
```

It also fixes a bug where struct types that source from aliased tables (i.e., in the above query, `relevant_dates`, a struct, comes from a table reference aliased `ro`, which would not work at the moment since it fails to handle the case where a column has multiple names in its namespace).

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #152 #495 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
