### PR TITLE
Use an enum for semantic type

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -13,7 +13,7 @@ from datajunction_server.construction.utils import to_namespaced_name
 from datajunction_server.errors import DJException, DJInvalidInputException
 from datajunction_server.internal.engines import get_engine
 from datajunction_server.models import User, access
-from datajunction_server.models.column import Column
+from datajunction_server.models.column import Column, SemanticType
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import GenericCubeConfig
 from datajunction_server.models.metric import TranslatedSQL
@@ -949,11 +949,11 @@ def build_metric_nodes(
                         col.set_semantic_entity(
                             metric_node.name + SEPARATOR + metric_node.columns[0].name,
                         )
-                        col.set_semantic_type("metric")
+                        col.set_semantic_type(SemanticType.METRIC)
                 metric_columns.append(col)
             else:
                 col.set_semantic_entity(from_amenable_name(col.alias_or_name.name))
-                col.set_semantic_type("dimension")
+                col.set_semantic_type(SemanticType.DIMENSION)
                 dimension_columns.append(col)
 
         all_dimension_columns += dimension_columns
@@ -1316,10 +1316,10 @@ def get_measures_query(
             column_identifier = expr.alias_or_name.identifier(False)  # type: ignore
             if from_amenable_name(column_identifier) in dimensions:
                 dimensional_columns.append(expr)
-                expr.set_semantic_type("dimension")  # type: ignore
+                expr.set_semantic_type(SemanticType.DIMENSION)  # type: ignore
             else:
                 measure_columns.append(expr)
-                expr.set_semantic_type("measure")  # type: ignore
+                expr.set_semantic_type(SemanticType.MEASURE)  # type: ignore
         parent_ast.compile(context)
 
         # Add the WITH statements to the combined query

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -9,6 +9,7 @@ from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build import get_measures_query
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models import NodeRevision, access
+from datajunction_server.models.column import SemanticType
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.sql.parsing import ast
@@ -114,7 +115,7 @@ def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-
                 name=col.name.name,  # type: ignore
                 type=str(types_lookup.get(col.name.name)),  # type: ignore
                 semantic_entity=from_amenable_name(col.name.name),  # type: ignore
-                semantic_type="dimension",
+                semantic_type=SemanticType.DIMENSION,
             )
             if col.name.name in types_lookup  # type: ignore
             else ColumnMetadata(name="count", type=str(IntegerType()))

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -15,6 +15,7 @@ from datajunction_server.materialization.jobs import (
     TrinoMaterializationJob,
 )
 from datajunction_server.models import Engine, NodeRevision, access
+from datajunction_server.models.column import SemanticType
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import (
     DruidCubeConfig,
@@ -69,7 +70,7 @@ def rewrite_metrics_expressions(
     measures_to_output_columns_lookup = {
         column.semantic_entity: column.name
         for column in measures_query.columns  # type: ignore # pylint: disable=not-an-iterable
-        if column.semantic_type == "measure"
+        if column.semantic_type == SemanticType.MEASURE
     }
     for metric in current_revision.cube_metrics():
         measures_for_metric = []
@@ -144,7 +145,7 @@ def build_cube_materialization_config(
             dimensions=[
                 col.name
                 for col in measures_query.columns  # type: ignore # pylint: disable=not-an-iterable
-                if col.semantic_type == "dimension"
+                if col.semantic_type == SemanticType.DIMENSION
             ],
             measures=metrics_expressions,
             spark=upsert.config.spark,

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -1,6 +1,7 @@
 """
 Models for columns.
 """
+import enum
 from typing import TYPE_CHECKING, List, Optional, Tuple, TypedDict
 
 from pydantic import root_validator
@@ -188,3 +189,13 @@ class ColumnAttributeInput(BaseSQLModel):
     attribute_type_namespace: Optional[str] = "system"
     attribute_type_name: str
     column_name: str
+
+
+class SemanticType(str, enum.Enum):
+    """
+    Semantic type of a column
+    """
+
+    MEASURE = "measure"
+    METRIC = "metric"
+    DIMENSION = "dimension"

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -29,6 +29,7 @@ from sqlmodel import Session
 
 from datajunction_server.construction.utils import get_dj_node, to_namespaced_name
 from datajunction_server.errors import DJError, DJErrorException, DJException, ErrorCode
+from datajunction_server.models.column import SemanticType
 from datajunction_server.models.node import BuildCriteria
 from datajunction_server.models.node import NodeRevision
 from datajunction_server.models.node import NodeRevision as DJNode
@@ -491,7 +492,7 @@ class Aliasable(Node):
     alias: Optional["Name"] = None
     as_: Optional[bool] = None
     semantic_entity: Optional[str] = None
-    semantic_type: Optional[str] = None
+    semantic_type: Optional[SemanticType] = None
 
     def set_alias(self: TNode, alias: Optional["Name"]) -> TNode:
         self.alias = alias
@@ -505,7 +506,7 @@ class Aliasable(Node):
         self.semantic_entity = semantic_entity
         return self
 
-    def set_semantic_type(self: TNode, semantic_type: str) -> TNode:
+    def set_semantic_type(self: TNode, semantic_type: SemanticType) -> TNode:
         self.semantic_type = semantic_type
         return self
 


### PR DESCRIPTION
### Summary

Mostly just code cleanup -- instead of returning a string for the `semantic_type` column property, this creates a `SemanticType` enum for all the valid values and sets the type of the property to be the enum. 

### Test Plan

Ran unit tests to check that 

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
