### PR TITLE
On the cube node edit page, enable editing of metrics

### DIFF
--- a/datajunction-ui/src/app/pages/CubeBuilderPage/DimensionsSelect.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/DimensionsSelect.jsx
@@ -61,7 +61,7 @@ export const DimensionsSelect = ({ cube }) => {
 
         // Set the selected cube dimensions if an existing cube is being edited
         if (cube) {
-          const currentSelectedDimensionsByGroup = selectedDimensionsByGroup;
+          const currentSelectedDimensionsByGroup = {};
           grouped.forEach(grouping => {
             const dimensionsInGroup = grouping[1];
             currentSelectedDimensionsByGroup[dimensionsInGroup[0].node_name] =

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
@@ -69,7 +69,6 @@ export const MetricsSelect = ({ cube }) => {
           isMulti
           isClearable
           closeMenuOnSelect={false}
-          isDisabled={!!(values.metrics.length && values.dimensions.length)}
         />
       );
     }


### PR DESCRIPTION
### Summary

When editing cube nodes, the metrics selector should be editable rather than disabled.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
