### PR TITLE
Switch DJ to support Python 3.10 and up only.

### DIFF
--- a/.github/workflows/client-integration-tests.yml
+++ b/.github/workflows/client-integration-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Build and launch DJ demo environment

--- a/.github/workflows/python-package-daily.yml
+++ b/.github/workflows/python-package-daily.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11.0rc1']
+        python-version: ['3.10', '3.11.0rc1']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
         library: ['client', 'server', 'djqs', 'djrs']
 
     defaults:


### PR DESCRIPTION
### Summary

Getting rid of Py3.8 and 3.9 support, because we'd like to rely on some newer async syntax features.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a
