### PR TITLE
Fix alembic migration for missing table attribute

### DIFF
--- a/datajunction-server/alembic/versions/2024_01_23_0617-c9cef8864ecb_add_missing_table_attribute_to_source_.py
+++ b/datajunction-server/alembic/versions/2024_01_23_0617-c9cef8864ecb_add_missing_table_attribute_to_source_.py
@@ -21,9 +21,15 @@ depends_on = None
 def upgrade():
     with op.batch_alter_table("node", schema=None) as batch_op:
         batch_op.add_column(
+            sa.Column("missing_table", sa.Boolean(), nullable=True, default=False),
+        )
+
+    op.execute("UPDATE node SET missing_table = False WHERE missing_table IS NULL")
+
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.alter_column(
             sa.Column("missing_table", sa.Boolean(), nullable=False, default=False),
         )
-    op.execute("UPDATE node SET missing_table = False WHERE missing_table IS NULL")
 
 
 def downgrade():

--- a/datajunction-server/alembic/versions/2024_01_23_0617-c9cef8864ecb_add_missing_table_attribute_to_source_.py
+++ b/datajunction-server/alembic/versions/2024_01_23_0617-c9cef8864ecb_add_missing_table_attribute_to_source_.py
@@ -27,9 +27,7 @@ def upgrade():
     op.execute("UPDATE node SET missing_table = False WHERE missing_table IS NULL")
 
     with op.batch_alter_table("node", schema=None) as batch_op:
-        batch_op.alter_column(
-            sa.Column("missing_table", sa.Boolean(), nullable=False, default=False),
-        )
+        batch_op.alter_column("missing_table", nullable=False)
 
 
 def downgrade():


### PR DESCRIPTION
### Summary

This fixes the alembic migration for adding the `missing_table` attribute. It didn't work because Postgres would fail with:
```
$ alembic upgrade a8e22109be24
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 20f060b02772 -> c9cef8864ecb, Add missing_table attribute to source nodes.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1969, in _exec_single_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 922, in do_execute
    cursor.execute(statement, parameters)
  File "/usr/local/lib/python3.10/site-packages/psycopg/cursor.py", line 732, in execute
    raise ex.with_traceback(None)
psycopg.errors.NotNullViolation: column "missing_table" of relation "node" contains null values
```

This changes it so that we first create a nullable `missing_table` column, and then add in the non-nullable constraint after we've backfilled all the values to `false`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
