### PR TITLE
Fix issue with search failing when it hits a null node description

### DIFF
--- a/datajunction-ui/src/app/components/Search.jsx
+++ b/datajunction-ui/src/app/components/Search.jsx
@@ -12,6 +12,9 @@ export default function Search() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
 
   const truncate = str => {
+    if (str === null) {
+      return '';
+    }
     return str.length > 100 ? str.substring(0, 90) + '...' : str;
   };
   useEffect(() => {
@@ -85,7 +88,7 @@ export default function Search() {
                 </span>
                 {item.display_name} (<b>{item.name}</b>){' '}
                 {item.description ? '- ' : ' '}
-                {truncate(item.description)}
+                {truncate(item.description || '')}
               </div>
             </a>
           );


### PR DESCRIPTION
### Summary

When someone searches and the search includes nodes with a null description, we get this error in the search UI:
```
Uncaught TypeError: Cannot read properties of null (reading 'length')
    at truncate (Search.jsx:154:16)
    at eval (Search.jsx:235:58)
    at Array.map (<anonymous>)
```

This is can be fixed by checking for null node descriptions and setting a sensible default.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
