### PR TITLE
Improve error catching during a source node refresh.

### DIFF
--- a/.github/workflows/version-test.yml
+++ b/.github/workflows/version-test.yml
@@ -3,6 +3,16 @@ name: "PR update : Test matching versions"
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      # python
+      - datajunction-clients/python/__about__.py
+      - datajunction-server/datajunction_server/__about__.py
+      - datajunction-query/djqs/__about__.py
+      - datajunction-reflection/datajunction_reflection/__about__.py
+      # javascript
+      - datajunction-clients/javascript/package.json
+      - datajunction-ui/package.json
+      # java: TODO
 
 jobs:
   test:

--- a/.github/workflows/version-test.yml
+++ b/.github/workflows/version-test.yml
@@ -3,16 +3,6 @@ name: "PR update : Test matching versions"
 on:
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      # python
-      - datajunction-clients/python/__about__.py
-      - datajunction-server/datajunction_server/__about__.py
-      - datajunction-query/djqs/__about__.py
-      - datajunction-reflection/datajunction_reflection/__about__.py
-      # javascript
-      - datajunction-clients/javascript/package.json
-      - datajunction-ui/package.json
-      # java: TODO
 
 jobs:
   test:

--- a/datajunction-query/djqs/api/helpers.py
+++ b/datajunction-query/djqs/api/helpers.py
@@ -9,7 +9,7 @@ from sqlalchemy import inspect
 from sqlalchemy.exc import NoResultFound, NoSuchTableError, OperationalError
 from sqlmodel import Session, create_engine, select
 
-from djqs.exceptions import DJException
+from djqs.exceptions import DJException, DJTableNotFound
 from djqs.models.catalog import Catalog
 from djqs.models.engine import Engine
 
@@ -66,8 +66,9 @@ def get_columns(
             schema=schema,
         )
     except NoSuchTableError as exc:  # pylint: disable=broad-except
-        raise DJException(
+        raise DJTableNotFound(
             message=f"No such table `{table}` in schema `{schema}` in catalog `{catalog}`",
+            http_status_code=404,
         ) from exc
     except OperationalError as exc:
         if "unknown database" in str(exc):

--- a/datajunction-query/djqs/exceptions.py
+++ b/datajunction-query/djqs/exceptions.py
@@ -212,3 +212,9 @@ class DJInvalidTableRef(DJException):
     """
     Raised for invalid table values
     """
+
+
+class DJTableNotFound(DJException):
+    """
+    Raised for tables that cannot be found
+    """

--- a/datajunction-server/alembic/versions/2024_01_23_0617-c9cef8864ecb_add_missing_table_attribute_to_source_.py
+++ b/datajunction-server/alembic/versions/2024_01_23_0617-c9cef8864ecb_add_missing_table_attribute_to_source_.py
@@ -1,0 +1,31 @@
+"""Add missing_table attribute to source nodes.
+
+Revision ID: c9cef8864ecb
+Revises: 20f060b02772
+Create Date: 2024-01-23 06:17:10.054149+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c9cef8864ecb"
+down_revision = "20f060b02772"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing_table", sa.Boolean(), nullable=False, default=False),
+        )
+    op.execute("UPDATE node SET missing_table = False WHERE missing_table IS NULL")
+
+
+def downgrade():
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.drop_column("missing_table")

--- a/datajunction-server/alembic/versions/2024_01_23_1655-a8e22109be24_availability_state_s_valid_through_ts_.py
+++ b/datajunction-server/alembic/versions/2024_01_23_1655-a8e22109be24_availability_state_s_valid_through_ts_.py
@@ -1,7 +1,7 @@
 """Availability state's valid_through_ts should be bigint
 
 Revision ID: a8e22109be24
-Revises: 20f060b02772
+Revises: c9cef8864ecb
 Create Date: 2024-01-23 16:55:20.951715+00:00
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a8e22109be24"
-down_revision = "20f060b02772"
+down_revision = "c9cef8864ecb"
 branch_labels = None
 depends_on = None
 

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-arguments
 """
 Cube related APIs.
 """

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-arguments
 """
 Data related APIs.
 """

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-arguments
 """
 Node materialization related APIs.
 """

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-arguments
 """
 SQL related APIs.
 """

--- a/datajunction-server/datajunction_server/database/attributetype.py
+++ b/datajunction-server/datajunction_server/database/attributetype.py
@@ -33,7 +33,9 @@ class AttributeType(Base):  # pylint: disable=too-few-public-methods
         return hash(self.id)
 
 
-class ColumnAttribute(Base):  # pylint: disable=too-few-public-methods
+class ColumnAttribute(
+    Base,
+):  # pylint: disable=too-few-public-methods,unsubscriptable-object
     """
     Column attributes.
     """

--- a/datajunction-server/datajunction_server/database/metricmetadata.py
+++ b/datajunction-server/datajunction_server/database/metricmetadata.py
@@ -13,7 +13,9 @@ from datajunction_server.models.node import (
 )
 
 
-class MetricMetadata(Base):  # pylint: disable=too-few-public-methods
+class MetricMetadata(
+    Base,
+):  # pylint: disable=too-few-public-methods,unsubscriptable-object
     """
     Additional metric metadata
     """

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -203,6 +203,8 @@ class Node(Base):  # pylint: disable=too-few-public-methods
         secondaryjoin="TagNodeRelationship.tag_id==Tag.id",
     )
 
+    missing_table: Mapped[bool] = mapped_column(sa.Boolean, default=False)
+
     def __hash__(self) -> int:
         return hash(self.id)
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -842,6 +842,7 @@ def _create_node_from_inactive(
                 update_node.schema_ = data.schema_
                 update_node.table = data.table
                 update_node.columns = data.columns
+                update_node.missing_table = data.missing_table
 
             if isinstance(data, CreateNode):
                 update_node.query = data.query

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-arguments
 """Nodes endpoint helper functions"""
 import logging
 from collections import defaultdict, deque
@@ -385,7 +385,7 @@ def save_node(
     session.refresh(node.current)
 
 
-def update_any_node(  # pylint: disable=too-many-arguments
+def update_any_node(
     name: str,
     data: UpdateNode,
     session: Session,
@@ -801,7 +801,7 @@ def copy_existing_node_revision(old_revision: NodeRevision):
     )
 
 
-def _create_node_from_inactive(  # pylint: disable=too-many-arguments
+def _create_node_from_inactive(
     new_node_type: NodeType,
     data: Union[CreateSourceNode, CreateNode, CreateCubeNode],
     session: Session,
@@ -875,7 +875,7 @@ def _create_node_from_inactive(  # pylint: disable=too-many-arguments
     return None
 
 
-def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-many-arguments,too-many-branches
+def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-many-branches
     session: Session,
     old_revision: NodeRevision,
     node: Node,

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -618,6 +618,7 @@ class SourceNodeFields(BaseModel):
     schema_: str
     table: str
     columns: List["SourceColumnOutput"]
+    missing_table: bool = False
 
 
 class CubeNodeFields(BaseModel):
@@ -778,6 +779,7 @@ class NodeOutput(OutputModel):
     created_at: UTCDatetime
     tags: List[TagOutput] = []
     current_version: str
+    missing_table: Optional[bool] = False
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         orm_mode = True

--- a/datajunction-server/pdm.lock
+++ b/datajunction-server/pdm.lock
@@ -2,9 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "test", "uvicorn", "transpilation", "dev"]
-strategy = ["cross_platform"]
-lock_version = "4.4.1"
+groups = ["default", "test", "uvicorn", "transpilation"]
+cross_platform = true
+static_urls = false
+lock_version = "4.3"
 content_hash = "sha256:0faccdec9eb7f20da81bbab157d1d6dfaeb45539936b6a30fb194d7a94738256"
 
 [[package]]
@@ -2199,7 +2200,7 @@ version = "2.0.23"
 requires_python = ">=3.7"
 summary = "Database Abstraction Library"
 dependencies = [
-    "greenlet!=0.4.17; platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\"",
+    "greenlet!=0.4.17; platform_machine == \"aarch64\" or (platform_machine == \"ppc64le\" or (platform_machine == \"x86_64\" or (platform_machine == \"amd64\" or (platform_machine == \"AMD64\" or (platform_machine == \"win32\" or platform_machine == \"WIN32\")))))",
     "typing-extensions>=4.2.0",
 ]
 files = [
@@ -2432,7 +2433,7 @@ dependencies = [
     "python-dotenv>=0.13",
     "pyyaml>=5.1",
     "uvicorn==0.23.2",
-    "uvloop!=0.15.0,!=0.15.1,>=0.14.0; (sys_platform != \"cygwin\" and sys_platform != \"win32\") and platform_python_implementation != \"PyPy\"",
+    "uvloop!=0.15.0,!=0.15.1,>=0.14.0; sys_platform != \"win32\" and (sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\")",
     "watchfiles>=0.13",
     "websockets>=10.4",
 ]

--- a/datajunction-server/requirements/docker.txt
+++ b/datajunction-server/requirements/docker.txt
@@ -2,18 +2,13 @@
 # Please do not edit it manually.
 
 accept-types==0.4.1
-aiohttp==3.9.0; python_version >= "3.11"
-aiosignal==1.3.1; python_version >= "3.11"
 alembic==1.11.2
 amqp==5.1.1
 antlr4-python3-runtime==4.12.0
 anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
-astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
-attrs==23.1.0; python_version >= "3.11"
-backports-zoneinfo==0.2.1; python_version < "3.9"
+async-timeout==4.0.3
 bcrypt==4.0.1
 billiard==4.1.0
 cachelib==0.10.2
@@ -26,14 +21,12 @@ click==8.1.6
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
-colorama==0.4.6; sys_platform == "win32" or platform_system == "Windows"
 cryptography==41.0.3
 deprecated==1.2.14
 ecdsa==0.18.0
-exceptiongroup==1.1.3; python_version < "3.11"
+exceptiongroup==1.1.3
 fastapi==0.79.1
 fastapi-cache2==0.2.1
-frozenlist==1.4.0; python_version >= "3.11"
 google-api-core==2.12.0
 google-api-python-client==2.101.0
 google-auth==2.23.2
@@ -41,13 +34,11 @@ google-auth-httplib2==0.1.1
 google-auth-oauthlib==1.1.0
 googleapis-common-protos==1.60.0
 graphql-core==3.2.3
-greenlet==2.0.2; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 h11==0.14.0
 httplib2==0.22.0
 httptools==0.6.0
 idna==3.4
 importlib-metadata==6.8.0
-importlib-resources==6.0.1; python_version < "3.9"
 kombu==5.3.1
 line-profiler==4.0.3
 Mako==1.2.4
@@ -73,7 +64,7 @@ pyasn1-modules==0.3.0
 pycparser==2.21
 pydantic==1.10.13
 pygments==2.16.1
-pyparsing==3.1.1; python_version > "3.0"
+pyparsing==3.1.1
 python-dateutil==2.8.2
 python-dotenv==0.21.1
 python-jose==3.3.0
@@ -101,12 +92,11 @@ tzdata==2023.3
 uritemplate==4.1.1
 urllib3==1.26.16
 uvicorn==0.23.2
-uvloop==0.17.0; (sys_platform != "cygwin" and sys_platform != "win32") and platform_python_implementation != "PyPy"
+uvloop==0.17.0
 vine==5.0.0
 watchfiles==0.19.0
 wcwidth==0.2.6
 websockets==11.0.3
-wheel==0.41.1; python_version < "3.9"
 wrapt==1.15.0
 yarl==1.9.2
 zipp==3.16.2

--- a/datajunction-server/requirements/test.txt
+++ b/datajunction-server/requirements/test.txt
@@ -2,8 +2,6 @@
 # Please do not edit it manually.
 
 accept-types==0.4.1
-aiohttp==3.9.0; python_version >= "3.11"
-aiosignal==1.3.1; python_version >= "3.11"
 alembic==1.11.2
 amqp==5.1.1
 antlr4-python3-runtime==4.12.0
@@ -11,10 +9,7 @@ anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
 astroid==3.0.2
-astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
-attrs==23.1.0; python_version >= "3.11"
-backports-zoneinfo==0.2.1; python_version < "3.9"
+async-timeout==4.0.3
 bcrypt==4.0.1
 billiard==4.1.0
 cachelib==0.10.2
@@ -29,7 +24,6 @@ click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
 codespell==2.2.5
-colorama==0.4.6; sys_platform == "win32" or platform_system == "Windows"
 coverage==7.3.0
 cryptography==41.0.3
 deprecated==1.2.14
@@ -39,13 +33,12 @@ distlib==0.3.7
 docker==7.0.0
 duckdb==0.8.1
 ecdsa==0.18.0
-exceptiongroup==1.1.3; python_version < "3.11"
+exceptiongroup==1.1.3
 execnet==2.0.2
 fastapi==0.79.1
 fastapi-cache2==0.2.1
 filelock==3.12.2
 freezegun==1.2.2
-frozenlist==1.4.0; python_version >= "3.11"
 google-api-core==2.12.0
 google-api-python-client==2.101.0
 google-auth==2.23.2
@@ -53,13 +46,11 @@ google-auth-httplib2==0.1.1
 google-auth-oauthlib==1.1.0
 googleapis-common-protos==1.60.0
 graphql-core==3.2.3
-greenlet==2.0.2; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 h11==0.14.0
 httplib2==0.22.0
 identify==2.5.26
 idna==3.4
 importlib-metadata==6.8.0
-importlib-resources==6.0.1; python_version < "3.9"
 iniconfig==2.0.0
 isort==5.12.0
 kombu==5.3.1
@@ -94,7 +85,7 @@ pycparser==2.21
 pydantic==1.10.13
 pygments==2.16.1
 pylint==3.0.3
-pyparsing==3.1.1; python_version > "3.0"
+pyparsing==3.1.1
 pytest==7.4.0
 pytest-asyncio==0.21.1
 pytest-cov==4.1.0
@@ -106,7 +97,6 @@ python-dotenv==0.21.1
 python-jose==3.3.0
 python-multipart==0.0.6
 pytzdata==2020.1
-pywin32==306; sys_platform == "win32"
 pyyaml==6.0.1
 redis==4.6.0
 requests==2.29.0
@@ -124,7 +114,7 @@ sse-starlette==1.6.5
 starlette==0.19.1
 strawberry-graphql==0.204.0
 testcontainers==3.7.1
-tomli==2.0.1; python_version < "3.11"
+tomli==2.0.1
 tomlkit==0.12.1
 types-cachetools==5.3.0.6
 typing-extensions==4.7.1
@@ -135,7 +125,6 @@ uvicorn==0.23.2
 vine==5.0.0
 virtualenv==20.24.3
 wcwidth==0.2.6
-wheel==0.41.1; python_version < "3.9"
 wrapt==1.15.0
 yarl==1.9.2
 zipp==3.16.2

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1642,6 +1642,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert len(data["columns"]) == 8
         assert response.status_code == 201
         assert data["status"] == "valid"
+        assert data["missing_table"] is False
 
         response = custom_client.get("/history?node=default.repair_orders")
         history = response.json()
@@ -1662,7 +1663,8 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data_second["version"] == "v3.0"
         assert data_second["node_revision_id"] != data["node_revision_id"]
         assert len(data_second["columns"]) == 8
-        assert data_second["status"] == "invalid"
+        assert data_second["status"] == "valid"
+        assert data_second["missing_table"] is True
 
         # Refresh it again, but this time the table is missing
         mocker.patch.object(
@@ -1679,7 +1681,8 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data_third["version"] == "v4.0"
         assert data_third["node_revision_id"] != data_second["node_revision_id"]
         assert len(data_third["columns"]) == 8
-        assert data_third["status"] == "invalid"
+        assert data_third["status"] == "valid"
+        assert data_third["missing_table"] is True
 
         # Refresh it again, back to normal state
         mocker.patch.object(
@@ -1695,6 +1698,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data_fourth["node_revision_id"] != data_second["node_revision_id"]
         assert len(data_fourth["columns"]) == 8
         assert data_fourth["status"] == "valid"
+        assert data_fourth["missing_table"] is False
 
     def test_create_update_source_node(
         self,

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -658,13 +658,6 @@ CROSS JOIN
         ),
         {},
     ),
-    # (
-    #     (
-    #         "/nodes/default.repair_orders_fact/columns/order_date/"
-    #         "?dimension=default.date_dim"
-    #     ),
-    #     {},
-    # ),
     (
         (
             "/nodes/default.repair_order_details/columns/repair_order_id/"


### PR DESCRIPTION
### Summary

Our `get_columns_for_table` function was not checking for any errors from the query service calls so for cases when a table was deleted (or renamed) we would end up with source nodes that were valid but had not columns on it.

This PR does two things:
1. Checks for errors in the response from the query service.
2. Tries to catch the case of a missing table and separate it from the generic query service error. And in the former case it sets a missing_table attribute on the source node.
3. If there are any columns visible on the table and the node has a missing table = True, we set it back to False (the initial condition).

### Test Plan

Unit tests mostly.

- [ ] PR has an associated issue: #887 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a
