### PR TITLE
Switch to async for the database connection

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -457,7 +457,8 @@ class DJClient:
         """
         Helper function to remove a complex dimension link.
         """
-        response = self._session.delete(
+        response = self._session.request(
+            "DELETE",
             f"/nodes/{node_name}/link/",
             timeout=self._timeout,
             json={

--- a/datajunction-clients/python/datajunction/admin.py
+++ b/datajunction-clients/python/datajunction/admin.py
@@ -31,7 +31,7 @@ class DJAdmin(DJBuilder):  # pylint: disable=too-many-public-methods
             timeout=self._timeout,
         )
         json_response = response.json()
-        if not response.ok:
+        if not response.status_code < 400:
             raise DJClientException(
                 f"Adding catalog `{name}` failed: {json_response}",
             )  # pragma: no cover
@@ -70,7 +70,7 @@ class DJAdmin(DJBuilder):  # pylint: disable=too-many-public-methods
             timeout=self._timeout,
         )
         json_response = response.json()
-        if not response.ok:
+        if not response.status_code < 400:
             raise DJClientException(
                 f"Adding engine failed: {json_response}",
             )  # pragma: no cover
@@ -95,7 +95,7 @@ class DJAdmin(DJBuilder):  # pylint: disable=too-many-public-methods
             timeout=self._timeout,
         )
         json_response = response.json()
-        if not response.ok:
+        if not response.status_code < 400:
             raise DJClientException(
                 f"Linking engine (name: {engine}, version: {version}) "
                 f"to catalog `{catalog}` failed: {json_response}",

--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -48,14 +48,15 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         """
         Delete a namespace by name.
         """
-        response = self._session.delete(
+        response = self._session.request(
+            "DELETE",
             f"/namespaces/{namespace}/",
             timeout=self._timeout,
             params={
                 "cascade": cascade,
             },
         )
-        if not response.ok:
+        if not response.status_code < 400:
             raise DJClientException(response.json()["message"])
 
     def restore_namespace(self, namespace: str, cascade: bool = False) -> None:
@@ -84,7 +85,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
             timeout=self._timeout,
         )
         json_response = response.json()
-        if not response.ok:
+        if not response.status_code < 400:
             raise DJClientException(
                 f"Deleting node `{node_name}` failed: {json_response}",
             )  # pragma: no cover
@@ -98,7 +99,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
             timeout=self._timeout,
         )
         json_response = response.json()
-        if not response.ok:
+        if not response.status_code < 400:
             raise DJClientException(
                 f"Restoring node `{node_name}` failed: {json_response}",
             )  # pragma: no cover

--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -221,7 +221,7 @@ class DJClient(_internal.DJClient):
                 results = response.json()
 
                 # Raise errors if any
-                if not response.ok:
+                if not response.status_code < 400:
                     raise DJClientException(f"Error retrieving data: {response.text}")
                 if results["state"] not in models.QueryState.list():
                     raise DJClientException(  # pragma: no cover

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -100,7 +100,7 @@ class Node(ClientEntity):  # pylint: disable=protected-access
             node_name=self.name,
             tags=[tag.name for tag in self.tags] if self.tags else None,
         )
-        if not response.ok:  # pragma: no cover
+        if not response.status_code < 400:  # pragma: no cover
             raise DJClientException(
                 f"Error updating tags for node {self.name}, {self.tags}",
             )
@@ -114,7 +114,7 @@ class Node(ClientEntity):  # pylint: disable=protected-access
             # update
             self._update_tags()
             response = self._update()
-            if not response.ok:  # pragma: no cover
+            if not response.status_code < 400:  # pragma: no cover
                 raise DJClientException(
                     f"Error updating node `{self.name}`: {response.text}",
                 )
@@ -125,7 +125,7 @@ class Node(ClientEntity):  # pylint: disable=protected-access
                 node=self,
                 mode=mode,
             )  # pragma: no cover
-            if not response.ok:  # pragma: no cover
+            if not response.status_code < 400:  # pragma: no cover
                 raise DJClientException(
                     f"Error creating new node `{self.name}`: {response.text}",
                 )

--- a/datajunction-clients/python/datajunction/tags.py
+++ b/datajunction-clients/python/datajunction/tags.py
@@ -45,7 +45,7 @@ class Tag(TagInfo, ClientEntity):
         if "name" in existing_tag:
             # update
             response = self._update()
-            if not response.ok:  # pragma: no cover
+            if not response.status_code < 400:  # pragma: no cover
                 raise DJClientException(
                     f"Error updating tag `{self.name}`: {response.text}",
                 )
@@ -55,7 +55,7 @@ class Tag(TagInfo, ClientEntity):
             response = self.dj_client._create_tag(
                 tag=self,
             )  # pragma: no cover
-            if not response.ok:  # pragma: no cover
+            if not response.status_code < 400:  # pragma: no cover
                 raise DJClientException(
                     f"Error creating new tag `{self.name}`: {response.text}",
                 )

--- a/datajunction-clients/python/pdm.lock
+++ b/datajunction-clients/python/pdm.lock
@@ -3,10 +3,9 @@
 
 [metadata]
 groups = ["default", "pandas", "test"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:a952673508d3432e9aa0375179db217d015605d9b7472b1bd465cf8e962ea67f"
+strategy = ["cross_platform"]
+lock_version = "4.4.1"
+content_hash = "sha256:e24494f15a19aa05ca58469d87165f511bb1fc1a4b8c1677c3185558a118e4dd"
 
 [[package]]
 name = "about-time"
@@ -132,6 +131,19 @@ files = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.20.0"
+requires_python = ">=3.8"
+summary = "asyncio bridge to the standard sqlite3 module"
+dependencies = [
+    "typing-extensions>=4.0",
+]
+files = [
+    {file = "aiosqlite-0.20.0-py3-none-any.whl", hash = "sha256:36a1deaca0cac40ebe32aac9977a6e2bbc7f5189f23f4a54d5908986729e5bd6"},
+    {file = "aiosqlite-0.20.0.tar.gz", hash = "sha256:6d35c8c256637f4672f843c31021464090805bf925385ac39473fb16eaaca3d7"},
+]
+
+[[package]]
 name = "alembic"
 version = "1.11.1"
 requires_python = ">=3.7"
@@ -249,12 +261,64 @@ files = [
 
 [[package]]
 name = "async-timeout"
-version = "4.0.2"
-requires_python = ">=3.6"
+version = "4.0.3"
+requires_python = ">=3.7"
 summary = "Timeout context manager for asyncio programs"
 files = [
-    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
-    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
+    {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
+    {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.29.0"
+requires_python = ">=3.8.0"
+summary = "An asyncio PostgreSQL driver"
+dependencies = [
+    "async-timeout>=4.0.3; python_version < \"3.12.0\"",
+]
+files = [
+    {file = "asyncpg-0.29.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72fd0ef9f00aeed37179c62282a3d14262dbbafb74ec0ba16e1b1864d8a12169"},
+    {file = "asyncpg-0.29.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52e8f8f9ff6e21f9b39ca9f8e3e33a5fcdceaf5667a8c5c32bee158e313be385"},
+    {file = "asyncpg-0.29.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9e6823a7012be8b68301342ba33b4740e5a166f6bbda0aee32bc01638491a22"},
+    {file = "asyncpg-0.29.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:746e80d83ad5d5464cfbf94315eb6744222ab00aa4e522b704322fb182b83610"},
+    {file = "asyncpg-0.29.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ff8e8109cd6a46ff852a5e6bab8b0a047d7ea42fcb7ca5ae6eaae97d8eacf397"},
+    {file = "asyncpg-0.29.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:97eb024685b1d7e72b1972863de527c11ff87960837919dac6e34754768098eb"},
+    {file = "asyncpg-0.29.0-cp310-cp310-win32.whl", hash = "sha256:5bbb7f2cafd8d1fa3e65431833de2642f4b2124be61a449fa064e1a08d27e449"},
+    {file = "asyncpg-0.29.0-cp310-cp310-win_amd64.whl", hash = "sha256:76c3ac6530904838a4b650b2880f8e7af938ee049e769ec2fba7cd66469d7772"},
+    {file = "asyncpg-0.29.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4900ee08e85af01adb207519bb4e14b1cae8fd21e0ccf80fac6aa60b6da37b4"},
+    {file = "asyncpg-0.29.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a65c1dcd820d5aea7c7d82a3fdcb70e096f8f70d1a8bf93eb458e49bfad036ac"},
+    {file = "asyncpg-0.29.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b52e46f165585fd6af4863f268566668407c76b2c72d366bb8b522fa66f1870"},
+    {file = "asyncpg-0.29.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc600ee8ef3dd38b8d67421359779f8ccec30b463e7aec7ed481c8346decf99f"},
+    {file = "asyncpg-0.29.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:039a261af4f38f949095e1e780bae84a25ffe3e370175193174eb08d3cecab23"},
+    {file = "asyncpg-0.29.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6feaf2d8f9138d190e5ec4390c1715c3e87b37715cd69b2c3dfca616134efd2b"},
+    {file = "asyncpg-0.29.0-cp311-cp311-win32.whl", hash = "sha256:1e186427c88225ef730555f5fdda6c1812daa884064bfe6bc462fd3a71c4b675"},
+    {file = "asyncpg-0.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:cfe73ffae35f518cfd6e4e5f5abb2618ceb5ef02a2365ce64f132601000587d3"},
+    {file = "asyncpg-0.29.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6011b0dc29886ab424dc042bf9eeb507670a3b40aece3439944006aafe023178"},
+    {file = "asyncpg-0.29.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b544ffc66b039d5ec5a7454667f855f7fec08e0dfaf5a5490dfafbb7abbd2cfb"},
+    {file = "asyncpg-0.29.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d84156d5fb530b06c493f9e7635aa18f518fa1d1395ef240d211cb563c4e2364"},
+    {file = "asyncpg-0.29.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54858bc25b49d1114178d65a88e48ad50cb2b6f3e475caa0f0c092d5f527c106"},
+    {file = "asyncpg-0.29.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bde17a1861cf10d5afce80a36fca736a86769ab3579532c03e45f83ba8a09c59"},
+    {file = "asyncpg-0.29.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:37a2ec1b9ff88d8773d3eb6d3784dc7e3fee7756a5317b67f923172a4748a175"},
+    {file = "asyncpg-0.29.0-cp312-cp312-win32.whl", hash = "sha256:bb1292d9fad43112a85e98ecdc2e051602bce97c199920586be83254d9dafc02"},
+    {file = "asyncpg-0.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:2245be8ec5047a605e0b454c894e54bf2ec787ac04b1cb7e0d3c67aa1e32f0fe"},
+    {file = "asyncpg-0.29.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0009a300cae37b8c525e5b449233d59cd9868fd35431abc470a3e364d2b85cb9"},
+    {file = "asyncpg-0.29.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5cad1324dbb33f3ca0cd2074d5114354ed3be2b94d48ddfd88af75ebda7c43cc"},
+    {file = "asyncpg-0.29.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:012d01df61e009015944ac7543d6ee30c2dc1eb2f6b10b62a3f598beb6531548"},
+    {file = "asyncpg-0.29.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:000c996c53c04770798053e1730d34e30cb645ad95a63265aec82da9093d88e7"},
+    {file = "asyncpg-0.29.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e0bfe9c4d3429706cf70d3249089de14d6a01192d617e9093a8e941fea8ee775"},
+    {file = "asyncpg-0.29.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:642a36eb41b6313ffa328e8a5c5c2b5bea6ee138546c9c3cf1bffaad8ee36dd9"},
+    {file = "asyncpg-0.29.0-cp38-cp38-win32.whl", hash = "sha256:a921372bbd0aa3a5822dd0409da61b4cd50df89ae85150149f8c119f23e8c408"},
+    {file = "asyncpg-0.29.0-cp38-cp38-win_amd64.whl", hash = "sha256:103aad2b92d1506700cbf51cd8bb5441e7e72e87a7b3a2ca4e32c840f051a6a3"},
+    {file = "asyncpg-0.29.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5340dd515d7e52f4c11ada32171d87c05570479dc01dc66d03ee3e150fb695da"},
+    {file = "asyncpg-0.29.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e17b52c6cf83e170d3d865571ba574577ab8e533e7361a2b8ce6157d02c665d3"},
+    {file = "asyncpg-0.29.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f100d23f273555f4b19b74a96840aa27b85e99ba4b1f18d4ebff0734e78dc090"},
+    {file = "asyncpg-0.29.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48e7c58b516057126b363cec8ca02b804644fd012ef8e6c7e23386b7d5e6ce83"},
+    {file = "asyncpg-0.29.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f9ea3f24eb4c49a615573724d88a48bd1b7821c890c2effe04f05382ed9e8810"},
+    {file = "asyncpg-0.29.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8d36c7f14a22ec9e928f15f92a48207546ffe68bc412f3be718eedccdf10dc5c"},
+    {file = "asyncpg-0.29.0-cp39-cp39-win32.whl", hash = "sha256:797ab8123ebaed304a1fad4d7576d5376c3a006a4100380fb9d517f0b59c1ab2"},
+    {file = "asyncpg-0.29.0-cp39-cp39-win_amd64.whl", hash = "sha256:cce08a178858b426ae1aa8409b5cc171def45d4293626e7aa6510696d46decd8"},
+    {file = "asyncpg-0.29.0.tar.gz", hash = "sha256:d1c49e1f44fffafd9a55e1a9b101590859d881d639ea2922516f5d9c512d354e"},
 ]
 
 [[package]]
@@ -749,16 +813,18 @@ path = "../../datajunction-server"
 summary = "DataJunction server library for running to a DataJunction server"
 dependencies = [
     "accept-types<1.0.0,>=0.4.1",
+    "aiosqlite>=0.20.0",
     "alembic>=1.10.3",
     "antlr4-python3-runtime==4.12.0",
     "asciidag<1.0.0,>=0.2.0",
+    "asyncpg>=0.29.0",
     "bcrypt>=4.0.1",
     "cachelib<1.0.0,>=0.10.2",
     "cachetools>=5.3.1",
     "celery<6.0.0,>=5.2.7",
     "cryptography>=41.0.3",
     "fastapi-cache2>=0.2.1",
-    "fastapi<0.80.0,>=0.79.0",
+    "fastapi>=0.110.0",
     "google-api-python-client>=2.95.0",
     "google-auth-httplib2>=0.1.0",
     "google-auth-oauthlib>=1.0.0",
@@ -767,6 +833,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi==0.38b0",
     "passlib>=1.7.4",
     "psycopg>=3.1.16",
+    "pydantic<2",
     "python-dotenv<1.0.0,>=0.19.0",
     "python-jose>=3.3.0",
     "python-multipart>=0.0.6",
@@ -796,6 +863,18 @@ files = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+summary = "A library to handle automated deprecations"
+dependencies = [
+    "packaging",
+]
+files = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
+]
+
+[[package]]
 name = "dill"
 version = "0.3.7"
 requires_python = ">=3.7"
@@ -812,6 +891,22 @@ summary = "Distribution utilities"
 files = [
     {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
     {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
+
+[[package]]
+name = "docker"
+version = "7.0.0"
+requires_python = ">=3.8"
+summary = "A Python library for the Docker Engine API."
+dependencies = [
+    "packaging>=14.0",
+    "pywin32>=304; sys_platform == \"win32\"",
+    "requests>=2.26.0",
+    "urllib3>=1.26.0",
+]
+files = [
+    {file = "docker-7.0.0-py3-none-any.whl", hash = "sha256:12ba681f2777a0ad28ffbcc846a69c31b4dfd9752b47eb425a274ee269c5e14b"},
+    {file = "docker-7.0.0.tar.gz", hash = "sha256:323736fb92cd9418fc5e7133bc953e11a9da04f4483f828b527db553f1e7e5a3"},
 ]
 
 [[package]]
@@ -849,16 +944,17 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.79.1"
-requires_python = ">=3.6.1"
+version = "0.110.1"
+requires_python = ">=3.8"
 summary = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 dependencies = [
-    "pydantic!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0,>=1.6.2",
-    "starlette==0.19.1",
+    "pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4",
+    "starlette<0.38.0,>=0.37.2",
+    "typing-extensions>=4.8.0",
 ]
 files = [
-    {file = "fastapi-0.79.1-py3-none-any.whl", hash = "sha256:3c584179c64e265749e88221c860520fc512ea37e253282dab378cc503dfd7fd"},
-    {file = "fastapi-0.79.1.tar.gz", hash = "sha256:006862dec0f0f5683ac21fb0864af2ff12a931e7ba18920f28cc8eceed51896b"},
+    {file = "fastapi-0.110.1-py3-none-any.whl", hash = "sha256:5df913203c482f820d31f48e635e022f8cbfe7350e4830ef05a3163925b1addc"},
+    {file = "fastapi-0.110.1.tar.gz", hash = "sha256:6feac43ec359dfe4f45b2c18ec8c94edb8dc2dfc461d417d9e626590c071baad"},
 ]
 
 [[package]]
@@ -1065,43 +1161,58 @@ files = [
 
 [[package]]
 name = "greenlet"
-version = "2.0.2"
-requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+version = "3.0.3"
+requires_python = ">=3.7"
 summary = "Lightweight in-process concurrent programming"
 files = [
-    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df"},
-    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088"},
-    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb"},
-    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470"},
-    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3a51c9751078733d88e013587b108f1b7a1fb106d402fb390740f002b6f6551a"},
-    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91"},
-    {file = "greenlet-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645"},
-    {file = "greenlet-2.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c"},
-    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca"},
-    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
-    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2"},
-    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:eff4eb9b7eb3e4d0cae3d28c283dc16d9bed6b193c2e1ace3ed86ce48ea8df19"},
-    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5454276c07d27a740c5892f4907c86327b632127dd9abec42ee62e12427ff7e3"},
-    {file = "greenlet-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:7cafd1208fdbe93b67c7086876f061f660cfddc44f404279c1585bbf3cdc64c5"},
-    {file = "greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acd2162a36d3de67ee896c43effcd5ee3de247eb00354db411feb025aa319857"},
-    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a"},
-    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
-    {file = "greenlet-2.0.2-cp38-cp38-win32.whl", hash = "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249"},
-    {file = "greenlet-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40"},
-    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be4ed120b52ae4d974aa40215fcdfde9194d63541c7ded40ee12eb4dda57b76b"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94c817e84245513926588caf1152e3b559ff794d505555211ca041f032abbb6b"},
-    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8"},
-    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7efde645ca1cc441d6dc4b48c0f7101e8d86b54c8530141b09fd31cef5149ec9"},
-    {file = "greenlet-2.0.2-cp39-cp39-win32.whl", hash = "sha256:ea9872c80c132f4663822dd2a08d404073a5a9b5ba6155bea72fb2a79d1093b5"},
-    {file = "greenlet-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:db1a39669102a1d8d12b57de2bb7e2ec9066a6f2b3da35ae511ff93b01b5d564"},
-    {file = "greenlet-2.0.2.tar.gz", hash = "sha256:e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0"},
+    {file = "greenlet-3.0.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dca1e2f3ca00b84a396bc1bce13dd21f680f035314d2379c4160c98153b2059b"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ed7fb269f15dc662787f4119ec300ad0702fa1b19d2135a37c2c4de6fadfd4a"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:73a411ef564e0e097dbe7e866bb2dda0f027e072b04da387282b02c308807405"},
+    {file = "greenlet-3.0.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:7f362975f2d179f9e26928c5b517524e89dd48530a0202570d55ad6ca5d8a56f"},
+    {file = "greenlet-3.0.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:649dde7de1a5eceb258f9cb00bdf50e978c9db1b996964cd80703614c86495eb"},
+    {file = "greenlet-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:68834da854554926fbedd38c76e60c4a2e3198c6fbed520b106a8986445caaf9"},
+    {file = "greenlet-3.0.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b1b5667cced97081bf57b8fa1d6bfca67814b0afd38208d52538316e9422fc61"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52f59dd9c96ad2fc0d5724107444f76eb20aaccb675bf825df6435acb7703559"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:afaff6cf5200befd5cec055b07d1c0a5a06c040fe5ad148abcd11ba6ab9b114e"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2797aa5aedac23af156bbb5a6aa2cd3427ada2972c828244eb7d1b9255846379"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7f009caad047246ed379e1c4dbcb8b020f0a390667ea74d2387be2998f58a22"},
+    {file = "greenlet-3.0.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3"},
+    {file = "greenlet-3.0.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:894393ce10ceac937e56ec00bb71c4c2f8209ad516e96033e4b3b1de270e200d"},
+    {file = "greenlet-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:1ea188d4f49089fc6fb283845ab18a2518d279c7cd9da1065d7a84e991748728"},
+    {file = "greenlet-3.0.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4d1ac74f5c0c0524e4a24335350edad7e5f03b9532da7ea4d3c54d527784f2e"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:149e94a2dd82d19838fe4b2259f1b6b9957d5ba1b25640d2380bea9c5df37676"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15d79dd26056573940fcb8c7413d84118086f2ec1a8acdfa854631084393efcc"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b7db1ebff4ba09aaaeae6aa491daeb226c8150fc20e836ad00041bcb11230"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf"},
+    {file = "greenlet-3.0.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305"},
+    {file = "greenlet-3.0.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6"},
+    {file = "greenlet-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:bba5387a6975598857d86de9eac14210a49d554a77eb8261cc68b7d082f78ce2"},
+    {file = "greenlet-3.0.3-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1996cb9306c8595335bb157d133daf5cf9f693ef413e7673cb07e3e5871379ca"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ddc0f794e6ad661e321caa8d2f0a55ce01213c74722587256fb6566049a8b04"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9db1c18f0eaad2f804728c67d6c610778456e3e1cc4ab4bbd5eeb8e6053c6fc"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7170375bcc99f1a2fbd9c306f5be8764eaf3ac6b5cb968862cad4c7057756506"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b66c9c1e7ccabad3a7d037b2bcb740122a7b17a53734b7d72a344ce39882a1b"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:098d86f528c855ead3479afe84b49242e174ed262456c342d70fc7f972bc13c4"},
+    {file = "greenlet-3.0.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:81bb9c6d52e8321f09c3d165b2a78c680506d9af285bfccbad9fb7ad5a5da3e5"},
+    {file = "greenlet-3.0.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da"},
+    {file = "greenlet-3.0.3-cp38-cp38-win32.whl", hash = "sha256:d46677c85c5ba00a9cb6f7a00b2bfa6f812192d2c9f7d9c4f6a55b60216712f3"},
+    {file = "greenlet-3.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:419b386f84949bf0e7c73e6032e3457b82a787c1ab4a0e43732898a761cc9dbf"},
+    {file = "greenlet-3.0.3-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b"},
+    {file = "greenlet-3.0.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6"},
+    {file = "greenlet-3.0.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113"},
+    {file = "greenlet-3.0.3-cp39-cp39-win32.whl", hash = "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e"},
+    {file = "greenlet-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067"},
+    {file = "greenlet-3.0.3.tar.gz", hash = "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491"},
 ]
 
 [[package]]
@@ -1115,6 +1226,20 @@ files = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.5"
+requires_python = ">=3.8"
+summary = "A minimal low-level HTTP client."
+dependencies = [
+    "certifi",
+    "h11<0.15,>=0.13",
+]
+files = [
+    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
+    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
+]
+
+[[package]]
 name = "httplib2"
 version = "0.22.0"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -1125,6 +1250,23 @@ dependencies = [
 files = [
     {file = "httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc"},
     {file = "httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81"},
+]
+
+[[package]]
+name = "httpx"
+version = "0.27.0"
+requires_python = ">=3.8"
+summary = "The next generation HTTP client."
+dependencies = [
+    "anyio",
+    "certifi",
+    "httpcore==1.*",
+    "idna",
+    "sniffio",
+]
+files = [
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
 ]
 
 [[package]]
@@ -2054,6 +2196,25 @@ files = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "306"
+summary = "Python for Window Extensions"
+files = [
+    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
+    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
+    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
+    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
+    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
+    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
+    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
+    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
+    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
+    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
+    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
+    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 requires_python = ">=3.6"
@@ -2284,7 +2445,7 @@ version = "2.0.23"
 requires_python = ">=3.7"
 summary = "Database Abstraction Library"
 dependencies = [
-    "greenlet!=0.4.17; platform_machine == \"aarch64\" or (platform_machine == \"ppc64le\" or (platform_machine == \"x86_64\" or (platform_machine == \"amd64\" or (platform_machine == \"AMD64\" or (platform_machine == \"win32\" or platform_machine == \"WIN32\")))))",
+    "greenlet!=0.4.17; platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\"",
     "typing-extensions>=4.2.0",
 ]
 files = [
@@ -2370,16 +2531,16 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.19.1"
-requires_python = ">=3.6"
+version = "0.37.2"
+requires_python = ">=3.8"
 summary = "The little ASGI library that shines."
 dependencies = [
     "anyio<5,>=3.4.0",
     "typing-extensions>=3.10.0; python_version < \"3.10\"",
 ]
 files = [
-    {file = "starlette-0.19.1-py3-none-any.whl", hash = "sha256:5a60c5c2d051f3a8eb546136aa0c9399773a689595e099e0877704d5888279bf"},
-    {file = "starlette-0.19.1.tar.gz", hash = "sha256:c6d21096774ecb9639acad41b86b7706e52ba3bf1dc13ea4ed9ad593d47e24c7"},
+    {file = "starlette-0.37.2-py3-none-any.whl", hash = "sha256:6fe59f29268538e5d0d182f2791a479a0c64638e6935d1c6989e63fb2699c6ee"},
+    {file = "starlette-0.37.2.tar.gz", hash = "sha256:9af890290133b79fc3db55474ade20f6220a364a0402e0b556e7cd5e1e093823"},
 ]
 
 [[package]]
@@ -2396,6 +2557,20 @@ dependencies = [
 files = [
     {file = "strawberry_graphql-0.204.0-py3-none-any.whl", hash = "sha256:e5f46abf49e7569335b51e992fb54f040355712274cf74a8bd540dd692457ccd"},
     {file = "strawberry_graphql-0.204.0.tar.gz", hash = "sha256:2c806036ecfe6d32cc0bae111346d9df24a7ca7156cc61047ce429efbb6cd630"},
+]
+
+[[package]]
+name = "testcontainers"
+version = "3.7.1"
+requires_python = ">=3.7"
+summary = "Library provides lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container"
+dependencies = [
+    "deprecation",
+    "docker>=4.0.0",
+    "wrapt",
+]
+files = [
+    {file = "testcontainers-3.7.1-py2.py3-none-any.whl", hash = "sha256:7f48cef4bf0ccd78f1a4534d4b701a003a3bace851f24eae58a32f9e3f0aeba0"},
 ]
 
 [[package]]
@@ -2438,12 +2613,12 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.7.1"
-requires_python = ">=3.7"
-summary = "Backported and Experimental Type Hints for Python 3.7+"
+version = "4.11.0"
+requires_python = ">=3.8"
+summary = "Backported and Experimental Type Hints for Python 3.8+"
 files = [
-    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
-    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
 ]
 
 [[package]]

--- a/datajunction-clients/python/pyproject.toml
+++ b/datajunction-clients/python/pyproject.toml
@@ -2,10 +2,6 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.pdm]
-[tool.pdm.build]
-includes = ["datajunction"]
-
 [project]
 name = "datajunction"
 dynamic = ["version"]
@@ -22,6 +18,7 @@ dependencies = [
     "pyyaml>=6.0.1",
     "rich>=13.7.0",
     "pytest-xdist>=3.5.0",
+    "httpx>=0.27.0",
 ]
 requires-python = ">=3.8,<4.0"
 readme = "README.md"
@@ -42,8 +39,10 @@ pandas = ["pandas>=2.0.2"]
 [tool.hatch.version]
 path = "datajunction/__about__.py"
 
-[project.urls]
-repository = "https://github.com/DataJunction/dj"
+
+[tool.pdm]
+[tool.pdm.build]
+includes = ["datajunction"]
 
 [tool.pdm.dev-dependencies]
 test = [
@@ -59,7 +58,12 @@ test = [
     "urllib3<2",
     "datajunction-server @ {root:uri}/../../datajunction-server",
     "namesgenerator==0.3",
+    "testcontainers>=3.7.1",
+    "greenlet>=3.0.3",
 ]
+
+[project.urls]
+repository = "https://github.com/DataJunction/dj"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -495,7 +495,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
             name="default.cube_one",
             description="Ice ice cube.",
             metrics=["default.number_of_account_types"],
-            dimensions=["default.payment_type"],
+            dimensions=["default.payment_type.payment_type_name"],
             mode=NodeMode.PUBLISHED,
         )
         assert cube_one.name == "default.cube_one"
@@ -577,7 +577,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         # Retrieve SQL for a single metric
         result = client.sql(
             metrics=["foo.bar.avg_repair_price"],
-            dimensions=["dimension_that_does_not_exist"],
+            dimensions=["foo.bar.dimension_that_does_not_exist"],
             filters=[],
         )
         assert (

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -556,19 +556,6 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         """
         Check that getting sql via the client works as expected.
         """
-        result = client.sql(metrics=["foo.bar.avg_repair_price"])
-        assert "SELECT" in result and "FROM" in result
-
-        # Retrieve SQL for a single metric
-        result = client.sql(
-            metrics=["foo.bar.avg_repair_price"],
-            dimensions=["dimension_that_does_not_exist"],
-            filters=[],
-        )
-        assert (
-            result["message"]
-            == "Please make sure that `dimension_that_does_not_exist` is a dimensional attribute."
-        )
 
         # Retrieve SQL for multiple metrics using the client object
         result = client.sql(
@@ -583,6 +570,20 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
             engine_version="3.1.1",
         )
         assert "SELECT" in result and "FROM" in result
+
+        result = client.sql(metrics=["foo.bar.avg_repair_price"])
+        assert "SELECT" in result and "FROM" in result
+
+        # Retrieve SQL for a single metric
+        result = client.sql(
+            metrics=["foo.bar.avg_repair_price"],
+            dimensions=["dimension_that_does_not_exist"],
+            filters=[],
+        )
+        assert (
+            result["message"]
+            == "Please make sure that `dimension_that_does_not_exist` is a dimensional attribute."
+        )
 
         # Should fail due to dimension not being available
         result = client.sql(

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -370,7 +370,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         Check that `client.list_catalogs()` works as expected.
         """
         result = client.list_catalogs()
-        assert result == ["unknown", "draft", "default", "public"]
+        assert set(result) == {"unknown", "draft", "default", "public"}
 
     def test_list_engines(self, client):
         """

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -76,7 +76,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         """
         # full list
         metrics = client.list_metrics()
-        assert metrics == [
+        assert set(metrics) == {
             "default.num_repair_orders",
             "default.avg_repair_price",
             "default.total_repair_cost",
@@ -91,11 +91,11 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             "foo.bar.total_repair_order_discounts",
             "foo.bar.avg_repair_order_discounts",
             "foo.bar.avg_time_to_dispatch",
-        ]
+        }
 
         # partial list
         metrics = client.list_metrics(namespace="foo.bar")
-        assert metrics == [
+        assert set(metrics) == {
             "foo.bar.num_repair_orders",
             "foo.bar.avg_repair_price",
             "foo.bar.total_repair_cost",
@@ -103,7 +103,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             "foo.bar.total_repair_order_discounts",
             "foo.bar.avg_repair_order_discounts",
             "foo.bar.avg_time_to_dispatch",
-        ]
+        }
 
     def test_list_cubes(self, client):
         """

--- a/datajunction-server/.coveragerc
+++ b/datajunction-server/.coveragerc
@@ -1,5 +1,6 @@
 # .coveragerc to control coverage.py
 [run]
+concurrency = thread,greenlet
 branch = True
 source = datajunction_server
 omit =

--- a/datajunction-server/datajunction_server/api/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/basic.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Form
 from fastapi.responses import JSONResponse, Response
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.constants import AUTH_COOKIE, LOGGED_IN_FLAG_COOKIE
 from datajunction_server.database.user import OAuthProvider, User
@@ -24,20 +24,17 @@ router = APIRouter(tags=["Basic OAuth2"])
 
 
 @router.post("/basic/user/")
-def create_a_user(
+async def create_a_user(
     email: str = Form(),
     username: str = Form(),
     password: str = Form(),
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
     """
     Create a new user
     """
-    if (
-        session.execute(select(User).where(User.username == username))
-        .scalars()
-        .one_or_none()
-    ):
+    user_result = await session.execute(select(User).where(User.username == username))
+    if user_result.scalar_one_or_none():
         raise DJException(
             http_status_code=HTTPStatus.CONFLICT,
             errors=[
@@ -54,8 +51,8 @@ def create_a_user(
         oauth_provider=OAuthProvider.BASIC,
     )
     session.add(new_user)
-    session.commit()
-    session.refresh(new_user)
+    await session.commit()
+    await session.refresh(new_user)
     return JSONResponse(
         content={"message": "User successfully created"},
         status_code=HTTPStatus.CREATED,
@@ -63,14 +60,14 @@ def create_a_user(
 
 
 @router.post("/basic/login/")
-def login(
+async def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ):
     """
     Get a JWT token and set it as an HTTP only cookie
     """
-    user = validate_user_password(
+    user = await validate_user_password(
         username=form_data.username,
         password=form_data.password,
         session=session,

--- a/datajunction-server/datajunction_server/api/access/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/whoami.py
@@ -18,7 +18,7 @@ router = SecureAPIRouter(tags=["Who am I?"])
 
 
 @router.get("/whoami/", response_model=UserOutput)
-def get_user(current_user: User = Depends(get_current_user)) -> UserOutput:
+async def get_user(current_user: User = Depends(get_current_user)) -> UserOutput:
     """
     Returns the current authenticated user
     """
@@ -26,7 +26,7 @@ def get_user(current_user: User = Depends(get_current_user)) -> UserOutput:
 
 
 @router.get("/token/")
-def get_short_lived_token(request: Request) -> JSONResponse:
+async def get_short_lived_token(request: Request) -> JSONResponse:
     """
     Returns a token that expires in 24 hours
     """

--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -66,6 +66,7 @@ async def client_code_for_creating_node(
     # Cube-specific params
     cube_params = []
     if node.type == NodeType.CUBE:  # type: ignore
+        node = await Node.get_cube_by_name(session, node_name)
         ordering = {
             col.name: col.order or idx
             for idx, col in enumerate(node.current.columns)  # type: ignore

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -6,10 +6,11 @@ import logging
 from typing import List, Optional
 
 from fastapi import Depends, Query
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from datajunction_server.api.helpers import get_catalog_by_name, get_node_by_name
+from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.dimensions import build_dimensions_from_cube_query
+from datajunction_server.database.node import Node
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.internal.nodes import get_cube_revision_metadata
@@ -20,7 +21,6 @@ from datajunction_server.models.cube import (
     DimensionValues,
 )
 from datajunction_server.models.metric import TranslatedSQL
-from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate
 from datajunction_server.naming import from_amenable_name
 from datajunction_server.service_clients import QueryServiceClient
@@ -36,17 +36,17 @@ router = SecureAPIRouter(tags=["cubes"])
 
 
 @router.get("/cubes/{name}/", name="Get a Cube")
-def get_cube(
-    name: str, *, session: Session = Depends(get_session)
+async def get_cube(
+    name: str, *, session: AsyncSession = Depends(get_session)
 ) -> CubeRevisionMetadata:
     """
     Get information on a cube
     """
-    return get_cube_revision_metadata(session, name)
+    return await get_cube_revision_metadata(session, name)
 
 
 @router.get("/cubes/{name}/dimensions/sql", name="Dimensions SQL for Cube")
-def get_cube_dimension_sql(
+async def get_cube_dimension_sql(
     name: str,
     *,
     dimensions: List[str] = Query([], description="Dimensions to get values for"),
@@ -59,7 +59,7 @@ def get_cube_dimension_sql(
         description="Number of rows to limit the data retrieved to",
     ),
     include_counts: bool = False,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=redefined-outer-name
         validate_access,
     ),
@@ -67,11 +67,11 @@ def get_cube_dimension_sql(
     """
     Generates SQL to retrieve all unique values of a dimension for the cube
     """
-    node = get_node_by_name(session=session, name=name, node_type=NodeType.CUBE)
-    cube = node.current
-    return build_dimensions_from_cube_query(
+    node = await Node.get_cube_by_name(session, name)
+    node_revision = node.current  # type: ignore
+    return await build_dimensions_from_cube_query(
         session,
-        cube,
+        node_revision,
         dimensions,
         filters,
         limit,
@@ -84,7 +84,7 @@ def get_cube_dimension_sql(
     "/cubes/{name}/dimensions/data",
     name="Dimensions Values for Cube",
 )
-def get_cube_dimension_values(  # pylint: disable=too-many-locals
+async def get_cube_dimension_values(  # pylint: disable=too-many-locals
     name: str,
     *,
     dimensions: List[str] = Query([], description="Dimensions to get values for"),
@@ -98,7 +98,7 @@ def get_cube_dimension_values(  # pylint: disable=too-many-locals
     ),
     include_counts: bool = False,
     async_: bool = False,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=redefined-outer-name
         validate_access,
@@ -107,9 +107,9 @@ def get_cube_dimension_values(  # pylint: disable=too-many-locals
     """
     All unique values of a dimension from the cube
     """
-    node = get_node_by_name(session=session, name=name, node_type=NodeType.CUBE)
-    cube = node.current
-    translated_sql = build_dimensions_from_cube_query(
+    node = await Node.get_cube_by_name(session, name)
+    cube = node.current  # type: ignore
+    translated_sql = await build_dimensions_from_cube_query(
         session,
         cube,
         dimensions,
@@ -119,7 +119,7 @@ def get_cube_dimension_values(  # pylint: disable=too-many-locals
         validate_access,
     )
     if cube.availability:
-        catalog = get_catalog_by_name(  # pragma: no cover
+        catalog = await get_catalog_by_name(  # pragma: no cover
             session,
             cube.availability.catalog,  # type: ignore
         )

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -7,19 +7,20 @@ from typing import Dict, List, Optional
 
 from fastapi import Depends, Query, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
 from sse_starlette.sse import EventSourceResponse
 
 from datajunction_server.api.helpers import (
     assemble_column_metadata,
     build_sql_for_multiple_metrics,
-    get_node_by_name,
     get_query,
     query_event_stream,
     validate_orderby,
 )
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJException,
@@ -50,11 +51,11 @@ router = SecureAPIRouter(tags=["data"])
 
 
 @router.post("/data/{node_name}/availability/", name="Add Availability State to Node")
-def add_availability_state(
+async def add_availability_state(
     node_name: str,
     data: AvailabilityStateBase,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -63,10 +64,21 @@ def add_availability_state(
     """
     Add an availability state to a node.
     """
-    node = get_node_by_name(session, node_name)
+
+    node = await Node.get_by_name(
+        session,
+        node_name,
+        options=[
+            joinedload(Node.current).options(
+                selectinload(NodeRevision.catalog),
+                selectinload(NodeRevision.availability),
+            ),
+        ],
+        raise_if_not_exists=True,
+    )
 
     # Source nodes require that any availability states set are for one of the defined tables
-    node_revision = node.current
+    node_revision = node.current  # type: ignore
     validate_access_requests(
         validate_access,
         current_user,
@@ -79,7 +91,7 @@ def add_availability_state(
         True,
     )
 
-    if node.current.type == NodeType.SOURCE:
+    if node.current.type == NodeType.SOURCE:  # type: ignore
         if (
             data.catalog != node_revision.catalog.name
             or data.schema_ != node_revision.schema_
@@ -132,7 +144,7 @@ def add_availability_state(
     session.add(
         History(
             entity_type=EntityType.AVAILABILITY,
-            node=node.name,
+            node=node.name,  # type: ignore
             activity_type=ActivityType.CREATE,
             pre=AvailabilityStateBase.from_orm(old_availability).dict()
             if old_availability
@@ -141,7 +153,7 @@ def add_availability_state(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
+    await session.commit()
     return JSONResponse(
         status_code=200,
         content={"message": "Availability state successfully posted"},
@@ -149,7 +161,7 @@ def add_availability_state(
 
 
 @router.get("/data/{node_name}/", name="Get Data for a Node")
-def get_data(  # pylint: disable=too-many-locals
+async def get_data(  # pylint: disable=too-many-locals
     node_name: str,
     *,
     dimensions: List[str] = Query([], description="Dimensional attributes to group by"),
@@ -163,7 +175,7 @@ def get_data(  # pylint: disable=too-many-locals
         default=False,
         description="Whether to run the query async or wait for results from the query engine",
     ),
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
@@ -175,12 +187,10 @@ def get_data(  # pylint: disable=too-many-locals
     """
     Gets data for a node
     """
-
-    node = get_node_by_name(session, node_name)
-
-    available_engines = node.current.catalog.engines
+    node = await Node.get_by_name(session, node_name, raise_if_not_exists=True)
+    available_engines = node.current.catalog.engines  # type: ignore
     engine = (
-        get_engine(session, engine_name, engine_version)  # type: ignore
+        await get_engine(session, engine_name, engine_version)  # type: ignore
         if engine_name
         else available_engines[0]
     )
@@ -197,7 +207,7 @@ def get_data(  # pylint: disable=too-many-locals
         base_verb=access.ResourceRequestVerb.EXECUTE,
     )
 
-    query_ast = get_query(
+    query_ast = await get_query(
         session=session,
         node_name=node_name,
         dimensions=dimensions,
@@ -220,7 +230,7 @@ def get_data(  # pylint: disable=too-many-locals
 
     query_create = QueryCreate(
         engine_name=engine.name,
-        catalog_name=node.current.catalog.name,
+        catalog_name=node.current.catalog.name,  # type: ignore
         engine_version=engine.version,
         submitted_query=query.sql,
         async_=async_,
@@ -255,7 +265,7 @@ def get_data_for_query(
 
 
 @router.get("/data/", response_model=QueryWithResults, name="Get Data For Metrics")
-def get_data_for_metrics(  # pylint: disable=R0914, R0913
+async def get_data_for_metrics(  # pylint: disable=R0914, R0913
     metrics: List[str] = Query([]),
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
@@ -263,7 +273,7 @@ def get_data_for_metrics(  # pylint: disable=R0914, R0913
     limit: Optional[int] = None,
     async_: bool = False,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
@@ -281,7 +291,7 @@ def get_data_for_metrics(  # pylint: disable=R0914, R0913
         base_verb=access.ResourceRequestVerb.READ,
     )
 
-    translated_sql, engine, catalog = build_sql_for_multiple_metrics(
+    translated_sql, engine, catalog = await build_sql_for_multiple_metrics(
         session,
         metrics,
         dimensions,
@@ -316,7 +326,7 @@ async def get_data_stream_for_metrics(  # pylint: disable=R0914, R0913
     orderby: List[str] = Query([]),
     limit: Optional[int] = None,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
@@ -325,7 +335,7 @@ async def get_data_stream_for_metrics(  # pylint: disable=R0914, R0913
     """
     Return data for a set of metrics with dimensions and filters using server side events
     """
-    translated_sql, engine, catalog = build_sql_for_multiple_metrics(
+    translated_sql, engine, catalog = await build_sql_for_multiple_metrics(
         session,
         metrics,
         dimensions,

--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -5,7 +5,7 @@ Data related APIs.
 from typing import Optional
 
 from fastapi import Depends, Request
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
 from datajunction_server.api.helpers import build_sql_for_dj_query, query_event_stream
@@ -27,11 +27,11 @@ router = SecureAPIRouter(tags=["DJSQL"])
 
 
 @router.get("/djsql/data", response_model=QueryWithResults)
-def get_data_for_djsql(  # pylint: disable=R0914, R0913
+async def get_data_for_djsql(  # pylint: disable=R0914, R0913
     query: str,
     async_: bool = False,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
@@ -48,7 +48,7 @@ def get_data_for_djsql(  # pylint: disable=R0914, R0913
         user=current_user,
         base_verb=access.ResourceRequestVerb.EXECUTE,
     )
-    translated_sql, engine, catalog = build_sql_for_dj_query(
+    translated_sql, engine, catalog = await build_sql_for_dj_query(
         session,
         query,
         access_control,
@@ -74,10 +74,10 @@ def get_data_for_djsql(  # pylint: disable=R0914, R0913
 
 # pylint: disable=R0914, R0913
 @router.get("/djsql/stream/", response_model=QueryWithResults)
-def get_data_stream_for_djsql(  # pragma: no cover
+async def get_data_stream_for_djsql(  # pragma: no cover
     query: str,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
@@ -94,7 +94,7 @@ def get_data_stream_for_djsql(  # pragma: no cover
         validate_access=validate_access,
         user=current_user,
     )
-    translated_sql, engine, catalog = build_sql_for_dj_query(
+    translated_sql, engine, catalog = await build_sql_for_dj_query(
         session,
         query,
         access_control,
@@ -113,7 +113,7 @@ def get_data_stream_for_djsql(  # pragma: no cover
     # Submits the query, equivalent to calling POST /data/ directly
     initial_query_info = query_service_client.submit_query(query_create)
     return EventSourceResponse(
-        query_event_stream(
+        await query_event_stream(
             query=initial_query_info,
             query_service_client=query_service_client,
             columns=translated_sql.columns,  # type: ignore

--- a/datajunction-server/datajunction_server/api/graphql/catalogs.py
+++ b/datajunction-server/datajunction_server/api/graphql/catalogs.py
@@ -21,7 +21,7 @@ class CatalogInfo:  # pylint: disable=R0903
     """
 
 
-def list_catalogs(
+async def list_catalogs(
     *,
     info: Info = None,
 ) -> List[CatalogInfo]:
@@ -31,5 +31,5 @@ def list_catalogs(
     session = info.context["session"]  # type: ignore
     return [
         CatalogInfo.from_pydantic(_CatalogInfo.from_orm(catalog))  # type: ignore #pylint: disable=E1101
-        for catalog in session.execute(select(Catalog)).scalars().all()
+        for catalog in (await session.execute(select(Catalog))).scalars().all()
     ]

--- a/datajunction-server/datajunction_server/api/graphql/engines.py
+++ b/datajunction-server/datajunction_server/api/graphql/engines.py
@@ -21,7 +21,7 @@ class EngineInfo:  # pylint: disable=R0903
     """
 
 
-def list_engines(
+async def list_engines(
     *,
     info: Info = None,
 ) -> List[EngineInfo]:
@@ -31,5 +31,5 @@ def list_engines(
     session = info.context["session"]  # type: ignore
     return [
         EngineInfo.from_pydantic(_EngineInfo.from_orm(engine))  # type: ignore #pylint: disable=E1101
-        for engine in session.execute(select(Engine)).scalars().all()
+        for engine in (await session.execute(select(Engine))).scalars().all()
     ]

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -98,16 +98,16 @@ async def get_node_by_name(  # pylint: disable=too-many-arguments
     with_current: bool = False,
     raise_if_not_exists: bool = True,
     include_inactive: bool = False,
-    for_update: bool = False,
+    # for_update: bool = False,
 ) -> Node:
     """
     Get a node by name
     """
     statement = select(Node).where(Node.name == name)
-    if for_update:
-        statement = statement.with_for_update().execution_options(
-            populate_existing=True,
-        )
+    # if for_update:
+    #     statement = statement.with_for_update().execution_options(
+    #         populate_existing=True,
+    #     )
     if not include_inactive:
         statement = statement.where(is_(Node.deactivated_at, None))
     if node_type:
@@ -377,8 +377,8 @@ async def validate_node_data(  # pylint: disable=too-many-locals,too-many-statem
     node_validator.columns = []
     type_inference_failures = {}
     for idx, col in enumerate(query_ast.select.projection):
-        if not col:
-            continue
+        # if not col:
+        #     continue
         column = None
         column_name = col.alias_or_name.name  # type: ignore
         existing_column = column_mapping.get(column_name)
@@ -679,6 +679,8 @@ async def validate_cube(  # pylint: disable=too-many-locals
                 f"Please make sure that `{dimension_attribute}` "
                 "is a dimensional attribute.",
             ) from exc
+        if not dimension_node:  # pragma: no cover
+            continue
         dimension_nodes.append(dimension_node)  # type: ignore
         columns = {col.name: col for col in dimension_node.current.columns}  # type: ignore
 

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -15,8 +15,10 @@ from http import HTTPStatus
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session, joinedload
-from sqlalchemy.sql.operators import is_
+from sqlalchemy.exc import MissingGreenlet
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+from sqlalchemy.sql.operators import and_, is_
 
 from datajunction_server.construction.build import (
     build_materialized_cube_node,
@@ -70,8 +72,8 @@ _logger = logging.getLogger(__name__)
 COLUMN_NAME_REGEX = r"([A-Za-z0-9_\.]+)(\[[A-Za-z0-9_]+\])?"
 
 
-def get_node_namespace(  # pylint: disable=too-many-arguments
-    session: Session,
+async def get_node_namespace(  # pylint: disable=too-many-arguments
+    session: AsyncSession,
     namespace: str,
     raise_if_not_exists: bool = True,
 ) -> NodeNamespace:
@@ -79,7 +81,7 @@ def get_node_namespace(  # pylint: disable=too-many-arguments
     Get a node namespace
     """
     statement = select(NodeNamespace).where(NodeNamespace.namespace == namespace)
-    node_namespace = session.execute(statement).scalar_one_or_none()
+    node_namespace = (await session.execute(statement)).scalar_one_or_none()
     if raise_if_not_exists:  # pragma: no cover
         if not node_namespace:
             raise DJException(
@@ -89,8 +91,8 @@ def get_node_namespace(  # pylint: disable=too-many-arguments
     return node_namespace
 
 
-def get_node_by_name(  # pylint: disable=too-many-arguments
-    session: Session,
+async def get_node_by_name(  # pylint: disable=too-many-arguments
+    session: AsyncSession,
     name: Optional[str],
     node_type: Optional[NodeType] = None,
     with_current: bool = False,
@@ -114,9 +116,11 @@ def get_node_by_name(  # pylint: disable=too-many-arguments
         statement = statement.options(joinedload(Node.current)).options(
             joinedload(Node.tags),
         )
-        node = session.execute(statement).unique().scalar_one_or_none()
+        result = await session.execute(statement)
+        node = result.unique().scalar_one_or_none()
     else:
-        node = session.execute(statement).scalar_one_or_none()
+        result = await session.execute(statement)
+        node = result.unique().scalar_one_or_none()
     if raise_if_not_exists:
         if not node:
             raise DJNodeNotFound(
@@ -129,11 +133,11 @@ def get_node_by_name(  # pylint: disable=too-many-arguments
     return node
 
 
-def raise_if_node_exists(session: Session, name: str) -> None:
+async def raise_if_node_exists(session: AsyncSession, name: str) -> None:
     """
     Raise an error if the node with the given name already exists.
     """
-    node = get_node_by_name(session, name, raise_if_not_exists=False)
+    node = await Node.get_by_name(session, name, raise_if_not_exists=False)
     if node:
         raise DJException(
             message=f"A node with name `{name}` already exists.",
@@ -141,11 +145,16 @@ def raise_if_node_exists(session: Session, name: str) -> None:
         )
 
 
-def get_column(node: NodeRevision, column_name: str) -> Column:
+async def get_column(
+    session: AsyncSession,
+    node: NodeRevision,
+    column_name: str,
+) -> Column:
     """
     Get a column from a node revision
     """
     requested_column = None
+    await session.refresh(node, ["columns"])
     for node_column in node.columns:
         if node_column.name == column_name:
             requested_column = node_column
@@ -159,8 +168,8 @@ def get_column(node: NodeRevision, column_name: str) -> Column:
     return requested_column
 
 
-def get_attribute_type(
-    session: Session,
+async def get_attribute_type(
+    session: AsyncSession,
     name: str,
     namespace: Optional[str] = RESERVED_ATTRIBUTE_NAMESPACE,
 ) -> Optional[AttributeType]:
@@ -172,15 +181,17 @@ def get_attribute_type(
         .where(AttributeType.name == name)
         .where(AttributeType.namespace == namespace)
     )
-    return session.execute(statement).scalar_one_or_none()
+    return (await session.execute(statement)).scalar_one_or_none()
 
 
-def get_catalog_by_name(session: Session, name: str) -> Catalog:
+async def get_catalog_by_name(session: AsyncSession, name: str) -> Catalog:
     """
     Get a catalog by name
     """
-    statement = select(Catalog).where(Catalog.name == name)
-    catalog = session.execute(statement).scalar()
+    statement = (
+        select(Catalog).where(Catalog.name == name).options(joinedload(Catalog.engines))
+    )
+    catalog = (await session.execute(statement)).scalar()
     if not catalog:
         raise DJException(
             message=f"Catalog with name `{name}` does not exist.",
@@ -189,8 +200,8 @@ def get_catalog_by_name(session: Session, name: str) -> Catalog:
     return catalog
 
 
-def get_query(  # pylint: disable=too-many-arguments
-    session: Session,
+async def get_query(  # pylint: disable=too-many-arguments
+    session: AsyncSession,
     node_name: str,
     dimensions: List[str],
     filters: List[str],
@@ -202,23 +213,23 @@ def get_query(  # pylint: disable=too-many-arguments
     """
     Get a query for a metric, dimensions, and filters
     """
-    node = get_node_by_name(session=session, name=node_name)
+    node = await Node.get_by_name(session, node_name)
 
     # Builds the node for the engine's dialect if one is set or defaults to Spark
     if (
         not engine
-        and node.current
-        and node.current.catalog
-        and node.current.catalog.engines
+        and node.current  # type: ignore
+        and node.current.catalog  # type: ignore
+        and node.current.catalog.engines  # type: ignore
     ):
-        engine = node.current.catalog.engines[0]
+        engine = node.current.catalog.engines[0]  # type: ignore
     build_criteria = BuildCriteria(
         dialect=(engine.dialect if engine and engine.dialect else Dialect.SPARK),
     )
 
-    query_ast = build_node(
+    query_ast = await build_node(
         session=session,
-        node=node.current,
+        node=node.current,  # type: ignore
         filters=filters,
         dimensions=dimensions,
         orderby=orderby,
@@ -226,7 +237,7 @@ def get_query(  # pylint: disable=too-many-arguments
         build_criteria=build_criteria,
         access_control=access_control,
     )
-    query_ast = rename_columns(query_ast, node.current)
+    query_ast = rename_columns(query_ast, node.current)  # type: ignore
     return query_ast
 
 
@@ -301,9 +312,9 @@ class NodeValidator:
         return updated_columns
 
 
-def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
+async def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
     data: Union[NodeRevisionBase, NodeRevision],
-    session: Session,
+    session: AsyncSession,
 ) -> NodeValidator:
     """
     Validate a node. This function should never raise any errors.
@@ -322,7 +333,6 @@ def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
     ctx = ast.CompileContext(session=session, exception=DJException())
 
     # Try to parse the node's query, extract dependencies and missing parents
-    # dependencies_map = missing_parents_map = {}
     try:
         formatted_query = (
             NodeRevision.format_metric_alias(
@@ -336,7 +346,7 @@ def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
         (
             dependencies_map,
             missing_parents_map,
-        ) = query_ast.bake_ctes().extract_dependencies(ctx)
+        ) = await query_ast.bake_ctes().extract_dependencies(ctx)
         node_validator.dependencies_map = dependencies_map
         node_validator.missing_parents_map = missing_parents_map
     except (DJParseException, ValueError, SqlSyntaxError) as raised_exceptions:
@@ -360,10 +370,15 @@ def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
     if invalid_parents:
         node_validator.status = NodeStatus.INVALID
 
-    column_mapping = {col.name: col for col in validated_node.columns}
+    try:
+        column_mapping = {col.name: col for col in validated_node.columns}
+    except MissingGreenlet:
+        column_mapping = {}
     node_validator.columns = []
     type_inference_failures = {}
     for idx, col in enumerate(query_ast.select.projection):
+        if not col:
+            continue
         column = None
         column_name = col.alias_or_name.name  # type: ignore
         existing_column = column_mapping.get(column_name)
@@ -389,11 +404,15 @@ def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
             node_validator.columns.append(column)
 
     # check that bound dimensions are from parent nodes
-    invalid_required_dimensions, matched_bound_columns = find_bound_dimensions(
-        validated_node,
-        dependencies_map,
-    )
-    node_validator.required_dimensions = matched_bound_columns
+    try:
+        invalid_required_dimensions, matched_bound_columns = find_bound_dimensions(
+            validated_node,
+            dependencies_map,
+        )
+        node_validator.required_dimensions = matched_bound_columns
+    except MissingGreenlet:
+        invalid_required_dimensions = set()
+        node_validator.required_dimensions = []
 
     if missing_parents_map or type_inference_failures or invalid_required_dimensions:
         # update status
@@ -459,8 +478,8 @@ def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
     return node_validator
 
 
-def resolve_downstream_references(
-    session: Session,
+async def resolve_downstream_references(
+    session: AsyncSession,
     node_revision: NodeRevision,
     current_user: Optional[User] = None,
 ) -> List[NodeRevision]:
@@ -468,8 +487,10 @@ def resolve_downstream_references(
     Find all node revisions with missing parent references to `node` and resolve them
     """
     missing_parents = (
-        session.execute(
-            select(MissingParent).where(MissingParent.name == node_revision.name),
+        (
+            await session.execute(
+                select(MissingParent).where(MissingParent.name == node_revision.name),
+            )
         )
         .scalars()
         .all()
@@ -477,10 +498,12 @@ def resolve_downstream_references(
     newly_valid_nodes = []
     for missing_parent in missing_parents:
         missing_parent_links = (
-            session.execute(
-                select(NodeMissingParents).where(
-                    NodeMissingParents.missing_parent_id == missing_parent.id,
-                ),
+            (
+                await session.execute(
+                    select(NodeMissingParents).where(
+                        NodeMissingParents.missing_parent_id == missing_parent.id,
+                    ),
+                )
             )
             .scalars()
             .all()
@@ -490,15 +513,20 @@ def resolve_downstream_references(
         ) in missing_parent_links:  # Remove from missing parents and add to parents
             downstream_node_id = link.referencing_node_id
             downstream_node_revision = (
-                session.execute(
-                    select(NodeRevision).where(NodeRevision.id == downstream_node_id),
+                (
+                    await session.execute(
+                        select(NodeRevision)
+                        .where(NodeRevision.id == downstream_node_id)
+                        .options(joinedload(NodeRevision.missing_parents)),
+                    )
                 )
                 .unique()
                 .scalar_one()
             )
+            await session.refresh(node_revision, ["node"])
             downstream_node_revision.parents.append(node_revision.node)
             downstream_node_revision.missing_parents.remove(missing_parent)
-            node_validator = validate_node_data(
+            node_validator = await validate_node_data(
                 data=downstream_node_revision,
                 session=session,
             )
@@ -519,15 +547,15 @@ def resolve_downstream_references(
             session.add(downstream_node_revision)
             if event:
                 session.add(event)
-            session.commit()
-            session.refresh(downstream_node_revision)
+            await session.commit()
+            await session.refresh(downstream_node_revision)
 
-        session.delete(missing_parent)  # Remove missing parent reference to node
+        await session.delete(missing_parent)  # Remove missing parent reference to node
     return newly_valid_nodes
 
 
-def propagate_valid_status(
-    session: Session,
+async def propagate_valid_status(
+    session: AsyncSession,
     valid_nodes: List[NodeRevision],
     catalog_id: int,
     current_user: Optional[User] = None,
@@ -542,13 +570,13 @@ def propagate_valid_status(
                 raise DJException(
                     f"Cannot propagate valid status: Node `{node_revision.name}` is not valid",
                 )
-            downstream_nodes = get_downstream_nodes(
+            downstream_nodes = await get_downstream_nodes(
                 session=session,
                 node_name=node_revision.name,
             )
             newly_valid_nodes = []
             for node in downstream_nodes:
-                node_validator = validate_node_data(
+                node_validator = await validate_node_data(
                     data=node.current,
                     session=session,
                 )
@@ -567,8 +595,8 @@ def propagate_valid_status(
                     )
                     newly_valid_nodes.append(node.current)
                 session.add(node.current)
-                session.commit()
-                session.refresh(node.current)
+                await session.commit()
+                await session.refresh(node.current)
             resolved_nodes.extend(newly_valid_nodes)
         valid_nodes = resolved_nodes
 
@@ -583,8 +611,8 @@ def map_dimensions_to_roles(dimensions: List[str]) -> Dict[str, str]:
     return {dim_rols[0]: dim_rols[1] for dim_rols in dimension_roles}
 
 
-def validate_cube(  # pylint: disable=too-many-locals
-    session: Session,
+async def validate_cube(  # pylint: disable=too-many-locals
+    session: AsyncSession,
     metric_names: List[str],
     dimension_names: List[str],
     require_dimensions: bool = True,
@@ -601,22 +629,33 @@ def validate_cube(  # pylint: disable=too-many-locals
 
     # Verify that the provided metrics are metric nodes
     for node_name in metric_names:
-        metric_node = get_node_by_name(session=session, name=node_name)
-        if metric_node.type != NodeType.METRIC:
+        metric_node = await Node.get_by_name(
+            session,
+            node_name,
+            options=[
+                joinedload(Node.current).options(
+                    joinedload(NodeRevision.catalog),
+                    joinedload(NodeRevision.columns),
+                    joinedload(NodeRevision.parents),
+                ),
+            ],
+            raise_if_not_exists=True,
+        )
+        if metric_node.type != NodeType.METRIC:  # type: ignore
             raise DJException(
                 message=(
-                    f"Node {metric_node.name} of type {metric_node.type} "
+                    f"Node {metric_node.name} of type {metric_node.type} "  # type: ignore
                     f"cannot be added to a cube."
                     + " Did you mean to add a dimension attribute?"
-                    if metric_node.type == NodeType.DIMENSION
+                    if metric_node.type == NodeType.DIMENSION  # type: ignore
                     else ""
                 ),
                 http_status_code=http.client.UNPROCESSABLE_ENTITY,
             )
-        catalogs.append(metric_node.current.catalog.name)
-        catalog = metric_node.current.catalog
-        metrics.append(metric_node.current.columns[0])
-        metric_nodes.append(metric_node)
+        catalogs.append(metric_node.current.catalog.name)  # type: ignore
+        catalog = metric_node.current.catalog  # type: ignore
+        metrics.append(metric_node.current.columns[0])  # type: ignore
+        metric_nodes.append(metric_node)  # type: ignore
 
     if not metrics:
         raise DJException(
@@ -628,14 +667,20 @@ def validate_cube(  # pylint: disable=too-many-locals
     for dimension_attribute in dimension_names:
         try:
             node_name, column_name = dimension_attribute.rsplit(".", 1)
-            dimension_node = get_node_by_name(session=session, name=node_name)
+            dimension_node = await Node.get_by_name(
+                session,
+                node_name,
+                options=[
+                    joinedload(Node.current).options(joinedload(NodeRevision.columns)),
+                ],
+            )
         except (ValueError, DJNodeNotFound) as exc:  # pragma: no cover
             raise DJException(
                 f"Please make sure that `{dimension_attribute}` "
                 "is a dimensional attribute.",
             ) from exc
-        dimension_nodes.append(dimension_node)
-        columns = {col.name: col for col in dimension_node.current.columns}
+        dimension_nodes.append(dimension_node)  # type: ignore
+        columns = {col.name: col for col in dimension_node.current.columns}  # type: ignore
 
         column_name_without_role = column_name
         match = re.fullmatch(COLUMN_NAME_REGEX, column_name)
@@ -663,7 +708,9 @@ def validate_cube(  # pylint: disable=too-many-locals
             message=("Metrics and dimensions must be part of a common catalog"),
         )
 
-    validate_shared_dimensions(
+    for dim in dimensions:
+        await session.refresh(dim, ["node_revisions"])
+    await validate_shared_dimensions(
         session,
         metric_nodes,
         dimension_names,
@@ -672,8 +719,8 @@ def validate_cube(  # pylint: disable=too-many-locals
     return metrics, metric_nodes, dimension_nodes, dimensions, catalog
 
 
-def get_history(
-    session: Session,
+async def get_history(
+    session: AsyncSession,
     entity_type: EntityType,
     entity_name: str,
     offset: int,
@@ -683,12 +730,14 @@ def get_history(
     Get the history for a given entity type and name
     """
     return (
-        session.execute(
-            select(History)
-            .where(History.entity_type == entity_type)
-            .where(History.entity_name == entity_name)
-            .offset(offset)
-            .limit(limit),
+        (
+            await session.execute(
+                select(History)
+                .where(History.entity_type == entity_type)
+                .where(History.entity_name == entity_name)
+                .offset(offset)
+                .limit(limit),
+            )
         )
         .scalars()
         .all()
@@ -716,8 +765,8 @@ def validate_orderby(
         )
 
 
-def find_existing_cube(
-    session: Session,
+async def find_existing_cube(
+    session: AsyncSession,
     metric_columns: List[Column],
     dimension_columns: List[Column],
     materialized: bool = True,
@@ -727,23 +776,36 @@ def find_existing_cube(
     If `materialized` is set, it will only look for materialized cubes.
     """
     element_names = [col.name for col in (metric_columns + dimension_columns)]
-    statement = select(NodeRevision)
+    statement = select(Node).join(
+        NodeRevision,
+        onclause=(
+            and_(
+                (Node.id == NodeRevision.node_id),
+                (Node.current_version == NodeRevision.version),
+            )
+        ),
+    )
     for name in element_names:
         statement = statement.filter(
             NodeRevision.cube_elements.any(Column.name == name),  # type: ignore  # pylint: disable=no-member
+        ).options(
+            joinedload(Node.current).options(
+                joinedload(NodeRevision.materializations),
+                joinedload(NodeRevision.availability),
+            ),
         )
 
-    existing_cubes = session.execute(statement).unique().scalars().all()
+    existing_cubes = (await session.execute(statement)).unique().scalars().all()
     for cube in existing_cubes:
         if not materialized or (  # pragma: no cover
-            materialized and cube.materializations and cube.availability
+            materialized and cube.current.materializations and cube.current.availability
         ):
-            return cube
+            return cube.current
     return None
 
 
-def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-many-locals
-    session: Session,
+async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-many-locals
+    session: AsyncSession,
     metrics: List[str],
     dimensions: List[str],
     filters: List[str] = None,
@@ -762,31 +824,39 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
     if not orderby:
         orderby = []
 
-    metric_columns, metric_nodes, _, dimension_columns, _ = validate_cube(
+    metric_columns, metric_nodes, _, dimension_columns, _ = await validate_cube(
         session,
         metrics,
         dimensions,
         require_dimensions=False,
     )
-    leading_metric_node = get_node_by_name(session, metrics[0])
-    available_engines = leading_metric_node.current.catalog.engines
+    leading_metric_node = await Node.get_by_name(
+        session,
+        metrics[0],
+        options=[
+            joinedload(Node.current).options(
+                joinedload(NodeRevision.catalog).options(joinedload(Catalog.engines)),
+            ),
+        ],
+    )
+    available_engines = leading_metric_node.current.catalog.engines  # type: ignore
 
     # Try to find a built cube that already has the given metrics and dimensions
     # The cube needs to have a materialization configured and an availability state
     # posted in order for us to use the materialized datasource
-    cube = find_existing_cube(
+    cube = await find_existing_cube(
         session,
         metric_columns,
         dimension_columns,
         materialized=True,
     )
     if cube:
-        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
+        catalog = await get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
         available_engines = catalog.engines + available_engines
 
     # Check if selected engine is available
     engine = (
-        get_engine(session, engine_name, engine_version)  # type: ignore
+        await get_engine(session, engine_name, engine_version)  # type: ignore
         if engine_name
         else available_engines[0]
     )
@@ -803,7 +873,7 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
             access_control.add_request_by_node(cube)
             access_control.state = access.AccessControlState.INDIRECT
             access_control.raise_if_invalid_requests()
-        materialized_cube_catalog = get_catalog_by_name(
+        materialized_cube_catalog = await get_catalog_by_name(
             session,
             cube.availability.catalog,
         )
@@ -846,7 +916,7 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
             cube.catalog,
         )
 
-    query_ast = build_metric_nodes(
+    query_ast = await build_metric_nodes(
         session,
         metric_nodes,
         filters=filters or [],
@@ -865,13 +935,13 @@ def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,too-ma
             columns=columns,
             dialect=engine.dialect if engine else None,
             upstream_tables=[
-                f"{leading_metric_node.current.catalog.name}.{tbl.identifier()}"
+                f"{leading_metric_node.current.catalog.name}.{tbl.identifier()}"  # type: ignore
                 for tbl in query_ast.find_all(ast.Table)
                 if tbl.dj_node and tbl.dj_node.type == NodeType.SOURCE
             ],
         ),
         engine,
-        leading_metric_node.current.catalog,
+        leading_metric_node.current.catalog,  # type: ignore
     )
 
 
@@ -939,8 +1009,8 @@ async def query_event_stream(  # pylint: disable=too-many-arguments
         await asyncio.sleep(stream_delay)  # pragma: no cover
 
 
-def build_sql_for_dj_query(  # pylint: disable=too-many-arguments,too-many-locals
-    session: Session,
+async def build_sql_for_dj_query(  # pylint: disable=too-many-arguments,too-many-locals
+    session: AsyncSession,
     query: str,
     access_control: access.AccessControl,
     engine_name: Optional[str] = None,
@@ -950,7 +1020,7 @@ def build_sql_for_dj_query(  # pylint: disable=too-many-arguments,too-many-local
     Build SQL for multiple metrics. Used by /djsql endpoints
     """
 
-    query_ast, dj_nodes = build_dj_query(session, query)
+    query_ast, dj_nodes = await build_dj_query(session, query)
 
     for node in dj_nodes:
         access_control.add_request_by_node(
@@ -964,7 +1034,7 @@ def build_sql_for_dj_query(  # pylint: disable=too-many-arguments,too-many-local
 
     # Check if selected engine is available
     engine = (
-        get_engine(session, engine_name, engine_version)  # type: ignore
+        await get_engine(session, engine_name, engine_version)  # type: ignore
         if engine_name
         else available_engines[0]
     )
@@ -991,8 +1061,8 @@ def build_sql_for_dj_query(  # pylint: disable=too-many-arguments,too-many-local
     )
 
 
-def deactivate_node(
-    session: Session,
+async def deactivate_node(
+    session: AsyncSession,
     name: str,
     message: str = None,
     current_user: Optional[User] = None,
@@ -1000,10 +1070,10 @@ def deactivate_node(
     """
     Deactivates a node and propagates to all downstreams.
     """
-    node = get_node_by_name(session, name, with_current=True)
+    node = await get_node_by_name(session, name, with_current=True)
 
     # Find all downstream nodes and mark them as invalid
-    downstreams = get_downstream_nodes(session, node.name)
+    downstreams = await get_downstream_nodes(session, node.name)
     for downstream in downstreams:
         if downstream.current.status != NodeStatus.INVALID:
             downstream.current.status = NodeStatus.INVALID
@@ -1038,17 +1108,23 @@ def deactivate_node(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
+    await session.commit()
+    await session.refresh(node, ["current"])
 
 
-def activate_node(
-    session: Session,
+async def activate_node(
+    session: AsyncSession,
     name: str,
     message: str = None,
     current_user: Optional[User] = None,
 ):
     """Restores node and revalidate all downstreams."""
-    node = get_node_by_name(session, name, with_current=True, include_inactive=True)
+    node = await get_node_by_name(
+        session,
+        name,
+        with_current=True,
+        include_inactive=True,
+    )
     if not node.deactivated_at:
         raise DJException(
             http_status_code=HTTPStatus.BAD_REQUEST,
@@ -1057,12 +1133,13 @@ def activate_node(
     node.deactivated_at = None  # type: ignore
 
     # Find all downstream nodes and revalidate them
-    downstreams = get_downstream_nodes(session, node.name)
+    downstreams = await get_downstream_nodes(session, node.name)
     for downstream in downstreams:
         old_status = downstream.current.status
         if downstream.type == NodeType.CUBE:
             downstream.current.status = NodeStatus.VALID
             for element in downstream.current.cube_elements:
+                await session.refresh(element, ["node_revisions"])
                 if (
                     element.node_revisions
                     and element.node_revisions[-1].status == NodeStatus.INVALID
@@ -1071,7 +1148,7 @@ def activate_node(
         else:
             # We should not fail node restoration just because of some nodes
             # that have been invalid already and stay that way.
-            node_validator = validate_node_data(downstream.current, session)
+            node_validator = await validate_node_data(downstream.current, session)
             downstream.current.status = node_validator.status
             if node_validator.errors:
                 downstream.current.status = NodeStatus.INVALID
@@ -1098,20 +1175,28 @@ def activate_node(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
+    await session.commit()
 
 
-def revalidate_node(
+async def revalidate_node(
     name: str,
-    session: Session,
+    session: AsyncSession,
     parent_node: str = None,
     current_user: Optional[User] = None,
 ):
     """
     Revalidate a single existing node and update its status appropriately
     """
-    node = get_node_by_name(session, name)
-    current_node_revision = node.current
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+        raise_if_not_exists=True,
+    )
+    current_node_revision = node.current  # type: ignore
     if current_node_revision.type == NodeType.SOURCE:
         if current_node_revision.status != NodeStatus.VALID:  # pragma: no cover
             current_node_revision.status = NodeStatus.VALID
@@ -1124,15 +1209,17 @@ def revalidate_node(
                 ),
             )
             session.add(current_node_revision)
-            session.commit()
-            session.refresh(current_node_revision)
+            await session.commit()
+            await session.refresh(current_node_revision)
         return NodeStatus.VALID
 
     if current_node_revision.type == NodeType.CUBE:
+        cube_node = await Node.get_cube_by_name(session, name)
+        current_node_revision = cube_node.current  # type: ignore
         cube_metrics = [metric.name for metric in current_node_revision.cube_metrics()]
         cube_dimensions = current_node_revision.cube_dimensions()
         try:
-            validate_cube(
+            await validate_cube(
                 session,
                 metric_names=cube_metrics,
                 dimension_names=cube_dimensions,
@@ -1142,46 +1229,65 @@ def revalidate_node(
         except DJException:  # pragma: no cover
             current_node_revision.status = NodeStatus.INVALID
         session.add(current_node_revision)
-        session.commit()
+        await session.commit()
         return current_node_revision.status
     previous_status = current_node_revision.status
-    node_validator = validate_node_data(current_node_revision, session)
-    current_node_revision.status = node_validator.status
-    if previous_status != current_node_revision.status:  # pragma: no cover
-        session.add(current_node_revision)
+    node_validator = await validate_node_data(current_node_revision, session)
+
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+        raise_if_not_exists=True,
+    )
+    node.current.status = node_validator.status  # type: ignore
+    if previous_status != node.current.status:  # type: ignore  # pragma: no cover
+        session.add(node)
         session.add(
             status_change_history(
-                current_node_revision,
+                node.current,  # type: ignore
                 previous_status,
-                current_node_revision.status,
+                node.current.status,  # type: ignore
                 parent_node=parent_node,
                 current_user=current_user,
             ),
         )
-        session.commit()
-        session.refresh(current_node_revision)
-        session.refresh(node)
-    return current_node_revision.status
+        await session.commit()
+    await session.refresh(node.current)  # type: ignore
+    await session.refresh(node, ["current"])
+    return node.current.status  # type: ignore
 
 
-def hard_delete_node(
+async def hard_delete_node(
     name: str,
-    session: Session,
+    session: AsyncSession,
     current_user: Optional[User] = None,
 ):
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
     This should be used with caution, deactivating a node is preferred.
     """
-    node = get_node_by_name(session, name, with_current=True, include_inactive=True)
-    downstream_nodes = get_downstream_nodes(session=session, node_name=name)
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[joinedload(Node.current), joinedload(Node.revisions)],
+        include_inactive=True,
+        raise_if_not_exists=False,
+    )
+    downstream_nodes = await get_downstream_nodes(session=session, node_name=name)
 
     linked_nodes = []
-    if node.type == NodeType.DIMENSION:
-        linked_nodes = get_nodes_with_dimension(session=session, dimension_node=node)
+    if node.type == NodeType.DIMENSION:  # type: ignore
+        linked_nodes = await get_nodes_with_dimension(
+            session=session,
+            dimension_node=node,  # type: ignore
+        )
 
-    session.delete(node)
-    session.commit()
+    await session.delete(node)
+    await session.commit()
     impact = []  # Aggregate all impact of this deletion to include in response
 
     # Revalidate all downstream nodes
@@ -1195,7 +1301,7 @@ def hard_delete_node(
                 user=current_user.username if current_user else None,
             ),
         )
-        status = revalidate_node(
+        status = await revalidate_node(
             name=node.name,
             session=session,
             parent_node=name,
@@ -1220,7 +1326,7 @@ def hard_delete_node(
                 user=current_user.username if current_user else None,
             ),
         )
-        status = revalidate_node(
+        status = await revalidate_node(
             name=node.name,
             session=session,
             current_user=current_user,
@@ -1244,7 +1350,7 @@ def hard_delete_node(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()  # Commit the history events
+    await session.commit()  # Commit the history events
     return impact
 
 

--- a/datajunction-server/datajunction_server/api/history.py
+++ b/datajunction-server/datajunction_server/api/history.py
@@ -7,7 +7,7 @@ from typing import List
 
 from fastapi import Depends, Query
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_history
 from datajunction_server.database.history import EntityType, History
@@ -21,18 +21,18 @@ router = SecureAPIRouter(tags=["history"])
 
 
 @router.get("/history/{entity_type}/{entity_name}/", response_model=List[HistoryOutput])
-def list_history(
+async def list_history(
     entity_type: EntityType,
     entity_name: str,
     offset: int = 0,
     limit: int = Query(default=100, lte=100),
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> List[HistoryOutput]:
     """
     List history for an entity type (i.e. Node) and entity name
     """
-    hist = get_history(
+    hist = await get_history(
         session=session,
         entity_name=entity_name,
         entity_type=entity_type,
@@ -43,23 +43,25 @@ def list_history(
 
 
 @router.get("/history/", response_model=List[HistoryOutput])
-def list_history_by_node_context(
+async def list_history_by_node_context(
     node: str,
     offset: int = 0,
     limit: int = Query(default=100, lte=100),
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> List[HistoryOutput]:
     """
     List all activity history for a node context
     """
     hist = (
-        session.execute(
-            select(History)
-            .where(History.node == node)
-            .order_by(History.created_at)
-            .offset(offset)
-            .limit(limit),
+        (
+            await session.execute(
+                select(History)
+                .where(History.node == node)
+                .order_by(History.created_at)
+                .offset(offset)
+                .limit(limit),
+            )
         )
         .scalars()
         .all()

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -114,7 +114,7 @@ async def startup():
     """
     Initialize FastAPI cache when the server starts up
     """
-    FastAPICache.init(InMemoryBackend(), prefix="inmemory-cache")
+    FastAPICache.init(InMemoryBackend(), prefix="inmemory-cache")  # pragma: no cover
 
 
 @app.exception_handler(DJException)

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -97,6 +97,9 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
             http_status_code=HTTPStatus.BAD_REQUEST,
             message=f"Cannot set materialization config for source node `{node_name}`!",
         )
+    if node.type == NodeType.CUBE:  # type: ignore
+        node = await Node.get_cube_by_name(session, node_name)
+
     current_revision = node.current  # type: ignore
     old_materializations = {mat.name: mat for mat in current_revision.materializations}
 

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -9,9 +9,10 @@ from typing import List, Optional
 
 from fastapi import Depends
 from fastapi.responses import JSONResponse
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
 
-from datajunction_server.api.helpers import get_node_by_name
+from datajunction_server.database import Column, ColumnAttribute, Node, NodeRevision
 from datajunction_server.database.backfill import Backfill
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.user import User
@@ -75,11 +76,11 @@ def materialization_jobs_info() -> JSONResponse:
     status_code=201,
     name="Insert or Update a Materialization for a Node",
 )
-def upsert_materialization(  # pylint: disable=too-many-locals
+async def upsert_materialization(  # pylint: disable=too-many-locals
     node_name: str,
     data: UpsertMaterialization,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
@@ -90,17 +91,17 @@ def upsert_materialization(  # pylint: disable=too-many-locals
     Add or update a materialization of the specified node. If a node_name is specified
     for the materialization config, it will always update that named config.
     """
-    node = get_node_by_name(session, node_name, with_current=True)
-    if node.type == NodeType.SOURCE:
+    node = await Node.get_by_name(session, node_name)
+    if node.type == NodeType.SOURCE:  # type: ignore
         raise DJException(
             http_status_code=HTTPStatus.BAD_REQUEST,
             message=f"Cannot set materialization config for source node `{node_name}`!",
         )
-    current_revision = node.current
+    current_revision = node.current  # type: ignore
     old_materializations = {mat.name: mat for mat in current_revision.materializations}
 
     if data.strategy == MaterializationStrategy.INCREMENTAL_TIME:
-        if not node.current.temporal_partition_columns():
+        if not node.current.temporal_partition_columns():  # type: ignore
             raise DJException(  # pragma: no cover
                 http_status_code=HTTPStatus.BAD_REQUEST,
                 message="Cannot create materialization with strategy "
@@ -108,7 +109,7 @@ def upsert_materialization(  # pylint: disable=too-many-locals
             )
 
     # Create a new materialization
-    new_materialization = create_new_materialization(
+    new_materialization = await create_new_materialization(
         session,
         current_revision,
         data,
@@ -131,14 +132,14 @@ def upsert_materialization(  # pylint: disable=too-many-locals
                 History(
                     entity_type=EntityType.MATERIALIZATION,
                     entity_name=existing_materialization.name,
-                    node=node.name,
+                    node=node.name,  # type: ignore
                     activity_type=ActivityType.RESTORE,
                     details={},
                     user=current_user.username if current_user else None,
                 ),
             )
-            session.commit()
-            session.refresh(existing_materialization)
+            await session.commit()
+            await session.refresh(existing_materialization)
         existing_materialization_info = query_service_client.get_materialization_info(
             node_name,
             current_revision.version,  # type: ignore
@@ -181,7 +182,7 @@ def upsert_materialization(  # pylint: disable=too-many-locals
     session.add(
         History(
             entity_type=EntityType.MATERIALIZATION,
-            node=node.name,
+            node=node.name,  # type: ignore
             entity_name=new_materialization.name,
             activity_type=(
                 ActivityType.CREATE
@@ -189,13 +190,13 @@ def upsert_materialization(  # pylint: disable=too-many-locals
                 else ActivityType.UPDATE
             ),
             details={
-                "node": node.name,
+                "node": node.name,  # type: ignore
                 "materialization": new_materialization.name,
             },
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
+    await session.commit()
 
     materialization_response = schedule_materialization_jobs(
         [new_materialization],
@@ -218,20 +219,20 @@ def upsert_materialization(  # pylint: disable=too-many-locals
     response_model=List[MaterializationConfigInfoUnified],
     name="List Materializations for a Node",
 )
-def list_node_materializations(
+async def list_node_materializations(
     node_name: str,
     show_deleted: bool = False,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
 ) -> List[MaterializationConfigInfoUnified]:
     """
     Show all materializations configured for the node, with any associated metadata
     like urls from the materialization service, if available.
     """
-    node = get_node_by_name(session, node_name, with_current=True)
+    node = await Node.get_by_name(session, node_name)
     materializations = []
-    for materialization in node.current.materializations:
+    for materialization in node.current.materializations:  # type: ignore
         if not materialization.deactivated_at or show_deleted:  # pragma: no cover
             info = query_service_client.get_materialization_info(
                 node_name,
@@ -256,11 +257,11 @@ def list_node_materializations(
     response_model=List[MaterializationConfigInfoUnified],
     name="Deactivate a Materialization for a Node",
 )
-def deactivate_node_materializations(
+async def deactivate_node_materializations(
     node_name: str,
     materialization_name: str,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> List[MaterializationConfigInfoUnified]:
@@ -268,9 +269,9 @@ def deactivate_node_materializations(
     Deactivate the node materialization with the provided name.
     Also calls the query service to deactivate the associated scheduled jobs.
     """
-    node = get_node_by_name(session, node_name, with_current=True)
+    node = await Node.get_by_name(session, node_name)
     query_service_client.deactivate_materialization(node_name, materialization_name)
-    for materialization in node.current.materializations:
+    for materialization in node.current.materializations:  # type: ignore
         if (
             materialization.name == materialization_name
             and not materialization.deactivated_at
@@ -290,14 +291,14 @@ def deactivate_node_materializations(
         History(
             entity_type=EntityType.MATERIALIZATION,
             entity_name=materialization_name,
-            node=node.name,
+            node=node.name,  # type: ignore
             activity_type=ActivityType.DELETE,
             details={},
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
-    session.refresh(node.current)
+    await session.commit()
+    await session.refresh(node.current)  # type: ignore
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={
@@ -312,20 +313,35 @@ def deactivate_node_materializations(
     status_code=201,
     name="Kick off a backfill run for a configured materialization",
 )
-def run_materialization_backfill(  # pylint: disable=too-many-locals
+async def run_materialization_backfill(  # pylint: disable=too-many-locals
     node_name: str,
     materialization_name: str,
     backfill_spec: PartitionBackfill,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> MaterializationInfo:
     """
     Start a backfill for a configured materialization.
     """
-    node = get_node_by_name(session, node_name)
-    node_revision = node.current
+    node = await Node.get_by_name(
+        session,
+        node_name,
+        options=[
+            joinedload(Node.current).options(
+                selectinload(NodeRevision.columns).options(
+                    selectinload(Column.attributes).joinedload(
+                        ColumnAttribute.attribute_type,
+                    ),
+                    selectinload(Column.dimension),
+                    selectinload(Column.partition),
+                ),
+                selectinload(NodeRevision.materializations),
+            ),
+        ],
+    )
+    node_revision = node.current  # type: ignore
     materializations = [
         mat
         for mat in node_revision.materializations
@@ -377,5 +393,5 @@ def run_materialization_backfill(  # pylint: disable=too-many-locals
         user=current_user.username if current_user else None,
     )
     session.add(backfill_event)
-    session.commit()
+    await session.commit()
     return materialization_output

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -7,12 +7,12 @@ from typing import List, Optional
 
 from fastapi import Depends, HTTPException, Query
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.operators import is_
 
-from datajunction_server.api.helpers import get_node_by_name
 from datajunction_server.api.nodes import list_nodes
-from datajunction_server.database.node import Node
+from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJError, DJException, ErrorCode
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
@@ -33,24 +33,34 @@ settings = get_settings()
 router = SecureAPIRouter(tags=["metrics"])
 
 
-def get_metric(session: Session, name: str) -> Node:
+async def get_metric(session: AsyncSession, name: str) -> Node:
     """
     Return a metric node given a node name.
     """
-    node = get_node_by_name(session, name)
-    if node.type != NodeType.METRIC:
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            selectinload(Node.current).options(
+                *NodeRevision.default_load_options(),
+                selectinload(NodeRevision.required_dimensions),
+            ),
+        ],
+        raise_if_not_exists=True,
+    )
+    if node.type != NodeType.METRIC:  # type: ignore
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
             detail=f"Not a metric node: `{name}`",
         )
-    return node
+    return node  # type: ignore
 
 
 @router.get("/metrics/", response_model=List[str])
-def list_metrics(
+async def list_metrics(
     prefix: Optional[str] = None,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -59,7 +69,7 @@ def list_metrics(
     """
     List all available metrics.
     """
-    return list_nodes(
+    return await list_nodes(
         node_type=NodeType.METRIC,
         prefix=prefix,
         session=session,
@@ -69,7 +79,7 @@ def list_metrics(
 
 
 @router.get("/metrics/metadata")
-def list_metric_metadata() -> MetricMetadataOptions:
+async def list_metric_metadata() -> MetricMetadataOptions:
     """
     Return available metric metadata attributes
     """
@@ -81,12 +91,14 @@ def list_metric_metadata() -> MetricMetadataOptions:
 
 
 @router.get("/metrics/{name}/", response_model=Metric)
-def get_a_metric(name: str, *, session: Session = Depends(get_session)) -> Metric:
+async def get_a_metric(
+    name: str, *, session: AsyncSession = Depends(get_session)
+) -> Metric:
     """
     Return a metric by name.
     """
-    node = get_metric(session, name)
-    dims = get_dimensions(session, node.current.parents[0])
+    node = await get_metric(session, name)
+    dims = await get_dimensions(session, node.current.parents[0])
     metric = Metric.parse_node(node, dims)
     return metric
 
@@ -95,12 +107,12 @@ def get_a_metric(name: str, *, session: Session = Depends(get_session)) -> Metri
     "/metrics/common/dimensions/",
     response_model=List[DimensionAttributeOutput],
 )
-def get_common_dimensions(
+async def get_common_dimensions(
     metric: List[str] = Query(
         title="List of metrics to find common dimensions for",
         default=[],
     ),
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> List[DimensionAttributeOutput]:
     """
     Return common dimensions for a set of metrics.
@@ -111,7 +123,7 @@ def get_common_dimensions(
         .where(Node.name.in_(metric))  # type: ignore  # pylint: disable=no-member
         .where(is_(Node.deactivated_at, None))
     )
-    metric_nodes = session.execute(statement).scalars().all()
+    metric_nodes = (await session.execute(statement)).scalars().all()
     for node in metric_nodes:
         if node.type != NodeType.METRIC:
             errors.append(
@@ -130,4 +142,4 @@ def get_common_dimensions(
 
     if errors:
         raise DJException(errors=errors)
-    return get_shared_dimensions(session, metric_nodes)
+    return await get_shared_dimensions(session, metric_nodes)

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -567,8 +567,6 @@ async def create_node(
                     [AttributeTypeIdentifier(name="primary_key", namespace="system")],
                     current_user=current_user,
                 )
-    # await session.refresh(node)
-    # await session.refresh(node.current)
     node = await Node.get_by_name(  # type: ignore
         session,
         node.name,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -39,6 +39,7 @@ from datajunction_server.database.partition import Partition
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJActionNotAllowedException,
+    DJAlreadyExistsException,
     DJDoesNotExistException,
     DJException,
     DJInvalidInputException,
@@ -1354,7 +1355,7 @@ async def copy_node(
         if existing_new_node.deactivated_at:
             await hard_delete_node(new_name, session, current_user)
         else:
-            raise DJInvalidInputException(
+            raise DJAlreadyExistsException(
                 f"A node with name {new_name} already exists.",
             )
 

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -301,10 +301,7 @@ async def get_node(
     node = await Node.get_by_name(
         session,
         name,
-        options=[
-            joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            joinedload(Node.tags),
-        ],
+        options=NodeOutput.load_options(),
         raise_if_not_exists=True,
     )
     end = time.time()
@@ -724,7 +721,8 @@ async def link_dimension(
         dimension,
         raise_if_not_exists=True,
     )
-    if dimension_node.type != NodeType.DIMENSION:  # type: ignore
+    if dimension_node.type != NodeType.DIMENSION:  # type: ignore  # pragma: no cover
+        # pragma: no cover
         raise DJException(message=f"Node {node.name} is not of type dimension!")  # type: ignore
     primary_key_columns = dimension_node.current.primary_key()  # type: ignore
     if len(primary_key_columns) > 1:
@@ -873,7 +871,7 @@ async def tags_node(
     """
     Add a tag to a node
     """
-    node = await Node.get_by_name(session=session, name=name, for_update=True)
+    node = await Node.get_by_name(session=session, name=name)
     if not tag_names:
         tag_names = []  # pragma: no cover
     tags = await get_tags_by_name(session, names=tag_names)
@@ -1153,7 +1151,7 @@ async def list_node_dag(
         node.current.parents[0] if node.type == NodeType.METRIC else node,  # type: ignore
         with_attributes=False,
     )
-    if node.type == NodeType.METRIC:  # type: ignore
+    if node.type == NodeType.METRIC:  # type: ignore  # pragma: no cover
         dimension_nodes = dimension_nodes + node.current.parents  # type: ignore
     dimension_nodes += [node]  # type: ignore
     downstreams = await get_downstream_nodes(

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -4,6 +4,7 @@ Node related APIs.
 """
 import logging
 import os
+import time
 from http import HTTPStatus
 from typing import List, Optional
 
@@ -11,7 +12,8 @@ from fastapi import BackgroundTasks, Depends, Query, Response
 from fastapi.responses import JSONResponse
 from fastapi_cache.decorator import cache
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.operators import is_
 from starlette.requests import Request
 
@@ -30,6 +32,7 @@ from datajunction_server.api.helpers import (
 from datajunction_server.api.namespaces import create_node_namespace
 from datajunction_server.api.tags import get_tags_by_name
 from datajunction_server.constants import NODE_LIST_MAX
+from datajunction_server.database.attributetype import ColumnAttribute
 from datajunction_server.database.column import Column
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.node import Node, NodeRevision
@@ -92,6 +95,7 @@ from datajunction_server.models.partition import (
 )
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
+    _node_output_options,
     get_dimensions,
     get_downstream_nodes,
     get_upstream_nodes,
@@ -112,10 +116,10 @@ router = SecureAPIRouter(tags=["nodes"])
 
 
 @router.post("/nodes/validate/", response_model=NodeValidation)
-def validate_node(
+async def validate_node(
     data: NodeRevisionBase,
     response: Response,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> NodeValidation:
     """
     Determines whether the provided node is valid and returns metadata from node validation.
@@ -124,7 +128,7 @@ def validate_node(
     if data.type == NodeType.SOURCE:
         raise DJException(message="Source nodes cannot be validated")
 
-    node_validator = validate_node_data(data, session)
+    node_validator = await validate_node_data(data, session)
     if node_validator.errors:
         response.status_code = HTTPStatus.UNPROCESSABLE_ENTITY
     else:
@@ -141,15 +145,19 @@ def validate_node(
 
 
 @router.post("/nodes/{name}/validate/", response_model=NodeValidation)
-def revalidate(
+async def revalidate(
     name: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
-) -> NodeValidation:
+) -> JSONResponse:
     """
     Revalidate a single existing node and update its status appropriately
     """
-    status = revalidate_node(name=name, session=session, current_user=current_user)
+    status = await revalidate_node(
+        name=name,
+        session=session,
+        current_user=current_user,
+    )
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={
@@ -164,21 +172,27 @@ def revalidate(
     response_model=List[ColumnOutput],
     status_code=201,
 )
-def set_column_attributes(
+async def set_column_attributes(
     node_name: str,
     column_name: str,
     attributes: List[AttributeTypeIdentifier],
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> List[ColumnOutput]:
     """
     Set column attributes for the node.
     """
-    node = get_node_by_name(session, node_name)
-    columns = set_node_column_attributes(
+    node = await Node.get_by_name(
         session,
-        node,
+        node_name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+        ],
+    )
+    columns = await set_node_column_attributes(
+        session,
+        node,  # type: ignore
         column_name,
         attributes,
         current_user=current_user,
@@ -187,11 +201,11 @@ def set_column_attributes(
 
 
 @router.get("/nodes/", response_model=List[str])
-def list_nodes(
+async def list_nodes(
     node_type: Optional[NodeType] = None,
     prefix: Optional[str] = None,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -200,14 +214,7 @@ def list_nodes(
     """
     List the available nodes.
     """
-    statement = select(Node).where(is_(Node.deactivated_at, None))
-    if prefix:
-        statement = statement.where(
-            Node.name.like(f"{prefix}%"),  # type: ignore  # pylint: disable=no-member
-        )
-    if node_type:
-        statement = statement.where(Node.type == node_type)
-    nodes = session.execute(statement).unique().scalars().all()
+    nodes = await Node.find(session, prefix, node_type)  # type: ignore
     return [
         approval.access_object.name
         for approval in validate_access_requests(
@@ -226,10 +233,10 @@ def list_nodes(
 
 @router.get("/nodes/details/", response_model=List[NodeIndexItem])
 @cache(expire=settings.index_cache_expire)
-def list_all_nodes_with_details(
+async def list_all_nodes_with_details(
     node_type: Optional[NodeType] = None,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -255,7 +262,7 @@ def list_all_nodes_with_details(
     )  # Very high limit as a safeguard
     results = [
         NodeIndexItem(name=row[0], display_name=row[1], description=row[2], type=row[3])
-        for row in session.execute(nodes_query).all()
+        for row in (await session.execute(nodes_query)).all()
     ]
     if len(results) == NODE_LIST_MAX:  # pragma: no cover
         _logger.warning(
@@ -283,26 +290,43 @@ def list_all_nodes_with_details(
     return [row for row in results if row.name in approvals]
 
 
-@router.get("/nodes/{name}/")
-def get_node(name: str, *, session: Session = Depends(get_session)) -> NodeOutput:
+@router.get("/nodes/{name}/", response_model=NodeOutput)
+async def get_node(
+    name: str, *, session: AsyncSession = Depends(get_session)
+) -> NodeOutput:
     """
     Show the active version of the specified node.
     """
-    node = get_node_by_name(session, name, with_current=True)
-    return NodeOutput.from_orm(node)
+    start = time.time()
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+        raise_if_not_exists=True,
+    )
+    end = time.time()
+    print("db TIME", end - start)
+    start = end
+    res = NodeOutput.from_orm(node)
+    end = time.time()
+    print("res TIME", end - start)
+    return res
 
 
 @router.delete("/nodes/{name}/")
-def delete_node(
+async def delete_node(
     name: str,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ):
     """
     Delete (aka deactivate) the specified node.
     """
-    deactivate_node(session, name, current_user=current_user)
+    await deactivate_node(session, name, current_user=current_user)
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={"message": f"Node `{name}` has been successfully deleted."},
@@ -310,16 +334,20 @@ def delete_node(
 
 
 @router.delete("/nodes/{name}/hard/", name="Hard Delete a DJ Node")
-def hard_delete(
+async def hard_delete(
     name: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
     This should be used with caution, deactivating a node is preferred.
     """
-    impact = hard_delete_node(name=name, session=session, current_user=current_user)
+    impact = await hard_delete_node(
+        name=name,
+        session=session,
+        current_user=current_user,
+    )
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={
@@ -330,16 +358,16 @@ def hard_delete(
 
 
 @router.post("/nodes/{name}/restore/")
-def restore_node(
+async def restore_node(
     name: str,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ):
     """
     Restore (aka re-activate) the specified node.
     """
-    activate_node(session, name, current_user=current_user)
+    await activate_node(session, name, current_user=current_user)
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={"message": f"Node `{name}` has been successfully restored."},
@@ -347,20 +375,27 @@ def restore_node(
 
 
 @router.get("/nodes/{name}/revisions/", response_model=List[NodeRevisionOutput])
-def list_node_revisions(
-    name: str, *, session: Session = Depends(get_session)
+async def list_node_revisions(
+    name: str, *, session: AsyncSession = Depends(get_session)
 ) -> List[NodeRevisionOutput]:
     """
     List all revisions for the node.
     """
-    node = get_node_by_name(session, name, with_current=False)
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            joinedload(Node.revisions).options(*NodeRevision.default_load_options()),
+        ],
+        raise_if_not_exists=True,
+    )
     return node.revisions  # type: ignore
 
 
 @router.post("/nodes/source/", response_model=NodeOutput, name="Create A Source Node")
-def create_source(
+async def create_source(
     data: CreateSourceNode,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
@@ -371,10 +406,10 @@ def create_source(
     Create a source node. If columns are not provided, the source node's schema
     will be inferred using the configured query service.
     """
-    raise_if_node_exists(session, data.name)
+    await raise_if_node_exists(session, data.name)
 
     # if the node previously existed and now is inactive
-    if recreated_node := _create_node_from_inactive(
+    if recreated_node := await _create_node_from_inactive(
         new_node_type=NodeType.SOURCE,
         data=data,
         session=session,
@@ -385,7 +420,7 @@ def create_source(
         return recreated_node
 
     namespace = get_namespace_from_name(data.name)
-    get_node_namespace(
+    await get_node_namespace(
         session=session,
         namespace=namespace,
     )  # Will return 404 if namespace doesn't exist
@@ -398,14 +433,14 @@ def create_source(
         type=NodeType.SOURCE,
         current_version=0,
     )
-    catalog = get_catalog_by_name(session=session, name=data.catalog)
+    catalog = await get_catalog_by_name(session=session, name=data.catalog)
 
     columns = [
         Column(
             name=column_data.name,
             type=column_data.type,
             dimension=(
-                get_node_by_name(
+                await get_node_by_name(
                     session,
                     name=column_data.dimension,
                     node_type=NodeType.DIMENSION,
@@ -432,7 +467,15 @@ def create_source(
     node.display_name = node_revision.display_name
 
     # Point the node to the new node revision.
-    save_node(session, node_revision, node, data.mode, current_user=current_user)
+    await save_node(session, node_revision, node, data.mode, current_user=current_user)
+    node = await Node.get_by_name(  # type: ignore
+        session,
+        node.name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+    )
     return node
 
 
@@ -454,11 +497,11 @@ def create_source(
     status_code=201,
     name="Create A Metric Node",
 )
-def create_node(
+async def create_node(
     data: CreateNode,
     request: Request,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     background_tasks: BackgroundTasks,
@@ -474,10 +517,10 @@ def create_node(
     if node_type == NodeType.DIMENSION and not data.primary_key:
         raise DJInvalidInputException("Dimension nodes must define a primary key!")
 
-    raise_if_node_exists(session, data.name)
+    await raise_if_node_exists(session, data.name)
 
     # if the node previously existed and now is inactive
-    if recreated_node := _create_node_from_inactive(
+    if recreated_node := await _create_node_from_inactive(
         new_node_type=node_type,
         data=data,
         session=session,
@@ -489,7 +532,7 @@ def create_node(
         return recreated_node  # pragma: no cover
 
     namespace = get_namespace_from_name(data.name)
-    get_node_namespace(
+    await get_node_namespace(
         session=session,
         namespace=namespace,
     )  # Will return 404 if namespace doesn't exist
@@ -501,16 +544,22 @@ def create_node(
         type=NodeType(node_type),
         current_version=0,
     )
-    node_revision = create_node_revision(data, node_type, session)
-    save_node(session, node_revision, node, data.mode, current_user=current_user)
+    node_revision = await create_node_revision(data, node_type, session)
+    await save_node(session, node_revision, node, data.mode, current_user=current_user)
     background_tasks.add_task(
         save_column_level_lineage,
         session=session,
         node_revision=node_revision,
     )
-    session.refresh(node_revision)
-    session.refresh(node)
 
+    node = await Node.get_by_name(  # type: ignore
+        session,
+        node.name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+        ],
+    )
+    node_revision = node.current
     column_names = {col.name for col in node_revision.columns}
     if data.primary_key and any(
         key_column not in column_names for key_column in data.primary_key
@@ -522,15 +571,23 @@ def create_node(
     if data.primary_key:
         for key_column in data.primary_key:
             if key_column in column_names:  # pragma: no cover
-                set_node_column_attributes(
+                await set_node_column_attributes(
                     session,
                     node,
                     key_column,
                     [AttributeTypeIdentifier(name="primary_key", namespace="system")],
                     current_user=current_user,
                 )
-    session.refresh(node)
-    session.refresh(node.current)
+    # await session.refresh(node)
+    # await session.refresh(node.current)
+    node = await Node.get_by_name(  # type: ignore
+        session,
+        node.name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+    )
     return node
 
 
@@ -540,10 +597,10 @@ def create_node(
     status_code=201,
     name="Create A Cube",
 )
-def create_cube(
+async def create_cube(
     data: CreateCubeNode,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
     background_tasks: BackgroundTasks,
@@ -554,10 +611,10 @@ def create_cube(
     """
     Create a cube node.
     """
-    raise_if_node_exists(session, data.name)
+    await raise_if_node_exists(session, data.name)
 
     # if the node previously existed and now is inactive
-    if recreated_node := _create_node_from_inactive(
+    if recreated_node := await _create_node_from_inactive(
         new_node_type=NodeType.CUBE,
         data=data,
         session=session,
@@ -569,7 +626,7 @@ def create_cube(
         return recreated_node  # pragma: no cover
 
     namespace = get_namespace_from_name(data.name)
-    get_node_namespace(
+    await get_node_namespace(
         session=session,
         namespace=namespace,
     )
@@ -581,8 +638,9 @@ def create_cube(
         type=NodeType.CUBE,
         current_version=0,
     )
-    node_revision = create_cube_node_revision(session=session, data=data)
-    save_node(session, node_revision, node, data.mode, current_user=current_user)
+    node_revision = await create_cube_node_revision(session=session, data=data)
+    await save_node(session, node_revision, node, data.mode, current_user=current_user)
+    node = await Node.get_by_name(session, data.name)  # type: ignore
     return node
 
 
@@ -591,11 +649,11 @@ def create_cube(
     response_model=NodeOutput,
     status_code=201,
 )
-def register_table(
+async def register_table(
     catalog: str,
     schema_: str,
     table: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> NodeOutput:
@@ -610,17 +668,17 @@ def register_table(
         )
     namespace = f"{settings.source_node_namespace}.{catalog}.{schema_}"
     name = f"{namespace}.{table}"
-    raise_if_node_exists(session, name)
+    await raise_if_node_exists(session, name)
 
     # Create the namespace if required (idempotent)
-    create_node_namespace(
+    await create_node_namespace(
         namespace=namespace,
         session=session,
         current_user=current_user,
     )
 
     # Use reflection to get column names and types
-    _catalog = get_catalog_by_name(session=session, name=catalog)
+    _catalog = await get_catalog_by_name(session=session, name=catalog)
     columns = query_service_client.get_columns_for_table(
         _catalog.name,
         schema_,
@@ -628,7 +686,7 @@ def register_table(
         _catalog.engines[0] if len(_catalog.engines) >= 1 else None,
     )
 
-    return create_source(
+    return await create_source(
         data=CreateSourceNode(
             catalog=catalog,
             schema_=schema_,
@@ -645,33 +703,43 @@ def register_table(
 
 
 @router.post("/nodes/{name}/columns/{column}/", status_code=201)
-def link_dimension(
+async def link_dimension(
     name: str,
     column: str,
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Add information to a node column
     """
-    node = get_node_by_name(session=session, name=name)
-    dimension_node = get_node_by_name(
-        session=session,
-        name=dimension,
-        node_type=NodeType.DIMENSION,
+    node = await Node.get_by_name(
+        session,
+        name,
+        raise_if_not_exists=True,
     )
-    primary_key_columns = dimension_node.current.primary_key()
+    dimension_node = await Node.get_by_name(
+        session,
+        dimension,
+        raise_if_not_exists=True,
+    )
+    if dimension_node.type != NodeType.DIMENSION:  # type: ignore
+        raise DJException(message=f"Node {node.name} is not of type dimension!")  # type: ignore
+    primary_key_columns = dimension_node.current.primary_key()  # type: ignore
     if len(primary_key_columns) > 1:
         raise DJActionNotAllowedException(  # pragma: no cover
             "Cannot use this endpoint to link a dimension with a compound primary key.",
         )
 
-    target_column = get_column(node.current, column)
+    target_column = await get_column(session, node.current, column)  # type: ignore
     if dimension_column:
         # Check that the dimension column exists
-        column_from_dimension = get_column(dimension_node.current, dimension_column)
+        column_from_dimension = await get_column(
+            session,
+            dimension_node.current,  # type: ignore
+            dimension_column,
+        )
 
         # Check the dimension column's type is compatible with the target column's type
         if not column_from_dimension.type.is_compatible(target_column.type):
@@ -685,13 +753,22 @@ def link_dimension(
     link_input = LinkDimensionInput(
         dimension_node=dimension,
         join_type=JoinType.LEFT,
-        join_on=f"{name}.{column} = {dimension_node.name}.{primary_key_columns[0].name}",
+        join_on=(
+            f"{name}.{column} = "
+            f"{dimension_node.name}.{primary_key_columns[0].name}"  # type: ignore
+        ),
     )
-    activity_type = upsert_complex_dimension_link(
+    activity_type = await upsert_complex_dimension_link(
         session,
         name,
         link_input,
         current_user,
+    )
+
+    node = await Node.get_by_name(
+        session,
+        name,
+        raise_if_not_exists=True,
     )
     return JSONResponse(
         status_code=201,
@@ -710,17 +787,17 @@ def link_dimension(
 
 
 @router.post("/nodes/{node_name}/link/", status_code=201)
-def add_complex_dimension_link(  # pylint: disable=too-many-locals
+async def add_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_input: LinkDimensionInput,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Links a source, dimension, or transform node to a dimension with a custom join query.
     If a link already exists, updates the link definition.
     """
-    activity_type = upsert_complex_dimension_link(
+    activity_type = await upsert_complex_dimension_link(
         session,
         node_name,
         link_input,
@@ -743,95 +820,40 @@ def add_complex_dimension_link(  # pylint: disable=too-many-locals
 
 
 @router.delete("/nodes/{node_name}/link/", status_code=201)
-def remove_complex_dimension_link(  # pylint: disable=too-many-locals
+async def remove_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_identifier: LinkDimensionIdentifier,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Removes a complex dimension link based on the dimension node and its role (if any).
     """
-    return remove_dimension_link(session, node_name, link_identifier, current_user)
+    return await remove_dimension_link(
+        session,
+        node_name,
+        link_identifier,
+        current_user,
+    )
 
 
 @router.delete("/nodes/{name}/columns/{column}/", status_code=201)
-def delete_dimension_link(
+async def delete_dimension_link(
     name: str,
     column: str,  # pylint: disable=unused-argument
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Remove the link between a node column and a dimension node
     """
-    return remove_dimension_link(
+    return await remove_dimension_link(
         session,
         name,
         LinkDimensionIdentifier(dimension_node=dimension, role=None),
         current_user,
-    )
-
-
-@router.post("/nodes/{name}/migrate_dim_link", status_code=201)  # pragma: no cover
-def migrate_dimension_link(  # pragma: no cover
-    name: str,
-    session: Session = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
-) -> JSONResponse:
-    """
-    Migrate dimension link from column-level to node-level
-    """
-    node = get_node_by_name(session=session, name=name)
-    migrated, errors = [], []
-    _logger.info("Migrating dimension links for %s", name)
-    for column in node.current.columns:
-        if column.dimension:
-            try:
-                _logger.info(
-                    "Started migration for column %s, dimension %s",
-                    column.name,
-                    column.dimension.name,
-                )
-                dimension_node = column.dimension
-                primary_key_columns = dimension_node.current.primary_key()
-                link_input = LinkDimensionInput(
-                    dimension_node=dimension_node.name,
-                    join_type=JoinType.LEFT,
-                    join_on=(
-                        f"{name}.{column.name} = "
-                        f"{dimension_node.name}.{primary_key_columns[0].name}"
-                    ),
-                )
-                upsert_complex_dimension_link(
-                    session,
-                    name,
-                    link_input,
-                    current_user,
-                )
-                column.dimension = None  # type: ignore
-                column.dimension_id = None
-                column.dimension_column = None
-                session.add(node)
-                session.commit()
-                session.refresh(node)
-                _logger.info(
-                    "Finished migration for column %s, dimension %s",
-                    column.name,
-                    dimension_node.name,
-                )
-                migrated.append((column.name, dimension_node.name))
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                errors.append((column.name, dimension_node.name, str(e)))
-
-    return JSONResponse(
-        status_code=201,
-        content={
-            "finished": migrated,
-            "errors": errors,
-        },
     )
 
 
@@ -841,28 +863,28 @@ def migrate_dimension_link(  # pragma: no cover
     tags=["tags"],
     name="Update Tags on Node",
 )
-def tags_node(
+async def tags_node(
     name: str,
     tag_names: Optional[List[str]] = Query(default=None),
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Add a tag to a node
     """
-    node = get_node_by_name(session=session, name=name)
+    node = await Node.get_by_name(session=session, name=name, for_update=True)
     if not tag_names:
         tag_names = []  # pragma: no cover
-    tags = get_tags_by_name(session, names=tag_names)
-    node.tags = tags
+    tags = await get_tags_by_name(session, names=tag_names)
+    node.tags = tags  # type: ignore
 
     session.add(node)
     session.add(
         History(
             entity_type=EntityType.NODE,
-            entity_name=node.name,
-            node=node.name,
+            entity_name=node.name,  # type: ignore
+            node=node.name,  # type: ignore
             activity_type=ActivityType.TAG,
             details={
                 "tags": tag_names,
@@ -870,10 +892,10 @@ def tags_node(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
-    session.refresh(node)
+    await session.commit()
+    await session.refresh(node)
     for tag in tags:
-        session.refresh(tag)
+        await session.refresh(tag)
 
     return JSONResponse(
         status_code=200,
@@ -891,18 +913,25 @@ def tags_node(
     response_model=NodeOutput,
     status_code=201,
 )
-def refresh_source_node(
+async def refresh_source_node(
     name: str,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> NodeOutput:
     """
     Refresh a source node with the latest columns from the query service.
     """
-    source_node = get_node_by_name(session, name, node_type=NodeType.SOURCE)
-    current_revision = source_node.current
+    source_node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+    )
+    current_revision = source_node.current  # type: ignore
 
     # Get the latest columns for the source node's table from the query service
     new_columns = []
@@ -930,19 +959,19 @@ def refresh_source_node(
 
         # if the columns haven't changed and the node has a table, we can skip the update
         if not column_changes:
-            if not source_node.missing_table:
-                return source_node
+            if not source_node.missing_table:  # type: ignore
+                return source_node  # type: ignore
             # if the columns haven't changed but the node has a missing table, we should fix it
-            source_node.missing_table = False
+            source_node.missing_table = False  # type: ignore
             refresh_details["missing_table"] = "False"
     else:
         # since we don't see any columns, we'll assume the table is gone
-        source_node.missing_table = True
+        source_node.missing_table = True  # type: ignore
         new_columns = current_revision.columns
         refresh_details["missing_table"] = "True"
 
     # Create a new node revision with the updated columns and bump the version
-    old_version = Version.parse(source_node.current_version)
+    old_version = Version.parse(source_node.current_version)  # type: ignore
     new_revision = NodeRevision(
         name=current_revision.name,
         type=current_revision.type,
@@ -971,7 +1000,7 @@ def refresh_source_node(
     new_revision.copy_dimension_links_from_revision(current_revision)
 
     # Point the source node to the new revision
-    source_node.current_version = new_revision.version
+    source_node.current_version = new_revision.version  # type: ignore
     new_revision.extra_validation()
 
     session.add(new_revision)
@@ -981,24 +1010,33 @@ def refresh_source_node(
     session.add(
         History(
             entity_type=EntityType.NODE,
-            entity_name=source_node.name,
-            node=source_node.name,
+            entity_name=source_node.name,  # type: ignore
+            node=source_node.name,  # type: ignore
             activity_type=ActivityType.REFRESH,
             details=refresh_details,
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
-    session.refresh(source_node.current)
+    await session.commit()
+
+    source_node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+    )
+    await session.refresh(source_node, ["current"])
     return source_node  # type: ignore
 
 
 @router.patch("/nodes/{name}/", response_model=NodeOutput)
-def update_node(
+async def update_node(
     name: str,
     data: UpdateNode,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: Optional[User] = Depends(get_current_user),
     background_tasks: BackgroundTasks,
@@ -1009,7 +1047,7 @@ def update_node(
     """
     Update a node.
     """
-    node = update_any_node(
+    await update_any_node(
         name,
         data,
         session=session,
@@ -1018,19 +1056,37 @@ def update_node(
         background_tasks=background_tasks,
         validate_access=validate_access,
     )
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            joinedload(Node.tags),
+        ],
+    )
     return node  # type: ignore
 
 
 @router.get("/nodes/similarity/{node1_name}/{node2_name}")
-def calculate_node_similarity(
-    node1_name: str, node2_name: str, *, session: Session = Depends(get_session)
+async def calculate_node_similarity(
+    node1_name: str, node2_name: str, *, session: AsyncSession = Depends(get_session)
 ) -> JSONResponse:
     """
     Compare two nodes by how similar their queries are
     """
-    node1 = get_node_by_name(session=session, name=node1_name)
-    node2 = get_node_by_name(session=session, name=node2_name)
-    if NodeType.SOURCE in (node1.type, node2.type):
+    node1 = await Node.get_by_name(
+        session,
+        node1_name,
+        options=[joinedload(Node.current)],
+        raise_if_not_exists=True,
+    )
+    node2 = await Node.get_by_name(
+        session,
+        node2_name,
+        options=[joinedload(Node.current)],
+        raise_if_not_exists=True,
+    )
+    if NodeType.SOURCE in (node1.type, node2.type):  # type: ignore
         raise DJException(
             message="Cannot determine similarity of source nodes",
             http_status_code=HTTPStatus.CONFLICT,
@@ -1046,16 +1102,16 @@ def calculate_node_similarity(
     response_model=List[DAGNodeOutput],
     name="List Downstream Nodes For A Node",
 )
-def list_downstream_nodes(
+async def list_downstream_nodes(
     name: str,
     *,
     node_type: NodeType = None,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> List[DAGNodeOutput]:
     """
     List all nodes that are downstream from the given node, filterable by type.
     """
-    return get_downstream_nodes(session, name, node_type)  # type: ignore
+    return await get_downstream_nodes(session, name, node_type)
 
 
 @router.get(
@@ -1063,46 +1119,52 @@ def list_downstream_nodes(
     response_model=List[DAGNodeOutput],
     name="List Upstream Nodes For A Node",
 )
-def list_upstream_nodes(
+async def list_upstream_nodes(
     name: str,
     *,
     node_type: NodeType = None,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> List[DAGNodeOutput]:
     """
     List all nodes that are upstream from the given node, filterable by type.
     """
-    return get_upstream_nodes(session, name, node_type)
+    return await get_upstream_nodes(session, name, node_type)
 
 
 @router.get(
     "/nodes/{name}/dag/",
     name="List All Connected Nodes (Upstreams + Downstreams)",
 )
-def list_node_dag(
-    name: str, *, session: Session = Depends(get_session)
+async def list_node_dag(
+    name: str, *, session: AsyncSession = Depends(get_session)
 ) -> List[DAGNodeOutput]:
     """
     List all nodes that are part of the DAG of the given node. This means getting all upstreams,
     downstreams, and linked dimension nodes.
     """
-    node = get_node_by_name(session, name, with_current=True)
-    dimension_nodes = (
-        get_dimensions(session, node.current.parents[0], with_attributes=False)
-        + node.current.parents
-        if node.type == NodeType.METRIC
-        else get_dimensions(session, node, with_attributes=False)
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=_node_output_options(),
+        raise_if_not_exists=True,
     )
-    dimension_nodes += [node]
-    downstreams = get_downstream_nodes(
+    dimension_nodes = await get_dimensions(
+        session,
+        node.current.parents[0] if node.type == NodeType.METRIC else node,  # type: ignore
+        with_attributes=False,
+    )
+    if node.type == NodeType.METRIC:  # type: ignore
+        dimension_nodes = dimension_nodes + node.current.parents  # type: ignore
+    dimension_nodes += [node]  # type: ignore
+    downstreams = await get_downstream_nodes(
         session,
         name,
         include_deactivated=False,
         include_cubes=False,
     )
-    upstreams = get_upstream_nodes(session, name, include_deactivated=False)
+    upstreams = await get_upstream_nodes(session, name, include_deactivated=False)
     dag_nodes = set(dimension_nodes + downstreams + upstreams)
-    return [DAGNodeOutput.from_orm(node) for node in dag_nodes]
+    return list(dag_nodes)
 
 
 @router.get(
@@ -1110,14 +1172,24 @@ def list_node_dag(
     response_model=List[DimensionAttributeOutput],
     name="List All Dimension Attributes",
 )
-def list_all_dimension_attributes(
-    name: str, *, session: Session = Depends(get_session)
+async def list_all_dimension_attributes(
+    name: str, *, session: AsyncSession = Depends(get_session)
 ) -> List[DimensionAttributeOutput]:
     """
     List all available dimension attributes for the given node.
     """
-    node = get_node_by_name(session, name)
-    return get_dimensions(session, node, with_attributes=True)
+    node = await (
+        Node.get_by_name(
+            session,
+            name,
+            options=[
+                joinedload(Node.current).options(
+                    joinedload(NodeRevision.parents).options(joinedload(Node.current)),
+                ),
+            ],
+        )
+    )
+    return await get_dimensions(session, node, with_attributes=True)  # type: ignore
 
 
 @router.get(
@@ -1125,16 +1197,31 @@ def list_all_dimension_attributes(
     response_model=List[LineageColumn],
     name="List column level lineage of node",
 )
-def column_lineage(
-    name: str, *, session: Session = Depends(get_session)
+async def column_lineage(
+    name: str, *, session: AsyncSession = Depends(get_session)
 ) -> List[LineageColumn]:
     """
     List column-level lineage of a node in a graph
     """
-    node = get_node_by_name(session, name)
-    if node.current.lineage:
+
+    node = await Node.get_by_name(
+        session,
+        name,
+        options=[
+            selectinload(Node.current).options(
+                selectinload(NodeRevision.columns).options(
+                    selectinload(Column.attributes).joinedload(
+                        ColumnAttribute.attribute_type,
+                    ),
+                    selectinload(Column.dimension),
+                    selectinload(Column.partition),
+                ),
+            ),
+        ],
+    )
+    if node.current.lineage:  # type: ignore
         return node.current.lineage  # type: ignore
-    return get_column_level_lineage(session, node.current)  # pragma: no cover
+    return await get_column_level_lineage(session, node.current)  # type: ignore  # pragma: no cover
 
 
 @router.patch(
@@ -1142,25 +1229,29 @@ def column_lineage(
     response_model=ColumnOutput,
     status_code=201,
 )
-def set_column_display_name(
+async def set_column_display_name(
     node_name: str,
     column_name: str,
     display_name: str,
     current_user: Optional[User] = Depends(get_current_user),
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> ColumnOutput:
     """
     Set column name for the node
     """
-    node = get_node_by_name(session, node_name)
-    column = get_column(node.current, column_name)
+    node = await Node.get_by_name(
+        session,
+        node_name,
+        options=[joinedload(Node.current)],
+    )
+    column = await get_column(session, node.current, column_name)  # type: ignore
     column.display_name = display_name
     session.add(column)
     session.add(
         History(
             entity_type=EntityType.COLUMN_ATTRIBUTE,
-            node=node.name,
+            node=node.name,  # type: ignore
             activity_type=ActivityType.UPDATE,
             details={
                 "column": column.name,
@@ -1169,10 +1260,7 @@ def set_column_display_name(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
-    session.refresh(column)
-    session.refresh(node)
-    session.refresh(node.current)
+    await session.commit()
     return column
 
 
@@ -1182,19 +1270,28 @@ def set_column_display_name(
     status_code=201,
     name="Set Node Column as Partition",
 )
-def set_column_partition(  # pylint: disable=too-many-locals
+async def set_column_partition(  # pylint: disable=too-many-locals
     node_name: str,
     column_name: str,
     input_partition: PartitionInput,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> ColumnOutput:
     """
     Add or update partition columns for the specified node.
     """
-    node = get_node_by_name(session, node_name)
-    column = get_node_column(node, column_name)
+    node = await Node.get_by_name(
+        session,
+        node_name,
+        options=[
+            joinedload(Node.current).options(
+                *NodeRevision.default_load_options(),
+                joinedload(NodeRevision.cube_elements),
+            ),
+        ],
+    )
+    column = get_node_column(node, column_name)  # type: ignore
     upsert_partition_event = History(
         entity_type=EntityType.PARTITION,
         node=node_name,
@@ -1234,8 +1331,8 @@ def set_column_partition(  # pylint: disable=too-many-locals
         session.add(partition)
         session.add(upsert_partition_event)
 
-    session.commit()
-    session.refresh(column)
+    await session.commit()
+    await session.refresh(column)
     return column
 
 
@@ -1244,11 +1341,11 @@ def set_column_partition(  # pylint: disable=too-many-locals
     response_model=DAGNodeOutput,
     name="Copy A Node",
 )
-def copy_node(
+async def copy_node(
     node_name: str,
     *,
     new_name: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> DAGNodeOutput:
     """
@@ -1256,10 +1353,10 @@ def copy_node(
     """
     # Check to make sure that the new node's namespace exists
     new_node_namespace = ".".join(new_name.split(".")[:-1])
-    get_node_namespace(session, new_node_namespace, raise_if_not_exists=True)
+    await get_node_namespace(session, new_node_namespace, raise_if_not_exists=True)
 
     # Check if there is already a node with the new name
-    existing_new_node = get_node_by_name(
+    existing_new_node = await get_node_by_name(
         session,
         new_name,
         raise_if_not_exists=False,
@@ -1267,13 +1364,13 @@ def copy_node(
     )
     if existing_new_node:
         if existing_new_node.deactivated_at:
-            hard_delete_node(new_name, session, current_user)
+            await hard_delete_node(new_name, session, current_user)
         else:
             raise DJInvalidInputException(
                 f"A node with name {new_name} already exists.",
             )
 
     # Copy existing node to the new name
-    existing_node = get_node_by_name(session, node_name)
-    new_node = copy_to_new_node(session, existing_node, new_name, current_user)
-    return new_node
+    await copy_to_new_node(session, node_name, new_name, current_user)
+    new_node = await Node.get_by_name(session, new_name)
+    return new_node  # type: ignore

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -4,7 +4,6 @@ Node related APIs.
 """
 import logging
 import os
-import time
 from http import HTTPStatus
 from typing import List, Optional
 
@@ -297,20 +296,13 @@ async def get_node(
     """
     Show the active version of the specified node.
     """
-    start = time.time()
     node = await Node.get_by_name(
         session,
         name,
         options=NodeOutput.load_options(),
         raise_if_not_exists=True,
     )
-    end = time.time()
-    print("db TIME", end - start)
-    start = end
-    res = NodeOutput.from_orm(node)
-    end = time.time()
-    print("res TIME", end - start)
-    return res
+    return NodeOutput.from_orm(node)
 
 
 @router.delete("/nodes/{name}/")

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -13,7 +13,7 @@ from datajunction_server.database import Node
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJDoesNotExistException, DJException
+from datajunction_server.errors import DJAlreadyExistsException, DJDoesNotExistException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
@@ -57,7 +57,7 @@ async def get_tag_by_name(
         )
     tag = (await session.execute(statement)).scalars().one_or_none()
     if not tag and raise_if_not_exists:
-        raise DJException(  # pragma: no cover
+        raise DJDoesNotExistException(  # pragma: no cover
             message=(f"A tag with name `{name}` does not exist."),
             http_status_code=404,
         )
@@ -100,7 +100,7 @@ async def create_a_tag(
     """
     tag = await get_tag_by_name(session, data.name, raise_if_not_exists=False)
     if tag:
-        raise DJException(
+        raise DJAlreadyExistsException(
             message=f"A tag with name `{data.name}` already exists!",
             http_status_code=500,
         )
@@ -180,7 +180,7 @@ async def list_nodes_for_a_tag(
     )
     tag = (await session.execute(statement)).unique().scalars().one_or_none()
     if not tag:
-        raise DJException(
+        raise DJDoesNotExistException(
             message=f"A tag with name `{name}` does not exist.",
             http_status_code=404,
         )

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -6,8 +6,10 @@ from typing import List, Optional
 
 from fastapi import Depends
 from sqlalchemy import select
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
+from datajunction_server.database import Node
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.user import User
@@ -22,15 +24,15 @@ settings = get_settings()
 router = SecureAPIRouter(tags=["tags"])
 
 
-def get_tags_by_name(
-    session: Session,
+async def get_tags_by_name(
+    session: AsyncSession,
     names: List[str],
 ) -> List[Tag]:
     """
     Retrieves a list of tags by name
     """
     statement = select(Tag).where(Tag.name.in_(names))  # type: ignore  # pylint: disable=no-member
-    tags = session.execute(statement).scalars().all()
+    tags = (await session.execute(statement)).scalars().all()
     difference = set(names) - {tag.name for tag in tags}
     if difference:
         raise DJDoesNotExistException(
@@ -39,8 +41,8 @@ def get_tags_by_name(
     return tags
 
 
-def get_tag_by_name(
-    session: Session,
+async def get_tag_by_name(
+    session: AsyncSession,
     name: str,
     raise_if_not_exists: bool = False,
     for_update: bool = False,
@@ -53,7 +55,7 @@ def get_tag_by_name(
         statement = statement.with_for_update().execution_options(
             populate_existing=True,
         )
-    tag = session.execute(statement).scalars().one_or_none()
+    tag = (await session.execute(statement)).scalars().one_or_none()
     if not tag and raise_if_not_exists:
         raise DJException(  # pragma: no cover
             message=(f"A tag with name `{name}` does not exist."),
@@ -63,8 +65,8 @@ def get_tag_by_name(
 
 
 @router.get("/tags/", response_model=List[TagOutput])
-def list_tags(
-    tag_type: Optional[str] = None, *, session: Session = Depends(get_session)
+async def list_tags(
+    tag_type: Optional[str] = None, *, session: AsyncSession = Depends(get_session)
 ) -> List[TagOutput]:
     """
     List all available tags.
@@ -72,28 +74,31 @@ def list_tags(
     statement = select(Tag)
     if tag_type:
         statement = statement.where(Tag.tag_type == tag_type)
-    return session.execute(statement).scalars().all()
+    result = await session.execute(statement)
+    return result.scalars().all()
 
 
 @router.get("/tags/{name}/", response_model=TagOutput)
-def get_a_tag(name: str, *, session: Session = Depends(get_session)) -> TagOutput:
+async def get_a_tag(
+    name: str, *, session: AsyncSession = Depends(get_session)
+) -> TagOutput:
     """
     Return a tag by name.
     """
-    tag = get_tag_by_name(session, name, raise_if_not_exists=True)
+    tag = await get_tag_by_name(session, name, raise_if_not_exists=True)
     return tag
 
 
 @router.post("/tags/", response_model=TagOutput, status_code=201)
-def create_a_tag(
+async def create_a_tag(
     data: CreateTag,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> TagOutput:
     """
     Create a tag.
     """
-    tag = get_tag_by_name(session, data.name, raise_if_not_exists=False)
+    tag = await get_tag_by_name(session, data.name, raise_if_not_exists=False)
     if tag:
         raise DJException(
             message=f"A tag with name `{data.name}` already exists!",
@@ -115,22 +120,27 @@ def create_a_tag(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
-    session.refresh(tag)
+    await session.commit()
+    await session.refresh(tag)
     return tag
 
 
 @router.patch("/tags/{name}/", response_model=TagOutput)
-def update_a_tag(
+async def update_a_tag(
     name: str,
     data: UpdateTag,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
     current_user: Optional[User] = Depends(get_current_user),
 ) -> TagOutput:
     """
     Update a tag.
     """
-    tag = get_tag_by_name(session, name, raise_if_not_exists=True, for_update=True)
+    tag = await get_tag_by_name(
+        session,
+        name,
+        raise_if_not_exists=True,
+        for_update=True,
+    )
 
     if data.description:
         tag.description = data.description
@@ -148,23 +158,27 @@ def update_a_tag(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
-    session.refresh(tag)
+    await session.commit()
+    await session.refresh(tag)
     return tag
 
 
 @router.get("/tags/{name}/nodes/", response_model=List[NodeMinimumDetail])
-def list_nodes_for_a_tag(
+async def list_nodes_for_a_tag(
     name: str,
     node_type: Optional[NodeType] = None,
     *,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_session),
 ) -> List[NodeMinimumDetail]:
     """
     Find nodes tagged with the tag, filterable by node type.
     """
-    statement = select(Tag).where(Tag.name == name).options(joinedload(Tag.nodes))
-    tag = session.execute(statement).unique().scalars().one_or_none()
+    statement = (
+        select(Tag)
+        .where(Tag.name == name)
+        .options(joinedload(Tag.nodes).options(joinedload(Node.current)))
+    )
+    tag = (await session.execute(statement)).unique().scalars().one_or_none()
     if not tag:
         raise DJException(
             message=f"A tag with name `{name}` does not exist.",

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -96,6 +96,8 @@ class Settings(
     db_max_overflow = 20
     db_pool_timeout = 10
     db_connect_timeout = 5
+    db_pool_pre_ping = True
+    db_echo = False
 
     @property
     def celery(self) -> Celery:

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -8,7 +8,8 @@ import time
 # pylint: disable=too-many-lines,protected-access
 from typing import DefaultDict, Deque, Dict, List, Optional, Set, Tuple, Union, cast
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from datajunction_server.construction.utils import to_namespaced_name
 from datajunction_server.database.column import Column
@@ -53,7 +54,8 @@ def _get_tables_from_select(
     return tables
 
 
-def _join_path(
+async def _join_path(
+    session: AsyncSession,
     dimension_node: NodeRevision,
     initial_nodes: Set[NodeRevision],
 ) -> Tuple[NodeRevision, Dict[Tuple[NodeRevision, NodeRevision], List[Column]]]:
@@ -102,13 +104,14 @@ def _join_path(
                 possible_join_paths.append(full_join_path)  # type: ignore
             if joinable_dim not in processed:  # pragma: no cover
                 to_process.append(full_join_path)
+                await session.refresh(joinable_dim, ["parents"])
                 for parent in joinable_dim.parents:
                     to_process.append((parent.current, next_join_path))
     return min(possible_join_paths, key=len)  # type: ignore
 
 
-def _get_or_build_join_table(
-    session: Session,
+async def _get_or_build_join_table(
+    session: AsyncSession,
     table_node: NodeRevision,
     build_criteria: Optional[BuildCriteria],
 ):
@@ -117,13 +120,15 @@ def _get_or_build_join_table(
     to build it from the dimension node's query if not
     """
     table_node_alias = amenable_name(table_node.name)
+    await session.refresh(table_node, ["availability"])
+    await session.refresh(table_node, ["columns"])
     join_table = cast(
         Optional[ast.TableExpression],
         _get_node_table(table_node, build_criteria),
     )
     if not join_table:  # pragma: no cover
         join_query = parse(cast(str, table_node.query))
-        join_table = build_ast(session, join_query)  # type: ignore
+        join_table = await build_ast(session, join_query)  # type: ignore
         join_table.parenthesized = True  # type: ignore
 
     join_table = cast(ast.TableExpression, join_table)  # type: ignore
@@ -133,13 +138,13 @@ def _get_or_build_join_table(
         child=join_table,
         as_=True,
     )
-    join_table.compile(CompileContext(session, DJException()))
+    await join_table.compile(CompileContext(session, DJException()))
     join_table.set_alias(right_alias)  # type: ignore
     return join_right
 
 
-def _build_joins_for_dimension_link(
-    session: Session,
+async def _build_joins_for_dimension_link(
+    session: AsyncSession,
     initial_nodes: Set[NodeRevision],
     tables: DefaultDict[NodeRevision, List[ast.Table]],
     build_criteria: Optional[BuildCriteria],
@@ -152,7 +157,7 @@ def _build_joins_for_dimension_link(
     """
     join_asts = []
     for link in join_path:
-        join_query = build_ast(session, link.join_sql_ast())
+        join_query = await build_ast(session, link.join_sql_ast())
         join = join_query.select.from_.relations[-1].extensions[0]  # type: ignore
 
         # Assemble table on left of join
@@ -162,10 +167,10 @@ def _build_joins_for_dimension_link(
             else tables[link.node_revision][0]
         )
         for dim_col in required_dimension_columns:
-            left_table.add_ref_column(dim_col)
+            await left_table.add_ref_column(dim_col)
 
         # Assemble table on right of join
-        join_right = _get_or_build_join_table(
+        join_right = await _get_or_build_join_table(
             session,
             link.dimension.current,  # if isinstance(dim_node, NodeRevision) else dim_node.current,
             build_criteria,
@@ -196,7 +201,7 @@ def _build_joins_for_dimension_link(
         # Replace the join right query
         join.right = join_right.child  # type: ignore
         for dim_col in required_dimension_columns:
-            join_right.child.add_ref_column(dim_col)
+            await join_right.child.add_ref_column(dim_col)
         join_asts.append(
             ast.Join(
                 str(link.join_type).upper(),
@@ -207,8 +212,8 @@ def _build_joins_for_dimension_link(
     return join_asts
 
 
-def _build_joins_for_dimension(
-    session: Session,
+async def _build_joins_for_dimension(
+    session: AsyncSession,
     dim_node: NodeRevision,
     initial_nodes: Set[NodeRevision],
     tables: DefaultDict[NodeRevision, List[ast.Table]],
@@ -219,7 +224,7 @@ def _build_joins_for_dimension(
     Returns the join ASTs needed to bring in the dimension node from
     the set of initial nodes.
     """
-    _, paths = _join_path(dim_node, initial_nodes)
+    _, paths = await _join_path(session, dim_node, initial_nodes)
     asts = []
     for connecting_nodes, join_columns in paths.items():
         start_node, table_node = connecting_nodes  # type: ignore
@@ -236,7 +241,7 @@ def _build_joins_for_dimension(
         }
 
         # Assemble table on right of join
-        join_right = _get_or_build_join_table(
+        join_right = await _get_or_build_join_table(
             session,
             table_node,
             build_criteria,
@@ -276,7 +281,7 @@ def _build_joins_for_dimension(
                 join_col.dimension_column in join_right_columns
                 or join_table_pk[0].name in join_right_columns
             ):
-                left_table.add_ref_column(
+                await left_table.add_ref_column(
                     cast(ast.Column, join_left_columns[join_col.name]),
                 )
                 join_on.append(
@@ -294,7 +299,7 @@ def _build_joins_for_dimension(
                     f"does not exist on {table_node.name}",
                 )
             for dim_col in required_dimension_columns:
-                join_right.child.add_ref_column(dim_col)
+                await join_right.child.add_ref_column(dim_col)
 
         if join_on:  # pragma: no cover
             asts.append(
@@ -309,8 +314,8 @@ def _build_joins_for_dimension(
     return asts
 
 
-def join_tables_for_dimensions(
-    session: Session,
+async def join_tables_for_dimensions(
+    session: AsyncSession,
     dimension_nodes_to_columns: Dict[NodeRevision, List[ast.Column]],
     tables: DefaultDict[NodeRevision, List[ast.Table]],
     build_criteria: Optional[BuildCriteria] = None,
@@ -350,7 +355,7 @@ def join_tables_for_dimensions(
             join_asts = []
             if dim_node not in initial_nodes:  # need to join dimension
                 if join_path:
-                    join_asts = _build_joins_for_dimension_link(
+                    join_asts = await _build_joins_for_dimension_link(
                         session,
                         initial_nodes,
                         tables,
@@ -359,7 +364,7 @@ def join_tables_for_dimensions(
                         join_path,
                     )
                 else:
-                    join_asts = _build_joins_for_dimension(
+                    join_asts = await _build_joins_for_dimension(
                         session,
                         dim_node,
                         initial_nodes,
@@ -374,8 +379,8 @@ def join_tables_for_dimensions(
                     )
 
 
-def _build_tables_on_select(
-    session: Session,
+async def _build_tables_on_select(
+    session: AsyncSession,
     select: ast.SelectExpression,
     tables: Dict[NodeRevision, List[ast.Table]],
     memoized_queries: Dict[int, ast.Query],
@@ -392,13 +397,25 @@ def _build_tables_on_select(
             Optional[ast.Table],
             _get_node_table(node, build_criteria),
         )  # got a materialization
-        fk_column_mapping = {
-            ",".join(
-                sorted([pk.name for pk in col.dimension.current.primary_key()]),
-            ): col
-            for col in node.columns
-            if col.dimension
-        }
+        fk_column_mapping = {}
+        for col in node.columns:
+            if col.dimension_id:
+                col_dimension = await Node.get_by_id(
+                    session,
+                    col.dimension_id,
+                    joinedload(Node.current).options(
+                        *NodeRevision.default_load_options()
+                    ),
+                )
+                fk_column_mapping[
+                    ",".join(
+                        sorted(
+                            [
+                                pk.name for pk in col_dimension.current.primary_key()  # type: ignore  # pylint: disable=line-too-long
+                            ],
+                        ),
+                    )
+                ] = col
 
         if node_table is None:  # no materialization - recurse to node first
             node_query = parse(cast(str, node.query))
@@ -440,7 +457,7 @@ def _build_tables_on_select(
                     if filter_asts:
                         node_query.select.where = ast.BinaryOp.And(*filter_asts)
 
-                query_ast = build_ast(  # type: ignore
+                query_ast = await build_ast(  # type: ignore
                     session,
                     node_query,
                     memoized_queries,
@@ -453,7 +470,7 @@ def _build_tables_on_select(
                 node_table.parenthesized = True  # type: ignore
                 memoized_queries[hash(node_query)] = query_ast
 
-        alias = amenable_name(node.node.name)
+        alias = amenable_name(node.name)
         context = CompileContext(session=session, exception=DJException())
 
         node_ast = ast.Alias(ast.Name(alias), child=node_table, as_=True)  # type: ignore
@@ -464,7 +481,7 @@ def _build_tables_on_select(
                     for col in node_ast.child.projection
                     if col in set(tbl.child.select.projection)
                 ]
-            node_ast.compile(context)
+            await node_ast.compile(context)
             select.replace(
                 tbl,
                 node_ast,
@@ -475,7 +492,7 @@ def _build_tables_on_select(
                 col._table
                 and isinstance(col._table, ast.Table)
                 and col._table.dj_node
-                and col._table.dj_node.name == node.node.name
+                and col._table.dj_node.name == node.name
             ):
                 col._table = node_ast
 
@@ -500,8 +517,8 @@ def dimension_columns_mapping(
 
 
 # flake8: noqa: C901
-def _build_select_ast(
-    session: Session,
+async def _build_select_ast(
+    session: AsyncSession,
     select: ast.SelectExpression,
     memoized_queries: Dict[int, ast.Query],
     build_criteria: Optional[BuildCriteria] = None,
@@ -517,13 +534,13 @@ def _build_select_ast(
     """
     tables = _get_tables_from_select(select)
     dimension_columns = dimension_columns_mapping(select)
-    join_tables_for_dimensions(
+    await join_tables_for_dimensions(
         session,
         dimension_columns,
         tables,
         build_criteria,
     )
-    _build_tables_on_select(
+    await _build_tables_on_select(
         session,
         select,
         tables,
@@ -592,8 +609,8 @@ def rename_dimension_primary_keys_to_foreign_keys(
 
 
 # pylint: disable=R0915
-def add_filters_dimensions_orderby_limit_to_query_ast(
-    session: Session,
+async def add_filters_dimensions_orderby_limit_to_query_ast(
+    session: AsyncSession,
     node: NodeRevision,
     query: ast.Query,
     dialect: Optional[str] = None,  # pylint: disable=unused-argument
@@ -631,11 +648,13 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 projection_addition[col.identifier(False)] = col
 
                 if access_control:
-                    dj_node = access_control.add_request_by_node_name(
+                    dj_node = await access_control.add_request_by_node_name(
                         session,
                         col,
                     )
                     if dj_node:
+                        await session.refresh(node, ["columns"])
+                        await session.refresh(node, ["dimension_links"])
                         rename_dimension_primary_keys_to_foreign_keys(
                             dj_node,
                             node,
@@ -663,7 +682,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
                 if not dimensions:
                     projection_addition[col.identifier(False)] = col
                 if access_control:
-                    dj_node = access_control.add_request_by_node_name(
+                    dj_node = await access_control.add_request_by_node_name(
                         session,
                         col,
                     )
@@ -691,7 +710,7 @@ def add_filters_dimensions_orderby_limit_to_query_ast(
             )
             for col in temp_query.find_all(ast.Column):
                 if access_control:  # pragma: no cover
-                    access_control.add_request_by_node_name(
+                    await access_control.add_request_by_node_name(
                         session,
                         col,
                     )
@@ -781,8 +800,8 @@ def _get_node_table(
     return table
 
 
-def build_node(  # pylint: disable=too-many-arguments
-    session: Session,
+async def build_node(  # pylint: disable=too-many-arguments
+    session: AsyncSession,
     node: NodeRevision,
     filters: Optional[List[str]] = None,
     dimensions: Optional[List[str]] = None,
@@ -816,12 +835,16 @@ def build_node(  # pylint: disable=too-many-arguments
     # get dimension columns which are required
     # in the stated bound dimensions on the metric node
     dimensions = dimensions or []
+    await session.refresh(node, ["required_dimensions"])
+    await session.refresh(node, ["node"])
     dimensions = [
         col.name for col in node.required_dimensions if col.name not in dimensions
     ] + dimensions
 
     # if no dimensions need to be added then we can see if the node is directly materialized
     if not (filters or dimensions):
+        await session.refresh(node, ["availability"])
+        await session.refresh(node, ["columns"])
         if select := cast(
             ast.Select,
             _get_node_table(node, build_criteria, as_select=True),
@@ -844,7 +867,7 @@ def build_node(  # pylint: disable=too-many-arguments
     else:
         query = build_source_node_query(node)
 
-    add_filters_dimensions_orderby_limit_to_query_ast(
+    await add_filters_dimensions_orderby_limit_to_query_ast(
         session,
         node,
         query,
@@ -863,7 +886,7 @@ def build_node(  # pylint: disable=too-many-arguments
 
     memoized_queries: Dict[int, ast.Query] = {}
     _logger.info("Calling build_ast on %s", node.name)
-    built_ast = build_ast(
+    built_ast = await build_ast(
         session,
         query,
         memoized_queries,
@@ -961,8 +984,8 @@ def group_metrics_by_parent(
     return common_parents
 
 
-def validate_shared_dimensions(
-    session: Session,
+async def validate_shared_dimensions(
+    session: AsyncSession,
     metric_nodes: List[Node],
     dimensions: List[str],
     filters: List[str],
@@ -971,7 +994,7 @@ def validate_shared_dimensions(
     Determine if dimensions are shared.
     """
     shared_dimensions = [
-        dim.name for dim in get_shared_dimensions(session, metric_nodes)
+        dim.name for dim in await get_shared_dimensions(session, metric_nodes)
     ]
     for dimension_attribute in dimensions:
         if dimension_attribute not in shared_dimensions:
@@ -1001,8 +1024,8 @@ def validate_shared_dimensions(
                 )
 
 
-def build_metric_nodes(
-    session: Session,
+async def build_metric_nodes(
+    session: AsyncSession,
     metric_nodes: List[Node],
     filters: List[str],
     dimensions: List[str],
@@ -1029,7 +1052,7 @@ def build_metric_nodes(
             "of them aren't metric nodes.",
         )
 
-    validate_shared_dimensions(session, metric_nodes, dimensions, filters)
+    await validate_shared_dimensions(session, metric_nodes, dimensions, filters)
 
     combined_ast: ast.Query = ast.Query(
         select=ast.Select(from_=ast.From(relations=[])),
@@ -1054,7 +1077,7 @@ def build_metric_nodes(
     common_parents = group_metrics_by_parent(metric_nodes)
 
     for parent_node, metrics in common_parents.items():
-        parent_ast = build_node(
+        parent_ast = await build_node(
             session=session,
             node=parent_node.current,
             dimensions=dimensions,
@@ -1099,7 +1122,7 @@ def build_metric_nodes(
             expr.set_alias(
                 ast.Name(amenable_name(expr.alias_or_name.identifier(False))),  # type: ignore
             )
-        parent_ast.compile(context)
+        await parent_ast.compile(context)
 
         # Add the metric expression into the parent node query
         for metric_node in metrics:
@@ -1109,8 +1132,8 @@ def build_metric_nodes(
                     metric_node.name,
                 ),
             )
-            metric_query.compile(context)
-            metric_query.build(session, {})
+            await metric_query.compile(context)
+            await metric_query.build(session, {})
             parent_ast.select.projection.extend(metric_query.select.projection)
 
         # Add the WITH statements to the combined query
@@ -1361,8 +1384,8 @@ def build_source_node_query(node: NodeRevision):
     return ast.Query(select=select)
 
 
-def build_ast(  # pylint: disable=too-many-arguments
-    session: Session,
+async def build_ast(  # pylint: disable=too-many-arguments
+    session: AsyncSession,
     query: ast.Query,
     memoized_queries: Dict[int, ast.Query] = None,
     build_criteria: Optional[BuildCriteria] = None,
@@ -1380,13 +1403,13 @@ def build_ast(  # pylint: disable=too-many-arguments
     if hash(query) in memoized_queries:
         query = memoized_queries[hash(query)]  # pragma: no cover
     else:
-        query.compile(context)
+        await query.compile(context)
         memoized_queries[hash(query)] = query
     end = time.time()
     _logger.info("Finished compiling query %s in %s", str(query)[-100:], end - start)
 
     start = time.time()
-    query.build(
+    await query.build(
         session,
         memoized_queries,
         build_criteria,
@@ -1399,8 +1422,8 @@ def build_ast(  # pylint: disable=too-many-arguments
     return query
 
 
-def metrics_to_measures(
-    session: Session,
+async def metrics_to_measures(
+    session: AsyncSession,
     metric_nodes: List[Node],
 ) -> Tuple[DefaultDict[str, Set[str]], DefaultDict[str, Set[str]]]:
     """
@@ -1417,7 +1440,7 @@ def metrics_to_measures(
     parents_to_measures = collections.defaultdict(set)
     for metric_node in metric_nodes:
         metric_ast = parse(metric_node.current.query)
-        metric_ast.compile(ctx)
+        await metric_ast.compile(ctx)
         for col in metric_ast.find_all(ast.Column):
             if col.table:  # pragma: no cover
                 parents_to_measures[col.table.dj_node.name].add(  # type: ignore
@@ -1429,8 +1452,8 @@ def metrics_to_measures(
     return parents_to_measures, metric_to_measures
 
 
-def get_measures_query(
-    session: Session,
+async def get_measures_query(
+    session: AsyncSession,
     metrics: List[str],
     dimensions: List[str],
     filters: List[str],
@@ -1451,7 +1474,7 @@ def get_measures_query(
     )
 
     engine = (
-        get_engine(session, engine_name, engine_version)
+        await get_engine(session, engine_name, engine_version)
         if engine_name and engine_version
         else None
     )
@@ -1474,7 +1497,7 @@ def get_measures_query(
     if not filters:
         filters = []
 
-    (_, metric_nodes, _, _, _) = validate_cube(
+    (_, metric_nodes, _, _, _) = await validate_cube(
         session,
         metrics,
         dimensions,
@@ -1483,7 +1506,7 @@ def get_measures_query(
     common_parents = group_metrics_by_parent(metric_nodes)
 
     # Mapping between each metric node and its measures
-    parents_to_measures, _ = metrics_to_measures(
+    parents_to_measures, _ = await metrics_to_measures(
         session,
         metric_nodes,
     )
@@ -1492,7 +1515,7 @@ def get_measures_query(
     dimensions_without_roles = [matcher.findall(dim)[0][0] for dim in dimensions]
     for parent_node, _ in common_parents.items():  # type: ignore
         measure_columns, dimensional_columns = [], []
-        parent_ast = build_node(
+        parent_ast = await build_node(
             session=session,
             node=parent_node.current,
             dimensions=dimensions,
@@ -1515,6 +1538,7 @@ def get_measures_query(
             or from_amenable_name(expr.alias_or_name.identifier(False))  # type: ignore
             in dimensions_without_roles
         ]
+        await session.refresh(parent_node.current, ["columns"])
         parent_ast = rename_columns(parent_ast, parent_node.current)
 
         # Sort the selected columns into dimension vs measure columns and
@@ -1527,7 +1551,7 @@ def get_measures_query(
             else:
                 measure_columns.append(expr)
                 expr.set_semantic_type(SemanticType.MEASURE)  # type: ignore
-        parent_ast.compile(context)
+        await parent_ast.compile(context)
 
         # Add the WITH statements to the combined query
         parent_ast_alias = ast.Name(amenable_name(parent_node.name))
@@ -1642,7 +1666,7 @@ def get_measures_query(
             cast(ast.Column, col),
         )
         columns_metadata.append(metadata)
-    dependencies, _ = combined_ast.extract_dependencies(
+    dependencies, _ = await combined_ast.extract_dependencies(
         CompileContext(session, DJException()),
     )
     return TranslatedSQL(

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -1503,22 +1503,33 @@ async def get_measures_query(
     if not filters:
         filters = []
 
+    start = time.time()
     (_, metric_nodes, _, _, _) = await validate_cube(
         session,
         metrics,
         dimensions,
     )
+    print("validate_cube", time.time() - start)
+    start = time.time()
     context = CompileContext(session=session, exception=DJException())
     common_parents = group_metrics_by_parent(metric_nodes)
 
+    print("group_metrics_by_parent", time.time() - start)
+    start = time.time()
     # Mapping between each metric node and its measures
     parents_to_measures, _ = await metrics_to_measures(
         session,
         metric_nodes,
     )
+
+    print("parents_to_measures", time.time() - start)
+    start = time.time()
     column_name_regex = r"([A-Za-z0-9_\.]+)(\[[A-Za-z0-9_]+\])?"
     matcher = re.compile(column_name_regex)
     dimensions_without_roles = [matcher.findall(dim)[0][0] for dim in dimensions]
+
+    print("dimensions_without_roles", time.time() - start)
+    start = time.time()
     for parent_node, _ in common_parents.items():  # type: ignore
         measure_columns, dimensional_columns = [], []
         parent_ast = await build_node(
@@ -1531,6 +1542,8 @@ async def get_measures_query(
             access_control=access_control,
         )
 
+        print("await build_node", parent_node.name, time.time() - start)
+        start = time.time()
         # Select only columns that were one of the necessary measures
         parent_ast.select.projection = [
             expr

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -3,7 +3,7 @@ Dimensions-related query building
 """
 from typing import List, Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build import get_measures_query
@@ -20,8 +20,8 @@ from datajunction_server.sql.parsing.types import IntegerType
 from datajunction_server.utils import SEPARATOR
 
 
-def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-many-locals
-    session: Session,
+async def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-many-locals
+    session: AsyncSession,
     cube: NodeRevision,
     dimensions: List[str],
     filters: Optional[str] = None,
@@ -34,6 +34,7 @@ def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-
     The filters provided here are additional filters layered on top of any existing cube filters.
     Setting `include_counts` to true will also provide associated counts for each dimension value.
     """
+    # await session.refresh(cube, ["columns"])
     unavailable_dimensions = set(dimensions) - set(cube.cube_dimensions())
     if unavailable_dimensions:
         raise DJInvalidInputException(
@@ -76,8 +77,14 @@ def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-
     # Build the FROM clause. The source table on the FROM clause depends on whether
     # the cube is available as a materialized datasource or if it needs to be built up
     # from the measures query.
+    # await session.refresh(cube, ["availability"])
+    # await session.refresh(cube, ["cube_elements"])
+    # for elem in cube.cube_elements:
+    #     await session.refresh(elem, ["node_revisions"])
+    #     for rev in elem.node_revisions:
+    #         await session.refresh(rev, ["node"])
     if cube.availability:
-        catalog = get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
+        catalog = await get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
         query_ast.select.from_.relations.append(  # type: ignore
             ast.Relation(primary=ast.Table(ast.Name(cube.availability.table))),  # type: ignore
         )
@@ -93,7 +100,7 @@ def build_dimensions_from_cube_query(  # pylint: disable=too-many-arguments,too-
             query_ast.select.where = temp_filters_select.select.where
     else:
         catalog = cube.catalog
-        measures_query = get_measures_query(
+        measures_query = await get_measures_query(
             session=session,
             metrics=[metric.name for metric in cube.cube_metrics()],
             dimensions=dimensions,

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -34,7 +34,6 @@ async def build_dimensions_from_cube_query(  # pylint: disable=too-many-argument
     The filters provided here are additional filters layered on top of any existing cube filters.
     Setting `include_counts` to true will also provide associated counts for each dimension value.
     """
-    # await session.refresh(cube, ["columns"])
     unavailable_dimensions = set(dimensions) - set(cube.cube_dimensions())
     if unavailable_dimensions:
         raise DJInvalidInputException(
@@ -77,12 +76,6 @@ async def build_dimensions_from_cube_query(  # pylint: disable=too-many-argument
     # Build the FROM clause. The source table on the FROM clause depends on whether
     # the cube is available as a materialized datasource or if it needs to be built up
     # from the measures query.
-    # await session.refresh(cube, ["availability"])
-    # await session.refresh(cube, ["cube_elements"])
-    # for elem in cube.cube_elements:
-    #     await session.refresh(elem, ["node_revisions"])
-    #     for rev in elem.node_revisions:
-    #         await session.refresh(rev, ["node"])
     if cube.availability:
         catalog = await get_catalog_by_name(session, cube.availability.catalog)  # type: ignore
         query_ast.select.from_.relations.append(  # type: ignore
@@ -130,5 +123,5 @@ async def build_dimensions_from_cube_query(  # pylint: disable=too-many-argument
             else ColumnMetadata(name="count", type=str(IntegerType()))
             for col in query_ast.select.projection
         ],
-        dialect=catalog.engines[0].dialect,
+        dialect=catalog.engines[0].dialect if catalog else None,
     )

--- a/datajunction-server/datajunction_server/construction/dj_query.py
+++ b/datajunction-server/datajunction_server/construction/dj_query.py
@@ -141,8 +141,8 @@ async def resolve_metric_queries(  # pylint: disable=R0914,R0912,R0915
             )
             built.parenthesized = True
             built.compile(ctx)
-            for built_col in built.columns:
-                built_col.alias_or_name.namespace = None
+            for built_col in built.columns:  # pragma: no cover
+                built_col.alias_or_name.namespace = None  # pragma: no cover
             for _, cur_col in curr_cols:
                 name = amenable_name(cur_col.identifier(False))
                 ref_type = [

--- a/datajunction-server/datajunction_server/database/attributetype.py
+++ b/datajunction-server/datajunction_server/database/attributetype.py
@@ -2,10 +2,12 @@
 from typing import TYPE_CHECKING, List, Optional
 
 import sqlalchemy as sa
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import UniqueConstraint, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
+from datajunction_server.models.attribute import MutableAttributeTypeFields
 
 if TYPE_CHECKING:
     from datajunction_server.database.column import Column
@@ -32,6 +34,51 @@ class AttributeType(Base):  # pylint: disable=too-few-public-methods
     def __hash__(self):
         return hash(self.id)
 
+    @classmethod
+    async def get_all(cls, session: AsyncSession):
+        """
+        Get all AttributeTypes.
+        """
+        stmt = select(cls)
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    @classmethod
+    async def get_by_name(
+        cls,
+        session: AsyncSession,
+        name: str,
+    ) -> Optional["AttributeType"]:
+        """
+        Get an AttributeType by name.
+        """
+        stmt = select(cls).where(cls.name == name)
+        result = await session.execute(stmt)
+        return result.unique().one_or_none()
+
+    @classmethod
+    async def create(
+        cls,
+        session: AsyncSession,
+        new_obj: MutableAttributeTypeFields,
+    ) -> Optional["AttributeType"]:
+        """
+        Get an AttributeType by name.
+        """
+        attribute_type = AttributeType(
+            namespace=new_obj.namespace,
+            name=new_obj.name,
+            description=new_obj.description,
+            allowed_node_types=new_obj.allowed_node_types,
+            uniqueness_scope=new_obj.uniqueness_scope
+            if new_obj.uniqueness_scope
+            else [],
+        )
+        session.add(attribute_type)
+        await session.commit()
+        await session.refresh(attribute_type)
+        return attribute_type
+
 
 class ColumnAttribute(
     Base,
@@ -56,6 +103,7 @@ class ColumnAttribute(
     )
     attribute_type: Mapped[AttributeType] = relationship(
         foreign_keys=[attribute_type_id],
+        lazy="joined",
     )
 
     column_id: Mapped[Optional[int]] = mapped_column(

--- a/datajunction-server/datajunction_server/database/catalog.py
+++ b/datajunction-server/datajunction_server/database/catalog.py
@@ -33,6 +33,7 @@ class Catalog(Base):
         secondary="catalogengines",
         primaryjoin="Catalog.id==CatalogEngines.catalog_id",
         secondaryjoin="Engine.id==CatalogEngines.engine_id",
+        lazy="selectin",
     )
     node_revisions: Mapped[List["NodeRevision"]] = relationship(
         back_populates="catalog",

--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -49,7 +49,7 @@ class Column(Base):  # type: ignore
     node_revisions: Mapped[List["NodeRevision"]] = relationship(
         back_populates="columns",
         secondary="nodecolumns",
-        lazy="select",
+        lazy="selectin",
     )
     attributes: Mapped[List["ColumnAttribute"]] = relationship(
         back_populates="column",

--- a/datajunction-server/datajunction_server/database/dimensionlink.py
+++ b/datajunction-server/datajunction_server/database/dimensionlink.py
@@ -55,6 +55,7 @@ class DimensionLink(Base):  # pylint: disable=too-few-public-methods
     dimension: Mapped[Node] = relationship(
         "Node",
         foreign_keys=[dimension_id],
+        lazy="joined",
     )
 
     # SQL used to join the two nodes

--- a/datajunction-server/datajunction_server/database/materialization.py
+++ b/datajunction-server/datajunction_server/database/materialization.py
@@ -82,4 +82,5 @@ class Materialization(Base):  # pylint: disable=too-few-public-methods
         back_populates="materialization",
         primaryjoin="Materialization.id==Backfill.materialization_id",
         cascade="all, delete",
+        lazy="selectin",
     )

--- a/datajunction-server/datajunction_server/database/namespace.py
+++ b/datajunction-server/datajunction_server/database/namespace.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql.operators import is_, or_
 
 from datajunction_server.database.base import Base
 from datajunction_server.database.node import Node, NodeRevision
-from datajunction_server.errors import DJException
+from datajunction_server.errors import DJDoesNotExistException
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.typing import UTCDatetime
@@ -70,7 +70,7 @@ class NodeNamespace(Base):  # pylint: disable=too-few-public-methods
         node_namespace = results.scalar_one_or_none()
         if raise_if_not_exists:  # pragma: no cover
             if not node_namespace:
-                raise DJException(
+                raise DJDoesNotExistException(
                     message=(f"node namespace `{namespace}` does not exist."),
                     http_status_code=404,
                 )

--- a/datajunction-server/datajunction_server/database/namespace.py
+++ b/datajunction-server/datajunction_server/database/namespace.py
@@ -1,8 +1,16 @@
 """Namespace database schema."""
-from sqlalchemy import DateTime
+from typing import List, Optional
+
+from sqlalchemy import DateTime, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql.operators import is_, or_
 
 from datajunction_server.database.base import Base
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.errors import DJException
+from datajunction_server.models.node import NodeMinimumDetail
+from datajunction_server.models.node_type import NodeType
 from datajunction_server.typing import UTCDatetime
 
 
@@ -23,3 +31,98 @@ class NodeNamespace(Base):  # pylint: disable=too-few-public-methods
         nullable=True,
         default=None,
     )
+
+    @classmethod
+    async def get_all_with_node_count(cls, session: AsyncSession):
+        """
+        Get all namespaces with the number of nodes in that namespaces.
+        """
+        statement = (
+            select(
+                NodeNamespace.namespace,
+                func.count(Node.id).label("num_nodes"),  # pylint: disable=not-callable
+            )
+            .join(
+                Node,
+                onclause=NodeNamespace.namespace == Node.namespace,
+                isouter=True,
+            )
+            .where(
+                is_(NodeNamespace.deactivated_at, None),
+            )
+            .group_by(NodeNamespace.namespace)
+        )
+        result = await session.execute(statement)
+        return result.all()
+
+    @classmethod
+    async def get(
+        cls,
+        session: AsyncSession,
+        namespace: str,
+        raise_if_not_exists: bool = True,
+    ) -> Optional["NodeNamespace"]:
+        """
+        List node names in namespace.
+        """
+        statement = select(cls).where(cls.namespace == namespace)
+        results = await session.execute(statement)
+        node_namespace = results.scalar_one_or_none()
+        if raise_if_not_exists:  # pragma: no cover
+            if not node_namespace:
+                raise DJException(
+                    message=(f"node namespace `{namespace}` does not exist."),
+                    http_status_code=404,
+                )
+        return node_namespace
+
+    @classmethod
+    async def list_nodes(
+        cls,
+        session: AsyncSession,
+        namespace: str,
+        node_type: NodeType = None,
+        include_deactivated: bool = False,
+    ) -> List["NodeMinimumDetail"]:
+        """
+        List node names in namespace.
+        """
+        await cls.get(session, namespace)
+
+        list_nodes_query = select(
+            Node.name,
+            NodeRevision.display_name,
+            NodeRevision.description,
+            Node.type,
+            Node.current_version.label(  # type: ignore # pylint: disable=no-member
+                "version",
+            ),
+            NodeRevision.status,
+            NodeRevision.mode,
+            NodeRevision.updated_at,
+        ).where(
+            or_(
+                Node.namespace.like(f"{namespace}.%"),  # pylint: disable=no-member
+                Node.namespace == namespace,
+            ),
+            Node.current_version == NodeRevision.version,
+            Node.name == NodeRevision.name,
+            Node.type == node_type if node_type else True,
+        )
+        if include_deactivated is False:
+            list_nodes_query = list_nodes_query.where(is_(Node.deactivated_at, None))
+
+        result = await session.execute(list_nodes_query)
+        return [
+            NodeMinimumDetail(
+                name=row.name,
+                display_name=row.display_name,
+                description=row.description,
+                version=row.version,
+                type=row.type,
+                status=row.status,
+                mode=row.mode,
+                updated_at=row.updated_at,
+            )
+            for row in result.all()
+        ]

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -504,20 +504,20 @@ class NodeRevision(
 
         return (
             selectinload(NodeRevision.columns).options(
-                selectinload(Column.attributes).selectinload(
+                joinedload(Column.attributes).selectinload(
                     ColumnAttribute.attribute_type,
                 ),
-                selectinload(Column.dimension),
-                selectinload(Column.partition),
+                joinedload(Column.dimension),
+                joinedload(Column.partition),
             ),
-            selectinload(NodeRevision.catalog),
+            joinedload(NodeRevision.catalog),
             selectinload(NodeRevision.parents),
-            selectinload(NodeRevision.materializations),
-            selectinload(NodeRevision.metric_metadata),
-            selectinload(NodeRevision.availability),
+            joinedload(NodeRevision.materializations),
+            joinedload(NodeRevision.metric_metadata),
+            joinedload(NodeRevision.availability),
             selectinload(NodeRevision.dimension_links).options(
-                selectinload(DimensionLink.dimension).options(
-                    selectinload(Node.current),
+                joinedload(DimensionLink.dimension).options(
+                    joinedload(Node.current),
                 ),
             ),
             selectinload(NodeRevision.required_dimensions),

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -190,6 +190,7 @@ class Node(Base):  # pylint: disable=too-few-public-methods
         back_populates="node",
         primaryjoin="Node.id==NodeRevision.node_id",
         cascade="all,delete",
+        order_by="NodeRevision.updated_at",
     )
     current: Mapped["NodeRevision"] = relationship(
         "NodeRevision",
@@ -446,7 +447,7 @@ class NodeRevision(
         secondaryjoin="Column.id==NodeColumns.column_id",
         cascade="all, delete",
         order_by="Column.order",
-        # lazy="joined",
+        # lazy="selectin",
     )
 
     dimension_links: Mapped[List["DimensionLink"]] = relationship(
@@ -503,7 +504,7 @@ class NodeRevision(
 
         return (
             selectinload(NodeRevision.columns).options(
-                selectinload(Column.attributes).joinedload(
+                selectinload(Column.attributes).selectinload(
                     ColumnAttribute.attribute_type,
                 ),
                 selectinload(Column.dimension),

--- a/datajunction-server/datajunction_server/internal/access/authentication/http.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/http.py
@@ -9,7 +9,7 @@ from fastapi.security import HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
 from fastapi.types import DecoratedCallable
 from jose.exceptions import JWEError, JWTError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from datajunction_server.constants import AUTH_COOKIE
@@ -27,7 +27,7 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
     async def __call__(
         self,
         request: Request,
-        session: Session = Depends(get_session),
+        session: AsyncSession = Depends(get_session),
     ) -> None:
         # First check for a JWT sent in a cookie
         jwt = request.cookies.get(AUTH_COOKIE)
@@ -44,7 +44,7 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
                         ),
                     ],
                 ) from exc
-            request.state.user = get_user(
+            request.state.user = await get_user(
                 username=jwt_data["username"],
                 session=session,
             )
@@ -77,7 +77,10 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
                 )
             return  # pragma: no cover
         jwt_data = decode_token(credentials)
-        request.state.user = get_user(username=jwt_data["username"], session=session)
+        request.state.user = await get_user(
+            username=jwt_data["username"],
+            session=session,
+        )
         return
 
 

--- a/datajunction-server/datajunction_server/internal/engines.py
+++ b/datajunction-server/datajunction_server/internal/engines.py
@@ -4,12 +4,12 @@ from http import HTTPStatus
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.engine import Engine
 
 
-def get_engine(session: Session, name: str, version: str) -> Engine:
+async def get_engine(session: AsyncSession, name: str, version: str) -> Engine:
     """
     Return an Engine instance given an engine name and version
     """
@@ -19,7 +19,7 @@ def get_engine(session: Session, name: str, version: str) -> Engine:
         .where(Engine.version == (version or ""))
     )
     try:
-        engine = session.execute(statement).scalar_one()
+        engine = (await session.execute(statement)).scalar_one()
     except NoResultFound as exc:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -3,7 +3,7 @@ import zlib
 from typing import Dict, List, Tuple, Union
 
 from pydantic import ValidationError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import build_sql_for_multiple_metrics
 from datajunction_server.construction.build import build_node, get_measures_query
@@ -36,8 +36,8 @@ from datajunction_server.utils import SEPARATOR
 MAX_COLUMN_NAME_LENGTH = 128
 
 
-def rewrite_metrics_expressions(
-    session: Session,
+async def rewrite_metrics_expressions(
+    session: AsyncSession,
     current_revision: NodeRevision,
     measures_query: TranslatedSQL,
 ) -> Dict[str, MetricMeasures]:
@@ -54,7 +54,7 @@ def rewrite_metrics_expressions(
     for metric in current_revision.cube_metrics():
         measures_for_metric = []
         metric_ast = parse(metric.current.query)
-        metric_ast.compile(context)
+        await metric_ast.compile(context)
         for col in metric_ast.select.find_all(ast.Column):
             full_column_name = (
                 col.table.dj_node.name + SEPARATOR + col.alias_or_name.name  # type: ignore
@@ -87,8 +87,8 @@ def rewrite_metrics_expressions(
     return metrics_expressions
 
 
-def build_cube_materialization_config(
-    session: Session,
+async def build_cube_materialization_config(
+    session: AsyncSession,
     current_revision: NodeRevision,
     upsert_input: UpsertMaterialization,
     validate_access: access.ValidateAccessFn,
@@ -110,7 +110,7 @@ def build_cube_materialization_config(
     try:
         # Druid Metrics Cube (Post-Agg)
         if upsert_input.job == MaterializationJobTypeEnum.DRUID_METRICS_CUBE:
-            metrics_query, _, _ = build_sql_for_multiple_metrics(
+            metrics_query, _, _ = await build_sql_for_multiple_metrics(
                 session=session,
                 metrics=[node.name for node in current_revision.cube_metrics()],
                 dimensions=current_revision.cube_dimensions(),
@@ -136,7 +136,7 @@ def build_cube_materialization_config(
             return generic_config
 
         # Druid Measures Cube (Pre-Agg)
-        measures_query = get_measures_query(
+        measures_query = await get_measures_query(
             session=session,
             metrics=[node.name for node in current_revision.cube_metrics()],
             dimensions=current_revision.cube_dimensions(),
@@ -144,7 +144,7 @@ def build_cube_materialization_config(
             validate_access=validate_access,
             cast_timestamp_to_ms=True,
         )
-        metrics_expressions = rewrite_metrics_expressions(
+        metrics_expressions = await rewrite_metrics_expressions(
             session,
             current_revision,
             measures_query,
@@ -174,15 +174,15 @@ def build_cube_materialization_config(
         ) from exc
 
 
-def build_non_cube_materialization_config(
-    session: Session,
+async def build_non_cube_materialization_config(
+    session: AsyncSession,
     current_revision: NodeRevision,
     upsert: UpsertMaterialization,
 ) -> GenericMaterializationConfig:
     """
     Build materialization config for non-cube nodes (transforms and dimensions).
     """
-    materialization_ast = build_node(
+    materialization_ast = await build_node(
         session=session,
         node=current_revision,
         dimensions=[],
@@ -204,8 +204,8 @@ def build_non_cube_materialization_config(
     return generic_config
 
 
-def create_new_materialization(
-    session: Session,
+async def create_new_materialization(
+    session: AsyncSession,
     current_revision: NodeRevision,
     upsert: UpsertMaterialization,
     validate_access: access.ValidateAccessFn,
@@ -222,7 +222,7 @@ def create_new_materialization(
         NodeType.DIMENSION,
         NodeType.TRANSFORM,
     ):
-        generic_config = build_non_cube_materialization_config(
+        generic_config = await build_non_cube_materialization_config(
             session,
             current_revision,
             upsert,
@@ -235,7 +235,7 @@ def create_new_materialization(
                 "temporal partition specified on the cube. Please make sure at "
                 "least one cube element has a temporal partition defined",
             )
-        generic_config = build_cube_materialization_config(
+        generic_config = await build_cube_materialization_config(
             session,
             current_revision,
             upsert,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -3,6 +3,7 @@ import zlib
 from typing import Dict, List, Tuple, Union
 
 from pydantic import ValidationError
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import build_sql_for_multiple_metrics
@@ -214,6 +215,10 @@ async def create_new_materialization(
     Create a new materialization based on the input values.
     """
     generic_config = None
+    try:
+        await session.refresh(current_revision, ["columns"])
+    except InvalidRequestError:
+        pass
     temporal_partition = current_revision.temporal_partition_columns()
     timestamp_columns = [
         col for col in current_revision.columns if col.type == TimestampType()

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -17,7 +17,7 @@ from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJActionNotAllowedException,
-    DJException,
+    DJDoesNotExistException,
     DJInvalidInputException,
 )
 from datajunction_server.internal.nodes import get_cube_revision_metadata
@@ -96,7 +96,7 @@ async def list_namespaces_in_hierarchy(  # pylint: disable=too-many-arguments
     )
     namespaces = (await session.execute(statement)).scalars().all()
     if len(namespaces) == 0:
-        raise DJException(
+        raise DJDoesNotExistException(
             message=(f"Namespace `{namespace}` does not exist."),
             http_status_code=404,
         )

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import or_, select
-from sqlalchemy.orm import Session
-from sqlalchemy.sql.operators import is_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from datajunction_server.api.helpers import get_node_namespace, hard_delete_node
 from datajunction_server.database.history import ActivityType, EntityType, History
@@ -33,8 +33,8 @@ RESERVED_NAMESPACE_NAMES = [
 ]
 
 
-def get_nodes_in_namespace(
-    session: Session,
+async def get_nodes_in_namespace(
+    session: AsyncSession,
     namespace: str,
     node_type: NodeType = None,
     include_deactivated: bool = False,
@@ -42,20 +42,25 @@ def get_nodes_in_namespace(
     """
     Gets a list of node names in the namespace
     """
-    get_node_namespace(session, namespace)
+    return await NodeNamespace.list_nodes(
+        session,
+        namespace,
+        node_type=node_type,
+        include_deactivated=include_deactivated,
+    )
+
+
+async def get_nodes_in_namespace_detailed(
+    session: AsyncSession,
+    namespace: str,
+    node_type: NodeType = None,
+) -> List[Node]:
+    """
+    Gets a list of node names (w/ full details) in the namespace
+    """
+    await get_node_namespace(session, namespace)
     list_nodes_query = (
-        select(
-            Node.name,
-            NodeRevision.display_name,
-            NodeRevision.description,
-            Node.type,
-            Node.current_version.label(  # type: ignore # pylint: disable=no-member
-                "version",
-            ),
-            NodeRevision.status,
-            NodeRevision.mode,
-            NodeRevision.updated_at,
-        )
+        select(Node)
         .where(
             or_(
                 Node.namespace.like(f"{namespace}.%"),  # pylint: disable=no-member
@@ -65,48 +70,17 @@ def get_nodes_in_namespace(
             Node.name == NodeRevision.name,
             Node.type == node_type if node_type else True,
         )
-        .order_by(Node.id)
-    )
-    if include_deactivated is False:
-        list_nodes_query = list_nodes_query.where(is_(Node.deactivated_at, None))
-    return [
-        NodeMinimumDetail(
-            name=row.name,
-            display_name=row.display_name,
-            description=row.description,
-            version=row.version,
-            type=row.type,
-            status=row.status,
-            mode=row.mode,
-            updated_at=row.updated_at,
+        .options(
+            joinedload(Node.current).options(
+                *NodeRevision.default_load_options(),
+            ),
         )
-        for row in session.execute(list_nodes_query).all()
-    ]
-
-
-def get_nodes_in_namespace_detailed(
-    session: Session,
-    namespace: str,
-    node_type: NodeType = None,
-) -> List[Node]:
-    """
-    Gets a list of node names (w/ full details) in the namespace
-    """
-    get_node_namespace(session, namespace)
-    list_nodes_query = select(Node).where(
-        or_(
-            Node.namespace.like(f"{namespace}.%"),  # pylint: disable=no-member
-            Node.namespace == namespace,
-        ),
-        Node.current_version == NodeRevision.version,
-        Node.name == NodeRevision.name,
-        Node.type == node_type if node_type else True,
     )
-    return session.execute(list_nodes_query).scalars().all()
+    return (await session.execute(list_nodes_query)).unique().scalars().all()
 
 
-def list_namespaces_in_hierarchy(  # pylint: disable=too-many-arguments
-    session: Session,
+async def list_namespaces_in_hierarchy(  # pylint: disable=too-many-arguments
+    session: AsyncSession,
     namespace: str,
 ) -> List[NodeNamespace]:
     """
@@ -120,7 +94,7 @@ def list_namespaces_in_hierarchy(  # pylint: disable=too-many-arguments
             NodeNamespace.namespace == namespace,
         ),
     )
-    namespaces = session.execute(statement).scalars().all()
+    namespaces = (await session.execute(statement)).scalars().all()
     if len(namespaces) == 0:
         raise DJException(
             message=(f"Namespace `{namespace}` does not exist."),
@@ -129,8 +103,8 @@ def list_namespaces_in_hierarchy(  # pylint: disable=too-many-arguments
     return namespaces
 
 
-def mark_namespace_deactivated(
-    session: Session,
+async def mark_namespace_deactivated(
+    session: AsyncSession,
     namespace: NodeNamespace,
     message: str = None,
     current_user: Optional[User] = None,
@@ -157,11 +131,11 @@ def mark_namespace_deactivated(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
+    await session.commit()
 
 
-def mark_namespace_restored(
-    session: Session,
+async def mark_namespace_restored(
+    session: AsyncSession,
     namespace: NodeNamespace,
     message: str = None,
     current_user: Optional[User] = None,
@@ -180,7 +154,7 @@ def mark_namespace_restored(
             user=current_user.username if current_user else None,
         ),
     )
-    session.commit()
+    await session.commit()
 
 
 def validate_namespace(namespace: str):
@@ -208,8 +182,8 @@ def get_parent_namespaces(namespace: str):
     return [SEPARATOR.join(parts[0:i]) for i in range(len(parts)) if parts[0:i]]
 
 
-def create_namespace(
-    session: Session,
+async def create_namespace(
+    session: AsyncSession,
     namespace: str,
     include_parents: bool = True,
     current_user: Optional[User] = None,
@@ -223,7 +197,7 @@ def create_namespace(
         else [namespace]
     )
     for parent_namespace in parents:
-        if not get_node_namespace(  # pragma: no cover
+        if not await get_node_namespace(  # pragma: no cover
             session=session,
             namespace=parent_namespace,
             raise_if_not_exists=False,
@@ -239,12 +213,12 @@ def create_namespace(
                     user=current_user.username if current_user else None,
                 ),
             )
-    session.commit()
+    await session.commit()
     return parents
 
 
-def hard_delete_namespace(
-    session: Session,
+async def hard_delete_namespace(
+    session: AsyncSession,
     namespace: str,
     cascade: bool = False,
     current_user: Optional[User] = None,
@@ -253,15 +227,19 @@ def hard_delete_namespace(
     Hard delete a node namespace.
     """
     node_names = (
-        session.execute(
-            select(Node.name)
-            .where(
-                or_(
-                    Node.namespace.like(f"{namespace}.%"),  # pylint: disable=no-member
-                    Node.namespace == namespace,
-                ),
+        (
+            await session.execute(
+                select(Node.name)
+                .where(
+                    or_(
+                        Node.namespace.like(
+                            f"{namespace}.%",
+                        ),  # pylint: disable=no-member
+                        Node.namespace == namespace,
+                    ),
+                )
+                .order_by(Node.name),
             )
-            .order_by(Node.name),
         )
         .scalars()
         .all()
@@ -279,20 +257,20 @@ def hard_delete_namespace(
 
     impacts = {}
     for node_name in node_names:
-        impacts[node_name] = hard_delete_node(
+        impacts[node_name] = await hard_delete_node(
             node_name,
             session,
             current_user=current_user,
         )
 
-    namespaces = list_namespaces_in_hierarchy(session, namespace)
+    namespaces = await list_namespaces_in_hierarchy(session, namespace)
     for _namespace in namespaces:
         impacts[_namespace.namespace] = {
             "namespace": _namespace.namespace,
             "status": "deleted",
         }
-        session.delete(_namespace)
-    session.commit()
+        await session.delete(_namespace)
+    await session.commit()
     return impacts
 
 
@@ -402,8 +380,8 @@ def _metric_project_config(node: Node, namespace_requested: str) -> Dict:
     }
 
 
-def _cube_project_config(
-    session: Session,
+async def _cube_project_config(
+    session: AsyncSession,
     node: Node,
     namespace_requested: str,
 ) -> Dict:
@@ -415,7 +393,7 @@ def _cube_project_config(
         node_type=NodeType.CUBE,
         namespace_requested=namespace_requested,
     )
-    cube_revision = get_cube_revision_metadata(session, node.name)
+    cube_revision = await get_cube_revision_metadata(session, node.name)
     metrics = []
     dimensions = []
     for element in cube_revision.cube_elements:
@@ -433,8 +411,8 @@ def _cube_project_config(
     }
 
 
-def get_project_config(
-    session: Session,
+async def get_project_config(
+    session: AsyncSession,
     nodes: List[Node],
     namespace_requested: str,
 ) -> List[Dict]:
@@ -473,7 +451,7 @@ def get_project_config(
             )
         else:
             project_components.append(
-                _cube_project_config(
+                await _cube_project_config(
                     session=session,
                     node=node,
                     namespace_requested=namespace_requested,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -200,9 +200,6 @@ async def set_node_column_attributes(
     )
     await session.commit()
     await session.refresh(column)
-
-    # await session.refresh(node)
-    # await session.refresh(node.current)
     return [column]
 
 
@@ -731,12 +728,6 @@ async def update_cube_node(  # pylint: disable=too-many-locals
     """
     Update cube node based on changes
     """
-    # await session.refresh(node_revision, ["columns"])
-    # await session.refresh(node_revision, ["cube_elements"])
-    # for elem in node_revision.cube_elements:
-    #     await session.refresh(elem, ["node_revisions"])
-    #     for rev in elem.node_revisions:
-    #         await session.refresh(rev, ["node"])
     minor_changes = has_minor_changes(node_revision, data)
     old_metrics = [m.name for m in node_revision.cube_metrics()]
     old_dimensions = node_revision.cube_dimensions()

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Callable, Iterable, Optional, Set, Union
 
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.utils import try_get_dj_node
 from datajunction_server.database.node import Node, NodeRevision
@@ -177,16 +177,16 @@ class AccessControlStore(BaseModel):
         else:
             self.indirect_requests.add(request)
 
-    def add_request_by_node_name(
+    async def add_request_by_node_name(
         self,
-        session: Session,
+        session: AsyncSession,
         node_name: Union[str, "Column"],
         verb: Optional[ResourceRequestVerb] = None,
     ):
         """
         Add a request using a node's name
         """
-        node = try_get_dj_node(session, node_name)
+        node = await try_get_dj_node(session, node_name)
         if node is not None:
             self.add_request_by_node(node, verb)
         return node

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -28,6 +28,7 @@ class ColumnTypeDecorator(
     """
 
     impl = Text
+    cache_ok = True
 
     def process_bind_param(self, value: ColumnType, dialect):
         return str(value)

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -722,8 +722,14 @@ class GenericNodeOutputModel(BaseModel):
         current = values.get("current")
         if current is None:
             return values
-        current_dict = NodeRevisionOutput.from_orm(current).dict()
-        final_dict = dict(values.items())
+        current_dict = dict(current.__dict__.items())
+        final_dict = {
+            "namespace": values.get("namespace"),
+            "created_at": values.get("created_at"),
+            "current_version": values.get("current_version"),
+            "catalog": values.get("catalog"),
+            "missing_table": values.get("missing_table"),
+        }
         for k, v in current_dict.items():
             final_dict[k] = v
         final_dict["node_revision_id"] = final_dict["id"]

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -561,8 +561,8 @@ async def get_nodes_with_dimension(
     while to_process:
         current_node = to_process.pop()
         processed.add(current_node.name)
-        if not current_node:
-            continue
+        # if not current_node:
+        #     continue
 
         # Dimension nodes are used to expand the searchable graph by finding
         # the next layer of nodes that are linked to this dimension

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -561,8 +561,6 @@ async def get_nodes_with_dimension(
     while to_process:
         current_node = to_process.pop()
         processed.add(current_node.name)
-        # if not current_node:
-        #     continue
 
         # Dimension nodes are used to expand the searchable graph by finding
         # the next layer of nodes that are linked to this dimension

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -26,7 +26,7 @@ from typing import (
 )
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.construction.utils import get_dj_node, to_namespaced_name
 from datajunction_server.database import DimensionLink
@@ -747,6 +747,15 @@ class Column(Aliasable, Named, Expression):
         self._type = type_
         return self
 
+    def copy(self):
+        return Column(
+            name=self.name,
+            alias=self.alias,
+            _table=self.table,
+            _type=self.type,
+            _is_compiled=self.is_compiled(),
+        )
+
     @property
     def expression(self) -> Optional[Expression]:
         """
@@ -948,7 +957,7 @@ class Column(Aliasable, Named, Expression):
                             dj_col.dimension.name,
                             options=[
                                 joinedload(DJNodeRef.current).options(
-                                    joinedload(DJNode.columns),
+                                    selectinload(DJNode.columns),
                                 ),
                             ],
                         )

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -25,10 +25,12 @@ from typing import (
     cast,
 )
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from datajunction_server.construction.utils import get_dj_node, to_namespaced_name
 from datajunction_server.database import DimensionLink
+from datajunction_server.database.node import Node as DJNodeRef
 from datajunction_server.database.node import NodeRevision
 from datajunction_server.database.node import NodeRevision as DJNode
 from datajunction_server.errors import DJError, DJErrorException, DJException, ErrorCode
@@ -77,7 +79,7 @@ def flatten(maybe_iterables: Any) -> Iterator:
 
 @dataclass
 class CompileContext:
-    session: Session
+    session: AsyncSession
     exception: DJException
 
 
@@ -456,7 +458,7 @@ class Node(ABC):
         Get the string of a node
         """
 
-    def compile(self, ctx: CompileContext):
+    async def compile(self, ctx: CompileContext):
         """
         Compile a DJ Node. By default, we call compile on all immediate children of this node.
         """
@@ -464,7 +466,7 @@ class Node(ABC):
             return
         for child in self.children:
             if not child.is_compiled():
-                child.compile(ctx)
+                await child.compile(ctx)
                 child._is_compiled = True
         self._is_compiled = True
 
@@ -830,7 +832,7 @@ class Column(Aliasable, Named, Expression):
             column_namespace = self.namespace[0].name
         return column_namespace, column_name, subscript_name
 
-    def find_table_sources(
+    async def find_table_sources(
         self,
         ctx: CompileContext,
     ) -> List["TableExpression"]:
@@ -853,7 +855,7 @@ class Column(Aliasable, Named, Expression):
             self.add_type(self.child.type)
         for table in direct_tables:
             if not table.is_compiled():
-                table.compile(ctx)
+                await table.compile(ctx)
 
         namespace = (
             self.name.namespace.identifier(False) if self.name.namespace else ""
@@ -876,7 +878,8 @@ class Column(Aliasable, Named, Expression):
                 not namespace
                 or namespace == table.alias_or_name.identifier(False)
             ):
-                if table.add_ref_column(self, ctx):
+                result = await table.add_ref_column(self, ctx)
+                if result:
                     found.append(table)
 
         # This column may be a struct, meaning it'll have an optional namespace,
@@ -886,7 +889,7 @@ class Column(Aliasable, Named, Expression):
                 if table.column_mapping.get(namespace) or (
                     table.column_mapping.get(column_name) and is_struct
                 ):
-                    if table.add_ref_column(self, ctx):
+                    if await table.add_ref_column(self, ctx):
                         found.append(table)
 
         if found:
@@ -902,7 +905,7 @@ class Column(Aliasable, Named, Expression):
             )
             for table in correlation_tables:
                 if not namespace or table.alias_or_name.identifier(False) == namespace:
-                    if table.add_ref_column(self, ctx):
+                    if await table.add_ref_column(self, ctx):
                         found.append(table)
 
         if found:
@@ -913,7 +916,7 @@ class Column(Aliasable, Named, Expression):
         if isinstance(alpha_query, Query) and alpha_query.ctes:
             for table in alpha_query.ctes:
                 if table.alias_or_name.identifier(False) == namespace:
-                    if table.add_ref_column(self, ctx):
+                    if await table.add_ref_column(self, ctx):
                         found.append(table)
 
         # If nothing was found in the initial AST, traverse through dimensions graph
@@ -940,43 +943,61 @@ class Column(Aliasable, Named, Expression):
                     current_table.set_dj_node(current_table.dj_node.current)
                 for dj_col in current_table.dj_node.columns:
                     if dj_col.dimension:
-                        new_table = Table(
-                            name=to_namespaced_name(dj_col.dimension.name),
-                            _dj_node=dj_col.dimension.current,
-                            path=path,
+                        col_dimension = await DJNodeRef.get_by_name(
+                            ctx.session,
+                            dj_col.dimension.name,
+                            options=[
+                                joinedload(DJNodeRef.current).options(
+                                    joinedload(DJNode.columns),
+                                ),
+                            ],
                         )
-                        new_table._columns = [
-                            Column(
-                                name=Name(col.name),
-                                _type=col.type,
-                                _table=new_table,
+                        if col_dimension:
+                            new_table = Table(
+                                name=to_namespaced_name(col_dimension.name),
+                                _dj_node=col_dimension.current,
+                                path=path,
                             )
-                            for col in dj_col.dimension.current.columns
-                        ]
-                        to_process.append((new_table, path))
+                            new_table._columns = [
+                                Column(
+                                    name=Name(col.name),
+                                    _type=col.type,
+                                    _table=new_table,
+                                )
+                                for col in col_dimension.current.columns
+                            ]
+                            to_process.append((new_table, path))
+                await ctx.session.refresh(current_table.dj_node, ["dimension_links"])
                 for link in current_table.dj_node.dimension_links:
                     all_roles = []
                     if self.role:
                         all_roles = self.role.split(" -> ")
                     if (not link.role and not all_roles) or (link.role in all_roles):
-                        new_table = Table(
-                            name=to_namespaced_name(link.dimension.name),
-                            _dj_node=link.dimension.current,
-                            dimension_link=link,
-                            path=path + [link],
-                        )
-                        new_table._columns = [
-                            Column(
-                                name=Name(col.name),
-                                _type=col.type,
-                                _table=new_table,
+                        await ctx.session.refresh(link, ["dimension"])
+                        if link.dimension:
+                            await ctx.session.refresh(link.dimension, ["current"])
+                            new_table = Table(
+                                name=to_namespaced_name(link.dimension.name),
+                                _dj_node=link.dimension.current,
+                                dimension_link=link,
+                                path=path + [link],
                             )
-                            for col in link.dimension.current.columns
-                        ]
-                        to_process.append((new_table, path + [link]))
+                            await ctx.session.refresh(
+                                link.dimension.current,
+                                ["columns"],
+                            )
+                            new_table._columns = [
+                                Column(
+                                    name=Name(col.name),
+                                    _type=col.type,
+                                    _table=new_table,
+                                )
+                                for col in link.dimension.current.columns
+                            ]
+                            to_process.append((new_table, path + [link]))
         return found
 
-    def compile(self, ctx: CompileContext):
+    async def compile(self, ctx: CompileContext):
         """
         Compile a column.
         Determines the table from which a column is from.
@@ -987,9 +1008,9 @@ class Column(Aliasable, Named, Expression):
 
         # check if the column was already given a table
         if self.table and isinstance(self.table.parent, Column):
-            self.table.add_ref_column(self, ctx)
+            await self.table.add_ref_column(self, ctx)
         else:
-            found_sources = self.find_table_sources(ctx)
+            found_sources = await self.find_table_sources(ctx)
             if len(found_sources) < 1:
                 ctx.exception.errors.append(
                     DJError(
@@ -1009,7 +1030,15 @@ class Column(Aliasable, Named, Expression):
                 return
 
             source_table = cast(TableExpression, found_sources[0])
-            source_table.add_ref_column(self, ctx)
+            added = await source_table.add_ref_column(self, ctx)
+            if not added:
+                ctx.exception.errors.append(
+                    DJError(
+                        code=ErrorCode.INVALID_COLUMN,
+                        message=f"Column `{self}` does not exist on any valid table.",
+                    ),
+                )
+                return
         self._is_compiled = True
 
     @property
@@ -1132,7 +1161,7 @@ class TableExpression(Aliasable, Expression):
         """
         return self._ref_columns
 
-    def add_ref_column(
+    async def add_ref_column(
         self,
         column: Column,
         ctx: Optional[CompileContext] = None,
@@ -1170,7 +1199,7 @@ class TableExpression(Aliasable, Expression):
                     "Uncompiled Table expression requested to "
                     "add Column ref without a compilation context.",
                 )
-            self.compile(ctx)
+            await self.compile(ctx)
 
         if not isinstance(column, Alias):
             ref_col_name = column.name.name
@@ -1304,13 +1333,13 @@ class Table(TableExpression, Named):
                 col.table.alias = self.alias
         return self
 
-    def compile(self, ctx: CompileContext):
+    async def compile(self, ctx: CompileContext):
         # things we can validate here:
         # - if the node is a dimension in a groupby, is it joinable?
         self._is_compiled = True
         try:
             if not self.dj_node:
-                dj_node = get_dj_node(
+                dj_node = await get_dj_node(
                     ctx.session,
                     self.identifier(quotes=False),
                     {DJNodeType.SOURCE, DJNodeType.TRANSFORM, DJNodeType.DIMENSION},
@@ -1544,7 +1573,7 @@ class BinaryOp(Operation):
         }
         return BINOP_TYPE_COMBO_LOOKUP[kind](left_type, right_type)
 
-    def compile(self, ctx: CompileContext):
+    async def compile(self, ctx: CompileContext):
         """
         Compile a DJ Node. By default, we call compile on all immediate children of this node.
         """
@@ -1552,7 +1581,7 @@ class BinaryOp(Operation):
             return
         for child in self.children:
             if not child.is_compiled():
-                child.compile(ctx)
+                await child.compile(ctx)
                 child._is_compiled = True
         self._is_compiled = True
 
@@ -1676,21 +1705,21 @@ class Function(Named, Operation):
     def type(self) -> ColumnType:
         return self.function().infer_type(*self.args)
 
-    def compile(self, ctx: CompileContext):
+    async def compile(self, ctx: CompileContext):
         """
         Compile a function
         """
         self._is_compiled = True
         for arg in self.args:
             if not arg.is_compiled():
-                arg.compile(ctx)
+                await arg.compile(ctx)
                 arg._is_compiled = True
 
         self.function().compile_lambda(*self.args)
 
         for child in self.children:
             if not child.is_compiled():
-                child.compile(ctx)
+                await child.compile(ctx)
                 child._is_compiled = True
 
 
@@ -2236,21 +2265,21 @@ class FunctionTable(FunctionTableExpression):
         self.alias = alias
         return self
 
-    def _type(self, ctx: Optional[CompileContext] = None) -> List[NestedField]:
+    async def _type(self, ctx: Optional[CompileContext] = None) -> List[NestedField]:
         name = self.name.name.upper()
         dj_func = table_function_registry[name]
         arg_types = []
         for arg in self.args:
             if ctx:
-                arg.compile(ctx)
+                await arg.compile(ctx)
             arg_types.append(arg.type)
         return dj_func.infer_type(*arg_types)
 
-    def compile(self, ctx):
+    async def compile(self, ctx):
         if self.is_compiled():
             return
         self._is_compiled = True
-        types = self._type(ctx)
+        types = await self._type(ctx)
         for type, col in zip_longest(types, self.column_list):
             if self.column_list:
                 if (type is None) or (col is None):
@@ -2469,7 +2498,7 @@ class Select(SelectExpression):
             )
         return self.projection[0].type
 
-    def compile(self, ctx: CompileContext):
+    async def compile(self, ctx: CompileContext):
         if not self.group_by and self.having:
             ctx.exception.errors.append(
                 DJError(
@@ -2482,7 +2511,7 @@ class Select(SelectExpression):
                 ),
             )
 
-        super().compile(ctx)
+        await super().compile(ctx)
 
 
 @dataclass(eq=False)
@@ -2499,14 +2528,14 @@ class Query(TableExpression, UnNamed):
             self.filter(lambda node: node is not self and not node.is_compiled()),
         )
 
-    def compile(self, ctx: CompileContext):
+    async def compile(self, ctx: CompileContext):
         if self._is_compiled:
             return
-        self.apply(
-            lambda node: node is not self
-            and not node.is_compiled()
-            and node.compile(ctx),
-        )
+
+        for child in self.children:
+            if child is not self and not child.is_compiled():
+                await child.compile(ctx)
+
         for expr in self.select.projection:
             self._columns += expr.columns
         self._is_compiled = True
@@ -2554,7 +2583,7 @@ class Query(TableExpression, UnNamed):
                 col.table.alias = self.alias
         return self
 
-    def extract_dependencies(
+    async def extract_dependencies(
         self,
         context: Optional[CompileContext] = None,
     ) -> Tuple[Dict[NodeRevision, List[Table]], Dict[str, List[Table]]]:
@@ -2565,7 +2594,7 @@ class Query(TableExpression, UnNamed):
         if not self.is_compiled():
             if not context:
                 raise DJException("Context not provided for query compilation!")
-            self.compile(context)
+            await self.compile(context)
 
         deps: Dict[NodeRevision, List[Table]] = {}
         danglers: Dict[str, List[Table]] = {}
@@ -2584,9 +2613,9 @@ class Query(TableExpression, UnNamed):
     def type(self) -> ColumnType:
         return self.select.type
 
-    def build(  # pylint: disable=R0913,C0415
+    async def build(  # pylint: disable=R0913,C0415
         self,
-        session: Session,
+        session: AsyncSession,
         memoized_queries: Dict[int, "Query"],
         build_criteria: Optional[BuildCriteria] = None,
         filters: Optional[List[str]] = None,
@@ -2599,7 +2628,7 @@ class Query(TableExpression, UnNamed):
         from datajunction_server.construction.build import _build_select_ast
 
         self.bake_ctes()  # pylint: disable=W0212
-        _build_select_ast(
+        await _build_select_ast(
             session,
             self.select,
             memoized_queries,

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -88,7 +88,7 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         autocommit=False,
         expire_on_commit=False,  # prevents attributes from being expired on commit
     )
-    async with async_session_factory() as session:
+    async with async_session_factory() as session:  # pragma: no cover
         yield session
 
 

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, AsyncGenerator, List, Optional
 
 from dotenv import load_dotenv
 from rich.logging import RichHandler
+from sqlalchemy import AsyncAdaptedQueuePool
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -66,11 +67,12 @@ def get_engine() -> AsyncEngine:
     engine = create_async_engine(
         settings.index,
         future=True,
-        echo=True,
-        pool_pre_ping=True,
+        echo=settings.db_echo,
+        pool_pre_ping=settings.db_pool_pre_ping,
         pool_size=settings.db_pool_size,
         max_overflow=settings.db_max_overflow,
         pool_timeout=settings.db_pool_timeout,
+        poolclass=AsyncAdaptedQueuePool,
         connect_args={
             "connect_timeout": settings.db_connect_timeout,
         },

--- a/datajunction-server/pdm.lock
+++ b/datajunction-server/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "uvicorn", "transpilation"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:2316f1f2b5483ccefe3e062930d44db2c85d78dcf8c5065223daf959c11b11e4"
+content_hash = "sha256:5b7a763ec6185a2c4a02772c3f58ec5c4860f8811bdfa6399adb0d9534664917"
 
 [[package]]
 name = "accept-types"
@@ -121,6 +121,19 @@ files = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.20.0"
+requires_python = ">=3.8"
+summary = "asyncio bridge to the standard sqlite3 module"
+dependencies = [
+    "typing-extensions>=4.0",
+]
+files = [
+    {file = "aiosqlite-0.20.0-py3-none-any.whl", hash = "sha256:36a1deaca0cac40ebe32aac9977a6e2bbc7f5189f23f4a54d5908986729e5bd6"},
+    {file = "aiosqlite-0.20.0.tar.gz", hash = "sha256:6d35c8c256637f4672f843c31021464090805bf925385ac39473fb16eaaca3d7"},
+]
+
+[[package]]
 name = "alembic"
 version = "1.13.1"
 requires_python = ">=3.8"
@@ -230,6 +243,58 @@ summary = "Timeout context manager for asyncio programs"
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
     {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.29.0"
+requires_python = ">=3.8.0"
+summary = "An asyncio PostgreSQL driver"
+dependencies = [
+    "async-timeout>=4.0.3; python_version < \"3.12.0\"",
+]
+files = [
+    {file = "asyncpg-0.29.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72fd0ef9f00aeed37179c62282a3d14262dbbafb74ec0ba16e1b1864d8a12169"},
+    {file = "asyncpg-0.29.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52e8f8f9ff6e21f9b39ca9f8e3e33a5fcdceaf5667a8c5c32bee158e313be385"},
+    {file = "asyncpg-0.29.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9e6823a7012be8b68301342ba33b4740e5a166f6bbda0aee32bc01638491a22"},
+    {file = "asyncpg-0.29.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:746e80d83ad5d5464cfbf94315eb6744222ab00aa4e522b704322fb182b83610"},
+    {file = "asyncpg-0.29.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ff8e8109cd6a46ff852a5e6bab8b0a047d7ea42fcb7ca5ae6eaae97d8eacf397"},
+    {file = "asyncpg-0.29.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:97eb024685b1d7e72b1972863de527c11ff87960837919dac6e34754768098eb"},
+    {file = "asyncpg-0.29.0-cp310-cp310-win32.whl", hash = "sha256:5bbb7f2cafd8d1fa3e65431833de2642f4b2124be61a449fa064e1a08d27e449"},
+    {file = "asyncpg-0.29.0-cp310-cp310-win_amd64.whl", hash = "sha256:76c3ac6530904838a4b650b2880f8e7af938ee049e769ec2fba7cd66469d7772"},
+    {file = "asyncpg-0.29.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4900ee08e85af01adb207519bb4e14b1cae8fd21e0ccf80fac6aa60b6da37b4"},
+    {file = "asyncpg-0.29.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a65c1dcd820d5aea7c7d82a3fdcb70e096f8f70d1a8bf93eb458e49bfad036ac"},
+    {file = "asyncpg-0.29.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b52e46f165585fd6af4863f268566668407c76b2c72d366bb8b522fa66f1870"},
+    {file = "asyncpg-0.29.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc600ee8ef3dd38b8d67421359779f8ccec30b463e7aec7ed481c8346decf99f"},
+    {file = "asyncpg-0.29.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:039a261af4f38f949095e1e780bae84a25ffe3e370175193174eb08d3cecab23"},
+    {file = "asyncpg-0.29.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6feaf2d8f9138d190e5ec4390c1715c3e87b37715cd69b2c3dfca616134efd2b"},
+    {file = "asyncpg-0.29.0-cp311-cp311-win32.whl", hash = "sha256:1e186427c88225ef730555f5fdda6c1812daa884064bfe6bc462fd3a71c4b675"},
+    {file = "asyncpg-0.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:cfe73ffae35f518cfd6e4e5f5abb2618ceb5ef02a2365ce64f132601000587d3"},
+    {file = "asyncpg-0.29.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6011b0dc29886ab424dc042bf9eeb507670a3b40aece3439944006aafe023178"},
+    {file = "asyncpg-0.29.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b544ffc66b039d5ec5a7454667f855f7fec08e0dfaf5a5490dfafbb7abbd2cfb"},
+    {file = "asyncpg-0.29.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d84156d5fb530b06c493f9e7635aa18f518fa1d1395ef240d211cb563c4e2364"},
+    {file = "asyncpg-0.29.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54858bc25b49d1114178d65a88e48ad50cb2b6f3e475caa0f0c092d5f527c106"},
+    {file = "asyncpg-0.29.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bde17a1861cf10d5afce80a36fca736a86769ab3579532c03e45f83ba8a09c59"},
+    {file = "asyncpg-0.29.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:37a2ec1b9ff88d8773d3eb6d3784dc7e3fee7756a5317b67f923172a4748a175"},
+    {file = "asyncpg-0.29.0-cp312-cp312-win32.whl", hash = "sha256:bb1292d9fad43112a85e98ecdc2e051602bce97c199920586be83254d9dafc02"},
+    {file = "asyncpg-0.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:2245be8ec5047a605e0b454c894e54bf2ec787ac04b1cb7e0d3c67aa1e32f0fe"},
+    {file = "asyncpg-0.29.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0009a300cae37b8c525e5b449233d59cd9868fd35431abc470a3e364d2b85cb9"},
+    {file = "asyncpg-0.29.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5cad1324dbb33f3ca0cd2074d5114354ed3be2b94d48ddfd88af75ebda7c43cc"},
+    {file = "asyncpg-0.29.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:012d01df61e009015944ac7543d6ee30c2dc1eb2f6b10b62a3f598beb6531548"},
+    {file = "asyncpg-0.29.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:000c996c53c04770798053e1730d34e30cb645ad95a63265aec82da9093d88e7"},
+    {file = "asyncpg-0.29.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e0bfe9c4d3429706cf70d3249089de14d6a01192d617e9093a8e941fea8ee775"},
+    {file = "asyncpg-0.29.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:642a36eb41b6313ffa328e8a5c5c2b5bea6ee138546c9c3cf1bffaad8ee36dd9"},
+    {file = "asyncpg-0.29.0-cp38-cp38-win32.whl", hash = "sha256:a921372bbd0aa3a5822dd0409da61b4cd50df89ae85150149f8c119f23e8c408"},
+    {file = "asyncpg-0.29.0-cp38-cp38-win_amd64.whl", hash = "sha256:103aad2b92d1506700cbf51cd8bb5441e7e72e87a7b3a2ca4e32c840f051a6a3"},
+    {file = "asyncpg-0.29.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5340dd515d7e52f4c11ada32171d87c05570479dc01dc66d03ee3e150fb695da"},
+    {file = "asyncpg-0.29.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e17b52c6cf83e170d3d865571ba574577ab8e533e7361a2b8ce6157d02c665d3"},
+    {file = "asyncpg-0.29.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f100d23f273555f4b19b74a96840aa27b85e99ba4b1f18d4ebff0734e78dc090"},
+    {file = "asyncpg-0.29.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48e7c58b516057126b363cec8ca02b804644fd012ef8e6c7e23386b7d5e6ce83"},
+    {file = "asyncpg-0.29.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f9ea3f24eb4c49a615573724d88a48bd1b7821c890c2effe04f05382ed9e8810"},
+    {file = "asyncpg-0.29.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8d36c7f14a22ec9e928f15f92a48207546ffe68bc412f3be718eedccdf10dc5c"},
+    {file = "asyncpg-0.29.0-cp39-cp39-win32.whl", hash = "sha256:797ab8123ebaed304a1fad4d7576d5376c3a006a4100380fb9d517f0b59c1ab2"},
+    {file = "asyncpg-0.29.0-cp39-cp39-win_amd64.whl", hash = "sha256:cce08a178858b426ae1aa8409b5cc171def45d4293626e7aa6510696d46decd8"},
+    {file = "asyncpg-0.29.0.tar.gz", hash = "sha256:d1c49e1f44fffafd9a55e1a9b101590859d881d639ea2922516f5d9c512d354e"},
 ]
 
 [[package]]
@@ -1108,47 +1173,58 @@ files = [
 
 [[package]]
 name = "greenlet"
-version = "2.0.2"
-requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+version = "3.0.3"
+requires_python = ">=3.7"
 summary = "Lightweight in-process concurrent programming"
 files = [
-    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c"},
-    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df"},
-    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088"},
-    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb"},
-    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470"},
-    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3a51c9751078733d88e013587b108f1b7a1fb106d402fb390740f002b6f6551a"},
-    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91"},
-    {file = "greenlet-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645"},
-    {file = "greenlet-2.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c"},
-    {file = "greenlet-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47"},
-    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca"},
-    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
-    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2"},
-    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:eff4eb9b7eb3e4d0cae3d28c283dc16d9bed6b193c2e1ace3ed86ce48ea8df19"},
-    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5454276c07d27a740c5892f4907c86327b632127dd9abec42ee62e12427ff7e3"},
-    {file = "greenlet-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:7cafd1208fdbe93b67c7086876f061f660cfddc44f404279c1585bbf3cdc64c5"},
-    {file = "greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30"},
-    {file = "greenlet-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b"},
-    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acd2162a36d3de67ee896c43effcd5ee3de247eb00354db411feb025aa319857"},
-    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a"},
-    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
-    {file = "greenlet-2.0.2-cp38-cp38-win32.whl", hash = "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249"},
-    {file = "greenlet-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40"},
-    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417"},
-    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be4ed120b52ae4d974aa40215fcdfde9194d63541c7ded40ee12eb4dda57b76b"},
-    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94c817e84245513926588caf1152e3b559ff794d505555211ca041f032abbb6b"},
-    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8"},
-    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7efde645ca1cc441d6dc4b48c0f7101e8d86b54c8530141b09fd31cef5149ec9"},
-    {file = "greenlet-2.0.2-cp39-cp39-win32.whl", hash = "sha256:ea9872c80c132f4663822dd2a08d404073a5a9b5ba6155bea72fb2a79d1093b5"},
-    {file = "greenlet-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:db1a39669102a1d8d12b57de2bb7e2ec9066a6f2b3da35ae511ff93b01b5d564"},
-    {file = "greenlet-2.0.2.tar.gz", hash = "sha256:e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0"},
+    {file = "greenlet-3.0.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dca1e2f3ca00b84a396bc1bce13dd21f680f035314d2379c4160c98153b2059b"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ed7fb269f15dc662787f4119ec300ad0702fa1b19d2135a37c2c4de6fadfd4a"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83"},
+    {file = "greenlet-3.0.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:73a411ef564e0e097dbe7e866bb2dda0f027e072b04da387282b02c308807405"},
+    {file = "greenlet-3.0.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:7f362975f2d179f9e26928c5b517524e89dd48530a0202570d55ad6ca5d8a56f"},
+    {file = "greenlet-3.0.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:649dde7de1a5eceb258f9cb00bdf50e978c9db1b996964cd80703614c86495eb"},
+    {file = "greenlet-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:68834da854554926fbedd38c76e60c4a2e3198c6fbed520b106a8986445caaf9"},
+    {file = "greenlet-3.0.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b1b5667cced97081bf57b8fa1d6bfca67814b0afd38208d52538316e9422fc61"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52f59dd9c96ad2fc0d5724107444f76eb20aaccb675bf825df6435acb7703559"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:afaff6cf5200befd5cec055b07d1c0a5a06c040fe5ad148abcd11ba6ab9b114e"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2797aa5aedac23af156bbb5a6aa2cd3427ada2972c828244eb7d1b9255846379"},
+    {file = "greenlet-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7f009caad047246ed379e1c4dbcb8b020f0a390667ea74d2387be2998f58a22"},
+    {file = "greenlet-3.0.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3"},
+    {file = "greenlet-3.0.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:894393ce10ceac937e56ec00bb71c4c2f8209ad516e96033e4b3b1de270e200d"},
+    {file = "greenlet-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:1ea188d4f49089fc6fb283845ab18a2518d279c7cd9da1065d7a84e991748728"},
+    {file = "greenlet-3.0.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4d1ac74f5c0c0524e4a24335350edad7e5f03b9532da7ea4d3c54d527784f2e"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:149e94a2dd82d19838fe4b2259f1b6b9957d5ba1b25640d2380bea9c5df37676"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15d79dd26056573940fcb8c7413d84118086f2ec1a8acdfa854631084393efcc"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b7db1ebff4ba09aaaeae6aa491daeb226c8150fc20e836ad00041bcb11230"},
+    {file = "greenlet-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf"},
+    {file = "greenlet-3.0.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305"},
+    {file = "greenlet-3.0.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6"},
+    {file = "greenlet-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:bba5387a6975598857d86de9eac14210a49d554a77eb8261cc68b7d082f78ce2"},
+    {file = "greenlet-3.0.3-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1996cb9306c8595335bb157d133daf5cf9f693ef413e7673cb07e3e5871379ca"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ddc0f794e6ad661e321caa8d2f0a55ce01213c74722587256fb6566049a8b04"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9db1c18f0eaad2f804728c67d6c610778456e3e1cc4ab4bbd5eeb8e6053c6fc"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7170375bcc99f1a2fbd9c306f5be8764eaf3ac6b5cb968862cad4c7057756506"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b66c9c1e7ccabad3a7d037b2bcb740122a7b17a53734b7d72a344ce39882a1b"},
+    {file = "greenlet-3.0.3-cp38-cp38-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:098d86f528c855ead3479afe84b49242e174ed262456c342d70fc7f972bc13c4"},
+    {file = "greenlet-3.0.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:81bb9c6d52e8321f09c3d165b2a78c680506d9af285bfccbad9fb7ad5a5da3e5"},
+    {file = "greenlet-3.0.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da"},
+    {file = "greenlet-3.0.3-cp38-cp38-win32.whl", hash = "sha256:d46677c85c5ba00a9cb6f7a00b2bfa6f812192d2c9f7d9c4f6a55b60216712f3"},
+    {file = "greenlet-3.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:419b386f84949bf0e7c73e6032e3457b82a787c1ab4a0e43732898a761cc9dbf"},
+    {file = "greenlet-3.0.3-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61"},
+    {file = "greenlet-3.0.3-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b"},
+    {file = "greenlet-3.0.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6"},
+    {file = "greenlet-3.0.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113"},
+    {file = "greenlet-3.0.3-cp39-cp39-win32.whl", hash = "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e"},
+    {file = "greenlet-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067"},
+    {file = "greenlet-3.0.3.tar.gz", hash = "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491"},
 ]
 
 [[package]]
@@ -1966,15 +2042,15 @@ files = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.5.post1"
+version = "0.23.6"
 requires_python = ">=3.8"
 summary = "Pytest support for asyncio"
 dependencies = [
     "pytest<9,>=7.0.0",
 ]
 files = [
-    {file = "pytest-asyncio-0.23.5.post1.tar.gz", hash = "sha256:b9a8806bea78c21276bc34321bbf234ba1b2ea5b30d9f0ce0f2dea45e4685813"},
-    {file = "pytest_asyncio-0.23.5.post1-py3-none-any.whl", hash = "sha256:30f54d27774e79ac409778889880242b0403d09cabd65b727ce90fe92dd5d80e"},
+    {file = "pytest-asyncio-0.23.6.tar.gz", hash = "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"},
+    {file = "pytest_asyncio-0.23.6-py3-none-any.whl", hash = "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a"},
 ]
 
 [[package]]

--- a/datajunction-server/pdm.lock
+++ b/datajunction-server/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "uvicorn", "transpilation"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:4b767390a02dbb87d10907d256b45b508c12fb7144b024da35edb15df5255331"
+content_hash = "sha256:429aa30b49f46bc2476c7aae2978331722a4436222e91a1134e9857478b08664"
 
 [[package]]
 name = "accept-types"
@@ -243,58 +243,6 @@ summary = "Timeout context manager for asyncio programs"
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
     {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
-]
-
-[[package]]
-name = "asyncpg"
-version = "0.29.0"
-requires_python = ">=3.8.0"
-summary = "An asyncio PostgreSQL driver"
-dependencies = [
-    "async-timeout>=4.0.3; python_version < \"3.12.0\"",
-]
-files = [
-    {file = "asyncpg-0.29.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72fd0ef9f00aeed37179c62282a3d14262dbbafb74ec0ba16e1b1864d8a12169"},
-    {file = "asyncpg-0.29.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52e8f8f9ff6e21f9b39ca9f8e3e33a5fcdceaf5667a8c5c32bee158e313be385"},
-    {file = "asyncpg-0.29.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9e6823a7012be8b68301342ba33b4740e5a166f6bbda0aee32bc01638491a22"},
-    {file = "asyncpg-0.29.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:746e80d83ad5d5464cfbf94315eb6744222ab00aa4e522b704322fb182b83610"},
-    {file = "asyncpg-0.29.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ff8e8109cd6a46ff852a5e6bab8b0a047d7ea42fcb7ca5ae6eaae97d8eacf397"},
-    {file = "asyncpg-0.29.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:97eb024685b1d7e72b1972863de527c11ff87960837919dac6e34754768098eb"},
-    {file = "asyncpg-0.29.0-cp310-cp310-win32.whl", hash = "sha256:5bbb7f2cafd8d1fa3e65431833de2642f4b2124be61a449fa064e1a08d27e449"},
-    {file = "asyncpg-0.29.0-cp310-cp310-win_amd64.whl", hash = "sha256:76c3ac6530904838a4b650b2880f8e7af938ee049e769ec2fba7cd66469d7772"},
-    {file = "asyncpg-0.29.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4900ee08e85af01adb207519bb4e14b1cae8fd21e0ccf80fac6aa60b6da37b4"},
-    {file = "asyncpg-0.29.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a65c1dcd820d5aea7c7d82a3fdcb70e096f8f70d1a8bf93eb458e49bfad036ac"},
-    {file = "asyncpg-0.29.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b52e46f165585fd6af4863f268566668407c76b2c72d366bb8b522fa66f1870"},
-    {file = "asyncpg-0.29.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc600ee8ef3dd38b8d67421359779f8ccec30b463e7aec7ed481c8346decf99f"},
-    {file = "asyncpg-0.29.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:039a261af4f38f949095e1e780bae84a25ffe3e370175193174eb08d3cecab23"},
-    {file = "asyncpg-0.29.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6feaf2d8f9138d190e5ec4390c1715c3e87b37715cd69b2c3dfca616134efd2b"},
-    {file = "asyncpg-0.29.0-cp311-cp311-win32.whl", hash = "sha256:1e186427c88225ef730555f5fdda6c1812daa884064bfe6bc462fd3a71c4b675"},
-    {file = "asyncpg-0.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:cfe73ffae35f518cfd6e4e5f5abb2618ceb5ef02a2365ce64f132601000587d3"},
-    {file = "asyncpg-0.29.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6011b0dc29886ab424dc042bf9eeb507670a3b40aece3439944006aafe023178"},
-    {file = "asyncpg-0.29.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b544ffc66b039d5ec5a7454667f855f7fec08e0dfaf5a5490dfafbb7abbd2cfb"},
-    {file = "asyncpg-0.29.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d84156d5fb530b06c493f9e7635aa18f518fa1d1395ef240d211cb563c4e2364"},
-    {file = "asyncpg-0.29.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54858bc25b49d1114178d65a88e48ad50cb2b6f3e475caa0f0c092d5f527c106"},
-    {file = "asyncpg-0.29.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bde17a1861cf10d5afce80a36fca736a86769ab3579532c03e45f83ba8a09c59"},
-    {file = "asyncpg-0.29.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:37a2ec1b9ff88d8773d3eb6d3784dc7e3fee7756a5317b67f923172a4748a175"},
-    {file = "asyncpg-0.29.0-cp312-cp312-win32.whl", hash = "sha256:bb1292d9fad43112a85e98ecdc2e051602bce97c199920586be83254d9dafc02"},
-    {file = "asyncpg-0.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:2245be8ec5047a605e0b454c894e54bf2ec787ac04b1cb7e0d3c67aa1e32f0fe"},
-    {file = "asyncpg-0.29.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0009a300cae37b8c525e5b449233d59cd9868fd35431abc470a3e364d2b85cb9"},
-    {file = "asyncpg-0.29.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5cad1324dbb33f3ca0cd2074d5114354ed3be2b94d48ddfd88af75ebda7c43cc"},
-    {file = "asyncpg-0.29.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:012d01df61e009015944ac7543d6ee30c2dc1eb2f6b10b62a3f598beb6531548"},
-    {file = "asyncpg-0.29.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:000c996c53c04770798053e1730d34e30cb645ad95a63265aec82da9093d88e7"},
-    {file = "asyncpg-0.29.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e0bfe9c4d3429706cf70d3249089de14d6a01192d617e9093a8e941fea8ee775"},
-    {file = "asyncpg-0.29.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:642a36eb41b6313ffa328e8a5c5c2b5bea6ee138546c9c3cf1bffaad8ee36dd9"},
-    {file = "asyncpg-0.29.0-cp38-cp38-win32.whl", hash = "sha256:a921372bbd0aa3a5822dd0409da61b4cd50df89ae85150149f8c119f23e8c408"},
-    {file = "asyncpg-0.29.0-cp38-cp38-win_amd64.whl", hash = "sha256:103aad2b92d1506700cbf51cd8bb5441e7e72e87a7b3a2ca4e32c840f051a6a3"},
-    {file = "asyncpg-0.29.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5340dd515d7e52f4c11ada32171d87c05570479dc01dc66d03ee3e150fb695da"},
-    {file = "asyncpg-0.29.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e17b52c6cf83e170d3d865571ba574577ab8e533e7361a2b8ce6157d02c665d3"},
-    {file = "asyncpg-0.29.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f100d23f273555f4b19b74a96840aa27b85e99ba4b1f18d4ebff0734e78dc090"},
-    {file = "asyncpg-0.29.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48e7c58b516057126b363cec8ca02b804644fd012ef8e6c7e23386b7d5e6ce83"},
-    {file = "asyncpg-0.29.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f9ea3f24eb4c49a615573724d88a48bd1b7821c890c2effe04f05382ed9e8810"},
-    {file = "asyncpg-0.29.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8d36c7f14a22ec9e928f15f92a48207546ffe68bc412f3be718eedccdf10dc5c"},
-    {file = "asyncpg-0.29.0-cp39-cp39-win32.whl", hash = "sha256:797ab8123ebaed304a1fad4d7576d5376c3a006a4100380fb9d517f0b59c1ab2"},
-    {file = "asyncpg-0.29.0-cp39-cp39-win_amd64.whl", hash = "sha256:cce08a178858b426ae1aa8409b5cc171def45d4293626e7aa6510696d46decd8"},
-    {file = "asyncpg-0.29.0.tar.gz", hash = "sha256:d1c49e1f44fffafd9a55e1a9b101590859d881d639ea2922516f5d9c512d354e"},
 ]
 
 [[package]]

--- a/datajunction-server/pdm.lock
+++ b/datajunction-server/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "uvicorn", "transpilation"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:5b7a763ec6185a2c4a02772c3f58ec5c4860f8811bdfa6399adb0d9534664917"
+content_hash = "sha256:4b767390a02dbb87d10907d256b45b508c12fb7144b024da35edb15df5255331"
 
 [[package]]
 name = "accept-types"
@@ -1071,6 +1071,62 @@ files = [
     {file = "frozenlist-1.4.0-cp39-cp39-win32.whl", hash = "sha256:19488c57c12d4e8095a922f328df3f179c820c212940a498623ed39160bc3c2f"},
     {file = "frozenlist-1.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:6221d84d463fb110bdd7619b69cb43878a11d51cbb9394ae3105d082d5199167"},
     {file = "frozenlist-1.4.0.tar.gz", hash = "sha256:09163bdf0b2907454042edb19f887c6d33806adc71fbd54afc14908bfdc22251"},
+]
+
+[[package]]
+name = "gevent"
+version = "24.2.1"
+requires_python = ">=3.8"
+summary = "Coroutine-based network library"
+dependencies = [
+    "cffi>=1.12.2; platform_python_implementation == \"CPython\" and sys_platform == \"win32\"",
+    "greenlet>=2.0.0; platform_python_implementation == \"CPython\" and python_version < \"3.11\"",
+    "greenlet>=3.0rc3; platform_python_implementation == \"CPython\" and python_version >= \"3.11\"",
+    "zope-event",
+    "zope-interface",
+]
+files = [
+    {file = "gevent-24.2.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6f947a9abc1a129858391b3d9334c45041c08a0f23d14333d5b844b6e5c17a07"},
+    {file = "gevent-24.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bde283313daf0b34a8d1bab30325f5cb0f4e11b5869dbe5bc61f8fe09a8f66f3"},
+    {file = "gevent-24.2.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1df555431f5cd5cc189a6ee3544d24f8c52f2529134685f1e878c4972ab026"},
+    {file = "gevent-24.2.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:14532a67f7cb29fb055a0e9b39f16b88ed22c66b96641df8c04bdc38c26b9ea5"},
+    {file = "gevent-24.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd23df885318391856415e20acfd51a985cba6919f0be78ed89f5db9ff3a31cb"},
+    {file = "gevent-24.2.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ca80b121bbec76d7794fcb45e65a7eca660a76cc1a104ed439cdbd7df5f0b060"},
+    {file = "gevent-24.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b9913c45d1be52d7a5db0c63977eebb51f68a2d5e6fd922d1d9b5e5fd758cc98"},
+    {file = "gevent-24.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:918cdf8751b24986f915d743225ad6b702f83e1106e08a63b736e3a4c6ead789"},
+    {file = "gevent-24.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:3d5325ccfadfd3dcf72ff88a92fb8fc0b56cacc7225f0f4b6dcf186c1a6eeabc"},
+    {file = "gevent-24.2.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:03aa5879acd6b7076f6a2a307410fb1e0d288b84b03cdfd8c74db8b4bc882fc5"},
+    {file = "gevent-24.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8bb35ce57a63c9a6896c71a285818a3922d8ca05d150fd1fe49a7f57287b836"},
+    {file = "gevent-24.2.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d7f87c2c02e03d99b95cfa6f7a776409083a9e4d468912e18c7680437b29222c"},
+    {file = "gevent-24.2.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:968581d1717bbcf170758580f5f97a2925854943c45a19be4d47299507db2eb7"},
+    {file = "gevent-24.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7899a38d0ae7e817e99adb217f586d0a4620e315e4de577444ebeeed2c5729be"},
+    {file = "gevent-24.2.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f5e8e8d60e18d5f7fd49983f0c4696deeddaf6e608fbab33397671e2fcc6cc91"},
+    {file = "gevent-24.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fbfdce91239fe306772faab57597186710d5699213f4df099d1612da7320d682"},
+    {file = "gevent-24.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cdf66977a976d6a3cfb006afdf825d1482f84f7b81179db33941f2fc9673bb1d"},
+    {file = "gevent-24.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:1dffb395e500613e0452b9503153f8f7ba587c67dd4a85fc7cd7aa7430cb02cc"},
+    {file = "gevent-24.2.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:6c47ae7d1174617b3509f5d884935e788f325eb8f1a7efc95d295c68d83cce40"},
+    {file = "gevent-24.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7cac622e11b4253ac4536a654fe221249065d9a69feb6cdcd4d9af3503602e0"},
+    {file = "gevent-24.2.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bf5b9c72b884c6f0c4ed26ef204ee1f768b9437330422492c319470954bc4cc7"},
+    {file = "gevent-24.2.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f5de3c676e57177b38857f6e3cdfbe8f38d1cd754b63200c0615eaa31f514b4f"},
+    {file = "gevent-24.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4faf846ed132fd7ebfbbf4fde588a62d21faa0faa06e6f468b7faa6f436b661"},
+    {file = "gevent-24.2.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:368a277bd9278ddb0fde308e6a43f544222d76ed0c4166e0d9f6b036586819d9"},
+    {file = "gevent-24.2.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f8a04cf0c5b7139bc6368b461257d4a757ea2fe89b3773e494d235b7dd51119f"},
+    {file = "gevent-24.2.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9d8d0642c63d453179058abc4143e30718b19a85cbf58c2744c9a63f06a1d388"},
+    {file = "gevent-24.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:94138682e68ec197db42ad7442d3cf9b328069c3ad8e4e5022e6b5cd3e7ffae5"},
+    {file = "gevent-24.2.1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:8f4b8e777d39013595a7740b4463e61b1cfe5f462f1b609b28fbc1e4c4ff01e5"},
+    {file = "gevent-24.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141a2b24ad14f7b9576965c0c84927fc85f824a9bb19f6ec1e61e845d87c9cd8"},
+    {file = "gevent-24.2.1-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:9202f22ef811053077d01f43cc02b4aaf4472792f9fd0f5081b0b05c926cca19"},
+    {file = "gevent-24.2.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2955eea9c44c842c626feebf4459c42ce168685aa99594e049d03bedf53c2800"},
+    {file = "gevent-24.2.1-cp38-cp38-win32.whl", hash = "sha256:44098038d5e2749b0784aabb27f1fcbb3f43edebedf64d0af0d26955611be8d6"},
+    {file = "gevent-24.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:117e5837bc74a1673605fb53f8bfe22feb6e5afa411f524c835b2ddf768db0de"},
+    {file = "gevent-24.2.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:2ae3a25ecce0a5b0cd0808ab716bfca180230112bb4bc89b46ae0061d62d4afe"},
+    {file = "gevent-24.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7ceb59986456ce851160867ce4929edaffbd2f069ae25717150199f8e1548b8"},
+    {file = "gevent-24.2.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:2e9ac06f225b696cdedbb22f9e805e2dd87bf82e8fa5e17756f94e88a9d37cf7"},
+    {file = "gevent-24.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:90cbac1ec05b305a1b90ede61ef73126afdeb5a804ae04480d6da12c56378df1"},
+    {file = "gevent-24.2.1-cp39-cp39-win32.whl", hash = "sha256:782a771424fe74bc7e75c228a1da671578c2ba4ddb2ca09b8f959abdf787331e"},
+    {file = "gevent-24.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:3adfb96637f44010be8abd1b5e73b5070f851b817a0b182e601202f20fa06533"},
+    {file = "gevent-24.2.1-pp310-pypy310_pp73-macosx_11_0_universal2.whl", hash = "sha256:7b00f8c9065de3ad226f7979154a7b27f3b9151c8055c162332369262fc025d8"},
+    {file = "gevent-24.2.1.tar.gz", hash = "sha256:432fc76f680acf7cf188c2ee0f5d3ab73b63c1f03114c7cd8a34cebbe5aa2056"},
 ]
 
 [[package]]
@@ -2918,4 +2974,59 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 files = [
     {file = "zipp-3.16.2-py3-none-any.whl", hash = "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0"},
     {file = "zipp-3.16.2.tar.gz", hash = "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"},
+]
+
+[[package]]
+name = "zope-event"
+version = "5.0"
+requires_python = ">=3.7"
+summary = "Very basic event publishing system"
+dependencies = [
+    "setuptools",
+]
+files = [
+    {file = "zope.event-5.0-py3-none-any.whl", hash = "sha256:2832e95014f4db26c47a13fdaef84cef2f4df37e66b59d8f1f4a8f319a632c26"},
+    {file = "zope.event-5.0.tar.gz", hash = "sha256:bac440d8d9891b4068e2b5a2c5e2c9765a9df762944bda6955f96bb9b91e67cd"},
+]
+
+[[package]]
+name = "zope-interface"
+version = "6.3"
+requires_python = ">=3.7"
+summary = "Interfaces for Python"
+dependencies = [
+    "setuptools",
+]
+files = [
+    {file = "zope.interface-6.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f32010ffb87759c6a3ad1c65ed4d2e38e51f6b430a1ca11cee901ec2b42e021"},
+    {file = "zope.interface-6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e78a183a3c2f555c2ad6aaa1ab572d1c435ba42f1dc3a7e8c82982306a19b785"},
+    {file = "zope.interface-6.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa0491a9f154cf8519a02026dc85a416192f4cb1efbbf32db4a173ba28b289a"},
+    {file = "zope.interface-6.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62e32f02b3f26204d9c02c3539c802afc3eefb19d601a0987836ed126efb1f21"},
+    {file = "zope.interface-6.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c40df4aea777be321b7e68facb901bc67317e94b65d9ab20fb96e0eb3c0b60a1"},
+    {file = "zope.interface-6.3-cp310-cp310-win_amd64.whl", hash = "sha256:46034be614d1f75f06e7dcfefba21d609b16b38c21fc912b01a99cb29e58febb"},
+    {file = "zope.interface-6.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:600101f43a7582d5b9504a7c629a1185a849ce65e60fca0f6968dfc4b76b6d39"},
+    {file = "zope.interface-6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d6b229f5e1a6375f206455cc0a63a8e502ed190fe7eb15e94a312dc69d40299"},
+    {file = "zope.interface-6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10cde8dc6b2fd6a1d0b5ca4be820063e46ddba417ab82bcf55afe2227337b130"},
+    {file = "zope.interface-6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40aa8c8e964d47d713b226c5baf5f13cdf3a3169c7a2653163b17ff2e2334d10"},
+    {file = "zope.interface-6.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d165d7774d558ea971cb867739fb334faf68fc4756a784e689e11efa3becd59e"},
+    {file = "zope.interface-6.3-cp311-cp311-win_amd64.whl", hash = "sha256:69dedb790530c7ca5345899a1b4cb837cc53ba669051ea51e8c18f82f9389061"},
+    {file = "zope.interface-6.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8d407e0fd8015f6d5dfad481309638e1968d70e6644e0753f229154667dd6cd5"},
+    {file = "zope.interface-6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:72d5efecad16c619a97744a4f0b67ce1bcc88115aa82fcf1dc5be9bb403bcc0b"},
+    {file = "zope.interface-6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:567d54c06306f9c5b6826190628d66753b9f2b0422f4c02d7c6d2b97ebf0a24e"},
+    {file = "zope.interface-6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:483e118b1e075f1819b3c6ace082b9d7d3a6a5eb14b2b375f1b80a0868117920"},
+    {file = "zope.interface-6.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb78c12c1ad3a20c0d981a043d133299117b6854f2e14893b156979ed4e1d2c"},
+    {file = "zope.interface-6.3-cp312-cp312-win_amd64.whl", hash = "sha256:ad4524289d8dbd6fb5aa17aedb18f5643e7d48358f42c007a5ee51a2afc2a7c5"},
+    {file = "zope.interface-6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:187f7900b63845dcdef1be320a523dbbdba94d89cae570edc2781eb55f8c2f86"},
+    {file = "zope.interface-6.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a058e6cf8d68a5a19cb5449f42a404f0d6c2778b897e6ce8fadda9cea308b1b0"},
+    {file = "zope.interface-6.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8fa0fb05083a1a4216b4b881fdefa71c5d9a106e9b094cd4399af6b52873e91"},
+    {file = "zope.interface-6.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:26c9a37fb395a703e39b11b00b9e921c48f82b6e32cc5851ad5d0618cd8876b5"},
+    {file = "zope.interface-6.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b0c4c90e5eefca2c3e045d9f9ed9f1e2cdbe70eb906bff6b247e17119ad89a1"},
+    {file = "zope.interface-6.3-cp38-cp38-win_amd64.whl", hash = "sha256:5683aa8f2639016fd2b421df44301f10820e28a9b96382a6e438e5c6427253af"},
+    {file = "zope.interface-6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2c3cfb272bcb83650e6695d49ae0d14dd06dc694789a3d929f23758557a23d92"},
+    {file = "zope.interface-6.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:01a0b3dd012f584afcf03ed814bce0fc40ed10e47396578621509ac031be98bf"},
+    {file = "zope.interface-6.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4137025731e824eee8d263b20682b28a0bdc0508de9c11d6c6be54163e5b7c83"},
+    {file = "zope.interface-6.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c8731596198198746f7ce2a4487a0edcbc9ea5e5918f0ab23c4859bce56055c"},
+    {file = "zope.interface-6.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf34840e102d1d0b2d39b1465918d90b312b1119552cebb61a242c42079817b9"},
+    {file = "zope.interface-6.3-cp39-cp39-win_amd64.whl", hash = "sha256:a1adc14a2a9d5e95f76df625a9b39f4709267a483962a572e3f3001ef90ea6e6"},
+    {file = "zope.interface-6.3.tar.gz", hash = "sha256:f83d6b4b22262d9a826c3bd4b2fbfafe1d0000f085ef8e44cd1328eea274ae6a"},
 ]

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["datajunction_server"]
 
-
-
-
-
 [tool.pdm]
 [tool.pdm.build]
 includes = ["dj"]
@@ -19,7 +15,7 @@ test = [
     "freezegun>=1.2.2",
     "pre-commit>=3.2.2",
     "pylint>=3.0.3",
-    "pytest-asyncio>=0.15.1",
+    "pytest-asyncio>=0.23.6",
     "pytest-cov>=4.0.0",
     "pytest-integration>=0.2.2",
     "pytest-mock>=3.10.0",
@@ -30,6 +26,7 @@ test = [
     "duckdb==0.8.1",
     "testcontainers>=3.7.1",
     "httpx>=0.27.0",
+    "greenlet>=3.0.3",
 ]
 
 [[tool.pdm.autoexport]]
@@ -83,6 +80,8 @@ dependencies = [
     "fastapi-cache2>=0.2.1",
     "psycopg>=3.1.16",
     "pydantic<2",
+    "asyncpg>=0.29.0",
+    "aiosqlite>=0.20.0",
 ]
 requires-python = ">=3.8,<4.0"
 readme = "README.md"
@@ -108,10 +107,6 @@ transpilation = [
 [project.entry-points.'superset.db_engine_specs']
 dj = 'datajunction_server.superset:DJEngineSpec'
 
-
-
-
-
 [tool.hatch.version]
 path = "datajunction_server/__about__.py"
 
@@ -124,3 +119,6 @@ source = ['datajunction_server/']
 [tool.isort]
 src_paths = ["datajunction_server/", "tests/"]
 profile = 'black'
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -82,7 +82,6 @@ dependencies = [
     "fastapi-cache2>=0.2.1",
     "psycopg>=3.1.16",
     "pydantic<2",
-    "asyncpg>=0.29.0",
     "aiosqlite>=0.20.0",
 ]
 requires-python = ">=3.8,<4.0"

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["datajunction_server"]
 
+
 [tool.pdm]
 [tool.pdm.build]
 includes = ["dj"]
@@ -27,6 +28,7 @@ test = [
     "testcontainers>=3.7.1",
     "httpx>=0.27.0",
     "greenlet>=3.0.3",
+    "gevent>=24.2.1",
 ]
 
 [[tool.pdm.autoexport]]
@@ -115,6 +117,7 @@ repository = "https://github.com/DataJunction/dj"
 
 [tool.coverage.run]
 source = ['datajunction_server/']
+concurrency = ["thread,greenlet"]
 
 [tool.isort]
 src_paths = ["datajunction_server/", "tests/"]

--- a/datajunction-server/requirements/docker.txt
+++ b/datajunction-server/requirements/docker.txt
@@ -4,6 +4,7 @@
 accept-types==0.4.1
 aiohttp==3.9.0; python_version >= "3.11"
 aiosignal==1.3.1; python_version >= "3.11"
+aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
 antlr4-python3-runtime==4.12.0
@@ -11,7 +12,8 @@ anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
 astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
+async-timeout==4.0.3; python_version < "3.12.0"
+asyncpg==0.29.0
 attrs==23.1.0; python_version >= "3.11"
 backports-zoneinfo==0.2.1; python_version < "3.9"
 bcrypt==4.1.2
@@ -41,7 +43,7 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 googleapis-common-protos==1.60.0
 graphql-core==3.2.3
-greenlet==2.0.2; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
+greenlet==3.0.3; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 h11==0.14.0
 httplib2==0.22.0
 httptools==0.6.0

--- a/datajunction-server/requirements/docker.txt
+++ b/datajunction-server/requirements/docker.txt
@@ -12,8 +12,7 @@ anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
 astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_version < "3.12.0"
-asyncpg==0.29.0
+async-timeout==4.0.3; python_full_version <= "3.11.2"
 attrs==23.1.0; python_version >= "3.11"
 backports-zoneinfo==0.2.1; python_version < "3.9"
 bcrypt==4.1.2

--- a/datajunction-server/requirements/test.txt
+++ b/datajunction-server/requirements/test.txt
@@ -55,7 +55,7 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 googleapis-common-protos==1.60.0
 graphql-core==3.2.3
-greenlet==3.0.3; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httplib2==0.22.0

--- a/datajunction-server/requirements/test.txt
+++ b/datajunction-server/requirements/test.txt
@@ -4,6 +4,7 @@
 accept-types==0.4.1
 aiohttp==3.9.0; python_version >= "3.11"
 aiosignal==1.3.1; python_version >= "3.11"
+aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
 antlr4-python3-runtime==4.12.0
@@ -12,7 +13,8 @@ asciidag==0.2.0
 asgiref==3.7.2
 astroid==3.1.0
 astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
+async-timeout==4.0.3; python_version < "3.12.0"
+asyncpg==0.29.0
 attrs==23.1.0; python_version >= "3.11"
 backports-zoneinfo==0.2.1; python_version < "3.9"
 bcrypt==4.1.2
@@ -53,9 +55,11 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 googleapis-common-protos==1.60.0
 graphql-core==3.2.3
-greenlet==2.0.2; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
+greenlet==3.0.3; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 h11==0.14.0
+httpcore==1.0.4
 httplib2==0.22.0
+httpx==0.27.0
 identify==2.5.26
 idna==3.4
 importlib-metadata==6.8.0
@@ -96,7 +100,7 @@ pygments==2.16.1
 pylint==3.1.0
 pyparsing==3.1.1; python_version > "3.0"
 pytest==8.1.1
-pytest-asyncio==0.23.5.post1
+pytest-asyncio==0.23.6
 pytest-cov==4.1.0
 pytest-integration==0.2.3
 pytest-mock==3.12.0

--- a/datajunction-server/requirements/test.txt
+++ b/datajunction-server/requirements/test.txt
@@ -13,8 +13,7 @@ asciidag==0.2.0
 asgiref==3.7.2
 astroid==3.1.0
 astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_version < "3.12.0"
-asyncpg==0.29.0
+async-timeout==4.0.3; python_full_version <= "3.11.2"
 attrs==23.1.0; python_version >= "3.11"
 backports-zoneinfo==0.2.1; python_version < "3.9"
 bcrypt==4.1.2
@@ -48,6 +47,7 @@ fastapi-cache2==0.2.1
 filelock==3.12.2
 freezegun==1.4.0
 frozenlist==1.4.0; python_version >= "3.11"
+gevent==24.2.1
 google-api-core==2.12.0
 google-api-python-client==2.122.0
 google-auth==2.23.2
@@ -143,3 +143,5 @@ wheel==0.41.1; python_version < "3.9"
 wrapt==1.15.0
 yarl==1.9.4
 zipp==3.16.2
+zope-event==5.0
+zope-interface==6.3

--- a/datajunction-server/tests/api/attributes_test.py
+++ b/datajunction-server/tests/api/attributes_test.py
@@ -3,16 +3,18 @@ Tests for the attributes API.
 """
 from unittest.mock import ANY
 
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
 
-def test_adding_new_attribute(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_adding_new_attribute(
+    client: AsyncClient,
 ) -> None:
     """
     Test adding an attribute.
     """
-    response = client.post(
+    response = await client.post(
         "/attributes/",
         json={
             "namespace": "custom",
@@ -32,7 +34,7 @@ def test_adding_new_attribute(
         "allowed_node_types": ["source"],
     }
 
-    response = client.post(
+    response = await client.post(
         "/attributes/",
         json={
             "namespace": "custom",
@@ -49,7 +51,7 @@ def test_adding_new_attribute(
         "warnings": [],
     }
 
-    response = client.post(
+    response = await client.post(
         "/attributes/",
         json={
             "namespace": "system",
@@ -67,13 +69,14 @@ def test_adding_new_attribute(
     }
 
 
-def test_list_attributes(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_list_attributes(
+    client: AsyncClient,
 ) -> None:
     """
     Test listing attributes. These should contain the default attributes.
     """
-    response = client.get("/attributes/")
+    response = await client.get("/attributes/")
     assert response.status_code == 200
     data = response.json()
     data = {

--- a/datajunction-server/tests/api/catalog_test.py
+++ b/datajunction-server/tests/api/catalog_test.py
@@ -1,17 +1,18 @@
 """
 Tests for the catalog API.
 """
+import pytest
+from httpx import AsyncClient
 
-from fastapi.testclient import TestClient
 
-
-def test_catalog_adding_a_new_catalog(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_adding_a_new_catalog(
+    client: AsyncClient,
 ) -> None:
     """
     Test adding a catalog
     """
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -22,13 +23,14 @@ def test_catalog_adding_a_new_catalog(
     assert data == {"name": "dev", "engines": []}
 
 
-def test_catalog_list(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_list(
+    client: AsyncClient,
 ) -> None:
     """
     Test listing catalogs
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -38,7 +40,7 @@ def test_catalog_list(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -53,7 +55,7 @@ def test_catalog_list(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "test",
@@ -61,7 +63,7 @@ def test_catalog_list(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "prod",
@@ -69,7 +71,7 @@ def test_catalog_list(
     )
     assert response.status_code == 201
 
-    response = client.get("/catalogs/")
+    response = await client.get("/catalogs/")
     assert response.status_code == 200
     assert response.json() == [
         {"name": "unknown", "engines": []},
@@ -84,13 +86,14 @@ def test_catalog_list(
     ]
 
 
-def test_catalog_get_catalog(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_get_catalog(
+    client: AsyncClient,
 ) -> None:
     """
     Test getting a catalog
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -100,7 +103,7 @@ def test_catalog_get_catalog(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -115,7 +118,7 @@ def test_catalog_get_catalog(
     )
     assert response.status_code == 201
 
-    response = client.get(
+    response = await client.get(
         "/catalogs/dev",
     )
     assert response.status_code == 200
@@ -128,13 +131,14 @@ def test_catalog_get_catalog(
     }
 
 
-def test_catalog_adding_a_new_catalog_with_engines(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_adding_a_new_catalog_with_engines(
+    client: AsyncClient,
 ) -> None:
     """
     Test adding a catalog with engines
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -146,7 +150,7 @@ def test_catalog_adding_a_new_catalog_with_engines(
     data = response.json()
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -174,13 +178,14 @@ def test_catalog_adding_a_new_catalog_with_engines(
     }
 
 
-def test_catalog_adding_a_new_catalog_then_attaching_engines(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_adding_a_new_catalog_then_attaching_engines(
+    client: AsyncClient,
 ) -> None:
     """
     Test adding a catalog then attaching a catalog
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -192,7 +197,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
     data = response.json()
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -200,7 +205,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
     )
     assert response.status_code == 201
 
-    client.post(
+    await client.post(
         "/catalogs/dev/engines/",
         json=[
             {
@@ -211,7 +216,7 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
         ],
     )
 
-    response = client.get("/catalogs/dev/")
+    response = await client.get("/catalogs/dev/")
     data = response.json()
     assert data == {
         "name": "dev",
@@ -226,13 +231,14 @@ def test_catalog_adding_a_new_catalog_then_attaching_engines(
     }
 
 
-def test_catalog_adding_without_duplicating(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_adding_without_duplicating(
+    client: AsyncClient,
 ) -> None:
     """
     Test adding a catalog and having existing catalogs not re-added
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -244,7 +250,7 @@ def test_catalog_adding_without_duplicating(
     data = response.json()
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -255,7 +261,7 @@ def test_catalog_adding_without_duplicating(
     data = response.json()
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -266,7 +272,7 @@ def test_catalog_adding_without_duplicating(
     data = response.json()
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -275,7 +281,7 @@ def test_catalog_adding_without_duplicating(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/dev/engines/",
         json=[
             {
@@ -297,7 +303,7 @@ def test_catalog_adding_without_duplicating(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/dev/engines/",
         json=[
             {
@@ -344,13 +350,14 @@ def test_catalog_adding_without_duplicating(
     }
 
 
-def test_catalog_raise_on_adding_a_new_catalog_with_nonexistent_engines(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_raise_on_adding_a_new_catalog_with_nonexistent_engines(
+    client: AsyncClient,
 ) -> None:
     """
     Test raising an error when adding a catalog with engines that do not exist
     """
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -368,13 +375,14 @@ def test_catalog_raise_on_adding_a_new_catalog_with_nonexistent_engines(
     assert data == {"detail": "Engine not found: `spark` version `4.0.0`"}
 
 
-def test_catalog_raise_on_catalog_already_exists(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_raise_on_catalog_already_exists(
+    client: AsyncClient,
 ) -> None:
     """
     Test raise on catalog already exists
     """
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -382,7 +390,7 @@ def test_catalog_raise_on_catalog_already_exists(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",

--- a/datajunction-server/tests/api/catalog_test.py
+++ b/datajunction-server/tests/api/catalog_test.py
@@ -73,17 +73,25 @@ async def test_catalog_list(
 
     response = await client.get("/catalogs/")
     assert response.status_code == 200
-    assert response.json() == [
-        {"name": "unknown", "engines": []},
-        {
-            "name": "dev",
-            "engines": [
-                {"name": "spark", "version": "3.3.1", "uri": None, "dialect": "spark"},
-            ],
-        },
-        {"name": "test", "engines": []},
-        {"name": "prod", "engines": []},
-    ]
+    assert sorted(response.json(), key=lambda v: v["name"]) == sorted(
+        [
+            {"name": "unknown", "engines": []},
+            {
+                "name": "dev",
+                "engines": [
+                    {
+                        "name": "spark",
+                        "version": "3.3.1",
+                        "uri": None,
+                        "dialect": "spark",
+                    },
+                ],
+            },
+            {"name": "test", "engines": []},
+            {"name": "prod", "engines": []},
+        ],
+        key=lambda v: v["name"],  # type: ignore
+    )
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -1,15 +1,16 @@
 """
 Tests for client code generator.
 """
+import pytest
+from httpx import AsyncClient
 
-from fastapi.testclient import TestClient
 
-
-def test_generated_python_client_code_new_metric(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_generated_python_client_code_new_metric(client_with_roads: AsyncClient):
     """
     Test generating Python client code for creating a new metric
     """
-    response = client_with_roads.get(
+    response = await client_with_roads.get(
         "/datajunction-clients/python/new_node/default.num_repair_orders",
     )
     assert (
@@ -19,18 +20,19 @@ def test_generated_python_client_code_new_metric(client_with_roads: TestClient):
 num_repair_orders = dj.create_metric(
     description="Number of repair orders",
     display_name="Default: Num Repair Orders",
+    mode="published",
     name="default.num_repair_orders",
-    primary_key=[],
     query=\"\"\"SELECT count(repair_order_id) FROM default.repair_orders_fact\"\"\"
 )"""
     )
 
 
-def test_generated_python_client_code_new_source(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_generated_python_client_code_new_source(client_with_roads: AsyncClient):
     """
     Test generating Python client code for creating a new source
     """
-    response = client_with_roads.get(
+    response = await client_with_roads.get(
         "/datajunction-clients/python/new_node/default.repair_order_details",
     )
     assert (
@@ -40,19 +42,22 @@ def test_generated_python_client_code_new_source(client_with_roads: TestClient):
 repair_order_details = dj.create_source(
     description="Details on repair orders",
     display_name="default.roads.repair_order_details",
+    mode="published",
     name="default.repair_order_details",
-    primary_key=[],
     schema_="roads",
     table="repair_order_details"
 )"""
     )
 
 
-def test_generated_python_client_code_new_dimension(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_generated_python_client_code_new_dimension(
+    client_with_roads: AsyncClient,
+):
     """
     Test generating Python client code for creating a new dimension
     """
-    response = client_with_roads.get(
+    response = await client_with_roads.get(
         "/datajunction-clients/python/new_node/default.repair_order",
     )
     assert (
@@ -62,6 +67,7 @@ def test_generated_python_client_code_new_dimension(client_with_roads: TestClien
 repair_order = dj.create_dimension(
     description="Repair order dimension",
     display_name="Default: Repair Order",
+    mode="published",
     name="default.repair_order",
     primary_key=['repair_order_id'],
     query=\"\"\"
@@ -79,11 +85,12 @@ repair_order = dj.create_dimension(
     )
 
 
-def test_generated_python_client_code_new_cube(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_generated_python_client_code_new_cube(client_with_roads: AsyncClient):
     """
     Test generating Python client code for creating a new dimension
     """
-    client_with_roads.post(
+    await client_with_roads.post(
         "/nodes/cube/",
         json={
             "metrics": ["default.num_repair_orders", "default.total_repair_cost"],
@@ -96,7 +103,7 @@ def test_generated_python_client_code_new_cube(client_with_roads: TestClient):
             "name": "default.repairs_cube",
         },
     )
-    response = client_with_roads.get(
+    response = await client_with_roads.get(
         "/datajunction-clients/python/new_node/default.repairs_cube",
     )
     assert (
@@ -106,22 +113,23 @@ def test_generated_python_client_code_new_cube(client_with_roads: TestClient):
 repairs_cube = dj.create_cube(
     description="Cube of various metrics related to repairs",
     display_name="Default: Repairs Cube",
+    mode="published",
     name="default.repairs_cube",
-    primary_key=[],
     metrics=["default.num_repair_orders", "default.total_repair_cost"],
     dimensions=["default.hard_hat.country", "default.hard_hat.city"]
 )"""
     )
 
 
-def test_generated_python_client_code_adding_materialization(
+@pytest.mark.asyncio
+async def test_generated_python_client_code_adding_materialization(
     client_with_query_service_example_loader,
 ):
     """
     Test that generating python client code for adding materialization works
     """
-    custom_client = client_with_query_service_example_loader(["BASIC"])
-    custom_client.post(
+    custom_client = await client_with_query_service_example_loader(["BASIC"])
+    await custom_client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -129,7 +137,7 @@ def test_generated_python_client_code_adding_materialization(
             "dialect": "spark",
         },
     )
-    custom_client.post(
+    await custom_client.post(
         "/nodes/basic.transform.country_agg/materialization/",
         json={
             "job": "spark_sql",
@@ -140,7 +148,7 @@ def test_generated_python_client_code_adding_materialization(
             "schedule": "0 * * * *",
         },
     )
-    response = custom_client.get(
+    response = await custom_client.get(
         "/datajunction-clients/python/add_materialization/"
         "basic.transform.country_agg/spark_sql__full",
     )
@@ -165,13 +173,14 @@ country_agg.add_materialization(
     )
 
 
-def test_generated_python_client_code_link_dimension(
-    client_with_namespaced_roads: TestClient,
+@pytest.mark.asyncio
+async def test_generated_python_client_code_link_dimension(
+    client_with_namespaced_roads: AsyncClient,
 ):
     """
     Test generating Python client code for creating a new dimension
     """
-    response = client_with_namespaced_roads.get(
+    response = await client_with_namespaced_roads.get(
         "/datajunction-clients/python/link_dimension/foo.bar.repair_orders/"
         "municipality_id/foo.bar.municipality_dim/",
     )

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -10,9 +10,10 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from datajunction_server.api.main import app
-from datajunction_server.database.node import Node
+from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.models import access
 from datajunction_server.models.node import AvailabilityStateBase
@@ -1502,10 +1503,18 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert response.status_code == 200
         assert data == {"message": "Availability state successfully posted"}
 
-        statement = select(Node).where(
-            Node.name == "default.large_revenue_payments_only",
+        statement = (
+            select(Node)
+            .where(
+                Node.name == "default.large_revenue_payments_only",
+            )
+            .options(
+                joinedload(Node.current).options(joinedload(NodeRevision.availability)),
+            )
         )
-        large_revenue_payments_only = (await session.execute(statement)).scalar_one()
+        large_revenue_payments_only = (
+            (await session.execute(statement)).unique().scalar_one()
+        )
         node_dict = AvailabilityStateBase.from_orm(
             large_revenue_payments_only.current.availability,
         ).dict()
@@ -1566,10 +1575,18 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         assert response.status_code == 200
         assert data == {"message": "Availability state successfully posted"}
 
-        statement = select(Node).where(
-            Node.name == "default.large_revenue_payments_only",
+        statement = (
+            select(Node)
+            .where(
+                Node.name == "default.large_revenue_payments_only",
+            )
+            .options(
+                joinedload(Node.current).options(joinedload(NodeRevision.availability)),
+            )
         )
-        large_revenue_payments_only = (await session.execute(statement)).scalar_one()
+        large_revenue_payments_only = (
+            (await session.execute(statement)).unique().scalar_one()
+        )
         node_dict = AvailabilityStateBase.from_orm(
             large_revenue_payments_only.current.availability,
         ).dict()

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -1,21 +1,22 @@
 """Dimension linking related tests."""
 
 import pytest
+import pytest_asyncio
+from httpx import AsyncClient
 from requests import Response
-from starlette.testclient import TestClient
 
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from tests.conftest import post_and_raise_if_error
 from tests.examples import COMPLEX_DIMENSION_LINK, SERVICE_SETUP
 
 
-@pytest.fixture
-def dimensions_link_client(client: TestClient) -> TestClient:
+@pytest_asyncio.fixture
+async def dimensions_link_client(client: AsyncClient) -> AsyncClient:
     """
     Add dimension link examples to the roads test client.
     """
     for endpoint, json in SERVICE_SETUP + COMPLEX_DIMENSION_LINK:
-        post_and_raise_if_error(  # type: ignore
+        await post_and_raise_if_error(  # type: ignore
             client=client,
             endpoint=endpoint,
             json=json,  # type: ignore
@@ -23,13 +24,14 @@ def dimensions_link_client(client: TestClient) -> TestClient:
     return client
 
 
-def test_link_dimension_with_errors(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+@pytest.mark.asyncio
+async def test_link_dimension_with_errors(
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
 ):
     """
     Test linking dimensions with errors
     """
-    response = dimensions_link_client.post(
+    response = await dimensions_link_client.post(
         "/nodes/default.elapsed_secs/link",
         json={
             "dimension_node": "default.users",
@@ -41,7 +43,7 @@ def test_link_dimension_with_errors(
         "Cannot link dimension to a node of type metric. Must be a source, "
         "dimension, or transform node."
     )
-    response = dimensions_link_client.post(
+    response = await dimensions_link_client.post(
         "/nodes/default.events/link",
         json={
             "dimension_node": "default.users",
@@ -54,7 +56,7 @@ def test_link_dimension_with_errors(
         "and the dimension node default.users that it's being joined to."
     )
 
-    response = dimensions_link_client.post(
+    response = await dimensions_link_client.post(
         "/nodes/default.events/link",
         json={
             "dimension_node": "default.users",
@@ -70,14 +72,14 @@ def test_link_dimension_with_errors(
 
 @pytest.fixture
 def link_events_to_users_without_role(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
 ):
     """
     Link events with the users dimension without a role
     """
 
-    def _link_events_to_users_without_role() -> Response:
-        response = dimensions_link_client.post(
+    async def _link_events_to_users_without_role() -> Response:
+        response = await dimensions_link_client.post(
             "/nodes/default.events/link",
             json={
                 "dimension_node": "default.users",
@@ -96,7 +98,7 @@ def link_events_to_users_without_role(
 
 @pytest.fixture
 def link_events_to_users_with_role_direct(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
 ):
     """
     Link events with the users dimension with the role "user_direct",
@@ -104,8 +106,8 @@ def link_events_to_users_with_role_direct(
     event's start date
     """
 
-    def _link_events_to_users_with_role_direct() -> Response:
-        response = dimensions_link_client.post(
+    async def _link_events_to_users_with_role_direct() -> Response:
+        response = await dimensions_link_client.post(
             "/nodes/default.events/link",
             json={
                 "dimension_node": "default.users",
@@ -125,15 +127,15 @@ def link_events_to_users_with_role_direct(
 
 @pytest.fixture
 def link_events_to_users_with_role_windowed(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
 ):
     """
     Link events with the users dimension with the role "user_windowed",
     indicating windowed join between events and the user dimension
     """
 
-    def _link_events_to_users_with_role_windowed() -> Response:
-        response = dimensions_link_client.post(
+    async def _link_events_to_users_with_role_windowed() -> Response:
+        response = await dimensions_link_client.post(
             "/nodes/default.events/link",
             json={
                 "dimension_node": "default.users",
@@ -152,14 +154,14 @@ def link_events_to_users_with_role_windowed(
 
 @pytest.fixture
 def link_users_to_countries_with_role_registration(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
 ):
     """
     Link users to the countries dimension with role "registration_country".
     """
 
-    def _link_users_to_countries_with_role_registration() -> Response:
-        response = dimensions_link_client.post(
+    async def _link_users_to_countries_with_role_registration() -> Response:
+        response = await dimensions_link_client.post(
             "/nodes/default.users/link",
             json={
                 "dimension_node": "default.countries",
@@ -174,20 +176,21 @@ def link_users_to_countries_with_role_registration(
     return _link_users_to_countries_with_role_registration
 
 
-def test_link_complex_dimension_without_role(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name,
+@pytest.mark.asyncio
+async def test_link_complex_dimension_without_role(
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name,
     link_events_to_users_without_role,  # pylint: disable=redefined-outer-name
 ):
     """
     Test linking complex dimension without role
     """
-    response = link_events_to_users_without_role()
+    response = await link_events_to_users_without_role()
     assert response.json() == {
         "message": "Dimension node default.users has been successfully "
         "linked to node default.events.",
     }
 
-    response = dimensions_link_client.get("/nodes/default.events")
+    response = await dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"] == [
         {
             "dimension": {"name": "default.users"},
@@ -204,7 +207,7 @@ def test_link_complex_dimension_without_role(
     ]
 
     # Update dimension link
-    response = dimensions_link_client.post(
+    response = await dimensions_link_client.post(
         "/nodes/default.events/link",
         json={
             "dimension_node": "default.users",
@@ -221,13 +224,13 @@ def test_link_complex_dimension_without_role(
         "default.users has been successfully updated.",
     }
 
-    response = dimensions_link_client.get("/nodes/default.events")
+    response = await dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"][0]["foreign_keys"] == {
         "default.events.event_end_date": "default.users.snapshot_date",
         "default.events.user_id": "default.users.user_id",
     }
 
-    response = dimensions_link_client.get("/history?node=default.events")
+    response = await dimensions_link_client.get("/history?node=default.events")
     assert [
         (entry["activity_type"], entry["details"])
         for entry in response.json()
@@ -256,9 +259,9 @@ def test_link_complex_dimension_without_role(
     ]
 
     # Switch back to original join definition
-    link_events_to_users_without_role()
+    await link_events_to_users_without_role()
 
-    response = dimensions_link_client.get(
+    response = await dimensions_link_client.get(
         "/sql/default.events?dimensions=default.users.user_id"
         "&dimensions=default.users.snapshot_date"
         "&dimensions=default.users.registration_country",
@@ -286,7 +289,7 @@ FROM (
   AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date"""
     assert str(parse(query)) == str(parse(expected))
 
-    response = dimensions_link_client.get("/nodes/default.events/dimensions")
+    response = await dimensions_link_client.get("/nodes/default.events/dimensions")
     assert [(attr["name"], attr["path"]) for attr in response.json()] == [
         ("default.users.account_type", ["default.events"]),
         ("default.users.registration_country", ["default.events"]),
@@ -296,8 +299,9 @@ FROM (
     ]
 
 
-def test_link_complex_dimension_with_role(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+@pytest.mark.asyncio
+async def test_link_complex_dimension_with_role(
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
     link_events_to_users_with_role_direct,  # pylint: disable=redefined-outer-name
     link_events_to_users_with_role_windowed,  # pylint: disable=redefined-outer-name
     link_users_to_countries_with_role_registration,  # pylint: disable=redefined-outer-name
@@ -305,13 +309,13 @@ def test_link_complex_dimension_with_role(
     """
     Testing linking complex dimension with roles.
     """
-    response = link_events_to_users_with_role_direct()
+    response = await link_events_to_users_with_role_direct()
     assert response.json() == {
         "message": "Dimension node default.users has been successfully "
         "linked to node default.events.",
     }
 
-    response = dimensions_link_client.get("/nodes/default.events")
+    response = await dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"] == [
         {
             "dimension": {"name": "default.users"},
@@ -328,20 +332,20 @@ def test_link_complex_dimension_with_role(
     ]
 
     # Add a dimension link with different role
-    response = link_events_to_users_with_role_windowed()
+    response = await link_events_to_users_with_role_windowed()
     assert response.json() == {
         "message": "Dimension node default.users has been successfully linked to node "
         "default.events.",
     }
 
     # Add a dimension link on users for registration country
-    response = link_users_to_countries_with_role_registration()
+    response = await link_users_to_countries_with_role_registration()
     assert response.json() == {
         "message": "Dimension node default.countries has been successfully linked to node "
         "default.users.",
     }
 
-    response = dimensions_link_client.get("/nodes/default.events")
+    response = await dimensions_link_client.get("/nodes/default.events")
     assert response.json()["dimension_links"] == [
         {
             "dimension": {"name": "default.users"},
@@ -370,7 +374,9 @@ def test_link_complex_dimension_with_role(
     ]
 
     # Verify that the dimensions on the downstream metric have roles specified
-    response = dimensions_link_client.get("/nodes/default.elapsed_secs/dimensions")
+    response = await dimensions_link_client.get(
+        "/nodes/default.elapsed_secs/dimensions",
+    )
     assert [(attr["name"], attr["path"]) for attr in response.json()] == [
         (
             "default.countries.country_code[user_direct->registration_country]",
@@ -424,7 +430,7 @@ def test_link_complex_dimension_with_role(
     ]
 
     # Get SQL for the downstream metric grouped by the user dimension of role "user_windowed"
-    response = dimensions_link_client.get(
+    response = await dimensions_link_client.get(
         "/sql/default.elapsed_secs",
         params={
             "dimensions": [
@@ -466,7 +472,7 @@ GROUP BY default_DOT_events.user_id,
     assert str(parse(query)) == str(parse(expected))
 
     # Get SQL for the downstream metric grouped by the user dimension of role "user"
-    response = dimensions_link_client.get(
+    response = await dimensions_link_client.get(
         "/sql/default.elapsed_secs?dimensions=default.users.user_id[user_direct]"
         "&dimensions=default.users.snapshot_date[user_direct]"
         "&dimensions=default.users.registration_country[user_direct]",
@@ -497,7 +503,7 @@ GROUP BY default_DOT_events.user_id,
 
     # Get SQL for the downstream metric grouped by the user's registration country and
     # filtered by the user's residence country
-    response = dimensions_link_client.get(
+    response = await dimensions_link_client.get(
         "/sql/default.elapsed_secs?",
         params={
             "dimensions": [
@@ -537,16 +543,23 @@ INNER JOIN (SELECT  default_DOT_countries_table.country_code,
     assert str(parse(query)) == str(parse(expected))
 
 
-def test_remove_dimension_link(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+@pytest.mark.asyncio
+async def test_remove_dimension_link(
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
     link_events_to_users_with_role_direct,  # pylint: disable=redefined-outer-name
     link_events_to_users_without_role,  # pylint: disable=redefined-outer-name
 ):
     """
     Test removing complex dimension links
     """
-    link_events_to_users_with_role_direct()
-    response = dimensions_link_client.request(
+    response = await link_events_to_users_with_role_direct()
+    assert response.json() == {
+        "message": "Dimension node default.users has been successfully linked to node "
+        "default.events.",
+    }
+    response = await dimensions_link_client.get("/nodes/default.events")
+    # assert response.json()["dimension_links"] == []
+    response = await dimensions_link_client.request(
         "DELETE",
         "/nodes/default.events/link",
         json={
@@ -559,8 +572,10 @@ def test_remove_dimension_link(
         "default.events has been removed.",
     }
 
+    response = await dimensions_link_client.get("/nodes/default.events")
+    assert response.json()["dimension_links"] == []
     # Deleting again should not work
-    response = dimensions_link_client.request(
+    response = await dimensions_link_client.request(
         "DELETE",
         "/nodes/default.events/link",
         json={
@@ -572,8 +587,8 @@ def test_remove_dimension_link(
         "message": "Dimension link to node default.users with role user_direct not found",
     }
 
-    link_events_to_users_without_role()
-    response = dimensions_link_client.request(
+    await link_events_to_users_without_role()
+    response = await dimensions_link_client.request(
         "DELETE",
         "/nodes/default.events/link",
         json={
@@ -586,7 +601,7 @@ def test_remove_dimension_link(
     }
 
     # Deleting again should not work
-    response = dimensions_link_client.request(
+    response = await dimensions_link_client.request(
         "DELETE",
         "/nodes/default.events/link",
         json={
@@ -598,8 +613,9 @@ def test_remove_dimension_link(
     }
 
 
-def test_measures_sql_with_dimension_roles(
-    dimensions_link_client: TestClient,  # pylint: disable=redefined-outer-name
+@pytest.mark.asyncio
+async def test_measures_sql_with_dimension_roles(
+    dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
     link_events_to_users_with_role_direct,  # pylint: disable=redefined-outer-name
     link_events_to_users_with_role_windowed,  # pylint: disable=redefined-outer-name
     link_users_to_countries_with_role_registration,  # pylint: disable=redefined-outer-name
@@ -607,9 +623,9 @@ def test_measures_sql_with_dimension_roles(
     """
     Test measures SQL with dimension roles
     """
-    link_events_to_users_with_role_direct()
-    link_events_to_users_with_role_windowed()
-    link_users_to_countries_with_role_registration()
+    await link_events_to_users_with_role_direct()
+    await link_events_to_users_with_role_windowed()
+    await link_users_to_countries_with_role_registration()
     sql_params = {
         "metrics": ["default.elapsed_secs"],
         "dimensions": [
@@ -619,7 +635,7 @@ def test_measures_sql_with_dimension_roles(
         ],
         "filters": ["default.countries.name[user_direct->registration_country] = 'UG'"],
     }
-    response = dimensions_link_client.get("/sql/measures", params=sql_params)
+    response = await dimensions_link_client.get("/sql/measures", params=sql_params)
     query = response.json()["sql"]
     expected = """WITH
 default_DOT_events AS (SELECT  default_DOT_events.elapsed_secs default_DOT_events_DOT_elapsed_secs,

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -640,7 +640,7 @@ async def test_measures_sql_with_dimension_roles(
     expected = """WITH
 default_DOT_events AS (SELECT  default_DOT_events.elapsed_secs default_DOT_events_DOT_elapsed_secs,
     default_DOT_countries.name default_DOT_countries_DOT_name,
-    default_DOT_events.event_start_date default_DOT_users_DOT_snapshot_date,
+    default_DOT_users.snapshot_date default_DOT_users_DOT_snapshot_date,
     default_DOT_users.registration_country default_DOT_users_DOT_registration_country
  FROM (SELECT  default_DOT_events_table.user_id,
     default_DOT_events_table.event_start_date,

--- a/datajunction-server/tests/api/djql_test.py
+++ b/datajunction-server/tests/api/djql_test.py
@@ -1,15 +1,17 @@
 """
 Tests for the djsql API.
 """
-# pylint: disable=too-many-lines,C0301
-
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
 from tests.sql.utils import compare_query_strings
 
+# pylint: disable=too-many-lines,C0301
 
-def test_get_djsql_data_only_nodes_query(
-    client_with_query_service: TestClient,
+
+@pytest.mark.asyncio
+async def test_get_djsql_data_only_nodes_query(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with just some non-metric nodes
@@ -21,7 +23,7 @@ SELECT default.hard_hat.country,
 FROM default.hard_hat
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -76,8 +78,9 @@ FROM default.hard_hat
     assert compare_query_strings(query, expected_query)
 
 
-def test_get_djsql_data_only_nested_metrics(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_data_only_nested_metrics(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with metric subquery
@@ -104,7 +107,7 @@ def test_get_djsql_data_only_nested_metrics(
     GROUP BY city
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -163,8 +166,9 @@ def test_get_djsql_data_only_nested_metrics(
     assert compare_query_strings(query, expected_query)
 
 
-def test_get_djsql_data_only_multiple_metrics(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_data_only_multiple_metrics(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with metric subquery
@@ -183,7 +187,7 @@ def test_get_djsql_data_only_multiple_metrics(
         default.hard_hat.city
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -244,8 +248,9 @@ def test_get_djsql_data_only_multiple_metrics(
     assert compare_query_strings(query, expected_query)
 
 
-def test_get_djsql_metric_table_exception(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_metric_table_exception(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with metric subquery from non `metrics`
@@ -264,7 +269,7 @@ def test_get_djsql_metric_table_exception(
 
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -274,8 +279,9 @@ def test_get_djsql_metric_table_exception(
     )
 
 
-def test_get_djsql_illegal_clause_metric_query(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_illegal_clause_metric_query(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with metric subquery from non `metrics`
@@ -294,7 +300,7 @@ def test_get_djsql_illegal_clause_metric_query(
         HAVING 5
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -304,8 +310,9 @@ def test_get_djsql_illegal_clause_metric_query(
     )
 
 
-def test_get_djsql_illegal_column_expression(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_illegal_column_expression(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with non col exp in projection
@@ -323,7 +330,7 @@ def test_get_djsql_illegal_column_expression(
         default.hard_hat.city
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -333,8 +340,9 @@ def test_get_djsql_illegal_column_expression(
     )
 
 
-def test_get_djsql_illegal_column(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_illegal_column(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with bad col in projection
@@ -352,7 +360,7 @@ def test_get_djsql_illegal_column(
         default.hard_hat.city
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -362,8 +370,9 @@ def test_get_djsql_illegal_column(
     )
 
 
-def test_get_djsql_illegal_limit(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_illegal_limit(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql with bad limit
@@ -379,7 +388,7 @@ def test_get_djsql_illegal_limit(
         LIMIT 1+2
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )
@@ -389,8 +398,9 @@ def test_get_djsql_illegal_limit(
     )
 
 
-def test_get_djsql_no_nodes(
-    client_with_query_service: TestClient,
+@pytest.mark.asyncio
+async def test_get_djsql_no_nodes(
+    client_with_query_service: AsyncClient,
 ) -> None:
     """
     Test djsql without dj node refs
@@ -400,7 +410,7 @@ def test_get_djsql_no_nodes(
         SELECT 1
     """
 
-    response = client_with_query_service.get(
+    response = await client_with_query_service.get(
         "/djsql/data/",
         params={"query": query},
     )

--- a/datajunction-server/tests/api/engine_test.py
+++ b/datajunction-server/tests/api/engine_test.py
@@ -1,17 +1,18 @@
 """
 Tests for the engine API.
 """
+import pytest
+from httpx import AsyncClient
 
-from fastapi.testclient import TestClient
 
-
-def test_engine_adding_a_new_engine(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_engine_adding_a_new_engine(
+    client: AsyncClient,
 ) -> None:
     """
     Test adding an engine
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -29,13 +30,14 @@ def test_engine_adding_a_new_engine(
     }
 
 
-def test_engine_list(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_engine_list(
+    client: AsyncClient,
 ) -> None:
     """
     Test listing engines
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -45,7 +47,7 @@ def test_engine_list(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -55,7 +57,7 @@ def test_engine_list(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -65,7 +67,7 @@ def test_engine_list(
     )
     assert response.status_code == 201
 
-    response = client.get("/engines/")
+    response = await client.get("/engines/")
     assert response.status_code == 200
     data = response.json()
     assert data == [
@@ -90,13 +92,14 @@ def test_engine_list(
     ]
 
 
-def test_engine_get_engine(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_engine_get_engine(
+    client: AsyncClient,
 ) -> None:
     """
     Test getting an engine
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -106,7 +109,7 @@ def test_engine_get_engine(
     )
     assert response.status_code == 201
 
-    response = client.get(
+    response = await client.get(
         "/engines/spark/3.3.1",
     )
     assert response.status_code == 200
@@ -119,13 +122,14 @@ def test_engine_get_engine(
     }
 
 
-def test_engine_raise_on_engine_already_exists(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_engine_raise_on_engine_already_exists(
+    client: AsyncClient,
 ) -> None:
     """
     Test raise on engine already exists
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -135,7 +139,7 @@ def test_engine_raise_on_engine_already_exists(
     )
     assert response.status_code == 201
 
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",

--- a/datajunction-server/tests/api/graphql/catalog_test.py
+++ b/datajunction-server/tests/api/graphql/catalog_test.py
@@ -1,17 +1,18 @@
 """
 Tests for the catalog API.
 """
+import pytest
+from httpx import AsyncClient
 
-from fastapi.testclient import TestClient
 
-
-def test_catalog_list(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_catalog_list(
+    client: AsyncClient,
 ) -> None:
     """
     Test listing catalogs
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -20,7 +21,7 @@ def test_catalog_list(
         },
     )
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "dev",
@@ -34,14 +35,14 @@ def test_catalog_list(
         },
     )
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "test",
         },
     )
 
-    response = client.post(
+    response = await client.post(
         "/catalogs/",
         json={
             "name": "prod",
@@ -55,7 +56,7 @@ def test_catalog_list(
     }
     """
 
-    response = client.post("/graphql", json={"query": query})
+    response = await client.post("/graphql", json={"query": query})
     assert response.status_code == 200
     assert response.json() == {
         "data": {

--- a/datajunction-server/tests/api/graphql/engine_test.py
+++ b/datajunction-server/tests/api/graphql/engine_test.py
@@ -1,17 +1,18 @@
 """
 Tests for the engine API.
 """
+import pytest
+from httpx import AsyncClient
 
-from fastapi.testclient import TestClient
 
-
-def test_engine_list(
-    client: TestClient,
+@pytest.mark.asyncio
+async def test_engine_list(
+    client: AsyncClient,
 ) -> None:
     """
     Test listing engines
     """
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -20,7 +21,7 @@ def test_engine_list(
         },
     )
 
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -29,7 +30,7 @@ def test_engine_list(
         },
     )
 
-    response = client.post(
+    response = await client.post(
         "/engines/",
         json={
             "name": "spark",
@@ -48,7 +49,7 @@ def test_engine_list(
     }
     """
 
-    response = client.post("/graphql", json={"query": query})
+    response = await client.post("/graphql", json={"query": query})
     assert response.status_code == 200
     data = response.json()
     assert data == {

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -3,25 +3,35 @@ Tests for API helpers.
 """
 
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api import helpers
-from datajunction_server.database.node import NodeRevision
+from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.errors import DJException
 from datajunction_server.models.node import NodeStatus
 
 
-def test_raise_get_node_when_node_does_not_exist(session: Session):
+@pytest.mark.asyncio
+async def test_raise_get_node_when_node_does_not_exist(session: AsyncSession):
     """
     Test raising when a node doesn't exist
     """
     with pytest.raises(DJException) as exc_info:
-        helpers.get_node_by_name(session=session, name="foo")
+        await helpers.get_node_by_name(
+            session=session,
+            name="foo",
+            raise_if_not_exists=True,
+        )
+
+    assert "A node with name `foo` does not exist." in str(exc_info.value)
+    with pytest.raises(DJException) as exc_info:
+        await Node.get_by_name(session=session, name="foo", raise_if_not_exists=True)
 
     assert "A node with name `foo` does not exist." in str(exc_info.value)
 
 
-def test_propagate_valid_status(session: Session):
+@pytest.mark.asyncio
+async def test_propagate_valid_status(session: AsyncSession):
     """
     Test raising when trying to propagate a valid status using an invalid node
     """
@@ -30,7 +40,7 @@ def test_propagate_valid_status(session: Session):
         status=NodeStatus.INVALID,
     )
     with pytest.raises(DJException) as exc_info:
-        helpers.propagate_valid_status(
+        await helpers.propagate_valid_status(
             session=session,
             valid_nodes=[invalid_node],
             catalog_id=1,

--- a/datajunction-server/tests/api/history_test.py
+++ b/datajunction-server/tests/api/history_test.py
@@ -3,7 +3,8 @@ Tests for the history endpoint
 """
 from unittest import mock
 
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
 from datajunction_server.database.history import ActivityType, EntityType, History
 
@@ -27,11 +28,12 @@ def test_history_hash():
     assert hash(foo1) == hash(foo2)
 
 
-def test_get_history_entity(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_get_history_entity(client_with_roads: AsyncClient):
     """
     Test getting history for an entity
     """
-    response = client_with_roads.get("/history/node/default.repair_orders/")
+    response = await client_with_roads.get("/history/node/default.repair_orders/")
     assert response.status_code in (200, 201)
     history = response.json()
     assert len(history) == 1
@@ -52,12 +54,13 @@ def test_get_history_entity(client_with_roads: TestClient):
     ]
 
 
-def test_get_history_node(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_get_history_node(client_with_roads: AsyncClient):
     """
     Test getting history for a node
     """
 
-    response = client_with_roads.get("/history?node=default.repair_order")
+    response = await client_with_roads.get("/history?node=default.repair_order")
     assert response.status_code in (200, 201)
     history = response.json()
     assert len(history) == 5
@@ -151,12 +154,13 @@ def test_get_history_node(client_with_roads: TestClient):
     ]
 
 
-def test_get_history_namespace(client_with_service_setup: TestClient):
+@pytest.mark.asyncio
+async def test_get_history_namespace(client_with_service_setup: AsyncClient):
     """
     Test getting history for a node context
     """
 
-    response = client_with_service_setup.get("/history/namespace/default")
+    response = await client_with_service_setup.get("/history/namespace/default")
     assert response.status_code in (200, 201)
     history = response.json()
     assert len(history) == 1

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -1,17 +1,20 @@
 """
 Tests for the namespaces API.
 """
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
+from datajunction_server.api.main import app
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.models import access
 
 
-def test_list_all_namespaces(client_with_examples: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_list_all_namespaces(client_with_examples: AsyncClient) -> None:
     """
     Test ``GET /namespaces/``.
     """
-    response = client_with_examples.get("/namespaces/")
+    response = await client_with_examples.get("/namespaces/")
     assert response.status_code in (200, 201)
     assert response.json() == [
         {"namespace": "basic", "num_nodes": 8},
@@ -28,7 +31,10 @@ def test_list_all_namespaces(client_with_examples: TestClient) -> None:
     ]
 
 
-def test_list_all_namespaces_access_limited(client_with_examples: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_list_all_namespaces_access_limited(
+    client_with_examples: AsyncClient,
+) -> None:
     """
     Test ``GET /namespaces/``.
     """
@@ -46,10 +52,9 @@ def test_list_all_namespaces_access_limited(client_with_examples: TestClient) ->
 
         return _validate_access
 
-    app = client_with_examples.app
     app.dependency_overrides[validate_access] = validate_access_override
 
-    response = client_with_examples.get("/namespaces/")
+    response = await client_with_examples.get("/namespaces/")
 
     assert response.status_code in (200, 201)
     assert response.json() == [
@@ -59,10 +64,12 @@ def test_list_all_namespaces_access_limited(client_with_examples: TestClient) ->
         {"namespace": "dbt.source.stripe", "num_nodes": 1},
         {"namespace": "dbt.transform", "num_nodes": 1},
     ]
+    app.dependency_overrides.clear()
 
 
-def test_list_all_namespaces_access_bad_injection(
-    client_with_examples: TestClient,
+@pytest.mark.asyncio
+async def test_list_all_namespaces_access_bad_injection(
+    client_with_examples: AsyncClient,
 ) -> None:
     """
     Test ``GET /namespaces/``.
@@ -76,10 +83,9 @@ def test_list_all_namespaces_access_bad_injection(
 
         return _validate_access
 
-    app = client_with_examples.app
     app.dependency_overrides[validate_access] = validate_access_override
 
-    response = client_with_examples.get("/namespaces/")
+    response = await client_with_examples.get("/namespaces/")
 
     assert response.status_code == 403
     assert response.json() == {
@@ -94,9 +100,11 @@ def test_list_all_namespaces_access_bad_injection(
         ],
         "warnings": [],
     }
+    app.dependency_overrides.clear()
 
 
-def test_list_all_namespaces_deny_all(client_with_examples: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_list_all_namespaces_deny_all(client_with_examples: AsyncClient) -> None:
     """
     Test ``GET /namespaces/``.
     """
@@ -107,27 +115,28 @@ def test_list_all_namespaces_deny_all(client_with_examples: TestClient) -> None:
 
         return _validate_access
 
-    app = client_with_examples.app
     app.dependency_overrides[validate_access] = validate_access_override
 
-    response = client_with_examples.get("/namespaces/")
+    response = await client_with_examples.get("/namespaces/")
 
     assert response.status_code in (200, 201)
     assert response.json() == []
+    app.dependency_overrides.clear()
 
 
-def test_list_nodes_by_namespace(client_with_basic: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_list_nodes_by_namespace(client_with_basic: AsyncClient) -> None:
     """
     Test ``GET /namespaces/{namespace}/``.
     """
-    response = client_with_basic.get("/namespaces/basic.source/")
+    response = await client_with_basic.get("/namespaces/basic.source/")
     assert response.status_code in (200, 201)
     assert {n["name"] for n in response.json()} == {
         "basic.source.users",
         "basic.source.comments",
     }
 
-    response = client_with_basic.get("/namespaces/basic/")
+    response = await client_with_basic.get("/namespaces/basic/")
     assert response.status_code in (200, 201)
     assert {n["name"] for n in response.json()} == {
         "basic.source.users",
@@ -139,14 +148,14 @@ def test_list_nodes_by_namespace(client_with_basic: TestClient) -> None:
         "basic.num_users",
     }
 
-    response = client_with_basic.get("/namespaces/basic/?type_=dimension")
+    response = await client_with_basic.get("/namespaces/basic/?type_=dimension")
     assert response.status_code in (200, 201)
     assert {n["name"] for n in response.json()} == {
         "basic.dimension.users",
         "basic.dimension.countries",
     }
 
-    response = client_with_basic.get("/namespaces/basic/?type_=source")
+    response = await client_with_basic.get("/namespaces/basic/?type_=source")
     assert response.status_code in (200, 201)
     assert {n["name"] for n in response.json()} == {
         "basic.source.comments",
@@ -154,19 +163,24 @@ def test_list_nodes_by_namespace(client_with_basic: TestClient) -> None:
     }
 
 
-def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_deactivate_namespaces(client_with_namespaced_roads: AsyncClient) -> None:
     """
     Test ``DELETE /namespaces/{namespace}``.
     """
     # Cannot deactivate if there are nodes under the namespace
-    response = client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=false")
+    response = await client_with_namespaced_roads.delete(
+        "/namespaces/foo.bar/?cascade=false",
+    )
     assert response.json() == {
         "message": "Cannot deactivate node namespace `foo.bar` as there are still "
         "active nodes under that namespace.",
     }
 
     # Can deactivate with cascade
-    response = client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=true")
+    response = await client_with_namespaced_roads.delete(
+        "/namespaces/foo.bar/?cascade=true",
+    )
     assert response.json() == {
         "message": "Namespace `foo.bar` has been deactivated. The following nodes "
         "have also been deactivated: foo.bar.repair_orders,foo.bar.repair_order_details,"
@@ -181,32 +195,34 @@ def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None
     }
 
     # Check that the namespace is no longer listed
-    response = client_with_namespaced_roads.get("/namespaces/")
+    response = await client_with_namespaced_roads.get("/namespaces/")
     assert response.status_code in (200, 201)
     assert "foo.bar" not in {n["namespace"] for n in response.json()}
 
-    response = client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=false")
+    response = await client_with_namespaced_roads.delete(
+        "/namespaces/foo.bar/?cascade=false",
+    )
     assert response.json()["message"] == "Namespace `foo.bar` is already deactivated."
 
     # Try restoring
-    response = client_with_namespaced_roads.post("/namespaces/foo.bar/restore/")
+    response = await client_with_namespaced_roads.post("/namespaces/foo.bar/restore/")
     assert response.json() == {
         "message": "Namespace `foo.bar` has been restored.",
     }
 
     # Check that the namespace is back
-    response = client_with_namespaced_roads.get("/namespaces/")
+    response = await client_with_namespaced_roads.get("/namespaces/")
     assert response.status_code in (200, 201)
     assert "foo.bar" in {n["namespace"] for n in response.json()}
 
     # Check that nodes in the namespace remain deactivated
-    response = client_with_namespaced_roads.get("/namespaces/foo.bar/")
+    response = await client_with_namespaced_roads.get("/namespaces/foo.bar/")
     assert response.status_code in (200, 201)
     assert response.json() == []
 
     # Restore with cascade=true should also restore all the nodes
-    client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=false")
-    response = client_with_namespaced_roads.post(
+    await client_with_namespaced_roads.delete("/namespaces/foo.bar/?cascade=false")
+    response = await client_with_namespaced_roads.post(
         "/namespaces/foo.bar/restore/?cascade=true",
     )
     assert response.json() == {
@@ -222,7 +238,7 @@ def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None
         "r_order_discounts,foo.bar.avg_time_to_dispatch",
     }
     # Calling restore again will raise
-    response = client_with_namespaced_roads.post(
+    response = await client_with_namespaced_roads.post(
         "/namespaces/foo.bar/restore/?cascade=true",
     )
     assert (
@@ -231,7 +247,7 @@ def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None
     )
 
     # Check that nodes in the namespace are restored
-    response = client_with_namespaced_roads.get("/namespaces/foo.bar/")
+    response = await client_with_namespaced_roads.get("/namespaces/foo.bar/")
     assert response.status_code in (200, 201)
     assert {n["name"] for n in response.json()} == {
         "foo.bar.repair_orders",
@@ -262,7 +278,7 @@ def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None
         "foo.bar.avg_time_to_dispatch",
     }
 
-    response = client_with_namespaced_roads.get("/history/namespace/foo.bar/")
+    response = await client_with_namespaced_roads.get("/history/namespace/foo.bar/")
     assert [
         (activity["activity_type"], activity["details"]) for activity in response.json()
     ] == [
@@ -307,7 +323,7 @@ def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None
         ),
     ]
 
-    response = client_with_namespaced_roads.get(
+    response = await client_with_namespaced_roads.get(
         "/history?node=foo.bar.avg_length_of_employment",
     )
     assert [
@@ -321,18 +337,19 @@ def test_deactivate_namespaces(client_with_namespaced_roads: TestClient) -> None
     ]
 
 
-def test_hard_delete_namespace(client_with_examples: TestClient):
+@pytest.mark.asyncio
+async def test_hard_delete_namespace(client_with_examples: AsyncClient):
     """
     Test hard deleting a namespace
     """
-    response = client_with_examples.delete("/namespaces/foo/hard/")
+    response = await client_with_examples.delete("/namespaces/foo/hard/")
     assert response.json()["message"] == (
         "Cannot hard delete namespace `foo` as there are still the following nodes "
         "under it: `['foo.bar.avg_length_of_employment', "
         "'foo.bar.avg_repair_order_discounts', 'foo.bar.avg_repair_price', "
         "'foo.bar.avg_time_to_dispatch', 'foo.bar.contractor', 'foo.bar.contractors', "
         "'foo.bar.dispatcher', 'foo.bar.dispatchers', 'foo.bar.hard_hat', "
-        "'foo.bar.hard_hats', 'foo.bar.hard_hat_state', 'foo.bar.local_hard_hats', "
+        "'foo.bar.hard_hat_state', 'foo.bar.hard_hats', 'foo.bar.local_hard_hats', "
         "'foo.bar.municipality', 'foo.bar.municipality_dim', "
         "'foo.bar.municipality_municipality_type', 'foo.bar.municipality_type', "
         "'foo.bar.num_repair_orders', 'foo.bar.repair_order', "
@@ -344,16 +361,16 @@ def test_hard_delete_namespace(client_with_examples: TestClient):
         "action cannot be undone."
     )
 
-    client_with_examples.post("/namespaces/foo/")
-    client_with_examples.post("/namespaces/foo.bar.baz/")
-    client_with_examples.post("/namespaces/foo.bar.baf/")
-    client_with_examples.post("/namespaces/foo.bar.bif.d/")
+    await client_with_examples.post("/namespaces/foo/")
+    await client_with_examples.post("/namespaces/foo.bar.baz/")
+    await client_with_examples.post("/namespaces/foo.bar.baf/")
+    await client_with_examples.post("/namespaces/foo.bar.bif.d/")
 
     # Deactivating a few nodes should still allow the hard delete to go through
-    client_with_examples.delete("/nodes/foo.bar.avg_length_of_employment")
-    client_with_examples.delete("/nodes/foo.bar.avg_repair_order_discounts")
+    await client_with_examples.delete("/nodes/foo.bar.avg_length_of_employment")
+    await client_with_examples.delete("/nodes/foo.bar.avg_repair_order_discounts")
 
-    hard_delete_response = client_with_examples.delete(
+    hard_delete_response = await client_with_examples.delete(
         "/namespaces/foo.bar/hard/?cascade=true",
     )
     assert hard_delete_response.json() == {
@@ -531,7 +548,7 @@ def test_hard_delete_namespace(client_with_examples: TestClient):
         },
         "message": "The namespace `foo.bar` has been completely removed.",
     }
-    list_namespaces_response = client_with_examples.get("/namespaces/")
+    list_namespaces_response = await client_with_examples.get("/namespaces/")
     assert list_namespaces_response.json() == [
         {"namespace": "basic", "num_nodes": 8},
         {"namespace": "basic.dimension", "num_nodes": 2},
@@ -546,7 +563,9 @@ def test_hard_delete_namespace(client_with_examples: TestClient):
         {"namespace": "foo", "num_nodes": 0},
     ]
 
-    response = client_with_examples.delete("/namespaces/jaffle_shop/hard/?cascade=true")
+    response = await client_with_examples.delete(
+        "/namespaces/jaffle_shop/hard/?cascade=true",
+    )
     assert response.json() == {
         "errors": [],
         "message": "Namespace `jaffle_shop` does not exist.",
@@ -554,12 +573,13 @@ def test_hard_delete_namespace(client_with_examples: TestClient):
     }
 
 
-def test_create_namespace(client_with_service_setup: TestClient):
+@pytest.mark.asyncio
+async def test_create_namespace(client_with_service_setup: AsyncClient):
     """
     Verify creating namespaces, both successful and validation errors
     """
     # By default, creating a namespace will also create its parents (i.e., like mkdir -p)
-    response = client_with_service_setup.post(
+    response = await client_with_service_setup.post(
         "/namespaces/aaa.bbb.ccc?include_parents=true",
     )
     assert response.json() == {
@@ -568,23 +588,23 @@ def test_create_namespace(client_with_service_setup: TestClient):
     }
 
     # Verify that the parent namespaces already exist if we try to create it again
-    response = client_with_service_setup.post("/namespaces/aaa")
+    response = await client_with_service_setup.post("/namespaces/aaa")
     assert response.json() == {"message": "Node namespace `aaa` already exists"}
-    response = client_with_service_setup.post("/namespaces/aaa.bbb")
+    response = await client_with_service_setup.post("/namespaces/aaa.bbb")
     assert response.json() == {"message": "Node namespace `aaa.bbb` already exists"}
 
     # Setting include_parents=false will not create the parents
-    response = client_with_service_setup.post(
+    response = await client_with_service_setup.post(
         "/namespaces/acde.mmm?include_parents=false",
     )
     assert response.json() == {
         "message": "The following node namespaces have been successfully created: acde.mmm",
     }
-    response = client_with_service_setup.get("/namespaces/acde")
+    response = await client_with_service_setup.get("/namespaces/acde")
     assert response.json()["message"] == "node namespace `acde` does not exist."
 
     # Setting include_parents=true will create the parents
-    response = client_with_service_setup.post(
+    response = await client_with_service_setup.post(
         "/namespaces/a.b.c?include_parents=true",
     )
     assert response.json() == {
@@ -605,7 +625,9 @@ def test_create_namespace(client_with_service_setup: TestClient):
         "aff.123_mmm",
     ]
     for invalid_namespace in invalid_namespaces:
-        response = client_with_service_setup.post(f"/namespaces/{invalid_namespace}")
+        response = await client_with_service_setup.post(
+            f"/namespaces/{invalid_namespace}",
+        )
         assert response.status_code == 422
         assert response.json()["message"] == (
             f"{invalid_namespace} is not a valid namespace. Namespace parts cannot start "
@@ -613,12 +635,13 @@ def test_create_namespace(client_with_service_setup: TestClient):
         )
 
 
-def test_export_namespaces(client_with_examples: TestClient):
+@pytest.mark.asyncio
+async def test_export_namespaces(client_with_examples: AsyncClient):
     """
     Test exporting a namespace to a project definition
     """
     # Create a cube so that the cube definition export path is tested
-    response = client_with_examples.post(
+    response = await client_with_examples.post(
         "/nodes/cube/",
         json={
             "name": "default.example_cube",
@@ -630,7 +653,7 @@ def test_export_namespaces(client_with_examples: TestClient):
         },
     )
     assert response.status_code in (200, 201)
-    response = client_with_examples.get(
+    response = await client_with_examples.get(
         "/namespaces/default/export/",
     )
     project_definition = response.json()

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -231,11 +231,11 @@ async def test_deactivate_namespaces(client_with_namespaced_roads: AsyncClient) 
         "bar.repair_type,foo.bar.contractors,foo.bar.municipality_municipality_type,"
         "foo.bar.municipality_type,foo.bar.municipality,foo.bar.dispatchers,foo.bar."
         "hard_hats,foo.bar.hard_hat_state,foo.bar.us_states,foo.bar.us_region,foo.ba"
-        "r.repair_order,foo.bar.contractor,foo.bar.hard_hat,foo.bar.local_hard_hats,"
-        "foo.bar.us_state,foo.bar.dispatcher,foo.bar.municipality_dim,foo.bar.num_re"
-        "pair_orders,foo.bar.avg_repair_price,foo.bar.total_repair_cost,foo.bar.avg_"
-        "length_of_employment,foo.bar.total_repair_order_discounts,foo.bar.avg_repai"
-        "r_order_discounts,foo.bar.avg_time_to_dispatch",
+        "r.contractor,foo.bar.hard_hat,foo.bar.us_state,foo.bar.avg_length_of_employ"
+        "ment,foo.bar.avg_repair_price,foo.bar.municipality_dim,foo.bar.dispatcher,f"
+        "oo.bar.total_repair_cost,foo.bar.repair_order,foo.bar.num_repair_orders,foo"
+        ".bar.avg_time_to_dispatch,foo.bar.total_repair_order_discounts,foo.bar.avg_"
+        "repair_order_discounts,foo.bar.local_hard_hats",
     }
     # Calling restore again will raise
     response = await client_with_namespaced_roads.post(
@@ -312,12 +312,12 @@ async def test_deactivate_namespaces(client_with_namespaced_roads: AsyncClient) 
                     ".bar.repair_type,foo.bar.contractors,foo.bar.municipality_municipalit"
                     "y_type,foo.bar.municipality_type,foo.bar.municipality,foo.bar.dispatc"
                     "hers,foo.bar.hard_hats,foo.bar.hard_hat_state,foo.bar.us_states,foo.b"
-                    "ar.us_region,foo.bar.repair_order,foo.bar.contractor,foo.bar.hard_hat"
-                    ",foo.bar.local_hard_hats,foo.bar.us_state,foo.bar.dispatcher,foo.bar."
-                    "municipality_dim,foo.bar.num_repair_orders,foo.bar.avg_repair_price,"
-                    "foo.bar.total_repair_cost,foo.bar.avg_length_of_employment,foo.bar.t"
-                    "otal_repair_order_discounts,foo.bar.avg_repair_order_discounts,foo.b"
-                    "ar.avg_time_to_dispatch"
+                    "ar.us_region,foo.bar.contractor,foo.bar.hard_hat,foo.bar.us_state,foo"
+                    ".bar.avg_length_of_employment,foo.bar.avg_repair_price,foo.bar.munici"
+                    "pality_dim,foo.bar.dispatcher,foo.bar.total_repair_cost,foo.bar.repai"
+                    "r_order,foo.bar.num_repair_orders,foo.bar.avg_time_to_dispatch,foo.ba"
+                    "r.total_repair_order_discounts,foo.bar.avg_repair_order_discounts,foo"
+                    ".bar.local_hard_hats"
                 ),
             },
         ),
@@ -349,7 +349,7 @@ async def test_hard_delete_namespace(client_with_examples: AsyncClient):
         "'foo.bar.avg_repair_order_discounts', 'foo.bar.avg_repair_price', "
         "'foo.bar.avg_time_to_dispatch', 'foo.bar.contractor', 'foo.bar.contractors', "
         "'foo.bar.dispatcher', 'foo.bar.dispatchers', 'foo.bar.hard_hat', "
-        "'foo.bar.hard_hat_state', 'foo.bar.hard_hats', 'foo.bar.local_hard_hats', "
+        "'foo.bar.hard_hats', 'foo.bar.hard_hat_state', 'foo.bar.local_hard_hats', "
         "'foo.bar.municipality', 'foo.bar.municipality_dim', "
         "'foo.bar.municipality_municipality_type', 'foo.bar.municipality_type', "
         "'foo.bar.num_repair_orders', 'foo.bar.repair_order', "

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5092,6 +5092,14 @@ class TestCopyNode:
                 copied[field] = mock.ANY
             for link in copied["dimension_links"]:
                 link["foreign_keys"] = mock.ANY
+            copied["dimension_links"] = sorted(
+                copied["dimension_links"],
+                key=lambda link: link["dimension"]["name"],
+            )
+            original["dimension_links"] = sorted(
+                original["dimension_links"],
+                key=lambda link: link["dimension"]["name"],
+            )
             assert original == copied
 
             # Metrics contain additional metadata, so compare the /metrics endpoint as well

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5053,6 +5053,14 @@ class TestCopyNode:
             copied[field] = mock.ANY
         for link in copied["dimension_links"]:
             link["foreign_keys"] = mock.ANY
+        copied["dimension_links"] = sorted(
+            copied["dimension_links"],
+            key=lambda li: li["dimension"]["name"],
+        )
+        original["dimension_links"] = sorted(
+            original["dimension_links"],
+            key=lambda li: li["dimension"]["name"],
+        )
         assert copied == original
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -8,10 +8,11 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
-from fastapi.testclient import TestClient
+import pytest_asyncio
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database import Catalog
 from datajunction_server.database.column import Column
@@ -40,11 +41,12 @@ def materialization_compare(response, expected):
         assert materialization_response == materialization_expected
 
 
-def test_read_node(client_with_roads: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_read_node(client_with_roads: AsyncClient) -> None:
     """
     Test ``GET /nodes/{node_id}``.
     """
-    response = client_with_roads.get("/nodes/default.repair_orders/")
+    response = await client_with_roads.get("/nodes/default.repair_orders/")
     data = response.json()
 
     assert response.status_code == 200
@@ -53,14 +55,14 @@ def test_read_node(client_with_roads: TestClient) -> None:
     assert data["node_revision_id"] == 1
     assert data["type"] == "source"
 
-    response = client_with_roads.get("/nodes/default.nothing/")
+    response = await client_with_roads.get("/nodes/default.nothing/")
     data = response.json()
 
     assert response.status_code == 404
     assert data["message"] == "A node with name `default.nothing` does not exist."
 
     # Check that getting nodes via prefixes works
-    response = client_with_roads.get("/nodes/?prefix=default.ha")
+    response = await client_with_roads.get("/nodes/?prefix=default.ha")
     data = response.json()
     assert set(data) == {
         "default.hard_hats",
@@ -69,7 +71,8 @@ def test_read_node(client_with_roads: TestClient) -> None:
     }
 
 
-def test_read_nodes(session: Session, client: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_read_nodes(session: AsyncSession, client: AsyncClient) -> None:
     """
     Test ``GET /nodes/``.
     """
@@ -113,16 +116,16 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     session.add(node_rev1)
     session.add(node_rev2)
     session.add(node_rev3)
-    session.commit()
+    await session.commit()
 
-    response = client.get("/nodes/")
+    response = await client.get("/nodes/")
     data = response.json()
 
     assert response.status_code == 200
     assert len(data) == 3
     assert set(data) == {"not-a-metric", "also-not-a-metric", "a-metric"}
 
-    response = client.get("/nodes?node_type=metric")
+    response = await client.get("/nodes?node_type=metric")
     data = response.json()
 
     assert response.status_code == 200
@@ -130,11 +133,12 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     assert set(data) == {"a-metric"}
 
 
-def test_get_nodes_with_details(client_with_examples: TestClient):
+@pytest.mark.asyncio
+async def test_get_nodes_with_details(client_with_examples: AsyncClient):
     """
     Test getting all nodes with some details
     """
-    response = client_with_examples.get("/nodes/details/")
+    response = await client_with_examples.get("/nodes/details/")
     assert response.status_code in (200, 201)
     data = response.json()
     assert {d["name"] for d in data} == {
@@ -294,19 +298,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ],
         }
 
-    @pytest.fixture
-    def catalog(self, session: Session) -> Catalog:
+    @pytest_asyncio.fixture
+    async def catalog(self, session: AsyncSession) -> Catalog:
         """
         A database fixture.
         """
 
         catalog = Catalog(name="prod", uuid=uuid4())
         session.add(catalog)
-        session.commit()
+        await session.commit()
         return catalog
 
-    @pytest.fixture
-    def source_node(self, session: Session) -> Node:
+    @pytest_asyncio.fixture
+    async def source_node(self, session: AsyncSession) -> Node:
         """
         A source node fixture.
         """
@@ -331,18 +335,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ],
         )
         session.add(node_revision)
-        session.commit()
+        await session.commit()
         return node
 
-    def test_create_dimension_without_catalog(
+    @pytest.mark.asyncio
+    async def test_create_dimension_without_catalog(
         self,
-        client_with_roads,
+        client_with_roads: AsyncClient,
     ):
         """
         Test that creating a dimension that's purely query-based and therefore
         doesn't reference a catalog works.
         """
-        response = client_with_roads.post(
+        response = await client_with_roads.post(
             "/nodes/dimension/",
             json={
                 "description": "Title",
@@ -379,12 +384,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # Link the dimension to a column on the source node
-        response = client_with_roads.post(
+        response = await client_with_roads.post(
             "/nodes/default.hard_hats/columns/title/"
             "?dimension=default.title&dimension_column=title",
         )
         assert response.status_code in (200, 201)
-        response = client_with_roads.get("/nodes/default.hard_hats/")
+        response = await client_with_roads.get("/nodes/default.hard_hats/")
         assert {
             "attributes": [],
             "dimension": None,
@@ -405,18 +410,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_deleting_node(
+    @pytest.mark.asyncio
+    async def test_deleting_node(
         self,
-        client_with_basic: TestClient,
+        client_with_basic: AsyncClient,
     ):
         """
         Test deleting a node
         """
         # Delete a node
-        response = client_with_basic.delete("/nodes/basic.source.users/")
+        response = await client_with_basic.delete("/nodes/basic.source.users/")
         assert response.status_code == 200
         # Check that then retrieving the node returns an error
-        response = client_with_basic.get("/nodes/basic.source.users/")
+        response = await client_with_basic.get("/nodes/basic.source.users/")
         assert response.status_code >= 400
         assert response.json() == {
             "message": "A node with name `basic.source.users` does not exist.",
@@ -431,11 +437,11 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "basic.num_users",
         ]
         for downstream in expected_downstreams:
-            response = client_with_basic.get(f"/nodes/{downstream}/")
+            response = await client_with_basic.get(f"/nodes/{downstream}/")
             assert response.json()["status"] == NodeStatus.INVALID
 
             # The downstreams' status change should be recorded in their histories
-            response = client_with_basic.get(f"/history?node={downstream}")
+            response = await client_with_basic.get(f"/history?node={downstream}")
             assert [
                 (activity["pre"], activity["post"], activity["details"])
                 for activity in response.json()
@@ -449,7 +455,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ]
 
         # Trying to create the node again should work.
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/source/",
             json={
                 "name": "basic.source.users",
@@ -474,7 +480,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert response.status_code in (200, 201)
 
         # The deletion action should be recorded in the node's history
-        response = client_with_basic.get("/history?node=basic.source.users")
+        response = await client_with_basic.get("/history?node=basic.source.users")
         history = response.json()
         assert history == [
             {
@@ -527,18 +533,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_deleting_source_upstream_from_metric(
+    @pytest.mark.asyncio
+    async def test_deleting_source_upstream_from_metric(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ):
         """
         Test deleting a source that's upstream from a metric
         """
-        response = client.post("/catalogs/", json={"name": "warehouse"})
+        response = await client.post("/catalogs/", json={"name": "warehouse"})
         assert response.status_code in (200, 201)
-        response = client.post("/namespaces/default/")
+        response = await client.post("/namespaces/default/")
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/source/",
             json={
                 "name": "default.users",
@@ -561,7 +568,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/metric/",
             json={
                 "description": "Total number of users",
@@ -572,14 +579,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
         assert response.status_code in (200, 201)
         # Delete the source node
-        response = client.delete("/nodes/default.users/")
+        response = await client.delete("/nodes/default.users/")
         assert response.status_code in (200, 201)
         # The downstream metric should have an invalid status
-        assert (
-            client.get("/nodes/default.num_users/").json()["status"]
-            == NodeStatus.INVALID
-        )
-        response = client.get("/history?node=default.num_users")
+        assert (await client.get("/nodes/default.num_users/")).json()[
+            "status"
+        ] == NodeStatus.INVALID
+        response = await client.get("/history?node=default.num_users")
         assert [
             (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
@@ -593,16 +599,16 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # Restore the source node
-        response = client.post("/nodes/default.users/restore/")
+        response = await client.post("/nodes/default.users/restore/")
         assert response.status_code in (200, 201)
         # Retrieving the restored node should work
-        response = client.get("/nodes/default.users/")
+        response = await client.get("/nodes/default.users/")
         assert response.status_code in (200, 201)
         # The downstream metric should have been changed to valid
-        response = client.get("/nodes/default.num_users/")
+        response = await client.get("/nodes/default.num_users/")
         assert response.json()["status"] == NodeStatus.VALID
         # Check activity history of downstream metric
-        response = client.get("/history?node=default.num_users")
+        response = await client.get("/history?node=default.num_users")
         assert [
             (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
@@ -620,18 +626,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ),
         ]
 
-    def test_deleting_transform_upstream_from_metric(
+    @pytest.mark.asyncio
+    async def test_deleting_transform_upstream_from_metric(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ):
         """
         Test deleting a transform that's upstream from a metric
         """
-        response = client.post("/catalogs/", json={"name": "warehouse"})
+        response = await client.post("/catalogs/", json={"name": "warehouse"})
         assert response.status_code in (200, 201)
-        response = client.post("/namespaces/default/")
+        response = await client.post("/namespaces/default/")
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/source/",
             json={
                 "name": "default.users",
@@ -654,7 +661,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/transform/",
             json={
                 "name": "default.us_users",
@@ -677,7 +684,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/metric/",
             json={
                 "description": "Total number of US users",
@@ -690,7 +697,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         # Create an invalid draft downstream node
         # so we can test that it stays invalid
         # when the upstream node is restored
-        response = client.post(
+        response = await client.post(
             "/nodes/metric/",
             json={
                 "description": "An invalid node downstream of default.us_users",
@@ -700,28 +707,26 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.status_code in (200, 201)
-        response = client.get("/nodes/default.invalid_metric/")
+        response = await client.get("/nodes/default.invalid_metric/")
         assert response.status_code in (200, 201)
         assert response.json()["status"] == NodeStatus.INVALID
         # Delete the transform node
-        response = client.delete("/nodes/default.us_users/")
+        response = await client.delete("/nodes/default.us_users/")
         assert response.status_code in (200, 201)
         # Retrieving the deleted node should respond that the node doesn't exist
-        assert client.get("/nodes/default.us_users/").json()["message"] == (
+        assert (await client.get("/nodes/default.us_users/")).json()["message"] == (
             "A node with name `default.us_users` does not exist."
         )
         # The downstream metrics should have an invalid status
-        assert (
-            client.get("/nodes/default.num_us_users/").json()["status"]
-            == NodeStatus.INVALID
-        )
-        assert (
-            client.get("/nodes/default.invalid_metric/").json()["status"]
-            == NodeStatus.INVALID
-        )
+        assert (await client.get("/nodes/default.num_us_users/")).json()[
+            "status"
+        ] == NodeStatus.INVALID
+        assert (await client.get("/nodes/default.invalid_metric/")).json()[
+            "status"
+        ] == NodeStatus.INVALID
 
         # Check history of downstream metrics
-        response = client.get("/history?node=default.num_us_users")
+        response = await client.get("/history?node=default.num_us_users")
         assert [
             (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
@@ -734,7 +739,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ),
         ]
         # No change recorded here because the metric was already invalid
-        response = client.get("/history?node=default.invalid_metric")
+        response = await client.get("/history?node=default.invalid_metric")
         assert [
             (activity["pre"], activity["post"])
             for activity in response.json()
@@ -742,23 +747,23 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ] == []
 
         # Restore the transform node
-        response = client.post("/nodes/default.us_users/restore/")
+        response = await client.post("/nodes/default.us_users/restore/")
         assert response.status_code in (200, 201)
         # Retrieving the restored node should work
-        response = client.get("/nodes/default.us_users/")
+        response = await client.get("/nodes/default.us_users/")
         assert response.status_code in (200, 201)
         # Check history of the restored node
-        response = client.get("/history?node=default.us_users")
+        response = await client.get("/history?node=default.us_users")
         history = response.json()
         assert [
             (activity["activity_type"], activity["entity_type"]) for activity in history
         ] == [("create", "node"), ("delete", "node"), ("restore", "node")]
 
         # This downstream metric should have been changed to valid
-        response = client.get("/nodes/default.num_us_users/")
+        response = await client.get("/nodes/default.num_us_users/")
         assert response.json()["status"] == NodeStatus.VALID
         # Check history of downstream metric
-        response = client.get("/history?node=default.num_us_users")
+        response = await client.get("/history?node=default.num_us_users")
         assert [
             (activity["pre"], activity["post"], activity["details"])
             for activity in response.json()
@@ -777,28 +782,29 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # The other downstream metric should have remained invalid
-        response = client.get("/nodes/default.invalid_metric/")
+        response = await client.get("/nodes/default.invalid_metric/")
         assert response.json()["status"] == NodeStatus.INVALID
         # Check history of downstream metric
-        response = client.get("/history?node=default.invalid_metric")
+        response = await client.get("/history?node=default.invalid_metric")
         assert [
             (activity["pre"], activity["post"])
             for activity in response.json()
             if activity["activity_type"] == "status_change"
         ] == []
 
-    def test_deleting_linked_dimension(
+    @pytest.mark.asyncio
+    async def test_deleting_linked_dimension(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ):
         """
         Test deleting a dimension that's linked to columns on other nodes
         """
-        response = client.post("/catalogs/", json={"name": "warehouse"})
+        response = await client.post("/catalogs/", json={"name": "warehouse"})
         assert response.status_code in (200, 201)
-        response = client.post("/namespaces/default/")
+        response = await client.post("/namespaces/default/")
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/source/",
             json={
                 "name": "default.users",
@@ -821,7 +827,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/dimension/",
             json={
                 "name": "default.us_users",
@@ -845,7 +851,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/source/",
             json={
                 "name": "default.messages",
@@ -864,7 +870,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
         assert response.status_code in (200, 201)
         # Create a metric on the source node
-        response = client.post(
+        response = await client.post(
             "/nodes/metric/",
             json={
                 "description": "Total number of user messages",
@@ -876,7 +882,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert response.status_code in (200, 201)
 
         # Create a metric on the source node w/ bound dimensions
-        response = client.post(
+        response = await client.post(
             "/nodes/metric/",
             json={
                 "description": "Total number of user messages by id",
@@ -890,7 +896,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Create a metric w/ bound dimensions that to not exist
         with pytest.raises(Exception) as exc:
-            response = client.post(
+            response = await client.post(
                 "/nodes/metric/",
                 json={
                     "description": "Total number of user messages by id",
@@ -903,7 +909,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             assert "required dimensions that are not on parent nodes" in str(exc)
 
         # Create a metric on the source node w/ an invalid bound dimension
-        response = client.post(
+        response = await client.post(
             "/nodes/metric/",
             json={
                 "description": "Total number of user messages by id",
@@ -930,13 +936,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Link the dimension to a column on the source node
-        response = client.post(
+        response = await client.post(
             "/nodes/default.messages/columns/user_id/"
             "?dimension=default.us_users&dimension_column=id",
         )
         assert response.status_code in (200, 201)
         # The dimension's attributes should now be available to the metric
-        response = client.get("/metrics/default.num_messages/")
+        response = await client.get("/metrics/default.num_messages/")
         assert response.status_code in (200, 201)
         assert response.json()["dimensions"] == [
             {
@@ -1014,7 +1020,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # Check history of the node with column dimension link
-        response = client.get(
+        response = await client.get(
             "/history?node=default.messages",
         )
         history = response.json()
@@ -1023,27 +1029,27 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ] == [("create", "node"), ("create", "link")]
 
         # Delete the dimension node
-        response = client.delete("/nodes/default.us_users/")
+        response = await client.delete("/nodes/default.us_users/")
         assert response.status_code in (200, 201)
         # Retrieving the deleted node should respond that the node doesn't exist
-        assert client.get("/nodes/default.us_users/").json()["message"] == (
+        assert (await client.get("/nodes/default.us_users/")).json()["message"] == (
             "A node with name `default.us_users` does not exist."
         )
         # The deleted dimension's attributes should no longer be available to the metric
-        response = client.get("/metrics/default.num_messages/")
+        response = await client.get("/metrics/default.num_messages/")
         assert response.status_code in (200, 201)
         assert [] == response.json()["dimensions"]
         # The metric should still be VALID
-        response = client.get("/nodes/default.num_messages/")
+        response = await client.get("/nodes/default.num_messages/")
         assert response.json()["status"] == NodeStatus.VALID
         # Restore the dimension node
-        response = client.post("/nodes/default.us_users/restore/")
+        response = await client.post("/nodes/default.us_users/restore/")
         assert response.status_code in (200, 201)
         # Retrieving the restored node should work
-        response = client.get("/nodes/default.us_users/")
+        response = await client.get("/nodes/default.us_users/")
         assert response.status_code in (200, 201)
         # The dimension's attributes should now once again show for the linked metric
-        response = client.get("/metrics/default.num_messages/")
+        response = await client.get("/metrics/default.num_messages/")
         assert response.status_code in (200, 201)
         assert response.json()["dimensions"] == [
             {
@@ -1120,21 +1126,22 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
         # The metric should still be VALID
-        response = client.get("/nodes/default.num_messages/")
+        response = await client.get("/nodes/default.num_messages/")
         assert response.json()["status"] == NodeStatus.VALID
 
-    def test_restoring_an_already_active_node(
+    @pytest.mark.asyncio
+    async def test_restoring_an_already_active_node(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ):
         """
         Test raising when restoring an already active node
         """
-        response = client.post("/catalogs/", json={"name": "warehouse"})
+        response = await client.post("/catalogs/", json={"name": "warehouse"})
         assert response.status_code in (200, 201)
-        response = client.post("/namespaces/default/")
+        response = await client.post("/namespaces/default/")
         assert response.status_code in (200, 201)
-        response = client.post(
+        response = await client.post(
             "/nodes/source/",
             json={
                 "name": "default.users",
@@ -1157,7 +1164,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.status_code in (200, 201)
-        response = client.post("/nodes/default.users/restore/")
+        response = await client.post("/nodes/default.users/restore/")
         assert response.status_code == 400
         assert response.json() == {
             "message": "Cannot restore `default.users`, node already active.",
@@ -1165,10 +1172,10 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "warnings": [],
         }
 
-    def verify_complete_hard_delete(
+    async def verify_complete_hard_delete(
         self,
-        session: Session,
-        client_with_roads: TestClient,
+        session: AsyncSession,
+        client_with_roads: AsyncClient,
         node_name: str,
     ):
         """
@@ -1177,35 +1184,39 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         """
         # Record its upstream nodes
         upstream_names = [
-            node.name for node in get_upstream_nodes(session, node_name=node_name)
+            node.name for node in await get_upstream_nodes(session, node_name=node_name)
         ]
 
         # Hard delete the node
-        response = client_with_roads.delete(f"/nodes/{node_name}/hard/")
+        response = await client_with_roads.delete(f"/nodes/{node_name}/hard/")
         assert response.status_code in (200, 201)
 
         # Check that all revisions (and their relations) for the node have been deleted
         nodes = (
-            session.execute(select(Node).where(Node.name == node_name))
+            (await session.execute(select(Node).where(Node.name == node_name)))
             .unique()
             .scalars()
             .all()
         )
         revisions = (
-            session.execute(
-                select(NodeRevision).where(NodeRevision.name == node_name),
+            (
+                await session.execute(
+                    select(NodeRevision).where(NodeRevision.name == node_name),
+                )
             )
             .unique()
             .scalars()
             .all()
         )
         relations = (
-            session.execute(
-                select(NodeRelationship).where(
-                    NodeRelationship.child_id.in_(  # type: ignore  # pylint: disable=no-member
-                        [rev.id for rev in revisions],
+            (
+                await session.execute(
+                    select(NodeRelationship).where(
+                        NodeRelationship.child_id.in_(  # type: ignore  # pylint: disable=no-member
+                            [rev.id for rev in revisions],
+                        ),
                     ),
-                ),
+                )
             )
             .unique()
             .scalars()
@@ -1217,10 +1228,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Check that upstreams and downstreams of the node still remain
         upstreams = (
-            session.execute(
-                select(Node).where(
-                    Node.name.in_(upstream_names),  # type: ignore  # pylint: disable=no-member
-                ),
+            (
+                await session.execute(
+                    select(Node).where(
+                        Node.name.in_(upstream_names),  # type: ignore  # pylint: disable=no-member
+                    ),
+                )
             )
             .unique()
             .scalars()
@@ -1228,20 +1241,21 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
         assert len(upstreams) == len(upstream_names)
 
-    def test_hard_deleting_node_with_versions(
+    @pytest.mark.asyncio
+    async def test_hard_deleting_node_with_versions(
         self,
-        client_with_roads: TestClient,
-        session: Session,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
     ):
         """
         Test that hard deleting a node will remove all previous node revisions.
         """
         # Create a few revisions for the `default.repair_order` dimension
-        client_with_roads.patch(
+        await client_with_roads.patch(
             "/nodes/default.repair_order/",
             json={"query": """SELECT repair_order_id FROM default.repair_orders"""},
         )
-        client_with_roads.patch(
+        await client_with_roads.patch(
             "/nodes/default.repair_order/",
             json={
                 "query": """SELECT
@@ -1255,13 +1269,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                         FROM default.repair_orders""",
             },
         )
-        response = client_with_roads.get("/nodes/default.repair_order")
+        response = await client_with_roads.get("/nodes/default.repair_order")
         assert response.json()["version"] == "v3.0"
 
         # Hard delete all nodes and verify after each delete
-        default_nodes = client_with_roads.get("/namespaces/default/").json()
+        default_nodes = (await client_with_roads.get("/namespaces/default/")).json()
         for node_name in default_nodes:
-            self.verify_complete_hard_delete(
+            await self.verify_complete_hard_delete(
                 session,
                 client_with_roads,
                 node_name["name"],
@@ -1269,7 +1283,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Check that all nodes under the `default` namespace and their revisions have been deleted
         nodes = (
-            session.execute(select(Node).where(Node.namespace == "default"))
+            (await session.execute(select(Node).where(Node.namespace == "default")))
             .unique()
             .scalars()
             .all()
@@ -1277,10 +1291,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert len(nodes) == 0
 
         revisions = (
-            session.execute(
-                select(NodeRevision).where(
-                    NodeRevision.name.like("default%"),  # type: ignore # pylint: disable=no-member
-                ),
+            (
+                await session.execute(
+                    select(NodeRevision).where(
+                        NodeRevision.name.like("default%"),  # type: ignore # pylint: disable=no-member
+                    ),
+                )
             )
             .unique()
             .scalars()
@@ -1288,15 +1304,16 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
         assert len(revisions) == 0
 
-    def test_hard_deleting_a_node(
+    @pytest.mark.asyncio
+    async def test_hard_deleting_a_node(
         self,
-        client_with_roads: TestClient,
+        client_with_roads: AsyncClient,
     ):
         """
         Test raising when restoring an already active node
         """
         # Hard deleting a node causes downstream nodes to become invalid
-        response = client_with_roads.delete("/nodes/default.repair_orders/hard/")
+        response = await client_with_roads.delete("/nodes/default.repair_orders/hard/")
         assert response.status_code in (200, 201)
         data = response.json()
         data["impact"] = sorted(data["impact"], key=lambda x: x["name"])
@@ -1362,7 +1379,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Hard deleting a dimension creates broken links
-        response = client_with_roads.delete("/nodes/default.repair_order/hard/")
+        response = await client_with_roads.delete("/nodes/default.repair_order/hard/")
         assert response.status_code in (200, 201)
         assert response.json() == {
             "impact": [
@@ -1431,7 +1448,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Hard deleting an unlinked node has no impact
-        response = client_with_roads.delete(
+        response = await client_with_roads.delete(
             "/nodes/default.regional_repair_efficiency/hard/",
         )
         assert response.status_code in (200, 201)
@@ -1441,7 +1458,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Hard delete a metric
-        response = client_with_roads.delete(
+        response = await client_with_roads.delete(
             "/nodes/default.avg_repair_order_discounts/hard/",
         )
         assert response.status_code in (200, 201)
@@ -1450,14 +1467,15 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "impact": [],
         }
 
-    def test_register_table_without_query_service(
+    @pytest.mark.asyncio
+    async def test_register_table_without_query_service(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ):
         """
         Trying to register a table without a query service set up should fail.
         """
-        response = client.post("/register/table/foo/bar/baz/")
+        response = await client.post("/register/table/foo/bar/baz/")
         data = response.json()
         assert data["message"] == (
             "Registering tables requires that a query "
@@ -1465,7 +1483,8 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
         assert response.status_code == 500
 
-    def test_create_source_node_with_query_service(
+    @pytest.mark.asyncio
+    async def test_create_source_node_with_query_service(
         self,
         client_with_query_service_example_loader,
     ):
@@ -1473,8 +1492,8 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         Creating a source node without columns but with a query service set should
         result in the source node columns being inferred via the query service.
         """
-        custom_client = client_with_query_service_example_loader(["BASIC"])
-        response = custom_client.post(
+        custom_client = await client_with_query_service_example_loader(["BASIC"])
+        response = await custom_client.post(
             "/register/table/public/basic/comments/",
         )
         data = response.json()
@@ -1523,15 +1542,16 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
         assert response.status_code == 201
 
-    def test_refresh_source_node(
+    @pytest.mark.asyncio
+    async def test_refresh_source_node(
         self,
         client_with_query_service_example_loader,
     ):
         """
         Refresh a source node with a query service
         """
-        custom_client = client_with_query_service_example_loader(["ROADS"])
-        response = custom_client.post(
+        custom_client = await client_with_query_service_example_loader(["ROADS"])
+        response = await custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data = response.json()
@@ -1609,7 +1629,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["columns"] == new_columns
         assert response.status_code == 201
 
-        response = custom_client.get("/history?node=default.repair_orders")
+        response = await custom_client.get("/history?node=default.repair_orders")
         history = response.json()
         assert [
             (activity["activity_type"], activity["entity_type"]) for activity in history
@@ -1617,7 +1637,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Refresh it again, but this time no columns will have changed so
         # verify that the node revision stays the same
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_second = response.json()
@@ -1625,7 +1645,8 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data_second["node_revision_id"] == data["node_revision_id"]
         assert data_second["columns"] == new_columns
 
-    def test_refresh_source_node_with_problems(
+    @pytest.mark.asyncio
+    async def test_refresh_source_node_with_problems(
         self,
         client_with_query_service_example_loader,
         query_service_client: QueryServiceClient,
@@ -1634,8 +1655,8 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         """
         Refresh a source node with a query service and find that no columns are returned.
         """
-        custom_client = client_with_query_service_example_loader(["ROADS"])
-        response = custom_client.post(
+        custom_client = await client_with_query_service_example_loader(["ROADS"])
+        response = await custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data = response.json()
@@ -1653,7 +1674,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["status"] == "valid"
         assert data["missing_table"] is False
 
-        response = custom_client.get("/history?node=default.repair_orders")
+        response = await custom_client.get("/history?node=default.repair_orders")
         history = response.json()
         assert [
             (activity["activity_type"], activity["entity_type"]) for activity in history
@@ -1665,7 +1686,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "get_columns_for_table",
             lambda *args: [],
         )
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_second = response.json()
@@ -1683,7 +1704,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 DJDoesNotExistException(message="Table not found: foo.bar.baz"),
             ),
         )
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_third = response.json()
@@ -1699,7 +1720,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "get_columns_for_table",
             lambda *args: the_good_columns,
         )
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_fourth = response.json()
@@ -1709,9 +1730,10 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data_fourth["status"] == "valid"
         assert data_fourth["missing_table"] is False
 
-    def test_create_update_source_node(
+    @pytest.mark.asyncio
+    async def test_create_update_source_node(
         self,
-        client_with_basic: TestClient,
+        client_with_basic: AsyncClient,
     ) -> None:
         """
         Test creating and updating a source node
@@ -1736,7 +1758,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         }
 
         # Trying to create it again should fail
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/source/",
             json=basic_source_comments,
         )
@@ -1748,7 +1770,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert response.status_code == 409
 
         # Update node with a new description should create a new revision
-        response = client_with_basic.patch(
+        response = await client_with_basic.patch(
             f"/nodes/{basic_source_comments['name']}/",
             json={
                 "description": "New description",
@@ -1764,7 +1786,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["description"] == "New description"
 
         # Try to update node with no changes
-        response = client_with_basic.patch(
+        response = await client_with_basic.patch(
             f"/nodes/{basic_source_comments['name']}/",
             json={"description": "New description", "display_name": "Comments facts"},
         )
@@ -1772,7 +1794,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data == new_data
 
         # Try to update a node with a table that has different columns
-        response = client_with_basic.patch(
+        response = await client_with_basic.patch(
             f"/nodes/{basic_source_comments['name']}/",
             json={
                 "columns": [
@@ -1824,15 +1846,15 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_update_nonexistent_node(
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_node(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ) -> None:
         """
         Test updating a non-existent node.
         """
-
-        response = client.patch(
+        response = await client.patch(
             "/nodes/something/",
             json={"description": "new"},
         )
@@ -1840,14 +1862,15 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert response.status_code == 404
         assert data["message"] == "A node with name `something` does not exist."
 
-    def test_raise_on_source_node_with_no_catalog(
+    @pytest.mark.asyncio
+    async def test_raise_on_source_node_with_no_catalog(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ) -> None:
         """
         Test raise on source node with no catalog
         """
-        response = client.post(
+        response = await client.post(
             "/nodes/source/",
             json={
                 "name": "basic.source.comments",
@@ -1886,18 +1909,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ],
         }
 
-    def test_create_invalid_transform_node(
+    @pytest.mark.asyncio
+    async def test_create_invalid_transform_node(
         self,
         catalog: Catalog,  # pylint: disable=unused-argument
         source_node: Node,  # pylint: disable=unused-argument
-        client: TestClient,
+        client: AsyncClient,
         create_invalid_transform_node_payload: Dict[str, Any],
     ) -> None:
         """
         Test creating an invalid transform node in draft and published modes.
         """
-        client.post("/namespaces/default/")
-        response = client.post(
+        await client.post("/namespaces/default/")
+        response = await client.post(
             "/nodes/transform/",
             json=create_invalid_transform_node_payload,
         )
@@ -1907,15 +1931,16 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "Node definition contains references to nodes that do not exist",
         )
 
-    def test_create_node_with_type_inference_failure(
+    @pytest.mark.asyncio
+    async def test_create_node_with_type_inference_failure(
         self,
-        client_with_namespaced_roads: TestClient,
+        client_with_namespaced_roads: AsyncClient,
     ):
         """
         Attempting to create a published metric where type inference fails should raise
         an appropriate error and fail.
         """
-        response = client_with_namespaced_roads.post(
+        response = await client_with_namespaced_roads.post(
             "/nodes/metric/",
             json={
                 "description": "Average length of employment",
@@ -1960,20 +1985,20 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "warnings": [],
         }
 
-    def test_create_update_transform_node(
+    @pytest.mark.asyncio
+    async def test_create_update_transform_node(
         self,
         catalog: Catalog,  # pylint: disable=unused-argument
         source_node: Node,  # pylint: disable=unused-argument
-        client: TestClient,
+        client: AsyncClient,
         create_transform_node_payload: Dict[str, Any],
     ) -> None:
         """
         Test creating and updating a transform node that references an existing source.
         """
-
-        client.post("/namespaces/default/")
+        await client.post("/namespaces/default/")
         # Create a transform node
-        response = client.post(
+        response = await client.post(
             "/nodes/transform/",
             json=create_transform_node_payload,
         )
@@ -2009,7 +2034,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["parents"] == [{"name": "basic.source.users"}]
 
         # Update the transform node with two minor changes
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.country_agg/",
             json={
                 "description": "Some new description",
@@ -2030,7 +2055,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["parents"] == [{"name": "basic.source.users"}]
 
         # Try to update with a new query that references a non-existent source
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.country_agg/",
             json={
                 "query": "SELECT country, COUNT(DISTINCT id) AS num_users FROM comments",
@@ -2042,7 +2067,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
 
         # Try to update with a new query that references an existing source
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.country_agg/",
             json={
                 "query": "SELECT country, COUNT(DISTINCT id) AS num_users, "
@@ -2086,12 +2111,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["parents"] == [{"name": "basic.source.users"}]
 
         # Verify that asking for revisions for a non-existent transform fails
-        response = client.get("/nodes/random_transform/revisions/")
+        response = await client.get("/nodes/random_transform/revisions/")
         data = response.json()
         assert data["message"] == "A node with name `random_transform` does not exist."
 
         # Verify that all historical revisions are available for the node
-        response = client.get("/nodes/default.country_agg/revisions/")
+        response = await client.get("/nodes/default.country_agg/revisions/")
         data = response.json()
         assert {rev["version"]: rev["query"] for rev in data} == {
             "v1.0": "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users",
@@ -2164,13 +2189,14 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             ],
         }
 
-    def test_update_metric_node(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_update_metric_node(self, client_with_roads: AsyncClient):
         """
         Verify that during metric node updates, if the query changes, DJ will automatically
         alias the metric column. If this aliased query is the same as the current revision's
         query, DJ won't promote the version.
         """
-        response = client_with_roads.patch(
+        response = await client_with_roads.patch(
             "/nodes/default.total_repair_cost/",
             json={
                 "query": (
@@ -2189,7 +2215,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "SELECT sum(repair_orders_fact.total_repair_cost) "
             "FROM default.repair_orders_fact repair_orders_fact"
         )
-        response = client_with_roads.get("/metrics/default.total_repair_cost")
+        response = await client_with_roads.get("/metrics/default.total_repair_cost")
         metric_data = response.json()
         assert metric_data["metric_metadata"] == {
             "direction": "higher_is_better",
@@ -2202,10 +2228,10 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         }
 
-        response = client_with_roads.get("/nodes/default.total_repair_cost")
+        response = await client_with_roads.get("/nodes/default.total_repair_cost")
         assert response.json()["version"] == "v2.0"
 
-        response = client_with_roads.patch(
+        response = await client_with_roads.patch(
             "/nodes/default.total_repair_cost/",
             json={
                 "query": "SELECT count(price) FROM default.repair_order_details",
@@ -2216,24 +2242,25 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert node_data["query"] == (
             "SELECT count(price) FROM default.repair_order_details"
         )
-        response = client_with_roads.get("/nodes/default.total_repair_cost")
+        response = await client_with_roads.get("/nodes/default.total_repair_cost")
         data = response.json()
         assert data["version"] == "v3.0"
-        response = client_with_roads.get("/metrics/default.total_repair_cost")
+        response = await client_with_roads.get("/metrics/default.total_repair_cost")
         data = response.json()
         assert data["required_dimensions"] == ["repair_order_id"]
 
-    def test_create_dimension_node_fails(
+    @pytest.mark.asyncio
+    async def test_create_dimension_node_fails(
         self,
         catalog: Catalog,  # pylint: disable=unused-argument
         source_node: Node,  # pylint: disable=unused-argument
-        client: TestClient,
+        client: AsyncClient,
     ):
         """
         Test various failure cases for dimension node creation.
         """
-        client.post("/namespaces/default/")
-        response = client.post(
+        await client.post("/namespaces/default/")
+        response = await client.post(
             "/nodes/dimension/",
             json={
                 "description": "Country dimension",
@@ -2247,7 +2274,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             response.json()["message"] == "Dimension nodes must define a primary key!"
         )
 
-        response = client.post(
+        response = await client.post(
             "/nodes/dimension/",
             json={
                 "description": "Country dimension",
@@ -2264,18 +2291,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "default.countries."
         )
 
-    def test_create_update_dimension_node(
+    @pytest.mark.asyncio
+    async def test_create_update_dimension_node(
         self,
         catalog: Catalog,  # pylint: disable=unused-argument
         source_node: Node,  # pylint: disable=unused-argument
-        client: TestClient,
+        client: AsyncClient,
         create_dimension_node_payload: Dict[str, Any],
     ) -> None:
         """
         Test creating and updating a dimension node that references an existing source.
         """
-        client.post("/namespaces/default/")
-        response = client.post(
+        await client.post("/namespaces/default/")
+        response = await client.post(
             "/nodes/dimension/",
             json=create_dimension_node_payload,
         )
@@ -2313,7 +2341,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # Test updating the dimension node with a new query
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.countries/",
             json={"query": "SELECT country FROM basic.source.users GROUP BY country"},
         )
@@ -2336,7 +2364,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         ]
 
         # Test updating the dimension node with a new primary key
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.countries/",
             json={
                 "query": "SELECT country, SUM(age) as sum_age, count(1) AS num_users "
@@ -2376,7 +2404,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.countries/",
             json={
                 "primary_key": ["country"],
@@ -2412,12 +2440,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_raise_on_multi_catalog_node(self, client_example_loader):
+    @pytest.mark.asyncio
+    async def test_raise_on_multi_catalog_node(self, client_example_loader):
         """
         Test raising when trying to select from multiple catalogs
         """
-        custom_client = client_example_loader(["BASIC", "ACCOUNT_REVENUE"])
-        response = custom_client.post(
+        custom_client = await client_example_loader(["BASIC", "ACCOUNT_REVENUE"])
+        response = await custom_client.post(
             "/nodes/transform/",
             json={
                 "query": (
@@ -2434,18 +2463,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             in response.json()["message"]
         )
 
-    def test_updating_node_to_invalid_draft(
+    @pytest.mark.asyncio
+    async def test_updating_node_to_invalid_draft(
         self,
         catalog: Catalog,  # pylint: disable=unused-argument
         source_node: Node,  # pylint: disable=unused-argument
-        client: TestClient,
+        client: AsyncClient,
         create_dimension_node_payload: Dict[str, Any],
     ) -> None:
         """
         Test creating an invalid node in draft mode
         """
-        client.post("/namespaces/default/")
-        response = client.post(
+        await client.post("/namespaces/default/")
+        response = await client.post(
             "/nodes/dimension/",
             json=create_dimension_node_payload,
         )
@@ -2482,36 +2512,37 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             },
         ]
 
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.countries/",
             json={"mode": "draft"},
         )
         assert response.status_code == 200
 
         # Test updating the dimension node with an invalid query
-        response = client.patch(
+        response = await client.patch(
             "/nodes/default.countries/",
             json={"query": "SELECT country FROM missing_parent GROUP BY country"},
         )
         assert response.status_code == 200
 
         # Check that node is now a draft with an invalid status
-        response = client.get("/nodes/default.countries")
+        response = await client.get("/nodes/default.countries")
         assert response.status_code == 200
         data = response.json()
         assert data["mode"] == "draft"
         assert data["status"] == "invalid"
 
-    def test_upsert_materialization_config(  # pylint: disable=too-many-arguments
+    @pytest.mark.asyncio
+    async def test_upsert_materialization_config(  # pylint: disable=too-many-arguments
         self,
         client_with_query_service_example_loader,
     ) -> None:
         """
         Test creating & updating materialization config for a node.
         """
-        custom_client = client_with_query_service_example_loader(["BASIC"])
+        custom_client = await client_with_query_service_example_loader(["BASIC"])
         # Setting the materialization config for a source node should fail
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/basic.source.comments/materialization/",
             json={
                 "job": "spark_sql",
@@ -2528,7 +2559,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Setting the materialization config for a materialization job type that
         # doesn't exist should fail
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/basic.transform.country_agg/materialization/",
             json={
                 "job": "something",
@@ -2544,12 +2575,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "types: ['SPARK_SQL', 'DRUID_MEASURES_CUBE', 'DRUID_METRICS_CUBE']"
         )
 
-    def test_node_with_struct(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_node_with_struct(self, client_with_roads: AsyncClient):
         """
         Test that building a query string with structs yields a correctly formatted struct
         reference.
         """
-        response = client_with_roads.post(
+        response = await client_with_roads.post(
             "/nodes/transform/",
             json={
                 "description": "Regional level agg with structs",
@@ -2613,7 +2645,7 @@ GROUP BY
             "partition": None,
         } in response.json()["columns"]
 
-        client_with_roads.post(
+        await client_with_roads.post(
             "/nodes/transform/",
             json={
                 "description": "Total Repair Amounts during the COVID-19 Pandemic",
@@ -2624,7 +2656,7 @@ GROUP BY
                 "mode": "published",
             },
         )
-        response = client_with_roads.get(
+        response = await client_with_roads.get(
             "/sql/default.total_amount_in_region_from_struct_transform?filters="
             "&dimensions=location_hierarchy",
         )
@@ -2655,7 +2687,8 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
  AS default_DOT_total_amount_in_region_from_struct_transform"""
         assert compare_query_strings(response.json()["sql"], expected)
 
-    def test_node_with_incremental_time_materialization(
+    @pytest.mark.asyncio
+    async def test_node_with_incremental_time_materialization(
         self,
         client_with_query_service_example_loader,
         query_service_client,
@@ -2667,8 +2700,8 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
         3. When SQL for the metric is requested without the transform having been materialized,
            the request will fail.
         """
-        custom_client = client_with_query_service_example_loader(["ROADS"])
-        custom_client.post(
+        custom_client = await client_with_query_service_example_loader(["ROADS"])
+        await custom_client.post(
             "/nodes/transform/",
             json={
                 "description": "Repair orders transform (partitioned)",
@@ -2689,7 +2722,7 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
             },
         )
         # Mark one of the columns as a time partition
-        custom_client.post(
+        await custom_client.post(
             "/nodes/default.repair_orders_partitioned/columns/dispatched_date/partition",
             json={
                 "type_": "temporal",
@@ -2699,7 +2732,7 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
         )
 
         # Set an incremental time materialization config with a lookback window of 100 days
-        custom_client.post(
+        await custom_client.post(
             "/nodes/default.repair_orders_partitioned/materialization/",
             json={
                 "job": "spark_sql",
@@ -2753,7 +2786,7 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
 
         # Set an incremental time materialization config without a lookback window
         # (defaults to 1 day)
-        custom_client.post(
+        await custom_client.post(
             "/nodes/default.repair_orders_partitioned/materialization/",
             json={
                 "job": "spark_sql",
@@ -2796,7 +2829,8 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
         """
         compare_query_strings(query, expected_query)
 
-    def test_node_with_dj_logical_timestamp(
+    @pytest.mark.asyncio
+    async def test_node_with_dj_logical_timestamp(
         self,
         client_with_query_service_example_loader,
     ) -> None:
@@ -2807,8 +2841,8 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
         3. When SQL for the metric is requested without the transform having been materialized,
            the request will fail.
         """
-        custom_client = client_with_query_service_example_loader(["ROADS"])
-        custom_client.post(
+        custom_client = await client_with_query_service_example_loader(["ROADS"])
+        await custom_client.post(
             "/nodes/transform/",
             json={
                 "description": "Repair orders transform (partitioned)",
@@ -2830,12 +2864,12 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
                 "primary_key": ["repair_order_id"],
             },
         )
-        custom_client.post(
+        await custom_client.post(
             "/nodes/default.repair_orders_partitioned/columns/hard_hat_id/"
             "?dimension=default.hard_hat&dimension_column=hard_hat_id",
         )
 
-        custom_client.post(
+        await custom_client.post(
             "/nodes/metric/",
             json={
                 "description": "Number of repair orders",
@@ -2844,7 +2878,7 @@ JOIN roads.contractors AS default_DOT_contractors ON default_DOT_repair_type.con
                 "name": "default.num_repair_orders_partitioned",
             },
         )
-        response = custom_client.get(
+        response = await custom_client.get(
             "/sql?metrics=default.num_repair_orders_partitioned"
             "&dimensions=default.hard_hat.last_name",
         )
@@ -2886,7 +2920,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
  FROM m0_default_DOT_num_repair_orders_partitioned""",
         )
 
-        custom_client.post(
+        await custom_client.post(
             "/engines/",
             json={
                 "name": "spark",
@@ -2896,7 +2930,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
         )
 
         # Setting the materialization config should succeed
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.repair_orders_partitioned/materialization/",
             json={
                 "job": "spark_sql",
@@ -2913,7 +2947,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             "`spark_sql__full` for node `default.repair_orders_partitioned`"
         )
 
-        response = custom_client.get(
+        response = await custom_client.get(
             "/nodes/default.repair_orders_partitioned",
         )
         result_sql = response.json()["materializations"][0]["config"]["query"]
@@ -2937,7 +2971,8 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             "'yyyyMMdd') = FORMATTED\n\n",
         )
 
-    def test_update_node_query_with_materializations(
+    @pytest.mark.asyncio
+    async def test_update_node_query_with_materializations(
         self,
         client_with_query_service_example_loader,
     ):
@@ -2945,8 +2980,8 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
         Testing updating a node's query when the node already has materializations. The node's
         materializations should be updated based on the new query and rescheduled.
         """
-        custom_client = client_with_query_service_example_loader(["BASIC"])
-        custom_client.post(
+        custom_client = await client_with_query_service_example_loader(["BASIC"])
+        await custom_client.post(
             "/engines/",
             json={
                 "name": "spark",
@@ -2955,7 +2990,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             },
         )
 
-        custom_client.post(
+        await custom_client.post(
             "/nodes/basic.transform.country_agg/materialization/",
             json={
                 "job": "spark_sql",
@@ -2966,7 +3001,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                 "schedule": "0 * * * *",
             },
         )
-        custom_client.patch(
+        await custom_client.patch(
             "/nodes/basic.transform.country_agg/",
             json={
                 "query": (
@@ -2976,9 +3011,9 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
                 ),
             },
         )
-        response = custom_client.get("/nodes/basic.transform.country_agg")
+        response = await custom_client.get("/nodes/basic.transform.country_agg")
         assert response.json()["version"] == "v2.0"
-        response = custom_client.get("/nodes/basic.transform.country_agg/")
+        response = await custom_client.get("/nodes/basic.transform.country_agg/")
         node_output = response.json()
         assert node_output["materializations"] == [
             {
@@ -3034,11 +3069,12 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             },
         ]
 
-    def test_update_column_display_name(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_update_column_display_name(self, client_with_roads: AsyncClient):
         """
         Test that updating a column display name works.
         """
-        response = client_with_roads.patch(
+        response = await client_with_roads.patch(
             url="/nodes/default.hard_hat/columns/hard_hat_id",
             params={"display_name": "test"},
         )
@@ -3054,11 +3090,12 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             "partition": None,
         }
 
-    def test_backfill_failures(self, client_with_query_service):
+    @pytest.mark.asyncio
+    async def test_backfill_failures(self, client_with_query_service):
         """Run backfill failure modes"""
 
         # Kick off backfill for non-existent materalization
-        response = client_with_query_service.post(
+        response = await client_with_query_service.post(
             "/nodes/default.hard_hat/materializations/non_existent/backfill",
             json={
                 "column_name": "birth_date",
@@ -3100,19 +3137,19 @@ class TestNodeColumnsAttributes:
             "mode": "published",
         }
 
-    @pytest.fixture
-    def catalog(self, session: Session) -> Catalog:
+    @pytest_asyncio.fixture
+    async def catalog(self, session: AsyncSession) -> Catalog:
         """
         A catalog fixture.
         """
 
         catalog = Catalog(name="postgres", uuid=uuid4())
         session.add(catalog)
-        session.commit()
+        await session.commit()
         return catalog
 
-    @pytest.fixture
-    def source_node(self, session: Session) -> Node:
+    @pytest_asyncio.fixture
+    async def source_node(self, session: AsyncSession) -> Node:
         """
         A source node fixture.
         """
@@ -3137,14 +3174,14 @@ class TestNodeColumnsAttributes:
             ],
         )
         session.add(node_revision)
-        session.commit()
+        await session.commit()
         return node
 
-    def set_id_primary_key(self, client_with_basic: TestClient):
+    async def set_id_primary_key(self, client_with_basic: AsyncClient):
         """
         Helper function to set id as primary key on basic.dimension.users
         """
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.dimension.users/columns/id/attributes/",
             json=[
                 {
@@ -3167,21 +3204,22 @@ class TestNodeColumnsAttributes:
             },
         ]
 
-    def test_set_column_attributes(
+    @pytest.mark.asyncio
+    async def test_set_column_attributes(
         self,
-        client_with_basic: TestClient,
+        client_with_basic: AsyncClient,
     ):
         """
         Validate that setting column attributes on the node works.
         """
         # Set id as primary key
-        self.set_id_primary_key(client_with_basic)
+        await self.set_id_primary_key(client_with_basic)
 
         # Can set again (idempotent)
-        self.set_id_primary_key(client_with_basic)
+        await self.set_id_primary_key(client_with_basic)
 
         # Set column attributes
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.dimension.users/columns/id/attributes/",
             json=[
                 {
@@ -3205,7 +3243,7 @@ class TestNodeColumnsAttributes:
         ]
 
         # Remove primary key attribute from column
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.source.comments/columns/id/attributes",
             json=[],
         )
@@ -3221,11 +3259,12 @@ class TestNodeColumnsAttributes:
             },
         ]
 
-    def test_set_columns_attributes_failed(self, client_with_basic: TestClient):
+    @pytest.mark.asyncio
+    async def test_set_columns_attributes_failed(self, client_with_basic: AsyncClient):
         """
         Test setting column attributes with different failure modes.
         """
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.dimension.users/columns/created_at/attributes/",
             json=[
                 {
@@ -3241,11 +3280,11 @@ class TestNodeColumnsAttributes:
             == "Attribute type `system.dimension` not allowed on node type `dimension`!"
         )
 
-        client_with_basic.get(
+        await client_with_basic.get(
             "/nodes/basic.source.comments/",
         )
 
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.source.comments/columns/nonexistent_col/attributes/",
             json=[
                 {
@@ -3261,7 +3300,7 @@ class TestNodeColumnsAttributes:
             "warnings": [],
         }
 
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.source.comments/columns/id/attributes/",
             json=[
                 {
@@ -3277,7 +3316,7 @@ class TestNodeColumnsAttributes:
             "warnings": [],
         }
 
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.source.comments/columns/user_id/attributes/",
             json=[
                 {
@@ -3300,7 +3339,7 @@ class TestNodeColumnsAttributes:
             },
         ]
 
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/attributes/",
             json={
                 "namespace": "example",
@@ -3314,7 +3353,7 @@ class TestNodeColumnsAttributes:
         )
         data = response.json()
 
-        client_with_basic.post(
+        await client_with_basic.post(
             "/nodes/basic.source.comments/columns/event_timestamp/attributes/",
             json=[
                 {
@@ -3324,7 +3363,7 @@ class TestNodeColumnsAttributes:
             ],
         )
 
-        response = client_with_basic.post(
+        response = await client_with_basic.post(
             "/nodes/basic.source.comments/columns/post_processing_timestamp/attributes/",
             json=[
                 {
@@ -3342,12 +3381,12 @@ class TestNodeColumnsAttributes:
             "warnings": [],
         }
 
-        client_with_basic.post(
+        await client_with_basic.post(
             "/nodes/basic.source.comments/columns/event_timestamp/attributes/",
             json=[],
         )
 
-        response = client_with_basic.get("/nodes/basic.source.comments/")
+        response = await client_with_basic.get("/nodes/basic.source.comments/")
         data = response.json()
         assert data["columns"] == [
             {
@@ -3416,14 +3455,15 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
     Test ``POST /nodes/validate/``.
     """
 
-    def test_validating_a_valid_node(
+    @pytest.mark.asyncio
+    async def test_validating_a_valid_node(
         self,
-        client_with_account_revenue: TestClient,
+        client_with_account_revenue: AsyncClient,
     ) -> None:
         """
         Test validating a valid node
         """
-        response = client_with_account_revenue.post(
+        response = await client_with_account_revenue.post(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3452,12 +3492,13 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         assert data["missing_parents"] == []
         assert data["errors"] == []
 
-    def test_validating_an_invalid_node(self, client: TestClient) -> None:
+    @pytest.mark.asyncio
+    async def test_validating_an_invalid_node(self, client: AsyncClient) -> None:
         """
         Test validating an invalid node
         """
 
-        response = client.post(
+        response = await client.post(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3481,12 +3522,13 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             }
         ]
 
-    def test_validating_invalid_sql(self, client: TestClient) -> None:
+    @pytest.mark.asyncio
+    async def test_validating_invalid_sql(self, client: AsyncClient) -> None:
         """
         Test validating an invalid node with invalid SQL
         """
 
-        response = client.post(
+        response = await client.post(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3518,12 +3560,13 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_validating_with_missing_parents(self, client: TestClient) -> None:
+    @pytest.mark.asyncio
+    async def test_validating_with_missing_parents(self, client: AsyncClient) -> None:
         """
         Test validating a node with a query that has missing parents
         """
 
-        response = client.post(
+        response = await client.post(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3561,12 +3604,16 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             ],
         }
 
-    def test_allowing_missing_parents_for_draft_nodes(self, client: TestClient) -> None:
+    @pytest.mark.asyncio
+    async def test_allowing_missing_parents_for_draft_nodes(
+        self,
+        client: AsyncClient,
+    ) -> None:
         """
         Test validating a draft node that's allowed to have missing parents
         """
 
-        response = client.post(
+        response = await client.post(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3602,15 +3649,16 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_raise_when_trying_to_validate_a_source_node(
+    @pytest.mark.asyncio
+    async def test_raise_when_trying_to_validate_a_source_node(
         self,
-        client: TestClient,
+        client: AsyncClient,
     ) -> None:
         """
         Test validating a source node which is not possible
         """
 
-        response = client.post(
+        response = await client.post(
             "/nodes/validate/",
             json={
                 "name": "foo",
@@ -3641,16 +3689,17 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "warnings": [],
         }
 
-    def test_adding_dimensions_to_node_columns(
+    @pytest.mark.asyncio
+    async def test_adding_dimensions_to_node_columns(
         self,
         client_example_loader,
     ):
         """
         Test linking dimensions to node columns
         """
-        custom_client = client_example_loader(["ACCOUNT_REVENUE", "BASIC"])
+        custom_client = await client_example_loader(["ACCOUNT_REVENUE", "BASIC"])
         # Attach the payment_type dimension to the payment_type column on the revenue node
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
         )
         data = response.json()
@@ -3660,14 +3709,14 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "linked to node default.revenue using column payment_type."
             ),
         }
-        response = custom_client.get("/nodes/default.revenue")
+        response = await custom_client.get("/nodes/default.revenue")
         data = response.json()
         assert [
             col["dimension"]["name"] for col in data["columns"] if col["dimension"]
         ] == []
 
         # Check that after deleting the dimension link, none of the columns have links
-        response = custom_client.delete(
+        response = await custom_client.delete(
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
         )
         data = response.json()
@@ -3677,17 +3726,18 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "been removed."
             ),
         }
-        response = custom_client.get("/nodes/default.revenue")
+        response = await custom_client.get("/nodes/default.revenue")
         data = response.json()
-        assert all(col["dimension"] is None for col in data["columns"])
-        response = custom_client.get("/history?node=default.revenue")
+        assert data["dimension_links"] == []
+        # assert all(col["dimension"] is None for col in data["columns"])
+        response = await custom_client.get("/history?node=default.revenue")
         assert [
             (activity["activity_type"], activity["entity_type"])
             for activity in response.json()
         ] == [("create", "node"), ("create", "link"), ("delete", "link")]
 
         # Removing the dimension link again will result in no change
-        response = custom_client.delete(
+        response = await custom_client.delete(
             "/nodes/default.revenue/columns/payment_type/?dimension=default.payment_type",
         )
         data = response.json()
@@ -3696,14 +3746,14 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "message": "Dimension link to node default.payment_type not found",
         }
         # Check history again, no change
-        response = custom_client.get("/history?node=default.revenue")
+        response = await custom_client.get("/history?node=default.revenue")
         assert [
             (activity["activity_type"], activity["entity_type"])
             for activity in response.json()
         ] == [("create", "node"), ("create", "link"), ("delete", "link")]
 
         # Check that the proper error is raised when the column doesn't exist
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.revenue/columns/non_existent_column/?dimension=default.payment_type",
         )
         assert response.status_code == 404
@@ -3713,7 +3763,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         )
 
         # Add a dimension including a specific dimension column name
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.revenue/columns/payment_type/"
             "?dimension=default.payment_type"
             "&dimension_column=payment_type_name",
@@ -3727,7 +3777,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "types are incompatible and the dimension cannot be linked"
         )
 
-        response = custom_client.post(
+        response = await custom_client.post(
             "/nodes/default.revenue/columns/payment_type/?dimension=basic.dimension.users",
         )
         data = response.json()
@@ -3735,13 +3785,17 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "Cannot link dimension to node, because catalogs do not match: default, public"
         )
 
-    def test_update_node_with_dimension_links(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_update_node_with_dimension_links(
+        self,
+        client_with_roads: AsyncClient,
+    ):
         """
         When a node is updated with a new query, the original dimension links and attributes
         on its columns should be preserved where possible (that is, where the new and old
         columns have the same names).
         """
-        client_with_roads.patch(
+        await client_with_roads.patch(
             "/nodes/default.hard_hat/",
             json={
                 "query": """
@@ -3753,7 +3807,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 """,
             },
         )
-        response = client_with_roads.get("/history?node=default.hard_hat")
+        response = await client_with_roads.get("/history?node=default.hard_hat")
         history = response.json()
         assert [
             (activity["activity_type"], activity["entity_type"]) for activity in history
@@ -3764,7 +3818,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             ("update", "node"),
         ]
 
-        response = client_with_roads.get("/nodes/default.hard_hat").json()
+        response = (await client_with_roads.get("/nodes/default.hard_hat")).json()
         assert response["columns"] == [
             {
                 "attributes": [
@@ -3795,7 +3849,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         ]
 
         # Check history of the node with column attribute set
-        response = client_with_roads.get(
+        response = await client_with_roads.get(
             "/history?node=default.hard_hat",
         )
         history = response.json()
@@ -3808,12 +3862,16 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             ("update", "node"),
         ]
 
-    def test_update_dimension_remove_pk_column(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_update_dimension_remove_pk_column(
+        self,
+        client_with_roads: AsyncClient,
+    ):
         """
         When a dimension node is updated with a new query that removes the original primary key
         column, either a new primary key must be set or the node will be set to invalid.
         """
-        response = client_with_roads.patch(
+        response = await client_with_roads.patch(
             "/nodes/default.hard_hat/",
             json={
                 "query": """
@@ -3826,7 +3884,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         )
         assert response.json()["status"] == "invalid"
-        response = client_with_roads.patch(
+        response = await client_with_roads.patch(
             "/nodes/default.hard_hat/",
             json={
                 "query": """
@@ -3840,11 +3898,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         )
         assert response.json()["status"] == "valid"
 
-    def test_node_downstreams(self, client_with_event: TestClient):
+    @pytest.mark.asyncio
+    async def test_node_downstreams(self, client_with_event: AsyncClient):
         """
         Test getting downstream nodes of different node types.
         """
-        response = client_with_event.get(
+        response = await client_with_event.get(
             "/nodes/default.event_source/downstream/?node_type=metric",
         )
         data = response.json()
@@ -3853,19 +3912,21 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.device_ids_count",
         }
 
-        response = client_with_event.get(
+        response = await client_with_event.get(
             "/nodes/default.event_source/downstream/?node_type=transform",
         )
         data = response.json()
         assert {node["name"] for node in data} == {"default.long_events"}
 
-        response = client_with_event.get(
+        response = await client_with_event.get(
             "/nodes/default.event_source/downstream/?node_type=dimension",
         )
         data = response.json()
         assert {node["name"] for node in data} == {"default.country_dim"}
 
-        response = client_with_event.get("/nodes/default.event_source/downstream/")
+        response = await client_with_event.get(
+            "/nodes/default.event_source/downstream/",
+        )
         data = response.json()
         assert {node["name"] for node in data} == {
             "default.long_events_distinct_countries",
@@ -3874,23 +3935,24 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.country_dim",
         }
 
-        response = client_with_event.get(
+        response = await client_with_event.get(
             "/nodes/default.device_ids_count/downstream/",
         )
         data = response.json()
         assert data == []
 
-        response = client_with_event.get("/nodes/default.long_events/downstream/")
+        response = await client_with_event.get("/nodes/default.long_events/downstream/")
         data = response.json()
         assert {node["name"] for node in data} == {
             "default.long_events_distinct_countries",
         }
 
-    def test_node_upstreams(self, client_with_event: TestClient):
+    @pytest.mark.asyncio
+    async def test_node_upstreams(self, client_with_event: AsyncClient):
         """
         Test getting upstream nodes of different node types.
         """
-        response = client_with_event.get(
+        response = await client_with_event.get(
             "/nodes/default.long_events_distinct_countries/upstream/",
         )
         data = response.json()
@@ -3899,12 +3961,13 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.long_events",
         }
 
-    def test_list_node_dag(self, client_example_loader):
+    @pytest.mark.asyncio
+    async def test_list_node_dag(self, client_example_loader):
         """
         Test getting the DAG for a node
         """
-        custom_client = client_example_loader(["EVENT", "ROADS"])
-        response = custom_client.get(
+        custom_client = await client_example_loader(["EVENT", "ROADS"])
+        response = await custom_client.get(
             "/nodes/default.long_events_distinct_countries/dag",
         )
         data = response.json()
@@ -3915,7 +3978,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.long_events_distinct_countries",
         }
 
-        response = custom_client.get("/nodes/default.num_repair_orders/dag")
+        response = await custom_client.get("/nodes/default.num_repair_orders/dag")
         data = response.json()
         assert {node["name"] for node in data} == {
             "default.dispatcher",
@@ -3928,11 +3991,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.us_state",
         }
 
-    def test_node_column_lineage(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_node_column_lineage(self, client_with_roads: AsyncClient):
         """
         Test endpoint to retrieve a node's column-level lineage
         """
-        response = client_with_roads.get(
+        response = await client_with_roads.get(
             "/nodes/default.num_repair_orders/lineage/",
         )
         assert response.json() == [
@@ -3961,7 +4025,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-        client_with_roads.post(
+        await client_with_roads.post(
             "/nodes/metric/",
             json={
                 "name": "default.discounted_repair_orders",
@@ -3976,7 +4040,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "description": "Discounted Repair Orders",
             },
         )
-        response = client_with_roads.get(
+        response = await client_with_roads.get(
             "/nodes/default.discounted_repair_orders/lineage/",
         )
         assert response.json() == [
@@ -4004,11 +4068,12 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-    def test_revalidating_existing_nodes(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_revalidating_existing_nodes(self, client_with_roads: AsyncClient):
         """
         Test revalidating all example nodes and confirm that they are set to valid
         """
-        client_with_roads.post(
+        await client_with_roads.post(
             "/nodes/cube/",
             json={
                 "metrics": [
@@ -4027,21 +4092,26 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "name": "default.repairs_cube",
             },
         )
-        for node in client_with_roads.get("/nodes/").json():
-            status = client_with_roads.post(
-                f"/nodes/{node}/validate/",
+        for node in (await client_with_roads.get("/nodes/")).json():
+            status = (
+                await client_with_roads.post(
+                    f"/nodes/{node}/validate/",
+                )
             ).json()["status"]
             assert status == "valid"
         # Confirm that they still show as valid server-side
-        for node in client_with_roads.get("/nodes/").json():
-            node = client_with_roads.get(f"/nodes/{node}").json()
+        for node in (await client_with_roads.get("/nodes/")).json():
+            node = (await client_with_roads.get(f"/nodes/{node}")).json()
             assert node["status"] == "valid"
 
-    def test_lineage_on_complex_transforms(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_lineage_on_complex_transforms(self, client_with_roads: AsyncClient):
         """
         Test metric lineage on more complex transforms and metrics
         """
-        response = client_with_roads.get("/nodes/default.regional_level_agg/").json()
+        response = (
+            await client_with_roads.get("/nodes/default.regional_level_agg/")
+        ).json()
         assert response["columns"] == [
             {
                 "attributes": [
@@ -4151,8 +4221,10 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             },
         ]
 
-        response = client_with_roads.get(
-            "/nodes/default.regional_repair_efficiency/",
+        response = (
+            await client_with_roads.get(
+                "/nodes/default.regional_repair_efficiency/",
+            )
         ).json()
         assert response["columns"] == [
             {
@@ -4164,8 +4236,10 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 "partition": None,
             },
         ]
-        response = client_with_roads.get(
-            "/nodes/default.regional_repair_efficiency/lineage/",
+        response = (
+            await client_with_roads.get(
+                "/nodes/default.regional_repair_efficiency/lineage/",
+            )
         ).json()
         assert response == [
             {
@@ -4260,7 +4334,8 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         ]
 
 
-def test_node_similarity(session: Session, client: TestClient):
+@pytest.mark.asyncio
+async def test_node_similarity(session: AsyncSession, client: AsyncClient):
     """
     Test determining node similarity based on their queries
     """
@@ -4324,25 +4399,27 @@ def test_node_similarity(session: Session, client: TestClient):
     session.add(a_transform_rev)
     session.add(another_transform_rev)
     session.add(yet_another_transform_rev)
-    session.commit()
+    await session.commit()
 
-    response = client.get("/nodes/similarity/a_transform/another_transform")
+    response = await client.get("/nodes/similarity/a_transform/another_transform")
     assert response.status_code == 200
     data = response.json()
     assert data["similarity"] == 1.0
 
-    response = client.get("/nodes/similarity/a_transform/yet_another_transform")
+    response = await client.get("/nodes/similarity/a_transform/yet_another_transform")
     assert response.status_code == 200
     data = response.json()
     assert data["similarity"] == 0.75
 
-    response = client.get("/nodes/similarity/yet_another_transform/another_transform")
+    response = await client.get(
+        "/nodes/similarity/yet_another_transform/another_transform",
+    )
     assert response.status_code == 200
     data = response.json()
     assert data["similarity"] == 0.75
 
     # Check that the proper error is raised when using a source node
-    response = client.get("/nodes/similarity/a_transform/source_data")
+    response = await client.get("/nodes/similarity/a_transform/source_data")
     assert response.status_code == 409
     data = response.json()
     assert data == {
@@ -4352,7 +4429,10 @@ def test_node_similarity(session: Session, client: TestClient):
     }
 
 
-def test_resolving_downstream_status(client_with_service_setup: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_resolving_downstream_status(
+    client_with_service_setup: AsyncClient,
+) -> None:
     """
     Test creating and updating a source node
     """
@@ -4433,7 +4513,7 @@ def test_resolving_downstream_status(client_with_service_setup: TestClient) -> N
         (metric2, NodeType.METRIC),
         (metric3, NodeType.METRIC),
     ]:
-        response = client_with_service_setup.post(
+        response = await client_with_service_setup.post(
             f"/nodes/{node_type.value}/",  # pylint: disable=no-member
             json=node,
         )
@@ -4459,7 +4539,7 @@ def test_resolving_downstream_status(client_with_service_setup: TestClient) -> N
         "table": "comments",
     }
 
-    response = client_with_service_setup.post(
+    response = await client_with_service_setup.post(
         "/nodes/source/",
         json=missing_parent_node,
     )
@@ -4471,7 +4551,7 @@ def test_resolving_downstream_status(client_with_service_setup: TestClient) -> N
 
     # Check that downstream nodes have now been switched to a "valid" status
     for node in [transform1, transform2, transform3, metric1, metric2, metric3]:
-        response = client_with_service_setup.get(f"/nodes/{node['name']}/")
+        response = await client_with_service_setup.get(f"/nodes/{node['name']}/")
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == node["name"]
@@ -4482,7 +4562,7 @@ def test_resolving_downstream_status(client_with_service_setup: TestClient) -> N
 
     # Check that nodes still not valid have an invalid status
     for node in [transform4, transform5]:
-        response = client_with_service_setup.get(f"/nodes/{node['name']}/")
+        response = await client_with_service_setup.get(f"/nodes/{node['name']}/")
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == node["name"]
@@ -4622,11 +4702,14 @@ def test_decompose_expression():
     ]
 
 
-def test_list_dimension_attributes(client_with_roads: TestClient) -> None:
+@pytest.mark.asyncio
+async def test_list_dimension_attributes(client_with_roads: AsyncClient) -> None:
     """
     Test that listing dimension attributes for any node works.
     """
-    response = client_with_roads.get("/nodes/default.regional_level_agg/dimensions/")
+    response = await client_with_roads.get(
+        "/nodes/default.regional_level_agg/dimensions/",
+    )
     assert response.status_code in (200, 201)
     assert response.json() == [
         {
@@ -4672,12 +4755,13 @@ def test_list_dimension_attributes(client_with_roads: TestClient) -> None:
     ]
 
 
-def test_set_column_partition(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_set_column_partition(client_with_roads: AsyncClient):
     """
     Test setting temporal and categorical partitions on node
     """
     # Set hire_date to temporal
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/default.hard_hat/columns/hire_date/partition",
         json={
             "type_": "temporal",
@@ -4700,7 +4784,7 @@ def test_set_column_partition(client_with_roads: TestClient):
     }
 
     # Set state to categorical
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/default.hard_hat/columns/state/partition",
         json={
             "type_": "categorical",
@@ -4721,7 +4805,7 @@ def test_set_column_partition(client_with_roads: TestClient):
     }
 
     # Attempt to set country to temporal (missing granularity)
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/default.hard_hat/columns/country/partition",
         json={
             "type_": "temporal",
@@ -4735,7 +4819,7 @@ def test_set_column_partition(client_with_roads: TestClient):
     )
 
     # Attempt to set country to temporal (missing format)
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/default.hard_hat/columns/country/partition",
         json={
             "type_": "temporal",
@@ -4748,7 +4832,7 @@ def test_set_column_partition(client_with_roads: TestClient):
     )
 
     # Set country to temporal
-    client_with_roads.post(
+    await client_with_roads.post(
         "/nodes/default.hard_hat/columns/country/partition",
         json={
             "type_": "temporal",
@@ -4758,7 +4842,7 @@ def test_set_column_partition(client_with_roads: TestClient):
     )
 
     # Update country to categorical
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/default.hard_hat/columns/country/partition",
         json={
             "type_": "categorical",
@@ -4780,14 +4864,15 @@ def test_set_column_partition(client_with_roads: TestClient):
     }
 
 
-def test_delete_recreate_for_all_nodes(client_with_roads: TestClient):
+@pytest.mark.asyncio
+async def test_delete_recreate_for_all_nodes(client_with_roads: AsyncClient):
     """
     Test deleting and recreating for all node types
     """
     # Delete a source node
-    client_with_roads.delete("/nodes/default.dispatchers")
+    await client_with_roads.delete("/nodes/default.dispatchers")
     # Recreating it should succeed
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/source",
         json={
             "columns": [
@@ -4804,22 +4889,22 @@ def test_delete_recreate_for_all_nodes(client_with_roads: TestClient):
         },
     )
     assert response.json()["version"] == "v2.0"
-    response = client_with_roads.get("/history?node=default.dispatchers")
+    response = await client_with_roads.get("/history?node=default.dispatchers")
     assert [activity["activity_type"] for activity in response.json()] == [
         "create",
         "delete",
         "update",
         "restore",
     ]
-    client_with_roads.patch(
+    await client_with_roads.patch(
         "/nodes/default.dispatcher",
         json={"primary_key": ["dispatcher_id"]},
     )
 
     # Delete a dimension node
-    client_with_roads.delete("/nodes/default.us_state")
+    await client_with_roads.delete("/nodes/default.us_state")
     # Trying to create a transform node with the same name will fail
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/transform",
         json={
             "description": "US state transform",
@@ -4842,7 +4927,7 @@ ON s.state_region = r.us_region_id""",
         "DELETE /nodes/{node_name}/hard"
     )
     # Trying to create a dimension node with the same name but an updated query will succeed
-    response = client_with_roads.post(
+    response = await client_with_roads.post(
         "/nodes/dimension",
         json={
             "description": "US state",
@@ -4860,7 +4945,7 @@ ON s.state_region = r.us_region_id""",
     )
     node_data = response.json()
     assert node_data["version"] == "v2.0"
-    response = client_with_roads.get("/history?node=default.us_state")
+    response = await client_with_roads.get("/history?node=default.us_state")
     assert [activity["activity_type"] for activity in response.json()] == [
         "create",
         "set_attribute",
@@ -4885,16 +4970,16 @@ ON s.state_region = r.us_region_id""",
         "mode": "published",
         "name": "default.repairs_cube",
     }
-    client_with_roads.post(
+    await client_with_roads.post(
         "/nodes/cube/",
         json=create_cube_payload,
     )
-    client_with_roads.delete("/nodes/default.repairs_cube")
-    client_with_roads.post(
+    await client_with_roads.delete("/nodes/default.repairs_cube")
+    await client_with_roads.post(
         "/nodes/cube/",
         json=create_cube_payload,
     )
-    response = client_with_roads.get("/history?node=default.repairs_cube")
+    response = await client_with_roads.get("/history?node=default.repairs_cube")
     assert [activity["activity_type"] for activity in response.json()] == [
         "create",
         "delete",
@@ -4936,11 +5021,12 @@ class TestCopyNode:
             "required_dimensions": ["manager"],
         }
 
-    def test_copy_node_failures(self, client_with_roads: TestClient):
+    @pytest.mark.asyncio
+    async def test_copy_node_failures(self, client_with_roads: AsyncClient):
         """
         Test reaching various failure states when copying nodes
         """
-        response = client_with_roads.post(
+        response = await client_with_roads.post(
             "/nodes/default.repair_order/copy?new_name=default.contractor",
         )
         assert (
@@ -4948,7 +5034,7 @@ class TestCopyNode:
             == "A node with name default.contractor already exists."
         )
 
-        response = client_with_roads.post(
+        response = await client_with_roads.post(
             "/nodes/default.repair_order/copy?new_name=default.blah.repair_order",
         )
         assert (
@@ -4957,39 +5043,43 @@ class TestCopyNode:
         )
 
         # Test copying over deactivated node
-        client_with_roads.delete("/nodes/default.contractor")
-        client_with_roads.post(
+        await client_with_roads.delete("/nodes/default.contractor")
+        await client_with_roads.post(
             "/nodes/default.repair_order/copy?new_name=default.contractor",
         )
-        copied = client_with_roads.get("/nodes/default.contractor").json()
-        original = client_with_roads.get("/nodes/default.repair_order").json()
+        copied = (await client_with_roads.get("/nodes/default.contractor")).json()
+        original = (await client_with_roads.get("/nodes/default.repair_order")).json()
         for field in ["name", "node_id", "node_revision_id", "updated_at"]:
             copied[field] = mock.ANY
         for link in copied["dimension_links"]:
             link["foreign_keys"] = mock.ANY
         assert copied == original
 
-    def test_copy_nodes(  # pylint: disable=too-many-locals
+    @pytest.mark.asyncio
+    async def test_copy_nodes(  # pylint: disable=too-many-locals
         self,
-        client_with_roads: TestClient,
+        client_with_roads: AsyncClient,
         repairs_cube_payload,  # pylint: disable=redefined-outer-name
         metric_with_required_dim_payload,  # pylint: disable=redefined-outer-name
     ):
         """
         Test copying all nodes in the roads database
         """
-        client_with_roads.post("/nodes/cube", json=repairs_cube_payload)
-        client_with_roads.post("/nodes/metric", json=metric_with_required_dim_payload)
+        await client_with_roads.post("/nodes/cube", json=repairs_cube_payload)
+        await client_with_roads.post(
+            "/nodes/metric",
+            json=metric_with_required_dim_payload,
+        )
 
         # Copy all nodes to a node name with _copy appended
-        nodes = client_with_roads.get("/nodes").json()
+        nodes = (await client_with_roads.get("/nodes")).json()
         for node in nodes:
-            client_with_roads.post(f"/nodes/{node}/copy?new_name={node}_copy")
+            await client_with_roads.post(f"/nodes/{node}/copy?new_name={node}_copy")
 
         # Check that each node was successfully copied by comparing against the original
         for node in nodes:
-            original = client_with_roads.get(f"/nodes/{node}").json()
-            copied = client_with_roads.get(f"/nodes/{node}_copy").json()
+            original = (await client_with_roads.get(f"/nodes/{node}")).json()
+            copied = (await client_with_roads.get(f"/nodes/{node}_copy")).json()
             for field in ["name", "node_id", "node_revision_id", "updated_at"]:
                 copied[field] = mock.ANY
             for link in copied["dimension_links"]:
@@ -4998,16 +5088,20 @@ class TestCopyNode:
 
             # Metrics contain additional metadata, so compare the /metrics endpoint as well
             if original["type"] == "metric":
-                metric_orig = client_with_roads.get(f"/metrics/{node}").json()
-                metric_copied = client_with_roads.get(f"/metrics/{node}_copy").json()
+                metric_orig = (await client_with_roads.get(f"/metrics/{node}")).json()
+                metric_copied = (
+                    await client_with_roads.get(f"/metrics/{node}_copy")
+                ).json()
                 for field in ["id", "name", "updated_at"]:
                     metric_copied[field] = mock.ANY
                 assert metric_orig == metric_copied
 
             # Cubes contain additional metadata, so compare the /metrics endpoint as well
             if original["type"] == "cube":
-                cube_orig = client_with_roads.get(f"/cubes/{node}").json()
-                cube_copied = client_with_roads.get(f"/cubes/{node}_copy").json()
+                cube_orig = (await client_with_roads.get(f"/cubes/{node}")).json()
+                cube_copied = (
+                    await client_with_roads.get(f"/cubes/{node}_copy")
+                ).json()
                 for field in ["name", "node_id", "node_revision_id", "updated_at"]:
                     cube_copied[field] = mock.ANY
                 assert cube_orig == cube_copied
@@ -5015,12 +5109,16 @@ class TestCopyNode:
             # Check that the dimensions DAG for the node has been copied
             original_dimensions = [
                 dim["name"]
-                for dim in client_with_roads.get(f"/nodes/{node}/dimensions").json()
+                for dim in (
+                    await client_with_roads.get(f"/nodes/{node}/dimensions")
+                ).json()
             ]
             copied_dimensions = [
                 dim["name"].replace(f"{node}_copy", node)
-                for dim in client_with_roads.get(
-                    f"/nodes/{node}_copy/dimensions",
+                for dim in (
+                    await client_with_roads.get(
+                        f"/nodes/{node}_copy/dimensions",
+                    )
                 ).json()
             ]
             assert original_dimensions == copied_dimensions

--- a/datajunction-server/tests/api/routers_test.py
+++ b/datajunction-server/tests/api/routers_test.py
@@ -1,32 +1,34 @@
 """
 Tests for the custom API routers.
 """
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
 
-def test_api_router_trailing_slashes(
-    client_with_basic: TestClient,
+@pytest.mark.asyncio
+async def test_api_router_trailing_slashes(
+    client_with_basic: AsyncClient,
 ) -> None:
     """
     Test that the API router used by our endpoints will send both routes without
     trailing slashes and those with trailing slashes to right place.
     """
-    response = client_with_basic.get("/attributes/")
+    response = await client_with_basic.get("/attributes/")
     assert response.status_code in (200, 201)
     assert len(response.json()) > 0
 
-    response = client_with_basic.get("/attributes")
+    response = await client_with_basic.get("/attributes")
     assert response.status_code in (200, 201)
     assert len(response.json()) > 0
 
-    response = client_with_basic.get("/namespaces/")
+    response = await client_with_basic.get("/namespaces/")
     assert response.status_code in (200, 201)
     assert len(response.json()) > 0
 
-    response = client_with_basic.get("/namespaces")
+    response = await client_with_basic.get("/namespaces")
     assert response.status_code in (200, 201)
     assert len(response.json()) > 0
 
-    response = client_with_basic.get("/namespaces/basic?type_=source")
+    response = await client_with_basic.get("/namespaces/basic?type_=source")
     assert response.status_code in (200, 201)
     assert len(response.json()) > 0

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -2749,6 +2749,7 @@ async def test_measures_sql_with_filters(  # pylint: disable=too-many-arguments
     }
     response = await client_with_roads.get("/sql/measures", params=sql_params)
     data = response.json()
+    print("data", data)
     assert str(parse(str(data["sql"]))) == str(parse(str(sql)))
     result = duckdb_conn.sql(data["sql"])
     assert result.fetchall() == rows

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -139,13 +139,14 @@ def postgres_container() -> PostgresContainer:
 
 
 @pytest_asyncio.fixture
-async def session() -> AsyncGenerator[AsyncSession, None]:
+async def session(
+    postgres_container: PostgresContainer,
+) -> AsyncGenerator[AsyncSession, None]:
     """
     Create a Postgres session to test models.
     """
     engine = create_async_engine(
-        "sqlite+aiosqlite://",
-        connect_args={"check_same_thread": False},
+        url=postgres_container.get_connection_url(),
         poolclass=StaticPool,
     )
     async with engine.begin() as conn:
@@ -290,7 +291,7 @@ def query_service_client(
     yield qs_client
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client(  # pylint: disable=too-many-statements
     session: AsyncSession,
     settings: Settings,

--- a/datajunction-server/tests/construction/fixtures.py
+++ b/datajunction-server/tests/construction/fixtures.py
@@ -5,7 +5,8 @@
 from typing import Dict, List, Optional, Tuple
 
 import pytest
-from sqlalchemy.orm import Session
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.attributetype import AttributeType, ColumnAttribute
 from datajunction_server.database.column import Column
@@ -190,10 +191,10 @@ def build_expectation() -> Dict[str, Dict[Optional[int], Tuple[bool, str]]]:
     }
 
 
-@pytest.fixture
-def construction_session(  # pylint: disable=too-many-locals
-    session: Session,
-) -> Session:
+@pytest_asyncio.fixture
+async def construction_session(  # pylint: disable=too-many-locals
+    session: AsyncSession,
+) -> AsyncSession:
     """
     Add some source nodes and transform nodes to facilitate testing of extracting dependencies
     """
@@ -556,5 +557,5 @@ def construction_session(  # pylint: disable=too-many-locals
     session.add(orders_src)
     session.add(customers_src)
 
-    session.commit()
+    await session.commit()
     return session

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=W0621,C0325
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.errors import DJException
 from datajunction_server.sql.parsing import ast
@@ -29,7 +29,8 @@ from datajunction_server.sql.parsing.types import (
 )
 
 
-def test_infer_column_with_table(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_column_with_table(construction_session: AsyncSession):
     """
     Test getting the type of a column that has a table
     """
@@ -40,7 +41,7 @@ def test_infer_column_with_table(construction_session: Session):
         session=construction_session,
         exception=DJException(),
     )
-    table.compile(ctx)
+    await table.compile(ctx)
     assert table.columns[0].type == IntegerType()
     assert table.columns[1].type == IntegerType()
     assert table.columns[2].type == DateType()
@@ -79,7 +80,8 @@ def test_raise_on_invalid_infer_binary_op():
     ) in str(exc_info.value)
 
 
-def test_infer_column_with_an_aliased_table(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_column_with_an_aliased_table(construction_session: AsyncSession):
     """
     Test getting the type of a column that has an aliased table
     """
@@ -103,7 +105,7 @@ def test_infer_column_with_an_aliased_table(construction_session: Session):
         ),
         child=table,
     )
-    alias.compile(ctx)
+    await alias.compile(ctx)
 
     assert alias.child.columns[0].type == IntegerType()
     assert alias.child.columns[1].type == IntegerType()
@@ -173,7 +175,8 @@ def test_raising_when_expression_has_no_parent():
     )
 
 
-def test_infer_map_subscripts(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_map_subscripts(construction_session: AsyncSession):
     """
     Test inferring map subscript types
     """
@@ -190,7 +193,7 @@ def test_infer_map_subscripts(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         StringType(),
         StringType(),
@@ -204,7 +207,8 @@ def test_infer_map_subscripts(construction_session: Session):
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
-def test_infer_types_complicated(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_complicated(construction_session: AsyncSession):
     """
     Test inferring complicated types
     """
@@ -270,7 +274,7 @@ def test_infer_types_complicated(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         IntegerType(),
         TimestampType(),
@@ -308,7 +312,8 @@ def test_infer_types_complicated(construction_session: Session):
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
-def test_infer_bad_case_types(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_bad_case_types(construction_session: AsyncSession):
     """
     Test inferring mismatched case types.
     """
@@ -324,7 +329,7 @@ def test_infer_bad_case_types(construction_session: Session):
             session=construction_session,
             exception=DJException(),
         )
-        query.compile(ctx)
+        await query.compile(ctx)
         [  # pylint: disable=pointless-statement
             exp.type for exp in query.select.projection  # type: ignore
         ]
@@ -332,7 +337,8 @@ def test_infer_bad_case_types(construction_session: Session):
     assert str(excinfo.value) == "Not all the same type in CASE! Found: bigint, string"
 
 
-def test_infer_types_avg(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_avg(construction_session: AsyncSession):
     """
     Test type inference of functions
     """
@@ -354,7 +360,7 @@ def test_infer_types_avg(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         DoubleType(),
         DecimalType(12, 10),
@@ -368,7 +374,8 @@ def test_infer_types_avg(construction_session: Session):
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
-def test_infer_types_min_max_sum_ceil(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_min_max_sum_ceil(construction_session: AsyncSession):
     """
     Test type inference of functions
     """
@@ -389,12 +396,13 @@ def test_infer_types_min_max_sum_ceil(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [IntegerType(), IntegerType(), BigIntType(), BigIntType(), DoubleType()]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
-def test_infer_types_count(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_count(construction_session: AsyncSession):
     """
     Test type inference of functions
     """
@@ -410,7 +418,7 @@ def test_infer_types_count(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         BigIntType(),
         BigIntType(),
@@ -418,7 +426,8 @@ def test_infer_types_count(construction_session: Session):
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
-def test_infer_types_coalesce(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_coalesce(construction_session: AsyncSession):
     """
     Test type inference of functions
     """
@@ -433,7 +442,7 @@ def test_infer_types_coalesce(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         IntegerType(),
         StringType(),
@@ -441,7 +450,8 @@ def test_infer_types_coalesce(construction_session: Session):
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
-def test_infer_types_array_map(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_array_map(construction_session: AsyncSession):
     """
     Test type inference for arrays and maps
     """
@@ -458,7 +468,7 @@ def test_infer_types_array_map(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         ListType(IntegerType()),
         MapType(IntegerType(), StringType()),
@@ -476,7 +486,7 @@ def test_infer_types_array_map(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == MapType(  # type: ignore
         key_type=IntegerType(),
         value_type=StringType(),
@@ -491,13 +501,14 @@ def test_infer_types_array_map(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     with pytest.raises(DJParseException) as exc_info:
         query.select.projection[0].type  # type: ignore  # pylint: disable=pointless-statement
     assert "Multiple types int, string passed to array" in str(exc_info)
 
 
-def test_infer_types_if(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_if(construction_session: AsyncSession):
     """
     Test type inference of IF
     """
@@ -512,7 +523,7 @@ def test_infer_types_if(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == IntegerType()  # type: ignore
     with pytest.raises(DJException) as exc_info:
         query.select.projection[1].type  # type: ignore  # pylint: disable=pointless-statement
@@ -523,7 +534,8 @@ def test_infer_types_if(construction_session: Session):
     assert query.select.projection[2].type == IntegerType()  # type: ignore
 
 
-def test_infer_types_exp(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_exp(construction_session: AsyncSession):
     """
     Test type inference of math functions
     """
@@ -551,7 +563,7 @@ def test_infer_types_exp(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         DoubleType(),
         BigIntType(),
@@ -573,7 +585,8 @@ def test_infer_types_exp(construction_session: Session):
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
 
 
-def test_infer_types_str(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_str(construction_session: AsyncSession):
     """
     Test type inference of EXP
     """
@@ -588,7 +601,7 @@ def test_infer_types_str(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         StringType(),
         StringType(),
@@ -614,7 +627,8 @@ def test_column_type_validation():
     assert ColumnType.validate("array<int>") == ListType(IntegerType())
 
 
-def test_infer_types_datetime(construction_session: Session):
+@pytest.mark.asyncio
+async def test_infer_types_datetime(construction_session: AsyncSession):
     """
     Test type inference of functions
     """
@@ -649,7 +663,7 @@ def test_infer_types_datetime(construction_session: Session):
     )
     exc = DJException()
     ctx = CompileContext(session=construction_session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     types = [
         DateType(),
         TimeType(),

--- a/datajunction-server/tests/construction/utils_test.py
+++ b/datajunction-server/tests/construction/utils_test.py
@@ -4,24 +4,29 @@ Tests for building nodes and extracting dependencies
 
 # pylint: disable=too-many-lines
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.utils import get_dj_node
 from datajunction_server.errors import DJErrorException
 from datajunction_server.models.node_type import NodeType
 
 
-def test_get_dj_node_raise_unknown_node_exception(session: Session):
+@pytest.mark.asyncio
+async def test_get_dj_node_raise_unknown_node_exception(session: AsyncSession):
     """
     Test raising an unknown node exception when calling get_dj_node
     """
     with pytest.raises(DJErrorException) as exc_info:
-        get_dj_node(session, "foobar")
+        await get_dj_node(session, "foobar")
 
     assert "No node" in str(exc_info.value)
 
     with pytest.raises(DJErrorException) as exc_info:
-        get_dj_node(session, "foobar", kinds={NodeType.METRIC, NodeType.DIMENSION})
+        await get_dj_node(
+            session,
+            "foobar",
+            kinds={NodeType.METRIC, NodeType.DIMENSION},
+        )
 
     assert "dimension" in str(exc_info.value)
     assert "metric" in str(exc_info.value)
@@ -30,7 +35,7 @@ def test_get_dj_node_raise_unknown_node_exception(session: Session):
 
     with pytest.raises(DJErrorException) as exc_info:
         # test that the event_type raises because it's a dimension and not a transform
-        get_dj_node(session, "event_type", kinds={NodeType.TRANSFORM})
+        await get_dj_node(session, "event_type", kinds={NodeType.TRANSFORM})
 
     assert (
         "No node `event_type` exists of kind transform"  # pylint: disable=C0301
@@ -39,7 +44,7 @@ def test_get_dj_node_raise_unknown_node_exception(session: Session):
 
     # test that the event_type raises because it's a dimension and not a transform
     with pytest.raises(DJErrorException) as exc_info:
-        get_dj_node(session, "event_type", kinds={NodeType.TRANSFORM})
+        await get_dj_node(session, "event_type", kinds={NodeType.TRANSFORM})
 
     assert "No node `event_type` exists of kind transform" in str(
         exc_info.value,

--- a/datajunction-server/tests/internal/authentication/whoami_test.py
+++ b/datajunction-server/tests/internal/authentication/whoami_test.py
@@ -1,26 +1,28 @@
 """
 Tests for whoami router
 """
-
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
 from datajunction_server.internal.access.authentication.tokens import decode_token
 
 
-def test_whoami(client: TestClient):
+@pytest.mark.asyncio
+async def test_whoami(client: AsyncClient):
     """
     Test /whoami endpoint
     """
-    response = client.get("/whoami/")
+    response = await client.get("/whoami/")
     assert response.status_code in (200, 201)
     assert response.json()["username"] == "dj"
 
 
-def test_short_lived_token(client: TestClient):
+@pytest.mark.asyncio
+async def test_short_lived_token(client: AsyncClient):
     """
     Test getting a short-lived token from the /token endpoint
     """
-    response = client.get("/token/")
+    response = await client.get("/token/")
     assert response.status_code in (200, 201)
     data = response.json()
     user = decode_token(data["token"])

--- a/datajunction-server/tests/models/node_test.py
+++ b/datajunction-server/tests/models/node_test.py
@@ -6,7 +6,7 @@ Tests for ``datajunction_server.models.node``.
 
 
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.node import Node, NodeRevision
@@ -14,7 +14,7 @@ from datajunction_server.models.node import AvailabilityStateBase, PartitionAvai
 from datajunction_server.models.node_type import NodeType
 
 
-def test_node_relationship(session: Session) -> None:
+def test_node_relationship(session: AsyncSession) -> None:
     """
     Test the n:n self-referential relationships.
     """

--- a/datajunction-server/tests/sql/dag_test.py
+++ b/datajunction-server/tests/sql/dag_test.py
@@ -1,8 +1,8 @@
 """
 Tests for ``datajunction_server.sql.dag``.
 """
-
-from sqlalchemy.orm import Session
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.column import Column
 from datajunction_server.database.database import Database
@@ -12,7 +12,8 @@ from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.sql.parsing.types import IntegerType, StringType
 
 
-def test_get_dimensions(session: Session) -> None:
+@pytest.mark.asyncio
+async def test_get_dimensions(session: AsyncSession) -> None:
     """
     Test ``get_dimensions``.
     """
@@ -64,9 +65,9 @@ def test_get_dimensions(session: Session) -> None:
     child_ref.current = child
     session.add(child)
     session.add(child_ref)
-    session.commit()
+    await session.commit()
 
-    assert get_dimensions(session, child_ref) == [
+    assert await get_dimensions(session, child_ref) == [
         DimensionAttributeOutput(
             name="B.attribute",
             node_name="B",

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -4,7 +4,7 @@ Tests for ``datajunction_server.sql.functions``.
 """
 
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import datajunction_server.sql.functions as F
 import datajunction_server.sql.parsing.types as ct
@@ -36,7 +36,8 @@ from datajunction_server.sql.parsing.types import (
 )
 
 
-def test_missing_functions() -> None:
+@pytest.mark.asyncio
+async def test_missing_functions() -> None:
     """
     Test missing functions.
     """
@@ -52,7 +53,8 @@ def test_missing_functions() -> None:
     )
 
 
-def test_bad_combo_types() -> None:
+@pytest.mark.asyncio
+async def test_bad_combo_types() -> None:
     """
     Tests dispatch raises on bad types
     """
@@ -61,7 +63,8 @@ def test_bad_combo_types() -> None:
     assert "got an invalid combination of types" in str(exc)
 
 
-def test_abs(session: Session):
+@pytest.mark.asyncio
+async def test_abs(session: AsyncSession):
     """
     Test the `abs` Spark function
     """
@@ -72,7 +75,7 @@ def test_abs(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
@@ -83,12 +86,13 @@ def test_abs(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
 
-def test_aggregate(session: Session):
+@pytest.mark.asyncio
+async def test_aggregate(session: AsyncSession):
     """
     Test the `aggregate` Spark function
     """
@@ -106,30 +110,32 @@ def test_aggregate(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == StringType()  # type: ignore
 
 
-def test_approx_percentile(session: Session):
+@pytest.mark.asyncio
+async def test_approx_percentile(session: AsyncSession):
     """
     Test the `approx_percentile` Spark function
     """
     query_with_list = parse("SELECT approx_percentile(10.0, array(0.5, 0.4, 0.1), 100)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_list.compile(ctx)
+    await query_with_list.compile(ctx)
     assert not exc.errors
     assert query_with_list.select.projection[0].type == ct.ListType(element_type=ct.FloatType())  # type: ignore
 
     query_with_list = parse("SELECT approx_percentile(10.0, 0.5, 100)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_list.compile(ctx)
+    await query_with_list.compile(ctx)
     assert not exc.errors
     assert query_with_list.select.projection[0].type == ct.FloatType()  # type: ignore
 
 
-def test_array(session: Session):
+@pytest.mark.asyncio
+async def test_array(session: AsyncSession):
     """
     Test the `array` Spark function
     """
@@ -140,7 +146,7 @@ def test_array(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.NullType())  # type: ignore
 
@@ -151,12 +157,13 @@ def test_array(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
 
-def test_array_agg(session: Session):
+@pytest.mark.asyncio
+async def test_array_agg(session: AsyncSession):
     """
     Test the `array_agg` Spark function
     """
@@ -167,7 +174,7 @@ def test_array_agg(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
@@ -178,38 +185,40 @@ def test_array_agg(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_array_append(session: Session):
+@pytest.mark.asyncio
+async def test_array_append(session: AsyncSession):
     """
     Test the `array_append` Spark function
     """
     query = parse("SELECT array_append(array('b', 'd', 'c', 'a'), 'd')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
     query = parse("SELECT array_append(array(1, 2, 3, 4), 5)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
     query = parse("SELECT array_append(array(true, false, true, true), false)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.BooleanType())  # type: ignore
 
 
-def test_array_compact(session: Session):
+@pytest.mark.asyncio
+async def test_array_compact(session: AsyncSession):
     """
     Test the `array_compact` Spark function
     """
@@ -218,25 +227,27 @@ def test_array_compact(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
     assert query.select.projection[1].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_array_contains(session: Session):
+@pytest.mark.asyncio
+async def test_array_contains(session: AsyncSession):
     """
     Test the `array_contains` Spark function
     """
     query = parse("select array_contains(array(1, 2, 3), 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_array_distinct(session: Session):
+@pytest.mark.asyncio
+async def test_array_distinct(session: AsyncSession):
     """
     Test the `array_distinct` Spark function
     """
@@ -246,7 +257,7 @@ def test_array_distinct(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
     query = parse(
@@ -255,11 +266,12 @@ def test_array_distinct(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_array_except(session: Session):
+@pytest.mark.asyncio
+async def test_array_except(session: AsyncSession):
     """
     Test the `array_except` Spark function
     """
@@ -269,7 +281,7 @@ def test_array_except(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
     query = parse(
@@ -278,11 +290,12 @@ def test_array_except(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_array_intersect(session: Session):
+@pytest.mark.asyncio
+async def test_array_intersect(session: AsyncSession):
     """
     Test the `array_intersect` Spark function
     """
@@ -292,7 +305,7 @@ def test_array_intersect(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
     query = parse(
@@ -301,11 +314,12 @@ def test_array_intersect(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_array_join(session: Session):
+@pytest.mark.asyncio
+async def test_array_join(session: AsyncSession):
     """
     Test the `array_join` Spark function
     """
@@ -315,7 +329,7 @@ def test_array_join(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
     query = parse(
@@ -324,11 +338,12 @@ def test_array_join(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_array_max(session: Session):
+@pytest.mark.asyncio
+async def test_array_max(session: AsyncSession):
     """
     Test the `array_max` Spark function
     """
@@ -338,11 +353,12 @@ def test_array_max(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_array_min(session: Session):
+@pytest.mark.asyncio
+async def test_array_min(session: AsyncSession):
     """
     Test the `array_min` Spark function
     """
@@ -352,11 +368,12 @@ def test_array_min(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
 
-def test_array_position(session: Session):
+@pytest.mark.asyncio
+async def test_array_position(session: AsyncSession):
     """
     Test the `array_position` function
     """
@@ -366,11 +383,12 @@ def test_array_position(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.LongType()  # type: ignore
 
 
-def test_array_remove(session: Session):
+@pytest.mark.asyncio
+async def test_array_remove(session: AsyncSession):
     """
     Test the `array_remove` function
     """
@@ -380,11 +398,12 @@ def test_array_remove(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.FloatType())  # type: ignore
 
 
-def test_array_repeat(session: Session):
+@pytest.mark.asyncio
+async def test_array_repeat(session: AsyncSession):
     """
     Test the `array_repeat` function
     """
@@ -394,13 +413,14 @@ def test_array_repeat(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
     assert query.select.projection[1].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
     assert query.select.projection[2].type == ct.ListType(element_type=ct.FloatType())  # type: ignore
 
 
-def test_array_size(session: Session):
+@pytest.mark.asyncio
+async def test_array_size(session: AsyncSession):
     """
     Test the `array_size` function
     """
@@ -410,11 +430,12 @@ def test_array_size(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.LongType()  # type: ignore
 
 
-def test_array_sort(session: Session):
+@pytest.mark.asyncio
+async def test_array_sort(session: AsyncSession):
     """
     Test the `array_sort` function
     """
@@ -425,13 +446,14 @@ def test_array_sort(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.StringType(),
     )
 
 
-def test_array_union(session: Session):
+@pytest.mark.asyncio
+async def test_array_union(session: AsyncSession):
     """
     Test the `array_union` function
     """
@@ -441,13 +463,14 @@ def test_array_union(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.StringType(),
     )
 
 
-def test_array_overlap(session: Session):
+@pytest.mark.asyncio
+async def test_array_overlap(session: AsyncSession):
     """
     Test the `array_overlap` function
     """
@@ -457,11 +480,12 @@ def test_array_overlap(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_avg() -> None:
+@pytest.mark.asyncio
+async def test_avg() -> None:
     """
     Test ``avg`` function.
     """
@@ -471,85 +495,91 @@ def test_avg() -> None:
     assert Avg.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == DoubleType()
 
 
-def test_cardinality(session: Session):
+@pytest.mark.asyncio
+async def test_cardinality(session: AsyncSession):
     """
     Test the `cardinality` Spark function
     """
     query_with_list = parse("SELECT cardinality(array('b', 'd', 'c', 'a'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_list.compile(ctx)
+    await query_with_list.compile(ctx)
     assert not exc.errors
     assert query_with_list.select.projection[0].type == ct.IntegerType()  # type: ignore
 
     query_with_map = parse("SELECT cardinality(map('a', 1, 'b', 2))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_map.compile(ctx)
+    await query_with_map.compile(ctx)
     assert not exc.errors
     assert query_with_map.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_cbrt_func(session: Session):
+@pytest.mark.asyncio
+async def test_cbrt_func(session: AsyncSession):
     """
     Test the `cbrt` function
     """
     query = parse("SELECT cbrt(27), cbrt(64.0)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == FloatType()  # type: ignore
     assert query.select.projection[1].type == FloatType()  # type: ignore
 
 
-def test_char_func(session: Session):
+@pytest.mark.asyncio
+async def test_char_func(session: AsyncSession):
     """
     Test the `char` function
     """
     query = parse("SELECT char(65), char(97)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == StringType()  # type: ignore
     assert query.select.projection[1].type == StringType()  # type: ignore
 
 
-def test_char_length_func(session: Session):
+@pytest.mark.asyncio
+async def test_char_length_func(session: AsyncSession):
     """
     Test the `char_length` function
     """
     query = parse("SELECT char_length('hello'), char_length('world')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == IntegerType()  # type: ignore
     assert query.select.projection[1].type == IntegerType()  # type: ignore
 
 
-def test_character_length_func(session: Session):
+@pytest.mark.asyncio
+async def test_character_length_func(session: AsyncSession):
     """
     Test the `character_length` function
     """
     query = parse("SELECT character_length('hello'), character_length('world')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == IntegerType()  # type: ignore
     assert query.select.projection[1].type == IntegerType()  # type: ignore
 
 
-def test_chr_func(session: Session):
+@pytest.mark.asyncio
+async def test_chr_func(session: AsyncSession):
     """
     Test the `chr` function
     """
     query = parse("SELECT chr(65), chr(97)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == StringType()  # type: ignore
     assert query.select.projection[1].type == StringType()  # type: ignore
@@ -577,7 +607,8 @@ def test_chr_func(session: Session):
         ),
     ],
 )
-def test_ceil(types, expected) -> None:
+@pytest.mark.asyncio
+async def test_ceil(types, expected) -> None:
     """
     Test ``ceil`` function.
     """
@@ -595,7 +626,8 @@ def test_ceil(types, expected) -> None:
         )
 
 
-def test_ceil_ceiling_funcs(session: Session):
+@pytest.mark.asyncio
+async def test_ceil_ceiling_funcs(session: AsyncSession):
     """
     Test the `ceil` and `ceiling` functions
     """
@@ -605,7 +637,7 @@ def test_ceil_ceiling_funcs(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == BigIntType()  # type: ignore
     assert query.select.projection[1].type == BigIntType()  # type: ignore
@@ -617,7 +649,8 @@ def test_ceil_ceiling_funcs(session: Session):
     assert query.select.projection[7].type == DecimalType(precision=14, scale=0)  # type: ignore
 
 
-def test_coalesce_infer_type() -> None:
+@pytest.mark.asyncio
+async def test_coalesce_infer_type() -> None:
     """
     Test type inference in the ``Coalesce`` function.
     """
@@ -649,7 +682,8 @@ def test_coalesce_infer_type() -> None:
     )
 
 
-def test_concat_func(session: Session):
+@pytest.mark.asyncio
+async def test_concat_func(session: AsyncSession):
     """
     Test the `concat` function
     """
@@ -658,13 +692,14 @@ def test_concat_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.ListType(ct.IntegerType())  # type: ignore
 
 
-def test_concat_ws_func(session: Session):
+@pytest.mark.asyncio
+async def test_concat_ws_func(session: AsyncSession):
     """
     Test the `concat_ws` function
     """
@@ -675,42 +710,45 @@ def test_concat_ws_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == StringType()  # type: ignore
     assert query.select.projection[1].type == StringType()  # type: ignore
     assert query.select.projection[2].type == StringType()  # type: ignore
 
 
-def test_collect_list(session: Session):
+@pytest.mark.asyncio
+async def test_collect_list(session: AsyncSession):
     """
     Test the `collect_list` function
     """
     query = parse("SELECT collect_list(col) FROM (SELECT (1), (2) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.IntegerType(),
     )
 
 
-def test_collect_set(session: Session):
+@pytest.mark.asyncio
+async def test_collect_set(session: AsyncSession):
     """
     Test the `collect_set` function
     """
     query = parse("SELECT collect_set(col) FROM (SELECT (1), (2) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.IntegerType(),
     )
 
 
-def test_contains_func(session: Session):
+@pytest.mark.asyncio
+async def test_contains_func(session: AsyncSession):
     """
     Test the `contains` function
     """
@@ -719,26 +757,28 @@ def test_contains_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
 
 
-def test_conv_func(session: Session):
+@pytest.mark.asyncio
+async def test_conv_func(session: AsyncSession):
     """
     Test the `conv` function
     """
     query = parse("SELECT conv('10', 10, 2), conv(15, 10, 16)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_convert_timezone_func(session: Session):
+@pytest.mark.asyncio
+async def test_convert_timezone_func(session: AsyncSession):
     """
     Test the `convert_timezone` function
     """
@@ -747,64 +787,69 @@ def test_convert_timezone_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
 
 
-def test_corr_func(session: Session):
+@pytest.mark.asyncio
+async def test_corr_func(session: AsyncSession):
     """
     Test the `corr` function
     """
     query = parse("SELECT corr(2.0, 3.0), corr(5, 10)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_cos_func(session: Session):
+@pytest.mark.asyncio
+async def test_cos_func(session: AsyncSession):
     """
     Test the `cos` function
     """
     query = parse("SELECT cos(0), cos(3.1416)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_cosh_func(session: Session):
+@pytest.mark.asyncio
+async def test_cosh_func(session: AsyncSession):
     """
     Test the `cosh` function
     """
     query = parse("SELECT cosh(0), cosh(1.0)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_cot_func(session: Session):
+@pytest.mark.asyncio
+async def test_cot_func(session: AsyncSession):
     """
     Test the `cot` function
     """
     query = parse("SELECT cot(1), cot(0.7854)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_count() -> None:
+@pytest.mark.asyncio
+async def test_count() -> None:
     """
     Test ``Count`` function.
     """
@@ -815,20 +860,22 @@ def test_count() -> None:
     assert Count.is_aggregation is True
 
 
-def test_count_if_func(session: Session):
+@pytest.mark.asyncio
+async def test_count_if_func(session: AsyncSession):
     """
     Test the `count_if` function
     """
     query = parse("SELECT count_if(true), count_if(false)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_count_min_sketch(session: Session):
+@pytest.mark.asyncio
+async def test_count_min_sketch(session: AsyncSession):
     """
     Test the `count_min_sketch` function
     """
@@ -837,129 +884,139 @@ def test_count_min_sketch(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BinaryType()  # type: ignore
 
 
-def test_covar_pop_func(session: Session):
+@pytest.mark.asyncio
+async def test_covar_pop_func(session: AsyncSession):
     """
     Test the `covar_pop` function
     """
     query = parse("SELECT covar_pop(1.0, 2.0), covar_pop(3, 4)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_covar_samp_func(session: Session):
+@pytest.mark.asyncio
+async def test_covar_samp_func(session: AsyncSession):
     """
     Test the `covar_samp` function
     """
     query = parse("SELECT covar_samp(1.0, 2.0), covar_samp(3, 4)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_crc32_func(session: Session):
+@pytest.mark.asyncio
+async def test_crc32_func(session: AsyncSession):
     """
     Test the `crc32` function
     """
     query = parse("SELECT crc32('hello'), crc32('world')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
     assert query.select.projection[1].type == ct.BigIntType()  # type: ignore
 
 
-def test_csc_func(session: Session):
+@pytest.mark.asyncio
+async def test_csc_func(session: AsyncSession):
     """
     Test the `csc` function
     """
     query = parse("SELECT csc(1), csc(0.7854)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_cume_dist_func(session: Session):
+@pytest.mark.asyncio
+async def test_cume_dist_func(session: AsyncSession):
     """
     Test the `cume_dist` function
     """
     query = parse("SELECT cume_dist(), cume_dist()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_curdate_func(session: Session):
+@pytest.mark.asyncio
+async def test_curdate_func(session: AsyncSession):
     """
     Test the `curdate` function
     """
     query = parse("SELECT curdate(), curdate()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DateType()  # type: ignore
     assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
-def test_current_catalog_func(session: Session):
+@pytest.mark.asyncio
+async def test_current_catalog_func(session: AsyncSession):
     """
     Test the `current_catalog` function
     """
     query = parse("SELECT current_catalog(), current_catalog()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_current_database_func(session: Session):
+@pytest.mark.asyncio
+async def test_current_database_func(session: AsyncSession):
     """
     Test the `current_database` function
     """
     query = parse("SELECT current_database(), current_database()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_current_schema_func(session: Session):
+@pytest.mark.asyncio
+async def test_current_schema_func(session: AsyncSession):
     """
     Test the `current_schema` function
     """
     query = parse("SELECT current_schema(), current_schema()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_current_timezone_current_user_funcs(session: Session):
+@pytest.mark.asyncio
+async def test_current_timezone_current_user_funcs(session: AsyncSession):
     """
     Test the `current_timezone` function
     Test the `current_user` function
@@ -967,13 +1024,14 @@ def test_current_timezone_current_user_funcs(session: Session):
     query = parse("SELECT current_timezone(), current_user()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_date_func(session: Session):
+@pytest.mark.asyncio
+async def test_date_func(session: AsyncSession):
     """
     Test the `date` function
     """
@@ -982,38 +1040,41 @@ def test_date_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DateType()  # type: ignore
     assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
-def test_date_from_unix_date_func(session: Session):
+@pytest.mark.asyncio
+async def test_date_from_unix_date_func(session: AsyncSession):
     """
     Test the `date_from_unix_date` function
     """
     query = parse("SELECT date_from_unix_date(0), date_from_unix_date(18500)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DateType()  # type: ignore
     assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
-def test_date_format(session: Session) -> None:
+@pytest.mark.asyncio
+async def test_date_format(session: AsyncSession) -> None:
     """
     Test ``date_format`` function.
     """
     query_with_array = parse("SELECT date_format(NOW(), 'yyyyMMdd') as date_partition")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_array.compile(ctx)
+    await query_with_array.compile(ctx)
     assert not exc.errors
     assert query_with_array.select.projection[0].type == StringType()  # type: ignore
 
 
-def test_date_part_func(session: Session):
+@pytest.mark.asyncio
+async def test_date_part_func(session: AsyncSession):
     """
     Test the `date_part` function
     """
@@ -1022,25 +1083,27 @@ def test_date_part_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_dj_logical_timestamp(session: Session) -> None:
+@pytest.mark.asyncio
+async def test_dj_logical_timestamp(session: AsyncSession) -> None:
     """
     Test ``DJ_LOGICAL_TIMESTAMP`` function.
     """
     query_with_array = parse("SELECT dj_logical_timestamp() as date_partition")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_array.compile(ctx)
+    await query_with_array.compile(ctx)
     assert not exc.errors
     assert query_with_array.select.projection[0].type == StringType()  # type: ignore
 
 
-def test_dayofmonth_func(session: Session):
+@pytest.mark.asyncio
+async def test_dayofmonth_func(session: AsyncSession):
     """
     Test the `dayofmonth` function
     """
@@ -1049,13 +1112,14 @@ def test_dayofmonth_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_dayofweek_func(session: Session):
+@pytest.mark.asyncio
+async def test_dayofweek_func(session: AsyncSession):
     """
     Test the `dayofweek` function
     """
@@ -1064,13 +1128,14 @@ def test_dayofweek_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_dayofyear_func(session: Session):
+@pytest.mark.asyncio
+async def test_dayofyear_func(session: AsyncSession):
     """
     Test the `dayofyear` function
     """
@@ -1079,172 +1144,185 @@ def test_dayofyear_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_decimal_func(session: Session):
+@pytest.mark.asyncio
+async def test_decimal_func(session: AsyncSession):
     """
     Test the `decimal` function
     """
     query = parse("SELECT decimal(123), decimal('456.78')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DecimalType(8, 6)  # type: ignore
     assert query.select.projection[1].type == ct.DecimalType(8, 6)  # type: ignore
 
 
-def test_decode_func(session: Session):
+@pytest.mark.asyncio
+async def test_decode_func(session: AsyncSession):
     """
     Test the `decode` function
     """
     query = parse("SELECT decode(unhex('4D7953514C'), 'UTF-8')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_degrees_func(session: Session):
+@pytest.mark.asyncio
+async def test_degrees_func(session: AsyncSession):
     """
     Test the `degrees` function
     """
     query = parse("SELECT degrees(1), degrees(3.141592653589793)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_double_func(session: Session):
+@pytest.mark.asyncio
+async def test_double_func(session: AsyncSession):
     """
     Test the `double` function
     """
     query = parse("SELECT double('123.45'), double(67890)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
     assert query.select.projection[1].type == ct.DoubleType()  # type: ignore
 
 
-def test_e_func(session: Session):
+@pytest.mark.asyncio
+async def test_e_func(session: AsyncSession):
     """
     Test the `e` function
     """
     query = parse("SELECT e(), e()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_element_at(session: Session):
+@pytest.mark.asyncio
+async def test_element_at(session: AsyncSession):
     """
     Test the `element_at` Spark function
     """
     query_with_array = parse("SELECT element_at(array(1, 2, 3, 4), 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_array.compile(ctx)
+    await query_with_array.compile(ctx)
     assert not exc.errors
     assert query_with_array.select.projection[0].type == IntegerType()  # type: ignore
 
     query_with_map = parse("SELECT element_at(map(1, 'a', 2, 'b'), 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query_with_map.compile(ctx)
+    await query_with_map.compile(ctx)
     assert not exc.errors
     assert query_with_map.select.projection[0].type == StringType()  # type: ignore
 
 
-def test_elt_func(session: Session):
+@pytest.mark.asyncio
+async def test_elt_func(session: AsyncSession):
     """
     Test the `elt` function
     """
     query = parse("SELECT elt(1, 'a', 'b', 'c'), elt(3, 'd', 'e', 'f')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_encode_func(session: Session):
+@pytest.mark.asyncio
+async def test_encode_func(session: AsyncSession):
     """
     Test the `encode` function
     """
     query = parse("SELECT encode('hello', 'UTF-8'), encode('world', 'UTF-8')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_endswith_func(session: Session):
+@pytest.mark.asyncio
+async def test_endswith_func(session: AsyncSession):
     """
     Test the `endswith` function
     """
     query = parse("SELECT endswith('hello', 'lo'), endswith('world', 'ld')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
 
 
-def test_equal_null_func(session: Session):
+@pytest.mark.asyncio
+async def test_equal_null_func(session: AsyncSession):
     """
     Test the `equal_null` function
     """
     query = parse("SELECT equal_null('hello', 'hello'), equal_null(NULL, NULL)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
 
 
-def test_every_func(session: Session):
+@pytest.mark.asyncio
+async def test_every_func(session: AsyncSession):
     """
     Test the `every` function
     """
     query = parse("SELECT every(col), every(col) FROM (SELECT (true), (false) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
 
 
-def test_exists_func(session: Session):
+@pytest.mark.asyncio
+async def test_exists_func(session: AsyncSession):
     """
     Test the `exists` function
     """
     query = parse("SELECT exists(array(1, 2, 3), x -> x % 2 > 0)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_explode_outer_func(session: Session):
+@pytest.mark.asyncio
+async def test_explode_outer_func(session: AsyncSession):
     """
     Test the `explode_outer` function
     """
@@ -1253,46 +1331,49 @@ def test_explode_outer_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_expm1_func(session: Session):
+@pytest.mark.asyncio
+async def test_expm1_func(session: AsyncSession):
     """
     Test the `expm1` function
     """
     query = parse("SELECT expm1(1), expm1(0.5)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_factorial_func(session: Session):
+@pytest.mark.asyncio
+async def test_factorial_func(session: AsyncSession):
     """
     Test the `factorial` function
     """
     query = parse("SELECT factorial(0), factorial(5)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_filter(session: Session):
+@pytest.mark.asyncio
+async def test_filter(session: AsyncSession):
     """
     Test the `filter` function
     """
     query = parse("SELECT filter(col, s -> s != 3) FROM (SELECT array(1, 2, 3) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.IntegerType(),
     )
@@ -1302,7 +1383,7 @@ def test_filter(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.IntegerType(),
     )
@@ -1313,23 +1394,25 @@ def test_filter(session: Session):
         )
         exc = DJException()
         ctx = ast.CompileContext(session=session, exception=exc)
-        query.compile(ctx)
+        await query.compile(ctx)
 
 
-def test_find_in_set_func(session: Session):
+@pytest.mark.asyncio
+async def test_find_in_set_func(session: AsyncSession):
     """
     Test the `find_in_set` function
     """
     query = parse("SELECT find_in_set('b', 'a,b,c,d'), find_in_set('e', 'a,b,c,d')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_first_and_first_value(session: Session):
+@pytest.mark.asyncio
+async def test_first_and_first_value(session: AsyncSession):
     """
     Test `first` and `first_value`
     """
@@ -1339,7 +1422,7 @@ def test_first_and_first_value(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
@@ -1347,28 +1430,30 @@ def test_first_and_first_value(session: Session):
     assert query.select.projection[3].type == ct.IntegerType()  # type: ignore
 
 
-def test_flatten(session: Session):
+@pytest.mark.asyncio
+async def test_flatten(session: AsyncSession):
     """
     Test `flatten`
     """
     query = parse("SELECT flatten(array(array(1, 2), array(3, 4)))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.IntegerType(),
     )
 
 
-def test_float_func(session: Session):
+@pytest.mark.asyncio
+async def test_float_func(session: AsyncSession):
     """
     Test the `float` function
     """
     query = parse("SELECT float(123), float('456.78')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
@@ -1396,7 +1481,8 @@ def test_float_func(session: Session):
         ),
     ],
 )
-def test_floor(types, expected) -> None:
+@pytest.mark.asyncio
+async def test_floor(types, expected) -> None:
     """
     Test ``floor`` function.
     """
@@ -1414,7 +1500,8 @@ def test_floor(types, expected) -> None:
         )
 
 
-def test_forall_func(session: Session):
+@pytest.mark.asyncio
+async def test_forall_func(session: AsyncSession):
     """
     Test the `forall` function
     """
@@ -1423,13 +1510,14 @@ def test_forall_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     # assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
 
 
-def test_format_number_func(session: Session):
+@pytest.mark.asyncio
+async def test_format_number_func(session: AsyncSession):
     """
     Test the `format_number` function
     """
@@ -1438,13 +1526,14 @@ def test_format_number_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_format_string_func(session: Session):
+@pytest.mark.asyncio
+async def test_format_string_func(session: AsyncSession):
     """
     Test the `format_string` function
     """
@@ -1453,41 +1542,44 @@ def test_format_string_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
 # TODO: Fix these two  # pylint: disable=fixme
-# def test_from_csv_func(session: Session):
+# @pytest.mark.asyncio
+# async def test_from_csv_func(session: AsyncSession):
 #     """
 #     Test the `from_csv` function
 #     """
 #     query = parse("SELECT from_csv('1,2,3', 'a INT, b INT, c INT'), from_csv('4,5,6', 'x INT, y INT, z INT')")
 #     exc = DJException()
 #     ctx = ast.CompileContext(session=session, exception=exc)
-#     query.compile(ctx)
+#     await query.compile(ctx)
 #     assert not exc.errors
 #     assert isinstance(query.select.projection[0].type, ct.StructType)  # type: ignore
 #     assert isinstance(query.select.projection[1].type, ct.StructType)  # type: ignore
 
 
 # TODO: Fix these two  # pylint: disable=fixme
-# def test_from_json_func(session: Session):
+# @pytest.mark.asyncio
+# async def test_from_json_func(session: AsyncSession):
 #     """
 #     Test the `from_json` function
 #     """
 #     query = parse("SELECT from_json('1,2,3', 'a INT, b INT, c INT'), from_json('4,5,6', 'x INT, y INT, z INT')")
 #     exc = DJException()
 #     ctx = ast.CompileContext(session=session, exception=exc)
-#     query.compile(ctx)
+#     await query.compile(ctx)
 #     assert not exc.errors
 #     assert isinstance(query.select.projection[0].type, Union[ct.StructType, ct.ListType])  # type: ignore
 #     assert isinstance(query.select.projection[1].type, Union[ct.StructType, ct.ListType])
 
 
-def test_from_unix_time_func(session: Session):
+@pytest.mark.asyncio
+async def test_from_unix_time_func(session: AsyncSession):
     """
     Test the `from_unix_time` function
     """
@@ -1496,13 +1588,14 @@ def test_from_unix_time_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_from_utc_timestamp_func(session: Session):
+@pytest.mark.asyncio
+async def test_from_utc_timestamp_func(session: AsyncSession):
     """
     Test the `from_utc_timestamp` function
     """
@@ -1512,26 +1605,28 @@ def test_from_utc_timestamp_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
     assert query.select.projection[1].type == ct.TimestampType()  # type: ignore
 
 
-def test_get_func(session: Session):
+@pytest.mark.asyncio
+async def test_get_func(session: AsyncSession):
     """
     Test the `get` function
     """
     query = parse("SELECT get(array(1, 2, 3), 0), get(array('a', 'b', 'c'), 1)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_get_json_object_func(session: Session):
+@pytest.mark.asyncio
+async def test_get_json_object_func(session: AsyncSession):
     """
     Test the `get_json_object` function
     """
@@ -1541,38 +1636,41 @@ def test_get_json_object_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_getbit_func(session: Session):
+@pytest.mark.asyncio
+async def test_getbit_func(session: AsyncSession):
     """
     Test the `getbit` function
     """
     query = parse("SELECT getbit(1010, 0), getbit(1010, 1)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_greatest(session: Session):
+@pytest.mark.asyncio
+async def test_greatest(session: AsyncSession):
     """
     Test `greatest`
     """
     query = parse("SELECT greatest(10, 9, 2, 4, 3)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_grouping_func(session: Session):
+@pytest.mark.asyncio
+async def test_grouping_func(session: AsyncSession):
     """
     Test the `grouping` function
     """
@@ -1582,13 +1680,14 @@ def test_grouping_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_grouping_id_func(session: Session):
+@pytest.mark.asyncio
+async def test_grouping_id_func(session: AsyncSession):
     """
     Test the `grouping_id` function
     """
@@ -1598,51 +1697,55 @@ def test_grouping_id_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
 
 
-def test_hash_func(session: Session):
+@pytest.mark.asyncio
+async def test_hash_func(session: AsyncSession):
     """
     Test the `hash` function
     """
     query = parse("SELECT hash('hello'), hash(123)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_hex_func(session: Session):
+@pytest.mark.asyncio
+async def test_hex_func(session: AsyncSession):
     """
     Test the `hex` function
     """
     query = parse("SELECT hex('hello'), hex(123)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_histogram_numeric_func(session: Session):
+@pytest.mark.asyncio
+async def test_histogram_numeric_func(session: AsyncSession):
     """
     Test the `histogram_numeric` function
     """
     query = parse("SELECT histogram_numeric(col, 5) FROM (SELECT (1), (2) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert isinstance(query.select.projection[0].type, ct.ListType)  # type: ignore
     assert isinstance(query.select.projection[0].type.element.type, ct.StructType)  # type: ignore
 
 
-def test_hour_func(session: Session):
+@pytest.mark.asyncio
+async def test_hour_func(session: AsyncSession):
     """
     Test the `hour` function
     """
@@ -1651,26 +1754,28 @@ def test_hour_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_hypot_func(session: Session):
+@pytest.mark.asyncio
+async def test_hypot_func(session: AsyncSession):
     """
     Test the `hypot` function
     """
     query = parse("SELECT hypot(3, 4), hypot(5.0, 12.0)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
     assert query.select.projection[1].type == ct.FloatType()  # type: ignore
 
 
-def test_if(session: Session):
+@pytest.mark.asyncio
+async def test_if(session: AsyncSession):
     """
     Test the `if` functions
     """
@@ -1679,12 +1784,13 @@ def test_if(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_ilike_like_func(session: Session):
+@pytest.mark.asyncio
+async def test_ilike_like_func(session: AsyncSession):
     """
     Test the `ilike`, `like` functions
     """
@@ -1694,27 +1800,29 @@ def test_ilike_like_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[2].type == ct.BooleanType()  # type: ignore
 
 
-def test_initcap_func(session: Session):
+@pytest.mark.asyncio
+async def test_initcap_func(session: AsyncSession):
     """
     Test the `initcap` function
     """
     query = parse("SELECT initcap('hello world'), initcap('SQL function')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_inline_func(session: Session):
+@pytest.mark.asyncio
+async def test_inline_func(session: AsyncSession):
     """
     Test the `inline` function
     """
@@ -1725,125 +1833,135 @@ def test_inline_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert isinstance(query.select.projection[0].type, ct.StructType)  # type: ignore
     assert isinstance(query.select.projection[1].type, ct.StructType)  # type: ignore
 
 
-def test_input_file_block_length_func(session: Session):
+@pytest.mark.asyncio
+async def test_input_file_block_length_func(session: AsyncSession):
     """
     Test the `input_file_block_length` function
     """
     query = parse("SELECT input_file_block_length()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.LongType()  # type: ignore
 
 
-def test_input_file_block_start_func(session: Session):
+@pytest.mark.asyncio
+async def test_input_file_block_start_func(session: AsyncSession):
     """
     Test the `input_file_block_start` function
     """
     query = parse("SELECT input_file_block_start()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.LongType()  # type: ignore
 
 
-def test_input_file_name_func(session: Session):
+@pytest.mark.asyncio
+async def test_input_file_name_func(session: AsyncSession):
     """
     Test the `input_file_name` function
     """
     query = parse("SELECT input_file_name()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_int(session: Session):
+@pytest.mark.asyncio
+async def test_int(session: AsyncSession):
     """
     Test the `int` function
     """
     query = parse("SELECT int('3')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_instr_func(session: Session):
+@pytest.mark.asyncio
+async def test_instr_func(session: AsyncSession):
     """
     Test the `instr` function
     """
     query = parse("SELECT instr('hello world', 'world'), instr('hello world', 'SQL')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_isnan_func(session: Session):
+@pytest.mark.asyncio
+async def test_isnan_func(session: AsyncSession):
     """
     Test the `isnan` function
     """
     query = parse("SELECT isnan(1/0), isnan(0.0/0.0)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
 
 
-def test_isnotnull_isnull(session: Session):
+@pytest.mark.asyncio
+async def test_isnotnull_isnull(session: AsyncSession):
     """
     Test the `isnotnull`, `isnull` functions
     """
     query = parse("SELECT isnotnull(0), isnull(null)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
 
 
-def test_json_array_length_func(session: Session):
+@pytest.mark.asyncio
+async def test_json_array_length_func(session: AsyncSession):
     """
     Test the `json_array_length` function
     """
     query = parse("SELECT json_array_length('[1, 2, 3]')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_json_object_keys_func(session: Session):
+@pytest.mark.asyncio
+async def test_json_object_keys_func(session: AsyncSession):
     """
     Test the `json_object_keys` function
     """
     query = parse('SELECT json_object_keys(\'{"key1": "value1", "key2": "value2"}\')')
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert isinstance(query.select.projection[0].type, ct.ListType)  # type: ignore
     assert query.select.projection[0].type.element.type == ct.StringType()  # type: ignore
 
 
-def test_json_tuple_func(session: Session):
+@pytest.mark.asyncio
+async def test_json_tuple_func(session: AsyncSession):
     """
     Test the `json_tuple` function
     """
@@ -1852,24 +1970,26 @@ def test_json_tuple_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert isinstance(query.select.projection[0].type, ct.ListType)  # type: ignore
 
 
-def test_kurtosis_func(session: Session):
+@pytest.mark.asyncio
+async def test_kurtosis_func(session: AsyncSession):
     """
     Test the `kurtosis` function
     """
     query = parse("SELECT kurtosis(col) FROM (SELECT (1), (2), (3) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
 
 
-def test_lag_func(session: Session):
+@pytest.mark.asyncio
+async def test_lag_func(session: AsyncSession):
     """
     Test the `lag` function
     """
@@ -1878,13 +1998,14 @@ def test_lag_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     # The output type depends on the type of `col`
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_last_and_last_value(session: Session):
+@pytest.mark.asyncio
+async def test_last_and_last_value(session: AsyncSession):
     """
     Test the `last` function
     """
@@ -1896,40 +2017,43 @@ def test_last_and_last_value(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     # The output type depends on the type of `col`
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_last_day_func(session: Session):
+@pytest.mark.asyncio
+async def test_last_day_func(session: AsyncSession):
     """
     Test the `last_day` function
     """
     query = parse("SELECT last_day('2023-01-01'), last_day(cast('2023-02-15' as date))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DateType()  # type: ignore
     assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
-def test_lcase_func(session: Session):
+@pytest.mark.asyncio
+async def test_lcase_func(session: AsyncSession):
     """
     Test the `lcase` function
     """
     query = parse("SELECT lcase('HELLO'), lcase('WORLD')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_lead_func(session: Session):
+@pytest.mark.asyncio
+async def test_lead_func(session: AsyncSession):
     """
     Test the `lead` function
     """
@@ -1938,53 +2062,57 @@ def test_lead_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     # The output type depends on the type of `col`
     # Assuming `col` is of type StringType for this test
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_least_func(session: Session):
+@pytest.mark.asyncio
+async def test_least_func(session: AsyncSession):
     """
     Test the `least` function
     """
     query = parse("SELECT least(10, 20, 30, 40)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
 # TODO: figure out why antlr parser fails
-# def test_left_func(session: Session):
+# @pytest.mark.asyncio
+# async def test_left_func(session: AsyncSession):
 #     """
 #     Test the `left` function
 #     """
 #     query = parse("SELECT left('hello world', 5)")
 #     exc = DJException()
 #     ctx = ast.CompileContext(session=session, exception=exc)
-#     query.compile(ctx)
+#     await query.compile(ctx)
 #     assert not exc.errors
 #     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 #     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_len_func(session: Session):
+@pytest.mark.asyncio
+async def test_len_func(session: AsyncSession):
     """
     Test the `len` function
     """
     query = parse("SELECT len('hello'), len('world')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_like_func(session: Session):
+@pytest.mark.asyncio
+async def test_like_func(session: AsyncSession):
     """
     Test the `like` function
     """
@@ -1993,24 +2121,26 @@ def test_like_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_localtimestamp_func(session: Session):
+@pytest.mark.asyncio
+async def test_localtimestamp_func(session: AsyncSession):
     """
     Test the `localtimestamp` function
     """
     query = parse("SELECT localtimestamp()")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
 
 
-def test_locate_func(session: Session):
+@pytest.mark.asyncio
+async def test_locate_func(session: AsyncSession):
     """
     Test the `locate` function
     """
@@ -2019,13 +2149,14 @@ def test_locate_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_log_functions(session: Session):
+@pytest.mark.asyncio
+async def test_log_functions(session: AsyncSession):
     """
     Test the `log1p`, `log10` and `log2` functions
     """
@@ -2034,89 +2165,96 @@ def test_log_functions(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
     assert query.select.projection[1].type == ct.DoubleType()  # type: ignore
     assert query.select.projection[2].type == ct.DoubleType()  # type: ignore
 
 
-def test_lpad_func(session: Session):
+@pytest.mark.asyncio
+async def test_lpad_func(session: AsyncSession):
     """
     Test the `lpad` function
     """
     query = parse("SELECT lpad('hello', 10, ' '), lpad('SQL', 5, '0')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_ltrim_func(session: Session):
+@pytest.mark.asyncio
+async def test_ltrim_func(session: AsyncSession):
     """
     Test the `ltrim` function
     """
     query = parse("SELECT ltrim('   hello'), ltrim('-----world-', '-')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_make_date_func(session: Session):
+@pytest.mark.asyncio
+async def test_make_date_func(session: AsyncSession):
     """
     Test the `make_date` function
     """
     query = parse("SELECT make_date(2023, 7, 30), make_date(2023, 12, 31)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DateType()  # type: ignore
     assert query.select.projection[1].type == ct.DateType()  # type: ignore
 
 
-def test_make_dt_interval_func(session: Session):
+@pytest.mark.asyncio
+async def test_make_dt_interval_func(session: AsyncSession):
     """
     Test the `make_dt_interval` function
     """
     query = parse("SELECT make_dt_interval(1, 2, 30, 45)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DayTimeIntervalType()  # type: ignore
 
 
-def test_make_interval_func(session: Session):
+@pytest.mark.asyncio
+async def test_make_interval_func(session: AsyncSession):
     """
     Test the `make_interval` function
     """
     query = parse("SELECT make_interval(1, 6)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.YearMonthIntervalType()  # type: ignore
 
 
-def test_make_timestamp_func(session: Session):
+@pytest.mark.asyncio
+async def test_make_timestamp_func(session: AsyncSession):
     """
     Test the `make_timestamp` function
     """
     query = parse("SELECT make_timestamp(2023, 7, 30, 14, 45, 30)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
 
 
-def test_make_timestamp_ltz_func(session: Session):
+@pytest.mark.asyncio
+async def test_make_timestamp_ltz_func(session: AsyncSession):
     """
     Test the `make_timestamp_ltz` function
     """
@@ -2126,68 +2264,73 @@ def test_make_timestamp_ltz_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
     assert query.select.projection[1].type == ct.TimestampType()  # type: ignore
 
 
-def test_make_timestamp_ntz_func(session: Session):
+@pytest.mark.asyncio
+async def test_make_timestamp_ntz_func(session: AsyncSession):
     """
     Test the `make_timestamp_ntz` function
     """
     query = parse("SELECT make_timestamp_ntz(2023, 7, 30, 14, 45, 30)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
 
 
-def test_make_ym_interval_func(session: Session):
+@pytest.mark.asyncio
+async def test_make_ym_interval_func(session: AsyncSession):
     """
     Test the `make_ym_interval` function
     """
     query = parse("SELECT make_ym_interval(1, 6)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.YearMonthIntervalType()  # type: ignore
 
 
-def test_map_concat_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_concat_func(session: AsyncSession):
     """
     Test the `map_concat` function
     """
     query = parse("SELECT map_concat(map(1, 'a', 2, 'b'), map(1, 'c'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.MapType(key_type=ct.IntegerType(), value_type=ct.StringType())  # type: ignore
 
 
-def test_map_contains_key_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_contains_key_func(session: AsyncSession):
     """
     Test the `map_contains_key` function
     """
     query = parse("SELECT map_contains_key(map(1, 'a', 2, 'b'), 1)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_map_entries_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_entries_func(session: AsyncSession):
     """
     Test the `map_entries` function
     """
     query = parse("SELECT map_entries(map(1, 'a', 2, 'b'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(  # type: ignore
         element_type=ct.StructType(
@@ -2197,28 +2340,30 @@ def test_map_entries_func(session: Session):
     )  # type: ignore
 
 
-def test_map_filter_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_filter_func(session: AsyncSession):
     """
     Test the `map_filter` function
     """
     query = parse("SELECT map_filter(map(1, 0, 2, 2, 3, -1), (k, v) -> k > v)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.MapType(  # type: ignore
         key_type=ct.IntegerType(),
         value_type=ct.IntegerType(),
     )
 
 
-def test_map_from_arrays_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_from_arrays_func(session: AsyncSession):
     """
     Test the `map_from_arrays` function
     """
     query = parse("SELECT map_from_arrays(array(1.0, 3.0), array('2', '4'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.MapType(  # type: ignore
         key_type=ct.FloatType(),
@@ -2226,14 +2371,15 @@ def test_map_from_arrays_func(session: Session):
     )
 
 
-def test_map_from_entries_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_from_entries_func(session: AsyncSession):
     """
     Test the `map_from_entries` function
     """
     query = parse("SELECT map_from_entries(array(struct(1, 'a'), struct(2, 'b')))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.MapType(  # type: ignore
         key_type=ct.IntegerType(),
@@ -2241,31 +2387,34 @@ def test_map_from_entries_func(session: Session):
     )
 
 
-def test_map_keys_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_keys_func(session: AsyncSession):
     """
     Test the `map_keys` function
     """
     query = parse("SELECT map_keys(map(1, 'a', 2, 'b'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
 
-def test_map_values_func(session: Session):
+@pytest.mark.asyncio
+async def test_map_values_func(session: AsyncSession):
     """
     Test the `map_values` function
     """
     query = parse("SELECT map_values(map(1, 'a', 2, 'b'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_max() -> None:
+@pytest.mark.asyncio
+async def test_max() -> None:
     """
     Test ``Max`` function.
     """
@@ -2286,7 +2435,8 @@ def test_max() -> None:
 
 
 # TODO
-# def test_map_zip_with_func(session: Session):
+# @pytest.mark.asyncio
+# async def test_map_zip_with_func(session: AsyncSession):
 #     """
 #     Test the `map_zip_with` function
 #     """
@@ -2295,12 +2445,13 @@ def test_max() -> None:
 #     query = parse("SELECT map_zip_with(map_col1, map_col2, func) FROM table")
 #     exc = DJException()
 #     ctx = ast.CompileContext(session=session, exception=exc)
-#     query.compile(ctx)
+#     await query.compile(ctx)
 #     assert not exc.errors
 #     assert isinstance(query.select.projection[0].type, ct.MapType)  # type: ignore
 
 
-def test_mask_func(session: Session):
+@pytest.mark.asyncio
+async def test_mask_func(session: AsyncSession):
     """
     Test the `mask` function
     """
@@ -2313,7 +2464,7 @@ def test_mask_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
@@ -2322,7 +2473,8 @@ def test_mask_func(session: Session):
     assert query.select.projection[4].type == ct.StringType()  # type: ignore
 
 
-def test_max_by_min_by_funcs(session: Session):
+@pytest.mark.asyncio
+async def test_max_by_min_by_funcs(session: AsyncSession):
     """
     Test the `max_by` function
     """
@@ -2332,49 +2484,53 @@ def test_max_by_min_by_funcs(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_md5_func(session: Session):
+@pytest.mark.asyncio
+async def test_md5_func(session: AsyncSession):
     """
     Test the `md5` function
     """
     query = parse("SELECT md5('Spark')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_mean_func(session: Session):
+@pytest.mark.asyncio
+async def test_mean_func(session: AsyncSession):
     """
     Test the `mean` function
     """
     query = parse("SELECT mean(col) FROM (SELECT (1), (2), (3) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
 
 
-def test_median_func(session: Session):
+@pytest.mark.asyncio
+async def test_median_func(session: AsyncSession):
     """
     Test the `median` function
     """
     query = parse("SELECT median(col) FROM (SELECT (1), (2), (3) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
 
 
-def test_min() -> None:
+@pytest.mark.asyncio
+async def test_min() -> None:
     """
     Test ``Min`` function.
     """
@@ -2392,7 +2548,8 @@ def test_min() -> None:
         ) == StringType()
 
 
-def test_minute(session: Session):
+@pytest.mark.asyncio
+async def test_minute(session: AsyncSession):
     """
     Test the `minute` function
     """
@@ -2401,13 +2558,14 @@ def test_minute(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_mod(session: Session):
+@pytest.mark.asyncio
+async def test_mod(session: AsyncSession):
     """
     Test the `mod` function
     """
@@ -2416,12 +2574,13 @@ def test_mod(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
 
-def test_mode(session: Session):
+@pytest.mark.asyncio
+async def test_mode(session: AsyncSession):
     """
     Test the `mode` function
     """
@@ -2430,12 +2589,13 @@ def test_mode(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_monotonically_increasing_id(session: Session):
+@pytest.mark.asyncio
+async def test_monotonically_increasing_id(session: AsyncSession):
     """
     Test the `monotonically_increasing_id` function
     """
@@ -2444,12 +2604,13 @@ def test_monotonically_increasing_id(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
 
 
-def test_months_between(session: Session):
+@pytest.mark.asyncio
+async def test_months_between(session: AsyncSession):
     """
     Test the `months_between` function
     """
@@ -2460,19 +2621,20 @@ def test_months_between(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
 
-def test_named_struct_func(session: Session):
+@pytest.mark.asyncio
+async def test_named_struct_func(session: AsyncSession):
     """
     Test the `named_struct` function
     """
     query = parse("SELECT named_struct('name', 'cactus', 'age', 30)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StructType(  # type: ignore
         ct.NestedField(name="name", field_type=ct.StringType()),  # type: ignore
@@ -2480,62 +2642,68 @@ def test_named_struct_func(session: Session):
     )
 
 
-def test_nanvl_func(session: Session):
+@pytest.mark.asyncio
+async def test_nanvl_func(session: AsyncSession):
     """
     Test the `nanvl` function
     """
     query = parse("SELECT nanvl(cast('NaN' as double), 123)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
 
 
-def test_negative_func(session: Session):
+@pytest.mark.asyncio
+async def test_negative_func(session: AsyncSession):
     """
     Test the `negative` function
     """
     query = parse("SELECT negative(1)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_next_day_func(session: Session):
+@pytest.mark.asyncio
+async def test_next_day_func(session: AsyncSession):
     """
     Test the `next_day` function
     """
     query = parse("SELECT next_day('2015-01-14', 'TU')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DateType()  # type: ignore
 
 
-def test_not_func(session: Session):
+@pytest.mark.asyncio
+async def test_not_func(session: AsyncSession):
     """
     Test the `not` function
     """
     query = parse("SELECT not(true)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_now() -> None:
+@pytest.mark.asyncio
+async def test_now() -> None:
     """
     Test ``Now`` function.
     """
     assert Now.infer_type() == ct.TimestampType()
 
 
-def test_nth_value_func(session: Session):
+@pytest.mark.asyncio
+async def test_nth_value_func(session: AsyncSession):
     """
     Test the `nth_value` function
     """
@@ -2545,12 +2713,13 @@ def test_nth_value_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[2].type == ct.IntegerType()  # type: ignore
 
 
-def test_ntile_func(session: Session):
+@pytest.mark.asyncio
+async def test_ntile_func(session: AsyncSession):
     """
     Test the `ntile` function
     """
@@ -2560,60 +2729,65 @@ def test_ntile_func(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[2].type == ct.IntegerType()  # type: ignore
 
 
-def test_nullif_func(session: Session):
+@pytest.mark.asyncio
+async def test_nullif_func(session: AsyncSession):
     """
     Test the `nullif` function
     """
     query = parse("SELECT nullif(2, 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_nvl_func(session: Session):
+@pytest.mark.asyncio
+async def test_nvl_func(session: AsyncSession):
     """
     Test the `nvl` function
     """
     query = parse("SELECT nvl(array('1'), array('2'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_nvl2_func(session: Session):
+@pytest.mark.asyncio
+async def test_nvl2_func(session: AsyncSession):
     """
     Test the `nvl2` function
     """
     query = parse("SELECT nvl2(3, NULL, 1)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_octet_length_func(session: Session):
+@pytest.mark.asyncio
+async def test_octet_length_func(session: AsyncSession):
     """
     Test the `octet_length` function
     """
     query = parse("SELECT octet_length('Spark SQL')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_overlay_func(session: Session):
+@pytest.mark.asyncio
+async def test_overlay_func(session: AsyncSession):
     """
     Test the `overlay` function
     TODO: support syntax like:  # pylint: disable=fixme
@@ -2622,19 +2796,20 @@ def test_overlay_func(session: Session):
     query = parse("SELECT overlay('Hello World', 'J', 7)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_percentile(session: Session):
+@pytest.mark.asyncio
+async def test_percentile(session: AsyncSession):
     """
     Test the `percentile` function
     """
     query = parse("SELECT percentile(col, 0.3) FROM (SELECT (0), (10) AS col)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
@@ -2643,7 +2818,7 @@ def test_percentile(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.FloatType())  # type: ignore
 
@@ -2653,7 +2828,7 @@ def test_percentile(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
@@ -2663,7 +2838,7 @@ def test_percentile(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.FloatType()  # type: ignore
 
@@ -2673,7 +2848,7 @@ def test_percentile(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(ct.FloatType())  # type: ignore
 
@@ -2683,12 +2858,13 @@ def test_percentile(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(ct.FloatType())  # type: ignore
 
 
-def test_random(session: Session):
+@pytest.mark.asyncio
+async def test_random(session: AsyncSession):
     """
     Test `random`, `rand` and `randn`
     """
@@ -2698,13 +2874,14 @@ def test_random(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     for column in query.select.projection:
         assert column.type == ct.FloatType()  # type: ignore
 
 
-def test_rank(session: Session):
+@pytest.mark.asyncio
+async def test_rank(session: AsyncSession):
     """
     Test `dense_rank`, `rank`
     """
@@ -2718,7 +2895,7 @@ def test_rank(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
@@ -2726,7 +2903,8 @@ def test_rank(session: Session):
     assert query.select.projection[3].type == ct.IntegerType()  # type: ignore
 
 
-def test_regexp_like(session: Session):
+@pytest.mark.asyncio
+async def test_regexp_like(session: AsyncSession):
     """
     Test `regexp_like`
     """
@@ -2735,12 +2913,13 @@ def test_regexp_like(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
-def test_replace(session: Session):
+@pytest.mark.asyncio
+async def test_replace(session: AsyncSession):
     """
     Test `replace`
     """
@@ -2750,7 +2929,7 @@ def test_replace(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     # three arguments
@@ -2759,12 +2938,13 @@ def test_replace(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_row_number(session: Session):
+@pytest.mark.asyncio
+async def test_row_number(session: AsyncSession):
     """
     Test `row_number`
     """
@@ -2773,12 +2953,13 @@ def test_row_number(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_round(session: Session):
+@pytest.mark.asyncio
+async def test_round(session: AsyncSession):
     """
     Test `round`
     """
@@ -2787,7 +2968,7 @@ def test_round(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
@@ -2796,26 +2977,27 @@ def test_round(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_sequence(session: Session):
+@pytest.mark.asyncio
+async def test_sequence(session: AsyncSession):
     """
     Test `sequence`
     """
     query = parse("SELECT sequence(1, 10)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
     query = parse("SELECT sequence(1, 10, 2)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
@@ -2824,7 +3006,7 @@ def test_sequence(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.DateType())  # type: ignore
 
@@ -2834,75 +3016,80 @@ def test_sequence(session: Session):
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.TimestampType())  # type: ignore
 
 
-def test_size(session: Session):
+@pytest.mark.asyncio
+async def test_size(session: AsyncSession):
     """
     Test the `size` Spark function
     """
     query = parse("SELECT size(array('b', 'd', 'c', 'a'))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
     query = parse("SELECT size(map('a', 1, 'b', 2))")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
 
 
-def test_split(session: Session):
+@pytest.mark.asyncio
+async def test_split(session: AsyncSession):
     """
     Test the `split` Spark function
     """
     query = parse("SELECT split('oneAtwoBthreeC', '[ABC]')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.ListType(element_type=ct.StringType())  # type: ignore
 
 
-def test_strpos(session: Session):
+@pytest.mark.asyncio
+async def test_strpos(session: AsyncSession):
     """
     Test `strpos`
     """
     query = parse("SELECT strpos('abcde', 'cde'), strpos('abcde', 'cde', 4)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
     assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
 
 
-def test_substring(session: Session):
+@pytest.mark.asyncio
+async def test_substring(session: AsyncSession):
     """
     Test `substring`
     """
     query = parse("SELECT substring('Spark SQL', 5), substring('Spark SQL', 5, 1)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
     query = parse("SELECT substr('Spark SQL', 5), substring('Spark SQL', 5, 1)")
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     assert query.select.projection[1].type == ct.StringType()  # type: ignore
 
 
-def test_sum() -> None:
+@pytest.mark.asyncio
+async def test_sum() -> None:
     """
     Test ``sum`` function.
     """
@@ -2915,7 +3102,8 @@ def test_sum() -> None:
     ) == DecimalType(18, 6)
 
 
-def test_transform(session: Session):
+@pytest.mark.asyncio
+async def test_transform(session: AsyncSession):
     """
     Test the `transform` Spark function
     """
@@ -2925,7 +3113,7 @@ def test_transform(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
     query = parse(
@@ -2934,11 +3122,12 @@ def test_transform(session: Session):
         """,
     )
     ctx = ast.CompileContext(session=session, exception=DJException())
-    query.compile(ctx)
+    await query.compile(ctx)
     assert query.select.projection[0].type == ct.ListType(element_type=ct.IntegerType())  # type: ignore
 
 
-def test_to_date() -> None:
+@pytest.mark.asyncio
+async def test_to_date() -> None:
     """
     Test ``to_date`` function.
     """
@@ -2947,38 +3136,41 @@ def test_to_date() -> None:
     )
 
 
-def test_trim(session: Session):
+@pytest.mark.asyncio
+async def test_trim(session: AsyncSession):
     """
     Test `trim`
     """
     query = parse("SELECT trim('    lmgi   ')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
 
 
-def test_unhex_func(session: Session):
+@pytest.mark.asyncio
+async def test_unhex_func(session: AsyncSession):
     """
     Test the `unhex` function
     """
     query = parse("SELECT unhex('4D'), unhex('7953514C')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BinaryType()  # type: ignore
     assert query.select.projection[1].type == ct.BinaryType()  # type: ignore
 
 
-def test_upper(session: Session):
+@pytest.mark.asyncio
+async def test_upper(session: AsyncSession):
     """
     Test `upper`
     """
     query = parse("SELECT upper('abcde')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
-    query.compile(ctx)
+    await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore

--- a/datajunction-server/tests/utils_test.py
+++ b/datajunction-server/tests/utils_test.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from pytest_mock import MockerFixture
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.background import BackgroundTasks
 from testcontainers.postgres import PostgresContainer
 from yarl import URL
@@ -37,7 +37,8 @@ def test_setup_logging() -> None:
     assert str(excinfo.value) == "Invalid log level: invalid"
 
 
-def test_get_session(mocker: MockerFixture) -> None:
+@pytest.mark.asyncio
+async def test_get_session(mocker: MockerFixture) -> None:
     """
     Test ``get_session``.
     """
@@ -46,8 +47,8 @@ def test_get_session(mocker: MockerFixture) -> None:
         mocker.MagicMock(autospec=BackgroundTasks),
     ) as background_tasks:
         background_tasks.side_effect = lambda x, y: None
-        session = next(get_session(background_tasks))
-        assert isinstance(session, Session)
+        session = await anext(get_session())
+        assert isinstance(session, AsyncSession)
 
 
 def test_get_settings(mocker: MockerFixture) -> None:


### PR DESCRIPTION
### Summary

This PR is fairly large and switches out the sync database connection with async and moves many of our API endpoints to be async. This doubles the RPS that the DJ backend can handle.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #963 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
