### PR TITLE
Editing cubes should retain information on tags and node mode

### DIFF
--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -65,7 +65,9 @@ def client_code_for_creating_node(
     # Cube-specific params
     cube_params = []
     if node.type == NodeType.CUBE:
-        ordering = {col.name: col.order for col in node.current.columns}
+        ordering = {
+            col.name: col.order or idx for idx, col in enumerate(node.current.columns)
+        }
         metrics_list = sorted(
             [
                 elem.node_revisions[-1].name

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1308,4 +1308,6 @@ def get_cube_revision_metadata(session: Session, name: str):
             http_status_code=404,
         )
     cube = result[0]
-    return CubeRevisionMetadata.from_orm(cube)
+    cube_metadata = CubeRevisionMetadata.from_orm(cube)
+    cube_metadata.tags = cube.node.tags
+    return cube_metadata

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -8,9 +8,15 @@ from pydantic import Field, root_validator
 from pydantic.main import BaseModel
 
 from datajunction_server.models.materialization import MaterializationConfigOutput
-from datajunction_server.models.node import AvailabilityStateBase, ColumnOutput
+from datajunction_server.models.node import (
+    AvailabilityStateBase,
+    ColumnOutput,
+    NodeMode,
+    NodeStatus,
+)
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionOutput
+from datajunction_server.models.tag import TagOutput
 from datajunction_server.typing import UTCDatetime
 
 
@@ -54,6 +60,8 @@ class CubeRevisionMetadata(BaseModel):
     name: str
     display_name: str
     version: str
+    status: NodeStatus
+    mode: NodeMode
     description: str = ""
     availability: Optional[AvailabilityStateBase] = None
     cube_elements: List[CubeElementMetadata]
@@ -61,6 +69,7 @@ class CubeRevisionMetadata(BaseModel):
     columns: List[ColumnOutput]
     updated_at: UTCDatetime
     materializations: List[MaterializationConfigOutput]
+    tags: Optional[List[TagOutput]]
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         allow_population_by_field_name = True

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -50,6 +50,8 @@ def test_read_cube(client_with_account_revenue: TestClient) -> None:
     assert data["type"] == "cube"
     assert data["name"] == "default.number_of_accounts_by_account_type"
     assert data["display_name"] == "Default: Number Of Accounts By Account Type"
+    assert data["mode"] == "published"
+    assert data["tags"] == []
 
     # Read the cube
     response = client_with_account_revenue.get(

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/index.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/index.jsx
@@ -149,15 +149,13 @@ export function CubeBuilderPage() {
             useEffect(() => {
               const fetchData = async () => {
                 if (name) {
-                  const node = await djClient.node(name);
                   const cube = await djClient.cube(name);
-                  cube.tags = node.tags;
-                  setNode(cube);
                   updateFieldsWithNodeData(cube, setFieldValue);
+                  setNode(cube);
                 }
               };
               fetchData().catch(console.error);
-            }, [djClient, djClient.metrics, name]);
+            }, [setFieldValue]);
 
             return (
               <Form>


### PR DESCRIPTION
### Summary

This PR fixes a bug where editing cubes (in the UI) does not retain information on tags and node mode. It also changes the /cubes/{cube}/ API endpoint to return all the information needed to power the cube add/edit interface, so that the UI does not need to make two backend calls in order to populate with the right info. There's a similar issue with the `/metrics/{metric}` API that we should also fix.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
