### PR TITLE
Fix UI tags bug + speed up node DAG

### DIFF
--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -5,7 +5,7 @@ import itertools
 from typing import Dict, List, Optional, Set, Union
 
 from sqlalchemy import and_, func, join, literal, or_, select
-from sqlalchemy.orm import Session, aliased, joinedload
+from sqlalchemy.orm import Session, aliased, joinedload, selectinload
 from sqlalchemy.sql.operators import is_
 
 from datajunction_server.database.attributetype import AttributeType, ColumnAttribute
@@ -30,7 +30,7 @@ def _node_output_options():
     """
     return [
         joinedload(Node.current).options(
-            joinedload(NodeRevision.columns).options(
+            selectinload(NodeRevision.columns).options(
                 joinedload(Column.attributes).joinedload(
                     ColumnAttribute.attribute_type,
                 ),

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
@@ -93,7 +93,7 @@ describe('AddEditNodePage submission failed', () => {
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalled();
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
         'default.num_repair_orders',
-        [{ display_name: 'Purpose', name: 'purpose' }],
+        ['purpose'],
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toReturnWith({
         json: { message: 'Some tags were not found' },

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -120,7 +120,7 @@ describe('AddEditNodePage submission succeeded', () => {
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
         'default.num_repair_orders',
-        [{ display_name: 'Purpose', name: 'purpose' }],
+        ['purpose'],
       );
 
       expect(mockDjClient.DataJunctionAPI.listMetricMetadata).toBeCalledTimes(

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -214,6 +214,11 @@ export function AddEditNodePage() {
     fields.forEach(field => {
       if (field === 'primary_key') {
         setFieldValue(field, primaryKey.join(', '));
+      } else if (field === 'tags') {
+        setFieldValue(
+          field,
+          data[field].map(tag => tag.name),
+        );
       } else {
         setFieldValue(field, data[field] || '', false);
       }


### PR DESCRIPTION
### Summary

#### Tags Bug

Fix UI bug where updating a node with tags would yield errors. This was due to an issue with setting the right tag values on the form when updating a node (it needs to be set to a list of tag name strings and not a list of objects). 

#### Node DAG 

Change node DAG retrieval query to use `selectinload` for columns rather than `joinedload`. This increases the retrieval speed for dimension nodes by a significant margin (in the tests I ran, the node DAG endpoint is 4-5x faster, yielding a much faster node graph display).

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A but should deploy asap
