### PR TITLE
[bugfixes] Add default catalog for nodes without them, redundant dimensions should not be included

### DIFF
--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -370,7 +370,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         Check that `client.list_catalogs()` works as expected.
         """
         result = client.list_catalogs()
-        assert result == ["draft", "default", "public"]
+        assert result == ["unknown", "draft", "default", "public"]
 
     def test_list_engines(self, client):
         """

--- a/datajunction-server/datajunction_server/api/catalogs.py
+++ b/datajunction-server/datajunction_server/api/catalogs.py
@@ -21,6 +21,8 @@ _logger = logging.getLogger(__name__)
 settings = get_settings()
 router = SecureAPIRouter(tags=["catalogs"])
 
+UNKNOWN_CATALOG_ID = 0
+
 
 @router.get("/catalogs/", response_model=List[CatalogInfo])
 def list_catalogs(*, session: Session = Depends(get_session)) -> List[CatalogInfo]:
@@ -127,13 +129,12 @@ def default_catalog(session: Session = Depends(get_session)):
     Loads a default catalog for nodes that are pure SQL and don't belong in any
     particular catalog. This typically applies to on-the-fly user-defined dimensions.
     """
-    # Update existing default attribute types
-    statement = select(Catalog).filter(Catalog.id == 0)
+    statement = select(Catalog).filter(Catalog.id == UNKNOWN_CATALOG_ID)
     catalogs = session.exec(statement).all()
     if not catalogs:
-        default = Catalog(
-            id=0,
-            name="default",
+        unknown = Catalog(
+            id=UNKNOWN_CATALOG_ID,
+            name="unknown",
         )
-        session.add(default)
+        session.add(unknown)
         session.commit()

--- a/datajunction-server/datajunction_server/api/catalogs.py
+++ b/datajunction-server/datajunction_server/api/catalogs.py
@@ -120,3 +120,20 @@ def list_new_engines(
         if not already_set:
             new_engines.append(engine)
     return new_engines
+
+
+def default_catalog(session: Session = Depends(get_session)):
+    """
+    Loads a default catalog for nodes that are pure SQL and don't belong in any
+    particular catalog. This typically applies to on-the-fly user-defined dimensions.
+    """
+    # Update existing default attribute types
+    statement = select(Catalog).filter(Catalog.id == 0)
+    catalogs = session.exec(statement).all()
+    if not catalogs:
+        default = Catalog(
+            id=0,
+            name="default",
+        )
+        session.add(default)
+        session.commit()

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -42,6 +42,7 @@ from datajunction_server.api import (
 )
 from datajunction_server.api.access.authentication import whoami
 from datajunction_server.api.attributes import default_attribute_types
+from datajunction_server.api.catalogs import default_catalog
 from datajunction_server.api.graphql.main import graphql_app
 from datajunction_server.constants import AUTH_COOKIE, LOGGED_IN_FLAG_COOKIE
 from datajunction_server.errors import DJException
@@ -64,7 +65,7 @@ config.fileConfig(
     disable_existing_loggers=False,
 )
 
-dependencies = [Depends(default_attribute_types)]
+dependencies = [Depends(default_attribute_types), Depends(default_catalog)]
 
 app = FastAPI(
     title=settings.name,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -13,6 +13,7 @@ from sqlalchemy.sql.operators import is_
 from sqlmodel import Session, select
 from starlette.requests import Request
 
+from datajunction_server.api.catalogs import UNKNOWN_CATALOG_ID
 from datajunction_server.api.helpers import (
     activate_node,
     deactivate_node,
@@ -640,7 +641,7 @@ def link_dimension(  # pylint: disable=too-many-arguments
         node_type=NodeType.DIMENSION,
     )
     if (
-        dimension_node.current.catalog_id != 0
+        dimension_node.current.catalog_id != UNKNOWN_CATALOG_ID
         and dimension_node.current.catalog is not None
         and node.current.catalog.name != dimension_node.current.catalog.name
     ):

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -640,7 +640,8 @@ def link_dimension(  # pylint: disable=too-many-arguments
         node_type=NodeType.DIMENSION,
     )
     if (
-        dimension_node.current.catalog is not None
+        dimension_node.current.catalog_id != 0
+        and dimension_node.current.catalog is not None
         and node.current.catalog.name != dimension_node.current.catalog.name
     ):
         raise DJException(

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -630,8 +630,8 @@ class MetricMetadataOutput(BaseSQLModel):
     Metric metadata output
     """
 
-    direction: MetricDirection
-    unit: Unit
+    direction: Optional[MetricDirection]
+    unit: Optional[Unit]
 
 
 class MetricMetadataInput(BaseSQLModel):

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -53,8 +53,12 @@ def get_dimensions(
 
         for column in current_node.current.columns:
             # Include the dimension if it's a column belonging to a dimension node
-            # or if it's tagged with the dimension column attribute
-            if current_node.type == NodeType.DIMENSION or column.is_dimensional():
+            # or if it's tagged with the dimension column attribute (but not
+            # additionally linked to a dimension)
+            if (
+                current_node.type == NodeType.DIMENSION
+                or (column.is_dimensional() and not column.dimension_id)
+            ):
                 join_path_str = [
                     (
                         (

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -55,9 +55,8 @@ def get_dimensions(
             # Include the dimension if it's a column belonging to a dimension node
             # or if it's tagged with the dimension column attribute (but not
             # additionally linked to a dimension)
-            if (
-                current_node.type == NodeType.DIMENSION
-                or (column.is_dimensional() and not column.dimension_id)
+            if current_node.type == NodeType.DIMENSION or (
+                column.is_dimensional() and not column.dimension_id
             ):
                 join_path_str = [
                     (
@@ -149,7 +148,7 @@ def get_shared_dimensions(
                         to_delete.add(common_dim)  # pragma: no cover
 
         for dim_key in to_delete:
-            del common[dim_key]
+            del common[dim_key]  # pragma: no cover
 
     return sorted(
         [y for x in common.values() for y in x],

--- a/datajunction-server/tests/api/catalog_test.py
+++ b/datajunction-server/tests/api/catalog_test.py
@@ -72,6 +72,7 @@ def test_catalog_list(
     response = client.get("/catalogs/")
     assert response.status_code == 200
     assert response.json() == [
+        {"name": "unknown", "engines": []},
         {
             "name": "dev",
             "engines": [

--- a/datajunction-server/tests/api/graphql/catalog_test.py
+++ b/datajunction-server/tests/api/graphql/catalog_test.py
@@ -58,5 +58,12 @@ def test_catalog_list(
     response = client.post("/graphql", json={"query": query})
     assert response.status_code == 200
     assert response.json() == {
-        "data": {"listCatalogs": [{"name": "dev"}, {"name": "test"}, {"name": "prod"}]},
+        "data": {
+            "listCatalogs": [
+                {"name": "unknown"},
+                {"name": "dev"},
+                {"name": "test"},
+                {"name": "prod"},
+            ],
+        },
     }

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -277,13 +277,6 @@ def test_common_dimensions(
             "path": ["default.repair_orders_fact.municipality_id"],
             "type": "int",
         },
-        {"name": "default.repair_orders_fact.dispatcher_id", "path": [], "type": "int"},
-        {"name": "default.repair_orders_fact.hard_hat_id", "path": [], "type": "int"},
-        {
-            "name": "default.repair_orders_fact.municipality_id",
-            "path": [],
-            "type": "string",
-        },
         {
             "name": "default.us_state.state_id",
             "path": [
@@ -503,13 +496,6 @@ def test_get_dimensions(client_with_roads: TestClient):
             "name": "default.municipality_dim.state_id",
             "path": ["default.repair_orders_fact.municipality_id"],
             "type": "int",
-        },
-        {"name": "default.repair_orders_fact.dispatcher_id", "path": [], "type": "int"},
-        {"name": "default.repair_orders_fact.hard_hat_id", "path": [], "type": "int"},
-        {
-            "name": "default.repair_orders_fact.municipality_id",
-            "path": [],
-            "type": "string",
         },
         {
             "name": "default.us_state.state_id",

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -312,7 +312,6 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         """
         A source node fixture.
         """
-
         table = Table(
             database=database,
             table="A",
@@ -324,13 +323,14 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         node = Node(
             name="basic.source.users",
             type=NodeType.SOURCE,
-            current_version="1",
+            current_version="v1",
         )
         node_revision = NodeRevision(
             node=node,
             name=node.name,
+            catalog_id=-100,
             type=node.type,
-            version="1",
+            version="v1",
             tables=[table],
             columns=[
                 Column(name="id", type=IntegerType()),
@@ -939,7 +939,6 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         response = client.get("/metrics/default.num_messages/")
         assert response.ok
         assert response.json()["dimensions"] == [
-            {"name": "default.messages.user_id", "path": [], "type": "int"},
             {
                 "name": "default.us_users.age",
                 "path": ["default.messages.user_id"],
@@ -1006,9 +1005,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         # The deleted dimension's attributes should no longer be available to the metric
         response = client.get("/metrics/default.num_messages/")
         assert response.ok
-        assert [
-            {"path": [], "name": "default.messages.user_id", "type": "int"},
-        ] == response.json()["dimensions"]
+        assert [] == response.json()["dimensions"]
         # The metric should still be VALID
         response = client.get("/nodes/default.num_messages/")
         assert response.json()["status"] == NodeStatus.VALID
@@ -1022,7 +1019,6 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         response = client.get("/metrics/default.num_messages/")
         assert response.ok
         assert response.json()["dimensions"] == [
-            {"name": "default.messages.user_id", "path": [], "type": "int"},
             {
                 "name": "default.us_users.age",
                 "path": ["default.messages.user_id"],


### PR DESCRIPTION
### Summary

#### Support catalog-less dimension nodes

This is a bug that shows up when we use a non-SQLite database for metadata: SQLite doesn't enforce that foreign keys constraints must reference an actual value that exists in the referenced table, but other databases (Postgres, CockroachDB etc) do. Therefore, when using other databases for metadata, we end up being unable to link dimension nodes that don't have a catalog (i.e., they are pure SQL) to catalog-ed nodes. This fixes it by creating a default "unknown" catalog for these types of nodes.

#### Redundant dimensions

When asking for the shared dimensions between several metric nodes, we return columns that are tagged with type "dimension" and are linked out to a dimension node. However, this leaves us with redundant dimensions, where we return both the foreign key on a node and the referenced primary key. This change makes it so that we only return the primary key, which is typically how users will think about their dimensions referencing.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
