### PR TITLE
Add a loading ticker for form submission

### DIFF
--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1a44",
+  "version": "0.0.1-a44.dev4",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.1-a44.dev4",
+  "version": "0.0.1a44",
   "description": "DataJunction Metrics Platform UI",
   "module": "src/index.tsx",
   "repository": {

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
@@ -101,9 +101,7 @@ describe('AddEditNodePage submission failed', () => {
         status: 404,
       });
 
-      expect(
-        await screen.getByText('Update failed, Some tags were not found'),
-      ).toBeInTheDocument();
+      expect(await screen.getByText('Update failed')).toBeInTheDocument();
     });
   }, 60000);
 });

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -24,6 +24,7 @@ import { DisplayNameField } from './DisplayNameField';
 import { DescriptionField } from './DescriptionField';
 import { NodeModeField } from './NodeModeField';
 import { RequiredDimensionsSelect } from './RequiredDimensionsSelect';
+import LoadingIcon from '../../icons/LoadingIcon';
 
 class Action {
   static Add = new Action('add');
@@ -63,19 +64,18 @@ export function AddEditNodePage() {
     return errors;
   };
 
-  const handleSubmit = (values, { setSubmitting, setStatus }) => {
+  const handleSubmit = async (values, { setSubmitting, setStatus }) => {
     if (action === Action.Add) {
-      setTimeout(() => {
-        createNode(values, setStatus);
+      await createNode(values, setStatus).then(_ => {
+        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
         setSubmitting(false);
-      }, 400);
+      });
     } else {
-      setTimeout(() => {
-        patchNode(values, setStatus);
+      await patchNode(values, setStatus).then(_ => {
+        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
         setSubmitting(false);
-      }, 400);
+      });
     }
-    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
   };
 
   const pageTitle =
@@ -169,7 +169,7 @@ export function AddEditNodePage() {
       });
     } else {
       setStatus({
-        failure: `${json.message}, ${tagsResponse.json.message}`,
+        failure: `${json.message}`,
       });
     }
   };
@@ -410,7 +410,12 @@ export function AddEditNodePage() {
                         <NodeModeField />
 
                         <button type="submit" disabled={isSubmitting}>
-                          {action === Action.Add ? 'Create' : 'Save'} {nodeType}
+                          {isSubmitting ? (
+                            <LoadingIcon />
+                          ) : (
+                            (action === Action.Add ? 'Create ' : 'Save ') +
+                            (nodeType ? nodeType : '')
+                          )}
                         </button>
                       </>
                     )}

--- a/datajunction-ui/src/app/pages/NodePage/MaterializationConfigField.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/MaterializationConfigField.jsx
@@ -30,7 +30,7 @@ export const ConfigField = ({ djClient, value }) => {
           id={'spark_config'}
           name={'spark_config'}
           extensions={[jsonExt]}
-          value={JSON.stringify(value, null, "    ")}
+          value={JSON.stringify(value, null, '    ')}
           options={{
             theme: 'default',
             lineNumbers: true,

--- a/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
@@ -15,8 +15,11 @@ const NodeLineage = djNode => {
         col.attributes.some(attr => attr.attribute_type.name === 'primary_key'),
       )
       .map(col => col.name);
-    const dimensionLinkForeignKeys = node.dimension_links ? node.dimension_links
-      .flatMap(link => Object.keys(link.foreign_keys).map(key => key.split('.').slice(-1))) : [];
+    const dimensionLinkForeignKeys = node.dimension_links
+      ? node.dimension_links.flatMap(link =>
+          Object.keys(link.foreign_keys).map(key => key.split('.').slice(-1)),
+        )
+      : [];
     const column_names = node.columns
       .map(col => {
         return {
@@ -51,11 +54,19 @@ const NodeLineage = djNode => {
   };
 
   const dimensionEdges = node => {
-    return node.dimension_links === undefined ? [] : node.dimension_links
-      .flatMap(link => {
-        return Object.keys(link.foreign_keys).map(fk => {
+    return node.dimension_links === undefined
+      ? []
+      : node.dimension_links.flatMap(link => {
+          return Object.keys(link.foreign_keys).map(fk => {
             return {
-              id: link.dimension.name + '->' + node.name + '=' + link.foreign_keys[fk] + '->' + fk,
+              id:
+                link.dimension.name +
+                '->' +
+                node.name +
+                '=' +
+                link.foreign_keys[fk] +
+                '->' +
+                fk,
               source: link.dimension.name,
               sourceHandle: link.foreign_keys[fk],
               target: node.name,
@@ -72,9 +83,8 @@ const NodeLineage = djNode => {
                 stroke: '#b0b9c2',
               },
             };
-          }
-        )
-      });
+          });
+        });
   };
 
   const parentEdges = node => {

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -134,8 +134,7 @@ export default function NodeMaterializationTab({ node, djClient }) {
       <div className="table-vertical">
         <div>
           <h2>Materializations</h2>
-          {node ?
-          <AddMaterializationPopover node={node} /> : <></>}
+          {node ? <AddMaterializationPopover node={node} /> : <></>}
           {materializations.length > 0 ? (
             <table
               className="card-inner-table table"


### PR DESCRIPTION
### Summary

When a user submits any of the following forms, we add a loading ticker so that it's clear that the backend is processing the request and we're awaiting an answer:
* Creating a node
* Editing a node
* Configuring materialization

https://github.com/DataJunction/dj/assets/9524628/af8e3f47-cf95-40eb-8d7d-38f62db9c146

This is especially useful for endpoints where the backend may take a moment to return an answer. Without this, the UX is confusing, since the user would be unsure if something is being processed.

Additionally fixes a bug around Spark config JSON parsing.

### Test Plan

Locally

- [x] PR has an associated issue: #922 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
