### PR TITLE
Add endpoint for copying nodes

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1432,13 +1432,12 @@ def copy_node(
         include_inactive=True,
     )
     if existing_new_node:
-        # TODO: support overwriting deactivated nodes  # pylint: disable=fixme
         if existing_new_node.deactivated_at:
+            hard_delete_node(new_name, session, current_user)
+        else:
             raise DJInvalidInputException(
-                f"A deactivated node with name {new_name} already exists. "
-                "To copy successfully, hard delete the deactivated node first.",
+                f"A node with name {new_name} already exists.",
             )
-        raise DJInvalidInputException(f"A node with name {new_name} already exists.")
 
     # Copy existing node to the new name
     existing_node = get_node_by_name(session, node_name)

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -49,6 +49,7 @@ from datajunction_server.internal.access.authorization import (
 )
 from datajunction_server.internal.nodes import (
     _create_node_from_inactive,
+    copy_to_new_node,
     create_cube_node_revision,
     create_node_revision,
     get_column_level_lineage,
@@ -1402,3 +1403,44 @@ def set_column_partition(  # pylint: disable=too-many-locals
     session.commit()
     session.refresh(column)
     return column
+
+
+@router.post(
+    "/nodes/{node_name}/copy",
+    response_model=DAGNodeOutput,
+    name="Copy A Node",
+)
+def copy_node(
+    node_name: str,
+    *,
+    new_name: str,
+    session: Session = Depends(get_session),
+    current_user: Optional[User] = Depends(get_current_user),
+) -> DAGNodeOutput:
+    """
+    Copy this node to a new name.
+    """
+    # Check to make sure that the new node's namespace exists
+    new_node_namespace = ".".join(new_name.split(".")[:-1])
+    get_node_namespace(session, new_node_namespace, raise_if_not_exists=True)
+
+    # Check if there is already a node with the new name
+    existing_new_node = get_node_by_name(
+        session,
+        new_name,
+        raise_if_not_exists=False,
+        include_inactive=True,
+    )
+    if existing_new_node:
+        # TODO: support overwriting deactivated nodes  # pylint: disable=fixme
+        if existing_new_node.deactivated_at:
+            raise DJInvalidInputException(
+                f"A deactivated node with name {new_name} already exists. "
+                "To copy successfully, hard delete the deactivated node first.",
+            )
+        raise DJInvalidInputException(f"A node with name {new_name} already exists.")
+
+    # Copy existing node to the new name
+    existing_node = get_node_by_name(session, node_name)
+    new_node = copy_to_new_node(session, existing_node, new_name, current_user)
+    return new_node

--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 from sqlalchemy import BigInteger, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from datajunction_server.database.attributetype import ColumnAttribute
 from datajunction_server.database.base import Base
 from datajunction_server.models.base import labelize
 from datajunction_server.models.column import ColumnTypeDecorator
 from datajunction_server.sql.parsing.types import ColumnType
 
 if TYPE_CHECKING:
-    from datajunction_server.database.attributetype import ColumnAttribute
     from datajunction_server.database.measure import Measure
     from datajunction_server.database.node import Node, NodeRevision
     from datajunction_server.database.partition import Partition
@@ -131,3 +131,22 @@ class Column(Base):  # type: ignore
         Full column name that includes the node it belongs to, i.e., default.hard_hat.first_name
         """
         return f"{self.node_revision().name}.{self.name}"  # type: ignore  # pragma: no cover
+
+    def copy(self) -> "Column":
+        """
+        Returns a full copy of the column
+        """
+        return Column(
+            order=self.order,
+            name=self.name,
+            display_name=self.display_name,
+            type=self.type,
+            dimension_id=self.dimension_id,
+            dimension_column=self.dimension_column,
+            attributes=[
+                ColumnAttribute(attribute_type_id=attr.attribute_type_id)
+                for attr in self.attributes
+            ],
+            measure_id=self.measure_id,
+            partition_id=self.partition_id,
+        )

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -306,11 +306,6 @@ class NodeRevision(
         secondaryjoin="Node.id==NodeRelationship.parent_id",
     )
 
-    parent_links: Mapped[List[NodeRelationship]] = relationship(
-        primaryjoin="NodeRevision.id==NodeRelationship.child_id",
-        cascade="all, delete",
-    )
-
     missing_parents: Mapped[List[MissingParent]] = relationship(
         secondary="nodemissingparents",
         primaryjoin="NodeRevision.id==NodeMissingParents.referencing_node_id",

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -429,13 +429,13 @@ def copy_to_new_node(
             for missing_parent in old_revision.missing_parents
         ],
         columns=[col.copy() for col in old_revision.columns],
+        dimension_links=[
+            DimensionLink(dimension_id=link.dimension_id)
+            for link in old_revision.dimension_links
+        ],
         # TODO: availability and materializations are missing here  # pylint: disable=fixme
         lineage=old_revision.lineage,
     )
-    new_revision.dimension_links = [
-        DimensionLink(node_revision=new_revision, dimension_id=link.dimension_id)
-        for link in old_revision.dimension_links
-    ]
 
     # Reset the version of the new node
     new_revision.version = (

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5501,3 +5501,111 @@ ON s.state_region = r.us_region_id""",
         "delete",
         "restore",
     ]
+
+
+@pytest.fixture
+def repairs_cube_payload():
+    """Repairs cube creation payload"""
+    return {
+        "metrics": [
+            "default.num_repair_orders",
+            "default.avg_repair_price",
+            "default.total_repair_cost",
+        ],
+        "dimensions": [
+            "default.hard_hat.state",
+            "default.dispatcher.company_name",
+            "default.municipality_dim.local_region",
+        ],
+        "filters": ["default.hard_hat.state='AZ'"],
+        "description": "Cube of various metrics related to repairs",
+        "mode": "published",
+        "name": "default.repairs_cube",
+    }
+
+
+@pytest.fixture
+def metric_with_required_dim_payload():
+    """Metric with required dimension"""
+    return {
+        "description": "Average length of employment per manager",
+        "query": "SELECT avg(NOW() - hire_date) FROM default.hard_hats",
+        "mode": "published",
+        "name": "default.avg_length_of_employment_per_manager",
+        "required_dimensions": ["manager"],
+    }
+
+
+def test_copy_nodes(
+    client_with_roads: TestClient,
+    repairs_cube_payload,  # pylint: disable=redefined-outer-name
+    metric_with_required_dim_payload,  # pylint: disable=redefined-outer-name
+):
+    """
+    Test copying nodes
+    """
+    client_with_roads.post("/nodes/cube", json=repairs_cube_payload)
+    client_with_roads.post("/nodes/metric", json=metric_with_required_dim_payload)
+
+    # Test the error states when copying nodes
+    response = client_with_roads.post(
+        "/nodes/default.repair_order/copy?new_name=default.contractor",
+    )
+    assert (
+        response.json()["message"]
+        == "A node with name default.contractor already exists."
+    )
+    client_with_roads.delete("/nodes/default.contractor")
+    response = client_with_roads.post(
+        "/nodes/default.repair_order/copy?new_name=default.contractor",
+    )
+    assert (
+        response.json()["message"]
+        == "A deactivated node with name default.contractor already exists. "
+        "To copy successfully, hard delete the deactivated node first."
+    )
+
+    response = client_with_roads.post(
+        "/nodes/default.repair_order/copy?new_name=default.blah.repair_order",
+    )
+    assert response.json()["message"] == "node namespace `default.blah` does not exist."
+
+    # Copy all nodes to a node name with _copy appended
+    nodes = client_with_roads.get("/nodes").json()
+    for node in nodes:
+        client_with_roads.post(f"/nodes/{node}/copy?new_name={node}_copy")
+
+    # Check that each node was successfully copied by comparing against the original
+    for node in nodes:
+        original = client_with_roads.get(f"/nodes/{node}").json()
+        copied = client_with_roads.get(f"/nodes/{node}_copy").json()
+        for field in ["name", "node_id", "node_revision_id", "updated_at"]:
+            copied[field] = mock.ANY
+        assert original == copied
+
+        # Metrics contain additional metadata, so compare the /metrics endpoint as well
+        if original["type"] == "metric":
+            metric_orig = client_with_roads.get(f"/metrics/{node}").json()
+            metric_copied = client_with_roads.get(f"/metrics/{node}_copy").json()
+            for field in ["id", "name", "updated_at"]:
+                metric_copied[field] = mock.ANY
+            assert metric_orig == metric_copied
+
+        # Cubes contain additional metadata, so compare the /metrics endpoint as well
+        if original["type"] == "cube":
+            cube_orig = client_with_roads.get(f"/cubes/{node}").json()
+            cube_copied = client_with_roads.get(f"/cubes/{node}_copy").json()
+            for field in ["name", "node_id", "node_revision_id", "updated_at"]:
+                cube_copied[field] = mock.ANY
+            assert cube_orig == cube_copied
+
+        # Check that the dimensions DAG for the node has been copied
+        original_dimensions = [
+            dim["name"]
+            for dim in client_with_roads.get(f"/nodes/{node}/dimensions").json()
+        ]
+        copied_dimensions = [
+            dim["name"].replace(f"{node}_copy", node)
+            for dim in client_with_roads.get(f"/nodes/{node}_copy/dimensions").json()
+        ]
+        assert original_dimensions == copied_dimensions


### PR DESCRIPTION
### Summary

This PR adds an API endpoint for copying nodes to a new name:
`POST /nodes/{node_name}/copy?new_name={new_name}` 

The functionality implemented here will copy over most attributes on the original node, like dimension links and column attributes, as well as metric-specific attributes like required dimensions and metric metadata. However, it does not handle copying over materialization (a useful feature that we can build in a follow-up PR).

### Test Plan

Added a test that makes a copy of every node in the roads examples set.

- [x] PR has an associated issue: #856 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
