### PR TITLE
Make node graph retrieval more efficient with recursive CTE

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -11,6 +11,7 @@ from datajunction_server.api.helpers import get_catalog_by_name, get_node_by_nam
 from datajunction_server.construction.dimensions import build_dimensions_from_cube_query
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import validate_access
+from datajunction_server.internal.nodes import get_cube_revision_metadata
 from datajunction_server.models import access
 from datajunction_server.models.cube import (
     CubeRevisionMetadata,
@@ -33,15 +34,14 @@ settings = get_settings()
 router = SecureAPIRouter(tags=["cubes"])
 
 
-@router.get("/cubes/{name}/", response_model=CubeRevisionMetadata, name="Get a Cube")
+@router.get("/cubes/{name}/", name="Get a Cube")
 def get_cube(
     name: str, *, session: Session = Depends(get_session)
 ) -> CubeRevisionMetadata:
     """
     Get information on a cube
     """
-    node = get_node_by_name(session=session, name=name, node_type=NodeType.CUBE)
-    return node.current
+    return get_cube_revision_metadata(session, name)
 
 
 @router.get("/cubes/{name}/dimensions/sql", name="Dimensions SQL for Cube")

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -43,7 +43,6 @@ from datajunction_server.models import (
     access,
 )
 from datajunction_server.models.attribute import RESERVED_ATTRIBUTE_NAMESPACE
-from datajunction_server.models.base import NodeColumns
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.history import (
     ActivityType,

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from http import HTTPStatus
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+from datajunction_server.models.base import NodeColumns
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.operators import is_
 from sqlmodel import Session, select
@@ -722,6 +723,7 @@ def validate_cube(  # pylint: disable=too-many-locals
         )
 
     validate_shared_dimensions(
+        session,
         metric_nodes,
         [dim.full_name() for dim in dimensions],
         [],

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -56,7 +56,6 @@ from datajunction_server.models.node import (
     Node,
     NodeMissingParents,
     NodeNamespace,
-    NodeRelationship,
     NodeRevision,
     NodeRevisionBase,
     NodeStatus,
@@ -64,7 +63,7 @@ from datajunction_server.models.node import (
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import ColumnMetadata, QueryWithResults
 from datajunction_server.service_clients import QueryServiceClient
-from datajunction_server.sql.dag import get_nodes_with_dimension
+from datajunction_server.sql.dag import get_downstream_nodes, get_nodes_with_dimension
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import SqlSyntaxError, parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
@@ -232,115 +231,6 @@ def get_query(  # pylint: disable=too-many-arguments
     )
     query_ast = rename_columns(query_ast, node.current)
     return query_ast
-
-
-def get_downstream_nodes(
-    session: Session,
-    node_name: str,
-    node_type: NodeType = None,
-) -> List[Node]:
-    """
-    Gets all downstream children of the given node, filterable by node type.
-    Uses a recursive CTE query to build out all descendants from the node.
-    """
-    node = get_node_by_name(session=session, name=node_name, include_inactive=True)
-
-    dag = (
-        select(
-            NodeRelationship.parent_id,
-            NodeRevision.node_id,
-        )
-        .where(NodeRelationship.parent_id == node.id)
-        .join(NodeRevision, NodeRelationship.child_id == NodeRevision.id)
-        .join(
-            Node,
-            (Node.id == NodeRevision.node_id)
-            & (Node.current_version == NodeRevision.version),
-        )
-    ).cte("dag", recursive=True)
-
-    paths = dag.union_all(
-        select(
-            dag.c.parent_id,
-            NodeRevision.node_id,
-        )
-        .join(NodeRelationship, dag.c.node_id == NodeRelationship.parent_id)
-        .join(NodeRevision, NodeRelationship.child_id == NodeRevision.id)
-        .join(Node, Node.id == NodeRevision.node_id),
-    )
-
-    statement = (
-        select(Node)
-        .join(paths, paths.c.node_id == Node.id)
-        .options(joinedload(Node.current))
-    )
-
-    results = session.exec(statement).unique().all()
-
-    return [
-        downstream
-        for downstream in results
-        if downstream.type == node_type or node_type is None
-    ]
-
-
-def get_upstream_nodes(
-    session: Session,
-    node_name: str,
-    node_type: NodeType = None,
-) -> List[Node]:
-    """
-    Gets all upstreams of the given node, filterable by node type.
-    Uses a recursive CTE query to build out all parents of the node.
-    """
-    node = get_node_by_name(
-        session=session,
-        name=node_name,
-        include_inactive=False,
-        with_current=True,
-    )
-
-    dag = (
-        select(
-            NodeRelationship.child_id,
-            NodeRevision.id,
-        )
-        .where(NodeRelationship.child_id == node.current.id)
-        .join(Node, NodeRelationship.parent_id == Node.id)
-        .join(
-            NodeRevision,
-            (Node.id == NodeRevision.node_id)
-            & (Node.current_version == NodeRevision.version),
-        )
-    ).cte("dag", recursive=True)
-
-    paths = dag.union_all(
-        select(
-            dag.c.child_id,
-            NodeRevision.id,
-        )
-        .join(NodeRelationship, dag.c.id == NodeRelationship.child_id)
-        .join(Node, NodeRelationship.parent_id == Node.id)
-        .join(
-            NodeRevision,
-            (Node.id == NodeRevision.node_id)
-            & (Node.current_version == NodeRevision.version),
-        ),
-    )
-
-    statement = (
-        select(NodeRevision)
-        .join(paths, paths.c.id == NodeRevision.id)
-        .options(joinedload(NodeRevision.node).joinedload(Node.current))
-    )
-
-    results = session.exec(statement).unique().all()
-
-    return [
-        upstream.node
-        for upstream in results
-        if upstream.type == node_type or node_type is None
-    ]
 
 
 def find_bound_dimensions(

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -14,7 +14,6 @@ from datetime import datetime
 from http import HTTPStatus
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from datajunction_server.models.base import NodeColumns
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.operators import is_
 from sqlmodel import Session, select
@@ -44,6 +43,7 @@ from datajunction_server.models import (
     access,
 )
 from datajunction_server.models.attribute import RESERVED_ATTRIBUTE_NAMESPACE
+from datajunction_server.models.base import NodeColumns
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.history import (
     ActivityType,

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -84,7 +84,7 @@ def get_a_metric(name: str, *, session: Session = Depends(get_session)) -> Metri
     Return a metric by name.
     """
     node = get_metric(session, name)
-    dims = get_shared_dimensions(session, [node])
+    dims = get_dimensions(session, node.current.parents[0])
     metric = Metric.parse_node(node, dims)
     return metric
 

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -24,7 +24,7 @@ from datajunction_server.models.node import (
     Node,
 )
 from datajunction_server.models.node_type import NodeType
-from datajunction_server.sql.dag import get_shared_dimensions, get_dimensions
+from datajunction_server.sql.dag import get_dimensions, get_shared_dimensions
 from datajunction_server.utils import get_current_user, get_session, get_settings
 
 settings = get_settings()

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -24,7 +24,7 @@ from datajunction_server.models.node import (
     Node,
 )
 from datajunction_server.models.node_type import NodeType
-from datajunction_server.sql.dag import get_shared_dimensions
+from datajunction_server.sql.dag import get_shared_dimensions, get_dimensions
 from datajunction_server.utils import get_current_user, get_session, get_settings
 
 settings = get_settings()
@@ -84,7 +84,8 @@ def get_a_metric(name: str, *, session: Session = Depends(get_session)) -> Metri
     Return a metric by name.
     """
     node = get_metric(session, name)
-    metric = Metric.parse_node(node)
+    dims = get_shared_dimensions(session, [node])
+    metric = Metric.parse_node(node, dims)
     return metric
 
 
@@ -127,4 +128,4 @@ async def get_common_dimensions(
 
     if errors:
         raise DJException(errors=errors)
-    return get_shared_dimensions(metric_nodes)
+    return get_shared_dimensions(session, metric_nodes)

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -318,6 +318,7 @@ def export_a_namespace(
     as well as a project definition file.
     """
     return get_project_config(
+        session=session,
         nodes=get_nodes_in_namespace_detailed(session, namespace),
         namespace_requested=namespace,
     )

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1005,7 +1005,13 @@ def list_node_dag(
     downstreams, and linked dimension nodes.
     """
     node = get_node_by_name(session, name)
-    dimension_nodes = get_dimensions(session, node, attributes=False)
+    dimension_nodes = (
+        get_dimensions(session, node.current.parents[0], attributes=False)
+        + node.current.parents
+        if node.type == NodeType.METRIC
+        else get_dimensions(session, node, attributes=False)
+    )
+    dimension_nodes += [node]
     downstreams = get_downstream_nodes(session, name)
     upstreams = get_upstream_nodes(session, name)
     return list(set(cast(List[Node], dimension_nodes) + downstreams + upstreams))  # type: ignore

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1005,7 +1005,7 @@ def list_node_dag(
     downstreams, and linked dimension nodes.
     """
     node = get_node_by_name(session, name)
-    dimension_nodes = get_dimensions(node, attributes=False)
+    dimension_nodes = get_dimensions(session, node, attributes=False)
     downstreams = get_downstream_nodes(session, name)
     upstreams = get_upstream_nodes(session, name)
     return list(set(cast(List[Node], dimension_nodes) + downstreams + upstreams))  # type: ignore
@@ -1023,7 +1023,7 @@ def list_all_dimension_attributes(
     List all available dimension attributes for the given node.
     """
     node = get_node_by_name(session, name)
-    return get_dimensions(node, attributes=True)
+    return get_dimensions(session, node, attributes=True)
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -793,6 +793,7 @@ def group_metrics_by_parent(
 
 
 def validate_shared_dimensions(
+    session: Session,
     metric_nodes: List[Node],
     dimensions: List[str],
     filters: List[str],
@@ -800,7 +801,9 @@ def validate_shared_dimensions(
     """
     Determine if dimensions are shared.
     """
-    shared_dimensions = [dim.name for dim in get_shared_dimensions(metric_nodes)]
+    shared_dimensions = [
+        dim.name for dim in get_shared_dimensions(session, metric_nodes)
+    ]
     for dimension_attribute in dimensions:
         if dimension_attribute not in shared_dimensions:
             raise DJInvalidInputException(
@@ -854,7 +857,7 @@ def build_metric_nodes(
             "of them aren't metric nodes.",
         )
 
-    validate_shared_dimensions(metric_nodes, dimensions, filters)
+    validate_shared_dimensions(session, metric_nodes, dimensions, filters)
 
     combined_ast: ast.Query = ast.Query(
         select=ast.Select(from_=ast.From(relations=[])),

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -15,8 +15,8 @@ from datajunction_server.errors import (
     DJException,
     DJInvalidInputException,
 )
+from datajunction_server.internal.nodes import get_cube_revision_metadata
 from datajunction_server.models import History, User
-from datajunction_server.models.cube import CubeRevisionMetadata
 from datajunction_server.models.history import ActivityType, EntityType
 from datajunction_server.models.node import Node, NodeNamespace, NodeRevision
 from datajunction_server.models.node_type import NodeType
@@ -362,7 +362,11 @@ def _metric_project_config(node: Node, namespace_requested: str) -> Dict:
     }
 
 
-def _cube_project_config(node: Node, namespace_requested: str) -> Dict:
+def _cube_project_config(
+    session: Session,
+    node: Node,
+    namespace_requested: str,
+) -> Dict:
     """
     Returns a project config definition for a cube node
     """
@@ -371,7 +375,7 @@ def _cube_project_config(node: Node, namespace_requested: str) -> Dict:
         node_type=NodeType.CUBE,
         namespace_requested=namespace_requested,
     )
-    cube_revision = CubeRevisionMetadata.from_orm(node.current)
+    cube_revision = get_cube_revision_metadata(session, node.name)
     metrics = []
     dimensions = []
     for element in cube_revision.cube_elements:
@@ -388,7 +392,11 @@ def _cube_project_config(node: Node, namespace_requested: str) -> Dict:
     }
 
 
-def get_project_config(nodes: List[Node], namespace_requested: str) -> List[Dict]:
+def get_project_config(
+    session: Session,
+    nodes: List[Node],
+    namespace_requested: str,
+) -> List[Dict]:
     """
     Returns a project config definition
     """
@@ -425,6 +433,7 @@ def get_project_config(nodes: List[Node], namespace_requested: str) -> List[Dict
         else:
             project_components.append(
                 _cube_project_config(
+                    session=session,
                     node=node,
                     namespace_requested=namespace_requested,
                 ),

--- a/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
@@ -120,7 +120,7 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
                 ),
                 ctes=query_ast.ctes,
             )
-        print("QUERY!!!", str(final_query))
+
         result = query_service_client.materialize(
             GenericMaterializationInput(
                 name=materialization.name,  # type: ignore

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -126,7 +126,7 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         """
         Whether this column is considered dimensional
         """
-        return (
+        return (  # pragma: no cover
             self.has_dimension_attribute()
             or self.has_primary_key_attribute()
             or self.dimension
@@ -136,7 +136,7 @@ class Column(BaseSQLModel, table=True):  # type: ignore
         """
         Whether the dimension attribute is set on this column.
         """
-        return self.has_attribute("dimension")
+        return self.has_attribute("dimension")  # pragma: no cover
 
     def has_primary_key_attribute(self) -> bool:
         """

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -5,11 +5,16 @@ Models for cubes.
 from typing import List, Optional
 
 from pydantic import Field, root_validator
+from pydantic.main import BaseModel
 from sqlmodel import SQLModel
 
 from datajunction_server.models.base import BaseSQLModel
 from datajunction_server.models.materialization import MaterializationConfigOutput
-from datajunction_server.models.node import AvailabilityState, ColumnOutput
+from datajunction_server.models.node import (
+    AttributeOutput,
+    AvailabilityState,
+    NodeNameOutput,
+)
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionOutput
 from datajunction_server.typing import UTCDatetime
@@ -41,7 +46,20 @@ class CubeElementMetadata(SQLModel):
         return values
 
 
-class CubeRevisionMetadata(SQLModel):
+class CubeColumnOutput(BaseModel):
+    """
+    A simplified column schema, without ID or dimensions.
+    """
+
+    name: str
+    display_name: Optional[str]
+    type: str
+    attributes: Optional[List[AttributeOutput]]
+    dimension: Optional[NodeNameOutput]
+    partition: Optional[PartitionOutput]
+
+
+class CubeRevisionMetadata(BaseSQLModel):
     """
     Metadata for a cube node
     """
@@ -55,8 +73,8 @@ class CubeRevisionMetadata(SQLModel):
     description: str = ""
     availability: Optional[AvailabilityState] = None
     cube_elements: List[CubeElementMetadata]
-    query: str
-    columns: List[ColumnOutput]
+    query: Optional[str]
+    columns: List[CubeColumnOutput]
     updated_at: UTCDatetime
     materializations: List[MaterializationConfigOutput]
 

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -13,7 +13,6 @@ from datajunction_server.models.node import (
     Node,
 )
 from datajunction_server.models.query import ColumnMetadata
-from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.transpilation import get_transpilation_plugin
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import get_settings

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -39,7 +39,7 @@ class Metric(SQLModel):
     metric_metadata: Optional[MetricMetadataOutput] = None
 
     @classmethod
-    def parse_node(cls, node: Node) -> "Metric":
+    def parse_node(cls, node: Node, dims: List[DimensionAttributeOutput]) -> "Metric":
         """
         Parses a node into a metric.
         """
@@ -49,7 +49,7 @@ class Metric(SQLModel):
             description=node.current.description,
             updated_at=node.current.updated_at,
             query=node.current.query,
-            dimensions=get_dimensions(node),
+            dimensions=dims,
             metric_metadata=node.current.metric_metadata,
         )
 

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -836,11 +836,9 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         Returns the primary key columns of this node.
         """
         primary_key_columns = []
-        print("START self.columns")
         for col in self.columns:  # pylint: disable=not-an-iterable
             if col.has_primary_key_attribute():
                 primary_key_columns.append(col)
-        print("END self.columns")
         return primary_key_columns
 
     @staticmethod

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -836,9 +836,11 @@ class NodeRevision(NodeRevisionBase, table=True):  # type: ignore
         Returns the primary key columns of this node.
         """
         primary_key_columns = []
+        print("START self.columns")
         for col in self.columns:  # pylint: disable=not-an-iterable
             if col.has_primary_key_attribute():
                 primary_key_columns.append(col)
+        print("END self.columns")
         return primary_key_columns
 
     @staticmethod

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -144,13 +144,18 @@ def get_dimensions_dag(
     # Otherwise return the dimension attributes, which include both the dimension
     # attributes on the dimension nodes in the DAG as well as the local dimension
     # attributes on the initial node
+    group_concat = (
+        func.group_concat
+        if session.bind.dialect.name in ("sqlite",)
+        else func.string_agg
+    )
     final_query = (
         select(
             paths.c.node_name,
             paths.c.node_display_name,
             column.name,
             column.type,
-            func.group_concat(AttributeType.name).label(
+            group_concat(AttributeType.name, ",").label(
                 "column_attribute_type_name",
             ),
             paths.c.join_path,
@@ -177,7 +182,7 @@ def get_dimensions_dag(
                 NodeRevision.display_name,
                 Column.name,
                 Column.type,
-                func.group_concat(AttributeType.name).label(
+                group_concat(AttributeType.name, ",").label(
                     "column_attribute_type_name",
                 ),
                 literal("").label("join_path"),

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -78,7 +78,6 @@ def get_dimensions_dag(
         .where(initial_node.id == node_revision.id)
     ).cte("dimensions_graph", recursive=True)
 
-    # dag = dimensions_graph.alias("dag")
     paths = dimensions_graph.union_all(
         select(
             [
@@ -127,9 +126,10 @@ def get_dimensions_dag(
         ),
     )
 
-    # Final SELECT statement
+    # Final SELECT statements
+    # ----
+    # If attributes was set to False, we only need to return the dimension nodes
     if not attributes:
-        # Only the dimension nodes are needed here
         return (
             session.exec(
                 select(Node)
@@ -141,7 +141,9 @@ def get_dimensions_dag(
             .all()
         )
 
-    # Otherwise return the dimension attributes
+    # Otherwise return the dimension attributes, which include both the dimension
+    # attributes on the dimension nodes in the DAG as well as the local dimension
+    # attributes on the initial node
     final_query = (
         select(
             paths.c.node_name,

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -61,7 +61,6 @@ def get_engine() -> Engine:
     engine = create_engine(
         settings.index,
         pool_pre_ping=True,
-        echo=True,
     )
 
     return engine

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -58,7 +58,10 @@ def get_engine() -> Engine:
     Create the metadata engine.
     """
     settings = get_settings()
-    engine = create_engine(settings.index)
+    engine = create_engine(
+        settings.index,
+        pool_pre_ping=True,
+    )
 
     return engine
 

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -52,12 +52,13 @@ def get_settings() -> Settings:
     return Settings()
 
 
+@lru_cache(maxsize=None)
 def get_engine() -> Engine:
     """
     Create the metadata engine.
     """
     settings = get_settings()
-    engine = create_engine(settings.index)
+    engine = create_engine(settings.index, echo=True)
 
     return engine
 

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -61,6 +61,7 @@ def get_engine() -> Engine:
     engine = create_engine(
         settings.index,
         pool_pre_ping=True,
+        echo=True,
     )
 
     return engine

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -58,7 +58,7 @@ def get_engine() -> Engine:
     Create the metadata engine.
     """
     settings = get_settings()
-    engine = create_engine(settings.index, echo=True)
+    engine = create_engine(settings.index)
 
     return engine
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -11,7 +11,6 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from datajunction_server.api.helpers import get_upstream_nodes
 from datajunction_server.internal.materializations import decompose_expression
 from datajunction_server.models import Database, Table
 from datajunction_server.models.column import Column
@@ -24,6 +23,7 @@ from datajunction_server.models.node import (
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionBackfill
 from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.sql.dag import get_upstream_nodes
 from datajunction_server.sql.parsing import ast, types
 from datajunction_server.sql.parsing.types import IntegerType, StringType, TimestampType
 from tests.sql.utils import compare_query_strings

--- a/datajunction-server/tests/sql/dag_test.py
+++ b/datajunction-server/tests/sql/dag_test.py
@@ -2,6 +2,8 @@
 Tests for ``datajunction_server.sql.dag``.
 """
 
+from sqlmodel import Session
+
 from datajunction_server.models.column import Column
 from datajunction_server.models.database import Database
 from datajunction_server.models.node import (
@@ -15,15 +17,17 @@ from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.sql.parsing.types import IntegerType, StringType
 
 
-def test_get_dimensions() -> None:
+def test_get_dimensions(session: Session) -> None:
     """
     Test ``get_dimensions``.
     """
     database = Database(id=1, name="one", URI="sqlite://")
+    session.add(database)
 
     dimension_ref = Node(name="B", type=NodeType.DIMENSION, current_version="1")
     dimension = NodeRevision(
         node=dimension_ref,
+        display_name="B",
         version="1",
         tables=[
             Table(
@@ -41,10 +45,13 @@ def test_get_dimensions() -> None:
         ],
     )
     dimension_ref.current = dimension
+    session.add(dimension)
+    session.add(dimension_ref)
 
     parent_ref = Node(name="A", current_version="1")
     parent = NodeRevision(
         node=parent_ref,
+        display_name="A",
         version="1",
         tables=[
             Table(
@@ -62,40 +69,38 @@ def test_get_dimensions() -> None:
         ],
     )
     parent_ref.current = parent
+    session.add(parent)
+    session.add(parent_ref)
 
     child_ref = Node(name="C", current_version="1", type=NodeType.METRIC)
     child = NodeRevision(
         node=child_ref,
+        display_name="C",
         version="1",
         query="SELECT COUNT(*) FROM A",
         parents=[parent_ref],
         type=NodeType.METRIC,
     )
     child_ref.current = child
+    session.add(child)
+    session.add(child_ref)
+    session.commit()
 
-    assert get_dimensions(child_ref) == [
+    assert get_dimensions(session, child_ref) == [
         DimensionAttributeOutput(
-            name="A.b_id",
-            node_name=None,
-            node_display_name=None,
+            name="B.attribute",
+            node_name="B",
+            node_display_name="B",
             is_primary_key=False,
-            type="int",
+            type="string",
             path=[],
         ),
         DimensionAttributeOutput(
-            name="B.attribute",
-            node_name=None,
-            node_display_name=None,
-            is_primary_key=False,
-            type="string",
-            path=["b_id"],
-        ),
-        DimensionAttributeOutput(
             name="B.id",
-            node_name=None,
-            node_display_name=None,
+            node_name="B",
+            node_display_name="B",
             is_primary_key=False,
             type="int",
-            path=["b_id"],
+            path=[],
         ),
     ]


### PR DESCRIPTION
### Summary

This change makes getting both node graphs (dimensions and data lineage) more efficient by switching from the current graph traversal approach to a single recursive CTE query. We are now able to get the full DAG for a node with three recursive CTE queries, defined in the following functions: `get_downstream_nodes`, `get_upstream_nodes`, and `get_dimensions`. 

The existing approach for getting the dimensions graph and upstream nodes causes us to issue dozens of calls to the database via retrieval of connected relational objects using the ORM for each layer of the graph traversal, which is inefficient. The new approach just retrieves all nodes in the graph through a single query. 

With this change the latency of the following endpoints drop significantly:
- `/metrics/common/dimensions` (one of the examples I tested with 30 metrics went from ~2s to <500ms)
- `/cubes/{name}`
- `/nodes/{name}/dag`
- `/nodes/{name}/upstreams`

For the dimensions graph CTE, this is the raw SQL query (which I started with and then translated to be SQLAlchemy-compatible):
```
WITH RECURSIVE dimensions_graph AS (
    SELECT
        initial_node.id AS path_start,
        c.name AS col_name,
        dimension_node.id AS path_end,
        initial_node.name || '.' || c.name || ',' || dimension_node.name AS join_path,
        dimension_node.name AS node_name,
        dimension_rev.id AS node_revision_id,
        dimension_rev.display_name AS node_display_name
    FROM noderevision initial_node
    JOIN nodecolumns nc ON initial_node.id = nc.node_id
    JOIN column c ON nc.column_id = c.id
    JOIN node dimension_node ON c.dimension_id = dimension_node.id
    JOIN noderevision dimension_rev 
    ON dimension_rev.version = dimension_node.current_version 
        AND dimension_rev.node_id = dimension_node.id
    WHERE initial_node.id=77

    UNION ALL

    SELECT
        ng.path_start,
        c.name AS col_name,
        next_node.id AS path_end,
        ng.join_path || '.' || c.name || ',' || next_node.name AS join_path,
        next_node.name AS node_name,
        next_rev.id AS node_revision_id,
        next_rev.display_name AS node_display_name
    FROM dimensions_graph ng
    JOIN node current_node ON ng.path_end = current_node.id
    JOIN noderevision current_rev ON current_rev.version = current_node.current_version AND current_rev.node_id = current_node.id
    JOIN nodecolumns current_columns ON current_columns.node_id = current_rev.id
    JOIN column c ON current_columns.column_id = c.id
    JOIN node next_node ON c.dimension_id = next_node.id
    JOIN noderevision next_rev ON next_rev.version = next_node.current_version AND next_rev.node_id=next_node.id
),
dims AS (
    SELECT * from dimensions_graph
)
SELECT 
    dims.node_name, 
    dims.node_revision_id, 
    dims.node_display_name,
    c.name,
    dims.join_path
FROM dims 
JOIN nodecolumns nc ON nc.node_id = dims.node_revision_id
JOIN column c ON nc.column_id = c.id
```

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #878 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
