### PR TITLE
Add support for inline tables using VALUES + misc bugfixes

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -245,7 +245,9 @@ def create_node_revision(
     ]
     node_revision.required_dimensions = node_validator.required_dimensions
     new_parents = [node.name for node in node_validator.dependencies_map]
-    catalog_ids = [node.catalog_id for node in node_validator.dependencies_map]
+    catalog_ids = [
+        node.catalog_id for node in node_validator.dependencies_map if node.catalog_id
+    ]
     if node_revision.mode == NodeMode.PUBLISHED and not len(set(catalog_ids)) <= 1:
         raise DJException(
             f"Cannot create nodes with multi-catalog dependencies: {set(catalog_ids)}",

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3001,6 +3001,20 @@ def infer_type(
     return arg.type
 
 
+@Min.register  # type: ignore
+def infer_type(
+    arg: ct.DateType,
+) -> ct.DateType:
+    return arg.type  # pragma: no cover
+
+
+@Min.register  # type: ignore
+def infer_type(
+    arg: ct.TimestampType,
+) -> ct.TimestampType:
+    return arg.type  # pragma: no cover
+
+
 class MinBy(Function):
     """
     min_by(val, key) - Returns the value of val corresponding to the minimum value of key.

--- a/datajunction-server/datajunction_server/sql/parsing/types.py
+++ b/datajunction-server/datajunction_server/sql/parsing/types.py
@@ -375,6 +375,13 @@ field_type=IntegerType(), is_optional=True, doc='an optional field'))
         """
         return self._fields  # pragma: no cover
 
+    @property
+    def fields_mapping(self) -> Dict[str, NestedField]:
+        """
+        Returns the struct's fields.
+        """
+        return {field.name.name: field for field in self._fields}  # pragma: no cover
+
 
 class ListType(ColumnType):
     """A list type
@@ -911,8 +918,10 @@ PRIMITIVE_TYPES: Dict[str, PrimitiveType] = {
     "bool": BooleanType(),
     "boolean": BooleanType(),
     "varchar": VarcharType(),
-    "bigint": BigIntType(),
     "int": IntegerType(),
+    "tinyint": TinyIntType(),
+    "smallint": SmallIntType(),
+    "bigint": BigIntType(),
     "long": BigIntType(),
     "float": FloatType(),
     "double": DoubleType(),

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """
 testing ast Nodes and their methods
 """
@@ -8,6 +9,7 @@ from sqlmodel import Session
 from datajunction_server.errors import DJException
 from datajunction_server.sql.parsing import ast, types
 from datajunction_server.sql.parsing.backends.antlr4 import parse
+from tests.sql.utils import compare_query_strings
 
 
 def test_ast_compile_table(
@@ -892,3 +894,111 @@ def test_ast_compile_lateral_view_explode8(session: Session):
         quote_style="",
         namespace=None,
     )
+
+
+def test_ast_compile_inline_table(session: Session):
+    """
+    Test parsing and compiling an inline table with VALUES (...)
+    """
+    query_str_explicit_columns = """SELECT
+  w.a AS one,
+  w.b AS two,
+  w.c AS three,
+  w.d AS four
+FROM VALUES
+  ('1', 1, 2, 1),
+  ('11', 1, 3, 1),
+  ('111', 1, 2, 1),
+  ('1111', 1, 3, 1),
+  ('11111', 1, 4, 1),
+  ('111111', 1, 5, 1) AS w(a, b, c, d)"""
+    expected_columns = [
+        ("one", types.StringType()),
+        ("two", types.IntegerType()),
+        ("three", types.IntegerType()),
+        ("four", types.IntegerType()),
+    ]
+    expected_values = [
+        [
+            ast.String(value="'1'"),
+            ast.Number(value=1, _type=None),
+            ast.Number(value=2, _type=None),
+            ast.Number(value=1, _type=None),
+        ],
+        [
+            ast.String(value="'11'"),
+            ast.Number(value=1, _type=None),
+            ast.Number(value=3, _type=None),
+            ast.Number(value=1, _type=None),
+        ],
+        [
+            ast.String(value="'111'"),
+            ast.Number(value=1, _type=None),
+            ast.Number(value=2, _type=None),
+            ast.Number(value=1, _type=None),
+        ],
+        [
+            ast.String(value="'1111'"),
+            ast.Number(value=1, _type=None),
+            ast.Number(value=3, _type=None),
+            ast.Number(value=1, _type=None),
+        ],
+        [
+            ast.String(value="'11111'"),
+            ast.Number(value=1, _type=None),
+            ast.Number(value=4, _type=None),
+            ast.Number(value=1, _type=None),
+        ],
+        [
+            ast.String(value="'111111'"),
+            ast.Number(value=1, _type=None),
+            ast.Number(value=5, _type=None),
+            ast.Number(value=1, _type=None),
+        ],
+    ]
+    expected_table_name = ast.Name(  # type: ignore
+        name="w",
+        quote_style="",
+        namespace=None,
+    )
+    query = parse(query_str_explicit_columns)
+    exc = DJException()
+    assert not exc.errors
+
+    ctx = ast.CompileContext(session=session, exception=exc)
+    assert parse(str(query)) == query
+    assert compare_query_strings(str(query), query_str_explicit_columns)
+
+    query.compile(ctx)
+    assert [
+        (col.alias_or_name.name, col.type) for col in query.select.projection  # type: ignore
+    ] == expected_columns
+    assert query.select.from_.relations[0].primary.values == expected_values  # type: ignore
+    assert query.columns[0].table.alias_or_name == expected_table_name  # type: ignore
+
+    query_str_implicit_columns = """SELECT
+  w.col1 AS one,
+  w.col2 AS two,
+  w.col3 AS three,
+  w.col4 AS four
+FROM VALUES
+  ('1', 1, 2, 1),
+  ('11', 1, 3, 1),
+  ('111', 1, 2, 1),
+  ('1111', 1, 3, 1),
+  ('11111', 1, 4, 1),
+  ('111111', 1, 5, 1) AS w"""
+    query = parse(query_str_implicit_columns)
+    exc = DJException()
+    assert not exc.errors
+
+    ctx = ast.CompileContext(session=session, exception=exc)
+    assert parse(str(query)) == query
+    assert compare_query_strings(str(query), query_str_implicit_columns)
+
+    query.compile(ctx)
+    assert [
+        (col.alias_or_name.name, col.type) for col in query.select.projection  # type: ignore
+    ] == expected_columns
+    assert query.select.from_.relations[0].primary.values == expected_values  # type: ignore
+    assert query.columns[0].table.alias_or_name == expected_table_name  # type: ignore


### PR DESCRIPTION
### Summary

This change adds support for inline tables using `VALUES (...)` by implementing a visitor for `InlineTableContext`:

```
SELECT
  w.col1 AS one,
  w.col2 AS two
FROM VALUES
  ('1', 1),
  ('11', 1) AS w
```

It also fixes a few bugs:
*  Subscripts should allow for accessing struct types (i.e., `somestruct['abcd']` will access the `abcd` field on `somestruct`)
* `MIN` should work on timestamps and date types
* `TINYINT` and `SMALLINT` should be exposed as DJ types (otherwise `CAST(... AS TINYINT)` won't work)

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #420 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
