### PR TITLE
Use background task for tasks that can be done async

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -243,6 +243,7 @@ def join_tables_for_dimensions(
     the select, it will traverse through available linked tables (via dimension
     nodes) and join them in.
     """
+    initial_nodes = set(tables)
     for dim_node, required_dimension_columns in sorted(
         dimension_nodes_to_columns.items(),
         key=lambda x: x[0].name,
@@ -256,7 +257,6 @@ def join_tables_for_dimensions(
         # Join the source tables (if necessary) for these dimension columns
         # onto each select clause
         for select in selects_map:
-            initial_nodes = set(tables)
             if dim_node not in initial_nodes:  # need to join dimension
                 join_asts = _build_joins_for_dimension(
                     session,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -218,8 +218,8 @@ def create_new_materialization(
         if not temporal_partition:
             raise DJInvalidInputException(
                 "The cube materialization cannot be configured if there is no "
-                "temporal partition specified on the cube. Please set at least one cube"
-                "element with a temporal partition.",
+                "temporal partition specified on the cube. Please make sure at "
+                "least one cube element has a temporal partition defined",
             )
         default_job = [
             conf

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -3,7 +3,6 @@ Cube materialization jobs
 """
 from typing import Dict
 
-from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.materialization.jobs.materialization_job import (
     MaterializationJob,
 )
@@ -87,13 +86,6 @@ class DruidCubeMaterializationJob(MaterializationJob):
 
         metrics_spec = list(_metrics_spec.values())
         temporal_partition_cols = node_revision.temporal_partition_columns()
-
-        if not temporal_partition_cols:
-            raise DJInvalidInputException(
-                "The cube materialization cannot be configured if there is no "
-                "temporal partition specified on the cube. Please set at least one cube"
-                "element with a temporal partition.",
-            )
         temporal_partition_column = temporal_partition_cols[0]
 
         druid_spec: Dict = {

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -1076,6 +1076,12 @@ class CreateSourceNode(ImmutableNodeFields, MutableNodeFields, SourceNodeFields)
     """
 
 
+class UpdateCubeNode(MutableNodeFields, CubeNodeFields):
+    """
+    An update object for cube nodes
+    """
+
+
 class CreateCubeNode(ImmutableNodeFields, MutableNodeFields, CubeNodeFields):
     """
     A create object for cube nodes

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -1076,19 +1076,18 @@ class CreateSourceNode(ImmutableNodeFields, MutableNodeFields, SourceNodeFields)
     """
 
 
-class UpdateCubeNode(MutableNodeFields, CubeNodeFields):
-    """
-    An update object for cube nodes
-    """
-
-
 class CreateCubeNode(ImmutableNodeFields, MutableNodeFields, CubeNodeFields):
     """
     A create object for cube nodes
     """
 
 
-class UpdateNode(MutableNodeFields, SourceNodeFields):
+class UpdateNode(
+    MutableNodeFields,
+    SourceNodeFields,
+    MutableNodeQueryField,
+    CubeNodeFields,
+):
     """
     Update node object where all fields are optional
     """

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -818,7 +818,7 @@ def test_add_materialization_cube_failures(
     )
     assert response.json()["message"] == (
         "The cube materialization cannot be configured if there is no temporal partition specified"
-        " on the cube. Please set at least one cubeelement with a temporal partition."
+        " on the cube. Please make sure at least one cube element has a temporal partition defined"
     )
 
     set_temporal_partition_cube(client_with_repairs_cube)
@@ -1652,5 +1652,6 @@ def test_updating_cube_with_existing_materialization(
     result = response.json()
     assert result["message"] == (
         "The cube materialization cannot be configured if there is no temporal partition "
-        "specified on the cube. Please set at least one cubeelement with a temporal partition."
+        "specified on the cube. Please make sure at least one cube element has a temporal "
+        "partition defined"
     )

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -36,18 +36,7 @@ class TestDataForNode:
         )
         data = response.json()
         assert response.status_code == 500
-        assert data["message"] == (
-            "Cannot resolve type of column something in SELECT  "
-            "default_DOT_payment_type.id,\n"
-            "\tdefault_DOT_payment_type.payment_type_classification,\n"
-            "\tdefault_DOT_payment_type.payment_type_name,\n"
-            "\tsomething \n"
-            " FROM (SELECT  default_DOT_payment_type_table.id,\n"
-            "\tdefault_DOT_payment_type_table.payment_type_classification,\n"
-            "\tdefault_DOT_payment_type_table.payment_type_name \n"
-            " FROM accounting.payment_type_table AS default_DOT_payment_type_table)\n"
-            " AS default_DOT_payment_type\n"
-        )
+        assert "Cannot resolve type of column something" in data["message"]
 
     def test_get_dimension_data(
         self,

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -1390,7 +1390,15 @@ default_DOT_simple_agg AS (SELECT  default_DOT_simple_agg.order_day default_DOT_
     COUNT(ro.repair_order_id) AS repair_orders_cnt
  FROM (SELECT  default_DOT_repair_orders.repair_order_id,
     struct(default_DOT_repair_orders.required_date AS required_dt, default_DOT_repair_orders.order_date AS order_dt, default_DOT_repair_orders.dispatched_date AS dispatched_dt) relevant_dates
- FROM roads.repair_orders AS default_DOT_repair_orders
+ FROM roads.repair_orders AS default_DOT_repair_orders LEFT OUTER JOIN (SELECT  default_DOT_repair_orders.dispatched_date,
+    default_DOT_repair_orders.dispatcher_id,
+    default_DOT_repair_orders.hard_hat_id,
+    default_DOT_repair_orders.municipality_id,
+    default_DOT_repair_orders.order_date,
+    default_DOT_repair_orders.repair_order_id,
+    default_DOT_repair_orders.required_date
+ FROM roads.repair_orders AS default_DOT_repair_orders)
+ AS default_DOT_repair_order ON default_DOT_repair_orders.repair_order_id = default_DOT_repair_order.repair_order_id
 
 ) AS ro
  GROUP BY  EXTRACT(YEAR, ro.relevant_dates.order_dt), EXTRACT(MONTH, ro.relevant_dates.order_dt), EXTRACT(DAY, ro.relevant_dates.order_dt))


### PR DESCRIPTION
### Summary

This PR modifies some API endpoints to use background tasks for any tasks that do not need to block the API response output. Changes include:
* Column lineage saving on node creates/updates
* Scheduling materialization jobs

This reduces the amount of time we take to return a response to certain API calls.

It also fixes a bug when recreating deactivated nodes, where the deactivated node should be treated differently depending on whether it's a source, a {transform|dimension|metric} or a cube.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
