### PR TITLE
Remove deactivated nodes when listing nodes for a tag + fix metric aggregate expression bug

### DIFF
--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -171,8 +171,15 @@ def list_nodes_for_a_tag(
             http_status_code=404,
         )
     if not node_type:
-        return sorted([node.current for node in tag.nodes], key=lambda x: x.name)
+        return sorted(
+            [node.current for node in tag.nodes if not node.deactivated_at],
+            key=lambda x: x.name,
+        )
     return sorted(
-        [node.current for node in tag.nodes if node.type == node_type],
+        [
+            node.current
+            for node in tag.nodes
+            if node.type == node_type and not node.deactivated_at
+        ],
         key=lambda x: x.name,
     )

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -410,7 +410,7 @@ class NodeRevision(
             raise DJInvalidInputException(
                 http_status_code=HTTPStatus.BAD_REQUEST,
                 message=f"Metric {self.name} has an invalid query, "
-                "should have a single aggregation",
+                "should have an aggregate expression",
             )
 
     def extra_validation(self) -> None:

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -586,14 +586,10 @@ class Expression(Node):
         """
         Determines whether an Expression is an aggregation or not
         """
-        return all(
-            [
-                child.is_aggregation()
-                for child in self.children
-                if isinstance(child, Expression)
-            ]
-            or [False],
-        )
+        for child in self.children:
+            if hasattr(child, "is_aggregation") and child.is_aggregation():
+                return True
+        return False
 
     def set_alias(self: TExpression, alias: "Name") -> Alias[TExpression]:
         return Alias(child=self).set_alias(alias)
@@ -1649,7 +1645,9 @@ class Function(Named, Operation):
         return function_registry[self.name.name.upper()]
 
     def is_aggregation(self) -> bool:
-        return self.function().is_aggregation
+        if self.function().is_aggregation:
+            return True
+        return super().is_aggregation()
 
     def is_runtime(self) -> bool:
         return self.function().is_runtime
@@ -1682,7 +1680,7 @@ class Value(Expression):
     """
 
     def is_aggregation(self) -> bool:
-        return True
+        return False
 
 
 @dataclass(eq=False)

--- a/datajunction-server/tests/api/tags_test.py
+++ b/datajunction-server/tests/api/tags_test.py
@@ -330,6 +330,16 @@ class TestTags:
             },
         ]
 
+        # Check getting nodes for tag after deactivating a node
+        client_with_dbt.delete("/nodes/default.total_profit")
+        response = client_with_dbt.get(
+            "/tags/sales_report/nodes/",
+        )
+        assert response.status_code == 200
+        response_data = response.json()
+        assert len(response_data) == 1
+        assert response_data[0]["name"] == "default.items_sold_count"
+
         # Check finding nodes for tag
         response = client_with_dbt.get(
             "/tags/random_tag/nodes/",

--- a/datajunction-server/tests/models/node_test.py
+++ b/datajunction-server/tests/models/node_test.py
@@ -88,15 +88,25 @@ def test_extra_validation() -> None:
         type=node.type,
         node=node,
         version="1",
-        query="SELECT count(repair_order_id) + "
+        query="SELECT repair_order_id + "
         "repair_order_id AS Anum_repair_orders "
         "FROM repair_orders",
     )
     with pytest.raises(Exception) as excinfo:
         node_revision.extra_validation()
     assert str(excinfo.value) == (
-        "Metric A has an invalid query, should have a single aggregation"
+        "Metric A has an invalid query, should have an aggregate expression"
     )
+
+    node = Node(name="AA", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
+        query="SELECT ln(count(distinct repair_order_id)) FROM repair_orders",
+    )
+    node_revision.extra_validation()
 
     node = Node(name="A", type=NodeType.TRANSFORM, current_version="1")
     node_revision = NodeRevision(

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1a43",
+  "version": "0.0.1-a43.dev0",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-a43.dev0",
+  "version": "0.0.1a43",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {


### PR DESCRIPTION
### Summary

This PR fixes two bugs:
* Deactivated nodes should not show up when listing nodes for a tag
* When we check a metric expression to contain an aggregate, we aren't checking nested functions in the right way, causing valid agg expressions to be rejected

### Test Plan

Added a test for this

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
