### PR TITLE
Fix filter pushdown + update node propagation

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -522,6 +522,10 @@ async def resolve_downstream_references(
                 .scalar_one()
             )
             await session.refresh(node_revision, ["node"])
+            await session.refresh(
+                downstream_node_revision,
+                ["parents", "missing_parents"],
+            )
             downstream_node_revision.parents.append(node_revision.node)
             downstream_node_revision.missing_parents.remove(missing_parent)
             node_validator = await validate_node_data(

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -426,21 +426,21 @@ async def _build_tables_on_select(
                     filter_asts = (  # pylint: disable=consider-using-ternary
                         node_query.select.where and [node_query.select.where] or []
                     )
+                    foreign_keys_map = {
+                        left.alias_or_name.name: right
+                        for link in node.dimension_links
+                        for left, right in link.foreign_key_mapping().items()
+                    }
+                    foreign_keys_alias_map = {
+                        col.alias_or_name.name: col  # type: ignore
+                        for col in node_query.select.projection
+                    }
                     for filter_ in filters:
                         temp_select = parse(f"select * where {filter_}").select
                         referenced_cols = list(temp_select.find_all(ast.Column))
 
                         # We can only push down the filter if all columns referenced by the filter
                         # are available as foreign key columns on the node
-                        foreign_keys_map = {
-                            left.alias_or_name.name: right
-                            for link in node.dimension_links
-                            for left, right in link.foreign_key_mapping().items()
-                        }
-                        foreign_keys_alias_map = {
-                            col.alias_or_name.name: col  # type: ignore
-                            for col in node_query.select.projection
-                        }
                         if all(
                             col.alias_or_name.name in fk_column_mapping
                             or col.alias_or_name.name in foreign_keys_map
@@ -456,7 +456,9 @@ async def _build_tables_on_select(
                                     ].alias_or_name
                                 )
                                 col.name = ast.Name(name=ref_col_name)
-                                if col.alias_or_name.name in foreign_keys_alias_map:
+                                if (  # pragma: no cover
+                                    col.alias_or_name.name in foreign_keys_alias_map
+                                ):
                                     col.name = foreign_keys_alias_map[  # type: ignore
                                         col.alias_or_name.name
                                     ].name

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -985,6 +985,16 @@ def copy_existing_node_revision(old_revision: NodeRevision):
         status=old_revision.status,
         required_dimensions=old_revision.required_dimensions,
         metric_metadata=old_revision.metric_metadata,
+        dimension_links=[
+            DimensionLink(
+                dimension_id=link.dimension_id,
+                join_sql=link.join_sql,
+                join_type=link.join_type,
+                join_cardinality=link.join_cardinality,
+                materialization_conf=link.materialization_conf,
+            )
+            for link in old_revision.dimension_links
+        ],
     )
 
 


### PR DESCRIPTION
### Summary

Fixes two bugs:
* [Fix an issue where pushing down filters should use the column names and not aliases on the node](https://github.com/DataJunction/dj/pull/965/commits/8cd6119da076517b9b5cdb839983cc7ed5401630)
* [Propagating updates downstream should copy over dimension links during propagation update](https://github.com/DataJunction/dj/pull/965/commits/996d1c6a9ab5aa3c0a631b1f8413a150496a57dd) 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
