### PR TITLE
AvailabilityState's valid_through_ts should be bigint

### DIFF
--- a/datajunction-server/alembic/versions/2024_01_23_1655-a8e22109be24_availability_state_s_valid_through_ts_.py
+++ b/datajunction-server/alembic/versions/2024_01_23_1655-a8e22109be24_availability_state_s_valid_through_ts_.py
@@ -1,0 +1,28 @@
+"""Availability state's valid_through_ts should be bigint
+
+Revision ID: a8e22109be24
+Revises: 20f060b02772
+Create Date: 2024-01-23 16:55:20.951715+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'a8e22109be24'
+down_revision = '20f060b02772'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("availabilitystate", schema=None) as batch_op:
+        batch_op.alter_column("valid_through_ts", type_=sa.BigInteger())
+
+
+def downgrade():
+    with op.batch_alter_table('availabilitystate', schema=None) as batch_op:
+        batch_op.alter_column("valid_through_ts", type_=sa.Integer())

--- a/datajunction-server/alembic/versions/2024_01_23_1655-a8e22109be24_availability_state_s_valid_through_ts_.py
+++ b/datajunction-server/alembic/versions/2024_01_23_1655-a8e22109be24_availability_state_s_valid_through_ts_.py
@@ -8,12 +8,13 @@ Create Date: 2024-01-23 16:55:20.951715+00:00
 # pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
 
+from alembic import op
+
 # revision identifiers, used by Alembic.
-revision = 'a8e22109be24'
-down_revision = '20f060b02772'
+revision = "a8e22109be24"
+down_revision = "20f060b02772"
 branch_labels = None
 depends_on = None
 
@@ -24,5 +25,5 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table('availabilitystate', schema=None) as batch_op:
+    with op.batch_alter_table("availabilitystate", schema=None) as batch_op:
         batch_op.alter_column("valid_through_ts", type_=sa.Integer())

--- a/datajunction-server/datajunction_server/database/availabilitystate.py
+++ b/datajunction-server/datajunction_server/database/availabilitystate.py
@@ -27,7 +27,7 @@ class AvailabilityState(Base):  # pylint: disable=too-few-public-methods
     catalog: Mapped[str]
     schema_: Mapped[Optional[str]] = mapped_column(nullable=True)
     table: Mapped[str]
-    valid_through_ts: Mapped[int]
+    valid_through_ts: Mapped[int] = mapped_column(sa.BigInteger())
     url: Mapped[Optional[str]]
 
     # An ordered list of categorical partitions like ["country", "group_id"]


### PR DESCRIPTION
### Summary

Database migration to switch AvailabilityState's valid_through_ts to `bigint`, since `int` in Postgres is not large enough to store millisecond timestamps.

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

Immediate
