### PR TITLE
Open up source node refresh in Python client.

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -420,6 +420,16 @@ class DJClient:
         response = self._session.get(f"/dimensions/{node_name}/nodes/")
         return response.json()
 
+    def _refresh_source_node(
+        self,
+        node_name,
+    ):
+        """
+        Find all nodes with this dimension
+        """
+        response = self._session.post(f"/nodes/{node_name}/refresh/")
+        return response.json()
+
 
 class ClientEntity(BaseModel):
     """

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -74,6 +74,7 @@ class Node(ClientEntity):  # pylint: disable=protected-access
     materializations: Optional[List[Dict[str, Any]]]
     version: Optional[str]
     deactivated_at: Optional[int]
+    current_version: Optional[str]
 
     #
     # Node level actions
@@ -258,6 +259,16 @@ class Source(Node):
         )
         return self.dj_client._update_node(self.name, update_node)
 
+    def validate(self) -> str:
+        """
+        This method is only for Source nodes.
+
+        It will compare the source node metadata and create a new revision if necessary.
+        """
+        response = self.dj_client._refresh_source_node(self.name)
+        self.refresh()
+        return response["status"]
+
 
 class NodeWithQuery(Node):
     """
@@ -279,9 +290,11 @@ class NodeWithQuery(Node):
         )
         return self.dj_client._update_node(self.name, update_node)
 
-    def _validate(self) -> str:
+    def validate(self) -> str:
         """
         Check if the node is valid by calling the /validate endpoint.
+
+        For source nodes, see the Source.validate() method.
         """
         validation = self.dj_client._validate_node(self)
         return validation["status"]

--- a/datajunction-clients/python/tests/examples.py
+++ b/datajunction-clients/python/tests/examples.py
@@ -1123,6 +1123,12 @@ EXAMPLES = (  # type: ignore
 )
 
 COLUMN_MAPPINGS = {
+    "default.roads.repair_orders": [
+        Column(name="id", type=IntegerType()),
+        Column(name="user_id", type=IntegerType()),
+        Column(name="timestamp", type=TimestampType()),
+        Column(name="text", type=StringType()),
+    ],
     "default.store.comments": [
         Column(name="id", type=IntegerType()),
         Column(name="user_id", type=IntegerType()),

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -377,7 +377,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             primary_key=["id"],
             mode=NodeMode.DRAFT,
         )
-        payment_type_dim._validate()  # pylint: disable=protected-access
+        payment_type_dim.validate()  # pylint: disable=protected-access
         assert payment_type_dim.name == "default.payment_type"
         assert "default.payment_type" in client.list_dimensions(namespace="default")
         payment_type_dim.publish()  # Test changing a draft node to published

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -293,6 +293,26 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             "default.avg_repair_order_discounts",
         ]
 
+    def test_refresh_source_node(self, client):
+        """
+        Check that `Source.validate()` works as expected.
+        """
+        # change the source node
+        source_node = client.source("default.repair_orders")
+        version_before = source_node.current_version
+        response = source_node.validate()
+        assert response == "valid"
+        version_after = source_node.current_version
+        assert version_before and version_after and version_before != version_after
+
+        # change the source node (but don't really)
+        source_node = client.source("default.repair_orders")
+        version_before = source_node.current_version
+        response = source_node.validate()
+        assert response == "valid"
+        version_after = source_node.current_version
+        assert version_before and version_after and version_before == version_after
+
     #
     # Get common metrics and dimensions
     #

--- a/datajunction-clients/python/tests/test_integration.py
+++ b/datajunction-clients/python/tests/test_integration.py
@@ -478,7 +478,7 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
     assert transform_4.status == NodeStatus.INVALID
     # Check that transform 4 is invalid because transform 3 does not exist
     with pytest.raises(DJClientException):
-        transform_4._validate()
+        transform_4.validate()
 
     # Create a draft transform 3 that's downstream from transform 2
     dj.create_transform(
@@ -497,11 +497,11 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
     )
     transform_3 = dj.transform(f"{namespace}.repair_orders_w_municipalities")
     # Check that transform 3 is valid
-    assert transform_3._validate() == NodeStatus.VALID
+    assert transform_3.validate() == NodeStatus.VALID
 
     # Check that transform 4 is now valid after transform 3 was created
     transform_4.refresh()
-    assert transform_4._validate() == NodeStatus.VALID
+    assert transform_4.validate() == NodeStatus.VALID
 
     # Check that publishing transform 3 works
     transform_3.publish()

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -839,7 +839,7 @@ def refresh_source_node(
     session: Session = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
-):
+) -> NodeOutput:
     """
     Refresh a source node with the latest columns from the query service.
     """

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -1349,6 +1349,7 @@ class NodeOutput(OutputModel):
     current: NodeRevisionOutput = PydanticField(flatten=True)
     created_at: UTCDatetime
     tags: List["Tag"] = []
+    current_version: str
 
 
 class NodeValidation(SQLModel):


### PR DESCRIPTION
### Summary

This is a 1st PR in a small series to build a source node monitoring job. This job will refresh the source nodes and will show its owner the impact that the change in their node has on the DJ dag. We can debate if such a change should be applied immediately or not, but for let's assume it will, because that is the reality and we don't want DJ dag to be based on wishful thinking.

### Test Plan

Unit tests.

- [ ] PR has an associated issue: #842 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

nah
