### PR TITLE
Support aggregated cube materialization

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -863,6 +863,11 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
             sql=str(query_ast),
             columns=columns,
             dialect=engine.dialect if engine else None,
+            upstream_tables=[
+                f"{leading_metric_node.current.catalog.name}.{tbl.identifier()}"
+                for tbl in query_ast.find_all(ast.Table)
+                if tbl.dj_node and tbl.dj_node.type == NodeType.SOURCE
+            ],
         ),
         engine,
         leading_metric_node.current.catalog,
@@ -1121,6 +1126,23 @@ def revalidate_node(
             session.commit()
             session.refresh(current_node_revision)
         return NodeStatus.VALID
+
+    if current_node_revision.type == NodeType.CUBE:
+        cube_metrics = [metric.name for metric in current_node_revision.cube_metrics()]
+        cube_dimensions = current_node_revision.cube_dimensions()
+        try:
+            validate_cube(
+                session,
+                metric_names=cube_metrics,
+                dimension_names=cube_dimensions,
+                require_dimensions=True,
+            )
+            current_node_revision.status = NodeStatus.VALID
+        except DJException:
+            current_node_revision.status = NodeStatus.INVALID
+        session.add(current_node_revision)
+        session.commit()
+        return current_node_revision.status
     previous_status = current_node_revision.status
     node_validator = validate_node_data(current_node_revision, session)
     current_node_revision.status = node_validator.status

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -752,6 +752,7 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
     access_control: Optional[access.AccessControlStore] = None,
+    use_materialized: bool = True,
 ) -> Tuple[TranslatedSQL, Engine, Catalog]:
     """
     Build SQL for multiple metrics. Used by both /sql and /data endpoints
@@ -797,7 +798,7 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
 
     validate_orderby(orderby, metrics, dimensions)
 
-    if cube and cube.materializations and cube.availability:
+    if cube and cube.materializations and cube.availability and use_materialized:
         if access_control:  # pragma: no cover
             access_control.add_request_by_node(cube)
             access_control.state = access.AccessControlState.INDIRECT
@@ -1138,7 +1139,7 @@ def revalidate_node(
                 require_dimensions=True,
             )
             current_node_revision.status = NodeStatus.VALID
-        except DJException:
+        except DJException:  # pragma: no cover
             current_node_revision.status = NodeStatus.INVALID
         session.add(current_node_revision)
         session.commit()

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -1181,9 +1181,10 @@ def build_metric_nodes(
     for col in all_dimension_columns:
         dimension_grouping.setdefault(col.identifier(), []).append(col)
     dimension_columns = [
-        ast.Function(name=ast.Name("COALESCE"), args=list(columns)).set_alias(
-            ast.Name(col_name),
-        )
+        ast.Function(name=ast.Name("COALESCE"), args=list(columns))
+        .set_alias(ast.Name(col_name))
+        .set_semantic_entity(columns[0].semantic_entity)
+        .set_semantic_type(columns[0].semantic_type)
         if len(columns) > 1
         else columns[0]
         for col_name, columns in dimension_grouping.items()

--- a/datajunction-server/datajunction_server/database/materialization.py
+++ b/datajunction-server/datajunction_server/database/materialization.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from datajunction_server.database.backfill import Backfill
 from datajunction_server.database.base import Base
 from datajunction_server.models.materialization import (
-    DruidCubeConfig,
+    DruidMeasuresCubeConfig,
     GenericMaterializationConfig,
     MaterializationStrategy,
 )
@@ -60,7 +60,7 @@ class Materialization(Base):  # pylint: disable=too-few-public-methods
 
     # Arbitrary config relevant to the materialization job
     config: Mapped[
-        Union[GenericMaterializationConfig, DruidCubeConfig]
+        Union[GenericMaterializationConfig, DruidMeasuresCubeConfig]
     ] = mapped_column(
         JSON,
         default={},

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 import sqlalchemy as sa
 from pydantic import Extra
 from sqlalchemy import JSON, DateTime, Enum, ForeignKey, String, UniqueConstraint
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.availabilitystate import AvailabilityState
@@ -528,6 +529,20 @@ class NodeRevision(
             ],
             key=lambda x: ordering[x],
         )
+
+    @hybrid_property
+    def cube_node_metrics(self) -> List[str]:
+        """
+        Cube node's metrics
+        """
+        return [metric.name for metric in self.cube_metrics()]
+
+    @hybrid_property
+    def cube_node_dimensions(self) -> List[str]:
+        """
+        Cube node's dimension attributes
+        """
+        return self.cube_dimensions()
 
     def temporal_partition_columns(self) -> List[Column]:
         """

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1079,6 +1079,16 @@ def create_new_revision_from_existing(  # pylint: disable=too-many-locals,too-ma
             if data and data.metric_metadata
             else old_revision.metric_metadata
         ),
+        dimension_links=[
+            DimensionLink(
+                dimension_id=link.dimension_id,
+                join_sql=link.join_sql,
+                join_type=link.join_type,
+                join_cardinality=link.join_cardinality,
+                materialization_conf=link.materialization_conf,
+            )
+            for link in old_revision.dimension_links
+        ],
     )
     if data.required_dimensions:  # type: ignore
         new_revision.required_dimensions = data.required_dimensions  # type: ignore

--- a/datajunction-server/datajunction_server/materialization/jobs/__init__.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/__init__.py
@@ -5,11 +5,13 @@ __all__ = [
     "MaterializationJob",
     "SparkSqlMaterializationJob",
     "DefaultCubeMaterialization",
-    "DruidCubeMaterializationJob",
+    "DruidMeasuresCubeMaterializationJob",
+    "DruidMetricsCubeMaterializationJob",
 ]
 from datajunction_server.materialization.jobs.cube_materialization import (
     DefaultCubeMaterialization,
-    DruidCubeMaterializationJob,
+    DruidMeasuresCubeMaterializationJob,
+    DruidMetricsCubeMaterializationJob,
 )
 from datajunction_server.materialization.jobs.materialization_job import (
     MaterializationJob,

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -9,9 +9,9 @@ from datajunction_server.materialization.jobs.materialization_job import (
 )
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import (
-    DruidAggCubeConfig,
-    DruidCubeConfig,
     DruidMaterializationInput,
+    DruidMeasuresCubeConfig,
+    DruidMetricsCubeConfig,
     MaterializationInfo,
 )
 from datajunction_server.naming import amenable_name
@@ -91,21 +91,21 @@ class DruidMaterializationJob(MaterializationJob):
         )
 
 
-class DruidAggCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
+class DruidMetricsCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
     """
     Druid materialization (aggregations aka metrics) for a cube node.
     """
 
-    config_class = DruidAggCubeConfig  # type: ignore
+    config_class = DruidMetricsCubeConfig  # type: ignore
 
 
-class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
+class DruidMeasuresCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
     """
     Druid materialization (measures) for a cube node.
     """
 
     dialect = Dialect.DRUID
-    config_class = DruidCubeConfig  # type: ignore
+    config_class = DruidMeasuresCubeConfig  # type: ignore
 
 
 def build_materialization_query(

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -41,7 +41,7 @@ class DefaultCubeMaterialization(
 
 class DruidMaterializationJob(MaterializationJob):
     """
-    Generic Druid materialization job, irrespective of measures or metrics load.
+    Generic Druid materialization job, irrespective of measures or aggregation load.
     """
 
     config_class = None
@@ -55,7 +55,7 @@ class DruidMaterializationJob(MaterializationJob):
         Use the query service to kick off the materialization setup.
         """
         if not self.config_class:
-            raise DJInvalidInputException(
+            raise DJInvalidInputException(  # pragma: no cover
                 "The materialization job config class must be defined!",
             )
         cube_config = self.config_class.parse_obj(materialization.config)

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -65,6 +65,8 @@ class CubeRevisionMetadata(BaseModel):
     description: str = ""
     availability: Optional[AvailabilityStateBase] = None
     cube_elements: List[CubeElementMetadata]
+    cube_node_metrics: List[str]
+    cube_node_dimensions: List[str]
     query: Optional[str]
     columns: List[ColumnOutput]
     updated_at: UTCDatetime

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -277,7 +277,7 @@ class DruidCubeConfigInput(GenericCubeConfigInput):
     druid: Optional[DruidConf]
 
 
-class DruidCubeConfig(DruidCubeConfigInput, GenericCubeConfig):
+class DruidMeasuresCubeConfig(DruidCubeConfigInput, GenericCubeConfig):
     """
     Specific cube materialization implementation with Spark and Druid ingestion and
     optional prefix and/or suffix to include with the materialized entity's name.
@@ -358,7 +358,9 @@ class DruidCubeConfig(DruidCubeConfigInput, GenericCubeConfig):
         return druid_spec
 
 
-class DruidAggCubeConfig(DruidCubeConfig):  # pylint: disable=too-many-ancestors
+class DruidMetricsCubeConfig(
+    DruidMeasuresCubeConfig,
+):  # pylint: disable=too-many-ancestors
     """
     Specific cube materialization implementation with Spark and Druid ingestion and
     optional prefix and/or suffix to include with the materialized entity's name.
@@ -409,9 +411,9 @@ class MaterializationJobTypeEnum(enum.Enum):
         job_class="SparkSqlMaterializationJob",
     )
 
-    DRUID_CUBE = MaterializationJobType(
-        name="druid_cube",
-        label="Druid Cube (Measures)",
+    DRUID_MEASURES_CUBE = MaterializationJobType(
+        name="druid_measures_cube",
+        label="Druid Measures Cube (Pre-Agg Cube)",
         description=(
             "Used to materialize a cube's measures to Druid for low-latency access to a set of "
             "metrics and dimensions. While the logical cube definition is at the level of metrics "
@@ -419,19 +421,19 @@ class MaterializationJobTypeEnum(enum.Enum):
             " with rollup configured on the measures where appropriate."
         ),
         allowed_node_types=[NodeType.CUBE],
-        job_class="DruidCubeMaterializationJob",
+        job_class="DruidMeasuresCubeMaterializationJob",
     )
 
-    DRUID_AGG_CUBE = MaterializationJobType(
-        name="druid_agg_cube",
-        label="Druid Cube (Aggregates)",
+    DRUID_METRICS_CUBE = MaterializationJobType(
+        name="druid_metrics_cube",
+        label="Druid Metrics Cube (Post-Agg Cube)",
         description=(
             "Used to materialize a cube of metrics and dimensions to Druid for low-latency access."
             " The materialized cube is at the metric level, meaning that all metrics will be "
             "aggregated to the level of the cube's dimensions."
         ),
         allowed_node_types=[NodeType.CUBE],
-        job_class="DruidAggCubeMaterializationJob",
+        job_class="DruidMetricsCubeMaterializationJob",
     )
 
     @classmethod

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -35,8 +35,6 @@ DRUID_AGG_MAPPING = {
     ("int", "count"): "longSum",
     ("double", "count"): "longSum",
     ("float", "count"): "longSum",
-    # ("string", "sum"): "count",
-    # ("string", "count"): "count",
 }
 
 

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -805,6 +805,7 @@ class DAGNodeRevisionOutput(BaseModel):
     columns: List[ColumnOutput]
     updated_at: UTCDatetime
     parents: List[NodeNameOutput]
+    dimension_links: List[LinkDimensionOutput]
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         allow_population_by_field_name = True

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -777,7 +777,7 @@ def test_add_materialization_cube_failures(
     response = client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization/",
         json={
-            "job": "druid_cube",
+            "job": "druid_measures_cube",
             "strategy": "full",
             "config": {},
             "schedule": "@daily",
@@ -793,7 +793,7 @@ def test_add_materialization_cube_failures(
     response = client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization/",
         json={
-            "job": "druid_cube",
+            "job": "druid_measures_cube",
             "strategy": "full",
             "config": {
                 "spark": {},
@@ -804,7 +804,7 @@ def test_add_materialization_cube_failures(
     assert (
         response.json()["message"]
         == "Successfully updated materialization config named "
-        "`druid_cube__full__default.hard_hat.hire_date` "
+        "`druid_measures_cube__full__default.hard_hat.hire_date` "
         "for node `default.repairs_cube`"
     )
     args, _ = query_service_client.materialize.call_args_list[0]  # type: ignore
@@ -817,7 +817,7 @@ def test_add_materialization_cube_failures(
     response = client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization/",
         json={
-            "job": "druid_cube",
+            "job": "druid_measures_cube",
             "strategy": "full",
             "config": {
                 "druid": {"a": "b"},
@@ -828,7 +828,7 @@ def test_add_materialization_cube_failures(
     )
     assert response.json()["message"] == (
         "The same materialization config with name "
-        "`druid_cube__full__default.hard_hat.hire_date` already exists for node "
+        "`druid_measures_cube__full__default.hard_hat.hire_date` already exists for node "
         "`default.repairs_cube` so no update was performed."
     )
 
@@ -844,7 +844,7 @@ def repairs_cube_with_materialization(
     return client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization/",
         json={
-            "job": "druid_cube",
+            "job": "druid_measures_cube",
             "strategy": "incremental_time",
             "config": {
                 "spark": {},
@@ -1165,7 +1165,7 @@ def test_add_materialization_config_to_cube(
     """
     assert repairs_cube_with_materialization.json() == {
         "message": "Successfully updated materialization config named "
-        "`druid_cube__incremental_time__default.hard_hat.hire_date` "
+        "`druid_measures_cube__incremental_time__default.hard_hat.hire_date` "
         "for node `default.repairs_cube`",
         "urls": [["http://fake.url/job"]],
     }
@@ -1174,7 +1174,7 @@ def test_add_materialization_config_to_cube(
         for call_ in query_service_client.materialize.call_args_list  # type: ignore
     ][0][0]
     assert (
-        called_kwargs.name == "druid_cube__incremental_time__default.hard_hat.hire_date"
+        called_kwargs.name == "druid_measures_cube__incremental_time__default.hard_hat.hire_date"
     )
     assert called_kwargs.node_name == "default.repairs_cube"
     assert called_kwargs.node_type == "cube"
@@ -1777,7 +1777,7 @@ def test_updating_cube_with_existing_materialization(
     response = client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization",
         json={
-            "job": "druid_cube",
+            "job": "druid_measures_cube",
             "strategy": "incremental_time",
             "config": {"spark": {"spark.executor.memory": "6g"}},
             "schedule": "@daily",
@@ -1786,7 +1786,7 @@ def test_updating_cube_with_existing_materialization(
     data = response.json()
     assert data == {
         "message": "Successfully updated materialization config named "
-        "`druid_cube__incremental_time__default.hard_hat.hire_date` for node "
+        "`druid_measures_cube__incremental_time__default.hard_hat.hire_date` for node "
         "`default.repairs_cube`",
         "urls": [["http://fake.url/job"]],
     }
@@ -1815,7 +1815,7 @@ def test_updating_cube_with_existing_materialization(
     )
     assert (
         last_call_args["name"]
-        == "druid_cube__incremental_time__default.hard_hat.hire_date"
+        == "druid_measures_cube__incremental_time__default.hard_hat.hire_date"
     )
     assert last_call_args["node_name"] == "default.repairs_cube"
     assert last_call_args["node_version"] == "v2.0"
@@ -1902,7 +1902,7 @@ def test_updating_cube_with_existing_materialization(
     assert data["materializations"][0]["job"] == "DruidMeasuresCubeMaterializationJob"
     assert (
         data["materializations"][0]["name"]
-        == "druid_cube__incremental_time__default.hard_hat.hire_date"
+        == "druid_measures_cube__incremental_time__default.hard_hat.hire_date"
     )
     assert data["materializations"][0]["schedule"] == "@daily"
 
@@ -1914,10 +1914,10 @@ def test_updating_cube_with_existing_materialization(
             "activity_type": "update",
             "created_at": mock.ANY,
             "details": {
-                "materialization": "druid_cube__incremental_time__default.hard_hat.hire_date",
+                "materialization": "druid_measures_cube__incremental_time__default.hard_hat.hire_date",
                 "node": "default.repairs_cube",
             },
-            "entity_name": "druid_cube__incremental_time__default.hard_hat.hire_date",
+            "entity_name": "druid_measures_cube__incremental_time__default.hard_hat.hire_date",
             "entity_type": "materialization",
             "id": mock.ANY,
             "node": "default.repairs_cube",
@@ -1941,7 +1941,7 @@ def test_updating_cube_with_existing_materialization(
             "activity_type": "update",
             "created_at": mock.ANY,
             "details": {},
-            "entity_name": "druid_cube__incremental_time__default.hard_hat.hire_date",
+            "entity_name": "druid_measures_cube__incremental_time__default.hard_hat.hire_date",
             "entity_type": "materialization",
             "id": mock.ANY,
             "node": "default.repairs_cube",

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1174,7 +1174,8 @@ def test_add_materialization_config_to_cube(
         for call_ in query_service_client.materialize.call_args_list  # type: ignore
     ][0][0]
     assert (
-        called_kwargs.name == "druid_measures_cube__incremental_time__default.hard_hat.hire_date"
+        called_kwargs.name
+        == "druid_measures_cube__incremental_time__default.hard_hat.hire_date"
     )
     assert called_kwargs.node_name == "default.repairs_cube"
     assert called_kwargs.node_type == "cube"
@@ -1914,7 +1915,8 @@ def test_updating_cube_with_existing_materialization(
             "activity_type": "update",
             "created_at": mock.ANY,
             "details": {
-                "materialization": "druid_measures_cube__incremental_time__default.hard_hat.hire_date",
+                "materialization": "druid_measures_cube__incremental_time__"
+                "default.hard_hat.hire_date",
                 "node": "default.repairs_cube",
             },
             "entity_name": "druid_measures_cube__incremental_time__default.hard_hat.hire_date",

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -761,7 +761,7 @@ SELECT  default_DOT_repair_orders_fact.default_DOT_repair_orders_fact_DOT_repair
     assert str(parse(data["materializations"][0]["config"]["query"])) == str(
         parse(expected_materialization_query),
     )
-    assert data["materializations"][0]["job"] == "DruidCubeMaterializationJob"
+    assert data["materializations"][0]["job"] == "DruidMeasuresCubeMaterializationJob"
     assert (
         data["materializations"][0]["config"]["measures"] == repair_orders_cube_measures
     )
@@ -865,7 +865,7 @@ def test_druid_cube_agg_materialization(
     repairs_cube_with_materialization = client_with_repairs_cube.post(
         "/nodes/default.repairs_cube/materialization/",
         json={
-            "job": "druid_agg_cube",
+            "job": "druid_metrics_cube",
             "strategy": "incremental_time",
             "config": {
                 "spark": {},
@@ -875,7 +875,7 @@ def test_druid_cube_agg_materialization(
     )
     assert repairs_cube_with_materialization.json() == {
         "message": "Successfully updated materialization config named "
-        "`druid_agg_cube__incremental_time__default.hard_hat.hire_date` "
+        "`druid_metrics_cube__incremental_time__default.hard_hat.hire_date` "
         "for node `default.repairs_cube`",
         "urls": [["http://fake.url/job"]],
     }
@@ -885,7 +885,7 @@ def test_druid_cube_agg_materialization(
     ][0][0]
     assert (
         called_kwargs.name
-        == "druid_agg_cube__incremental_time__default.hard_hat.hire_date"
+        == "druid_metrics_cube__incremental_time__default.hard_hat.hire_date"
     )
     assert called_kwargs.node_name == "default.repairs_cube"
     assert called_kwargs.node_type == "cube"
@@ -1088,7 +1088,7 @@ def test_druid_cube_agg_materialization(
     druid_materialization = [
         materialization
         for materialization in materializations
-        if materialization["job"] == "DruidAggCubeMaterializationJob"
+        if materialization["job"] == "DruidMetricsCubeMaterializationJob"
     ][0]
     assert set(druid_materialization["config"]["dimensions"]) == {
         "default_DOT_hard_hat_DOT_country",
@@ -1362,7 +1362,7 @@ def test_add_materialization_config_to_cube(
     druid_materialization = [
         materialization
         for materialization in materializations
-        if materialization["job"] == "DruidCubeMaterializationJob"
+        if materialization["job"] == "DruidMeasuresCubeMaterializationJob"
     ][0]
     assert set(druid_materialization["config"]["dimensions"]) == {
         "default_DOT_dispatcher_DOT_company_name",
@@ -1899,7 +1899,7 @@ def test_updating_cube_with_existing_materialization(
         "default.roads.hard_hats",
     }
     assert data["materializations"][0]["strategy"] == "incremental_time"
-    assert data["materializations"][0]["job"] == "DruidCubeMaterializationJob"
+    assert data["materializations"][0]["job"] == "DruidMeasuresCubeMaterializationJob"
     assert (
         data["materializations"][0]["name"]
         == "druid_cube__incremental_time__default.hard_hat.hire_date"

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -21,16 +21,27 @@ def test_materialization_info(client: TestClient) -> None:
             },
             {
                 "allowed_node_types": ["cube"],
-                "description": "Used to materialize a cube to Druid for "
+                "description": "Used to materialize a cube's measures to Druid for "
                 "low-latency access to a set of metrics and "
                 "dimensions. While the logical cube definition "
-                "is at the level of metrics and dimensions, a "
-                "materialized Druid cube will reference "
+                "is at the level of metrics and dimensions, this "
+                "materialized Druid cube will contain "
                 "measures and dimensions, with rollup "
                 "configured on the measures where appropriate.",
                 "job_class": "DruidCubeMaterializationJob",
-                "label": "Druid Cube",
+                "label": "Druid Cube (Measures)",
                 "name": "druid_cube",
+            },
+            {
+                "allowed_node_types": ["cube"],
+                "description": "Used to materialize a cube of metrics and "
+                "dimensions to Druid for low-latency access. "
+                "The materialized cube is at the metric level, "
+                "meaning that all metrics will be aggregated to "
+                "the level of the cube's dimensions.",
+                "job_class": "DruidAggCubeMaterializationJob",
+                "label": "Druid Cube (Aggregates)",
+                "name": "druid_agg_cube",
             },
         ],
         "strategies": [

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -28,9 +28,9 @@ def test_materialization_info(client: TestClient) -> None:
                 "materialized Druid cube will contain "
                 "measures and dimensions, with rollup "
                 "configured on the measures where appropriate.",
-                "job_class": "DruidCubeMaterializationJob",
-                "label": "Druid Cube (Measures)",
-                "name": "druid_cube",
+                "job_class": "DruidMeasuresCubeMaterializationJob",
+                "label": "Druid Measures Cube (Pre-Agg Cube)",
+                "name": "druid_measures_cube",
             },
             {
                 "allowed_node_types": ["cube"],
@@ -39,9 +39,9 @@ def test_materialization_info(client: TestClient) -> None:
                 "The materialized cube is at the metric level, "
                 "meaning that all metrics will be aggregated to "
                 "the level of the cube's dimensions.",
-                "job_class": "DruidAggCubeMaterializationJob",
-                "label": "Druid Cube (Aggregates)",
-                "name": "druid_agg_cube",
+                "job_class": "DruidMetricsCubeMaterializationJob",
+                "label": "Druid Metrics Cube (Post-Agg Cube)",
+                "name": "druid_metrics_cube",
             },
         ],
         "strategies": [

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2543,7 +2543,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data["message"] == (
             "Materialization job type `SOMETHING` not found. Available job "
-            "types: ['SPARK_SQL', 'DRUID_CUBE', 'DRUID_AGG_CUBE']"
+            "types: ['SPARK_SQL', 'DRUID_MEASURES_CUBE', 'DRUID_METRICS_CUBE']"
         )
 
     def test_node_with_struct(self, client_with_roads: TestClient):

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2543,7 +2543,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data["message"] == (
             "Materialization job type `SOMETHING` not found. Available job "
-            "types: ['SPARK_SQL', 'DRUID_CUBE']"
+            "types: ['SPARK_SQL', 'DRUID_CUBE', 'DRUID_AGG_CUBE']"
         )
 
     def test_node_with_struct(self, client_with_roads: TestClient):
@@ -4626,6 +4626,25 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         """
         Test revalidating all example nodes and confirm that they are set to valid
         """
+        client_with_roads.post(
+            "/nodes/cube/",
+            json={
+                "metrics": [
+                    "default.num_repair_orders",
+                    "default.avg_repair_price",
+                    "default.total_repair_cost",
+                ],
+                "dimensions": [
+                    "default.hard_hat.hire_date",
+                    "default.hard_hat.state",
+                    "default.dispatcher.company_name",
+                ],
+                "filters": [],
+                "description": "Cube of various metrics related to repairs",
+                "mode": "published",
+                "name": "default.repairs_cube",
+            },
+        )
         for node in client_with_roads.get("/nodes/").json():
             status = client_with_roads.post(
                 f"/nodes/{node}/validate/",

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -162,7 +162,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 90,
+        "statements": 89,
         "branches": 75,
         "lines": 90,
         "functions": 85

--- a/datajunction-ui/src/app/components/djgraph/DJNode.jsx
+++ b/datajunction-ui/src/app/components/djgraph/DJNode.jsx
@@ -68,7 +68,7 @@ export function DJNode({ id, data }) {
             {data.type === 'source' ? data.table : data.display_name}
           </a>
           <Collapse
-            collapsed={data.is_current ? false : true}
+            collapsed={data.is_current && data.type != 'metric' ? false : true}
             text={data.type !== 'metric' ? 'columns' : 'dimensions'}
             data={data}
           />

--- a/datajunction-ui/src/app/components/djgraph/DJNode.jsx
+++ b/datajunction-ui/src/app/components/djgraph/DJNode.jsx
@@ -68,7 +68,7 @@ export function DJNode({ id, data }) {
             {data.type === 'source' ? data.table : data.display_name}
           </a>
           <Collapse
-            collapsed={true}
+            collapsed={data.is_current ? false : true}
             text={data.type !== 'metric' ? 'columns' : 'dimensions'}
             data={data}
           />

--- a/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
@@ -87,7 +87,7 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
         <Formik
           initialValues={{
             node: node?.name,
-            job_type: 'spark_sql',
+            job_type: node?.type === 'cube' ? 'druid_cube' : 'spark_sql',
             strategy: 'full',
             config: '{"spark": {"spark.executor.memory": "6g"}}',
             schedule: '@daily',
@@ -104,11 +104,9 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
                   <label htmlFor="job_type">Job Type</label>
                   <Field as="select" name="job_type">
                     <>
-                      {jobs?.map(job => (
-                        <option key={job.name} value={job.name}>
-                          {job.label}
-                        </option>
-                      ))}
+                      <option key={'druid_cube'} value={'druid_cube'}>Druid Measures Cube</option>
+                      <option key={'druid_agg_cube'} value={'druid_agg_cube'}>Druid Agg Cube</option>
+                      <option key={'spark_sql'} value={'spark_sql'}>Iceberg Table</option>
                     </>
                   </Field>
                 </span>
@@ -124,9 +122,15 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
                   <label htmlFor="strategy">Strategy</label>
                   <Field as="select" name="strategy">
                     <>
-                      {options.strategies?.map(strategy => (
-                        <option value={strategy.name}>{strategy.label}</option>
-                      ))}
+                      {/*{options.strategies?.map(strategy => (*/}
+                      {/*  <option value={strategy.name}>{strategy.label}</option>*/}
+                      {/*))}*/}
+                      <option key={'full'} value={'full'}>
+                        Full
+                      </option>
+                      <option key={'incremental_time'} value={'incremental_time'}>
+                        Incremental Time
+                      </option>
                     </>
                   </Field>
                 </span>

--- a/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
@@ -108,8 +108,8 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
                   <label htmlFor="job_type">Job Type</label>
                   <Field as="select" name="job_type">
                     <>
-                      <option key={'druid_cube'} value={'druid_cube'}>Druid Cube (Measures)</option>
-                      <option key={'druid_agg_cube'} value={'druid_agg_cube'}>Druid Cube (Aggregates)</option>
+                      <option key={'druid_measures_cube'} value={'druid_measures_cube'}>Druid Measures Cube (Pre-Agg Cube)</option>
+                      <option key={'druid_metrics_cube'} value={'druid_metrics_cube'}>Druid Metrics Cube (Post-Agg Cube)</option>
                       <option key={'spark_sql'} value={'spark_sql'}>Iceberg Table</option>
                     </>
                   </Field>

--- a/datajunction-ui/src/app/pages/NodePage/MaterializationConfigField.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/MaterializationConfigField.jsx
@@ -1,0 +1,53 @@
+/**
+ * Materialization configuration field.
+ */
+import React from 'react';
+import { ErrorMessage, Field, useFormikContext } from 'formik';
+import CodeMirror from '@uiw/react-codemirror';
+import { langs } from '@uiw/codemirror-extensions-langs';
+
+export const ConfigField = ({ djClient, value }) => {
+  const formik = useFormikContext();
+  const jsonExt = langs.json();
+
+  const updateFormik = val => {
+    formik.setFieldValue('spark_config', val);
+  };
+
+  return (
+    <div className="DescriptionInput">
+      <ErrorMessage name="spark_config" component="span" />
+      <label htmlFor="SparkConfig">Spark Config</label>
+      <Field
+        type="textarea"
+        style={{ display: 'none' }}
+        as="textarea"
+        name="spark_config"
+        id="SparkConfig"
+      />
+      <div role="button" tabIndex={0} className="relative flex bg-[#282a36]">
+        <CodeMirror
+          id={'spark_config'}
+          name={'spark_config'}
+          extensions={[jsonExt]}
+          value={JSON.stringify(value, null, "    ")}
+          options={{
+            theme: 'default',
+            lineNumbers: true,
+          }}
+          width="100%"
+          height="170px"
+          style={{
+            margin: '0 0 23px 0',
+            flex: 1,
+            fontSize: '150%',
+            textAlign: 'left',
+          }}
+          onChange={(value, viewUpdate) => {
+            updateFormik(value);
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
@@ -15,6 +15,8 @@ const NodeLineage = djNode => {
         col.attributes.some(attr => attr.attribute_type.name === 'primary_key'),
       )
       .map(col => col.name);
+    const dimensionLinkForeignKeys = node.dimension_links
+      .flatMap(link => Object.keys(link.foreign_keys).map(key => key.split('.').slice(-1)));
     const column_names = node.columns
       .map(col => {
         return {
@@ -23,7 +25,7 @@ const NodeLineage = djNode => {
           dimension: col.dimension !== null ? col.dimension.name : null,
           order: primary_key.includes(col.name)
             ? -1
-            : col.dimension !== null
+            : dimensionLinkForeignKeys.includes(col.name)
             ? 0
             : 1,
         };
@@ -49,27 +51,29 @@ const NodeLineage = djNode => {
   };
 
   const dimensionEdges = node => {
-    return node.columns
-      .filter(col => col.dimension)
-      .map(col => {
-        return {
-          id: col.dimension.name + '->' + node.name + '.' + col.name,
-          source: col.dimension.name,
-          sourceHandle: col.dimension.name,
-          target: node.name,
-          targetHandle: node.name + '.' + col.name,
-          draggable: true,
-          markerStart: {
-            type: MarkerType.Arrow,
-            width: 20,
-            height: 20,
-            color: '#b0b9c2',
-          },
-          style: {
-            strokeWidth: 3,
-            stroke: '#b0b9c2',
-          },
-        };
+    return node.dimension_links
+      .flatMap(link => {
+        return Object.keys(link.foreign_keys).map(fk => {
+            return {
+              id: link.dimension.name + '->' + node.name + '=' + link.foreign_keys[fk] + '->' + fk,
+              source: link.dimension.name,
+              sourceHandle: link.foreign_keys[fk],
+              target: node.name,
+              targetHandle: fk,
+              draggable: true,
+              markerStart: {
+                type: MarkerType.Arrow,
+                width: 20,
+                height: 20,
+                color: '#b0b9c2',
+              },
+              style: {
+                strokeWidth: 3,
+                stroke: '#b0b9c2',
+              },
+            };
+          }
+        )
       });
   };
 

--- a/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
@@ -15,8 +15,8 @@ const NodeLineage = djNode => {
         col.attributes.some(attr => attr.attribute_type.name === 'primary_key'),
       )
       .map(col => col.name);
-    const dimensionLinkForeignKeys = node.dimension_links
-      .flatMap(link => Object.keys(link.foreign_keys).map(key => key.split('.').slice(-1)));
+    const dimensionLinkForeignKeys = node.dimension_links ? node.dimension_links
+      .flatMap(link => Object.keys(link.foreign_keys).map(key => key.split('.').slice(-1))) : [];
     const column_names = node.columns
       .map(col => {
         return {
@@ -51,7 +51,7 @@ const NodeLineage = djNode => {
   };
 
   const dimensionEdges = node => {
-    return node.dimension_links
+    return node.dimension_links === undefined ? [] : node.dimension_links
       .flatMap(link => {
         return Object.keys(link.foreign_keys).map(fk => {
             return {

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -134,7 +134,8 @@ export default function NodeMaterializationTab({ node, djClient }) {
       <div className="table-vertical">
         <div>
           <h2>Materializations</h2>
-          <AddMaterializationPopover node={node} />
+          {node ?
+          <AddMaterializationPopover node={node} /> : <></>}
           {materializations.length > 0 ? (
             <table
               className="card-inner-table table"

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/AddMaterializationPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/AddMaterializationPopover.test.jsx
@@ -17,6 +17,9 @@ describe('<AddMaterializationPopover />', () => {
     const onSubmitMock = jest.fn();
     mockDjClient.DataJunctionAPI.materialize.mockReturnValue({
       status: 201,
+      json: {
+        message: 'Saved!',
+      },
     });
     mockDjClient.DataJunctionAPI.materializationInfo.mockReturnValue({
       status: 200,

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodeGraphTab.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodeGraphTab.test.jsx
@@ -73,6 +73,7 @@ describe('<NodeLineage />', () => {
       parents: [],
       created_at: '2023-08-21T16:48:52.970554+00:00',
       tags: [],
+      dimension_links: [],
     },
     {
       namespace: 'default',
@@ -98,6 +99,7 @@ describe('<NodeLineage />', () => {
       query:
         '\n            SELECT\n              dateint,\n              month,\n              year,\n              day\n            FROM default.date\n        ',
       availability: null,
+      dimension_links: [],
       columns: [
         {
           name: 'dateint',
@@ -165,6 +167,7 @@ describe('<NodeLineage />', () => {
       query:
         '\n            SELECT\n            hard_hat_id,\n            last_name,\n            first_name,\n            title,\n            birth_date,\n            hire_date,\n            address,\n            city,\n            state,\n            postal_code,\n            country,\n            manager,\n            contractor_id\n            FROM default.hard_hats\n        ',
       availability: null,
+      dimension_links: [],
       columns: [
         {
           name: 'hard_hat_id',
@@ -292,6 +295,7 @@ describe('<NodeLineage />', () => {
       query:
         'SELECT  avg(price) default_DOT_avg_repair_price \n FROM default.repair_order_details\n\n',
       availability: null,
+      dimension_links: [],
       columns: [
         {
           name: 'default_DOT_avg_repair_price',

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -241,7 +241,7 @@ table {
 }
 tr {
   display: table-row;
-  vertical-align: inherit;
+  vertical-align: top;
   border-color: inherit;
 }
 .card-table {
@@ -339,7 +339,7 @@ tr {
 .table thead th,
 td,
 tbody th {
-  vertical-align: middle;
+  vertical-align: top;
   text-align: left;
 }
 .table [data-sort],
@@ -371,6 +371,7 @@ tbody th {
   border-bottom: 0;
   padding: 1rem;
   max-width: 25rem;
+  vertical-align: top;
 }
 .card-inner-table td,
 .card-inner-table th {


### PR DESCRIPTION
### Summary

This PR supports materialization for aggregate cubes. Prior to this, we only supported measures cubes, where we would directly ingest the underlying measures to Druid, allowing for maximum flexibility when authoring metrics. However, some use cases would benefit from working with a materialized aggregate cube (for better performance) instead of the raw measures.

The changes also include a modified the materialization config form where the Spark config editor uses CodeMirror to enable JSON highlighting:

<img width="813" alt="Screenshot 2024-03-06 at 8 21 36 AM" src="https://github.com/DataJunction/dj/assets/9524628/04b10a02-b6b7-48de-b9bb-15649a7a6259">

#### Bugfixes

There are a few additional bugfixes, like:
* Appropriate revalidation for cube nodes
* Dimension links should be kept when a node is updated
* Removed a number of materialization options from the UI, since these have yet to be implemented

### Test Plan

Tested locally 

- [ ] PR has an associated issue: #934
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A

<!-- Any special instructions around deployment? -->
