### PR TITLE
Fix python client create_source call to not use `schema_`

### DIFF
--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -105,7 +105,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         self,
         name: str,
         catalog: str,
-        schema_: str,
+        schema: str,
         table: str,
         description: Optional[str] = None,
         display_name: Optional[str] = None,
@@ -125,7 +125,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
             tags=tags,
             primary_key=primary_key,
             catalog=catalog,
-            schema_=schema_,
+            schema_=schema,
             table=table,
             columns=columns,
         )

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -269,7 +269,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             description="A source table for account type data",
             display_name="Default: Account Type Table",
             catalog="default",
-            schema_="store",
+            schema="store",
             table="account_type_table",
             columns=[
                 Column(name="id", type="int"),
@@ -296,7 +296,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             description="A source table for account type data",
             display_name="Default: Account Type Table",
             catalog="default",
-            schema_="store",
+            schema="store",
             table="account_type_table",
             columns=[
                 Column(name="id", type="int"),
@@ -314,7 +314,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             description="A source table for payment type data",
             display_name="Default: Payment Type Table",
             catalog="default",
-            schema_="store",
+            schema="store",
             table="payment_type_table",
             columns=[
                 Column(name="id", type="int"),
@@ -331,7 +331,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             description="Record of payments",
             display_name="Default: Payment Records",
             catalog="default",
-            schema_="accounting",
+            schema="accounting",
             table="revenue",
             columns=[
                 Column(name="payment_id", type="int"),
@@ -352,7 +352,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
                 description="Record of payments",
                 display_name="Default: Payment Records",
                 catalog="default",
-                schema_="accounting",
+                schema="accounting",
                 table="revenue",
                 columns=[
                     Column(name="payment_id", type="int"),

--- a/datajunction-clients/python/tests/test_integration.py
+++ b/datajunction-clients/python/tests/test_integration.py
@@ -34,7 +34,7 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
         name=f"{namespace}.repair_orders",
         description="Repair orders",
         catalog="warehouse",
-        schema_="roads",
+        schema="roads",
         table="repair_orders",
         columns=[
             {"name": "repair_order_id", "type": "int"},
@@ -51,7 +51,7 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
         name=f"{namespace}.repair_order_details",
         description="Details on repair orders",
         display_name="Default: Repair Order Details",
-        schema_="roads",
+        schema="roads",
         catalog="warehouse",
         table="repair_order_details",
         columns=[
@@ -115,7 +115,7 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
         name=f"{namespace}.dispatchers",
         description="Different third party dispatcher companies that coordinate repairs",
         catalog="warehouse",
-        schema_="roads",
+        schema="roads",
         table="dispatchers",
         columns=[
             {"name": "dispatcher_id", "type": "int"},


### PR DESCRIPTION
### Summary

Replace `schema_` with `schema` in the Python client's `create_source` method. This makes it less confusing for users who might not anticipate `schema_`, which we use to get around Pydantic's restricted field names.

### Test Plan

Tested locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
