### PR TITLE
Switch to node-level dimension links

### DIFF
--- a/datajunction-clients/python/datajunction/compile.py
+++ b/datajunction-clients/python/datajunction/compile.py
@@ -498,8 +498,11 @@ class Project(BaseModel):
                     for dimension in node["dimensions"]
                 ]
             if node.get("dimension_links"):
-                for _, dim in node["dimension_links"].items():
-                    dim["dimension"] = inject_prefixes(dim["dimension"], namespace)
+                for _, dim in node["dimension_links"].items():  # pragma: no cover
+                    dim["dimension"] = inject_prefixes(
+                        dim["dimension"],
+                        namespace,
+                    )  # pragma: no cover
             with open(
                 node_definition_dir / Path(node.pop("filename")),
                 "w",

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -498,8 +498,8 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             "contractor_id",
         )
         assert result["message"] == (
-            "Dimension node foo.bar.contractor has been successfully linked to "
-            "column contractor_id on node foo.bar.repair_type"
+            "The dimension link between foo.bar.repair_type and foo.bar.contractor "
+            "has been successfully updated."
         )
 
         # Unlink the dimension
@@ -509,8 +509,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             "contractor_id",
         )
         assert result["message"] == (
-            "The dimension link on the node foo.bar.repair_type's contractor_id to "
-            "foo.bar.contractor has been successfully removed."
+            "Dimension link foo.bar.contractor to node foo.bar.repair_type has been removed."
         )
 
     def test_link_complex_dimension(self, client):
@@ -598,8 +597,8 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods
             "node_display_name": "Foo: Bar: Dispatcher",
             "is_primary_key": False,
             "path": [
-                "foo.bar.repair_order_details.repair_order_id",
-                "foo.bar.repair_order.dispatcher_id",
+                "foo.bar.repair_order_details",
+                "foo.bar.repair_order",
             ],
         } in result
 

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.operators import is_
 from starlette.requests import Request
 
-from datajunction_server.api.catalogs import UNKNOWN_CATALOG_ID
 from datajunction_server.api.helpers import (
     activate_node,
     deactivate_node,
@@ -32,12 +31,12 @@ from datajunction_server.api.namespaces import create_node_namespace
 from datajunction_server.api.tags import get_tags_by_name
 from datajunction_server.constants import NODE_LIST_MAX
 from datajunction_server.database.column import Column
-from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.partition import Partition
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
+    DJActionNotAllowedException,
     DJDoesNotExistException,
     DJException,
     DJInvalidInputException,
@@ -54,18 +53,20 @@ from datajunction_server.internal.nodes import (
     create_node_revision,
     get_column_level_lineage,
     get_node_column,
+    remove_dimension_link,
     save_column_level_lineage,
     save_node,
     set_node_column_attributes,
     update_any_node,
+    upsert_complex_dimension_link,
 )
 from datajunction_server.models import access
 from datajunction_server.models.attribute import AttributeTypeIdentifier
 from datajunction_server.models.dimensionlink import (
+    JoinType,
     LinkDimensionIdentifier,
     LinkDimensionInput,
 )
-from datajunction_server.models.history import status_change_history
 from datajunction_server.models.node import (
     ColumnOutput,
     CreateCubeNode,
@@ -93,10 +94,8 @@ from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
     get_dimensions,
     get_downstream_nodes,
-    get_nodes_with_dimension,
     get_upstream_nodes,
 )
-from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.utils import (
     Version,
@@ -650,7 +649,7 @@ def link_dimension(
     name: str,
     column: str,
     dimension: str,
-    dimension_column: Optional[str] = None,
+    dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: Session = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
@@ -663,16 +662,10 @@ def link_dimension(
         name=dimension,
         node_type=NodeType.DIMENSION,
     )
-    if (
-        dimension_node.current.catalog_id != UNKNOWN_CATALOG_ID
-        and dimension_node.current.catalog is not None
-        and node.current.catalog.name != dimension_node.current.catalog.name
-    ):
-        raise DJException(
-            message=(
-                "Cannot add dimension to column, because catalogs do not match: "
-                f"{node.current.catalog.name}, {dimension_node.current.catalog.name}"
-            ),
+    primary_key_columns = dimension_node.current.primary_key()
+    if len(primary_key_columns) > 1:
+        raise DJActionNotAllowedException(
+            "Cannot use this endpoint to link a dimension with a compound primary key.",
         )
 
     target_column = get_column(node.current, column)
@@ -689,33 +682,28 @@ def link_dimension(
                 " These column types are incompatible and the dimension cannot be linked",
             )
 
-    target_column.dimension = dimension_node
-    target_column.dimension_id = dimension_node.id
-    target_column.dimension_column = dimension_column
-
-    session.add(node)
-    session.add(
-        History(
-            entity_type=EntityType.LINK,
-            entity_name=node.name,
-            node=node.name,
-            activity_type=ActivityType.CREATE,
-            details={
-                "column": target_column.name,
-                "dimension": dimension_node.name,
-                "dimension_column": dimension_column or "",
-            },
-            user=current_user.username if current_user else None,
-        ),
+    link_input = LinkDimensionInput(
+        dimension_node=dimension,
+        join_type=JoinType.LEFT,
+        join_on=f"{name}.{column} = {dimension_node.name}.{primary_key_columns[0].name}",
     )
-    session.commit()
-    session.refresh(node)
+    is_update = upsert_complex_dimension_link(
+        session,
+        name,
+        link_input,
+        current_user,
+    )
     return JSONResponse(
         status_code=201,
         content={
             "message": (
                 f"Dimension node {dimension} has been successfully "
-                f"linked to column {column} on node {name}"
+                f"linked to node {name} using column {column}."
+            )
+            if not is_update
+            else (
+                f"The dimension link between {name} and {dimension} "
+                "has been successfully updated."
             ),
         },
     )
@@ -732,118 +720,22 @@ def add_complex_dimension_link(  # pylint: disable=too-many-locals
     Links a source, dimension, or transform node to a dimension with a custom join query.
     If a link already exists, updates the link definition.
     """
-    node = get_node_by_name(session=session, name=node_name)
-    if node.type not in (NodeType.SOURCE, NodeType.DIMENSION, NodeType.TRANSFORM):
-        raise DJInvalidInputException(
-            message=f"Cannot link dimension to a node of type {node.type}. "
-            "Must be a source, dimension, or transform node.",
-        )
-
-    # Find the dimension node and check that the catalogs match
-    dimension_node = get_node_by_name(
-        session=session,
-        name=link_input.dimension_node,
-        node_type=NodeType.DIMENSION,
+    is_update = upsert_complex_dimension_link(
+        session,
+        node_name,
+        link_input,
+        current_user,
     )
-    if (
-        dimension_node.current.catalog_id != UNKNOWN_CATALOG_ID
-        and dimension_node.current.catalog is not None
-        and node.current.catalog.name != dimension_node.current.catalog.name
-    ):
-        raise DJException(  # pragma: no cover
-            message=(
-                "Cannot link dimension to node, because catalogs do not match: "
-                f"{node.current.catalog.name}, {dimension_node.current.catalog.name}"
-            ),
-        )
-
-    # Parse the join query and do some basic verification of its validity
-    join_query = parse(
-        f"SELECT 1 FROM {node_name} "
-        f"{link_input.join_type} JOIN {link_input.dimension_node} "
-        f"ON {link_input.join_on}",
-    )
-    exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
-    join_query.compile(ctx)
-    join_relation = join_query.select.from_.relations[0].extensions[0]  # type: ignore
-
-    # Verify that the query references both the node and the dimension being joined
-    expected_references = {node_name, link_input.dimension_node}
-    references = {
-        table.name.namespace.identifier()  # type: ignore
-        for table in join_relation.criteria.on.find_all(ast.Column)  # type: ignore
-    }
-    if expected_references.difference(references):
-        raise DJInvalidInputException(
-            f"The join SQL provided does not reference both the origin node {node_name} and the "
-            f"dimension node {link_input.dimension_node} that it's being joined to.",
-        )
-
-    # Verify that the columns in the ON clause exist on both nodes
-    if ctx.exception.errors:
-        raise DJException(
-            message=f"Join query {link_input.join_on} is not valid",
-            errors=ctx.exception.errors,
-        )
-
-    # Find an existing dimension link if there is already one defined for this node
-    existing_link = [
-        link
-        for link in node.current.dimension_links
-        if link.dimension_id == dimension_node.id and link.role == link_input.role
-    ]
-    is_update = False
-
-    if existing_link:
-        # Update the existing dimension link
-        is_update = True
-        dimension_link = existing_link[0]
-        dimension_link.join_sql = link_input.join_on
-        dimension_link.join_type = DimensionLink.parse_join_type(
-            join_relation.join_type,
-        )
-        dimension_link.join_cardinality = link_input.join_cardinality
-    else:
-        # If there is no existing link, create new dimension link object
-        dimension_link = DimensionLink(
-            node_revision_id=node.current.id,
-            dimension_id=dimension_node.id,
-            join_sql=link_input.join_on,
-            join_type=DimensionLink.parse_join_type(join_relation.join_type),
-            join_cardinality=link_input.join_cardinality,
-            role=link_input.role,
-        )
-
-    # Add/update the dimension link in the database
-    session.add(dimension_link)
-    session.add(
-        History(
-            entity_type=EntityType.LINK,
-            entity_name=node.name,
-            node=node.name,
-            activity_type=ActivityType.CREATE if not is_update else ActivityType.UPDATE,
-            details={
-                "dimension": dimension_node.name,
-                "join_sql": link_input.join_on,
-                "join_cardinality": link_input.join_cardinality,
-                "role": link_input.role,
-            },
-            user=current_user.username if current_user else None,
-        ),
-    )
-    session.commit()
-    session.refresh(node)
     return JSONResponse(
         status_code=201,
         content={
             "message": (
-                f"Dimension node {dimension_node.name} has been successfully "
+                f"Dimension node {link_input.dimension_node} has been successfully "
                 f"linked to node {node_name}."
             )
             if not is_update
             else (
-                f"The dimension link between {node_name} and {dimension_node.name} "
+                f"The dimension link between {node_name} and {link_input.dimension_node} "
                 "has been successfully updated."
             ),
         },
@@ -860,164 +752,85 @@ def remove_complex_dimension_link(  # pylint: disable=too-many-locals
     """
     Removes a complex dimension link based on the dimension node and its role (if any).
     """
-    node = get_node_by_name(session=session, name=node_name)
-
-    # Find the dimension node
-    dimension_node = get_node_by_name(
-        session=session,
-        name=link_identifier.dimension_node,
-        node_type=NodeType.DIMENSION,
-    )
-    removed = False
-
-    # Find cubes that are affected by this dimension link removal and update their statuses
-    affected_cubes = get_nodes_with_dimension(
-        session,
-        dimension_node,
-        [NodeType.CUBE],
-    )
-    if affected_cubes:
-        for cube in affected_cubes:
-            if cube.status != NodeStatus.INVALID:  # pragma: no cover
-                cube.status = NodeStatus.INVALID
-                session.add(cube)
-                session.add(
-                    status_change_history(
-                        node,
-                        NodeStatus.VALID,
-                        NodeStatus.INVALID,
-                        current_user=current_user,
-                    ),
-                )
-
-    # Delete the dimension link if one exists
-    for link in node.current.dimension_links:
-        if (
-            link.dimension_id == dimension_node.id  # pragma: no cover
-            and link.role == link_identifier.role  # pragma: no cover
-        ):
-            removed = True
-            session.delete(link)
-    if not removed:
-        return JSONResponse(
-            status_code=HTTPStatus.NOT_FOUND,
-            content={
-                "message": f"Dimension link to node {link_identifier.dimension_node} "
-                + (f"with role {link_identifier.role} " if link_identifier.role else "")
-                + "not found",
-            },
-        )
-
-    session.add(
-        History(
-            entity_type=EntityType.LINK,
-            entity_name=node.name,
-            node=node.name,
-            activity_type=ActivityType.DELETE,
-            details={
-                "dimension": dimension_node.name,
-                "role": link_identifier.role,
-            },
-            user=current_user.username if current_user else None,
-        ),
-    )
-    session.commit()
-    session.refresh(node)
-    return JSONResponse(
-        status_code=201,
-        content={
-            "message": (
-                f"Dimension link {dimension_node.name} "
-                + (f"(role {link_identifier.role}) " if link_identifier.role else "")
-                + f"to node {node_name} has been removed."
-            )
-            if removed
-            else (
-                f"Dimension link {dimension_node.name} "
-                + (f"(role {link_identifier.role}) " if link_identifier.role else "")
-                + f"to node {node_name} does not exist!"
-            ),
-        },
-    )
+    return remove_dimension_link(session, node_name, link_identifier, current_user)
 
 
 @router.delete("/nodes/{name}/columns/{column}/", status_code=201)
 def delete_dimension_link(
     name: str,
-    column: str,
+    column: str,  # pylint: disable=unused-argument
     dimension: str,
-    dimension_column: Optional[str] = None,
+    dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: Session = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Remove the link between a node column and a dimension node
     """
-    node = get_node_by_name(session=session, name=name)
-    target_column = get_column(node.current, column)
-    if (not target_column.dimension or target_column.dimension.name != dimension) and (
-        not target_column.dimension_column
-        or target_column.dimension_column != dimension_column
-    ):
-        return JSONResponse(
-            status_code=304,
-            content={
-                "message": (
-                    f"No change was made to {column} on node {name} as the "
-                    f"specified dimension link to {dimension} on "
-                    f"{dimension_column} was not found."
-                ),
-            },
-        )
-
-    # Find cubes that are affected by this dimension link removal and update their statuses
-    affected_cubes = get_nodes_with_dimension(
+    return remove_dimension_link(
         session,
-        target_column.dimension,
-        [NodeType.CUBE],
+        name,
+        LinkDimensionIdentifier(dimension_node=dimension, role=None),
+        current_user,
     )
-    if affected_cubes:
-        for cube in affected_cubes:  # pragma: no cover
-            if cube.status != NodeStatus.INVALID:
-                cube.status = NodeStatus.INVALID
-                session.add(cube)
-                session.add(
-                    status_change_history(
-                        node,
-                        NodeStatus.VALID,
-                        NodeStatus.INVALID,
-                        current_user=current_user,
+
+
+@router.post("/nodes/{name}/migrate", status_code=201)  # pragma: no cover
+def migrate_dimension_link(  # pragma: no cover
+    name: str,
+    session: Session = Depends(get_session),
+    current_user: Optional[User] = Depends(get_current_user),
+) -> JSONResponse:
+    """
+    Migrate dimension link from column-level to node-level
+    """
+    node = get_node_by_name(session=session, name=name)
+    migrated, errors = [], []
+    _logger.info("Migrating dimension links for %s", name)
+    for column in node.current.columns:
+        if column.dimension:
+            try:
+                _logger.info(
+                    "Started migration for column %s, dimension %s",
+                    column.name,
+                    column.dimension.name,
+                )
+                dimension_node = column.dimension
+                primary_key_columns = dimension_node.current.primary_key()
+                link_input = LinkDimensionInput(
+                    dimension_node=dimension_node.name,
+                    join_type=JoinType.LEFT,
+                    join_on=(
+                        f"{name}.{column.name} = "
+                        f"{dimension_node.name}.{primary_key_columns[0].name}",
                     ),
                 )
-
-    target_column.dimension = None  # type: ignore
-    target_column.dimension_id = None
-    target_column.dimension_column = None
-    session.add(node)
-    session.add(
-        History(
-            entity_type=EntityType.LINK,
-            entity_name=node.name,
-            node=node.name,
-            activity_type=ActivityType.DELETE,
-            details={
-                "column": column,
-                "dimension": dimension,
-                "dimension_column": dimension_column or "",
-            },
-            user=current_user.username if current_user else None,
-        ),
-    )
-    session.commit()
-    session.refresh(node)
+                upsert_complex_dimension_link(
+                    session,
+                    name,
+                    link_input,
+                    current_user,
+                )
+                column.dimension = None  # type: ignore
+                column.dimension_id = None
+                column.dimension_column = None
+                session.add(node)
+                session.commit()
+                session.refresh(node)
+                _logger.info(
+                    "Finished migration for column %s, dimension %s",
+                    column.name,
+                    dimension_node.name,
+                )
+                migrated.append((column.name, dimension_node.name))
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                errors.append((column.name, dimension_node.name, str(e)))
 
     return JSONResponse(
         status_code=201,
         content={
-            "message": (
-                f"The dimension link on the node {name}'s {column} to "
-                f"{dimension} has been successfully removed."
-            ),
+            "finished": migrated,
+            "errors": errors,
         },
     )
 

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -664,7 +664,7 @@ def link_dimension(
     )
     primary_key_columns = dimension_node.current.primary_key()
     if len(primary_key_columns) > 1:
-        raise DJActionNotAllowedException(
+        raise DJActionNotAllowedException(  # pragma: no cover
             "Cannot use this endpoint to link a dimension with a compound primary key.",
         )
 
@@ -687,7 +687,7 @@ def link_dimension(
         join_type=JoinType.LEFT,
         join_on=f"{name}.{column} = {dimension_node.name}.{primary_key_columns[0].name}",
     )
-    is_update = upsert_complex_dimension_link(
+    activity_type = upsert_complex_dimension_link(
         session,
         name,
         link_input,
@@ -700,7 +700,7 @@ def link_dimension(
                 f"Dimension node {dimension} has been successfully "
                 f"linked to node {name} using column {column}."
             )
-            if not is_update
+            if activity_type == ActivityType.CREATE
             else (
                 f"The dimension link between {name} and {dimension} "
                 "has been successfully updated."
@@ -720,7 +720,7 @@ def add_complex_dimension_link(  # pylint: disable=too-many-locals
     Links a source, dimension, or transform node to a dimension with a custom join query.
     If a link already exists, updates the link definition.
     """
-    is_update = upsert_complex_dimension_link(
+    activity_type = upsert_complex_dimension_link(
         session,
         node_name,
         link_input,
@@ -733,7 +733,7 @@ def add_complex_dimension_link(  # pylint: disable=too-many-locals
                 f"Dimension node {link_input.dimension_node} has been successfully "
                 f"linked to node {node_name}."
             )
-            if not is_update
+            if activity_type == ActivityType.CREATE
             else (
                 f"The dimension link between {node_name} and {link_input.dimension_node} "
                 "has been successfully updated."
@@ -775,7 +775,7 @@ def delete_dimension_link(
     )
 
 
-@router.post("/nodes/{name}/migrate", status_code=201)  # pragma: no cover
+@router.post("/nodes/{name}/migrate_dim_link", status_code=201)  # pragma: no cover
 def migrate_dimension_link(  # pragma: no cover
     name: str,
     session: Session = Depends(get_session),
@@ -802,7 +802,7 @@ def migrate_dimension_link(  # pragma: no cover
                     join_type=JoinType.LEFT,
                     join_on=(
                         f"{name}.{column.name} = "
-                        f"{dimension_node.name}.{primary_key_columns[0].name}",
+                        f"{dimension_node.name}.{primary_key_columns[0].name}"
                     ),
                 )
                 upsert_complex_dimension_link(

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -84,7 +84,7 @@ def _join_path(
             if joinable_dim == dimension_node:
                 for col in join_cols:
                     dim_pk = dimension_node.primary_key()
-                    if not col.dimension_column:
+                    if not col.dimension_column:  # pragma: no cover
                         if len(dim_pk) != 1:
                             raise DJException(  # pragma: no cover
                                 f"Node {current_node.name} specifying dimension "

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -6,9 +6,11 @@ from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 
 from fastapi import BackgroundTasks
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
+from datajunction_server.api.catalogs import UNKNOWN_CATALOG_ID
 from datajunction_server.api.helpers import (
     activate_node,
     get_attribute_type,
@@ -19,9 +21,9 @@ from datajunction_server.api.helpers import (
     validate_cube,
     validate_node_data,
 )
-from datajunction_server.database import DimensionLink
 from datajunction_server.database.attributetype import AttributeType, ColumnAttribute
 from datajunction_server.database.column import Column
+from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.metricmetadata import MetricMetadata
@@ -31,6 +33,7 @@ from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJDoesNotExistException,
     DJException,
+    DJInvalidInputException,
     DJNodeNotFound,
 )
 from datajunction_server.internal.materializations import (
@@ -44,6 +47,10 @@ from datajunction_server.models.attribute import (
 )
 from datajunction_server.models.base import labelize
 from datajunction_server.models.cube import CubeRevisionMetadata
+from datajunction_server.models.dimensionlink import (
+    LinkDimensionIdentifier,
+    LinkDimensionInput,
+)
 from datajunction_server.models.history import status_change_history
 from datajunction_server.models.materialization import (
     MaterializationConfigOutput,
@@ -63,6 +70,7 @@ from datajunction_server.models.node import (
 )
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.sql.dag import get_nodes_with_dimension
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import parse
@@ -1317,3 +1325,213 @@ def get_cube_revision_metadata(session: Session, name: str):
     cube_metadata = CubeRevisionMetadata.from_orm(cube)
     cube_metadata.tags = cube.node.tags
     return cube_metadata
+
+
+def upsert_complex_dimension_link(
+    session: Session,
+    node_name: str,
+    link_input: LinkDimensionInput,
+    current_user: Optional[User] = None,
+) -> bool:
+    """
+    Create or update a node-level dimension link.
+
+    A dimension link is uniquely identified by the origin node, the dimension node being linked,
+    and the role, if any. If an existing dimension link identified by those fields already exists,
+    we'll update that dimension link. If no dimension link exists, we'll create a new one.
+    """
+    node = get_node_by_name(session=session, name=node_name)
+    if node.type not in (NodeType.SOURCE, NodeType.DIMENSION, NodeType.TRANSFORM):
+        raise DJInvalidInputException(
+            message=f"Cannot link dimension to a node of type {node.type}. "
+            "Must be a source, dimension, or transform node.",
+        )
+
+    # Find the dimension node and check that the catalogs match
+    dimension_node = get_node_by_name(
+        session=session,
+        name=link_input.dimension_node,
+        node_type=NodeType.DIMENSION,
+    )
+    if (
+        dimension_node.current.catalog_id != UNKNOWN_CATALOG_ID
+        and dimension_node.current.catalog is not None
+        and node.current.catalog.name != dimension_node.current.catalog.name
+    ):
+        raise DJException(  # pragma: no cover
+            message=(
+                "Cannot link dimension to node, because catalogs do not match: "
+                f"{node.current.catalog.name}, {dimension_node.current.catalog.name}"
+            ),
+        )
+
+    # Parse the join query and do some basic verification of its validity
+    join_query = parse(
+        f"SELECT 1 FROM {node_name} "
+        f"{link_input.join_type} JOIN {link_input.dimension_node} "
+        f"ON {link_input.join_on}",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    join_query.compile(ctx)
+    join_relation = join_query.select.from_.relations[0].extensions[0]  # type: ignore
+
+    # Verify that the query references both the node and the dimension being joined
+    expected_references = {node_name, link_input.dimension_node}
+    references = {
+        table.name.namespace.identifier()  # type: ignore
+        for table in join_relation.criteria.on.find_all(ast.Column)  # type: ignore
+    }
+    if expected_references.difference(references):
+        raise DJInvalidInputException(
+            f"The join SQL provided does not reference both the origin node {node_name} and the "
+            f"dimension node {link_input.dimension_node} that it's being joined to.",
+        )
+
+    # Verify that the columns in the ON clause exist on both nodes
+    if ctx.exception.errors:
+        raise DJException(
+            message=f"Join query {link_input.join_on} is not valid",
+            errors=ctx.exception.errors,
+        )
+
+    # Find an existing dimension link if there is already one defined for this node
+    existing_link = [
+        link
+        for link in node.current.dimension_links
+        if link.dimension_id == dimension_node.id and link.role == link_input.role
+    ]
+    is_update = False
+
+    if existing_link:
+        # Update the existing dimension link
+        is_update = True
+        dimension_link = existing_link[0]
+        dimension_link.join_sql = link_input.join_on
+        dimension_link.join_type = DimensionLink.parse_join_type(
+            join_relation.join_type,
+        )
+        dimension_link.join_cardinality = link_input.join_cardinality
+    else:
+        # If there is no existing link, create new dimension link object
+        dimension_link = DimensionLink(
+            node_revision_id=node.current.id,
+            dimension_id=dimension_node.id,
+            join_sql=link_input.join_on,
+            join_type=DimensionLink.parse_join_type(join_relation.join_type),
+            join_cardinality=link_input.join_cardinality,
+            role=link_input.role,
+        )
+
+    # Add/update the dimension link in the database
+    session.add(dimension_link)
+    session.add(
+        History(
+            entity_type=EntityType.LINK,
+            entity_name=node.name,
+            node=node.name,
+            activity_type=ActivityType.CREATE if not is_update else ActivityType.UPDATE,
+            details={
+                "dimension": dimension_node.name,
+                "join_sql": link_input.join_on,
+                "join_cardinality": link_input.join_cardinality,
+                "role": link_input.role,
+            },
+            user=current_user.username if current_user else None,
+        ),
+    )
+    session.commit()
+    session.refresh(node)
+    return is_update
+
+
+def remove_dimension_link(
+    session: Session,
+    node_name: str,
+    link_identifier: LinkDimensionIdentifier,
+    current_user: Optional[User] = None,
+):
+    """
+    Removes the dimension link identified by the origin node, the dimension node, and its role.
+    """
+    node = get_node_by_name(session=session, name=node_name)
+
+    # Find the dimension node
+    dimension_node = get_node_by_name(
+        session=session,
+        name=link_identifier.dimension_node,
+        node_type=NodeType.DIMENSION,
+    )
+    removed = False
+
+    # Find cubes that are affected by this dimension link removal and update their statuses
+    affected_cubes = (
+        get_nodes_with_dimension(
+            session,
+            dimension_node,
+            [NodeType.CUBE],
+        )
+        or []
+    )
+    for cube in affected_cubes:
+        if cube.status != NodeStatus.INVALID:  # pragma: no cover
+            cube.status = NodeStatus.INVALID
+            session.add(cube)
+            session.add(
+                status_change_history(
+                    node,
+                    NodeStatus.VALID,
+                    NodeStatus.INVALID,
+                    current_user=current_user,
+                ),
+            )
+
+    # Delete the dimension link if one exists
+    for link in node.current.dimension_links:
+        if (
+            link.dimension_id == dimension_node.id  # pragma: no cover
+            and link.role == link_identifier.role  # pragma: no cover
+        ):
+            removed = True
+            session.delete(link)
+    if not removed:
+        return JSONResponse(
+            status_code=HTTPStatus.NOT_FOUND,
+            content={
+                "message": f"Dimension link to node {link_identifier.dimension_node} "
+                + (f"with role {link_identifier.role} " if link_identifier.role else "")
+                + "not found",
+            },
+        )
+
+    session.add(
+        History(
+            entity_type=EntityType.LINK,
+            entity_name=node.name,
+            node=node.name,
+            activity_type=ActivityType.DELETE,
+            details={
+                "dimension": dimension_node.name,
+                "role": link_identifier.role,
+            },
+            user=current_user.username if current_user else None,
+        ),
+    )
+    session.commit()
+    session.refresh(node)
+    return JSONResponse(
+        status_code=201,
+        content={
+            "message": (
+                f"Dimension link {link_identifier.dimension_node} "
+                + (f"(role {link_identifier.role}) " if link_identifier.role else "")
+                + f"to node {node_name} has been removed."
+            )
+            if removed
+            else (
+                f"Dimension link {link_identifier.dimension_node} "
+                + (f"(role {link_identifier.role}) " if link_identifier.role else "")
+                + f"to node {node_name} does not exist!"
+            ),
+        },
+    )

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1332,7 +1332,7 @@ def upsert_complex_dimension_link(
     node_name: str,
     link_input: LinkDimensionInput,
     current_user: Optional[User] = None,
-) -> bool:
+) -> ActivityType:
     """
     Create or update a node-level dimension link.
 
@@ -1401,11 +1401,11 @@ def upsert_complex_dimension_link(
         for link in node.current.dimension_links
         if link.dimension_id == dimension_node.id and link.role == link_input.role
     ]
-    is_update = False
+    activity_type = ActivityType.CREATE
 
     if existing_link:
         # Update the existing dimension link
-        is_update = True
+        activity_type = ActivityType.UPDATE
         dimension_link = existing_link[0]
         dimension_link.join_sql = link_input.join_on
         dimension_link.join_type = DimensionLink.parse_join_type(
@@ -1430,7 +1430,7 @@ def upsert_complex_dimension_link(
             entity_type=EntityType.LINK,
             entity_name=node.name,
             node=node.name,
-            activity_type=ActivityType.CREATE if not is_update else ActivityType.UPDATE,
+            activity_type=activity_type,
             details={
                 "dimension": dimension_node.name,
                 "join_sql": link_input.join_on,
@@ -1442,7 +1442,7 @@ def upsert_complex_dimension_link(
     )
     session.commit()
     session.refresh(node)
-    return is_update
+    return activity_type
 
 
 def remove_dimension_link(

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -875,14 +875,19 @@ class Column(Aliasable, Named, Expression):
                 # it should be sourced from the immediate table
                 not namespace
                 or namespace == table.alias_or_name.identifier(False)
-            ) or (
-                # This column may be a struct, meaning it'll have an optional namespace,
-                # a column name, and a subscript
-                table.column_mapping.get(namespace)
-                or (table.column_mapping.get(column_name) and is_struct)
             ):
                 if table.add_ref_column(self, ctx):
                     found.append(table)
+
+        # This column may be a struct, meaning it'll have an optional namespace,
+        # a column name, and a subscript
+        if not found:
+            for table in direct_tables:
+                if table.column_mapping.get(namespace) or (
+                    table.column_mapping.get(column_name) and is_struct
+                ):
+                    if table.add_ref_column(self, ctx):
+                        found.append(table)
 
         if found:
             return found

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2529,7 +2529,7 @@ class Query(TableExpression, UnNamed):
         parts = [f"{with_}{self.select}\n"]
         query = "".join(parts)
         if self.parenthesized:
-            query = f"({query})"
+            query = f"({query.strip()})"
         if self.alias:
             as_ = " AS " if self.as_ else " "
             if is_cte:

--- a/datajunction-server/datajunction_server/sql/parsing/types.py
+++ b/datajunction-server/datajunction_server/sql/parsing/types.py
@@ -937,4 +937,5 @@ PRIMITIVE_TYPES: Dict[str, PrimitiveType] = {
     "binary": BinaryType(),
     "none": NullType(),
     "null": NullType(),
+    "wildcard": WildcardType(),
 }

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -935,7 +935,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.age",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "int",
             },
             {
@@ -943,7 +943,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.country",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -951,7 +951,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.created_at",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "timestamp",
             },
             {
@@ -959,7 +959,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.full_name",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -967,7 +967,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.gender",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -975,7 +975,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.id",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "int",
             },
             {
@@ -983,7 +983,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.post_processing_timestamp",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "timestamp",
             },
             {
@@ -991,7 +991,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.preferred_language",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -999,7 +999,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.secret_number",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "float",
             },
         ]
@@ -1042,7 +1042,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.age",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "int",
             },
             {
@@ -1050,7 +1050,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.country",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -1058,7 +1058,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.created_at",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "timestamp",
             },
             {
@@ -1066,7 +1066,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.full_name",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -1074,7 +1074,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.gender",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -1082,7 +1082,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.id",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "int",
             },
             {
@@ -1090,7 +1090,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.post_processing_timestamp",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "timestamp",
             },
             {
@@ -1098,7 +1098,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.preferred_language",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "string",
             },
             {
@@ -1106,7 +1106,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "name": "default.us_users.secret_number",
                 "node_display_name": "Default: Us Users",
                 "node_name": "default.us_users",
-                "path": ["default.messages.user_id"],
+                "path": ["default.messages"],
                 "type": "float",
             },
         ]
@@ -3295,7 +3295,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             "default_DOT_hard_hats.state, default_DOT_hard_hats.postal_code, "
             "default_DOT_hard_hats.country, default_DOT_hard_hats.manager, "
             "default_DOT_hard_hats.contractor_id FROM roads.hard_hats AS "
-            "default_DOT_hard_hats ) AS default_DOT_hard_hat WHERE birth_date = "
+            "default_DOT_hard_hats) AS default_DOT_hard_hat WHERE birth_date = "
             "CAST(DATE_FORMAT(CAST(${dj_logical_timestamp} AS TIMESTAMP), 'yyyyMMdd') AS "
             "TIMESTAMP)"
         )
@@ -4264,14 +4264,14 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert data == {
             "message": (
                 "Dimension node default.payment_type has been successfully "
-                "linked to column payment_type on node default.revenue"
+                "linked to node default.revenue using column payment_type."
             ),
         }
         response = custom_client.get("/nodes/default.revenue")
         data = response.json()
         assert [
             col["dimension"]["name"] for col in data["columns"] if col["dimension"]
-        ] == ["default.payment_type"]
+        ] == []
 
         # Check that after deleting the dimension link, none of the columns have links
         response = custom_client.delete(
@@ -4280,8 +4280,8 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data == {
             "message": (
-                "The dimension link on the node default.revenue's payment_type to "
-                "default.payment_type has been successfully removed."
+                "Dimension link default.payment_type to node default.revenue has "
+                "been removed."
             ),
         }
         response = custom_client.get("/nodes/default.revenue")
@@ -4298,10 +4298,9 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
         )
         data = response.json()
-        assert response.status_code == 304
+        assert response.status_code == 404
         assert data == {
-            "message": "No change was made to payment_type on node default.revenue as the"
-            " specified dimension link to default.payment_type on None was not found.",
+            "message": "Dimension link to node default.payment_type not found",
         }
         # Check history again, no change
         response = custom_client.get("/history?node=default.revenue")
@@ -4340,7 +4339,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         )
         data = response.json()
         assert data["message"] == (
-            "Cannot add dimension to column, because catalogs do not match: default, public"
+            "Cannot link dimension to node, because catalogs do not match: default, public"
         )
 
     def test_update_node_with_dimension_links(self, client_with_roads: TestClient):

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -389,12 +389,23 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         response = client_with_roads.get("/nodes/default.hard_hats/")
         assert {
             "attributes": [],
-            "dimension": {"name": "default.title"},
+            "dimension": None,
             "display_name": "Title",
             "name": "title",
             "type": "string",
             "partition": None,
         } in response.json()["columns"]
+
+        assert response.json()["dimension_links"] == [
+            {
+                "dimension": {"name": "default.title"},
+                "foreign_keys": {"default.hard_hats.title": "default.title.title"},
+                "join_cardinality": "many_to_one",
+                "join_sql": "default.hard_hats.title = default.title.title",
+                "join_type": "left",
+                "role": None,
+            },
+        ]
 
     def test_deleting_node(
         self,

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -1803,7 +1803,7 @@ LATERAL_VIEW = (  # type: ignore
             "description": "Mural paint colors",
             "mode": "published",
             "name": "basic.paint_colors_trino",
-            "primary_key": ["color_id", "color_name"],
+            "primary_key": ["color_id"],
         },
     ),
     (
@@ -1825,7 +1825,7 @@ LATERAL_VIEW = (  # type: ignore
             "description": "Mural paint colors",
             "mode": "published",
             "name": "basic.paint_colors_spark",
-            "primary_key": ["color_id", "color_name"],
+            "primary_key": ["color_id"],
         },
     ),
     (

--- a/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
@@ -8,6 +8,7 @@ import { displayMessageAfterSubmit } from '../../../utils/form';
 
 export default function LinkDimensionPopover({
   column,
+  referencedDimensionNode,
   node,
   options,
   onSubmit,
@@ -28,15 +29,15 @@ export default function LinkDimensionPopover({
     };
   }, [setPopoverAnchor]);
 
-  const columnDimension = column.dimension;
+  const columnDimension = referencedDimensionNode;
 
   const handleSubmit = async (
     { node, column, dimension },
     { setSubmitting, setStatus },
   ) => {
     setSubmitting(false);
-    if (columnDimension?.name && dimension === 'Remove') {
-      await unlinkDimension(node, column, columnDimension?.name, setStatus);
+    if (referencedDimensionNode && dimension === 'Remove') {
+      await unlinkDimension(node, column, referencedDimensionNode, setStatus);
     } else {
       await linkDimension(node, column, dimension, setStatus);
     }
@@ -93,7 +94,7 @@ export default function LinkDimensionPopover({
             column: column.name,
             node: node.name,
             dimension: '',
-            currentDimension: column.dimension?.name,
+            currentDimension: referencedDimensionNode,
           }}
           onSubmit={handleSubmit}
         >
@@ -110,10 +111,10 @@ export default function LinkDimensionPopover({
                     placeholder="Select dimension to link"
                     className=""
                     defaultValue={
-                      column.dimension
+                      referencedDimensionNode
                         ? {
-                            value: column.dimension.name,
-                            label: column.dimension.name,
+                            value: referencedDimensionNode,
+                            label: referencedDimensionNode,
                           }
                         : ''
                     }

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -91,93 +91,101 @@ export default function NodeColumnTab({ node, djClient }) {
 
   const columnList = columns => {
     return columns.map(col => {
-      const dimensionLinks = (links.length > 0 ? links : node?.dimension_links).map(
-              link => [link.dimension.name, Object.entries(link.foreign_keys).filter(
-                entry => entry[0] === (node.name + '.' + col.name))]
-      ).filter(keys => keys[1].length >= 1);
-      const referencedDimensionNode = dimensionLinks.length > 0 ? dimensionLinks[0][0] : null;
+      const dimensionLinks = (links.length > 0 ? links : node?.dimension_links)
+        .map(link => [
+          link.dimension.name,
+          Object.entries(link.foreign_keys).filter(
+            entry => entry[0] === node.name + '.' + col.name,
+          ),
+        ])
+        .filter(keys => keys[1].length >= 1);
+      const referencedDimensionNode =
+        dimensionLinks.length > 0 ? dimensionLinks[0][0] : null;
       return (
-      <tr key={col.name}>
-        <td
-          className="text-start"
-          role="columnheader"
-          aria-label="ColumnName"
-          aria-hidden="false"
-        >
-          {col.name}
-        </td>
-        <td>
-          <span
-            className=""
+        <tr key={col.name}>
+          <td
+            className="text-start"
             role="columnheader"
-            aria-label="ColumnDisplayName"
+            aria-label="ColumnName"
             aria-hidden="false"
           >
-            {col.display_name}
-          </span>
-        </td>
-        <td>
-          <span
-            className={`node_type__${
-              node.type === 'cube' ? col.type : 'transform'
-            } badge node_type`}
-            role="columnheader"
-            aria-label="ColumnType"
-            aria-hidden="false"
-          >
-            {col.type}
-          </span>
-        </td>
-        {node.type !== 'cube' ? (
+            {col.name}
+          </td>
           <td>
-            {referencedDimensionNode !== null ?
-              <a href={`/nodes/${referencedDimensionNode}`}>
-                {referencedDimensionNode}
-              </a> : ''}
-            <LinkDimensionPopover
+            <span
+              className=""
+              role="columnheader"
+              aria-label="ColumnDisplayName"
+              aria-hidden="false"
+            >
+              {col.display_name}
+            </span>
+          </td>
+          <td>
+            <span
+              className={`node_type__${
+                node.type === 'cube' ? col.type : 'transform'
+              } badge node_type`}
+              role="columnheader"
+              aria-label="ColumnType"
+              aria-hidden="false"
+            >
+              {col.type}
+            </span>
+          </td>
+          {node.type !== 'cube' ? (
+            <td>
+              {referencedDimensionNode !== null ? (
+                <a href={`/nodes/${referencedDimensionNode}`}>
+                  {referencedDimensionNode}
+                </a>
+              ) : (
+                ''
+              )}
+              <LinkDimensionPopover
+                column={col}
+                referencedDimensionNode={referencedDimensionNode}
+                node={node}
+                options={dimensions}
+                onSubmit={async () => {
+                  const res = await djClient.node(node.name);
+                  setColumns(res.columns);
+                  setLinks(res.dimension_links);
+                }}
+              />
+            </td>
+          ) : (
+            ''
+          )}
+          {node.type !== 'cube' ? (
+            <td>
+              {showColumnAttributes(col)}
+              <EditColumnPopover
+                column={col}
+                node={node}
+                options={attributes}
+                onSubmit={async () => {
+                  const res = await djClient.node(node.name);
+                  setColumns(res.columns);
+                }}
+              />
+            </td>
+          ) : (
+            ''
+          )}
+          <td>
+            {showColumnPartition(col)}
+            <PartitionColumnPopover
               column={col}
-              referencedDimensionNode={referencedDimensionNode}
               node={node}
-              options={dimensions}
               onSubmit={async () => {
                 const res = await djClient.node(node.name);
                 setColumns(res.columns);
-                setLinks(res.dimension_links);
               }}
             />
           </td>
-        ) : (
-          ''
-        )}
-        {node.type !== 'cube' ? (
-          <td>
-            {showColumnAttributes(col)}
-            <EditColumnPopover
-              column={col}
-              node={node}
-              options={attributes}
-              onSubmit={async () => {
-                const res = await djClient.node(node.name);
-                setColumns(res.columns);
-              }}
-            />
-          </td>
-        ) : (
-          ''
-        )}
-        <td>
-          {showColumnPartition(col)}
-          <PartitionColumnPopover
-            column={col}
-            node={node}
-            onSubmit={async () => {
-              const res = await djClient.node(node.name);
-              setColumns(res.columns);
-            }}
-          />
-        </td>
-      </tr>
-    );
+        </tr>
+      );
     });
   };
 

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/LinkDimensionPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/LinkDimensionPopover.test.jsx
@@ -42,6 +42,7 @@ describe('<LinkDimensionPopover />', () => {
       <DJClientContext.Provider value={mockDjClient}>
         <LinkDimensionPopover
           column={column}
+          referencedDimensionNode={'default.dimension1'}
           node={node}
           options={options}
           onSubmit={onSubmitMock}
@@ -94,7 +95,6 @@ describe('<LinkDimensionPopover />', () => {
     };
     const node = { name: 'default.node1' };
     const options = [
-      { value: 'Remove', label: '[Remove dimension link]' },
       { value: 'default.dimension1', label: 'Dimension 1' },
       { value: 'default.dimension2', label: 'Dimension 2' },
     ];
@@ -117,6 +117,7 @@ describe('<LinkDimensionPopover />', () => {
       <DJClientContext.Provider value={mockDjClient}>
         <LinkDimensionPopover
           column={column}
+          referencedDimensionNode={'default.dimension1'}
           node={node}
           options={options}
           onSubmit={onSubmitMock}
@@ -148,7 +149,7 @@ describe('<LinkDimensionPopover />', () => {
 
     // Click on the 'Remove' option and save
     fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
-    fireEvent.click(screen.getByText('[Remove dimension link]'));
+    fireEvent.click(screen.getByText('[Remove Dimension]'));
     fireEvent.click(getByText('Save'));
     getByText('Save').click();
 

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodeColumnTab.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodeColumnTab.test.jsx
@@ -98,6 +98,10 @@ describe('<NodeColumnTab />', () => {
           'default.contractor.contractor_id = default.repair_orders.contractor_id',
         join_cardinality: 'one_to_one',
         role: 'contractor',
+        foreign_keys: {
+          'default.repair_orders.contractor_id':
+            'default.contractor.contractor_id',
+        },
       },
     ],
   };

--- a/datajunction-ui/src/app/pages/Root/index.tsx
+++ b/datajunction-ui/src/app/pages/Root/index.tsx
@@ -24,11 +24,19 @@ export function Root() {
       <div className="container d-flex align-items-center justify-content-between">
         <div className="header">
           <div className="logo">
-            <a href={'/'} style={{textTransform: 'none', textDecoration: 'none', color: '#000'}}>
+            <a
+              href={'/'}
+              style={{
+                textTransform: 'none',
+                textDecoration: 'none',
+                color: '#000',
+              }}
+            >
               <h2>
-              <DJLogo />
-              Data<b>Junction</b>
-            </h2></a>
+                <DJLogo />
+                Data<b>Junction</b>
+              </h2>
+            </a>
           </div>
           <Search />
           <div className="menu">


### PR DESCRIPTION
### Summary

This PR makes the final switch over to node-level dimension links. It does so by:
* Changing the APIs for column-level dimension linking and unlinking to use node-level dimension links
* Changing the UI to display column-level dimension links
* Adding a migration endpoint that we can remove once we are done with migration

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP. This blocks all other materialization-related changes. Once this PR has been merged, we also can't make new changes without deploying this migration successfully.
