### PR TITLE
Remove unused attributes to not clutter the column attributes space

### DIFF
--- a/datajunction-server/datajunction_server/api/attributes.py
+++ b/datajunction-server/datajunction_server/api/attributes.py
@@ -63,7 +63,7 @@ def add_attribute_type(
         name=data.name,
         description=data.description,
         allowed_node_types=data.allowed_node_types,
-        uniqueness_scope=[],
+        uniqueness_scope=data.uniqueness_scope if data.uniqueness_scope else [],
     )
     session.add(attribute_type)
     session.commit()
@@ -87,33 +87,6 @@ def default_attribute_types(session: Session = Depends(get_session)):
                 NodeType.TRANSFORM,
                 NodeType.DIMENSION,
             ],
-        ),
-        AttributeType(
-            namespace=RESERVED_ATTRIBUTE_NAMESPACE,
-            name="event_time",
-            description="Points to a column which represents the time of the event in a given "
-            "fact related node. Used to facilitate proper joins with dimension node "
-            "to match the desired effect.",
-            uniqueness_scope=["node", "column_type"],
-            allowed_node_types=[NodeType.SOURCE, NodeType.TRANSFORM],
-        ),
-        AttributeType(
-            namespace=RESERVED_ATTRIBUTE_NAMESPACE,
-            name="effective_time",
-            description="Points to a column which represents the effective time of a row in a "
-            "dimension node. Used to facilitate proper joins with fact nodes"
-            " on event time.",
-            uniqueness_scope=["node", "column_type"],
-            allowed_node_types=[NodeType.DIMENSION],
-        ),
-        AttributeType(
-            namespace=RESERVED_ATTRIBUTE_NAMESPACE,
-            name="expired_time",
-            description="Points to a column which represents the expired time of a row in a "
-            "dimension node. Used to facilitate proper joins with fact nodes "
-            "on event time.",
-            uniqueness_scope=["node", "column_type"],
-            allowed_node_types=[NodeType.DIMENSION],
         ),
         AttributeType(
             namespace=RESERVED_ATTRIBUTE_NAMESPACE,

--- a/datajunction-server/datajunction_server/models/attribute.py
+++ b/datajunction-server/datajunction_server/models/attribute.py
@@ -1,7 +1,7 @@
 """
 Models for attributes.
 """
-from typing import List
+from typing import List, Optional
 
 from pydantic.main import BaseModel
 
@@ -20,15 +20,6 @@ class AttributeTypeIdentifier(BaseModel):
     name: str
 
 
-class MutableAttributeTypeFields(AttributeTypeIdentifier):
-    """
-    Fields on attribute types that users can set.
-    """
-
-    description: str
-    allowed_node_types: List[NodeType]
-
-
 class UniquenessScope(StrEnum):
     """
     The scope at which this attribute needs to be unique.
@@ -38,15 +29,17 @@ class UniquenessScope(StrEnum):
     COLUMN_TYPE = "column_type"
 
 
-class RestrictedAttributeTypeFields(BaseModel):
+class MutableAttributeTypeFields(AttributeTypeIdentifier):
     """
-    Fields on attribute types that aren't configurable by users.
+    Fields on attribute types that users can set.
     """
 
-    uniqueness_scope: List[UniquenessScope] = []
+    description: str
+    allowed_node_types: List[NodeType]
+    uniqueness_scope: Optional[List[UniquenessScope]]
 
 
-class AttributeTypeBase(MutableAttributeTypeFields, RestrictedAttributeTypeFields):
+class AttributeTypeBase(MutableAttributeTypeFields):
     """Base attribute type."""
 
     id: int

--- a/datajunction-server/tests/api/attributes_test.py
+++ b/datajunction-server/tests/api/attributes_test.py
@@ -87,33 +87,6 @@ def test_list_attributes(
             "name": "primary_key",
             "description": "Points to a column which is part of the primary key of the node",
         },
-        "expired_time": {
-            "namespace": "system",
-            "uniqueness_scope": ["node", "column_type"],
-            "allowed_node_types": ["dimension"],
-            "name": "expired_time",
-            "description": "Points to a column which represents the expired time of a row in "
-            "a dimension node. Used to facilitate proper joins with fact nodes "
-            "on event time.",
-        },
-        "effective_time": {
-            "namespace": "system",
-            "uniqueness_scope": ["node", "column_type"],
-            "allowed_node_types": ["dimension"],
-            "name": "effective_time",
-            "description": "Points to a column which represents the effective time of a row "
-            "in a dimension node. Used to facilitate proper joins with fact "
-            "nodes on event time.",
-        },
-        "event_time": {
-            "namespace": "system",
-            "uniqueness_scope": ["node", "column_type"],
-            "allowed_node_types": ["source", "transform"],
-            "name": "event_time",
-            "description": "Points to a column which represents the time of the event in a "
-            "given fact related node. Used to facilitate proper joins with "
-            "dimension node to match the desired effect.",
-        },
         "dimension": {
             "namespace": "system",
             "uniqueness_scope": [],

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -3811,34 +3811,6 @@ class TestNodeColumnsAttributes:
             },
         ]
 
-        response = client_with_basic.post(
-            "/nodes/basic.dimension.users/columns/created_at/attributes/",
-            json=[
-                {
-                    "namespace": "system",
-                    "name": "effective_time",
-                },
-            ],
-        )
-        data = response.json()
-        assert data == [
-            {
-                "name": "created_at",
-                "type": "timestamp",
-                "display_name": "Created At",
-                "attributes": [
-                    {
-                        "attribute_type": {
-                            "name": "effective_time",
-                            "namespace": "system",
-                        },
-                    },
-                ],
-                "dimension": None,
-                "partition": None,
-            },
-        ]
-
         # Remove primary key attribute from column
         response = client_with_basic.post(
             "/nodes/basic.source.comments/columns/id/attributes",
@@ -3861,11 +3833,11 @@ class TestNodeColumnsAttributes:
         Test setting column attributes with different failure modes.
         """
         response = client_with_basic.post(
-            "/nodes/basic.source.comments/columns/event_timestamp/attributes/",
+            "/nodes/basic.dimension.users/columns/created_at/attributes/",
             json=[
                 {
-                    "name": "effective_time",
                     "namespace": "system",
+                    "name": "dimension",
                 },
             ],
         )
@@ -3873,7 +3845,7 @@ class TestNodeColumnsAttributes:
         assert response.status_code == 500
         assert (
             data["message"]
-            == "Attribute type `system.effective_time` not allowed on node type `source`!"
+            == "Attribute type `system.dimension` not allowed on node type `dimension`!"
         )
 
         client_with_basic.get(
@@ -3935,10 +3907,25 @@ class TestNodeColumnsAttributes:
             },
         ]
 
+        response = client_with_basic.post(
+            "/attributes/",
+            json={
+                "namespace": "example",
+                "name": "event_time",
+                "description": "Points to a column which represents the time of the event in a "
+                "given fact related node. Used to facilitate proper joins with dimension node "
+                "to match the desired effect.",
+                "allowed_node_types": ["source", "transform"],
+                "uniqueness_scope": ["node", "column_type"],
+            },
+        )
+        data = response.json()
+
         client_with_basic.post(
             "/nodes/basic.source.comments/columns/event_timestamp/attributes/",
             json=[
                 {
+                    "namespace": "example",
                     "name": "event_time",
                 },
             ],
@@ -3948,6 +3935,7 @@ class TestNodeColumnsAttributes:
             "/nodes/basic.source.comments/columns/post_processing_timestamp/attributes/",
             json=[
                 {
+                    "namespace": "example",
                     "name": "event_time",
                 },
             ],


### PR DESCRIPTION
### Summary

Removes the following system-level column attributes: `event_time`, `effective_time`, `expired_time`. These aren't used by the system in any way, so it's better to remove them until we're ready to implement features that can actually use them. 

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
