### PR TITLE
Add dense_rank() and add additional type inference for rank()

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -59,7 +59,7 @@ def compare_registers(types, register) -> bool:
         fillvalue=(-1, None),
     ):
         if type_b == -1 and register_b is None:
-            if register[-1][0] == -1:  # args
+            if register and register[-1] and register[-1][0] == -1:  # args
                 register_b = register[-1][1]
             else:
                 return False  # pragma: no cover
@@ -1420,11 +1420,20 @@ def infer_type(arg: ct.NumberType) -> ct.ColumnType:
     return ct.FloatType()
 
 
-class DenseRank(Function):  # pragma: no cover
+class DenseRank(Function):
     """
-    TODO
     dense_rank() - Computes the dense rank of a value in a group of values.
     """
+
+
+@DenseRank.register
+def infer_type() -> ct.IntegerType:
+    return ct.IntegerType()
+
+
+@DenseRank.register
+def infer_type(_: ct.ColumnType) -> ct.IntegerType:
+    return ct.IntegerType()
 
 
 class Div(Function):
@@ -3435,6 +3444,11 @@ class Rank(Function):
 
 @Rank.register
 def infer_type() -> ct.IntegerType:
+    return ct.IntegerType()
+
+
+@Rank.register
+def infer_type(_: ct.ColumnType) -> ct.IntegerType:
     return ct.IntegerType()
 
 

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2706,16 +2706,24 @@ def test_random(session: Session):
 
 def test_rank(session: Session):
     """
-    Test `rank`
+    Test `dense_rank`, `rank`
     """
     query = parse(
-        "SELECT rank() OVER (PARTITION BY col ORDER BY col) FROM (SELECT (1), (2) AS col)",
+        "SELECT "
+        "rank() OVER (PARTITION BY col ORDER BY col),"
+        "rank(col) OVER (PARTITION BY col ORDER BY col),"
+        "dense_rank() OVER (PARTITION BY col ORDER BY col),"
+        "dense_rank(col) OVER (PARTITION BY col ORDER BY col)"
+        " FROM (SELECT (1), (2) AS col)",
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[1].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[2].type == ct.IntegerType()  # type: ignore
+    assert query.select.projection[3].type == ct.IntegerType()  # type: ignore
 
 
 def test_regexp_like(session: Session):


### PR DESCRIPTION
### Summary

This PR adds the `dense_rank()` Spark function and includes an additional input type pattern for `rank()`.

### Test Plan

Added test cases for all input types to `dense_rank()` and `rank()`

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
