### PR TITLE
Remove the mixture of async endpoints with a sync db connection

### DIFF
--- a/datajunction-server/datajunction_server/api/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/basic.py
@@ -24,7 +24,7 @@ router = APIRouter(tags=["Basic OAuth2"])
 
 
 @router.post("/basic/user/")
-async def create_a_user(
+def create_a_user(
     email: str = Form(),
     username: str = Form(),
     password: str = Form(),
@@ -63,7 +63,7 @@ async def create_a_user(
 
 
 @router.post("/basic/login/")
-async def login(
+def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
     session: Session = Depends(get_session),
 ):
@@ -89,7 +89,7 @@ async def login(
 
 
 @router.post("/logout/")
-async def logout():
+def logout():
     """
     Logout a user by deleting the auth cookie
     """

--- a/datajunction-server/datajunction_server/api/access/authentication/github.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/github.py
@@ -20,7 +20,7 @@ router = APIRouter(tags=["GitHub OAuth2"])
 
 
 @router.get("/github/login/", status_code=HTTPStatus.FOUND)
-async def login() -> RedirectResponse:  # pragma: no cover
+def login() -> RedirectResponse:  # pragma: no cover
     """
     Login
     """
@@ -42,7 +42,7 @@ async def login() -> RedirectResponse:  # pragma: no cover
 
 
 @router.get("/github/token/")
-async def get_access_token(
+def get_access_token(
     code: str,
     response: Response,
 ) -> JSONResponse:  # pragma: no cover

--- a/datajunction-server/datajunction_server/api/access/authentication/google.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/google.py
@@ -35,7 +35,7 @@ settings = get_settings()
 
 
 @router.get("/google/login/", status_code=HTTPStatus.FOUND)
-async def login(target: Optional[str] = None):
+def login(target: Optional[str] = None):
     """
     Login using Google OAuth
     """
@@ -46,7 +46,7 @@ async def login(target: Optional[str] = None):
 
 
 @router.get("/google/token/")
-async def get_access_token(
+def get_access_token(
     request: Request,
     state: Optional[str] = None,
     error: Optional[str] = None,

--- a/datajunction-server/datajunction_server/api/access/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/whoami.py
@@ -18,7 +18,7 @@ router = SecureAPIRouter(tags=["Who am I?"])
 
 
 @router.get("/whoami/", response_model=UserOutput)
-async def get_user(current_user: User = Depends(get_current_user)) -> UserOutput:
+def get_user(current_user: User = Depends(get_current_user)) -> UserOutput:
     """
     Returns the current authenticated user
     """
@@ -26,7 +26,7 @@ async def get_user(current_user: User = Depends(get_current_user)) -> UserOutput
 
 
 @router.get("/token/")
-async def get_short_lived_token(request: Request) -> JSONResponse:
+def get_short_lived_token(request: Request) -> JSONResponse:
     """
     Returns a token that expires in 24 hours
     """

--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -74,7 +74,7 @@ def get_data_for_djsql(  # pylint: disable=R0914, R0913
 
 # pylint: disable=R0914, R0913
 @router.get("/djsql/stream/", response_model=QueryWithResults)
-async def get_data_stream_for_djsql(  # pragma: no cover
+def get_data_stream_for_djsql(  # pragma: no cover
     query: str,
     *,
     session: Session = Depends(get_session),

--- a/datajunction-server/datajunction_server/api/health.py
+++ b/datajunction-server/datajunction_server/api/health.py
@@ -35,7 +35,7 @@ class HealthCheck(BaseModel):
     status: HealthcheckStatus
 
 
-async def database_health(session: Session) -> HealthcheckStatus:
+def database_health(session: Session) -> HealthcheckStatus:
     """
     The status of the database.
     """
@@ -50,7 +50,7 @@ async def database_health(session: Session) -> HealthcheckStatus:
 
 
 @router.get("/health/", response_model=List[HealthCheck])
-async def health_check(
+def health_check(
     session: Session = Depends(get_session),
 ) -> List[HealthCheck]:
     """
@@ -59,6 +59,6 @@ async def health_check(
     return [
         HealthCheck(
             name="database",
-            status=await database_health(session),
+            status=database_health(session),
         ),
     ]

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -95,7 +95,7 @@ def get_a_metric(name: str, *, session: Session = Depends(get_session)) -> Metri
     "/metrics/common/dimensions/",
     response_model=List[DimensionAttributeOutput],
 )
-async def get_common_dimensions(
+def get_common_dimensions(
     metric: List[str] = Query(
         title="List of metrics to find common dimensions for",
         default=[],

--- a/datajunction-server/datajunction_server/internal/access/authentication/http.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/http.py
@@ -33,7 +33,7 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
         jwt = request.cookies.get(AUTH_COOKIE)
         if jwt:
             try:
-                jwt_data = await decode_token(jwt)
+                jwt_data = decode_token(jwt)
             except (JWEError, JWTError) as exc:
                 raise DJException(
                     http_status_code=HTTPStatus.UNAUTHORIZED,
@@ -76,7 +76,7 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
                     ],
                 )
             return  # pragma: no cover
-        jwt_data = await decode_token(credentials)
+        jwt_data = decode_token(credentials)
         request.state.user = get_user(username=jwt_data["username"], session=session)
         return
 

--- a/datajunction-server/datajunction_server/internal/access/authentication/tokens.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/tokens.py
@@ -62,7 +62,7 @@ def create_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     return encrypt(encoded_jwt)
 
 
-async def decode_token(token: str) -> dict:
+def decode_token(token: str) -> dict:
     """
     Decodes a token by first decrypting the JWE and then decoding the signed JWT.
     """

--- a/datajunction-server/tests/construction/build_test.py
+++ b/datajunction-server/tests/construction/build_test.py
@@ -19,8 +19,7 @@ from .fixtures import BUILD_EXPECTATION_PARAMETERS
 
 
 @pytest.mark.parametrize("node_name,db_id", BUILD_EXPECTATION_PARAMETERS)
-@pytest.mark.asyncio
-async def test_build_node(node_name: str, db_id: int, request):
+def test_build_node(node_name: str, db_id: int, request):
     """
     Test building a node
     """
@@ -51,8 +50,7 @@ async def test_build_node(node_name: str, db_id: int, request):
             assert expected in str(exc)
 
 
-@pytest.mark.asyncio
-async def test_build_metric_with_dimensions_aggs(request):
+def test_build_metric_with_dimensions_aggs(request):
     """
     Test building metric with dimensions
     """
@@ -122,8 +120,7 @@ def test_build_metric_with_required_dimensions(request):
     assert compare_query_strings(str(query), expected)
 
 
-@pytest.mark.asyncio
-async def test_raise_on_build_without_required_dimension_column(request):
+def test_raise_on_build_without_required_dimension_column(request):
     """
     Test building a node that has a dimension reference without a column and a compound PK
     """
@@ -209,8 +206,7 @@ async def test_raise_on_build_without_required_dimension_column(request):
     )
 
 
-@pytest.mark.asyncio
-async def test_build_metric_with_dimensions_filters(request):
+def test_build_metric_with_dimensions_filters(request):
     """
     Test building metric with dimension filters
     """
@@ -244,8 +240,7 @@ async def test_build_metric_with_dimensions_filters(request):
     assert compare_query_strings(str(query), expected)
 
 
-@pytest.mark.asyncio
-async def test_build_node_with_unnamed_column(request):
+def test_build_node_with_unnamed_column(request):
     """
     Test building a node that has an unnamed column (so defaults to col<n>)
     """

--- a/datajunction-server/tests/internal/authentication/token_test.py
+++ b/datajunction-server/tests/internal/authentication/token_test.py
@@ -1,7 +1,6 @@
 """
 Test JWT helper functions
 """
-import asyncio
 from datetime import timedelta
 
 from datajunction_server.internal.access.authentication import tokens
@@ -15,7 +14,7 @@ def test_create_and_get_token():
         data={"foo": "bar"},
         expires_delta=timedelta(minutes=30),
     )
-    data = asyncio.run(tokens.decode_token(jwe_string))
+    data = tokens.decode_token(jwe_string)
     assert data["foo"] == "bar"
 
 

--- a/datajunction-server/tests/internal/authentication/whoami_test.py
+++ b/datajunction-server/tests/internal/authentication/whoami_test.py
@@ -1,7 +1,6 @@
 """
 Tests for whoami router
 """
-import asyncio
 
 from fastapi.testclient import TestClient
 
@@ -24,5 +23,5 @@ def test_short_lived_token(client: TestClient):
     response = client.get("/token/")
     assert response.ok
     data = response.json()
-    user = asyncio.run(decode_token(data["token"]))
+    user = decode_token(data["token"])
     assert user["username"] == "dj"


### PR DESCRIPTION
### Summary

We should not mix async API endpoints with a synchronous db connection (`psycopg3`). Because our database client does not support async, every database call will introduce blocking calls to the event loop, eventually resulting in the uvicorn workers timing out.

The issue is very similar to the one described here (in their case it was sync API call vs sync database query): https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/issues/145#issuecomment-1442005465

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

Ideally we deploy this right away. Otherwise over time the deployed DJ servers will experience more and more blocking calls, gradually causing workers to time out. 