### PR TITLE
Fix two tag-related bugs

### DIFF
--- a/datajunction-server/datajunction_server/models/tag.py
+++ b/datajunction-server/datajunction_server/models/tag.py
@@ -15,7 +15,7 @@ class MutableTagFields(BaseModel):
     Tag fields that can be changed.
     """
 
-    description: str
+    description: Optional[str]
     display_name: Optional[str]
     tag_metadata: Optional[Dict[str, Any]] = {}
 

--- a/datajunction-server/tests/api/tags_test.py
+++ b/datajunction-server/tests/api/tags_test.py
@@ -58,9 +58,31 @@ class TestTags:
         assert response.status_code == 201
         assert response.json() == expected_tag_output
 
+        response = client.post(
+            "/tags/",
+            json={
+                "name": "sales_report2",
+                "display_name": "Sales Report2",
+                "tag_type": "group",
+            },
+        )
+        assert response.status_code == 201
+        expected_tag_output2 = {
+            "tag_metadata": {},
+            "display_name": "Sales Report2",
+            "description": None,
+            "name": "sales_report2",
+            "tag_type": "group",
+        }
+        assert response.json() == expected_tag_output2
+
         response = client.get("/tags/sales_report/")
         assert response.status_code == 200
         assert response.json() == expected_tag_output
+
+        response = client.get("/tags/sales_report2/")
+        assert response.status_code == 200
+        assert response.json() == expected_tag_output2
 
         # Check history
         response = client.get("/history/tag/sales_report/")

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
@@ -93,7 +93,7 @@ describe('AddEditNodePage submission failed', () => {
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalled();
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
         'default.num_repair_orders',
-        [{ display_name: 'Purpose', name: 'purpose' }],
+        ['purpose'],
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toReturnWith({
         json: { message: 'Some tags were not found' },

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -120,7 +120,7 @@ describe('AddEditNodePage submission succeeded', () => {
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
         'default.num_repair_orders',
-        [{ display_name: 'Purpose', name: 'purpose' }],
+        ['purpose'],
       );
 
       expect(mockDjClient.DataJunctionAPI.listMetricMetadata).toBeCalledTimes(

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -144,9 +144,11 @@ export function AddEditNodePage() {
       values.metric_direction,
       values.metric_unit,
     );
+
+    console.log("TAGS", values.tags);
     const tagsResponse = await djClient.tagsNode(
       values.name,
-      values.tags.map(tag => tag),
+      values.tags.map(tag => tag.name),
     );
     if ((status === 200 || status === 201) && tagsResponse.status === 200) {
       setStatus({

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -145,7 +145,6 @@ export function AddEditNodePage() {
       values.metric_unit,
     );
 
-    console.log("TAGS", values.tags);
     const tagsResponse = await djClient.tagsNode(
       values.name,
       values.tags.map(tag => tag.name),


### PR DESCRIPTION
### Summary

Fixes two tag-related bugs:
* Fix bug where tags cannot be edited on a node from the UI
* Fix bug where tags cannot be created without a description (it should be optional and not required)

### Test Plan

Tested locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

This fix should be deployed immediately 