### PR TITLE
Fix deadlock issue with FastAPI Depends

### DIFF
--- a/datajunction-server/datajunction_server/internal/access/authentication/github.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/github.py
@@ -42,7 +42,7 @@ def get_github_user(access_token: str) -> Optional[User]:  # pragma: no cover
     ).json()
     if "message" in user_data and user_data["message"] == "Bad credentials":
         return None
-    session = next(get_session())
+    session = next(get_session())  # type: ignore  # pylint: disable=no-value-for-parameter
     existing_user: Optional[User] = None
     try:
         existing_user = session.execute(

--- a/datajunction-server/datajunction_server/internal/access/authentication/google.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/google.py
@@ -82,7 +82,7 @@ def get_google_user(token: str) -> User:
             http_status_code=HTTPStatus.FORBIDDEN,
             message=f"Error retrieving Google user: {response.text}",
         )
-    session = next(get_session())
+    session = next(get_session())  # type: ignore  # pylint: disable=no-value-for-parameter
     existing_user = session.execute(
         select(User).where(User.email == user_data["login"]),
     ).scalar()


### PR DESCRIPTION
### Summary

This PR fixes an issue where using FastAPI `Depends` for a database session causes [deadlock issues](https://github.com/tiangolo/fastapi/issues/3205) and a huge increase in the number of database connections as concurrent requests increase. 

### Test Plan

In progress

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
