### PR TITLE
Try a better way to skip the unit tests matrix on version bump.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,16 @@ name: "PR update : Run tests and linters"
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      # python
+      - datajunction-clients/python/__about__.py
+      - datajunction-server/datajunction_server/__about__.py
+      - datajunction-query/djqs/__about__.py
+      - datajunction-reflection/datajunction_reflection/__about__.py
+      # javascript
+      - datajunction-clients/javascript/package.json
+      - datajunction-ui/package.json
+      # java: TODO
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -102,7 +102,7 @@ jobs:
           git add ./datajunction-server/datajunction_server/__about__.py
           git add ./datajunction-ui/package.json
           git add ./docs
-          git commit -m "Bumping DJ to version $NEW_VERSION [skip ci]"
+          git commit -m "Bumping DJ to version $NEW_VERSION"
           git checkout -b releases/version-$NEW_VERSION
           git push --set-upstream origin releases/version-$NEW_VERSION -f
 


### PR DESCRIPTION
### Summary

So we don't need to wait for expensive tests on version bump.

### Test Plan

In the wash.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
