### PR TITLE
Filter Pushdowns + Optimized Dimension Joins

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -307,12 +307,11 @@ def _build_tables_on_select(
                         node_query.select.where and [node_query.select.where] or []
                     )
                     for filter_ in filters:
-                        # use parse to get the asts from the strings we got
                         temp_select = parse(f"select * where {filter_}").select
                         referenced_cols = temp_select.find_all(ast.Column)
 
-                        # We can only push down the filter if they're all available as
-                        # FK cols on the node
+                        # We can only push down the filter if all columns referenced by the filter
+                        # are available as foreign key columns on the node
                         if all(
                             col.alias_or_name.name in fk_column_mapping
                             for col in referenced_cols
@@ -418,7 +417,8 @@ def rename_dimension_primary_keys_to_foreign_keys(
     """
     Optimize the query build by renaming any requested dimension node primary key columns to
     foreign keys on the current processing node. This results in one less join if the user is
-    only requesting the dimension node's PK, since that column is already present via the FK.
+    only requesting the dimension node's primary key, since that column is already present via
+    current node's foreign key column.
     """
     if (
         dimension_node.name != current_node.name

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -292,7 +292,9 @@ def _build_tables_on_select(
             _get_node_table(node, build_criteria),
         )  # got a materialization
         fk_column_mapping = {
-            ",".join([pk.name for pk in col.dimension.current.primary_key()]): col
+            ",".join(
+                sorted([pk.name for pk in col.dimension.current.primary_key()]),
+            ): col
             for col in node.columns
             if col.dimension
         }

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -189,6 +189,7 @@ class AccessControlStore(BaseModel):
         node = try_get_dj_node(session, node_name)
         if node is not None:
             self.add_request_by_node(node, verb)
+        return node
 
     def add_request_by_node(
         self,

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2531,7 +2531,6 @@ class Query(TableExpression, UnNamed):
         """
         from datajunction_server.construction.build import _build_select_ast
 
-        print("Building query", filters)
         self.bake_ctes()  # pylint: disable=W0212
         _build_select_ast(
             session,

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2522,14 +2522,26 @@ class Query(TableExpression, UnNamed):
         session: Session,
         memoized_queries: Dict[int, "Query"],
         build_criteria: Optional[BuildCriteria] = None,
+        filters: Optional[List[str]] = None,
+        dimensions: Optional[List[str]] = None,
+        access_control=None,
     ):
         """
         Transforms a query ast by replacing dj node references with their asts
         """
         from datajunction_server.construction.build import _build_select_ast
 
+        print("Building query", filters)
         self.bake_ctes()  # pylint: disable=W0212
-        _build_select_ast(session, self.select, memoized_queries, build_criteria)
+        _build_select_ast(
+            session,
+            self.select,
+            memoized_queries,
+            build_criteria,
+            filters,
+            dimensions,
+            access_control,
+        )
         self.select.add_aliases_to_unnamed_columns()
 
         # Make the generated query deterministic

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -812,7 +812,6 @@ def test_sql_with_filters(  # pylint: disable=too-many-arguments
         params={"dimensions": dimensions, "filters": filters},
     )
     data = response.json()
-    print("SQLLL", data["sql"])
     assert compare_query_strings(data["sql"], sql)
     assert data["columns"] == columns
 

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -407,6 +407,7 @@ def test_sql(
                   default_DOT_repair_orders.municipality_id,
                   default_DOT_repair_orders.repair_order_id
                 FROM roads.repair_orders AS default_DOT_repair_orders
+                WHERE default_DOT_repair_orders.dispatcher_id = 1
               ) AS default_DOT_repair_order ON default_DOT_repair_orders.repair_order_id = default_DOT_repair_order.repair_order_id
               LEFT OUTER JOIN (
                 SELECT default_DOT_hard_hats.hard_hat_id,
@@ -460,6 +461,7 @@ def test_sql(
                   default_DOT_repair_orders.municipality_id,
                   default_DOT_repair_orders.repair_order_id
                 FROM roads.repair_orders AS default_DOT_repair_orders
+                WHERE default_DOT_repair_orders.dispatcher_id = 1
               ) AS default_DOT_repair_order ON default_DOT_repair_orders.repair_order_id = default_DOT_repair_order.repair_order_id
               LEFT OUTER JOIN (
                 SELECT default_DOT_dispatchers.company_name,
@@ -756,6 +758,7 @@ def test_sql_with_filters(  # pylint: disable=too-many-arguments
         params={"dimensions": dimensions, "filters": filters},
     )
     data = response.json()
+    print("SQLLL", data["sql"])
     assert compare_query_strings(data["sql"], sql)
     assert data["columns"] == columns
 
@@ -840,6 +843,7 @@ def test_sql_with_filters(  # pylint: disable=too-many-arguments
                   foo_DOT_bar_DOT_repair_orders.municipality_id,
                   foo_DOT_bar_DOT_repair_orders.repair_order_id
                 FROM roads.repair_orders AS foo_DOT_bar_DOT_repair_orders
+                WHERE foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1
               ) AS foo_DOT_bar_DOT_repair_order ON foo_DOT_bar_DOT_repair_orders.repair_order_id = foo_DOT_bar_DOT_repair_order.repair_order_id
               LEFT OUTER JOIN (
                 SELECT foo_DOT_bar_DOT_hard_hats.hard_hat_id,
@@ -879,6 +883,7 @@ def test_sql_with_filters(  # pylint: disable=too-many-arguments
                   foo_DOT_bar_DOT_repair_orders.municipality_id,
                   foo_DOT_bar_DOT_repair_orders.repair_order_id
                 FROM roads.repair_orders AS foo_DOT_bar_DOT_repair_orders
+                WHERE foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1
               ) AS foo_DOT_bar_DOT_repair_order ON foo_DOT_bar_DOT_repair_orders.repair_order_id = foo_DOT_bar_DOT_repair_order.repair_order_id
               LEFT OUTER JOIN (
                 SELECT foo_DOT_bar_DOT_dispatchers.company_name,


### PR DESCRIPTION
### Summary

* **Filter pushdowns:** Pushdown filters to the upstream transforms (based on linked dimensions) where possible. This means that if the downstream transform has a filter set, and the upstream transform has that filter's dimension attribute linked on an FK column, it'll try to filter the upstream transform where possible
* **Optimized dimension joins:** If a user requests a dimension node's primary key column, don't join the dimension node into the generated SQL, since it's unnecessary and we can just use the original node's foreign key column

### Test Plan

Tested locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
