### PR TITLE
Required dimensions, node tab links, node name/namespace validation, 

### DIFF
--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -2,6 +2,7 @@
 Helper methods for namespaces endpoints.
 """
 import os
+import re
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
@@ -188,7 +189,11 @@ def validate_namespace(namespace: str):
     """
     parts = namespace.split(SEPARATOR)
     for part in parts:
-        if not part or (part and part[0].isdigit()) or part in RESERVED_NAMESPACE_NAMES:
+        if (
+            not part
+            or not re.match("^[a-zA-Z][a-zA-Z0-9_]*$", part)
+            or part in RESERVED_NAMESPACE_NAMES
+        ):
             raise DJInvalidInputException(
                 f"{namespace} is not a valid namespace. Namespace parts cannot start with numbers"
                 f", be empty, or use the reserved keyword [{', '.join(RESERVED_NAMESPACE_NAMES)}]",

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -599,6 +599,10 @@ def test_create_namespace(client_with_service_setup: TestClient):
         "1234",
         "aa..bb",
         "user.abc",
+        "[aff].mmm",
+        "aff._mmm",
+        "aff.mmm+",
+        "aff.123_mmm",
     ]
     for invalid_namespace in invalid_namespaces:
         response = client_with_service_setup.post(f"/namespaces/{invalid_namespace}")

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -874,7 +874,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "query": "SELECT COUNT(DISTINCT id) FROM default.messages",
                 "mode": "published",
                 "name": "default.num_messages_id",
-                "required_dimensions": ["default.messages.id"],
+                "required_dimensions": ["user_id"],
             },
         )
         assert response.ok
@@ -2198,14 +2198,21 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         response = client_with_roads.patch(
             "/nodes/default.total_repair_cost/",
-            json={"query": "SELECT count(price) FROM default.repair_order_details"},
+            json={
+                "query": "SELECT count(price) FROM default.repair_order_details",
+                "required_dimensions": ["repair_order_id"],
+            },
         )
         node_data = response.json()
         assert node_data["query"] == (
             "SELECT count(price) FROM default.repair_order_details"
         )
         response = client_with_roads.get("/nodes/default.total_repair_cost")
-        assert response.json()["version"] == "v2.0"
+        data = response.json()
+        assert data["version"] == "v2.0"
+        response = client_with_roads.get("/metrics/default.total_repair_cost")
+        data = response.json()
+        assert data["required_dimensions"] == ["repair_order_id"]
 
     def test_create_dimension_node_fails(
         self,

--- a/datajunction-ui/src/app/index.tsx
+++ b/datajunction-ui/src/app/index.tsx
@@ -58,6 +58,7 @@ export function App() {
                           key="edit-cube"
                           element={<CubeBuilderPage />}
                         />
+                        <Route path=":name/:tab" element={<NodePage />} />
                       </Route>
 
                       <Route path="/" element={<NamespacePage />} key="index" />

--- a/datajunction-ui/src/app/pages/AddEditNodePage/FullNameField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/FullNameField.jsx
@@ -11,12 +11,13 @@ export const FullNameField = props => {
 
   useEffect(() => {
     // Set the value of the node's full name based on its namespace and display name
-    if (values.namespace && values.display_name) {
+    if (values.namespace || values.display_name) {
       setFieldValue(
         props.name,
         `${values.namespace}.${values.display_name
           .toLowerCase()
-          .replace(/ /g, '_')}` || '',
+          .replace(/ /g, '_')
+          .replace(/[^a-zA-Z0-9_]/g, '')}` || '',
       );
     }
   }, [setFieldValue, props.name, values]);

--- a/datajunction-ui/src/app/pages/AddEditNodePage/MetricMetadataFields.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/MetricMetadataFields.jsx
@@ -2,7 +2,7 @@
  * Metric unit select component
  */
 import { ErrorMessage, Field } from 'formik';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
 import { labelize } from '../../../utils/form';
 
@@ -14,7 +14,7 @@ export const MetricMetadataFields = () => {
   const [metricDirections, setMetricDirections] = useState([]);
 
   // Get metric metadata values
-  useMemo(() => {
+  useEffect(() => {
     const fetchData = async () => {
       const metadata = await djClient.listMetricMetadata();
       setMetricDirections(metadata.directions);

--- a/datajunction-ui/src/app/pages/AddEditNodePage/RequiredDimensionsSelect.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/RequiredDimensionsSelect.jsx
@@ -1,0 +1,54 @@
+/**
+ * Required dimensions select component
+ */
+import { ErrorMessage, useFormikContext } from 'formik';
+import React, { useContext, useMemo, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+import { FormikSelect } from './FormikSelect';
+
+export const RequiredDimensionsSelect = ({
+  defaultValue,
+  style,
+  className = 'MultiSelectInput',
+}) => {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+
+  // Used to pull out current form values for node validation
+  const { values } = useFormikContext();
+
+  // Select options, i.e., the available dimensions
+  const [selectOptions, setSelectOptions] = useState([]);
+
+  useMemo(() => {
+    const fetchData = async () => {
+      if (values.upstream_node) {
+        const data = await djClient.node(values.upstream_node);
+        setSelectOptions(
+          data.columns.map(col => {
+            return {
+              value: col.name,
+              label: col.name,
+            };
+          }),
+        );
+      }
+    };
+    fetchData().catch(console.error);
+  }, [djClient, values.upstream_node]);
+
+  return (
+    <div className="RequiredDimensionsInput CubeCreationInput">
+      <ErrorMessage name="required_dimensions" component="span" />
+      <label htmlFor="requiredDimensions">Required Dimensions</label>
+      <FormikSelect
+        className={className}
+        defaultValue={defaultValue}
+        selectOptions={selectOptions}
+        formikFieldName={'required_dimensions'}
+        placeholder={'Choose Required Dimensions'}
+        styles={style}
+        isMulti={true}
+      />
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/RequiredDimensionsSelect.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/RequiredDimensionsSelect.jsx
@@ -2,7 +2,7 @@
  * Required dimensions select component
  */
 import { ErrorMessage, useFormikContext } from 'formik';
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
 import { FormikSelect } from './FormikSelect';
 
@@ -19,7 +19,7 @@ export const RequiredDimensionsSelect = ({
   // Select options, i.e., the available dimensions
   const [selectOptions, setSelectOptions] = useState([]);
 
-  useMemo(() => {
+  useEffect(() => {
     const fetchData = async () => {
       if (values.upstream_node) {
         const data = await djClient.node(values.upstream_node);

--- a/datajunction-ui/src/app/pages/AddEditNodePage/TagsField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/TagsField.jsx
@@ -2,7 +2,7 @@
  * Tags select field
  */
 import { ErrorMessage } from 'formik';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
 import { FormikSelect } from './FormikSelect';
 
@@ -12,7 +12,7 @@ export const TagsField = ({ defaultValue }) => {
   // All available tags
   const [tags, setTags] = useState([]);
 
-  useMemo(() => {
+  useEffect(() => {
     const fetchData = async () => {
       const tags = await djClient.listTags();
       setTags(

--- a/datajunction-ui/src/app/pages/AddEditNodePage/UpstreamNodeField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/UpstreamNodeField.jsx
@@ -2,7 +2,7 @@
  * Upstream node select field
  */
 import { ErrorMessage } from 'formik';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
 import { FormikSelect } from './FormikSelect';
 
@@ -12,7 +12,7 @@ export const UpstreamNodeField = ({ defaultValue }) => {
   // All available nodes
   const [availableNodes, setAvailableNodes] = useState([]);
 
-  useMemo(() => {
+  useEffect(() => {
     async function fetchData() {
       const sources = await djClient.nodesWithType('source');
       const transforms = await djClient.nodesWithType('transform');

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
@@ -54,6 +54,7 @@ describe('AddEditNodePage submission failed', () => {
         null,
         undefined,
         undefined,
+        undefined,
       );
       expect(
         screen.getByText(/Some columns in the primary key \[] were not found/),

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -66,6 +66,7 @@ describe('AddEditNodePage submission succeeded', () => {
         null,
         undefined,
         undefined,
+        undefined,
       );
       expect(screen.getByText(/default.some_test_dim/)).toBeInTheDocument();
     });
@@ -133,6 +134,7 @@ describe('AddEditNodePage submission succeeded', () => {
           null,
           undefined,
           undefined,
+          undefined,
         );
         expect(
           screen.getByText(/default.some_test_metric/),
@@ -187,6 +189,7 @@ describe('AddEditNodePage submission succeeded', () => {
         'SELECT repair_order_id, municipality_id, hard_hat_id, dispatcher_id FROM default.repair_orders',
         'published',
         [],
+        undefined,
         undefined,
         undefined,
       );
@@ -248,6 +251,7 @@ describe('AddEditNodePage submission succeeded', () => {
         [],
         'neutral',
         'unitless',
+        undefined,
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -23,6 +23,7 @@ import { AlertMessage } from './AlertMessage';
 import { DisplayNameField } from './DisplayNameField';
 import { DescriptionField } from './DescriptionField';
 import { NodeModeField } from './NodeModeField';
+import { RequiredDimensionsSelect } from './RequiredDimensionsSelect';
 
 class Action {
   static Add = new Action('add');
@@ -100,10 +101,6 @@ export function AddEditNodePage() {
     </>
   );
 
-  const isMetric = (nodeType, node) => {
-    return nodeType === 'metric' || node.type === 'metric';
-  };
-
   const primaryKeyToList = primaryKey => {
     return primaryKey.map(columnName => columnName.trim());
   };
@@ -122,6 +119,7 @@ export function AddEditNodePage() {
       values.primary_key ? primaryKeyToList(values.primary_key) : null,
       values.metric_direction,
       values.metric_unit,
+      values.required_dimensions,
     );
     if (status === 200 || status === 201) {
       if (values.tags) {
@@ -154,6 +152,7 @@ export function AddEditNodePage() {
       values.primary_key ? primaryKeyToList(values.primary_key) : null,
       values.metric_direction,
       values.metric_unit,
+      values.required_dimensions,
     );
     const tagsResponse = await djClient.tagsNode(
       values.name,
@@ -235,6 +234,7 @@ export function AddEditNodePage() {
     setSelectTags,
     setSelectPrimaryKey,
     setSelectUpstreamNode,
+    setSelectRequiredDims,
   ) => {
     // Update fields with existing data to prepare for edit
     const fields = [
@@ -294,6 +294,13 @@ export function AddEditNodePage() {
         })}
       />,
     );
+    setSelectRequiredDims(
+      <RequiredDimensionsSelect
+        defaultValue={data.required_dimensions.map(dim => {
+          return { value: dim, label: dim };
+        })}
+      />,
+    );
     setSelectUpstreamNode(
       <UpstreamNodeField
         defaultValue={{
@@ -319,6 +326,8 @@ export function AddEditNodePage() {
               {function Render({ isSubmitting, status, setFieldValue }) {
                 const [node, setNode] = useState([]);
                 const [selectPrimaryKey, setSelectPrimaryKey] = useState(null);
+                const [selectRequiredDims, setSelectRequiredDims] =
+                  useState(null);
                 const [selectUpstreamNode, setSelectUpstreamNode] =
                   useState(null);
                 const [selectTags, setSelectTags] = useState(null);
@@ -336,6 +345,7 @@ export function AddEditNodePage() {
                         setSelectTags,
                         setSelectPrimaryKey,
                         setSelectUpstreamNode,
+                        setSelectRequiredDims,
                       );
                     }
                   };
@@ -357,7 +367,7 @@ export function AddEditNodePage() {
                         {action === Action.Add ? fullNameInput : ''}
                         <DescriptionField />
                         <br />
-                        {isMetric(nodeType, node) ? (
+                        {nodeType === 'metric' || node?.type === 'metric' ? (
                           action === Action.Edit ? (
                             selectUpstreamNode
                           ) : (
@@ -391,8 +401,10 @@ export function AddEditNodePage() {
                           ) : (
                             <PrimaryKeySelect />
                           )
+                        ) : action === Action.Edit ? (
+                          selectRequiredDims
                         ) : (
-                          ''
+                          <RequiredDimensionsSelect />
                         )}
                         {action === Action.Edit ? selectTags : <TagsField />}
                         <NodeModeField />

--- a/datajunction-ui/src/app/pages/NamespacePage/Explorer.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/Explorer.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import CollapsedIcon from '../../icons/CollapsedIcon';
 import ExpandedIcon from '../../icons/ExpandedIcon';
 
@@ -7,7 +7,7 @@ const Explorer = ({ item = [], current }) => {
   const [expand, setExpand] = useState(false);
   const [highlight, setHighlight] = useState(false);
 
-  useMemo(() => {
+  useEffect(() => {
     setItems(item);
     setHighlight(current);
     if (current === undefined || current?.startsWith(item.path)) {

--- a/datajunction-ui/src/app/pages/NamespacePage/Explorer.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/Explorer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import CollapsedIcon from '../../icons/CollapsedIcon';
 import ExpandedIcon from '../../icons/ExpandedIcon';
 
@@ -7,7 +7,7 @@ const Explorer = ({ item = [], current }) => {
   const [expand, setExpand] = useState(false);
   const [highlight, setHighlight] = useState(false);
 
-  useEffect(() => {
+  useMemo(() => {
     setItems(item);
     setHighlight(current);
     if (current === undefined || current?.startsWith(item.path)) {

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import NodeStatus from '../NodePage/NodeStatus';
 import DJClientContext from '../../providers/djclient';
 import Explorer from '../NamespacePage/Explorer';
@@ -47,7 +47,7 @@ export function NamespacePage() {
     return hierarchy;
   };
 
-  useEffect(() => {
+  useMemo(() => {
     const fetchData = async () => {
       const namespaces = await djClient.namespaces();
       const hierarchy = createNamespaceHierarchy(namespaces);
@@ -56,7 +56,7 @@ export function NamespacePage() {
     fetchData().catch(console.error);
   }, [djClient, djClient.namespaces]);
 
-  useEffect(() => {
+  useMemo(() => {
     const fetchData = async () => {
       if (namespace === undefined && namespaceHierarchy !== undefined) {
         namespace = namespaceHierarchy[0].namespace;

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import NodeStatus from '../NodePage/NodeStatus';
 import DJClientContext from '../../providers/djclient';
 import Explorer from '../NamespacePage/Explorer';
@@ -47,7 +47,7 @@ export function NamespacePage() {
     return hierarchy;
   };
 
-  useMemo(() => {
+  useEffect(() => {
     const fetchData = async () => {
       const namespaces = await djClient.namespaces();
       const hierarchy = createNamespaceHierarchy(namespaces);
@@ -56,7 +56,7 @@ export function NamespacePage() {
     fetchData().catch(console.error);
   }, [djClient, djClient.namespaces]);
 
-  useMemo(() => {
+  useEffect(() => {
     const fetchData = async () => {
       if (namespace === undefined && namespaceHierarchy !== undefined) {
         namespace = namespaceHierarchy[0].namespace;

--- a/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
@@ -11,8 +11,8 @@ export default function NodeHistory({ node, djClient }) {
     const fetchData = async () => {
       if (node) {
         const data = await djClient.history('node', node.name);
-        setHistory(data);
         const revisions = await djClient.revisions(node.name);
+        setHistory(data);
         setRevisions(revisions);
       }
     };

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext, useMemo } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
@@ -20,7 +20,8 @@ export default function NodeInfoTab({ node }) {
     </div>
   ));
   const djClient = useContext(DJClientContext).DataJunctionAPI;
-  useEffect(() => {
+
+  useMemo(() => {
     const fetchData = async () => {
       if (checked === true) {
         const data = await djClient.compiledSql(node.name);
@@ -38,7 +39,7 @@ export default function NodeInfoTab({ node }) {
   function toggle(value) {
     return !value;
   }
-  const metricQueryDiv = node?.expression ? (
+  const metricQueryDiv = (
     <div className="list-group-item d-flex">
       <div className="gap-2 w-100 justify-content-between py-3">
         <div style={{ marginBottom: '30px' }}>
@@ -55,8 +56,6 @@ export default function NodeInfoTab({ node }) {
         </div>
       </div>
     </div>
-  ) : (
-    ''
   );
   const queryDiv = node?.query ? (
     <div className="list-group-item d-flex">
@@ -173,8 +172,39 @@ export default function NodeInfoTab({ node }) {
   ) : (
     <></>
   );
+
+  const primaryKeyOrRequiredDims = (
+    <div style={{ maxWidth: '25%' }}>
+      <h6 className="mb-0 w-100">
+        {node?.type !== 'metric' ? 'Primary Key' : 'Required Dimensions'}
+      </h6>
+      <p
+        className="mb-0 opacity-75"
+        role="dialog"
+        aria-hidden="false"
+        aria-label={
+          node?.type !== 'metric' ? 'PrimaryKey' : 'RequiredDimensions'
+        }
+      >
+        {node?.type !== 'metric'
+          ? node?.primary_key?.map(dim => (
+              <span className="rounded-pill badge bg-secondary-soft PrimaryKey">
+                <a href={`/nodes/${node?.name}`}>{dim}</a>
+              </span>
+            ))
+          : node?.required_dimensions?.map(dim => (
+              <span className="rounded-pill badge bg-secondary-soft PrimaryKey">
+                <a href={`/nodes/${node?.upstream_node}`}>{dim}</a>
+              </span>
+            ))}
+      </p>
+    </div>
+  );
   return (
-    <div className="list-group align-items-center justify-content-between flex-md-row gap-2">
+    <div
+      className="list-group align-items-center justify-content-between flex-md-row gap-2"
+      style={{ minWidth: '700px' }}
+    >
       <ListGroupItem label="Description" value={node?.description} />
       <div className="list-group-item d-flex">
         <div className="d-flex gap-2 w-100 justify-content-between py-3">
@@ -243,17 +273,7 @@ export default function NodeInfoTab({ node }) {
               {nodeTags}
             </p>
           </div>
-          <div>
-            <h6 className="mb-0 w-100">Primary Key</h6>
-            <p
-              className="mb-0 opacity-75"
-              role="dialog"
-              aria-hidden="false"
-              aria-label="PrimaryKey"
-            >
-              {node?.primary_key?.join(', ')}
-            </p>
-          </div>
+          {primaryKeyOrRequiredDims}
           <div>
             <h6 className="mb-0 w-100">Last Updated</h6>
             <p

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useMemo } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
@@ -21,7 +21,7 @@ export default function NodeInfoTab({ node }) {
   ));
   const djClient = useContext(DJClientContext).DataJunctionAPI;
 
-  useMemo(() => {
+  useEffect(() => {
     const fetchData = async () => {
       if (checked === true) {
         const data = await djClient.compiledSql(node.name);

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
@@ -271,7 +271,7 @@ describe('<NodePage />', () => {
     },
   };
 
-  it('renders the NodeInfo tab correctly', async () => {
+  it('renders the NodeInfo tab correctly for a metric node', async () => {
     const djClient = mockDJClient();
     djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
     djClient.DataJunctionAPI.metric.mockReturnValue(mocks.mockMetricNode);
@@ -281,9 +281,9 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     const { container } = render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders/info']}>
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
@@ -292,7 +292,6 @@ describe('<NodePage />', () => {
       expect(djClient.DataJunctionAPI.node).toHaveBeenCalledWith(
         'default.num_repair_orders',
       );
-      userEvent.click(screen.getByRole('button', { name: 'Info' }));
 
       expect(
         screen.getByRole('dialog', { name: 'NodeName' }),
@@ -316,8 +315,8 @@ describe('<NodePage />', () => {
       );
 
       expect(
-        screen.getByRole('dialog', { name: 'PrimaryKey' }),
-      ).toHaveTextContent('repair_order_id, country');
+        screen.getByRole('dialog', { name: 'RequiredDimensions' }),
+      ).toHaveTextContent('');
 
       expect(
         screen.getByRole('dialog', { name: 'DisplayName' }),
@@ -411,14 +410,15 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter
+        initialEntries={['/nodes/default.num_repair_orders/columns']}
+      >
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
     await waitFor(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Columns' }));
       expect(djClient.DataJunctionAPI.columns).toHaveBeenCalledWith(
         mocks.mockMetricNode,
       );
@@ -484,9 +484,11 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     const { container } = render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter
+        initialEntries={['/nodes/default.num_repair_orders/history']}
+      >
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
@@ -585,9 +587,11 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter
+        initialEntries={['/nodes/default.num_repair_orders/materializations']}
+      >
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
@@ -618,9 +622,11 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter
+        initialEntries={['/nodes/default.num_repair_orders/materializations']}
+      >
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
@@ -656,9 +662,9 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders/sql']}>
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
@@ -687,9 +693,11 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter
+        initialEntries={['/nodes/default.num_repair_orders/lineage']}
+      >
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
@@ -713,9 +721,9 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders']}>
+      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders/graph']}>
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );
@@ -740,9 +748,9 @@ describe('<NodePage />', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/nodes/default.dispatcher']}>
+      <MemoryRouter initialEntries={['/nodes/default.dispatcher/linked']}>
         <Routes>
-          <Route path="nodes/:name" element={element} />
+          <Route path="nodes/:name/:tab" element={element} />
         </Routes>
       </MemoryRouter>,
     );

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
@@ -100,7 +100,7 @@ exports[`<NodePage /> renders the NodeHistory tab correctly 1`] = `
 </table>
 `;
 
-exports[`<NodePage /> renders the NodeInfo tab correctly 1`] = `
+exports[`<NodePage /> renders the NodeInfo tab correctly for a metric node 1`] = `
 HTMLCollection [
   <code
     class="language-sql"

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import Tab from '../../components/Tab';
 import NamespaceHeader from '../../components/NamespaceHeader';
 import NodeInfoTab from './NodeInfoTab';
@@ -47,7 +47,7 @@ export function NodePage() {
     ) : null;
   };
 
-  useMemo(() => {
+  useEffect(() => {
     const fetchData = async () => {
       const data = await djClient.node(name);
       data.createNodeClientCode = await djClient.clientCode(name);

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import Tab from '../../components/Tab';
 import NamespaceHeader from '../../components/NamespaceHeader';
 import NodeInfoTab from './NodeInfoTab';
@@ -16,16 +16,22 @@ import NodeColumnLineage from './NodeLineageTab';
 import EditIcon from '../../icons/EditIcon';
 import AlertIcon from '../../icons/AlertIcon';
 import NodeDimensionsTab from './NodeDimensionsTab';
+import { useNavigate } from 'react-router-dom';
 
 export function NodePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const navigate = useNavigate();
+
+  const { name, tab } = useParams();
+
   const [state, setState] = useState({
-    selectedTab: 0,
+    selectedTab: tab || 'info',
   });
 
   const [node, setNode] = useState();
 
   const onClickTab = id => () => {
+    navigate(`/nodes/${name}/${id}`);
     setState({ selectedTab: id });
   };
 
@@ -41,13 +47,10 @@ export function NodePage() {
     ) : null;
   };
 
-  const { name } = useParams();
-
-  useEffect(() => {
+  useMemo(() => {
     const fetchData = async () => {
       const data = await djClient.node(name);
       data.createNodeClientCode = await djClient.clientCode(name);
-      setNode(data);
       if (data.type === 'metric') {
         const metric = await djClient.metric(name);
         data.dimensions = metric.dimensions;
@@ -55,13 +58,12 @@ export function NodePage() {
         data.required_dimensions = metric.required_dimensions;
         data.upstream_node = metric.upstream_node;
         data.expression = metric.expression;
-        setNode(data);
       }
       if (data.type === 'cube') {
         const cube = await djClient.cube(name);
         data.cube_elements = cube.cube_elements;
-        setNode(data);
       }
+      setNode(data);
     };
     fetchData().catch(console.error);
   }, [djClient, name]);
@@ -69,84 +71,82 @@ export function NodePage() {
   const tabsList = node => {
     return [
       {
-        id: 0,
+        id: 'info',
         name: 'Info',
         display: true,
       },
       {
-        id: 1,
+        id: 'columns',
         name: 'Columns',
         display: true,
       },
       {
-        id: 2,
+        id: 'graph',
         name: 'Graph',
         display: true,
       },
       {
-        id: 3,
+        id: 'history',
         name: 'History',
         display: true,
       },
       {
-        id: 4,
+        id: 'sql',
         name: 'SQL',
         display: node?.type !== 'dimension' && node?.type !== 'source',
       },
       {
-        id: 5,
+        id: 'materializations',
         name: 'Materializations',
         display: node?.type !== 'source',
       },
       {
-        id: 6,
+        id: 'linked',
         name: 'Linked Nodes',
         display: node?.type === 'dimension',
       },
       {
-        id: 7,
+        id: 'lineage',
         name: 'Lineage',
         display: node?.type === 'metric',
       },
       {
-        id: 8,
+        id: 'dimensions',
         name: 'Dimensions',
         display: node?.type !== 'cube',
       },
     ];
   };
-
-  //
-  //
   let tabToDisplay = null;
+
   switch (state.selectedTab) {
-    case 0:
+    case 'info':
       tabToDisplay =
         node && node.message === undefined ? <NodeInfoTab node={node} /> : '';
       break;
-    case 1:
+    case 'columns':
       tabToDisplay = <NodeColumnTab node={node} djClient={djClient} />;
       break;
-    case 2:
+    case 'graph':
       tabToDisplay = <NodeLineage djNode={node} djClient={djClient} />;
       break;
-    case 3:
+    case 'history':
       tabToDisplay = <NodeHistory node={node} djClient={djClient} />;
       break;
-    case 4:
+    case 'sql':
       tabToDisplay =
         node?.type === 'metric' ? <NodeSQLTab djNode={node} /> : <br />;
       break;
-    case 5:
+    case 'materializations':
       tabToDisplay = <NodeMaterializationTab node={node} djClient={djClient} />;
       break;
-    case 6:
+    case 'linked':
       tabToDisplay = <NodesWithDimension node={node} djClient={djClient} />;
       break;
-    case 7:
+    case 'lineage':
       tabToDisplay = <NodeColumnLineage djNode={node} djClient={djClient} />;
       break;
-    case 8:
+    case 'dimensions':
       tabToDisplay = <NodeDimensionsTab node={node} djClient={djClient} />;
       break;
     default: /* istanbul ignore next */

--- a/datajunction-ui/src/app/pages/Root/index.tsx
+++ b/datajunction-ui/src/app/pages/Root/index.tsx
@@ -24,10 +24,11 @@ export function Root() {
       <div className="container d-flex align-items-center justify-content-between">
         <div className="header">
           <div className="logo">
-            <h2>
+            <a href={'/'} style={{textTransform: 'none', textDecoration: 'none', color: '#000'}}>
+              <h2>
               <DJLogo />
               Data<b>Junction</b>
-            </h2>
+            </h2></a>
           </div>
           <Search />
           <div className="menu">

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -112,6 +112,7 @@ export const DataJunctionAPI = {
     primary_key,
     metric_direction,
     metric_unit,
+    required_dimensions,
   ) {
     const metricMetadata =
       metric_direction || metric_unit
@@ -134,6 +135,7 @@ export const DataJunctionAPI = {
         namespace: namespace,
         primary_key: primary_key,
         metric_metadata: metricMetadata,
+        required_dimensions: required_dimensions,
       }),
       credentials: 'include',
     });
@@ -149,6 +151,7 @@ export const DataJunctionAPI = {
     primary_key,
     metric_direction,
     metric_unit,
+    required_dimensions,
   ) {
     try {
       const metricMetadata =
@@ -170,6 +173,7 @@ export const DataJunctionAPI = {
           mode: mode,
           primary_key: primary_key,
           metric_metadata: metricMetadata,
+          required_dimensions: required_dimensions,
         }),
         credentials: 'include',
       });

--- a/datajunction-ui/src/mocks/mockNodes.jsx
+++ b/datajunction-ui/src/mocks/mockNodes.jsx
@@ -279,6 +279,7 @@ export const mocks = {
     upstream_node: 'default.repair_orders',
     expression: 'count(repair_order_id)',
     aggregate_expression: 'count(repair_order_id)',
+    required_dimensions: [],
   },
   attributes: [
     {

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -1106,3 +1106,9 @@ pre {
   padding: 5px;
   font-family: Consolas, serif;
 }
+
+.PrimaryKey {
+  margin-right: 10px;
+  font-size: 100%;
+  margin-bottom: 5px;
+}

--- a/datajunction-ui/src/styles/node-creation.scss
+++ b/datajunction-ui/src/styles/node-creation.scss
@@ -202,6 +202,12 @@ form {
     }
   }
 
+  .FullNameField {
+    background-color: #fff;
+    box-shadow: none;
+    color: #7c7c7c;
+  }
+
   button {
     display: block;
     border-radius: 10px;


### PR DESCRIPTION
### Summary

#### Required Dimensions
- This adds a backend change to support editing required dimensions for a metric. Currently we only allow for setting required dimensions when creating a metric
- Also adds a UI component to set required dimensions when creating or editing a metric.

<img width="1229" alt="Screenshot 2024-02-05 at 1 25 54 PM" src="https://github.com/DataJunction/dj/assets/9524628/51c8c15c-5daa-4401-bab0-6c7d366374b8">

#### Node Tab Links

Makes each tab in the node info UI accessible under a separate URL, i.e.:
- http://localhost:3000/nodes/default.num_repair_orders/info
- http://localhost:3000/nodes/default.num_repair_orders/columns
- http://localhost:3000/nodes/default.num_repair_orders/graph
etc

#### Node Name/Namespace Validation

This adds a backend validation stage for namespaces to check that they only contain alphanumeric or underscore characters. It also adds a change in the UI so that the full node name does not include non-alphanumeric or underscore characters when it is derived from the display name. The full name field's background color has also been changed to indicate that it isn't modifiable.

<img width="1220" alt="Screenshot 2024-02-05 at 1 28 35 PM" src="https://github.com/DataJunction/dj/assets/9524628/738bb471-30f2-4f8d-b7b4-bc832056537c">


### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
