### PR TITLE
Fix failure on wildcards in node info API

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/types.py
+++ b/datajunction-server/datajunction_server/sql/parsing/types.py
@@ -937,4 +937,5 @@ PRIMITIVE_TYPES: Dict[str, PrimitiveType] = {
     "binary": BinaryType(),
     "none": NullType(),
     "null": NullType(),
+    "wildcard": WildcardType(),
 }


### PR DESCRIPTION
### Summary

This is a small fix so that if a user authors a query with a wildcard in it, the node info page will continue to load and not fail due to a "DJ does not know the type" error. While we still don't support wildcards, it's better for the page to load so that users can edit the query and bring themselves out of this failure state.

### Test Plan

Tested locally

- [ ] PR has an associated issue: #648 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
