### PR TITLE
Fix subscript dereferencing bug + concat_ws input types

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -877,6 +877,14 @@ def infer_type(
     return ct.StringType()
 
 
+@ConcatWs.register  # type: ignore
+def infer_type(
+    sep: ct.StringType,
+    *strings: ct.ListType,
+) -> ct.ColumnType:
+    return ct.StringType()
+
+
 class Contains(Function):
     """
     contains(left, right) - Returns a boolean. The value is True if right is found inside left.

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -620,8 +620,11 @@ def _(ctx: sbp.StringLitContext):
 def _(ctx: sbp.DereferenceContext):
     base = visit(ctx.base)
     field = visit(ctx.fieldName)
-    field.namespace = base.name
-    base.name = field
+    if isinstance(base, ast.Subscript) and isinstance(base.expr, ast.Column):
+        field.namespace = base.expr.name
+    if isinstance(base, ast.Column):
+        field.namespace = base.name
+        base.name = field
     return base
 
 

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -671,7 +671,7 @@ def test_concat_ws_func(session: Session):
     query = parse(
         "SELECT concat_ws(',', 'hello', 'world'), "
         "concat_ws('-', 'spark', 'sql', 'function'), "
-        "concat_ws('-', array('spark', 'sql', 'function')), ",
+        "concat_ws('-', array('spark', 'sql', 'function'))",
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -669,7 +669,9 @@ def test_concat_ws_func(session: Session):
     Test the `concat_ws` function
     """
     query = parse(
-        "SELECT concat_ws(',', 'hello', 'world'), concat_ws('-', 'spark', 'sql', 'function')",
+        "SELECT concat_ws(',', 'hello', 'world'), "
+        "concat_ws('-', 'spark', 'sql', 'function'), "
+        "concat_ws('-', array('spark', 'sql', 'function')), ",
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
@@ -677,6 +679,7 @@ def test_concat_ws_func(session: Session):
     assert not exc.errors
     assert query.select.projection[0].type == StringType()  # type: ignore
     assert query.select.projection[1].type == StringType()  # type: ignore
+    assert query.select.projection[2].type == StringType()  # type: ignore
 
 
 def test_collect_list(session: Session):


### PR DESCRIPTION
### Summary

This PR does two things:
* Fixes a bug with subscript dereferencing: The field's namespace can only be extracted from the subscript's column, and the order of the dereferencing should not be swapped.
* Adds additional input types for the `concat_ws` function

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
