### PR TITLE
Alter metrics UI to use upstream + aggregate expression

### DIFF
--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -13,6 +13,7 @@ from datajunction_server.models.node import (
     MetricMetadataOutput,
 )
 from datajunction_server.models.query import ColumnMetadata
+from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.transpilation import get_transpilation_plugin
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import get_settings
@@ -33,16 +34,19 @@ class Metric(BaseModel):
     updated_at: UTCDatetime
 
     query: str
+    upstream_node: str
+    expression: str
 
     dimensions: List[DimensionAttributeOutput]
     metric_metadata: Optional[MetricMetadataOutput] = None
+    required_dimensions: List[str]
 
     @classmethod
     def parse_node(cls, node: Node, dims: List[DimensionAttributeOutput]) -> "Metric":
         """
         Parses a node into a metric.
         """
-
+        query_ast = parse(node.current.query)
         return cls(
             id=node.id,
             name=node.name,
@@ -52,8 +56,11 @@ class Metric(BaseModel):
             created_at=node.created_at,
             updated_at=node.current.updated_at,
             query=node.current.query,
+            upstream_node=node.current.parents[0].name,
+            expression=str(query_ast.select.projection[0]),
             dimensions=dims,
             metric_metadata=node.current.metric_metadata,
+            required_dimensions=[dim.name for dim in node.current.required_dimensions],
         )
 
 

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -37,6 +37,8 @@ def test_read_metrics(client_with_roads: TestClient) -> None:
             "name": "DOLLAR",
         },
     }
+    assert data["upstream_node"] == "default.repair_orders_fact"
+    assert data["expression"] == "count(repair_order_id)"
 
 
 def test_read_metric(session: Session, client: TestClient) -> None:

--- a/datajunction-ui/src/app/pages/AddEditNodePage/AlertMessage.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/AlertMessage.jsx
@@ -1,0 +1,10 @@
+import AlertIcon from '../../icons/AlertIcon';
+
+export const AlertMessage = ({ message }) => {
+  return (
+    <div className="message alert">
+      <AlertIcon />
+      {message}
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/DescriptionField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/DescriptionField.jsx
@@ -1,0 +1,17 @@
+import { ErrorMessage, Field } from 'formik';
+
+export const DescriptionField = () => {
+  return (
+    <div className="DescriptionInput NodeCreationInput">
+      <ErrorMessage name="description" component="span" />
+      <label htmlFor="Description">Description</label>
+      <Field
+        type="textarea"
+        as="textarea"
+        name="description"
+        id="Description"
+        placeholder="Describe your node"
+      />
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/DisplayNameField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/DisplayNameField.jsx
@@ -1,0 +1,16 @@
+import { ErrorMessage, Field } from 'formik';
+
+export const DisplayNameField = () => {
+  return (
+    <div className="DisplayNameInput NodeCreationInput">
+      <ErrorMessage name="display_name" component="span" />
+      <label htmlFor="displayName">Display Name *</label>
+      <Field
+        type="text"
+        name="display_name"
+        id="displayName"
+        placeholder="Human readable display name"
+      />
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/MetricMetadataFields.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/MetricMetadataFields.jsx
@@ -1,0 +1,60 @@
+/**
+ * Metric unit select component
+ */
+import { ErrorMessage, Field } from 'formik';
+import { useContext, useMemo, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+import { labelize } from '../../../utils/form';
+
+export const MetricMetadataFields = () => {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+
+  // Metric metadata
+  const [metricUnits, setMetricUnits] = useState([]);
+  const [metricDirections, setMetricDirections] = useState([]);
+
+  // Get metric metadata values
+  useMemo(() => {
+    const fetchData = async () => {
+      const metadata = await djClient.listMetricMetadata();
+      setMetricDirections(metadata.directions);
+      setMetricUnits(metadata.units);
+    };
+    fetchData().catch(console.error);
+  }, [djClient]);
+
+  return (
+    <>
+      <div
+        className="MetricDirectionInput NodeCreationInput"
+        style={{ width: '25%' }}
+      >
+        <ErrorMessage name="metric_direction" component="span" />
+        <label htmlFor="MetricDirection">Metric Direction</label>
+        <Field as="select" name="metric_direction" id="MetricDirection">
+          <option value=""></option>
+          {metricDirections.map(direction => (
+            <option value={direction} key={direction}>
+              {labelize(direction)}
+            </option>
+          ))}
+        </Field>
+      </div>
+      <div
+        className="MetricUnitInput NodeCreationInput"
+        style={{ width: '25%' }}
+      >
+        <ErrorMessage name="metric_unit" component="span" />
+        <label htmlFor="MetricUnit">Metric Unit</label>
+        <Field as="select" name="metric_unit" id="MetricUnit">
+          <option value=""></option>
+          {metricUnits.map(unit => (
+            <option value={unit.name} key={unit.name}>
+              {unit.label}
+            </option>
+          ))}
+        </Field>
+      </div>
+    </>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/MetricQueryField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/MetricQueryField.jsx
@@ -1,0 +1,71 @@
+/**
+ * Metric aggregate expression input field, which consists of a CodeMirror SQL
+ * editor with autocompletion for node columns and syntax highlighting.
+ */
+import React from 'react';
+import { ErrorMessage, Field, useFormikContext } from 'formik';
+import CodeMirror from '@uiw/react-codemirror';
+import { langs } from '@uiw/codemirror-extensions-langs';
+
+export const MetricQueryField = ({ djClient, value }) => {
+  const [schema, setSchema] = React.useState([]);
+  const formik = useFormikContext();
+  const sqlExt = langs.sql({ schema: schema });
+
+  const initialAutocomplete = async context => {
+    // Based on the selected upstream, we load the upstream node's columns
+    // into the autocomplete schema
+    const nodeName = formik.values['upstream_node'];
+    const nodeDetails = await djClient.node(nodeName);
+    nodeDetails.columns.forEach(col => {
+      schema[col.name] = [];
+    });
+    setSchema(schema);
+  };
+
+  const updateFormik = val => {
+    formik.setFieldValue('aggregate_expression', val);
+  };
+
+  return (
+    <div className="QueryInput MetricQueryInput NodeCreationInput">
+      <ErrorMessage name="query" component="span" />
+      <label htmlFor="Query">Aggregate Expression *</label>
+      <Field
+        type="textarea"
+        style={{ display: 'none' }}
+        as="textarea"
+        name="aggregate_expression"
+        id="Query"
+      />
+      <div role="button" tabIndex={0} className="relative flex bg-[#282a36]">
+        <CodeMirror
+          id={'aggregate_expression'}
+          name={'aggregate_expression'}
+          extensions={[
+            sqlExt,
+            sqlExt.language.data.of({
+              autocomplete: initialAutocomplete,
+            }),
+          ]}
+          value={value}
+          options={{
+            theme: 'default',
+            lineNumbers: true,
+          }}
+          width="100%"
+          height="100px"
+          style={{
+            margin: '0 0 23px 0',
+            flex: 1,
+            fontSize: '150%',
+            textAlign: 'left',
+          }}
+          onChange={(value, viewUpdate) => {
+            updateFormik(value);
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/NamespaceField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/NamespaceField.jsx
@@ -1,0 +1,40 @@
+import { ErrorMessage } from 'formik';
+import { FormikSelect } from './FormikSelect';
+import { useContext, useEffect, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+
+export const NamespaceField = ({ initialNamespace }) => {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+
+  const [namespaces, setNamespaces] = useState([]);
+
+  // Get namespaces, only necessary when creating a node
+  useEffect(() => {
+    const fetchData = async () => {
+      const namespaces = await djClient.namespaces();
+      setNamespaces(
+        namespaces.map(m => ({
+          value: m['namespace'],
+          label: m['namespace'],
+        })),
+      );
+    };
+    fetchData().catch(console.error);
+  }, [djClient]);
+
+  return (
+    <div className="NamespaceInput">
+      <ErrorMessage name="namespace" component="span" />
+      <label htmlFor="react-select-3-input">Namespace *</label>
+      <FormikSelect
+        selectOptions={namespaces}
+        formikFieldName="namespace"
+        placeholder="Choose Namespace"
+        defaultValue={{
+          value: initialNamespace,
+          label: initialNamespace,
+        }}
+      />
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/NodeModeField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/NodeModeField.jsx
@@ -1,0 +1,14 @@
+import { ErrorMessage, Field } from 'formik';
+
+export const NodeModeField = () => {
+  return (
+    <div className="NodeModeInput NodeCreationInput">
+      <ErrorMessage name="mode" component="span" />
+      <label htmlFor="Mode">Mode</label>
+      <Field as="select" name="mode" id="Mode">
+        <option value="draft">Draft</option>
+        <option value="published">Published</option>
+      </Field>
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
@@ -3,7 +3,7 @@
  * (for node names and columns) and syntax highlighting.
  */
 import React from 'react';
-import { Field, useFormikContext } from 'formik';
+import { ErrorMessage, Field, useFormikContext } from 'formik';
 import CodeMirror from '@uiw/react-codemirror';
 import { langs } from '@uiw/codemirror-extensions-langs';
 
@@ -47,7 +47,9 @@ export const NodeQueryField = ({ djClient, value }) => {
   };
 
   return (
-    <>
+    <div className="QueryInput NodeCreationInput">
+      <ErrorMessage name="query" component="span" />
+      <label htmlFor="Query">Query *</label>
       <Field
         type="textarea"
         style={{ display: 'none' }}
@@ -84,6 +86,6 @@ export const NodeQueryField = ({ djClient, value }) => {
           }}
         />
       </div>
-    </>
+    </div>
   );
 };

--- a/datajunction-ui/src/app/pages/AddEditNodePage/PrimaryKeySelect.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/PrimaryKeySelect.jsx
@@ -1,7 +1,7 @@
 /**
  * Primary key select component
  */
-import { useFormikContext } from 'formik';
+import { ErrorMessage, useFormikContext } from 'formik';
 import { useContext, useMemo, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
 import { FormikSelect } from './FormikSelect';
@@ -42,14 +42,20 @@ export const PrimaryKeySelect = ({ defaultValue }) => {
   };
 
   return (
-    <FormikSelect
-      className="MultiSelectInput"
-      defaultValue={defaultValue}
-      selectOptions={selectableOptions}
-      formikFieldName="primary_key"
-      placeholder="Choose Primary Key"
-      onFocus={event => refreshColumns(event)}
-      isMulti={true}
-    />
+    <div className="CubeCreationInput">
+      <ErrorMessage name="primary_key" component="span" />
+      <label htmlFor="react-select-3-input">Primary Key</label>
+      <span data-testid="select-primary-key">
+        <FormikSelect
+          className="MultiSelectInput"
+          defaultValue={defaultValue}
+          selectOptions={selectableOptions}
+          formikFieldName="primary_key"
+          placeholder="Choose Primary Key"
+          onFocus={event => refreshColumns(event)}
+          isMulti={true}
+        />
+      </span>
+    </div>
   );
 };

--- a/datajunction-ui/src/app/pages/AddEditNodePage/TagsField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/TagsField.jsx
@@ -1,0 +1,47 @@
+/**
+ * Tags select field
+ */
+import { ErrorMessage } from 'formik';
+import { useContext, useMemo, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+import { FormikSelect } from './FormikSelect';
+
+export const TagsField = ({ defaultValue }) => {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+
+  // All available tags
+  const [tags, setTags] = useState([]);
+
+  useMemo(() => {
+    const fetchData = async () => {
+      const tags = await djClient.listTags();
+      setTags(
+        tags.map(tag => ({
+          value: tag.name,
+          label: tag.display_name,
+        })),
+      );
+    };
+    fetchData().catch(console.error);
+  }, [djClient]);
+
+  return (
+    <div
+      className="TagsInput"
+      style={{ width: '25%', margin: '1rem 0 1rem 1.2rem' }}
+    >
+      <ErrorMessage name="tags" component="span" />
+      <label htmlFor="react-select-3-input">Tags</label>
+      <span data-testid="select-tags">
+        <FormikSelect
+          isMulti={true}
+          selectOptions={tags}
+          formikFieldName="tags"
+          className="MultiSelectInput"
+          placeholder="Choose Tags"
+          defaultValue={defaultValue}
+        />
+      </span>
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/UpstreamNodeField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/UpstreamNodeField.jsx
@@ -1,0 +1,49 @@
+/**
+ * Upstream node select field
+ */
+import { ErrorMessage } from 'formik';
+import { useContext, useMemo, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+import { FormikSelect } from './FormikSelect';
+
+export const UpstreamNodeField = ({ defaultValue }) => {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+
+  // All available nodes
+  const [availableNodes, setAvailableNodes] = useState([]);
+
+  useMemo(() => {
+    async function fetchData() {
+      const sources = await djClient.nodesWithType('source');
+      const transforms = await djClient.nodesWithType('transform');
+      const dimensions = await djClient.nodesWithType('dimension');
+      const nodes = sources.concat(transforms).concat(dimensions);
+      setAvailableNodes(
+        nodes.map(node => {
+          return {
+            value: node,
+            label: node,
+          };
+        }),
+      );
+    }
+    fetchData();
+  }, [djClient]);
+
+  return (
+    <div className="NodeCreationInput">
+      <ErrorMessage name="mode" component="span" />
+      <label htmlFor="Mode">Upstream Node *</label>
+      <span data-testid="select-upstream-node">
+        <FormikSelect
+          className="SelectInput"
+          defaultValue={defaultValue}
+          selectOptions={availableNodes}
+          formikFieldName="upstream_node"
+          placeholder="Select Upstream Node"
+          isMulti={false}
+        />
+      </span>
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -4,8 +4,10 @@ import fetchMock from 'jest-fetch-mock';
 import userEvent from '@testing-library/user-event';
 import {
   initializeMockDJClient,
+  renderCreateMetric,
   renderCreateNode,
   renderEditNode,
+  renderEditTransformNode,
   testElement,
 } from './index.test';
 import { mocks } from '../../../../mocks/mockNodes';
@@ -21,11 +23,11 @@ describe('AddEditNodePage submission succeeded', () => {
     window.scrollTo = jest.fn();
   });
 
-  it('for creating a node', async () => {
+  it('for creating a dimension/transform node', async () => {
     const mockDjClient = initializeMockDJClient();
     mockDjClient.DataJunctionAPI.createNode.mockReturnValue({
       status: 200,
-      json: { name: 'default.some_test_metric' },
+      json: { name: 'default.some_test_dim' },
     });
 
     mockDjClient.DataJunctionAPI.tagsNode.mockReturnValue({
@@ -43,11 +45,11 @@ describe('AddEditNodePage submission succeeded', () => {
 
     await userEvent.type(
       screen.getByLabelText('Display Name *'),
-      'Some Test Metric',
+      'Some Test Dim',
     );
     await userEvent.type(
       screen.getByLabelText('Query *'),
-      'SELECT * FROM test',
+      'SELECT a, b, c FROM test',
     );
     await userEvent.click(screen.getByText('Create dimension'));
 
@@ -55,18 +57,89 @@ describe('AddEditNodePage submission succeeded', () => {
       expect(mockDjClient.DataJunctionAPI.createNode).toBeCalled();
       expect(mockDjClient.DataJunctionAPI.createNode).toBeCalledWith(
         'dimension',
-        'default.some_test_metric',
-        'Some Test Metric',
+        'default.some_test_dim',
+        'Some Test Dim',
         '',
-        'SELECT * FROM test',
+        'SELECT a, b, c FROM test',
         'draft',
         'default',
         null,
         undefined,
         undefined,
       );
-      expect(screen.getByText(/default.some_test_metric/)).toBeInTheDocument();
+      expect(screen.getByText(/default.some_test_dim/)).toBeInTheDocument();
     });
+
+    // After successful creation, it should return a success message
+    expect(screen.getByTestId('success')).toHaveTextContent(
+      'Successfully created node default.some_test_dim',
+    );
+  }, 60000);
+
+  it('for creating a metric node', async () => {
+    const mockDjClient = initializeMockDJClient();
+    mockDjClient.DataJunctionAPI.createNode.mockReturnValue({
+      status: 200,
+      json: { name: 'default.some_test_metric' },
+    });
+
+    mockDjClient.DataJunctionAPI.tagsNode.mockReturnValue({
+      status: 200,
+      json: { message: 'Success' },
+    });
+
+    mockDjClient.DataJunctionAPI.nodesWithType
+      .mockReturnValueOnce(['default.test1'])
+      .mockReturnValueOnce(['default.test2'])
+      .mockReturnValueOnce([]);
+
+    mockDjClient.DataJunctionAPI.listTags.mockReturnValue([
+      { name: 'purpose', display_name: 'Purpose' },
+      { name: 'intent', display_name: 'Intent' },
+    ]);
+
+    mockDjClient.DataJunctionAPI.listMetricMetadata.mockReturnValue(
+      mocks.metricMetadata,
+    );
+
+    const element = testElement(mockDjClient);
+    const { container } = renderCreateMetric(element);
+
+    await userEvent.type(
+      screen.getByLabelText('Display Name *'),
+      'Some Test Metric',
+    );
+    const selectUpstream = screen.getByTestId('select-upstream-node');
+    fireEvent.keyDown(selectUpstream.firstChild, { key: 'ArrowDown' });
+    fireEvent.click(screen.getByText('default.repair_orders'));
+
+    await userEvent.type(
+      screen.getByLabelText('Aggregate Expression *'),
+      'SUM(a)',
+    );
+    await userEvent.click(screen.getByText('Create metric'));
+
+    await waitFor(
+      () => {
+        expect(mockDjClient.DataJunctionAPI.createNode).toBeCalled();
+        expect(mockDjClient.DataJunctionAPI.createNode).toBeCalledWith(
+          'metric',
+          'default.some_test_metric',
+          'Some Test Metric',
+          '',
+          'SELECT SUM(a) FROM default.repair_orders',
+          'draft',
+          'default',
+          null,
+          undefined,
+          undefined,
+        );
+        expect(
+          screen.getByText(/default.some_test_metric/),
+        ).toBeInTheDocument();
+      },
+      { timeout: 10000 },
+    );
 
     // After successful creation, it should return a success message
     expect(screen.getByTestId('success')).toHaveTextContent(
@@ -74,10 +147,69 @@ describe('AddEditNodePage submission succeeded', () => {
     );
   }, 60000);
 
-  it('for editing a node', async () => {
+  it('for editing a transform or dimension node', async () => {
+    const mockDjClient = initializeMockDJClient();
+
+    mockDjClient.DataJunctionAPI.node.mockReturnValue(mocks.mockTransformNode);
+    mockDjClient.DataJunctionAPI.patchNode = jest.fn();
+    mockDjClient.DataJunctionAPI.patchNode.mockReturnValue({
+      status: 201,
+      json: { name: 'default.repair_order_transform', type: 'transform' },
+    });
+
+    mockDjClient.DataJunctionAPI.tagsNode.mockReturnValue({
+      status: 200,
+      json: { message: 'Success' },
+    });
+
+    mockDjClient.DataJunctionAPI.listTags.mockReturnValue([
+      { name: 'purpose', display_name: 'Purpose' },
+      { name: 'intent', display_name: 'Intent' },
+    ]);
+
+    const element = testElement(mockDjClient);
+    const { getByTestId } = renderEditTransformNode(element);
+
+    await userEvent.type(screen.getByLabelText('Display Name *'), '!!!');
+    await userEvent.type(screen.getByLabelText('Description'), '!!!');
+    await userEvent.click(screen.getByText('Save'));
+
+    const selectTags = getByTestId('select-tags');
+    fireEvent.keyDown(selectTags.firstChild, { key: 'ArrowDown' });
+    fireEvent.click(screen.getByText('Purpose'));
+
+    await waitFor(async () => {
+      expect(mockDjClient.DataJunctionAPI.patchNode).toBeCalledTimes(1);
+      expect(mockDjClient.DataJunctionAPI.patchNode).toBeCalledWith(
+        'default.repair_order_transform',
+        'Default: Repair Order Transform!!!',
+        'Repair order dimension!!!',
+        'SELECT repair_order_id, municipality_id, hard_hat_id, dispatcher_id FROM default.repair_orders',
+        'published',
+        [],
+        undefined,
+        undefined,
+      );
+      expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
+      expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
+        'default.repair_order_transform',
+        [],
+      );
+
+      expect(mockDjClient.DataJunctionAPI.listMetricMetadata).toBeCalledTimes(
+        0,
+      );
+      expect(
+        await screen.getByText(/Successfully updated transform node/),
+      ).toBeInTheDocument();
+    });
+  }, 1000000);
+
+  it('for editing a metric node', async () => {
     const mockDjClient = initializeMockDJClient();
 
     mockDjClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    mockDjClient.DataJunctionAPI.metric.mockReturnValue(mocks.mockMetricNode);
     mockDjClient.DataJunctionAPI.patchNode = jest.fn();
     mockDjClient.DataJunctionAPI.patchNode.mockReturnValue({
       status: 201,
@@ -102,8 +234,8 @@ describe('AddEditNodePage submission succeeded', () => {
     await userEvent.click(screen.getByText('Save'));
 
     const selectTags = getByTestId('select-tags');
-    await fireEvent.keyDown(selectTags.firstChild, { key: 'ArrowDown' });
-    await fireEvent.click(screen.getByText('Purpose'));
+    fireEvent.keyDown(selectTags.firstChild, { key: 'ArrowDown' });
+    fireEvent.click(screen.getByText('Purpose'));
 
     await waitFor(async () => {
       expect(mockDjClient.DataJunctionAPI.patchNode).toBeCalledTimes(1);
@@ -111,7 +243,7 @@ describe('AddEditNodePage submission succeeded', () => {
         'default.num_repair_orders',
         'Default: Num Repair Orders!!!',
         'Number of repair orders!!!',
-        'SELECT count(repair_order_id) default_DOT_num_repair_orders FROM default.repair_orders',
+        'SELECT count(repair_order_id) FROM default.repair_orders',
         'published',
         [],
         'neutral',

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
@@ -38,7 +38,6 @@ export const MetricsSelect = ({ cube }) => {
 
       const metrics = await djClient.metrics();
       setMetrics(metrics.map(m => ({ value: m, label: m })));
-      console.log('metrics', metrics);
     };
     fetchData().catch(console.error);
   }, [djClient, djClient.metrics, cube]);

--- a/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
@@ -40,7 +40,6 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
     setSubmitting(false);
     const config = JSON.parse(values.config);
     config.lookback_window = values.lookback_window;
-    console.log('values', values);
     const response = await djClient.materialize(
       values.node,
       values.job_type,

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -38,6 +38,26 @@ export default function NodeInfoTab({ node }) {
   function toggle(value) {
     return !value;
   }
+  const metricQueryDiv = node?.expression ? (
+    <div className="list-group-item d-flex">
+      <div className="gap-2 w-100 justify-content-between py-3">
+        <div style={{ marginBottom: '30px' }}>
+          <h6 className="mb-0 w-100">Upstream Node</h6>
+          <p>
+            <a href={`/nodes/${node?.upstream_node}`}>{node?.upstream_node}</a>
+          </p>
+        </div>
+        <div>
+          <h6 className="mb-0 w-100">Aggregate Expression</h6>
+          <SyntaxHighlighter language="sql" style={foundation}>
+            {node?.expression}
+          </SyntaxHighlighter>
+        </div>
+      </div>
+    </div>
+  ) : (
+    ''
+  );
   const queryDiv = node?.query ? (
     <div className="list-group-item d-flex">
       <div className="d-flex gap-2 w-100 justify-content-between py-3">
@@ -248,7 +268,8 @@ export default function NodeInfoTab({ node }) {
         </div>
       </div>
       {metricMetadataDiv}
-      {node?.type !== 'cube' ? queryDiv : ''}
+      {node?.type !== 'cube' && node?.type !== 'metric' ? queryDiv : ''}
+      {node?.type === 'metric' ? metricQueryDiv : ''}
       {cubeElementsDiv}
     </div>
   );

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
@@ -543,14 +543,12 @@ describe('<NodePage />', () => {
             'Status changed from valid to invalid Caused by a change in upstream default.repair_order_details',
           ),
         );
-      screen.debug();
     });
   });
 
   it('renders compiled sql correctly', async () => {
     const djClient = mockDJClient();
-    djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
-    djClient.DataJunctionAPI.metric.mockReturnValue(mocks.mockMetricNode);
+    djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockTransformNode);
     djClient.DataJunctionAPI.columns.mockReturnValue(mocks.metricNodeColumns);
     djClient.DataJunctionAPI.compiledSql.mockReturnValue('select 1');
 
@@ -560,7 +558,7 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter initialEntries={[`/nodes/${mocks.mockTransformNode.name}`]}>
         <Routes>
           <Route path="nodes/:name" element={element} />
         </Routes>
@@ -569,7 +567,7 @@ describe('<NodePage />', () => {
     await waitFor(() => {
       fireEvent.click(screen.getByRole('checkbox', { name: 'ToggleSwitch' }));
       expect(djClient.DataJunctionAPI.compiledSql).toHaveBeenCalledWith(
-        mocks.mockMetricNode.name,
+        mocks.mockTransformNode.name,
       );
     });
   });

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
@@ -107,28 +107,12 @@ HTMLCollection [
     style="white-space: pre;"
   >
     <span
-      style="color: rgb(0, 153, 153);"
-    >
-      SELECT
-    </span>
-    <span>
-       
-    </span>
-    <span
       class="hljs-built_in"
     >
       count
     </span>
     <span>
-      (repair_order_id) default_DOT_num_repair_orders 
-    </span>
-    <span
-      style="color: rgb(0, 153, 153);"
-    >
-      FROM
-    </span>
-    <span>
-       default.repair_orders
+      (repair_order_id)
     </span>
   </code>,
 ]

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -52,6 +52,9 @@ export function NodePage() {
         const metric = await djClient.metric(name);
         data.dimensions = metric.dimensions;
         data.metric_metadata = metric.metric_metadata;
+        data.required_dimensions = metric.required_dimensions;
+        data.upstream_node = metric.upstream_node;
+        data.expression = metric.expression;
         setNode(data);
       }
       if (data.type === 'cube') {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -60,6 +60,14 @@ export const DataJunctionAPI = {
     ).json();
   },
 
+  nodesWithType: async function (nodeType) {
+    return await (
+      await fetch(`${DJ_URL}/nodes/?node_type=${nodeType}`, {
+        credentials: 'include',
+      })
+    ).json();
+  },
+
   nodeDetails: async () => {
     return await (
       await fetch(`${DJ_URL}/nodes/details/`, {

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -65,6 +65,18 @@ describe('DataJunctionAPI', () => {
     });
   });
 
+  it('calls nodesWithType correctly', async () => {
+    const nodeType = 'transform';
+    fetch.mockResponseOnce(JSON.stringify({}));
+    await DataJunctionAPI.nodesWithType(nodeType);
+    expect(fetch).toHaveBeenCalledWith(
+      `${DJ_URL}/nodes/?node_type=${nodeType}`,
+      {
+        credentials: 'include',
+      },
+    );
+  });
+
   it('calls createNode correctly', async () => {
     const sampleArgs = [
       'type',
@@ -262,6 +274,17 @@ describe('DataJunctionAPI', () => {
     fetch.mockResponseOnce(JSON.stringify({}));
     await DataJunctionAPI.metrics('');
     expect(fetch).toHaveBeenCalledWith(`${DJ_URL}/metrics/`, {
+      credentials: 'include',
+    });
+  });
+
+  it('calls listMetricMetadata correctly', async () => {
+    const nodeType = 'transform';
+    fetch.mockResponseOnce(JSON.stringify({}));
+    await DataJunctionAPI.listMetricMetadata();
+    expect(fetch).toHaveBeenCalledWith(`${DJ_URL}/metrics/metadata`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
     });
   });

--- a/datajunction-ui/src/mocks/mockNodes.jsx
+++ b/datajunction-ui/src/mocks/mockNodes.jsx
@@ -1,4 +1,63 @@
 export const mocks = {
+  metricMetadata: {
+    directions: ['higher_is_better', 'lower_is_better', 'neutral'],
+    units: [
+      { name: 'dollar', label: 'Dollar' },
+      { name: 'second', label: 'Second' },
+    ],
+  },
+  mockTransformNode: {
+    namespace: 'default',
+    node_revision_id: 15,
+    node_id: 15,
+    type: 'transform',
+    name: 'default.repair_order_transform',
+    display_name: 'Default: Repair Order Transform',
+    version: 'v1.0',
+    status: 'valid',
+    mode: 'published',
+    catalog: {
+      name: 'warehouse',
+      engines: [],
+    },
+    schema_: null,
+    table: null,
+    description: 'Repair order dimension',
+    query:
+      'SELECT repair_order_id, municipality_id, hard_hat_id, dispatcher_id FROM default.repair_orders',
+    availability: null,
+    columns: [
+      {
+        name: 'repair_order_id',
+        display_name: 'Repair Order Id',
+        type: 'int',
+        attributes: [],
+        dimension: null,
+        partition: null,
+      },
+      {
+        name: 'municipality_id',
+        display_name: 'Municipality Id',
+        type: 'string',
+        attributes: [],
+        dimension: null,
+        partition: null,
+      },
+    ],
+    updated_at: '2024-01-24T16:39:14.029366+00:00',
+    materializations: [],
+    parents: [
+      {
+        name: 'default.repair_orders',
+      },
+    ],
+    metric_metadata: null,
+    dimension_links: [],
+    created_at: '2024-01-24T16:39:14.028077+00:00',
+    tags: [],
+    current_version: 'v1.0',
+    missing_table: false,
+  },
   mockMetricNode: {
     namespace: 'default',
     node_revision_id: 23,
@@ -217,6 +276,9 @@ export const mocks = {
       },
       direction: 'neutral',
     },
+    upstream_node: 'default.repair_orders',
+    expression: 'count(repair_order_id)',
+    aggregate_expression: 'count(repair_order_id)',
   },
   attributes: [
     {

--- a/datajunction-ui/src/styles/node-creation.scss
+++ b/datajunction-ui/src/styles/node-creation.scss
@@ -9,6 +9,7 @@ form {
     padding: 1rem;
     font-family: Lato, 'sans-serif';
     font-size: 110%;
+    border-right: 16px solid transparent;
   }
 
   input {
@@ -98,7 +99,7 @@ form {
   .SelectInput {
     background-color: #eee;
     border-radius: 10px;
-    border-style: none;
+    border-style: none !important;
     border-color: transparent;
     box-sizing: border-box;
     padding: 0.5rem;
@@ -106,10 +107,18 @@ form {
     box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
       rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
   }
+  .SelectInput div {
+    border: none;
+    background: transparent;
+  }
   .SelectInput div:first-child {
     background-color: #eee !important;
     border: none;
     color: #0c4128;
+  }
+  .SelectInput div:last-child div {
+    border: none;
+    background-color: #efefef;
   }
   .MultiSelectInput {
     background-color: #eee;
@@ -129,6 +138,9 @@ form {
   .MultiSelectInput div:last-child div {
     border: none;
     background-color: #efefef;
+  }
+  .MultiSelectInput div:last-child input {
+    box-shadow: none;
   }
   .MultiSelectInput div div {
     border: none;
@@ -176,12 +188,14 @@ form {
   .QueryInput {
     width: 75%;
   }
+  .MetricQueryInput {
+    height: 200px;
+  }
 
   .NodeModeInput {
     select {
       background-color: #eeeeee;
       border-radius: 10px;
-      border-style: none;
       padding: 1rem;
       font-family: Lato, Sans;
       font-size: 110%;


### PR DESCRIPTION
### Summary

In the metric node create/edit UI, instead of asking for SQL, which is unclear from the user perspective, we instead explicitly ask for an upstream node and an aggregate expression (written in SQL). 

Given that we already have these restrictions in place for metric node SQL (i.e., it must source from one node and there must be an aggregation in the expression), we can just be explicit about these requirements in the UI rather than expecting users to structure it nicely into an ill-defined SQL blob. 

After the changes, this is what the new metric create/edit flow looks like:

<img width="1261" alt="Screenshot 2024-02-04 at 12 17 06 AM" src="https://github.com/DataJunction/dj/assets/9524628/3cb4c479-1588-499e-a9f1-10ac8fe910c1">

The metric node info page also includes the split into upstream + agg expression:

<img width="850" alt="Screenshot 2024-02-04 at 12 21 04 AM" src="https://github.com/DataJunction/dj/assets/9524628/cf261ef6-9e89-427a-923d-d78b1e10c81d">

This PR includes some additional changes that help streamline the structure of the add/edit node form page, primarily by splitting out various fields into separate components rather than keeping them in a single file. Some minor server-side changes were also made to support this on the `/metrics` endpoint.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #910 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
