### PR TITLE
Add explicit deps in client + display name to yaml import/export

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -108,7 +108,8 @@ class RequestsSessionWithEndpoint(requests.Session):  # pragma: no cover
             error_message = None
             if not exc.response:
                 error_message = str(exc)
-            if exc.response.headers.get("Content-Type") == "application/json":
+                print(error_message)
+            if exc.response and exc.response.headers.get("Content-Type") == "application/json":
                 error_message = exc.response.json().get("message")
             if not error_message:
                 error_message = (

--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -109,7 +109,10 @@ class RequestsSessionWithEndpoint(requests.Session):  # pragma: no cover
             if not exc.response:
                 error_message = str(exc)
                 print(error_message)
-            if exc.response and exc.response.headers.get("Content-Type") == "application/json":
+            if (
+                exc.response
+                and exc.response.headers.get("Content-Type") == "application/json"
+            ):
                 error_message = exc.response.json().get("message")
             if not error_message:
                 error_message = (

--- a/datajunction-clients/python/datajunction/compile.py
+++ b/datajunction-clients/python/datajunction/compile.py
@@ -52,25 +52,25 @@ def str_presenter(dumper, data):
 yaml.add_representer(str, str_presenter)
 
 
-def _parent_dir(path: Path):
+def _parent_dir(path: Union[str, Path]):
     """
     Returns the parent directory
     """
     return os.path.dirname(path)
 
 
-def _conf_exists(path: Path):
+def _conf_exists(path: Union[str, Path]):
     """
     Returns True if a config exists in the Path
     """
     return os.path.isfile(os.path.join(path, CONFIG_FILENAME))
 
 
-def find_project_root(dir: Optional[str] = None):
+def find_project_root(directory: Optional[str] = None):
     """
     Returns the project root, identified by a root config file
     """
-    checked_dir = dir or os.getcwd()
+    checked_dir = directory or os.getcwd()
     while not _conf_exists(checked_dir):
         checked_dir = _parent_dir(checked_dir)
         if checked_dir == "/" and not _conf_exists(checked_dir):
@@ -419,11 +419,11 @@ class Project(BaseModel):
     mode: NodeMode = NodeMode.PUBLISHED
 
     @classmethod
-    def load_current(cls, dir: Optional[str] = None):
+    def load_current(cls, directory: Optional[str] = None):
         """
         Return's the nearest project configuration
         """
-        root = find_project_root(dir)
+        root = find_project_root(directory)
         config_file_path = os.path.join(root, CONFIG_FILENAME)
         with open(config_file_path, encoding="utf-8") as f_config:
             config = parse_yaml_raw_as(cls, f_config)
@@ -794,7 +794,7 @@ def get_name_from_path(repository: Path, path: Path) -> str:
 async def load_data(
     repository: Path,
     path: Path,
-) -> NodeConfig:
+) -> Optional[NodeConfig]:
     """
     Load data from a YAML file.
     """
@@ -819,10 +819,7 @@ async def load_data(
                 definition=definition,
                 path=str(path),
             )
-    # raise DJClientException(
-    #     "Definition file stem must end with .source, "
-    #     f".transform, .dimension, .metric, or .cube: {path}",
-    # )
+    return None
 
 
 def load_node_configs_notebook_safe(repository: Path, priority: List[str]):

--- a/datajunction-clients/python/datajunction/compile.py
+++ b/datajunction-clients/python/datajunction/compile.py
@@ -847,7 +847,7 @@ def load_node_configs_notebook_safe(repository: Path, priority: List[str]):
 async def load_node_configs(
     repository: Path,
     priority: List[str],
-) -> List[NodeYAML]:
+) -> List[Optional[NodeConfig]]:
     """
     Load all configs from a repository.
     """

--- a/datajunction-clients/python/datajunction/compile.py
+++ b/datajunction-clients/python/datajunction/compile.py
@@ -419,7 +419,14 @@ class Project(BaseModel):
     mode: NodeMode = NodeMode.PUBLISHED
 
     @classmethod
-    def load_current(cls, directory: Optional[str] = None):
+    def load_current(cls):
+        """
+        Return's the nearest project configuration
+        """
+        return cls.load()
+
+    @classmethod
+    def load(cls, directory: Optional[str] = None):
         """
         Return's the nearest project configuration
         """

--- a/datajunction-clients/python/pdm.lock
+++ b/datajunction-clients/python/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "pandas", "test"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:bb158bf0838da7ed1175d2cf54e156f7570190ac02d0be628bfa9863ab0e510c"
+content_hash = "sha256:06f2a110bb231bb3e02b1eb4421ece9be25fbef019ac2f870cf59b4d639f9a42"
 
 [[package]]
 name = "about-time"
@@ -2055,38 +2055,48 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0"
+version = "6.0.1"
 requires_python = ">=3.6"
 summary = "YAML parser and emitter for Python"
 files = [
-    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
-    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
-    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
-    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
-    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
-    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
-    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
-    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
-    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
-    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
-    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
-    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
+    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
 ]
 
 [[package]]
@@ -2150,7 +2160,7 @@ files = [
 
 [[package]]
 name = "rich"
-version = "13.4.2"
+version = "13.7.0"
 requires_python = ">=3.7.0"
 summary = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 dependencies = [
@@ -2159,8 +2169,8 @@ dependencies = [
     "typing-extensions<5.0,>=4.0.0; python_version < \"3.9\"",
 ]
 files = [
-    {file = "rich-13.4.2-py3-none-any.whl", hash = "sha256:8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec"},
-    {file = "rich-13.4.2.tar.gz", hash = "sha256:d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898"},
+    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
+    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
 ]
 
 [[package]]

--- a/datajunction-clients/python/pyproject.toml
+++ b/datajunction-clients/python/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "alive-progress>=3.1.2",
     "pydantic-yaml>=1.2.0",
     "fastapi-cache2>=0.2.1",
+    "pyyaml>=6.0.1",
+    "rich>=13.7.0",
 ]
 requires-python = ">=3.8,<4.0"
 readme = "README.md"

--- a/datajunction-clients/python/tests/examples/project1/roads/avg_length_of_employment.metric.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/avg_length_of_employment.metric.yaml
@@ -1,2 +1,3 @@
 description: Average length of employment
 query: SELECT avg(NOW() - hire_date) FROM ${prefix}roads.hard_hats
+display_name: Avg Length of Employment

--- a/datajunction-clients/python/tests/examples/project1/roads/avg_repair_price.metric.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/avg_repair_price.metric.yaml
@@ -1,2 +1,3 @@
 description: Average repair price
 query: SELECT avg(price) FROM ${prefix}roads.repair_order_details
+display_name: Avg Repair Price

--- a/datajunction-clients/python/tests/examples/project1/roads/avg_time_to_dispatch.metric.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/avg_time_to_dispatch.metric.yaml
@@ -1,2 +1,3 @@
 description: Average time to dispatch a repair order
 query: SELECT avg(dispatched_date - order_date) FROM ${prefix}roads.repair_orders
+display_name: Avg Time to Dispatch Repair Order

--- a/datajunction-clients/python/tests/examples/project1/roads/contractor.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/contractor.dimension.yaml
@@ -13,3 +13,4 @@ query: |
   FROM ${prefix}roads.contractors
 primary_key:
   - contractor_id
+display_name: Contractor

--- a/datajunction-clients/python/tests/examples/project1/roads/contractors.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/contractors.source.yaml
@@ -19,3 +19,4 @@ columns:
     type: string
   - name: country
     type: string
+display_name: default.roads.contractors

--- a/datajunction-clients/python/tests/examples/project1/roads/date.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/date.source.yaml
@@ -9,3 +9,4 @@ columns:
     type: int
   - name: day
     type: int
+display_name: default.roads.date

--- a/datajunction-clients/python/tests/examples/project1/roads/date_dim.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/date_dim.dimension.yaml
@@ -8,3 +8,4 @@ query: |
   FROM ${prefix}roads.date
 primary_key:
   - dateint
+display_name: Date

--- a/datajunction-clients/python/tests/examples/project1/roads/dispatcher.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/dispatcher.dimension.yaml
@@ -7,3 +7,4 @@ query: |
   FROM ${prefix}roads.dispatchers
 primary_key:
   - dispatcher_id
+display_name: Dispatcher

--- a/datajunction-clients/python/tests/examples/project1/roads/dispatchers.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/dispatchers.source.yaml
@@ -7,3 +7,4 @@ columns:
     type: string
   - name: phone
     type: string
+display_name: default.roads.dispatchers

--- a/datajunction-clients/python/tests/examples/project1/roads/hard_hat.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/hard_hat.dimension.yaml
@@ -27,3 +27,4 @@ dimension_links:
   hire_date:
     dimension: ${prefix}roads.date_dim
     column: dateint
+display_name: Hard Hat

--- a/datajunction-clients/python/tests/examples/project1/roads/hard_hat_state.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/hard_hat_state.source.yaml
@@ -5,3 +5,4 @@ columns:
     type: int
   - name: state_id
     type: string
+display_name: default.roads.hard_hat_state

--- a/datajunction-clients/python/tests/examples/project1/roads/hard_hats.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/hard_hats.source.yaml
@@ -27,3 +27,4 @@ columns:
     type: int
   - name: contractor_id
     type: int
+display_name: default.roads.hard_hats

--- a/datajunction-clients/python/tests/examples/project1/roads/local_hard_hats.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/local_hard_hats.dimension.yaml
@@ -25,3 +25,4 @@ dimension_links:
   state_id:
     dimension: ${prefix}roads.us_state
     column: state_abbr
+display_name: Local Hard Hats

--- a/datajunction-clients/python/tests/examples/project1/roads/municipality.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/municipality.source.yaml
@@ -13,3 +13,4 @@ columns:
     type: string
   - name: state_id
     type: int
+display_name: default.roads.municipality

--- a/datajunction-clients/python/tests/examples/project1/roads/municipality_dim.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/municipality_dim.dimension.yaml
@@ -15,3 +15,4 @@ query: |
   ON mmt.municipality_type_id = mt.municipality_type_desc
 primary_key:
   - municipality_id
+display_name: Municipality

--- a/datajunction-clients/python/tests/examples/project1/roads/municipality_municipality_type.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/municipality_municipality_type.source.yaml
@@ -5,3 +5,4 @@ columns:
     type: string
   - name: municipality_type_id
     type: string
+display_name: default.roads.municipality_municipality_type

--- a/datajunction-clients/python/tests/examples/project1/roads/municipality_type.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/municipality_type.source.yaml
@@ -5,3 +5,4 @@ columns:
     type: string
   - name: municipality_type_desc
     type: string
+display_name: default.roads.municipality_type

--- a/datajunction-clients/python/tests/examples/project1/roads/national_level_agg.transform.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/national_level_agg.transform.yaml
@@ -1,2 +1,3 @@
 description: National level aggregates
 query: SELECT SUM(rd.price * rd.quantity) AS total_amount_nationwide FROM ${prefix}roads.repair_order_details rd
+display_name: National Level Aggs

--- a/datajunction-clients/python/tests/examples/project1/roads/num_repair_orders.metric.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/num_repair_orders.metric.yaml
@@ -1,2 +1,3 @@
 description: Number of repair orders
 query: SELECT count(repair_order_id) FROM ${prefix}roads.repair_orders
+display_name: Num Repair Orders

--- a/datajunction-clients/python/tests/examples/project1/roads/regional_level_agg.transform.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/regional_level_agg.transform.yaml
@@ -1,4 +1,5 @@
 description: Regional-level aggregates
+display_name: Regional-level Aggs
 query: |
   SELECT
       usr.us_region_id,

--- a/datajunction-clients/python/tests/examples/project1/roads/regional_repair_efficiency.metric.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/regional_repair_efficiency.metric.yaml
@@ -14,3 +14,4 @@ query: |
   ${prefix}roads.regional_level_agg rm
   CROSS JOIN
   ${prefix}roads.national_level_agg na
+display_name: Regional Repair Efficiency

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_order.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_order.dimension.yaml
@@ -18,3 +18,4 @@ dimension_links:
   municipality_id:
     dimension: ${prefix}roads.municipality_dim
     column: municipality_id
+display_name: Repair Order Dim

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_order_details.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_order_details.source.yaml
@@ -15,3 +15,4 @@ dimension_links:
   repair_order_id:
     dimension: ${prefix}roads.repair_order
     column: repair_order_id
+display_name: default.roads.repair_order_details

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_order_transform.transform.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_order_transform.transform.yaml
@@ -7,3 +7,4 @@ query: |
     dispatcher_id
   FROM ${prefix}roads.repair_orders
   WHERE dispatcher_id IS NOT NULL
+display_name: Repair Order Transform

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_orders.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_orders.source.yaml
@@ -19,3 +19,4 @@ dimension_links:
   repair_order_id:
     dimension: ${prefix}roads.repair_order
     column: repair_order_id
+display_name: default.roads.repair_orders

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_type.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_type.source.yaml
@@ -11,3 +11,4 @@ dimension_links:
   contractor_id:
     dimension: ${prefix}roads.contractor
     column: contractor_id
+display_name: default.roads.repair_type

--- a/datajunction-clients/python/tests/examples/project1/roads/total_repair_cost.metric.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/total_repair_cost.metric.yaml
@@ -1,2 +1,3 @@
 description: Total repair cost
 query: SELECT sum(price) FROM ${prefix}roads.repair_order_details
+display_name: Total Repair Cost

--- a/datajunction-clients/python/tests/examples/project1/roads/total_repair_order_discounts.metric.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/total_repair_order_discounts.metric.yaml
@@ -1,2 +1,3 @@
 description: Total repair order discounts
 query: SELECT sum(price * discount) FROM ${prefix}roads.repair_order_details
+display_name: Total Repair Order Discounts

--- a/datajunction-clients/python/tests/examples/project1/roads/us_region.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/us_region.source.yaml
@@ -5,3 +5,4 @@ columns:
     type: int
   - name: us_region_description
     type: string
+display_name: default.roads.us_region

--- a/datajunction-clients/python/tests/examples/project1/roads/us_state.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/us_state.dimension.yaml
@@ -11,3 +11,4 @@ query: |
   ON s.state_region = r.us_region_description
 primary_key:
   - state_id
+display_name: US State

--- a/datajunction-clients/python/tests/examples/project1/roads/us_states.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/us_states.source.yaml
@@ -9,3 +9,4 @@ columns:
     type: string
   - name: state_region
     type: int
+display_name: default.roads.us_states

--- a/datajunction-clients/python/tests/test_compile.py
+++ b/datajunction-clients/python/tests/test_compile.py
@@ -207,12 +207,8 @@ def test_compile_raising_on_invalid_file_name(
     """
     change_to_project_dir("project3")
     project = Project.load_current()
-    with pytest.raises(DJClientException) as exc_info:
-        project.compile()
-    assert (
-        "Definition file stem must end with .source, .transform, "
-        ".dimension, .metric, or .cube"
-    ) in str(exc_info.value)
+    compiled_project = project.compile()
+    assert compiled_project.definitions == []
 
     change_to_project_dir("project5")
     project = Project.load_current()

--- a/datajunction-clients/python/tests/test_compile.py
+++ b/datajunction-clients/python/tests/test_compile.py
@@ -42,6 +42,35 @@ def test_compile_loading_a_project(change_to_project_dir: Callable):
     assert project.root_path.endswith("project1")
 
 
+def test_load_project_from_different_dir(change_to_project_dir: Callable):
+    """
+    Test loading a project
+    """
+    change_to_project_dir("./")
+    project = Project.load("./project1")
+    assert project.name == "My DJ Project 1"
+    assert project.prefix == "projects.project1"
+    assert project.tags[0].name == "deprecated"
+    assert project.build.priority == [
+        "roads.date",
+        "roads.date_dim",
+        "roads.repair_orders",
+        "roads.repair_order_transform",
+        "roads.repair_order_details",
+        "roads.contractors",
+        "roads.hard_hats",
+        "roads.hard_hat_state",
+        "roads.us_states",
+        "roads.us_region",
+        "roads.dispatchers",
+        "roads.municipality",
+        "roads.municipality_municipality_type",
+        "roads.municipality_type",
+    ]
+    assert project.mode == NodeMode.PUBLISHED
+    assert project.root_path.endswith("project1")
+
+
 def test_compile_loading_a_project_from_a_nested_dir(change_to_project_dir: Callable):
     """
     Test loading a project while in a nested directory

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -286,6 +286,7 @@ def _source_project_config(node: Node, namespace_requested: str) -> Dict:
     return {
         "filename": filename,
         "directory": directory,
+        "display_name": node.current.display_name,
         "description": node.current.description,
         "table": f"{node.current.catalog}.{node.current.schema_}.{node.current.table}",
         "columns": [
@@ -312,6 +313,7 @@ def _transform_project_config(node: Node, namespace_requested: str) -> Dict:
     return {
         "filename": filename,
         "directory": directory,
+        "display_name": node.current.display_name,
         "description": node.current.description,
         "query": node.current.query,
         "dimension_links": {
@@ -334,6 +336,7 @@ def _dimension_project_config(node: Node, namespace_requested: str) -> Dict:
     return {
         "filename": filename,
         "directory": directory,
+        "display_name": node.current.display_name,
         "description": node.current.description,
         "query": node.current.query,
         "primary_key": [pk.name for pk in node.current.primary_key()],
@@ -357,6 +360,7 @@ def _metric_project_config(node: Node, namespace_requested: str) -> Dict:
     return {
         "filename": filename,
         "directory": directory,
+        "display_name": node.current.display_name,
         "description": node.current.description,
         "query": node.current.query,
     }
@@ -382,6 +386,7 @@ def _cube_project_config(node: Node, namespace_requested: str) -> Dict:
     return {
         "filename": filename,
         "directory": directory,
+        "display_name": cube_revision.display_name,
         "description": cube_revision.description,
         "metrics": metrics,
         "dimensions": dimensions,

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -607,6 +607,7 @@ def test_export_namespaces(client_with_examples: TestClient):
         "/nodes/cube/",
         json={
             "name": "default.example_cube",
+            "display_name": "Example Cube",
             "description": "An example cube so that the export path is tested",
             "metrics": ["default.num_repair_orders"],
             "dimensions": ["default.hard_hat.city"],
@@ -618,7 +619,16 @@ def test_export_namespaces(client_with_examples: TestClient):
         "/namespaces/default/export/",
     )
     project_definition = response.json()
-    assert {d["filename"] for d in project_definition} == {
+    node_defs = {d["filename"]: d for d in project_definition}
+    assert node_defs["example_cube.cube.yaml"] == {
+        "description": "An example cube so that the export path is tested",
+        "dimensions": ["default.hard_hat.city"],
+        "directory": "",
+        "display_name": "Example Cube",
+        "filename": "example_cube.cube.yaml",
+        "metrics": ["default.num_repair_orders"],
+    }
+    assert set(node_defs.keys()) == {
         "repair_orders.source.yaml",
         "repair_order_details.source.yaml",
         "repair_type.source.yaml",


### PR DESCRIPTION
### Summary

* Adds explicit python client dependencies on `rich` and `pyyaml`
* Adds `display_name` to the yaml import/export functionality

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A

