### PR TITLE
Fix alembic migration autogenerate

### DIFF
--- a/datajunction-server/alembic/env.py
+++ b/datajunction-server/alembic/env.py
@@ -5,7 +5,7 @@ Environment for Alembic migrations.
 
 from logging.config import fileConfig
 
-from sqlmodel import create_engine
+from sqlalchemy import create_engine
 
 from alembic import context
 from datajunction_server.database import (
@@ -18,6 +18,7 @@ from datajunction_server.database import (
     History,
     Measure,
     Node,
+    NodeNamespace,
     NodeRevision,
     Partition,
     Table,

--- a/datajunction-server/alembic/script.py.mako
+++ b/datajunction-server/alembic/script.py.mako
@@ -8,7 +8,6 @@ Create Date: ${create_date}
 # pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
 
 import sqlalchemy as sa
-import sqlmodel
 from alembic import op
 ${imports if imports else ""}
 

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -31,7 +31,7 @@ class Settings(
     cors_origin_whitelist: List[str] = ["http://localhost:3000"]
 
     # SQLAlchemy URI for the metadata database.
-    index: str = "postgresql://dj:dj@postgres_metadata:5432/dj"
+    index: str = "postgresql+psycopg://dj:dj@postgres_metadata:5432/dj"
 
     # Directory where the repository lives. This should have 2 subdirectories, "nodes" and
     # "databases".

--- a/datajunction-server/datajunction_server/database/__init__.py
+++ b/datajunction-server/datajunction_server/database/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "Engine",
     "History",
     "Node",
+    "NodeNamespace",
     "NodeRevision",
     "Partition",
     "Table",
@@ -22,6 +23,7 @@ from datajunction_server.database.column import Column
 from datajunction_server.database.database import Database, Table
 from datajunction_server.database.engine import Engine
 from datajunction_server.database.measure import Measure
+from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.partition import Partition
 from datajunction_server.database.tag import Tag


### PR DESCRIPTION
### Summary

This PR fixes some remaining bits in our alembic setup that were using sqlmodel, namely:
* The migration script was using sqlmodel's `create_engine` and now uses the equivalent from `sqlalchemy`
* The autogenerated migration template had `import sqlmodel` in it
* `NodeNamespace` was not included in the default alembic migration models list

### Test Plan

Ran alembic migrations.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
