### PR TITLE
Fix setting node tags via edit page in UI

### DIFF
--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
@@ -93,7 +93,7 @@ describe('AddEditNodePage submission failed', () => {
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalled();
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
         'default.num_repair_orders',
-        ['purpose'],
+        [{display_name: 'Purpose', name: 'purpose'}],
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toReturnWith({
         json: { message: 'Some tags were not found' },

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -120,7 +120,7 @@ describe('AddEditNodePage submission succeeded', () => {
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
         'default.num_repair_orders',
-        ['purpose'],
+        [{ display_name: 'Purpose', name: 'purpose' }],
       );
 
       expect(mockDjClient.DataJunctionAPI.listMetricMetadata).toBeCalledTimes(

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -145,7 +145,7 @@ export function AddEditNodePage() {
     );
     const tagsResponse = await djClient.tagsNode(
       values.name,
-      values.tags.map(tag => tag.name),
+      values.tags.map(tag => tag),
     );
     if ((status === 200 || status === 201) && tagsResponse.status === 200) {
       setStatus({

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/AddBackfillPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/AddBackfillPopover.test.jsx
@@ -36,7 +36,6 @@ describe('<AddBackfillPopover />', () => {
     fireEvent.click(getByLabelText('AddBackfill'));
 
     fireEvent.click(getByText('Save'));
-    getByText('Save').click();
 
     // Expect setAttributes to be called
     await waitFor(() => {


### PR DESCRIPTION
### Summary

A bug that broke the setting of node tags via the edit page in the UI. The fix is minor.

### Test Plan

Tested locally.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A