### PR TITLE
Add support for using complex dimensions by role + Python client functionality for complex dims

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -405,13 +405,13 @@ class DJClient:
         role: Optional[str] = None,
     ):
         """
-        Helper function to link a dimension to the node.
+        Helper function to link a complex dimension to the node.
         """
         params = {
             "dimension_node": dimension_node,
             "join_type": join_type or "LEFT",
             "join_on": join_on,
-            "join_cardinality": join_cardinality or "one_to_one",
+            "join_cardinality": join_cardinality or "one_to_many",
             "role": role,
         }
         response = self._session.post(
@@ -445,7 +445,7 @@ class DJClient:
         role: Optional[str] = None,
     ):
         """
-        Helper function to link a dimension to the node.
+        Helper function to remove a complex dimension link.
         """
         response = self._session.delete(
             f"/nodes/{node_name}/link/",

--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -323,6 +323,36 @@ class DJClient:
         except DJClientException as exc:  # pragma: no cover
             return exc.__dict__
 
+    def _get_node_upstreams(self, node_name: str):
+        """
+        Retrieves a node's upstreams
+        """
+        try:
+            response = self._session.get(f"/nodes/{node_name}/upstream")
+            return response.json()
+        except DJClientException as exc:  # pragma: no cover
+            return exc.__dict__
+
+    def _get_node_downstreams(self, node_name: str):
+        """
+        Retrieves a node's downstreams
+        """
+        try:
+            response = self._session.get(f"/nodes/{node_name}/downstream")
+            return response.json()
+        except DJClientException as exc:  # pragma: no cover
+            return exc.__dict__
+
+    def _get_node_dimensions(self, node_name: str):
+        """
+        Retrieves a node's dimensions
+        """
+        try:
+            response = self._session.get(f"/nodes/{node_name}/dimensions")
+            return response.json()
+        except DJClientException as exc:  # pragma: no cover
+            return exc.__dict__
+
     def _get_cube(self, node_name: str):
         """
         Retrieves a Cube node.
@@ -364,6 +394,33 @@ class DJClient:
         )
         return response.json()
 
+    def _link_complex_dimension_to_node(  # pylint: disable=too-many-arguments
+        self,
+        node_name: str,
+        dimension_node: str,
+        join_type: Optional[str] = None,
+        *,
+        join_on: str,
+        join_cardinality: Optional[str] = None,
+        role: Optional[str] = None,
+    ):
+        """
+        Helper function to link a dimension to the node.
+        """
+        params = {
+            "dimension_node": dimension_node,
+            "join_type": join_type or "LEFT",
+            "join_on": join_on,
+            "join_cardinality": join_cardinality or "one_to_one",
+            "role": role,
+        }
+        response = self._session.post(
+            f"/nodes/{node_name}/link/",
+            timeout=self._timeout,
+            json=params,
+        )
+        return response.json()
+
     def _unlink_dimension_from_node(
         self,
         node_name: str,
@@ -378,6 +435,25 @@ class DJClient:
             f"/nodes/{node_name}/columns/{column_name}/"
             f"?dimension={dimension_name}&dimension_column={dimension_column}",
             timeout=self._timeout,
+        )
+        return response.json()
+
+    def _remove_complex_dimension_link(
+        self,
+        node_name: str,
+        dimension_node: str,
+        role: Optional[str] = None,
+    ):
+        """
+        Helper function to link a dimension to the node.
+        """
+        response = self._session.delete(
+            f"/nodes/{node_name}/link/",
+            timeout=self._timeout,
+            json={
+                "dimension_node": dimension_node,
+                "role": role,
+            },
         )
         return response.json()
 

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -366,13 +366,13 @@ class NodeWithQuery(Node):
         )
         return True
 
-    def upstreams(self) -> List[str]:
+    def get_upstreams(self) -> List[str]:
         """
         Lists the upstream nodes of this node
         """
         return [node["name"] for node in self.dj_client._get_node_upstreams(self.name)]
 
-    def downstreams(self) -> List[str]:
+    def get_downstreams(self) -> List[str]:
         """
         Lists the downstream nodes of this node
         """
@@ -380,7 +380,7 @@ class NodeWithQuery(Node):
             node["name"] for node in self.dj_client._get_node_downstreams(self.name)
         ]
 
-    def dimensions(self) -> List[str]:
+    def get_dimensions(self) -> List[str]:
         """
         Lists dimensions available for the node
         """

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -179,6 +179,29 @@ class Node(ClientEntity):  # pylint: disable=protected-access
         self.refresh()
         return link_response
 
+    def link_complex_dimension(  # pylint: disable=too-many-arguments
+        self,
+        dimension_node: str,
+        join_type: Optional[str] = None,
+        *,
+        join_on: str,
+        join_cardinality: Optional[str] = None,
+        role: Optional[str] = None,
+    ):
+        """
+        Links the dimension to this node via the specified join SQL.
+        """
+        link_response = self.dj_client._link_complex_dimension_to_node(
+            node_name=self.name,
+            dimension_node=dimension_node,
+            join_type=join_type,
+            join_on=join_on,
+            join_cardinality=join_cardinality,
+            role=role,
+        )
+        self.refresh()
+        return link_response
+
     def unlink_dimension(
         self,
         column: str,
@@ -196,6 +219,22 @@ class Node(ClientEntity):  # pylint: disable=protected-access
         )
         self.refresh()
         return link_response
+
+    def remove_complex_dimension_link(
+        self,
+        dimension_node: str,
+        role: Optional[str] = None,
+    ):
+        """
+        Removes a complex dimension link from this node
+        """
+        unlink_response = self.dj_client._remove_complex_dimension_link(
+            node_name=self.name,
+            dimension_node=dimension_node,
+            role=role,
+        )
+        self.refresh()
+        return unlink_response
 
     def add_materialization(self, config: models.Materialization):
         """
@@ -326,6 +365,26 @@ class NodeWithQuery(Node):
             models.UpdateNode(mode=models.NodeMode.PUBLISHED),
         )
         return True
+
+    def upstreams(self) -> List[str]:
+        """
+        Lists the upstream nodes of this node
+        """
+        return [node["name"] for node in self.dj_client._get_node_upstreams(self.name)]
+
+    def downstreams(self) -> List[str]:
+        """
+        Lists the downstream nodes of this node
+        """
+        return [
+            node["name"] for node in self.dj_client._get_node_downstreams(self.name)
+        ]
+
+    def dimensions(self) -> List[str]:
+        """
+        Lists dimensions available for the node
+        """
+        return self.dj_client._get_node_dimensions(self.name)
 
 
 class Transform(NodeWithQuery):

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -513,6 +513,33 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             "foo.bar.contractor has been successfully removed."
         )
 
+    def test_link_complex_dimension(self, client):
+        """
+        Check that linking complex dimensions to a node works as expected
+        """
+
+        repair_type = client.source("foo.bar.repair_type")
+        result = repair_type.link_complex_dimension(
+            dimension_node="foo.bar.contractor",
+            join_type="inner",
+            join_on="foo.bar.repair_type.contractor_id = foo.bar.contractor.contractor_id",
+            role="repair_contractor",
+        )
+        assert result["message"] == (
+            "Dimension node foo.bar.contractor has been "
+            "successfully linked to node foo.bar.repair_type."
+        )
+
+        # Unlink the dimension
+        result = repair_type.remove_complex_dimension_link(
+            dimension_node="foo.bar.contractor",
+            role="repair_contractor",
+        )
+        assert result["message"] == (
+            "Dimension link foo.bar.contractor (role repair_contractor) to "
+            "node foo.bar.repair_type has been removed."
+        )
+
     def test_sql(self, client):  # pylint: disable=unused-argument
         """
         Check that getting sql via the client works as expected.

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -388,17 +388,17 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         all work as expected
         """
         num_repair_orders = client.metric("default.num_repair_orders")
-        result = num_repair_orders.upstreams()
+        result = num_repair_orders.get_upstreams()
         assert result == ["default.repair_orders"]
-        result = num_repair_orders.downstreams()
+        result = num_repair_orders.get_downstreams()
         assert result == ["default.cube_two"]
-        result = num_repair_orders.dimensions()
+        result = num_repair_orders.get_dimensions()
         assert len(result) == 28
 
         hard_hat = client.dimension("default.hard_hat")
-        result = hard_hat.upstreams()
+        result = hard_hat.get_upstreams()
         assert result == ["default.hard_hats"]
-        result = hard_hat.downstreams()
+        result = hard_hat.get_downstreams()
         assert result == []
-        result = hard_hat.dimensions()
+        result = hard_hat.get_dimensions()
         assert len(result) == 18

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -381,3 +381,24 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             {"name": "spark", "version": "3.1.1"},
             {"name": "postgres", "version": "15.2"},
         ]
+
+    def test_get_dag(self, client):
+        """
+        Check that `node.upstreams()`, `node.downstreams()`, and `node.dimensions()`
+        all work as expected
+        """
+        num_repair_orders = client.metric("default.num_repair_orders")
+        result = num_repair_orders.upstreams()
+        assert result == ["default.repair_orders"]
+        result = num_repair_orders.downstreams()
+        assert result == ["default.cube_two"]
+        result = num_repair_orders.dimensions()
+        assert len(result) == 28
+
+        hard_hat = client.dimension("default.hard_hat")
+        result = hard_hat.upstreams()
+        assert result == ["default.hard_hats"]
+        result = hard_hat.downstreams()
+        assert result == []
+        result = hard_hat.dimensions()
+        assert len(result) == 18

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -867,7 +867,10 @@ def remove_complex_dimension_link(  # pylint: disable=too-many-locals
 
     # Delete the dimension link if one exists
     for link in node.current.dimension_links:
-        if link.dimension_id == dimension_node.id and link.role == link_identifier.role:
+        if (
+            link.dimension_id == dimension_node.id  # pragma: no cover
+            and link.role == link_identifier.role  # pragma: no cover
+        ):
             removed = True
             session.delete(link)
     if not removed:

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -573,7 +573,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 # dimension role to the column metadata
                 if isinstance(col.parent, ast.Subscript):
                     if isinstance(col.parent.index, ast.Lambda):
-                        col.role = str(col)
+                        col.role = str(col.parent.index)
                     else:
                         col.role = col.parent.index.identifier()  # type: ignore
                     col.parent.swap(col)

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -537,7 +537,10 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 # if the dimension has a role (encoded in its subscript), attach the
                 # dimension role to the column metadata
                 if isinstance(dim, ast.Subscript):
-                    dim.expr.role = dim.index.identifier()  # type: ignore
+                    if isinstance(dim.index, ast.Lambda):
+                        dim.expr.role = str(dim.index)
+                    else:
+                        dim.expr.role = dim.index.identifier()  # type: ignore
                     dim.swap(dim.expr)
 
             if include_dimensions_in_groupby:
@@ -569,7 +572,10 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 # if the dimension has a role (encoded in its subscript), attach the
                 # dimension role to the column metadata
                 if isinstance(col.parent, ast.Subscript):
-                    col.role = col.parent.index.identifier()  # type: ignore
+                    if isinstance(col.parent.index, ast.Lambda):
+                        col.role = str(col)
+                    else:
+                        col.role = col.parent.index.identifier()  # type: ignore
                     col.parent.swap(col)
 
                 if not dimensions:

--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -130,4 +130,4 @@ class Column(Base):  # type: ignore
         """
         Full column name that includes the node it belongs to, i.e., default.hard_hat.first_name
         """
-        return f"{self.node_revision().name}.{self.name}"  # type: ignore
+        return f"{self.node_revision().name}.{self.name}"  # type: ignore  # pragma: no cover

--- a/datajunction-server/datajunction_server/database/dimensionlink.py
+++ b/datajunction-server/datajunction_server/database/dimensionlink.py
@@ -71,4 +71,4 @@ class DimensionLink(Base):  # pylint: disable=too-few-public-methods
         for key, value in join_mapping.items():
             if key in join_type:
                 return value
-        return JoinType.LEFT
+        return JoinType.LEFT  # pragma: no cover

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -509,10 +509,25 @@ class NodeRevision(
             raise DJInvalidInputException(  # pragma: no cover
                 "Cannot retrieve dimensions for a non-cube node!",
             )
-        ordering = {col.name: col.order for col in self.columns}
+        dimension_to_roles_mapping = {
+            col.name: col.dimension_column for col in self.columns
+        }
+        ordering = {
+            col.name + (col.dimension_column or ""): col.order for col in self.columns
+        }
         return sorted(
             [
-                node_revision.name + SEPARATOR + element.name
+                node_revision.name
+                + SEPARATOR
+                + element.name
+                + (
+                    dimension_to_roles_mapping[
+                        node_revision.name + SEPARATOR + element.name
+                    ]
+                    if node_revision.name + SEPARATOR + element.name
+                    in dimension_to_roles_mapping
+                    else ""
+                )
                 for element, node_revision in self.cube_elements_with_nodes()
                 if node_revision and node_revision.type != NodeType.METRIC
             ],

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -13,6 +13,7 @@ from datajunction_server.api.helpers import (
     activate_node,
     get_attribute_type,
     get_node_by_name,
+    map_dimensions_to_roles,
     propagate_valid_status,
     resolve_downstream_references,
     validate_cube,
@@ -301,6 +302,7 @@ def create_cube_node_revision(  # pylint: disable=too-many-locals
     # Build the "columns" for this node based on the cube elements. These are used
     # for marking partition columns when the cube gets materialized.
     node_columns = []
+    dimension_to_roles_mapping = map_dimensions_to_roles(data.dimensions)
     for idx, col in enumerate(metric_columns + dimension_columns):
         referenced_node = col.node_revision()
         full_element_name = (
@@ -318,6 +320,9 @@ def create_cube_node_revision(  # pylint: disable=too-many-locals
             ],
             order=idx,
         )
+        if full_element_name in dimension_to_roles_mapping:
+            node_column.dimension_column = dimension_to_roles_mapping[full_element_name]
+
         node_columns.append(node_column)
 
     node_revision = NodeRevision(

--- a/datajunction-server/datajunction_server/models/dimensionlink.py
+++ b/datajunction-server/datajunction_server/models/dimensionlink.py
@@ -30,13 +30,23 @@ class JoinType(StrEnum):
     CROSS = "cross"
 
 
+class LinkDimensionIdentifier(BaseModel):
+    """
+    Input for linking a dimension to a node
+    """
+
+    dimension_node: str
+    role: Optional[str]
+
+
 class LinkDimensionInput(BaseModel):
     """
     Input for linking a dimension to a node
     """
 
     dimension_node: str
-    join_sql: str
+    join_type: Optional[JoinType] = JoinType.LEFT
+    join_on: str
     join_cardinality: Optional[JoinCardinality]
     role: Optional[str]
 
@@ -47,6 +57,7 @@ class LinkDimensionOutput(BaseModel):
     """
 
     dimension: NodeNameOutput
+    join_type: JoinType
     join_sql: str
     join_cardinality: Optional[JoinCardinality]
     role: Optional[str]

--- a/datajunction-server/datajunction_server/models/partition.py
+++ b/datajunction-server/datajunction_server/models/partition.py
@@ -101,3 +101,6 @@ class BackfillOutput(BaseModel):
 
     spec: Optional[PartitionBackfill]
     urls: Optional[List[str]]
+
+    class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
+        orm_mode = True

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -19,7 +19,7 @@ from datajunction_server.database.node import (
 )
 from datajunction_server.models.node import DimensionAttributeOutput
 from datajunction_server.models.node_type import NodeType
-from datajunction_server.utils import SEPARATOR, get_settings
+from datajunction_server.utils import get_settings
 
 settings = get_settings()
 
@@ -467,34 +467,6 @@ def get_dimensions(
             with_attributes,
         )
     return get_dimensions_dag(session, node.current, with_attributes)
-
-
-def check_convergence(path1: List[str], path2: List[str]) -> bool:
-    """
-    Determines whether two join paths converge before we reach the
-    final element, the dimension attribute.
-    """
-    if path1 == path2:
-        return True  # pragma: no cover
-    len1 = len(path1)
-    len2 = len(path2)
-    min_len = min(len1, len2)
-
-    for i in range(min_len):
-        partial1 = path1[len1 - i - 1 :]
-        partial2 = path2[len2 - i - 1 :]
-        if partial1 == partial2:
-            return True
-
-    # TODO: Once we introduce dimension roles, we can remove this.  # pylint: disable=fixme
-    # To workaround this for now, we're using column names as the effective role of the dimension
-    if (
-        path1
-        and path2
-        and path1[-1].split(SEPARATOR)[-1] == path2[-1].split(SEPARATOR)[-1]
-    ):
-        return True
-    return False  # pragma: no cover
 
 
 def group_dimensions_by_name(

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -215,13 +215,13 @@ def get_dimensions_dag(  # pylint: disable=too-many-locals
             select(
                 DimensionLink.node_revision_id,
                 DimensionLink.dimension_id,
-                func.concat(  # pylint: disable=not-callable
-                    literal("["),
-                    func.coalesce(  # pylint: disable=not-callable
+                (
+                    literal("[")
+                    + func.coalesce(  # pylint: disable=not-callable
                         DimensionLink.role,
                         literal(""),
-                    ),
-                    literal("]"),
+                    )
+                    + literal("]")
                 ).label("name"),
             ).select_from(DimensionLink),
         )

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -402,7 +402,8 @@ def get_dimensions_dag(  # pylint: disable=too-many-locals
             for path in join_path.split(",")
             if "[" in path  # this indicates that this a role
         ]
-        return f"[{'->'.join(roles)}]" if roles else ""
+        non_empty_roles = [role for role in roles if role]
+        return f"[{'->'.join(non_empty_roles)}]" if non_empty_roles else ""
 
     # Only include a given column it's an attribute on a dimension node or
     # if the column is tagged with the attribute type 'dimension'

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -551,16 +551,8 @@ def get_shared_dimensions(
         common_dim_keys = common.keys() & list(node_dimensions.keys())
         if not common_dim_keys:
             return []
-        for common_dim in common_dim_keys:
-            for existing_attr in common[common_dim]:
-                for new_attr in node_dimensions[common_dim]:
-                    converged = check_convergence(existing_attr.path, new_attr.path)
-                    if not converged:
-                        to_delete.add(common_dim)  # pragma: no cover
-
         for dim_key in to_delete:
             del common[dim_key]  # pragma: no cover
-
     return sorted(
         [y for x in common.values() for y in x],
         key=lambda x: (x.name, x.path),

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -953,7 +953,10 @@ class Column(Aliasable, Named, Expression):
                         ]
                         to_process.append(new_table)
                 for link in current_table.dj_node.dimension_links:
-                    if link.role == self.role:
+                    all_roles = []
+                    if self.role:
+                        all_roles = self.role.split(" -> ")
+                    if (not link.role and not all_roles) or (link.role in all_roles):
                         new_table = Table(
                             name=to_namespaced_name(link.dimension.name),
                             _dj_node=link.dimension,

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -492,42 +492,40 @@ GROUP BY default_DOT_users.user_id,
     )
 
     # Get SQL for the downstream metric grouped by the user's registration country
-
-
-#     response = dimensions_link_client.get(
-#         "/sql/default.elapsed_secs?"
-#         "dimensions=default.countries.name[user_direct->registration_country]"
-#         "&dimensions=default.users.snapshot_date[user_direct]"
-#         "&dimensions=default.users.registration_country[user_direct]",
-#     )
-#     query = response.json()["sql"]
-#     assert compare_query_strings(
-#         query,
-#         # pylint: disable=line-too-long
-#         """SELECT SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
-#   default_DOT_users.user_id default_DOT_users_DOT_user_id,
-#   default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
-#   default_DOT_users.registration_country default_DOT_users_DOT_registration_country
-# FROM (
-#     SELECT default_DOT_events_table.user_id,
-#       default_DOT_events_table.event_start_date,
-#       default_DOT_events_table.event_end_date,
-#       default_DOT_events_table.elapsed_secs
-#     FROM examples.events AS default_DOT_events_table
-#   ) AS default_DOT_events
-#   LEFT JOIN (
-#     SELECT default_DOT_users.user_id,
-#       default_DOT_users.snapshot_date,
-#       default_DOT_users.registration_country,
-#       default_DOT_users.residence_country,
-#       default_DOT_users.account_type
-#     FROM examples.users AS default_DOT_users
-#   ) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id
-#   AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
-# GROUP BY default_DOT_users.user_id,
-#   default_DOT_users.snapshot_date,
-#   default_DOT_users.registration_country""",
-#     )
+    response = dimensions_link_client.get(
+        "/sql/default.elapsed_secs?"
+        "dimensions=default.countries.name[user_direct->registration_country]"
+        "&dimensions=default.users.snapshot_date[user_direct]"
+        "&dimensions=default.users.registration_country[user_direct]",
+    )
+    query = response.json()["sql"]
+    print("query!!", query)
+    assert compare_query_strings(
+        query,
+        # pylint: disable=line-too-long
+        """SELECT  SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
+    default_DOT_countries.name default_DOT_countries_DOT_name,
+    default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+    default_DOT_users.registration_country default_DOT_users_DOT_registration_country
+ FROM (SELECT  default_DOT_events_table.user_id,
+    default_DOT_events_table.event_start_date,
+    default_DOT_events_table.event_end_date,
+    default_DOT_events_table.elapsed_secs
+ FROM examples.events AS default_DOT_events_table)
+ AS default_DOT_events INNER  JOIN (SELECT  default_DOT_countries.country_code,
+    default_DOT_countries.name,
+    default_DOT_countries.population
+ FROM examples.countries AS default_DOT_countries
+) default_DOT_countries ON default.users.registration_country = default_DOT_countries.country_code
+LEFT  JOIN (SELECT  default_DOT_users.user_id,
+    default_DOT_users.snapshot_date,
+    default_DOT_users.registration_country,
+    default_DOT_users.residence_country,
+    default_DOT_users.account_type
+ FROM examples.users AS default_DOT_users
+) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
+ GROUP BY  default_DOT_countries.name, default_DOT_users.snapshot_date, default_DOT_users.registration_country""",
+    )
 
 
 def test_remove_dimension_link(

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -1,26 +1,27 @@
 """Dimension linking related tests."""
-from unittest import mock
+from typing import Optional
 
 import pytest
+from requests import Response
 from starlette.testclient import TestClient
 
 from tests.conftest import post_and_raise_if_error
-from tests.examples import EXAMPLES
+from tests.examples import COMPLEX_DIMENSION_LINK, EXAMPLES, SERVICE_SETUP
 from tests.sql.utils import compare_query_strings
 
 
 @pytest.fixture
-def dimensions_link_client(client_with_roads: TestClient) -> TestClient:
+def dimensions_link_client(client: TestClient) -> TestClient:
     """
     Add dimension link examples to the roads test client.
     """
-    for endpoint, json in EXAMPLES["DIMENSION_LINK"]:
+    for endpoint, json in SERVICE_SETUP + COMPLEX_DIMENSION_LINK:
         post_and_raise_if_error(  # type: ignore
-            client=client_with_roads,
+            client=client,
             endpoint=endpoint,
             json=json,  # type: ignore
         )
-    return client_with_roads
+    return client
 
 
 def test_link_dimension_with_errors(
@@ -30,12 +31,10 @@ def test_link_dimension_with_errors(
     Test linking dimensions with errors
     """
     response = dimensions_link_client.post(
-        "/nodes/default.num_repair_orders/link",
+        "/nodes/default.elapsed_secs/link",
         json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.num_repair_orders A JOIN default.date_dim D ON A.x = D.y"
-            ),
+            "dimension_node": "default.users",
+            "join_on": ("default.elapsed_secs.x = default.users.y"),
             "join_cardinality": "many_to_one",
         },
     )
@@ -44,376 +43,355 @@ def test_link_dimension_with_errors(
         "dimension, or transform node."
     )
     response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
+        "/nodes/default.events/link",
         json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.regional_level_agg A JOIN default.regional_level_agg D "
-                "ON A.order_year = D.order_year"
-            ),
+            "dimension_node": "default.users",
+            "join_on": ("default.users.user_id = default.users.user_id"),
             "join_cardinality": "many_to_one",
         },
     )
     assert response.json()["message"] == (
-        "The join SQL provided does not reference both the origin node "
-        "default.regional_level_agg and the dimension node default.date_dim that "
-        "it's being joined to."
+        "The join SQL provided does not reference both the origin node default.events "
+        "and the dimension node default.users that it's being joined to."
     )
 
     response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
+        "/nodes/default.events/link",
         json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.regional_level_agg A JOIN default.date_dim D "
-                "ON A.order_year = D.year "
-                "AND A.order_month = D.month "
-                "AND A.order_day = D.daym"
+            "dimension_node": "default.users",
+            "join_on": ("default.events.order_year = default.users.year"),
+            "join_cardinality": "many_to_one",
+        },
+    )
+    assert (
+        response.json()["message"]
+        == "Join query default.events.order_year = default.users.year is not valid"
+    )
+
+
+@pytest.fixture
+def link_events_with_users(dimensions_link_client: TestClient):
+    """
+    Link events with the users dimension
+    """
+
+    def _link_events_with_users(role: Optional[str] = None) -> Response:
+        params = {
+            "dimension_node": "default.users",
+            "join_type": "left",
+            "join_on": (
+                "default.events.user_id = default.users.user_id "
+                "AND default.events.event_start_date = default.users.snapshot_date"
             ),
-            "join_cardinality": "many_to_one",
-        },
-    )
-    assert response.json()["message"] == "Column D.daym does not exist on node"
+            "join_cardinality": "one_to_one",
+        }
+        if role:
+            params["role"] = role
+        response = dimensions_link_client.post(
+            "/nodes/default.events/link",
+            json=params,
+        )
+        return response
 
-    response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
-        json={
-            "dimension_node": "default.date_dim",
-            "join_sql": ("default.regional_level_agg A"),
-            "join_cardinality": "many_to_one",
-        },
-    )
-    assert response.json()["message"] == (
-        "Provided SQL `default.regional_level_agg A` does not contain JOIN clause"
-    )
+    return _link_events_with_users
 
 
-def test_link_dimension_success(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+def test_link_complex_dimension_without_role(
+    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name,
+    link_events_with_users,
 ):
     """
-    Test linking dimensions (with join SQL) successfully
+    Test linking complex dimension without role
     """
-    response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
-        json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.regional_level_agg A LEFT JOIN default.date_dim D "
-                "ON A.order_year = D.year "
-                "AND A.order_month = D.month "
-                "AND A.order_day = D.day"
-            ),
-            "join_cardinality": "many_to_one",
-        },
-    )
+    response = link_events_with_users(role=None)
     assert response.json() == {
-        "message": "Dimension node default.date_dim has been successfully linked to "
-        "node default.regional_level_agg.",
+        "message": "Dimension node default.users has been successfully "
+        "linked to node default.events.",
     }
 
-    response = dimensions_link_client.get("/nodes/default.regional_level_agg")
+    response = dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"] == [
         {
-            "dimension": {"name": "default.date_dim"},
-            "join_cardinality": "many_to_one",
-            "join_sql": "default.regional_level_agg A LEFT JOIN default.date_dim D ON "
-            "A.order_year = D.year AND A.order_month = D.month AND "
-            "A.order_day = D.day",
+            "dimension": {"name": "default.users"},
+            "join_cardinality": "one_to_one",
+            "join_sql": "default.events.user_id = default.users.user_id "
+            "AND default.events.event_start_date = default.users.snapshot_date",
+            "join_type": "left",
             "role": None,
         },
     ]
 
     # Update dimension link
     response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
+        "/nodes/default.events/link",
         json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.regional_level_agg A JOIN default.date_dim D "
-                "ON A.order_year = D.year "
-                "AND A.order_month = D.month"
+            "dimension_node": "default.users",
+            "join_type": "left",
+            "join_on": (
+                "default.events.user_id = default.users.user_id "
+                "AND default.events.event_end_date = default.users.snapshot_date"
             ),
-            "join_cardinality": "many_to_one",
+            "join_cardinality": "one_to_many",
         },
     )
     assert response.json() == {
-        "message": "The dimension link between default.regional_level_agg and "
-        "default.date_dim has been successfully updated.",
+        "message": "The dimension link between default.events and "
+        "default.users has been successfully updated.",
     }
 
-    response = dimensions_link_client.get("/history?node=default.regional_level_agg")
-    assert [entry for entry in response.json() if entry["entity_type"] == "link"] == [
-        {
-            "activity_type": "create",
-            "created_at": mock.ANY,
-            "details": {
-                "dimension": "default.date_dim",
-                "join_cardinality": "many_to_one",
-                "join_sql": "default.regional_level_agg A LEFT JOIN default.date_dim "
-                "D ON A.order_year = D.year AND A.order_month = "
-                "D.month AND A.order_day = D.day",
+    response = dimensions_link_client.get("/history?node=default.events")
+    assert [
+        (entry["activity_type"], entry["details"])
+        for entry in response.json()
+        if entry["entity_type"] == "link"
+    ] == [
+        (
+            "create",
+            {
+                "dimension": "default.users",
+                "join_cardinality": "one_to_one",
+                "join_sql": "default.events.user_id = default.users.user_id AND "
+                "default.events.event_start_date = default.users.snapshot_date",
                 "role": None,
             },
-            "entity_name": "default.regional_level_agg",
-            "entity_type": "link",
-            "id": mock.ANY,
-            "node": "default.regional_level_agg",
-            "post": {},
-            "pre": {},
-            "user": mock.ANY,
-        },
-        {
-            "activity_type": "update",
-            "created_at": mock.ANY,
-            "details": {
-                "dimension": "default.date_dim",
-                "join_cardinality": "many_to_one",
-                "join_sql": "default.regional_level_agg A JOIN default.date_dim "
-                "D ON A.order_year = D.year AND A.order_month = D.month",
+        ),
+        (
+            "update",
+            {
+                "dimension": "default.users",
+                "join_cardinality": "one_to_many",
+                "join_sql": "default.events.user_id = default.users.user_id AND "
+                "default.events.event_end_date = default.users.snapshot_date",
                 "role": None,
             },
-            "entity_name": "default.regional_level_agg",
-            "entity_type": "link",
-            "id": mock.ANY,
-            "node": "default.regional_level_agg",
-            "post": {},
-            "pre": {},
-            "user": mock.ANY,
-        },
+        ),
     ]
 
-    response = dimensions_link_client.get(
-        "/sql/default.regional_level_agg?dimensions=default.date_dim.year",
-    )
-    query = response.json()["sql"]
-    compare_query_strings(
-        query,
-        # pylint: disable=line-too-long
-        """SELECT
-  default_DOT_regional_level_agg.us_region_id default_DOT_regional_level_agg_DOT_us_region_id,
-  default_DOT_regional_level_agg.state_name default_DOT_regional_level_agg_DOT_state_name,
-  default_DOT_regional_level_agg.location_hierarchy default_DOT_regional_level_agg_DOT_location_hierarchy,
-  default_DOT_regional_level_agg.order_year default_DOT_regional_level_agg_DOT_order_year,
-  default_DOT_regional_level_agg.order_month default_DOT_regional_level_agg_DOT_order_month,
-  default_DOT_regional_level_agg.order_day default_DOT_regional_level_agg_DOT_order_day,
-  default_DOT_regional_level_agg.completed_repairs default_DOT_regional_level_agg_DOT_completed_repairs,
-  default_DOT_regional_level_agg.total_repairs_dispatched default_DOT_regional_level_agg_DOT_total_repairs_dispatched,
-  default_DOT_regional_level_agg.total_amount_in_region default_DOT_regional_level_agg_DOT_total_amount_in_region,
-  default_DOT_regional_level_agg.avg_repair_amount_in_region default_DOT_regional_level_agg_DOT_avg_repair_amount_in_region,
-  default_DOT_regional_level_agg.avg_dispatch_delay default_DOT_regional_level_agg_DOT_avg_dispatch_delay,
-  default_DOT_regional_level_agg.unique_contractors default_DOT_regional_level_agg_DOT_unique_contractors,
-  default.date_dim.year default_DOT_date_dim_DOT_year
-FROM (
-    SELECT default_DOT_us_region.us_region_id,
-      default_DOT_us_states.state_name,
-      CONCAT(
-        default_DOT_us_states.state_name,
-        '-',
-        default_DOT_us_region.us_region_description
-      ) AS location_hierarchy,
-      EXTRACT(YEAR, ro.order_date) AS order_year,
-      EXTRACT(MONTH, ro.order_date) AS order_month,
-      EXTRACT(DAY, ro.order_date) AS order_day,
-      COUNT(
-        DISTINCT CASE
-          WHEN ro.dispatched_date IS NOT NULL THEN ro.repair_order_id
-          ELSE NULL
-        END
-      ) AS completed_repairs,
-      COUNT(DISTINCT ro.repair_order_id) AS total_repairs_dispatched,
-      SUM(
-        default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity
-      ) AS total_amount_in_region,
-      AVG(
-        default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity
-      ) AS avg_repair_amount_in_region,
-      AVG(DATEDIFF(ro.dispatched_date, ro.order_date)) AS avg_dispatch_delay,
-      COUNT(DISTINCT default_DOT_contractors.contractor_id) AS unique_contractors
-    FROM (
-        SELECT default_DOT_repair_orders.repair_order_id,
-          default_DOT_repair_orders.municipality_id,
-          default_DOT_repair_orders.hard_hat_id,
-          default_DOT_repair_orders.order_date,
-          default_DOT_repair_orders.required_date,
-          default_DOT_repair_orders.dispatched_date,
-          default_DOT_repair_orders.dispatcher_id
-        FROM roads.repair_orders AS default_DOT_repair_orders
-      ) AS ro
-      JOIN roads.municipality AS default_DOT_municipality ON ro.municipality_id = default_DOT_municipality.municipality_id
-      JOIN roads.us_states AS default_DOT_us_states ON default_DOT_municipality.state_id = default_DOT_us_states.state_id
-      AND AVG(
-        default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity
-      ) > (
-        SELECT AVG(
-            default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity
-          )
-        FROM roads.repair_order_details AS default_DOT_repair_order_details
-        WHERE default_DOT_repair_order_details.repair_order_id = ro.repair_order_id
-      )
-      JOIN roads.us_states AS default_DOT_us_states ON default_DOT_municipality.state_id = default_DOT_us_states.state_id
-      JOIN roads.us_region AS default_DOT_us_region ON default_DOT_us_states.state_region = default_DOT_us_region.us_region_id
-      JOIN roads.repair_order_details AS default_DOT_repair_order_details ON ro.repair_order_id = default_DOT_repair_order_details.repair_order_id
-      JOIN roads.repair_type AS default_DOT_repair_type ON default_DOT_repair_order_details.repair_type_id = default_DOT_repair_type.repair_type_id
-      JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.contractor_id = default_DOT_contractors.contractor_id
-    GROUP BY default_DOT_us_region.us_region_id,
-      EXTRACT(YEAR, ro.order_date),
-      EXTRACT(MONTH, ro.order_date),
-      EXTRACT(DAY, ro.order_date)
-  ) AS default_DOT_regional_level_agg
-  JOIN (
-    SELECT default_DOT_date.dateint,
-      default_DOT_date.month,
-      default_DOT_date.year,
-      default_DOT_date.day
-    FROM examples.date AS default_DOT_date
-  ) AS default_DOT_date_dim ON default.regional_level_agg.order_year = default_DOT_date_dim.year
-  AND default.regional_level_agg.order_month = default_DOT_date_dim.month
-        """,
-    )
+    # Switch back to original join definition
+    link_events_with_users(role=None)
 
     response = dimensions_link_client.get(
-        "/nodes/default.regional_level_agg/dimensions",
+        "/sql/default.events?dimensions=default.users.user_id"
+        "&dimensions=default.users.snapshot_date"
+        "&dimensions=default.users.registration_country",
     )
+    query = response.json()["sql"]
+    assert compare_query_strings(
+        query,
+        # pylint: disable=line-too-long
+        """SELECT  default_DOT_users.user_id default_DOT_events_DOT_user_id,
+	default_DOT_events.event_start_date default_DOT_events_DOT_event_start_date,
+	default_DOT_events.event_end_date default_DOT_events_DOT_event_end_date,
+	default_DOT_events.elapsed_secs default_DOT_events_DOT_elapsed_secs,
+	default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+	default_DOT_users.registration_country default_DOT_users_DOT_registration_country 
+ FROM (SELECT  default_DOT_events_table.user_id,
+	default_DOT_events_table.event_start_date,
+	default_DOT_events_table.event_end_date,
+	default_DOT_events_table.elapsed_secs 
+ FROM examples.events AS default_DOT_events_table)
+ AS default_DOT_events LEFT  JOIN (SELECT  default_DOT_users.user_id,
+	default_DOT_users.snapshot_date,
+	default_DOT_users.registration_country,
+	default_DOT_users.residence_country,
+	default_DOT_users.account_type 
+ FROM examples.users AS default_DOT_users
+) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date""",
+    )
+
+    response = dimensions_link_client.get("/nodes/default.events/dimensions")
     assert [(attr["name"], attr["path"]) for attr in response.json()] == [
-        ("default.date_dim.dateint", ["default.regional_level_agg."]),
-        ("default.date_dim.day", ["default.regional_level_agg."]),
-        ("default.date_dim.month", ["default.regional_level_agg."]),
-        ("default.date_dim.year", ["default.regional_level_agg."]),
-        ("default.regional_level_agg.order_day", []),
-        ("default.regional_level_agg.order_month", []),
-        ("default.regional_level_agg.order_year", []),
-        ("default.regional_level_agg.state_name", []),
-        ("default.regional_level_agg.us_region_id", []),
+        ("default.users.account_type[]", ["default.events."]),
+        ("default.users.registration_country[]", ["default.events."]),
+        ("default.users.residence_country[]", ["default.events."]),
+        ("default.users.snapshot_date[]", ["default.events."]),
+        ("default.users.user_id[]", ["default.events."]),
     ]
 
 
 def test_link_dimension_with_role(
     dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+    link_events_with_users,
 ):
-    """
-    Test linking dimension with role
-    """
-    # Link the date dimension with a role of "order_date"
-    response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
-        json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.regional_level_agg A LEFT JOIN default.date_dim D "
-                "ON A.order_year = D.year "
-                "AND A.order_month = D.month "
-                "AND A.order_day = D.day"
-            ),
-            "join_cardinality": "many_to_one",
-            "role": "order_date",
-        },
-    )
-    assert response.status_code == 201
+    response = link_events_with_users(role="user_direct")
+    assert response.json() == {
+        "message": "Dimension node default.users has been successfully "
+        "linked to node default.events.",
+    }
 
-    response = dimensions_link_client.get(
-        "/nodes/default.regional_level_agg/dimensions",
-    )
-    assert [(attr["name"], attr["path"]) for attr in response.json()] == [
-        ("default.date_dim.dateint", ["default.regional_level_agg.order_date"]),
-        ("default.date_dim.day", ["default.regional_level_agg.order_date"]),
-        ("default.date_dim.month", ["default.regional_level_agg.order_date"]),
-        ("default.date_dim.year", ["default.regional_level_agg.order_date"]),
-        ("default.regional_level_agg.order_day", []),
-        ("default.regional_level_agg.order_month", []),
-        ("default.regional_level_agg.order_year", []),
-        ("default.regional_level_agg.state_name", []),
-        ("default.regional_level_agg.us_region_id", []),
-    ]
-
-    # Link the date dimension with a role of "backorder_date"
-    response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
-        json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.regional_level_agg A LEFT JOIN default.date_dim D "
-                "ON A.order_year = D.year "
-                "AND A.order_month = D.month "
-                "AND A.order_day = D.day"
-            ),
-            "join_cardinality": "many_to_one",
-            "role": "backorder_date",
-        },
-    )
-    assert response.status_code == 201
-
-    response = dimensions_link_client.get("/nodes/default.regional_level_agg")
+    response = dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"] == [
         {
-            "dimension": {"name": "default.date_dim"},
-            "join_cardinality": "many_to_one",
-            "join_sql": "default.regional_level_agg A LEFT JOIN default.date_dim D ON "
-            "A.order_year = D.year AND A.order_month = D.month AND "
-            "A.order_day = D.day",
-            "role": "order_date",
-        },
-        {
-            "dimension": {"name": "default.date_dim"},
-            "join_cardinality": "many_to_one",
-            "join_sql": "default.regional_level_agg A LEFT JOIN default.date_dim D ON "
-            "A.order_year = D.year AND A.order_month = D.month AND "
-            "A.order_day = D.day",
-            "role": "backorder_date",
+            "dimension": {"name": "default.users"},
+            "join_cardinality": "one_to_one",
+            "join_sql": "default.events.user_id = default.users.user_id "
+            "AND default.events.event_start_date = default.users.snapshot_date",
+            "join_type": "left",
+            "role": "user_direct",
         },
     ]
 
-    response = dimensions_link_client.get(
-        "/nodes/default.regional_level_agg/dimensions",
-    )
-    assert [(attr["name"], attr["path"]) for attr in response.json()] == [
-        ("default.date_dim.dateint", ["default.regional_level_agg.backorder_date"]),
-        ("default.date_dim.dateint", ["default.regional_level_agg.order_date"]),
-        ("default.date_dim.day", ["default.regional_level_agg.backorder_date"]),
-        ("default.date_dim.day", ["default.regional_level_agg.order_date"]),
-        ("default.date_dim.month", ["default.regional_level_agg.backorder_date"]),
-        ("default.date_dim.month", ["default.regional_level_agg.order_date"]),
-        ("default.date_dim.year", ["default.regional_level_agg.backorder_date"]),
-        ("default.date_dim.year", ["default.regional_level_agg.order_date"]),
-        ("default.regional_level_agg.order_day", []),
-        ("default.regional_level_agg.order_month", []),
-        ("default.regional_level_agg.order_year", []),
-        ("default.regional_level_agg.state_name", []),
-        ("default.regional_level_agg.us_region_id", []),
-    ]
-
-    # Update the "backorder_date" dimension role
+    # Add a dimension link with different role
     response = dimensions_link_client.post(
-        "/nodes/default.regional_level_agg/link",
+        "/nodes/default.events/link",
         json={
-            "dimension_node": "default.date_dim",
-            "join_sql": (
-                "default.regional_level_agg R LEFT JOIN default.date_dim D "
-                "ON R.order_year = D.year "
-                "AND R.order_month = D.month"
-            ),
-            "join_cardinality": "many_to_one",
-            "role": "backorder_date",
+            "dimension_node": "default.users",
+            "join_type": "left",
+            "join_on": "default.events.user_id = default.users.user_id "
+            "AND default.events.event_start_date BETWEEN default.users.snapshot_date "
+            "AND CAST(DATE_ADD(CAST(default.users.snapshot_date AS DATE), 10) AS INT)",
+            "join_cardinality": "one_to_many",
+            "role": "user_windowed",
         },
     )
-    assert response.status_code == 201
+    assert response.json() == {
+        "message": "Dimension node default.users has been successfully linked to node "
+        "default.events.",
+    }
 
-    # Check that only the backorder_date dimension role was updated
-    response = dimensions_link_client.get("/nodes/default.regional_level_agg")
+    # Add a dimension link on users for registration country
+    response = dimensions_link_client.post(
+        "/nodes/default.users/link",
+        json={
+            "dimension_node": "default.countries",
+            "join_type": "inner",
+            "join_on": "default.users.registration_country = default.countries.country_code ",
+            "join_cardinality": "one_to_one",
+            "role": "registration_country",
+        },
+    )
+    assert response.json() == {
+        "message": "Dimension node default.countries has been successfully linked to node "
+        "default.users.",
+    }
+
+    # # Add a dimension link on users for registration country
+    # response = dimensions_link_client.get(
+    #     "/nodes/default.users",
+    # )
+    # assert response.json()["dimension_links"] == []
+
+    response = dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"] == [
         {
-            "dimension": {"name": "default.date_dim"},
-            "join_cardinality": "many_to_one",
-            "join_sql": "default.regional_level_agg A LEFT JOIN default.date_dim D ON "
-            "A.order_year = D.year AND A.order_month = D.month AND "
-            "A.order_day = D.day",
-            "role": "order_date",
+            "dimension": {"name": "default.users"},
+            "join_cardinality": "one_to_one",
+            "join_sql": "default.events.user_id = default.users.user_id AND "
+            "default.events.event_start_date = default.users.snapshot_date",
+            "join_type": "left",
+            "role": "user_direct",
         },
         {
-            "dimension": {"name": "default.date_dim"},
-            "join_cardinality": "many_to_one",
-            "join_sql": "default.regional_level_agg R LEFT JOIN default.date_dim D ON "
-            "R.order_year = D.year AND R.order_month = D.month",
-            "role": "backorder_date",
+            "dimension": {"name": "default.users"},
+            "join_cardinality": "one_to_many",
+            "join_sql": "default.events.user_id = default.users.user_id AND "
+            "default.events.event_start_date BETWEEN "
+            "default.users.snapshot_date AND "
+            "CAST(DATE_ADD(CAST(default.users.snapshot_date AS DATE), 10) AS "
+            "INT)",
+            "join_type": "left",
+            "role": "user_windowed",
         },
     ]
+
+    # Verify that the dimensions on the downstream metric have roles specified
+    response = dimensions_link_client.get("/nodes/default.elapsed_secs/dimensions")
+    assert [(attr["name"], attr["path"]) for attr in response.json()] == [
+        ('default.countries.country_code[user_direct->registration_country]',
+         ['default.events.user_direct', 'default.users.registration_country']),
+        ('default.countries.country_code[user_windowed->registration_country]',
+         ['default.events.user_windowed', 'default.users.registration_country']),
+        ('default.countries.name[user_direct->registration_country]',
+         ['default.events.user_direct', 'default.users.registration_country']),
+        ('default.countries.name[user_windowed->registration_country]',
+         ['default.events.user_windowed', 'default.users.registration_country']),
+        ('default.countries.population[user_direct->registration_country]',
+         ['default.events.user_direct', 'default.users.registration_country']),
+        ('default.countries.population[user_windowed->registration_country]',
+         ['default.events.user_windowed', 'default.users.registration_country']),
+        ("default.users.account_type[user_direct]", ["default.events.user_direct"]),
+        ("default.users.account_type[user_windowed]", ["default.events.user_windowed"]),
+        (
+            "default.users.registration_country[user_direct]",
+            ["default.events.user_direct"],
+        ),
+        (
+            "default.users.registration_country[user_windowed]",
+            ["default.events.user_windowed"],
+        ),
+        (
+            "default.users.residence_country[user_direct]",
+            ["default.events.user_direct"],
+        ),
+        (
+            "default.users.residence_country[user_windowed]",
+            ["default.events.user_windowed"],
+        ),
+        ("default.users.snapshot_date[user_direct]", ["default.events.user_direct"]),
+        (
+            "default.users.snapshot_date[user_windowed]",
+            ["default.events.user_windowed"],
+        ),
+        ("default.users.user_id[user_direct]", ["default.events.user_direct"]),
+        ("default.users.user_id[user_windowed]", ["default.events.user_windowed"]),
+    ]
+
+    # Get SQL for the downstream metric grouped by the user dimension of role "user_windowed"
+    response = dimensions_link_client.get(
+        "/sql/default.elapsed_secs?dimensions=default.users.user_id[user_windowed]"
+        "&dimensions=default.users.snapshot_date[user_windowed]"
+        "&dimensions=default.users.registration_country[user_windowed]",
+    )
+    query = response.json()["sql"]
+    assert compare_query_strings(
+        query,
+        # pylint: disable=line-too-long
+        """SELECT  SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
+	default_DOT_users.user_id default_DOT_users_DOT_user_id,
+	default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+	default_DOT_users.registration_country default_DOT_users_DOT_registration_country 
+ FROM (SELECT  default_DOT_events_table.user_id,
+	default_DOT_events_table.event_start_date,
+	default_DOT_events_table.event_end_date,
+	default_DOT_events_table.elapsed_secs 
+ FROM examples.events AS default_DOT_events_table)
+ AS default_DOT_events LEFT  JOIN (SELECT  default_DOT_users.user_id,
+	default_DOT_users.snapshot_date,
+	default_DOT_users.registration_country,
+	default_DOT_users.residence_country,
+	default_DOT_users.account_type 
+ FROM examples.users AS default_DOT_users
+
+) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id AND default_DOT_events.event_start_date BETWEEN default_DOT_users.snapshot_date AND CAST(DATE_ADD(CAST(default_DOT_users.snapshot_date AS DATE), 10) AS INT) 
+ GROUP BY  default_DOT_users.user_id, default_DOT_users.snapshot_date, default_DOT_users.registration_country""",
+    )
+
+    # Get SQL for the downstream metric grouped by the user dimension of role "user"
+    response = dimensions_link_client.get(
+        "/sql/default.elapsed_secs?dimensions=default.users.user_id[user_direct]"
+        "&dimensions=default.users.snapshot_date[user_direct]"
+        "&dimensions=default.users.registration_country[user_direct]",
+    )
+    query = response.json()["sql"]
+    assert compare_query_strings(
+        query,
+        # pylint: disable=line-too-long
+        """SELECT  SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
+	default_DOT_users.user_id default_DOT_users_DOT_user_id,
+	default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+	default_DOT_users.registration_country default_DOT_users_DOT_registration_country 
+ FROM (SELECT  default_DOT_events_table.user_id,
+	default_DOT_events_table.event_start_date,
+	default_DOT_events_table.event_end_date,
+	default_DOT_events_table.elapsed_secs 
+ FROM examples.events AS default_DOT_events_table)
+ AS default_DOT_events LEFT  JOIN (SELECT  default_DOT_users.user_id,
+	default_DOT_users.snapshot_date,
+	default_DOT_users.registration_country,
+	default_DOT_users.residence_country,
+	default_DOT_users.account_type 
+ FROM examples.users AS default_DOT_users
+
+) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date 
+ GROUP BY  default_DOT_users.user_id, default_DOT_users.snapshot_date, default_DOT_users.registration_country""",
+    )

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -1,12 +1,11 @@
 """Dimension linking related tests."""
-from typing import Optional
 
 import pytest
 from requests import Response
 from starlette.testclient import TestClient
 
 from tests.conftest import post_and_raise_if_error
-from tests.examples import COMPLEX_DIMENSION_LINK, EXAMPLES, SERVICE_SETUP
+from tests.examples import COMPLEX_DIMENSION_LINK, SERVICE_SETUP
 from tests.sql.utils import compare_query_strings
 
 
@@ -70,40 +69,119 @@ def test_link_dimension_with_errors(
 
 
 @pytest.fixture
-def link_events_with_users(dimensions_link_client: TestClient):
+def link_events_to_users_without_role(
+    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+):
     """
-    Link events with the users dimension
+    Link events with the users dimension without a role
     """
 
-    def _link_events_with_users(role: Optional[str] = None) -> Response:
-        params = {
-            "dimension_node": "default.users",
-            "join_type": "left",
-            "join_on": (
-                "default.events.user_id = default.users.user_id "
-                "AND default.events.event_start_date = default.users.snapshot_date"
-            ),
-            "join_cardinality": "one_to_one",
-        }
-        if role:
-            params["role"] = role
+    def _link_events_to_users_without_role() -> Response:
         response = dimensions_link_client.post(
             "/nodes/default.events/link",
-            json=params,
+            json={
+                "dimension_node": "default.users",
+                "join_type": "left",
+                "join_on": (
+                    "default.events.user_id = default.users.user_id "
+                    "AND default.events.event_start_date = default.users.snapshot_date"
+                ),
+                "join_cardinality": "one_to_one",
+            },
         )
         return response
 
-    return _link_events_with_users
+    return _link_events_to_users_without_role
+
+
+@pytest.fixture
+def link_events_to_users_with_role_direct(
+    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+):
+    """
+    Link events with the users dimension with the role "user_direct",
+    indicating a direct mapping between the user's snapshot date with the
+    event's start date
+    """
+
+    def _link_events_to_users_with_role_direct() -> Response:
+        response = dimensions_link_client.post(
+            "/nodes/default.events/link",
+            json={
+                "dimension_node": "default.users",
+                "join_type": "left",
+                "join_on": (
+                    "default.events.user_id = default.users.user_id "
+                    "AND default.events.event_start_date = default.users.snapshot_date"
+                ),
+                "join_cardinality": "one_to_one",
+                "role": "user_direct",
+            },
+        )
+        return response
+
+    return _link_events_to_users_with_role_direct
+
+
+@pytest.fixture
+def link_events_to_users_with_role_windowed(
+    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+):
+    """
+    Link events with the users dimension with the role "user_windowed",
+    indicating windowed join between events and the user dimension
+    """
+
+    def _link_events_to_users_with_role_windowed() -> Response:
+        response = dimensions_link_client.post(
+            "/nodes/default.events/link",
+            json={
+                "dimension_node": "default.users",
+                "join_type": "left",
+                "join_on": "default.events.user_id = default.users.user_id "
+                "AND default.events.event_start_date BETWEEN default.users.snapshot_date "
+                "AND CAST(DATE_ADD(CAST(default.users.snapshot_date AS DATE), 10) AS INT)",
+                "join_cardinality": "one_to_many",
+                "role": "user_windowed",
+            },
+        )
+        return response
+
+    return _link_events_to_users_with_role_windowed
+
+
+@pytest.fixture
+def link_users_to_countries_with_role_registration(
+    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+):
+    """
+    Link users to the countries dimension with role "registration_country".
+    """
+
+    def _link_users_to_countries_with_role_registration() -> Response:
+        response = dimensions_link_client.post(
+            "/nodes/default.users/link",
+            json={
+                "dimension_node": "default.countries",
+                "join_type": "inner",
+                "join_on": "default.users.registration_country = default.countries.country_code ",
+                "join_cardinality": "one_to_one",
+                "role": "registration_country",
+            },
+        )
+        return response
+
+    return _link_users_to_countries_with_role_registration
 
 
 def test_link_complex_dimension_without_role(
     dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name,
-    link_events_with_users,
+    link_events_to_users_without_role,  # pylint: disable=redefined-outer-name
 ):
     """
     Test linking complex dimension without role
     """
-    response = link_events_with_users(role=None)
+    response = link_events_to_users_without_role()
     assert response.json() == {
         "message": "Dimension node default.users has been successfully "
         "linked to node default.events.",
@@ -168,7 +246,7 @@ def test_link_complex_dimension_without_role(
     ]
 
     # Switch back to original join definition
-    link_events_with_users(role=None)
+    link_events_to_users_without_role()
 
     response = dimensions_link_client.get(
         "/sql/default.events?dimensions=default.users.user_id"
@@ -179,24 +257,28 @@ def test_link_complex_dimension_without_role(
     assert compare_query_strings(
         query,
         # pylint: disable=line-too-long
-        """SELECT  default_DOT_users.user_id default_DOT_events_DOT_user_id,
-	default_DOT_events.event_start_date default_DOT_events_DOT_event_start_date,
-	default_DOT_events.event_end_date default_DOT_events_DOT_event_end_date,
-	default_DOT_events.elapsed_secs default_DOT_events_DOT_elapsed_secs,
-	default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
-	default_DOT_users.registration_country default_DOT_users_DOT_registration_country 
- FROM (SELECT  default_DOT_events_table.user_id,
-	default_DOT_events_table.event_start_date,
-	default_DOT_events_table.event_end_date,
-	default_DOT_events_table.elapsed_secs 
- FROM examples.events AS default_DOT_events_table)
- AS default_DOT_events LEFT  JOIN (SELECT  default_DOT_users.user_id,
-	default_DOT_users.snapshot_date,
-	default_DOT_users.registration_country,
-	default_DOT_users.residence_country,
-	default_DOT_users.account_type 
- FROM examples.users AS default_DOT_users
-) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date""",
+        """SELECT default_DOT_users.user_id default_DOT_events_DOT_user_id,
+  default_DOT_events.event_start_date default_DOT_events_DOT_event_start_date,
+  default_DOT_events.event_end_date default_DOT_events_DOT_event_end_date,
+  default_DOT_events.elapsed_secs default_DOT_events_DOT_elapsed_secs,
+  default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+  default_DOT_users.registration_country default_DOT_users_DOT_registration_country
+FROM (
+    SELECT default_DOT_events_table.user_id,
+      default_DOT_events_table.event_start_date,
+      default_DOT_events_table.event_end_date,
+      default_DOT_events_table.elapsed_secs
+    FROM examples.events AS default_DOT_events_table
+  ) AS default_DOT_events
+  LEFT JOIN (
+    SELECT default_DOT_users.user_id,
+      default_DOT_users.snapshot_date,
+      default_DOT_users.registration_country,
+      default_DOT_users.residence_country,
+      default_DOT_users.account_type
+    FROM examples.users AS default_DOT_users
+  ) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id
+  AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date""",
     )
 
     response = dimensions_link_client.get("/nodes/default.events/dimensions")
@@ -209,11 +291,16 @@ def test_link_complex_dimension_without_role(
     ]
 
 
-def test_link_dimension_with_role(
+def test_link_complex_dimension_with_role(
     dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
-    link_events_with_users,
+    link_events_to_users_with_role_direct,  # pylint: disable=redefined-outer-name
+    link_events_to_users_with_role_windowed,  # pylint: disable=redefined-outer-name
+    link_users_to_countries_with_role_registration,  # pylint: disable=redefined-outer-name
 ):
-    response = link_events_with_users(role="user_direct")
+    """
+    Testing linking complex dimension with roles.
+    """
+    response = link_events_to_users_with_role_direct()
     assert response.json() == {
         "message": "Dimension node default.users has been successfully "
         "linked to node default.events.",
@@ -232,44 +319,18 @@ def test_link_dimension_with_role(
     ]
 
     # Add a dimension link with different role
-    response = dimensions_link_client.post(
-        "/nodes/default.events/link",
-        json={
-            "dimension_node": "default.users",
-            "join_type": "left",
-            "join_on": "default.events.user_id = default.users.user_id "
-            "AND default.events.event_start_date BETWEEN default.users.snapshot_date "
-            "AND CAST(DATE_ADD(CAST(default.users.snapshot_date AS DATE), 10) AS INT)",
-            "join_cardinality": "one_to_many",
-            "role": "user_windowed",
-        },
-    )
+    response = link_events_to_users_with_role_windowed()
     assert response.json() == {
         "message": "Dimension node default.users has been successfully linked to node "
         "default.events.",
     }
 
     # Add a dimension link on users for registration country
-    response = dimensions_link_client.post(
-        "/nodes/default.users/link",
-        json={
-            "dimension_node": "default.countries",
-            "join_type": "inner",
-            "join_on": "default.users.registration_country = default.countries.country_code ",
-            "join_cardinality": "one_to_one",
-            "role": "registration_country",
-        },
-    )
+    response = link_users_to_countries_with_role_registration()
     assert response.json() == {
         "message": "Dimension node default.countries has been successfully linked to node "
         "default.users.",
     }
-
-    # # Add a dimension link on users for registration country
-    # response = dimensions_link_client.get(
-    #     "/nodes/default.users",
-    # )
-    # assert response.json()["dimension_links"] == []
 
     response = dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"] == [
@@ -297,18 +358,30 @@ def test_link_dimension_with_role(
     # Verify that the dimensions on the downstream metric have roles specified
     response = dimensions_link_client.get("/nodes/default.elapsed_secs/dimensions")
     assert [(attr["name"], attr["path"]) for attr in response.json()] == [
-        ('default.countries.country_code[user_direct->registration_country]',
-         ['default.events.user_direct', 'default.users.registration_country']),
-        ('default.countries.country_code[user_windowed->registration_country]',
-         ['default.events.user_windowed', 'default.users.registration_country']),
-        ('default.countries.name[user_direct->registration_country]',
-         ['default.events.user_direct', 'default.users.registration_country']),
-        ('default.countries.name[user_windowed->registration_country]',
-         ['default.events.user_windowed', 'default.users.registration_country']),
-        ('default.countries.population[user_direct->registration_country]',
-         ['default.events.user_direct', 'default.users.registration_country']),
-        ('default.countries.population[user_windowed->registration_country]',
-         ['default.events.user_windowed', 'default.users.registration_country']),
+        (
+            "default.countries.country_code[user_direct->registration_country]",
+            ["default.events.user_direct", "default.users.registration_country"],
+        ),
+        (
+            "default.countries.country_code[user_windowed->registration_country]",
+            ["default.events.user_windowed", "default.users.registration_country"],
+        ),
+        (
+            "default.countries.name[user_direct->registration_country]",
+            ["default.events.user_direct", "default.users.registration_country"],
+        ),
+        (
+            "default.countries.name[user_windowed->registration_country]",
+            ["default.events.user_windowed", "default.users.registration_country"],
+        ),
+        (
+            "default.countries.population[user_direct->registration_country]",
+            ["default.events.user_direct", "default.users.registration_country"],
+        ),
+        (
+            "default.countries.population[user_windowed->registration_country]",
+            ["default.events.user_windowed", "default.users.registration_country"],
+        ),
         ("default.users.account_type[user_direct]", ["default.events.user_direct"]),
         ("default.users.account_type[user_windowed]", ["default.events.user_windowed"]),
         (
@@ -338,32 +411,49 @@ def test_link_dimension_with_role(
 
     # Get SQL for the downstream metric grouped by the user dimension of role "user_windowed"
     response = dimensions_link_client.get(
-        "/sql/default.elapsed_secs?dimensions=default.users.user_id[user_windowed]"
-        "&dimensions=default.users.snapshot_date[user_windowed]"
-        "&dimensions=default.users.registration_country[user_windowed]",
+        "/sql/default.elapsed_secs",
+        params={
+            "dimensions": [
+                "default.users.user_id[user_windowed]",
+                "default.users.snapshot_date[user_windowed]",
+                "default.users.registration_country[user_windowed]",
+            ],
+            "filters": ["default.users.registration_country[user_windowed] = 'NZ'"],
+        },
     )
     query = response.json()["sql"]
     assert compare_query_strings(
         query,
         # pylint: disable=line-too-long
-        """SELECT  SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
-	default_DOT_users.user_id default_DOT_users_DOT_user_id,
-	default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
-	default_DOT_users.registration_country default_DOT_users_DOT_registration_country 
- FROM (SELECT  default_DOT_events_table.user_id,
-	default_DOT_events_table.event_start_date,
-	default_DOT_events_table.event_end_date,
-	default_DOT_events_table.elapsed_secs 
- FROM examples.events AS default_DOT_events_table)
- AS default_DOT_events LEFT  JOIN (SELECT  default_DOT_users.user_id,
-	default_DOT_users.snapshot_date,
-	default_DOT_users.registration_country,
-	default_DOT_users.residence_country,
-	default_DOT_users.account_type 
- FROM examples.users AS default_DOT_users
-
-) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id AND default_DOT_events.event_start_date BETWEEN default_DOT_users.snapshot_date AND CAST(DATE_ADD(CAST(default_DOT_users.snapshot_date AS DATE), 10) AS INT) 
- GROUP BY  default_DOT_users.user_id, default_DOT_users.snapshot_date, default_DOT_users.registration_country""",
+        """SELECT SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
+  default_DOT_users.user_id default_DOT_users_DOT_user_id,
+  default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+  default_DOT_users.registration_country default_DOT_users_DOT_registration_country
+FROM (
+    SELECT default_DOT_events_table.user_id,
+      default_DOT_events_table.event_start_date,
+      default_DOT_events_table.event_end_date,
+      default_DOT_events_table.elapsed_secs
+    FROM examples.events AS default_DOT_events_table
+  ) AS default_DOT_events
+  LEFT JOIN (
+    SELECT default_DOT_users.user_id,
+      default_DOT_users.snapshot_date,
+      default_DOT_users.registration_country,
+      default_DOT_users.residence_country,
+      default_DOT_users.account_type
+    FROM examples.users AS default_DOT_users
+  ) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id
+  AND default_DOT_events.event_start_date BETWEEN default_DOT_users.snapshot_date AND CAST(
+    DATE_ADD(
+      CAST(default_DOT_users.snapshot_date AS DATE),
+      10
+    ) AS INT
+  )
+WHERE default_DOT_users.registration_country = 'NZ'
+GROUP BY default_DOT_users.user_id,
+  default_DOT_users.snapshot_date,
+  default_DOT_users.registration_country""",
     )
 
     # Get SQL for the downstream metric grouped by the user dimension of role "user"
@@ -376,22 +466,122 @@ def test_link_dimension_with_role(
     assert compare_query_strings(
         query,
         # pylint: disable=line-too-long
-        """SELECT  SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
-	default_DOT_users.user_id default_DOT_users_DOT_user_id,
-	default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
-	default_DOT_users.registration_country default_DOT_users_DOT_registration_country 
- FROM (SELECT  default_DOT_events_table.user_id,
-	default_DOT_events_table.event_start_date,
-	default_DOT_events_table.event_end_date,
-	default_DOT_events_table.elapsed_secs 
- FROM examples.events AS default_DOT_events_table)
- AS default_DOT_events LEFT  JOIN (SELECT  default_DOT_users.user_id,
-	default_DOT_users.snapshot_date,
-	default_DOT_users.registration_country,
-	default_DOT_users.residence_country,
-	default_DOT_users.account_type 
- FROM examples.users AS default_DOT_users
-
-) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date 
- GROUP BY  default_DOT_users.user_id, default_DOT_users.snapshot_date, default_DOT_users.registration_country""",
+        """SELECT SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
+  default_DOT_users.user_id default_DOT_users_DOT_user_id,
+  default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+  default_DOT_users.registration_country default_DOT_users_DOT_registration_country
+FROM (
+    SELECT default_DOT_events_table.user_id,
+      default_DOT_events_table.event_start_date,
+      default_DOT_events_table.event_end_date,
+      default_DOT_events_table.elapsed_secs
+    FROM examples.events AS default_DOT_events_table
+  ) AS default_DOT_events
+  LEFT JOIN (
+    SELECT default_DOT_users.user_id,
+      default_DOT_users.snapshot_date,
+      default_DOT_users.registration_country,
+      default_DOT_users.residence_country,
+      default_DOT_users.account_type
+    FROM examples.users AS default_DOT_users
+  ) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id
+  AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
+GROUP BY default_DOT_users.user_id,
+  default_DOT_users.snapshot_date,
+  default_DOT_users.registration_country""",
     )
+
+    # Get SQL for the downstream metric grouped by the user's registration country
+
+
+#     response = dimensions_link_client.get(
+#         "/sql/default.elapsed_secs?"
+#         "dimensions=default.countries.name[user_direct->registration_country]"
+#         "&dimensions=default.users.snapshot_date[user_direct]"
+#         "&dimensions=default.users.registration_country[user_direct]",
+#     )
+#     query = response.json()["sql"]
+#     assert compare_query_strings(
+#         query,
+#         # pylint: disable=line-too-long
+#         """SELECT SUM(default_DOT_events.elapsed_secs) default_DOT_elapsed_secs,
+#   default_DOT_users.user_id default_DOT_users_DOT_user_id,
+#   default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
+#   default_DOT_users.registration_country default_DOT_users_DOT_registration_country
+# FROM (
+#     SELECT default_DOT_events_table.user_id,
+#       default_DOT_events_table.event_start_date,
+#       default_DOT_events_table.event_end_date,
+#       default_DOT_events_table.elapsed_secs
+#     FROM examples.events AS default_DOT_events_table
+#   ) AS default_DOT_events
+#   LEFT JOIN (
+#     SELECT default_DOT_users.user_id,
+#       default_DOT_users.snapshot_date,
+#       default_DOT_users.registration_country,
+#       default_DOT_users.residence_country,
+#       default_DOT_users.account_type
+#     FROM examples.users AS default_DOT_users
+#   ) default_DOT_users ON default_DOT_events.user_id = default_DOT_users.user_id
+#   AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
+# GROUP BY default_DOT_users.user_id,
+#   default_DOT_users.snapshot_date,
+#   default_DOT_users.registration_country""",
+#     )
+
+
+def test_remove_dimension_link(
+    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+    link_events_to_users_with_role_direct,  # pylint: disable=redefined-outer-name
+    link_events_to_users_without_role,  # pylint: disable=redefined-outer-name
+):
+    """
+    Test removing complex dimension links
+    """
+    link_events_to_users_with_role_direct()
+    response = dimensions_link_client.delete(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.users",
+            "role": "user_direct",
+        },
+    )
+    assert response.json() == {
+        "message": "Dimension link default.users (role user_direct) to node "
+        "default.events has been removed.",
+    }
+
+    # Deleting again should not work
+    response = dimensions_link_client.delete(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.users",
+            "role": "user_direct",
+        },
+    )
+    assert response.json() == {
+        "message": "Dimension link to node default.users with role user_direct not found",
+    }
+
+    link_events_to_users_without_role()
+    response = dimensions_link_client.delete(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.users",
+        },
+    )
+    assert response.json() == {
+        "message": "Dimension link default.users to node "
+        "default.events has been removed.",
+    }
+
+    # Deleting again should not work
+    response = dimensions_link_client.delete(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.users",
+        },
+    )
+    assert response.json() == {
+        "message": "Dimension link to node default.users not found",
+    }

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -1812,6 +1812,119 @@ LATERAL_VIEW = (  # type: ignore
     ),
 )
 
+COMPLEX_DIMENSION_LINK = (
+    (
+        "/nodes/source/",
+        {
+            "columns": [
+                {"name": "user_id", "type": "int"},
+                {"name": "event_start_date", "type": "int"},
+                {"name": "event_end_date", "type": "int"},
+                {"name": "elapsed_secs", "type": "int"},
+            ],
+            "description": "Events table",
+            "mode": "published",
+            "name": "default.events_table",
+            "catalog": "default",
+            "schema_": "examples",
+            "table": "events",
+        },
+    ),
+    (
+        "/nodes/source/",
+        {
+            "columns": [
+                {"name": "user_id", "type": "int"},
+                {"name": "snapshot_date", "type": "int"},
+                {"name": "registration_country", "type": "string"},
+                {"name": "residence_country", "type": "string"},
+                {"name": "account_type", "type": "string"},
+            ],
+            "description": "Users table",
+            "mode": "published",
+            "name": "default.users_table",
+            "catalog": "default",
+            "schema_": "examples",
+            "table": "users",
+        },
+    ),
+    (
+        "/nodes/source/",
+        {
+            "columns": [
+                {"name": "country_code", "type": "string"},
+                {"name": "name", "type": "string"},
+                {"name": "population", "type": "int"},
+            ],
+            "description": "Countries table",
+            "mode": "published",
+            "name": "default.countries_table",
+            "catalog": "default",
+            "schema_": "examples",
+            "table": "countries",
+        },
+    ),
+    (
+        "/nodes/transform/",
+        {
+            "description": "Events fact",
+            "query": """
+        SELECT
+            user_id,
+            event_start_date,
+            event_end_date,
+            elapsed_secs
+        FROM default.events_table
+    """,
+            "mode": "published",
+            "name": "default.events",
+        },
+    ),
+    (
+        "/nodes/dimension/",
+        {
+            "description": "Users",
+            "query": """
+        SELECT
+            user_id,
+            snapshot_date,
+            registration_country,
+            residence_country,
+            account_type
+        FROM default.users_table
+    """,
+            "mode": "published",
+            "name": "default.users",
+            "primary_key": ["user_id", "snapshot_date"],
+        },
+    ),
+    (
+        "/nodes/dimension/",
+        {
+            "description": "Countries",
+            "query": """
+        SELECT
+            country_code,
+            name,
+            population
+        FROM default.countries_table
+    """,
+            "mode": "published",
+            "name": "default.countries",
+            "primary_key": ["country_code"],
+        },
+    ),
+    (
+        "/nodes/metric/",
+        {
+            "description": "Elapsed Time in Seconds",
+            "query": "SELECT SUM(elapsed_secs) FROM default.events",
+            "mode": "published",
+            "name": "default.elapsed_secs",
+        },
+    ),
+)
+
 DIMENSION_LINK = (  # type: ignore
     (
         "/nodes/source/",


### PR DESCRIPTION
### Summary

#### Support for using dimension roles

This PR adds support for specifying dimension roles when asking DJ to generate SQL for nodes. In the current setup, asking for a dimension that had multiple roles would just return an arbitrary role, and it wasn't possible to specify a particular dimension role.

With this PR, dimensions with roles can be referenced following the pattern `<dimension>[<role>]`:
```
default.users.user_id[user_direct]
default.users.first_name[user_direct]

default.countries.name[registration_country]
default.countries.population[registration_country]
```

Note that roles are **not required** and non-roled dimensions still work as previously (i.e., `default.users.user_id`). Dimension roles are also only supported when linking complex dimensions (that is, through the `/nodes/<node_name>/link` endpoint), and not via the column-level dimension links. 

#### Endpoint for removing complex dimension links

This PR adds an API endpoint for removing complex dimension links:
```
DELETE /nodes/<node_name>/links
{
    "dimension_node": <dimension name>,
    "role": <if any>
}
```

#### DJ Python client support for complex dimension links

This PR also adds functionality on the Python client to add and remove complex dimension links. For example, the following snippet adds two complex dimension links with different roles for `registration_country` and `residence_country`:

```
users = dj.dimension("default.users")
users.link_complex_dimension(
    dimension_node="default.countries",
    join_type="left",  # optional
    join_on=(
        "default.users.registration_country = default.countries.country_code"
    ),
    join_cardinality="one_to_one",  # optional
    role="registration_country",  # optional
)

users.link_complex_dimension(
    dimension_node="default.countries",
    join_type="left",  # optional
    join_on=(
        "default.users.residence_country = default.countries.country_code"
    ),
    join_cardinality="one_to_one",  # optional
    role="residence_country",  # optional
)
```

### Test Plan

Added a new set of tests for complex dimensions that involve the following setup: `default.events`, `default.users`, and `default.countries`.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A