### PR TITLE
Fix bug where updating nodes that have deactivated children fail

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -865,7 +865,7 @@ async def propagate_update_downstream(  # pylint: disable=too-many-locals
                         ),
                     ],
                 )
-                if child_node:  # pragma: no cover
+                if child_node:
                     await update_cube_node(
                         session,
                         child_node.current,  # type: ignore
@@ -894,6 +894,8 @@ async def propagate_update_downstream(  # pylint: disable=too-many-locals
                     ),
                 ],
             )
+            if not result:
+                continue
             child = result.current  # type: ignore
             # Update the child with a new node revision if its columns or status have changed
             if node_validator.differs_from(child):

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1863,14 +1863,14 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["message"] == "A node with name `something` does not exist."
 
     @pytest.mark.asyncio
-    async def test_update_node_with_deleted_children(
+    async def test_update_node_with_deactivated_children(
         self,
         client_with_roads: AsyncClient,
     ) -> None:
         """
-        Test updating a node with deleted children
+        Test updating a node with deactivated children
         """
-        # Test updating a transform with a deleted downstream cube
+        # Test updating a transform with a deactivated downstream cube
         response = await client_with_roads.post(
             "/nodes/cube/",
             json={
@@ -1902,7 +1902,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         )
         assert response.status_code == 200
 
-        # Test updating a transform with a deleted downstream metric
+        # Test updating a transform with a deactivated downstream metric
         response = await client_with_roads.delete(
             "/nodes/default.num_repair_orders/",
         )


### PR DESCRIPTION
### Summary

This PR fixes an issue where updating nodes that have deactivated children will fail due to the deactivated node revisions continuing to live in the parent node's `children`. Because deactivated nodes aren't fully deleted, we should keep the parent - child relationships stored in the database, but we should skip over processing these nodes when propagating updates to downstreams. Not skipping over these was causing node updates to fail with 500s.

This was partially fixed in https://github.com/DataJunction/dj/pull/966/files#diff-a05c3c3e637b6978560b513567cbe3e855805a33fef38e3243116015ae769fbaR868 for updating nodes with deactivated cubes downstream, but this fix also fixes it for downstream deactivated non-cube nodes.

### Test Plan

Added a unit test that covers both the deactivated downstream cube and non-cube test cases.

- [x] PR has an associated issue: #969 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
