### PR TITLE
Cube Dimension Values

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -118,7 +118,10 @@ def get_cube_dimension_values(  # pylint: disable=too-many-locals
         validate_access,
     )
     if cube.availability:
-        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
+        catalog = get_catalog_by_name(  # pragma: no cover
+            session,
+            cube.availability.catalog,  # type: ignore
+        )
     else:
         catalog = cube.catalog
     query_create = QueryCreate(
@@ -134,14 +137,14 @@ def get_cube_dimension_values(  # pylint: disable=too-many-locals
         for idx, col in enumerate(translated_sql.columns)  # type: ignore
         if col.name == "count"
     ]
-    dimension_values = [
+    dimension_values = [  # pragma: no cover
         DimensionValue(
             value=row[0 : count_column[0]] if count_column else row,
             count=row[count_column[0]] if count_column else None,
         )
         for row in result.results.__root__[0].rows
     ]
-    return DimensionValues(
+    return DimensionValues(  # pragma: no cover
         dimensions=[
             from_amenable_name(col.name)
             for col in translated_sql.columns  # type: ignore # pylint: disable=not-an-iterable

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -6,11 +6,25 @@ import logging
 from fastapi import Depends
 from sqlmodel import Session
 
-from datajunction_server.api.helpers import get_node_by_name
+from datajunction_server.api.helpers import get_catalog_by_name, get_node_by_name
+from datajunction_server.construction.dimensions import build_dimensions_from_cube_query
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
-from datajunction_server.models.cube import CubeRevisionMetadata
+from datajunction_server.internal.access.authorization import validate_access
+from datajunction_server.models import access
+from datajunction_server.models.cube import (
+    CubeRevisionMetadata,
+    DimensionValue,
+    DimensionValues,
+)
+from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node import NodeType
-from datajunction_server.utils import get_session, get_settings
+from datajunction_server.models.query import QueryCreate
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.utils import (
+    get_query_service_client,
+    get_session,
+    get_settings,
+)
 
 _logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -26,3 +40,74 @@ def get_cube(
     """
     node = get_node_by_name(session=session, name=name, node_type=NodeType.CUBE)
     return node.current
+
+
+@router.get("/cubes/{name}/dimensions/{dimension}/sql", name="Dimensions SQL for Cube")
+def get_cube_dimension_sql(
+    name: str,
+    dimension: str,
+    *,
+    include_counts: bool = False,
+    session: Session = Depends(get_session),
+    validate_access: access.ValidateAccessFn = Depends(validate_access),
+) -> TranslatedSQL:
+    """
+    Generates SQL to retrieve all unique values of a dimension for the cube
+    """
+    node = get_node_by_name(session=session, name=name, node_type=NodeType.CUBE)
+    cube = node.current
+    return build_dimensions_from_cube_query(
+        session,
+        cube,
+        dimension,
+        include_counts,
+        validate_access=validate_access,
+    )
+
+
+@router.get(
+    "/cubes/{name}/dimensions/{dimension}/values",
+    name="Dimension Values From Cube",
+)
+def get_cube_dimension_values(
+    name: str,
+    dimension: str,
+    *,
+    include_counts: bool = False,
+    async_: bool = False,
+    session: Session = Depends(get_session),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+    validate_access: access.ValidateAccessFn = Depends(validate_access),
+) -> DimensionValues:
+    """
+    All unique values of a dimension from the cube
+    """
+    node = get_node_by_name(session=session, name=name, node_type=NodeType.CUBE)
+    cube = node.current
+    translated_sql = build_dimensions_from_cube_query(
+        session,
+        cube,
+        dimension,
+        include_counts,
+        validate_access,
+    )
+    if cube.availability:
+        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
+    else:
+        catalog = cube.catalog
+    query_create = QueryCreate(
+        engine_name=catalog.engines[0].name,
+        catalog_name=catalog.name,
+        engine_version=catalog.engines[0].version,
+        submitted_query=translated_sql.sql,
+        async_=async_,
+    )
+    result = query_service_client.submit_query(query_create)
+    dimension_values = [
+        DimensionValue(value=row[0], count=row[1] if len(row) > 1 else None)
+        for row in result.results.__root__[0].rows
+    ]
+    return DimensionValues(
+        values=dimension_values,
+        cardinality=len(dimension_values),
+    )

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -1,34 +1,52 @@
+"""
+Dimensions-related query building
+"""
+from typing import List, Optional
+
 from sqlmodel import Session
 
 from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build import get_measures_query
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models import NodeRevision, access
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
-from datajunction_server.utils import amenable_name, from_amenable_name, SEPARATOR
+from datajunction_server.sql.parsing.types import IntegerType
+from datajunction_server.utils import SEPARATOR, amenable_name, from_amenable_name
 
 
-def build_dimensions_from_cube_query(
+def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-many-locals
     session: Session,
     cube: NodeRevision,
-    dimension: str,
+    dimensions: List[str],
+    filters: Optional[str] = None,
+    limit: Optional[int] = 50000,
     include_counts: bool = False,
     validate_access: access.ValidateAccessFn = None,
 ) -> TranslatedSQL:
     """
     Builds a query for retrieving unique values of a dimension for the given cube.
+    The filters provided here are additional filters layered on top of any existing cube filters.
+    Setting `include_counts` to true will also provide associated counts for each dimension value.
     """
+    unavailable_dimensions = set(dimensions) - set(cube.cube_dimensions())
+    if unavailable_dimensions:
+        raise DJInvalidInputException(
+            f"The following dimensions {unavailable_dimensions} are not "
+            f"available in the cube {cube.name}.",
+        )
     query_ast: ast.Query = ast.Query(
         select=ast.Select(from_=ast.From(relations=[])),
         ctes=[],
     )
-    dimension_column = ast.Column(
-        name=ast.Name(amenable_name(dimension)),
-    )
-    query_ast.select.projection.append(dimension_column)
-    query_ast.select.group_by.append(dimension_column)
+    for dimension in dimensions:
+        dimension_column = ast.Column(
+            name=ast.Name(amenable_name(dimension)),
+        )
+        query_ast.select.projection.append(dimension_column)
+        query_ast.select.group_by.append(dimension_column)
     if include_counts:
         query_ast.select.projection.append(
             ast.Function(
@@ -39,24 +57,42 @@ def build_dimensions_from_cube_query(
         query_ast.select.organization = ast.Organization(
             order=[
                 ast.SortItem(
-                    expr=ast.Column(name=ast.Name("2")),
+                    expr=ast.Column(
+                        name=ast.Name(str(len(query_ast.select.projection))),
+                    ),
                     asc="DESC",
                     nulls="",
                 ),
             ],
         )
-    if cube.availability and dimension in cube.cube_dimensions():
+        query_ast.select.where = None
+
+    if limit is not None:
+        query_ast.select.limit = ast.Number(limit)
+
+    # Build the FROM clause. The source table on the FROM clause depends on whether
+    # the cube is available as a materialized datasource or if it needs to be built up
+    # from the measures query.
+    if cube.availability:
+        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
         query_ast.select.from_.relations.append(  # type: ignore
             ast.Relation(primary=ast.Table(ast.Name(cube.availability.table))),  # type: ignore
         )
-        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
+        if filters:
+            temp_filters_select = parse(f"select * where {filters}")
+            for col in temp_filters_select.find_all(ast.Column):
+                if col.alias_or_name.identifier() in cube.cube_dimensions():
+                    col.name = ast.Name(
+                        name=amenable_name(col.alias_or_name.identifier()),
+                    )
+            query_ast.select.where = temp_filters_select.select.where
     else:
         catalog = cube.catalog
         measures_query = get_measures_query(
             session=session,
             metrics=[metric.name for metric in cube.cube_metrics()],
-            dimensions=[dimension],
-            filters=[],
+            dimensions=dimensions,
+            filters=[filters] if filters else [],
             validate_access=validate_access,
         )
         measures_query_ast = parse(measures_query.sql)
@@ -65,18 +101,22 @@ def build_dimensions_from_cube_query(
         query_ast.select.from_.relations.append(  # type: ignore
             ast.Relation(primary=measures_query_ast),
         )
-    dimension_type = [
-        elem.type for elem in cube.cube_elements if (elem.node_revision().name + SEPARATOR + elem.name) == dimension
-    ][0]
+    types_lookup = {
+        amenable_name(elem.node_revision().name + SEPARATOR + elem.name): elem.type  # type: ignore
+        for elem in cube.cube_elements
+    }
     return TranslatedSQL(
         sql=str(query_ast),
         columns=[
             ColumnMetadata(
-                name=dimension_column.name.name,
-                type=str(dimension_type),
-                semantic_entity=from_amenable_name(dimension_column.name.name),
+                name=col.name.name,  # type: ignore
+                type=str(types_lookup.get(col.name.name)),  # type: ignore
+                semantic_entity=from_amenable_name(col.name.name),  # type: ignore
                 semantic_type="dimension",
-            ),
+            )
+            if col.name.name in types_lookup  # type: ignore
+            else ColumnMetadata(name="count", type=str(IntegerType()))
+            for col in query_ast.select.projection
         ],
         dialect=catalog.engines[0].dialect,
     )

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -1,0 +1,82 @@
+from sqlmodel import Session
+
+from datajunction_server.api.helpers import get_catalog_by_name
+from datajunction_server.construction.build import get_measures_query
+from datajunction_server.models import NodeRevision, access
+from datajunction_server.models.metric import TranslatedSQL
+from datajunction_server.models.query import ColumnMetadata
+from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.backends.antlr4 import parse
+from datajunction_server.utils import amenable_name, from_amenable_name, SEPARATOR
+
+
+def build_dimensions_from_cube_query(
+    session: Session,
+    cube: NodeRevision,
+    dimension: str,
+    include_counts: bool = False,
+    validate_access: access.ValidateAccessFn = None,
+) -> TranslatedSQL:
+    """
+    Builds a query for retrieving unique values of a dimension for the given cube.
+    """
+    query_ast: ast.Query = ast.Query(
+        select=ast.Select(from_=ast.From(relations=[])),
+        ctes=[],
+    )
+    dimension_column = ast.Column(
+        name=ast.Name(amenable_name(dimension)),
+    )
+    query_ast.select.projection.append(dimension_column)
+    query_ast.select.group_by.append(dimension_column)
+    if include_counts:
+        query_ast.select.projection.append(
+            ast.Function(
+                name=ast.Name("COUNT"),
+                args=[ast.Column(name=ast.Name("*"))],
+            ),
+        )
+        query_ast.select.organization = ast.Organization(
+            order=[
+                ast.SortItem(
+                    expr=ast.Column(name=ast.Name("2")),
+                    asc="DESC",
+                    nulls="",
+                ),
+            ],
+        )
+    if cube.availability and dimension in cube.cube_dimensions():
+        query_ast.select.from_.relations.append(  # type: ignore
+            ast.Relation(primary=ast.Table(ast.Name(cube.availability.table))),  # type: ignore
+        )
+        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
+    else:
+        catalog = cube.catalog
+        measures_query = get_measures_query(
+            session=session,
+            metrics=[metric.name for metric in cube.cube_metrics()],
+            dimensions=[dimension],
+            filters=[],
+            validate_access=validate_access,
+        )
+        measures_query_ast = parse(measures_query.sql)
+        measures_query_ast.bake_ctes()
+        measures_query_ast.parenthesized = True
+        query_ast.select.from_.relations.append(  # type: ignore
+            ast.Relation(primary=measures_query_ast),
+        )
+    dimension_type = [
+        elem.type for elem in cube.cube_elements if (elem.node_revision().name + SEPARATOR + elem.name) == dimension
+    ][0]
+    return TranslatedSQL(
+        sql=str(query_ast),
+        columns=[
+            ColumnMetadata(
+                name=dimension_column.name.name,
+                type=str(dimension_type),
+                semantic_entity=from_amenable_name(dimension_column.name.name),
+                semantic_type="dimension",
+            ),
+        ],
+        dialect=catalog.engines[0].dialect,
+    )

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -81,7 +81,9 @@ def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-
         if filters:
             temp_filters_select = parse(f"select * where {filters}")
             for col in temp_filters_select.find_all(ast.Column):
-                if col.alias_or_name.identifier() in cube.cube_dimensions():
+                if (  # pragma: no cover
+                    col.alias_or_name.identifier() in cube.cube_dimensions()
+                ):
                     col.name = ast.Name(
                         name=amenable_name(col.alias_or_name.identifier()),
                     )

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -68,7 +68,7 @@ class DimensionValue(BaseSQLModel):
     Dimension value and count
     """
 
-    value: str
+    value: List[str]
     count: Optional[int]
 
 
@@ -77,5 +77,6 @@ class DimensionValues(BaseSQLModel):
     Dimension values
     """
 
+    dimensions: List[str]
     values: List[DimensionValue]
     cardinality: int

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from pydantic import Field, root_validator
 from sqlmodel import SQLModel
 
+from datajunction_server.models.base import BaseSQLModel
 from datajunction_server.models.materialization import MaterializationConfigOutput
 from datajunction_server.models.node import AvailabilityState, ColumnOutput, NodeType
 from datajunction_server.models.partition import PartitionOutput
@@ -60,3 +61,21 @@ class CubeRevisionMetadata(SQLModel):
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         allow_population_by_field_name = True
+
+
+class DimensionValue(BaseSQLModel):
+    """
+    Dimension value and count
+    """
+
+    value: str
+    count: Optional[int]
+
+
+class DimensionValues(BaseSQLModel):
+    """
+    Dimension values
+    """
+
+    values: List[DimensionValue]
+    cardinality: int

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2388,7 +2388,7 @@ class Select(SelectExpression):
         if self.organization:
             select += f"\n{self.organization}"
         if self.limit:
-            select += f"LIMIT {self.limit}"
+            select += f"\nLIMIT {self.limit}"
 
         if self.alias:
             as_ = " AS " if self.as_ else " "


### PR DESCRIPTION
### Summary

This PR adds two endpoints that allow for retrieving dimensions values for a cube. This is useful for cases where we need a list of cube-scoped dimensions values, often for building out a dashboard based on the cube.

These endpoints provide the ability to:
* Ask for all unique dimension values for each dimension attribute in the cube, as well as any combination of dimension attributes
* Ask for counts for each of the dimension values
* Ask for dimensions values given certain filters
* Limit the number of dimension values returned

Example:
```
curl -X 'GET' \
  'http://localhost:8000/cubes/default.repair_orders_cube/dimensions/data?dimensions=default.hard_hat.postal_code&dimensions=default.hard_hat.state&include_counts=true&async_=false' \
  -H 'accept: application/json'
```
Returns
```
{
  "dimensions": ["default.hard_hat.postal_code", "default.hard_hat.state"],
  "values": [
    {
      "value": ["33125", "MI"],
      "count": 25
    },
    {
      "value": ["37421", "NJ"],
      "count": 16
    },
    {
      "value": ["71730", "PA"],
      "count": 16
    },
    {
      "value": ["13440", "MA"],
      "count": 9
    },
    {
      "value": ["42001", "GA"],
      "count": 9
    },
    {
      "value": ["85021", "AZ"],
      "count": 4
    },
    {
      "value": ["27292", "CT"],
      "count": 4
    },
    {
      "value": ["74403", "OK"],
      "count": 1
    },
    {
      "value": ["14304", "NY"],
      "count": 1
    }
  ],
  "cardinality": 9
}
```

### Test Plan

Locally, with roads and other test data

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
