### PR TITLE
Improve UI for primary key selection

### DIFF
--- a/datajunction-ui/src/app/pages/AddEditNodePage/FormikSelect.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/FormikSelect.jsx
@@ -12,6 +12,7 @@ export const FormikSelect = ({
   style,
   className = 'SelectInput',
   isMulti = false,
+  onFocus = event => {},
 }) => {
   // eslint-disable-next-line no-unused-vars
   const [field, _, helpers] = useField(formikFieldName);
@@ -37,6 +38,7 @@ export const FormikSelect = ({
       onChange={selected => setValue(getValue(selected))}
       styles={style}
       isMulti={isMulti}
+      onFocus={event => onFocus(event)}
     />
   );
 };

--- a/datajunction-ui/src/app/pages/AddEditNodePage/PrimaryKeySelect.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/PrimaryKeySelect.jsx
@@ -1,0 +1,55 @@
+/**
+ * Primary key select component
+ */
+import { useFormikContext } from 'formik';
+import { useContext, useMemo, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+import { FormikSelect } from './FormikSelect';
+
+export const PrimaryKeySelect = ({ defaultValue }) => {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+
+  // Used to pull out current form values for node validation
+  const { values } = useFormikContext();
+
+  // The available columns, determined from validating the node query
+  const [availableColumns, setAvailableColumns] = useState([]);
+  const selectableOptions = useMemo(() => {
+    if (availableColumns && availableColumns.length > 0) {
+      return availableColumns;
+    }
+  }, [availableColumns]);
+
+  // When focus is on the primary key field, refresh the list of available
+  // primary key columns for selection
+  const refreshColumns = event => {
+    async function fetchData() {
+      // eslint-disable-next-line no-unused-vars
+      const { status, json } = await djClient.validateNode(
+        values.type,
+        values.name,
+        values.display_name,
+        values.description,
+        values.query,
+      );
+      setAvailableColumns(
+        json.columns.map(col => {
+          return { value: col.name, label: col.name };
+        }),
+      );
+    }
+    fetchData();
+  };
+
+  return (
+    <FormikSelect
+      className="MultiSelectInput"
+      defaultValue={defaultValue}
+      selectOptions={selectableOptions}
+      formikFieldName="primary_key"
+      placeholder="Choose Primary Key"
+      onFocus={event => refreshColumns(event)}
+      isMulti={true}
+    />
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -113,7 +113,7 @@ describe('AddEditNodePage submission succeeded', () => {
         'Number of repair orders!!!',
         'SELECT count(repair_order_id) default_DOT_num_repair_orders FROM default.repair_orders',
         'published',
-        null,
+        [],
         'neutral',
         'unitless',
       );

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -68,6 +68,31 @@ export const DataJunctionAPI = {
     ).json();
   },
 
+  validateNode: async function (
+    nodeType,
+    name,
+    display_name,
+    description,
+    query,
+  ) {
+    const response = await fetch(`${DJ_URL}/nodes/validate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: name,
+        display_name: display_name,
+        description: description,
+        query: query,
+        type: nodeType,
+        mode: 'published',
+      }),
+      credentials: 'include',
+    });
+    return { status: response.status, json: await response.json() };
+  },
+
   createNode: async function (
     nodeType,
     name,

--- a/datajunction-ui/src/styles/node-creation.scss
+++ b/datajunction-ui/src/styles/node-creation.scss
@@ -106,13 +106,51 @@ form {
     box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
       rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
   }
-  .SelectInput div,
-  .SelectInput div div {
-    border: none;
-  }
-
   .SelectInput div:first-child {
     background-color: #eee !important;
+    border: none;
+    color: #0c4128;
+  }
+  .MultiSelectInput {
+    background-color: #eee;
+    border-radius: 10px;
+    border-style: none;
+    border-color: transparent;
+    box-sizing: border-box;
+    padding: 0.5rem 0;
+    font-size: 110%;
+    box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
+      rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
+  }
+  .MultiSelectInput div {
+    border: none;
+    background-color: #fff;
+  }
+  .MultiSelectInput div:last-child div {
+    border: none;
+    background-color: #efefef;
+  }
+  .MultiSelectInput div div {
+    border: none;
+    background-color: #efefef;
+  }
+
+  .MultiSelectInput div div div,
+  .MultiSelectInput div div div:last-child {
+    border: none;
+    background-color: #ffffff;
+    border-radius: 0.4rem;
+    padding: 0.2em;
+  }
+
+  .MultiSelectInput div div div:last-child {
+    background-color: #efefef;
+  }
+  .MultiSelectInput div div div div:last-child {
+    border: none;
+    background-color: #fff;
+  }
+  .SelectInput div:first-child {
     border: none;
     color: #0c4128;
   }


### PR DESCRIPTION
### Summary

When users add or edit a node, they can specify the primary key of the node, but this is currently done by asking the user to input a comma-separated list of column names. This PR changes it so that we show a dropdown with the available columns as input options:
<img width="899" alt="Screenshot 2024-01-29 at 8 46 09 PM" src="https://github.com/DataJunction/dj/assets/9524628/5e524214-dd27-4558-b18c-e296ff29462e">

This makes it so that users will always input a valid primary key, since the columns they select will be confined to those that exist on the node. To achieve this, we do the following:
- Every time a node query gets updated during node creation or update, we save the updated query to the form's values
- When the user focuses on the primary key input, we call the backend api's `/validate` endpoint, which will return a list of columns based on parsing the latest version of the query. We only do this on focus to limit the number of times we call `/validate`, which is relatively expensive.

This sets us up nicely for a similar setup for the required dimensions (metrics only), where we'll want the user to pick from a set of available dimensions rather than freeform type dimensions.

https://github.com/DataJunction/dj/assets/9524628/3fd775c7-dad9-449e-a6db-600cdb01945e

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
