### PR TITLE
Allow reading/creating tags from the python client as well as in YAML definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ djqs.db
 
 # oauth credentials
 client_secret*
+
+# random notebooks
+Untitled*

--- a/datajunction-clients/python/README.md
+++ b/datajunction-clients/python/README.md
@@ -188,6 +188,28 @@ djbuilder.restore_namespace("foo")
 The `cascade` parameter in both of above methods allows for cascading
 effect applied to all underlying nodes and namespaces. Use it with caution!
 
+### Tags
+
+You can read existing tags as well as create new ones.
+```python
+djbuilder.tag(name="deprecated", description="This node has been deprecated.", tag_type="standard", tag_metadata={"contact": "Foo Bar"})
+
+Tag(dj_client=..., name='deprecated', description='This node has been deprecated.', tag_type='standard', tag_metadata={"contact": "Foo Bar"})
+```
+```python
+djbuilder.tag("official")
+
+[DJClientException]: Tag `official` does not exist.
+```
+
+To create a tag:
+
+```python
+djbuilder.create_tag(name="deprecated", description="This node has been deprecated.", tag_type="standard", tag_metadata={"contact": "Foo Bar"})
+
+Tag(dj_client=..., name="deprecated", description="This node has been deprecated.", tag_type="standard", tag_metadata={"contact": "Foo Bar"})
+```
+
 ### Nodes
 
 To learn what **Node** means in the context of DJ, please check out [this datajuntion.io page](https://datajunction.io/docs/0.1.0/dj-concepts/nodes/).

--- a/datajunction-clients/python/datajunction/__init__.py
+++ b/datajunction-clients/python/datajunction/__init__.py
@@ -23,6 +23,7 @@ from datajunction.nodes import (
     Source,
     Transform,
 )
+from datajunction.tags import Tag
 
 try:
     # Change here if project is renamed and does not equal the package name
@@ -51,4 +52,5 @@ __all__ = [
     "Namespace",
     "Engine",
     "Project",
+    "Tag",
 ]

--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -288,7 +288,10 @@ class DJClient:
         """
         Call tag update API with attributes to update.
         """
-        return self._session.patch(f"/tags/{tag_name}/", json=update_input.dict())
+        return self._session.patch(
+            f"/tags/{tag_name}/",
+            json=update_input.dict(exclude_none=True),
+        )
 
     def _publish_node(self, node_name: str, update_input: models.UpdateNode):
         """

--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -22,10 +22,15 @@ from pydantic import BaseModel, Field
 from requests.adapters import CaseInsensitiveDict, HTTPAdapter
 
 from datajunction import models
-from datajunction.exceptions import DJClientException, DJNodeAlreadyExists
+from datajunction.exceptions import (
+    DJClientException,
+    DJNodeAlreadyExists,
+    DJTagAlreadyExists,
+)
 
 if TYPE_CHECKING:
     from datajunction.nodes import Node  # pragma: no cover
+    from datajunction.tags import Tag  # pragma: no cover
 
 DEFAULT_NAMESPACE = "default"
 _logger = logging.getLogger(__name__)
@@ -279,6 +284,12 @@ class DJClient:
         """
         return self._session.patch(f"/nodes/{node_name}/", json=update_input.dict())
 
+    def _update_tag(self, tag_name: str, update_input: models.UpdateNode):
+        """
+        Call tag update API with attributes to update.
+        """
+        return self._session.patch(f"/tags/{tag_name}/", json=update_input.dict())
+
     def _publish_node(self, node_name: str, update_input: models.UpdateNode):
         """
         Retrieves a node.
@@ -429,6 +440,34 @@ class DJClient:
         """
         response = self._session.post(f"/nodes/{node_name}/refresh/")
         return response.json()
+
+    def _get_tag(self, tag_name: str):
+        """
+        Retrieves a tag.
+        """
+        try:
+            response = self._session.get(f"/tags/{tag_name}/")
+            return response.json()
+        except DJClientException as exc:  # pragma: no cover
+            return exc.__dict__
+
+    def _create_tag(
+        self,
+        tag: "Tag",
+    ):
+        """
+        Helper function to create a tag.
+        Raises an error if tag already exists.
+        """
+        existing_tag = self._get_tag(tag_name=tag.name)
+        if "name" in existing_tag:
+            raise DJTagAlreadyExists(tag_name=tag.name)
+        response = self._session.post(
+            "/tags/",
+            timeout=self._timeout,
+            json=tag.dict(exclude_none=True),
+        )
+        return response
 
 
 class ClientEntity(BaseModel):

--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -1,12 +1,13 @@
 """DataJunction builder client module."""
 
 from http import HTTPStatus
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from datajunction import models
 from datajunction.client import DJClient
 from datajunction.exceptions import DJClientException, DJNamespaceAlreadyExists
 from datajunction.nodes import Cube, Dimension, Metric, Namespace, Source, Transform
+from datajunction.tags import Tag
 
 
 class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
@@ -111,7 +112,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         display_name: Optional[str] = None,
         columns: Optional[List[models.Column]] = None,
         primary_key: Optional[List[str]] = None,
-        tags: Optional[List[models.Tag]] = None,
+        tags: Optional[List[Tag]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
     ) -> "Source":
         """
@@ -155,7 +156,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         description: Optional[str] = None,
         display_name: Optional[str] = None,
         primary_key: Optional[List[str]] = None,
-        tags: Optional[List[models.Tag]] = None,
+        tags: Optional[List[Tag]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
     ) -> "Transform":
         """
@@ -184,7 +185,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         primary_key: Optional[List[str]],
         description: Optional[str] = None,
         display_name: Optional[str] = None,
-        tags: Optional[List[models.Tag]] = None,
+        tags: Optional[List[Tag]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
     ) -> "Transform":
         """
@@ -213,7 +214,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         description: Optional[str] = None,
         display_name: Optional[str] = None,
         primary_key: Optional[List[str]] = None,
-        tags: Optional[List[models.Tag]] = None,
+        tags: Optional[List[Tag]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
     ) -> "Transform":
         """
@@ -260,3 +261,20 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         self._create_node(node=new_node, mode=mode)  # pragma: no cover
         new_node.refresh()
         return new_node  # pragma: no cover
+
+    #
+    # Tag
+    #
+    def create_tag(self, tag: str, tag_metadata: Dict, tag_type: str) -> Tag:
+        """
+        Create a tag with a given name.
+        """
+        new_tag = Tag(
+            dj_client=self,
+            name=tag,
+            tag_type=tag_type,
+            tag_metadata=tag_metadata,
+        )
+        self._create_tag(tag=new_tag)
+        new_tag.refresh()
+        return new_tag

--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -265,13 +265,14 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
     #
     # Tag
     #
-    def create_tag(self, tag: str, tag_metadata: Dict, tag_type: str) -> Tag:
+    def create_tag(self, name: str, description: Optional[str], tag_metadata: Dict, tag_type: str) -> Tag:
         """
         Create a tag with a given name.
         """
         new_tag = Tag(
             dj_client=self,
-            name=tag,
+            name=name,
+            description=description,
             tag_type=tag_type,
             tag_metadata=tag_metadata,
         )

--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -9,6 +9,7 @@ from alive_progress import alive_bar
 from datajunction import _internal, models
 from datajunction.exceptions import DJClientException
 from datajunction.nodes import Cube, Dimension, Metric, Source, Transform
+from datajunction.tags import Tag
 
 
 class DJClient(_internal.DJClient):
@@ -365,5 +366,17 @@ class DJClient(_internal.DJClient):
             **node_dict,
             metrics=metrics,
             dimensions=dimensions,
+            dj_client=self,
+        )
+
+    def tag(self, tag_name: str) -> "Tag":  # pragma: no cover
+        """
+        Retrieves a Tag with that name if one exists.
+        """
+        tag_dict = self._get_tag(tag_name)
+        if "name" not in tag_dict:
+            raise DJClientException(f"Tag `{tag_name}` does not exist")
+        return Tag(
+            **tag_dict,
             dj_client=self,
         )

--- a/datajunction-clients/python/datajunction/exceptions.py
+++ b/datajunction-clients/python/datajunction/exceptions.py
@@ -14,6 +14,16 @@ class DJNamespaceAlreadyExists(DJClientException):
     """
 
 
+class DJTagAlreadyExists(DJClientException):
+    """
+    Raised when a tag to be created already exists.
+    """
+
+    def __init__(self, tag_name: str, *args) -> None:
+        self.message = f"Tag `{tag_name}` already exists."
+        super().__init__(self.message, *args)
+
+
 class DJNodeAlreadyExists(DJClientException):
     """
     Raised when a node to be created already exists.

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -99,6 +99,15 @@ class UpdateNode(BaseModel):
     limit: Optional[int]
 
 
+class UpdateTag(BaseModel):
+    """
+    Model for a tag update
+    """
+
+    description: str
+    tag_metadata: dict
+
+
 class QueryState(str, enum.Enum):
     """
     Different states of a query.
@@ -118,16 +127,6 @@ class QueryState(str, enum.Enum):
         List of available query states as strings
         """
         return list(map(lambda c: c.value, cls))  # type: ignore
-
-
-class Tag(BaseModel):
-    """
-    Node tags
-    """
-
-    name: str
-    display_name: str
-    tag_type: str
 
 
 class AvailabilityState(BaseModel):

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -105,7 +105,7 @@ class UpdateTag(BaseModel):
     """
 
     description: str
-    tag_metadata: dict
+    tag_metadata: Optional[Dict]
 
 
 class QueryState(str, enum.Enum):

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -9,6 +9,7 @@ from pydantic import validator
 from datajunction import models
 from datajunction._internal import ClientEntity
 from datajunction.exceptions import DJClientException
+from datajunction.tags import Tag
 
 
 class Namespace(ClientEntity):  # pylint: disable=protected-access
@@ -69,7 +70,7 @@ class Node(ClientEntity):  # pylint: disable=protected-access
     status: Optional[str] = None
     display_name: Optional[str]
     availability: Optional[models.AvailabilityState]
-    tags: Optional[List[models.Tag]]
+    tags: Optional[List[Tag]]
     primary_key: Optional[List[str]]
     materializations: Optional[List[Dict[str, Any]]]
     version: Optional[str]

--- a/datajunction-clients/python/datajunction/tags.py
+++ b/datajunction-clients/python/datajunction/tags.py
@@ -1,0 +1,64 @@
+"""
+Models related to tags
+"""
+# pylint: disable=protected-access
+from typing import Dict, Optional
+
+from datajunction._internal import ClientEntity
+from datajunction.exceptions import DJClientException
+from datajunction.models import UpdateTag
+
+
+class Tag(ClientEntity):
+    """
+    Node tags
+    """
+
+    name: str
+    description: str = ""
+    tag_type: str
+    tag_metadata: Optional[Dict] = None
+
+    def _update(self) -> "Tag":
+        """
+        Update the tag for fields that have changed
+        """
+        update_tag = UpdateTag(
+            description=self.description,
+            tag_metadata=self.tag_metadata,
+        )
+        return self.dj_client._update_tag(self.name, update_tag)
+
+    def save(self) -> dict:
+        """
+        Saves the tag to DJ, whether it existed before or not.
+        """
+        existing_tag = self.dj_client._get_tag(tag_name=self.name)
+        if "name" in existing_tag:
+            # update
+            response = self._update()
+            if not response.ok:  # pragma: no cover
+                raise DJClientException(
+                    f"Error updating tag `{self.name}`: {response.text}",
+                )
+            self.refresh()
+        else:
+            # create
+            response = self.dj_client._create_tag(
+                tag=self,
+            )  # pragma: no cover
+            if not response.ok:  # pragma: no cover
+                raise DJClientException(
+                    f"Error creating new tag `{self.name}`: {response.text}",
+                )
+        return response.json()
+
+    def refresh(self):
+        """
+        Refreshes a tag with its latest version from the database.
+        """
+        refreshed_tag = self.dj_client._get_tag(self.name)
+        for key, value in refreshed_tag.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+        return self

--- a/datajunction-clients/python/dj.project.schema.json
+++ b/datajunction-clients/python/dj.project.schema.json
@@ -29,9 +29,10 @@
     },
     "tags": {
       "title": "Tags",
+      "default": [],
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Tag"
+        "$ref": "#/definitions/TagYAML"
       }
     },
     "mode": {
@@ -63,27 +64,31 @@
         }
       }
     },
-    "Tag": {
-      "title": "Tag",
-      "description": "Node tags",
+    "TagYAML": {
+      "title": "TagYAML",
+      "description": "YAML representation of a tag",
       "type": "object",
       "properties": {
         "name": {
           "title": "Name",
           "type": "string"
         },
-        "display_name": {
-          "title": "Display Name",
+        "description": {
+          "title": "Description",
+          "default": "",
           "type": "string"
         },
         "tag_type": {
           "title": "Tag Type",
           "type": "string"
+        },
+        "tag_metadata": {
+          "title": "Tag Metadata",
+          "type": "object"
         }
       },
       "required": [
         "name",
-        "display_name",
         "tag_type"
       ]
     },

--- a/datajunction-clients/python/tests/examples/project1/dj.yaml
+++ b/datajunction-clients/python/tests/examples/project1/dj.yaml
@@ -1,6 +1,10 @@
 name: My DJ Project 1
 prefix: projects.project1
 mode: published
+tags:
+  - name: deprecated
+    description: This node is deprecated
+    tag_type: Maintenance
 build:
   priority:
     - roads.date

--- a/datajunction-clients/python/tests/test_compile.py
+++ b/datajunction-clients/python/tests/test_compile.py
@@ -21,6 +21,7 @@ def test_compile_loading_a_project(change_to_project_dir: Callable):
     project = Project.load_current()
     assert project.name == "My DJ Project 1"
     assert project.prefix == "projects.project1"
+    assert project.tags[0].name == "deprecated"
     assert project.build.priority == [
         "roads.date",
         "roads.date_dim",
@@ -50,6 +51,7 @@ def test_compile_loading_a_project_from_a_nested_dir(change_to_project_dir: Call
     project = Project.load_current()
     assert project.name == "My DJ Project 1"
     assert project.prefix == "projects.project1"
+    assert project.tags[0].name == "deprecated"
     assert project.build.priority == [
         "roads.date",
         "roads.date_dim",

--- a/notebooks/Loading a Local Project.ipynb
+++ b/notebooks/Loading a Local Project.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7d74fec0-8ef7-4bd6-bb93-7d56ef1f7974",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "8ac90215-a081-43b8-89c0-992727979509",
    "metadata": {},
    "outputs": [],
@@ -27,101 +27,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "88cb4ca7-d0fb-470e-b642-a2ac7dfcf5e0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34ef6db2f5104200978260832ee9920c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "compiled_project.validate(client=dj)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "7b1ee788-afa2-46b9-b6d4-610633c2f1eb",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bd7cec7770344a54858d7ef7d1e3c83f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "compiled_project.deploy(client=dj)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2d95d910-5042-43ad-a530-cee7f17318f9",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/Loading a Local Project.ipynb
+++ b/notebooks/Loading a Local Project.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7d74fec0-8ef7-4bd6-bb93-7d56ef1f7974",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datajunction import DJBuilder, Project\n",
+    "from datajunction._internal import RequestsSessionWithEndpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8ac90215-a081-43b8-89c0-992727979509",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session = RequestsSessionWithEndpoint(endpoint=\"http://localhost:8000\")\n",
+    "session.post(\"/basic/login/\", data={\"username\": \"dj\", \"password\": \"dj\"})\n",
+    "dj = DJBuilder(requests_session=session)\n",
+    "project = Project.load_current()\n",
+    "compiled_project = project.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "88cb4ca7-d0fb-470e-b642-a2ac7dfcf5e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "34ef6db2f5104200978260832ee9920c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "compiled_project.validate(client=dj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7b1ee788-afa2-46b9-b6d4-610633c2f1eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bd7cec7770344a54858d7ef7d1e3c83f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "compiled_project.deploy(client=dj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d95d910-5042-43ad-a530-cee7f17318f9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Summary

This adds some logic to the python client for creating and pulling tags and then uses that logic to enable tags to be created from YAML projects. Added the below section to the python client readme:

---
### Tags

You can read existing tags as well as create new ones.
```python
djbuilder.tag(name="deprecated", description="This node has been deprecated.", tag_type="standard", tag_metadata={"contact": "Foo Bar"})

Tag(dj_client=..., name='deprecated', description='This node has been deprecated.', tag_type='standard', tag_metadata={"contact": "Foo Bar"})
```
```python
djbuilder.tag("official")

[DJClientException]: Tag `official` does not exist.
```

To create a tag:

```python
djbuilder.create_tag(name="deprecated", description="This node has been deprecated.", tag_type="standard", tag_metadata={"contact": "Foo Bar"})

Tag(dj_client=..., name="deprecated", description="This node has been deprecated.", tag_type="standard", tag_metadata={"contact": "Foo Bar"})
```
---

### Test Plan

Updated some existing tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
