### PR TITLE
Fix official release docs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: "PR update : Run tests and linters"
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/docs/content/0.1.0/docs/developers/releasing-new-version.md
+++ b/docs/content/0.1.0/docs/developers/releasing-new-version.md
@@ -8,7 +8,7 @@ DataJunction project publishes all of its backend services and the Python client
 - datajunction-clients/python
 - datajunction-query
 - datajunction-server
-- datajunction-reflection (NOT YET IMPLEMENTED)
+- datajunction-reflection
 
 Javascript client and the UI component go to [NPM](https://www.npmjs.com/):
 
@@ -62,8 +62,8 @@ In order to simplify version management we decided to release all the components
 
 Three steps:
 
-1. To make a new official release for all the components simply run the [Version Bump](https://github.com/DataJunction/dj/actions/workflows/bump-version.yml) Github action with the default settings. The default setting will make sure you are staying with the current version cycle, which at the moment is **ALPHA**.
+1. To make a new official release for all the components simply run the [Version Bump](https://github.com/DataJunction/dj/actions/workflows/version-bump.yml) Github action with the default settings. The default setting will make sure you are staying with the current version cycle, which at the moment is **ALPHA**.
 
 2. Once the above workflow runs succesfully we should recive a PR for the version updates. This will allow us to double-check the versions before the final release.
 
-3. After the above PR is merged a [Version Release](https://github.com/DataJunction/dj/actions/workflows/bump-version.yml) Github action will build and publish all the versions to its corresponding repositories.
+3. After the above PR is merged a [Version Publish'ing](https://github.com/DataJunction/dj/actions/workflows/version-publish.yml) Github action will build and publish all the versions to its corresponding repositories.


### PR DESCRIPTION
### Summary

Final fix for the official release pattern to update the doc links.

Piggyback: turn off the Unit Tests and Linters for merging to main trigger, since this job main purpose is to run during PR update.

### Test Plan

In the wash.

- [ ] PR has an associated issue: #811 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a
