### PR TITLE
Increase database connection limit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
   #  additional_dependencies: [flake8-bugbear]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.931'  # Use the sha / tag you want to point at
+  rev: 'v0.981'  # Use the sha / tag you want to point at
   hooks:
   - id: mypy
     exclude: ^templates/

--- a/datajunction-clients/python/.pre-commit-config.yaml
+++ b/datajunction-clients/python/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
   hooks:
   - id: flake8
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.931'  # Use the sha / tag you want to point at
+  rev: 'v0.981'  # Use the sha / tag you want to point at
   hooks:
   - id: mypy
     additional_dependencies:

--- a/datajunction-server/.pre-commit-config.yaml
+++ b/datajunction-server/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
   #  additional_dependencies: [flake8-bugbear]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.931'  # Use the sha / tag you want to point at
+  rev: 'v0.981'  # Use the sha / tag you want to point at
   hooks:
   - id: mypy
     exclude: ^templates/

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -91,6 +91,12 @@ class Settings(
     # Interval in seconds with which to expire caching of any indexes
     index_cache_expire = 60
 
+    # SQLAlchemy engine config
+    db_pool_size = 20
+    db_max_overflow = 20
+    db_pool_timeout = 10
+    db_connect_timeout = 5
+
     @property
     def celery(self) -> Celery:
         """

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1216,7 +1216,7 @@ class TableExpression(Aliasable, Expression):
                 # For struct types we can additionally check if there's a column that matches
                 # the search column's namespace and if there's a nested field that matches the
                 # search column's name
-                if isinstance(col.type, StructType):
+                if col._type and isinstance(col.type, StructType):
                     # struct column name
                     column_namespace = ".".join(
                         [name.name for name in column.namespace],
@@ -2546,7 +2546,7 @@ class Query(TableExpression, UnNamed):
     def set_alias(self: TNode, alias: "Name") -> TNode:
         self.alias = alias
         for col in self._columns:
-            if isinstance(col, Column):
+            if isinstance(col, Column) and col.table is not None:
                 col.table.alias = self.alias
         return self
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2609,16 +2609,3 @@ class Query(TableExpression, UnNamed):
             access_control,
         )
         self.select.add_aliases_to_unnamed_columns()
-
-
-@dataclass(eq=False)
-class Parameter(Expression):
-    """
-    Sets up parameters
-    """
-
-    name: Name
-    colon: str = ":"
-
-    def __str__(self) -> str:
-        return f"{self.colon}{self.name.identifier()}"

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1216,7 +1216,11 @@ class TableExpression(Aliasable, Expression):
                 # For struct types we can additionally check if there's a column that matches
                 # the search column's namespace and if there's a nested field that matches the
                 # search column's name
-                if col._type and isinstance(col.type, StructType):
+                if (
+                    hasattr(col, "_type")
+                    and col._type
+                    and isinstance(col.type, StructType)
+                ) or (not hasattr(col, "_type") and isinstance(col.type, StructType)):
                     # struct column name
                     column_namespace = ".".join(
                         [name.name for name in column.namespace],
@@ -2605,3 +2609,16 @@ class Query(TableExpression, UnNamed):
             access_control,
         )
         self.select.add_aliases_to_unnamed_columns()
+
+
+@dataclass(eq=False)
+class Parameter(Expression):
+    """
+    Sets up parameters
+    """
+
+    name: Name
+    colon: str = ":"
+
+    def __str__(self) -> str:
+        return f"{self.colon}{self.name.identifier()}"

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -62,10 +62,12 @@ def get_engine() -> Engine:
     engine = create_engine(
         settings.index,
         pool_pre_ping=True,
-        pool_size=20,
-        max_overflow=20,
-        pool_timeout=10,
-        connect_args={"connect_timeout": 5},
+        pool_size=settings.db_pool_size,
+        max_overflow=settings.db_max_overflow,
+        pool_timeout=settings.db_pool_timeout,
+        connect_args={
+            "connect_timeout": settings.db_connect_timeout,
+        },
     )
 
     return engine

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -62,6 +62,10 @@ def get_engine() -> Engine:
     engine = create_engine(
         settings.index,
         pool_pre_ping=True,
+        pool_size=20,
+        max_overflow=20,
+        pool_timeout=10,
+        connect_args={"connect_timeout": 5},
     )
 
     return engine


### PR DESCRIPTION
### Summary

We were getting this error on the DJ backend:
```
TimeoutError
sqlalchemy.exc: "QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/20/3o7r)"
```

This change will make it so that the connection pool limit and a few other database engine settings are configurable with `.env`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
