### PR TITLE
Try out `[skip-ci]` for version bump PRs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -101,8 +101,8 @@ jobs:
           git add ./datajunction-reflection/datajunction_reflection/__about__.py
           git add ./datajunction-server/datajunction_server/__about__.py
           git add ./datajunction-ui/package.json
-          git add ./docs          
-          git commit -m "Bumping DJ to version $NEW_VERSION ."
+          git add ./docs
+          git commit -m "Bumping DJ to version $NEW_VERSION [skip ci]"
           git checkout -b releases/version-$NEW_VERSION
           git push --set-upstream origin releases/version-$NEW_VERSION -f
 


### PR DESCRIPTION
### Summary

Trying out `[skip-ci]` in the commit message for version bump PRs. Not sure how well this plays with the required passing builds on a PR though.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
