### PR TITLE
Druid Functions Compatibility

### DIFF
--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -13,7 +13,7 @@ from datajunction_server.models.node import (
     MetricMetadataOutput,
 )
 from datajunction_server.models.query import ColumnMetadata
-from datajunction_server.sql.parsing.backends.antlr4 import parse, ast
+from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
 from datajunction_server.transpilation import get_transpilation_plugin
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import get_settings
@@ -50,7 +50,11 @@ class Metric(BaseModel):
         """
         query_ast = parse(node.current.query)
         functions = [func.function() for func in query_ast.find_all(ast.Function)]
-        incompatible_druid_functions = [func.__name__.upper() for func in functions if Dialect.DRUID not in func.dialects]
+        incompatible_druid_functions = [
+            func.__name__.upper()
+            for func in functions
+            if Dialect.DRUID not in func.dialects
+        ]
         return cls(
             id=node.id,
             name=node.name,

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -13,7 +13,7 @@ from datajunction_server.models.node import (
     MetricMetadataOutput,
 )
 from datajunction_server.models.query import ColumnMetadata
-from datajunction_server.sql.parsing.backends.antlr4 import parse
+from datajunction_server.sql.parsing.backends.antlr4 import parse, ast
 from datajunction_server.transpilation import get_transpilation_plugin
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import get_settings
@@ -41,12 +41,16 @@ class Metric(BaseModel):
     metric_metadata: Optional[MetricMetadataOutput] = None
     required_dimensions: List[str]
 
+    incompatible_druid_functions: List[str]
+
     @classmethod
     def parse_node(cls, node: Node, dims: List[DimensionAttributeOutput]) -> "Metric":
         """
         Parses a node into a metric.
         """
         query_ast = parse(node.current.query)
+        functions = [func.function() for func in query_ast.find_all(ast.Function)]
+        incompatible_druid_functions = [func.__name__.upper() for func in functions if Dialect.DRUID not in func.dialects]
         return cls(
             id=node.id,
             name=node.name,
@@ -61,6 +65,7 @@ class Metric(BaseModel):
             dimensions=dims,
             metric_metadata=node.current.metric_metadata,
             required_dimensions=[dim.name for dim in node.current.required_dimensions],
+            incompatible_druid_functions=incompatible_druid_functions,
         )
 
 

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -398,7 +398,6 @@ def infer_type(
     return col.type  # type: ignore
 
 
-
 class ApproxQuantileDs(Function):
     """
     approx_quantile_ds(col, percentage [, accuracy]) -
@@ -421,6 +420,7 @@ class Array(Function):
     """
     Returns an array of constants
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -446,6 +446,7 @@ class ArrayAgg(Function):
     """
     Collects and returns a list of non-unique elements.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -466,6 +467,7 @@ class ArrayAppend(Function):
     """
     Add the element at the end of the array passed as first argument
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -495,6 +497,7 @@ class ArrayConcat(Function):
     array_concat(arr1, arr2)
     Concatenates arr2 to arr1. The resulting array type is determined by the type of arr1.
     """
+
     dialects = [Dialect.DRUID]
 
 
@@ -510,6 +513,7 @@ class ArrayContains(Function):
     """
     array_contains(array, value) - Returns true if the array contains the value.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -553,6 +557,7 @@ class ArrayLength(Function):
     """
     array_length(expr) - Returns the size of an array. The function returns null for null input.
     """
+
     dialects = [Dialect.DRUID]
 
 
@@ -637,6 +642,7 @@ class ArrayOffset(Function):
     ARRAY_OFFSET(arr, long)
     Returns the array element at the 0-based index supplied
     """
+
     dialects = [Dialect.DRUID]
 
 
@@ -653,6 +659,7 @@ class ArrayOrdinal(Function):
     ARRAY_ORDINAL(arr, long)
     Returns the array element at the 1-based index supplied
     """
+
     dialects = [Dialect.DRUID]
 
 
@@ -846,6 +853,7 @@ class Ceil(Function):
     """
     Computes the smallest integer greater than or equal to the input value.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -926,6 +934,7 @@ class CharLength(Function):
     """
     char_length(expr) - Returns the length of the value expr.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -938,6 +947,7 @@ class CharacterLength(Function):
     """
     character_length(expr) - Returns the length of the value expr.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1020,6 +1030,7 @@ class Concat(Function):
     """
     concat(col1, col2, ..., colN) - Returns the concatenation of col1, col2, ..., colN.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1077,6 +1088,7 @@ class ContainsString(Function):
     """
     contains_string(left, right) - Returns a boolean
     """
+
     dialects = [Dialect.DRUID]
 
 
@@ -1151,6 +1163,7 @@ class Cos(Function):
     """
     cos(expr) - Compute the cosine of expr.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1174,6 +1187,7 @@ class Cot(Function):
     """
     cot(expr) - Compute the cotangent of expr.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1320,6 +1334,7 @@ class CurrentDate(Function):
     """
     Returns the current date.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1354,6 +1369,7 @@ class CurrentTimestamp(Function):
     """
     Returns the current timestamp.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1605,6 +1621,7 @@ class Degrees(Function):
     """
     degrees(expr) - Converts radians to degrees.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1634,6 +1651,7 @@ class Div(Function):
     expr1 div expr2 - Divide expr1 by expr2. It returns NULL if an operand is NULL or
     expr2 is 0. The result is casted to long.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1788,6 +1806,7 @@ class Exp(Function):
     """
     Returns e to the power of expr.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -1845,6 +1864,7 @@ class Extract(Function):
     """
     Returns a specified component of a timestamp, such as year, month or day.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
     @staticmethod
@@ -1998,6 +2018,7 @@ class Floor(Function):
     """
     Returns the largest integer less than or equal to a specified number.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2227,6 +2248,7 @@ class Greatest(Function):
     """
     greatest(expr, ...) - Returns the greatest value of all parameters, skipping null values.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2241,6 +2263,7 @@ class Grouping(Function):
     """
     grouping(col) - Returns 1 if the specified column is aggregated, and 0 otherwise.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2641,6 +2664,7 @@ class Least(Function):
     """
     least(expr1, expr2, ...) - Returns the smallest value of the list of values.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2655,6 +2679,7 @@ class Left(Function):
     """
     left(str, len) - Returns the leftmost `len` characters from the string.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2681,6 +2706,7 @@ class Length(Function):
     """
     Returns the length of a string.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2720,6 +2746,7 @@ class Ln(Function):
     """
     Returns the natural logarithm of a number.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2774,6 +2801,7 @@ class Log10(Function):
     """
     Returns the base-10 logarithm of a number.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2812,6 +2840,7 @@ class Lower(Function):
     """
     Converts a string to lowercase.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
     @staticmethod
@@ -2824,6 +2853,7 @@ class Lpad(Function):
     lpad(str, len[, pad]) - Left-pads the string with pad to a length of len.
     If str is longer than len, the return value is shortened to len characters.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -2840,6 +2870,7 @@ class Ltrim(Function):
     """
     ltrim(str[, trimStr]) - Trims the spaces from left end of the string.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3274,6 +3305,7 @@ class Mod(Function):
     """
     mod(expr1, expr2) - Returns the remainder after expr1/expr2.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3437,6 +3469,7 @@ class Nullif(Function):
     """
     nullif(expr1, expr2) - Returns null if expr1 equals expr2, or expr1 otherwise.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3450,6 +3483,7 @@ class Nvl(Function):
     nvl(expr1, expr2) - Returns the first argument if it is not null, or the
     second argument if the first argument is null.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3574,6 +3608,7 @@ class Power(Function):
     """
     Raises a base expression to the power of an exponent expression.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3673,6 +3708,7 @@ class RegexpLike(Function):
     """
     regexp_like(str, regexp) - Returns true if str matches regexp, or false otherwise
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3688,6 +3724,7 @@ class Replace(Function):
     """
     replace(str, search[, replace]) - Replaces all occurrences of `search` with `replace`.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3716,6 +3753,7 @@ class Round(Function):
     """
     Rounds a numeric column or expression to the specified number of decimal places.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3830,6 +3868,7 @@ class Sqrt(Function):
     """
     Computes the square root of a numeric column or expression.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3890,6 +3929,7 @@ class Strpos(Function):
         negative number the search will start from the end of string. Positions start with 1.
         If not found, 0 is returned.
     """
+
     dialects = [Dialect.TRINO, Dialect.DRUID]
 
 
@@ -3933,6 +3973,7 @@ class Substring(Function):
     """
     Extracts a substring from a string column or expression.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3957,6 +3998,7 @@ class Substr(Function):
     """
     Extracts a substring from a string column or expression.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -4085,6 +4127,7 @@ class Trim(Function):
     """
     Removes leading and trailing whitespace from a string value.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -4110,6 +4153,7 @@ class Upper(Function):
     """
     Converts a string value to uppercase.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -4220,6 +4264,7 @@ class Unnest(TableFunction):
     nested array, or map column into multiple rows.
     It will generate a new row for each element in the specified column.
     """
+
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -42,6 +42,7 @@ from datajunction_server.errors import (
     DJNotImplementedException,
     ErrorCode,
 )
+from datajunction_server.models.engine import Dialect
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.utils import get_settings
 
@@ -166,6 +167,7 @@ class Function(Dispatch):  # pylint: disable=too-few-public-methods
 
     is_aggregation: ClassVar[bool] = False
     is_runtime: ClassVar[bool] = False
+    dialects: List[Dialect] = [Dialect.SPARK]
 
     @staticmethod
     def infer_type(*args) -> ct.ColumnType:
@@ -233,6 +235,7 @@ class Abs(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Abs.register
@@ -241,6 +244,21 @@ def infer_type(
 ) -> ct.NumberType:
     type_ = arg.type
     return type_
+
+
+class Acos(Function):
+    """
+    Returns the inverse cosine (a.k.a. arc cosine) of expr
+    """
+
+    dialects = [Dialect.SPARK, Dialect.DRUID]
+
+
+@Acos.register
+def infer_type(
+    arg: ct.NumberType,
+) -> ct.FloatType:
+    return ct.FloatType()
 
 
 class Aggregate(Function):
@@ -286,6 +304,72 @@ def infer_type(
     return merge.expr.type
 
 
+class AnyValue(Function):
+    """
+    Returns any value of the specified expression
+    """
+
+    is_aggregation = True
+    dialects = [Dialect.DRUID]
+
+
+@AnyValue.register
+def infer_type(
+    expr: ct.ColumnType,
+) -> ct.ColumnType:
+    return expr.type  # type: ignore
+
+
+class ApproxCountDistinct(Function):
+    """
+    approx_percentile(col, percentage [, accuracy]) -
+    Returns the approximate percentile of the numeric or ansi interval
+    column col which is the smallest value in the ordered col values
+    """
+
+    is_aggregation = True
+    dialects = [Dialect.DRUID]
+
+
+@ApproxCountDistinct.register
+def infer_type(
+    expr: ct.ColumnType,
+) -> ct.LongType:
+    return ct.LongType()
+
+
+class ApproxCountDistinctDsHll(Function):
+    """
+    Counts distinct values of an HLL sketch column or a regular column
+    """
+
+    is_aggregation = True
+    dialects = [Dialect.DRUID]
+
+
+@ApproxCountDistinctDsHll.register
+def infer_type(
+    expr: ct.ColumnType,
+) -> ct.LongType:
+    return ct.LongType()
+
+
+class ApproxCountDistinctDsTheta(Function):
+    """
+    Counts distinct values of a Theta sketch column or a regular column.
+    """
+
+    is_aggregation = True
+    dialects = [Dialect.DRUID]
+
+
+@ApproxCountDistinctDsTheta.register
+def infer_type(
+    expr: ct.ColumnType,
+) -> ct.LongType:
+    return ct.LongType()
+
+
 class ApproxPercentile(Function):
     """
     approx_percentile(col, percentage [, accuracy]) -
@@ -314,10 +398,30 @@ def infer_type(
     return col.type  # type: ignore
 
 
+
+class ApproxQuantileDs(Function):
+    """
+    approx_quantile_ds(col, percentage [, accuracy]) -
+    Computes approximate quantiles on a Quantiles sketch column or a regular numeric column.
+    """
+
+    is_aggregation = True
+
+
+@ApproxQuantileDs.register
+def infer_type(
+    col: ct.NumberType,
+    percentage: ct.ListType,
+    accuracy: Optional[ct.NumberType],
+) -> ct.DoubleType:
+    return ct.ListType(element_type=col.type)  # type: ignore
+
+
 class Array(Function):
     """
     Returns an array of constants
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Array.register  # type: ignore
@@ -342,6 +446,7 @@ class ArrayAgg(Function):
     """
     Collects and returns a list of non-unique elements.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @ArrayAgg.register  # type: ignore
@@ -361,6 +466,7 @@ class ArrayAppend(Function):
     """
     Add the element at the end of the array passed as first argument
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @ArrayAppend.register  # type: ignore
@@ -384,10 +490,27 @@ def infer_type(
     return array.type
 
 
+class ArrayConcat(Function):
+    """
+    array_concat(arr1, arr2)
+    Concatenates arr2 to arr1. The resulting array type is determined by the type of arr1.
+    """
+    dialects = [Dialect.DRUID]
+
+
+@ArrayConcat.register
+def infer_type(
+    arr1: ct.ListType,
+    arr2: ct.ListType,
+) -> ct.ListType:
+    return arr1.type
+
+
 class ArrayContains(Function):
     """
     array_contains(array, value) - Returns true if the array contains the value.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @ArrayContains.register
@@ -424,6 +547,20 @@ def infer_type(
     array2: ct.ListType,
 ) -> ct.ListType:
     return array1.type
+
+
+class ArrayLength(Function):
+    """
+    array_length(expr) - Returns the size of an array. The function returns null for null input.
+    """
+    dialects = [Dialect.DRUID]
+
+
+@ArrayLength.register
+def infer_type(
+    array: ct.ListType,
+) -> ct.LongType:
+    return ct.LongType()
 
 
 class ArrayIntersect(Function):
@@ -493,6 +630,38 @@ def infer_type(
     array: ct.ListType,
 ) -> ct.NumberType:
     return array.type.element.type
+
+
+class ArrayOffset(Function):
+    """
+    ARRAY_OFFSET(arr, long)
+    Returns the array element at the 0-based index supplied
+    """
+    dialects = [Dialect.DRUID]
+
+
+@ArrayOffset.register
+def infer_type(
+    array: ct.ListType,
+    index: ct.LongType,
+) -> ct.LongType:
+    return array.type.element.type  # type: ignore
+
+
+class ArrayOrdinal(Function):
+    """
+    ARRAY_ORDINAL(arr, long)
+    Returns the array element at the 1-based index supplied
+    """
+    dialects = [Dialect.DRUID]
+
+
+@ArrayOrdinal.register
+def infer_type(
+    array: ct.ListType,
+    index: ct.LongType,
+) -> ct.LongType:
+    return array.type.element.type  # type: ignore
 
 
 class ArrayPosition(Function):
@@ -608,6 +777,7 @@ class Avg(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Avg.register
@@ -676,6 +846,7 @@ class Ceil(Function):
     """
     Computes the smallest integer greater than or equal to the input value.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 class Ceiling(Function):
@@ -755,6 +926,7 @@ class CharLength(Function):
     """
     char_length(expr) - Returns the length of the value expr.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @CharLength.register  # type: ignore
@@ -766,6 +938,7 @@ class CharacterLength(Function):
     """
     character_length(expr) - Returns the length of the value expr.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @CharacterLength.register  # type: ignore
@@ -790,6 +963,7 @@ class Coalesce(Function):
     """
 
     is_aggregation = False
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Coalesce.register  # type: ignore
@@ -846,6 +1020,7 @@ class Concat(Function):
     """
     concat(col1, col2, ..., colN) - Returns the concatenation of col1, col2, ..., colN.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Concat.register  # type: ignore
@@ -894,6 +1069,18 @@ class Contains(Function):
 
 
 @Contains.register  # type: ignore
+def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
+    return ct.BooleanType()
+
+
+class ContainsString(Function):
+    """
+    contains_string(left, right) - Returns a boolean
+    """
+    dialects = [Dialect.DRUID]
+
+
+@ContainsString.register  # type: ignore
 def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
     return ct.BooleanType()
 
@@ -964,6 +1151,7 @@ class Cos(Function):
     """
     cos(expr) - Compute the cosine of expr.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Cos.register  # type: ignore
@@ -986,6 +1174,7 @@ class Cot(Function):
     """
     cot(expr) - Compute the cotangent of expr.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Cot.register  # type: ignore
@@ -999,6 +1188,7 @@ class Count(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Count.register  # type: ignore
@@ -1130,6 +1320,7 @@ class CurrentDate(Function):
     """
     Returns the current date.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @CurrentDate.register  # type: ignore
@@ -1163,6 +1354,7 @@ class CurrentTimestamp(Function):
     """
     Returns the current timestamp.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @CurrentTimestamp.register  # type: ignore
@@ -1413,6 +1605,7 @@ class Degrees(Function):
     """
     degrees(expr) - Converts radians to degrees.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Degrees.register  # type: ignore
@@ -1438,10 +1631,15 @@ def infer_type(_: ct.ColumnType) -> ct.IntegerType:
 
 class Div(Function):
     """
-    TODO
     expr1 div expr2 - Divide expr1 by expr2. It returns NULL if an operand is NULL or
     expr2 is 0. The result is casted to long.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
+
+
+@Div.register
+def infer_type(_: ct.NumberType) -> ct.LongType:
+    return ct.LongType()
 
 
 class Double(Function):
@@ -1590,6 +1788,7 @@ class Exp(Function):
     """
     Returns e to the power of expr.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Exp.register  # type: ignore
@@ -1646,6 +1845,7 @@ class Extract(Function):
     """
     Returns a specified component of a timestamp, such as year, month or day.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
     @staticmethod
     def infer_type(  # type: ignore
@@ -1798,6 +1998,7 @@ class Floor(Function):
     """
     Returns the largest integer less than or equal to a specified number.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Floor.register  # type: ignore
@@ -2026,6 +2227,7 @@ class Greatest(Function):
     """
     greatest(expr, ...) - Returns the greatest value of all parameters, skipping null values.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Greatest.register  # type: ignore
@@ -2039,6 +2241,7 @@ class Grouping(Function):
     """
     grouping(col) - Returns 1 if the specified column is aggregated, and 0 otherwise.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Grouping.register  # type: ignore
@@ -2438,6 +2641,7 @@ class Least(Function):
     """
     least(expr1, expr2, ...) - Returns the smallest value of the list of values.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Least.register  # type: ignore
@@ -2451,6 +2655,7 @@ class Left(Function):
     """
     left(str, len) - Returns the leftmost `len` characters from the string.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Left.register  # type: ignore
@@ -2476,6 +2681,7 @@ class Length(Function):
     """
     Returns the length of a string.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Length.register  # type: ignore
@@ -2514,6 +2720,7 @@ class Ln(Function):
     """
     Returns the natural logarithm of a number.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Ln.register  # type: ignore
@@ -2567,6 +2774,7 @@ class Log10(Function):
     """
     Returns the base-10 logarithm of a number.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Log10.register  # type: ignore
@@ -2604,6 +2812,7 @@ class Lower(Function):
     """
     Converts a string to lowercase.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
     @staticmethod
     def infer_type(arg: "Expression") -> ct.StringType:  # type: ignore
@@ -2615,6 +2824,7 @@ class Lpad(Function):
     lpad(str, len[, pad]) - Left-pads the string with pad to a length of len.
     If str is longer than len, the return value is shortened to len characters.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Lpad.register  # type: ignore
@@ -2630,6 +2840,7 @@ class Ltrim(Function):
     """
     ltrim(str[, trimStr]) - Trims the spaces from left end of the string.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Ltrim.register  # type: ignore
@@ -2937,6 +3148,7 @@ class Max(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Max.register  # type: ignore
@@ -3012,6 +3224,7 @@ class Min(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Min.register  # type: ignore
@@ -3061,6 +3274,7 @@ class Mod(Function):
     """
     mod(expr1, expr2) - Returns the remainder after expr1/expr2.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Mod.register  # type: ignore
@@ -3223,6 +3437,7 @@ class Nullif(Function):
     """
     nullif(expr1, expr2) - Returns null if expr1 equals expr2, or expr1 otherwise.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Nullif.register  # type: ignore
@@ -3235,6 +3450,7 @@ class Nvl(Function):
     nvl(expr1, expr2) - Returns the first argument if it is not null, or the
     second argument if the first argument is null.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Nvl.register  # type: ignore
@@ -3358,6 +3574,7 @@ class Power(Function):
     """
     Raises a base expression to the power of an exponent expression.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Power.register  # type: ignore
@@ -3456,6 +3673,7 @@ class RegexpLike(Function):
     """
     regexp_like(str, regexp) - Returns true if str matches regexp, or false otherwise
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @RegexpLike.register
@@ -3470,6 +3688,7 @@ class Replace(Function):
     """
     replace(str, search[, replace]) - Replaces all occurrences of `search` with `replace`.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Replace.register
@@ -3497,6 +3716,7 @@ class Round(Function):
     """
     Rounds a numeric column or expression to the specified number of decimal places.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Round.register  # type: ignore
@@ -3610,6 +3830,7 @@ class Sqrt(Function):
     """
     Computes the square root of a numeric column or expression.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Sqrt.register
@@ -3623,6 +3844,7 @@ class Stddev(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Stddev.register
@@ -3636,6 +3858,7 @@ class StddevPop(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @StddevPop.register
@@ -3649,6 +3872,7 @@ class StddevSamp(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @StddevSamp.register
@@ -3665,8 +3889,8 @@ class Strpos(Function):
         Returns the position of the N-th instance of substring in string. When instance is a
         negative number the search will start from the end of string. Positions start with 1.
         If not found, 0 is returned.
-    Note: Trino-only
     """
+    dialects = [Dialect.TRINO, Dialect.DRUID]
 
 
 @Strpos.register
@@ -3709,6 +3933,7 @@ class Substring(Function):
     """
     Extracts a substring from a string column or expression.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Substring.register
@@ -3732,6 +3957,7 @@ class Substr(Function):
     """
     Extracts a substring from a string column or expression.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Substr.register
@@ -3757,6 +3983,7 @@ class Sum(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Sum.register  # type: ignore
@@ -3858,6 +4085,7 @@ class Trim(Function):
     """
     Removes leading and trailing whitespace from a string value.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Trim.register
@@ -3882,6 +4110,7 @@ class Upper(Function):
     """
     Converts a string value to uppercase.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Upper.register
@@ -3895,6 +4124,7 @@ class Variance(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Variance.register
@@ -3908,9 +4138,24 @@ class VarPop(Function):
     """
 
     is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @VarPop.register
+def infer_type(arg: ct.NumberType) -> ct.DoubleType:
+    return ct.DoubleType()
+
+
+class VarSamp(Function):
+    """
+    Computes the sample variance of the input column or expression.
+    """
+
+    is_aggregation = True
+    dialects = [Dialect.SPARK, Dialect.DRUID]
+
+
+@VarSamp.register
 def infer_type(arg: ct.NumberType) -> ct.DoubleType:
     return ct.DoubleType()
 
@@ -3975,6 +4220,7 @@ class Unnest(TableFunction):
     nested array, or map column into multiple rows.
     It will generate a new row for each element in the specified column.
     """
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @Unnest.register

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -310,7 +310,7 @@ class AnyValue(Function):
     """
 
     is_aggregation = True
-    dialects = [Dialect.DRUID]
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @AnyValue.register
@@ -322,9 +322,7 @@ def infer_type(
 
 class ApproxCountDistinct(Function):
     """
-    approx_percentile(col, percentage [, accuracy]) -
-    Returns the approximate percentile of the numeric or ansi interval
-    column col which is the smallest value in the ordered col values
+    approx_count_distinct(expr)
     """
 
     is_aggregation = True
@@ -396,24 +394,6 @@ def infer_type(
     accuracy: Optional[ct.NumberType],
 ) -> ct.NumberType:
     return col.type  # type: ignore
-
-
-class ApproxQuantileDs(Function):
-    """
-    approx_quantile_ds(col, percentage [, accuracy]) -
-    Computes approximate quantiles on a Quantiles sketch column or a regular numeric column.
-    """
-
-    is_aggregation = True
-
-
-@ApproxQuantileDs.register
-def infer_type(
-    col: ct.NumberType,
-    percentage: ct.ListType,
-    accuracy: Optional[ct.NumberType],
-) -> ct.DoubleType:
-    return ct.ListType(element_type=col.type)  # type: ignore
 
 
 class Array(Function):
@@ -649,8 +629,8 @@ class ArrayOffset(Function):
 @ArrayOffset.register
 def infer_type(
     array: ct.ListType,
-    index: ct.LongType,
-) -> ct.LongType:
+    index: Union[ct.LongType, ct.IntegerType],
+) -> ct.NumberType:
     return array.type.element.type  # type: ignore
 
 
@@ -666,8 +646,8 @@ class ArrayOrdinal(Function):
 @ArrayOrdinal.register
 def infer_type(
     array: ct.ListType,
-    index: ct.LongType,
-) -> ct.LongType:
+    index: Union[ct.LongType, ct.IntegerType],
+) -> ct.NumberType:
     return array.type.element.type  # type: ignore
 
 
@@ -1177,6 +1157,8 @@ class Cosh(Function):
     cosh(expr) - Compute the hyperbolic cosine of expr.
     """
 
+    dialects = [Dialect.SPARK, Dialect.DRUID]
+
 
 @Cosh.register  # type: ignore
 def infer_type(arg: ct.NumberType) -> ct.ColumnType:
@@ -1656,7 +1638,7 @@ class Div(Function):
 
 
 @Div.register
-def infer_type(_: ct.NumberType) -> ct.LongType:
+def infer_type(expr1: ct.NumberType, expr2: ct.NumberType) -> ct.LongType:
     return ct.LongType()
 
 

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -256,6 +256,11 @@ def _(ctx: list, nones=False):
 
 
 @visit.register
+def _(ctx: sbp.Any_valueContext):
+    return ast.Function(ast.Name("ANY_VALUE"), args=[visit(ctx.expression())])
+
+
+@visit.register
 def _(ctx: sbp.SingleStatementContext):
     return visit(ctx.statement())
 

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -41,6 +41,10 @@ async def test_read_metrics(client_with_roads: AsyncClient) -> None:
     assert data["upstream_node"] == "default.repair_orders_fact"
     assert data["expression"] == "count(repair_order_id)"
 
+    response = await client_with_roads.get("/metrics/default.discounted_orders_rate")
+    data = response.json()
+    assert data["incompatible_druid_functions"] == ["IF"]
+
 
 @pytest.mark.asyncio
 async def test_read_metric(session: AsyncSession, client: AsyncClient) -> None:

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.errors import DJException
+from datajunction_server.models.engine import Dialect
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import parse
@@ -583,6 +584,16 @@ async def test_infer_types_exp(construction_session: AsyncSession):
         DoubleType(),
     ]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
+    assert query.select.projection[4].function().dialects == [  # type: ignore
+        Dialect.SPARK,
+        Dialect.DRUID,
+    ]
+    assert query.select.projection[5].function().dialects == [Dialect.SPARK]  # type: ignore
+    assert query.select.projection[6].function().dialects == [Dialect.SPARK]  # type: ignore
+    assert query.select.projection[7].function().dialects == [  # type: ignore
+        Dialect.SPARK,
+        Dialect.DRUID,
+    ]
 
 
 @pytest.mark.asyncio

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -7,6 +7,9 @@ import ListGroupItem from '../../components/ListGroupItem';
 import ToggleSwitch from '../../components/ToggleSwitch';
 import DJClientContext from '../../providers/djclient';
 import { labelize } from '../../../utils/form';
+import { AlertMessage } from '../AddEditNodePage/AlertMessage';
+import AlertIcon from '../../icons/AlertIcon';
+import InvalidIcon from '../../icons/InvalidIcon';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 foundation.hljs['padding'] = '2rem';
@@ -39,6 +42,35 @@ export default function NodeInfoTab({ node }) {
   function toggle(value) {
     return !value;
   }
+  const metricsWarning =
+    node?.type === 'metric' ? (
+      <div className="message warning" style={{ marginTop: '0.7rem' }}>
+        ⚠{' '}
+        <small>
+          The following functions used in the metric definition may not be
+          compatible with Druid SQL:{' '}
+          {node?.incompatible_druid_functions.map(func => (
+            <li style={{ listStyleType: 'none', margin: '0.7rem 0.7rem' }}>
+              ⇢{' '}
+              <span style={{ background: '#fff', padding: '0.3rem' }}>
+                {func}
+              </span>
+            </li>
+          ))}
+          If you need your metrics to be compatible with Druid, please use{' '}
+          <a
+            href={
+              'https://druid.apache.org/docs/latest/querying/sql-functions/'
+            }
+          >
+            these supported functions
+          </a>
+          .
+        </small>
+      </div>
+    ) : (
+      ''
+    );
   const metricQueryDiv = (
     <div className="list-group-item d-flex">
       <div className="gap-2 w-100 justify-content-between py-3">
@@ -205,6 +237,7 @@ export default function NodeInfoTab({ node }) {
       className="list-group align-items-center justify-content-between flex-md-row gap-2"
       style={{ minWidth: '700px' }}
     >
+      {node?.type === 'metric' ? metricsWarning : ''}
       <ListGroupItem label="Description" value={node?.description} />
       <div className="list-group-item d-flex">
         <div className="d-flex gap-2 w-100 justify-content-between py-3">

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -43,7 +43,7 @@ export default function NodeInfoTab({ node }) {
     return !value;
   }
   const metricsWarning =
-    node?.type === 'metric' ? (
+    node?.type === 'metric' && node?.incompatible_druid_functions.length > 0 ? (
       <div className="message warning" style={{ marginTop: '0.7rem' }}>
         ⚠{' '}
         <small>

--- a/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
@@ -149,7 +149,7 @@ export default function RevisionDiff() {
           </div>
           {Object.keys(diffObjects).map(field => {
             return (
-              <div className="diff">
+              <div className="diff" aria-label={'DiffView'} role={'gridcell'}>
                 <h4>
                   {labelize(field)}{' '}
                   <small className="no-change-banner">

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
@@ -88,6 +88,7 @@ describe('<NodePage />', () => {
       created_at: '2023-08-21T16:48:56.932162+00:00',
       tags: [{ name: 'purpose', display_name: 'Purpose' }],
       primary_key: [],
+      incompatible_druid_functions: ['IF'],
       createNodeClientCode:
         'dj = DJBuilder(DJ_URL)\n\navg_repair_price = dj.create_metric(\n    description="Average repair price",\n    display_name="Default: Avg Repair Price",\n    name="default.avg_repair_price",\n    primary_key=[],\n    query="""SELECT  avg(price) default_DOT_avg_repair_price \n FROM default.repair_order_details\n\n"""\n)',
       dimensions: [

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/RevisionDiff.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/RevisionDiff.test.jsx
@@ -14,71 +14,11 @@ describe('<RevisionDiff />', () => {
 
   const mockNodesWithDimension = [
     {
-      node_revision_id: 2,
-      node_id: 2,
-      type: 'source',
-      name: 'default.repair_order_details',
-      display_name: 'Default: Repair Order Details',
-      version: 'v1.0',
-      status: 'valid',
-      mode: 'published',
-      catalog: {
-        id: 1,
-        uuid: '0fc18295-e1a2-4c3c-b72a-894725c12488',
-        created_at: '2023-08-21T16:48:51.146121+00:00',
-        updated_at: '2023-08-21T16:48:51.146122+00:00',
-        extra_params: {},
-        name: 'warehouse',
-      },
-      schema_: 'roads',
-      table: 'repair_order_details',
-      description: 'Details on repair orders',
-      query: null,
-      availability: null,
-      columns: [
-        {
-          name: 'repair_order_id',
-          type: 'int',
-          attributes: [],
-          dimension: {
-            name: 'default.repair_order',
-          },
-        },
-        {
-          name: 'repair_type_id',
-          type: 'int',
-          attributes: [],
-          dimension: null,
-        },
-        {
-          name: 'price',
-          type: 'float',
-          attributes: [],
-          dimension: null,
-        },
-        {
-          name: 'quantity',
-          type: 'int',
-          attributes: [],
-          dimension: null,
-        },
-        {
-          name: 'discount',
-          type: 'float',
-          attributes: [],
-          dimension: null,
-        },
-      ],
-      updated_at: '2023-08-21T16:48:52.981201+00:00',
-      materializations: [],
-      parents: [],
-    },
-    {
       node_revision_id: 1,
       node_id: 1,
-      type: 'source',
-      name: 'default.repair_orders',
-      display_name: 'Default: Repair Orders',
+      type: 'dimension',
+      name: 'default.repair_order',
+      display_name: 'Repair Orders',
       version: 'v1.0',
       status: 'valid',
       mode: 'published',
@@ -90,10 +30,10 @@ describe('<RevisionDiff />', () => {
         extra_params: {},
         name: 'warehouse',
       },
-      schema_: 'roads',
-      table: 'repair_orders',
-      description: 'Repair orders',
-      query: null,
+      description: 'Repair order dimension',
+      query:
+        'SELECT repair_order_id, municipality_id, hard_hat_id, order_date, ' +
+        'dispatcher_id FROM default.repair_orders',
       availability: null,
       columns: [
         {
@@ -106,7 +46,7 @@ describe('<RevisionDiff />', () => {
         },
         {
           name: 'municipality_id',
-          type: 'string',
+          type: 'int',
           attributes: [],
           dimension: null,
         },
@@ -123,14 +63,56 @@ describe('<RevisionDiff />', () => {
           dimension: null,
         },
         {
-          name: 'required_date',
-          type: 'date',
+          name: 'dispatcher_id',
+          type: 'int',
+          attributes: [],
+          dimension: null,
+        },
+      ],
+      updated_at: '2023-08-21T16:48:52.981201+00:00',
+      materializations: [],
+      parents: [],
+    },
+    {
+      node_revision_id: 2,
+      node_id: 2,
+      type: 'dimension',
+      name: 'default.repair_order',
+      display_name: 'Repair Orders',
+      version: 'v2.0',
+      status: 'valid',
+      mode: 'published',
+      catalog: {
+        id: 1,
+        uuid: '0fc18295-e1a2-4c3c-b72a-894725c12488',
+        created_at: '2023-08-21T16:48:51.146121+00:00',
+        updated_at: '2023-08-21T16:48:51.146122+00:00',
+        extra_params: {},
+        name: 'warehouse',
+      },
+      description: 'Repair order dimension',
+      query:
+        'SELECT repair_order_id, municipality_id, hard_hat_id, ' +
+        'dispatcher_id FROM default.repair_orders',
+      availability: null,
+      columns: [
+        {
+          name: 'repair_order_id',
+          type: 'int',
+          attributes: [],
+          dimension: {
+            name: 'default.repair_order',
+          },
+        },
+        {
+          name: 'municipality_id',
+          type: 'int',
           attributes: [],
           dimension: null,
         },
         {
-          name: 'dispatched_date',
-          type: 'date',
+          name: 'hard_hat_id',
+          type: 'int',
           attributes: [],
           dimension: null,
         },
@@ -141,7 +123,7 @@ describe('<RevisionDiff />', () => {
           dimension: null,
         },
       ],
-      updated_at: '2023-08-21T16:48:52.880498+00:00',
+      updated_at: '2023-08-21T16:48:52.981201+00:00',
       materializations: [],
       parents: [],
     },
@@ -163,7 +145,7 @@ describe('<RevisionDiff />', () => {
     );
     const { container } = render(
       <MemoryRouter
-        initialEntries={['/nodes/default.repair_orders_cube/revisions/v1.0']}
+        initialEntries={['/nodes/default.repair_orders_cube/revisions/v2.0']}
       >
         <Routes>
           <Route path="nodes/:name/revisions/:revision" element={element} />
@@ -174,6 +156,9 @@ describe('<RevisionDiff />', () => {
       expect(mockDjClient.DataJunctionAPI.revisions).toHaveBeenCalledWith(
         'default.repair_orders_cube',
       );
+
+      const diffViews = screen.getAllByRole('gridcell', 'DiffView');
+      diffViews.map(diffView => expect(diffView).toBeInTheDocument());
     });
   });
 });

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -58,6 +58,7 @@ export function NodePage() {
         data.required_dimensions = metric.required_dimensions;
         data.upstream_node = metric.upstream_node;
         data.expression = metric.expression;
+        data.incompatible_druid_functions = metric.incompatible_druid_functions;
       }
       if (data.type === 'cube') {
         const cube = await djClient.cube(name);

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -34,6 +34,22 @@ describe('DataJunctionAPI', () => {
     });
   });
 
+  it('calls catalogs correctly', async () => {
+    fetch.mockResponseOnce(JSON.stringify({}));
+    await DataJunctionAPI.catalogs();
+    expect(fetch).toHaveBeenCalledWith(`${DJ_URL}/catalogs`, {
+      credentials: 'include',
+    });
+  });
+
+  it('calls engines correctly', async () => {
+    fetch.mockResponseOnce(JSON.stringify({}));
+    await DataJunctionAPI.engines();
+    expect(fetch).toHaveBeenCalledWith(`${DJ_URL}/engines`, {
+      credentials: 'include',
+    });
+  });
+
   it('calls node correctly', async () => {
     fetch.mockResponseOnce(JSON.stringify(mocks.mockMetricNode));
     const nodeData = await DataJunctionAPI.node(mocks.mockMetricNode.name);

--- a/datajunction-ui/src/mocks/mockNodes.jsx
+++ b/datajunction-ui/src/mocks/mockNodes.jsx
@@ -103,6 +103,7 @@ export const mocks = {
     created_at: '2023-08-21T16:48:56.841631+00:00',
     tags: [{ name: 'purpose', display_name: 'Purpose' }],
     dimension_links: [],
+    incompatible_druid_functions: ['IF'],
     dimensions: [
       {
         value: 'default.date_dim.dateint',

--- a/datajunction-ui/src/styles/node-creation.scss
+++ b/datajunction-ui/src/styles/node-creation.scss
@@ -254,6 +254,15 @@ form {
   }
 }
 
+.warning {
+  background-color: rgb(253, 248, 242);
+  color: rgb(190, 105, 37);
+  svg {
+    filter: invert(16%) sepia(68%) saturate(2827%) hue-rotate(344deg)
+      brightness(96%) contrast(100%);
+  }
+}
+
 .SourceCreationInput {
   margin: 0.5rem 0;
   display: inline-grid;


### PR DESCRIPTION
### Summary

This PR adds a `dialects` field to the base `Function` class, allowing us to specify what SQL dialects a particular function is compatible with. By default, the base class sets `dialects=[Dialect.SPARK]`, because all of our existing functions are from Spark SQL. Then we annotate all the existing functions that are compatible with Druid SQL, adding a few additional Druid SQL functions as well.

For metric nodes queried using the `GET /metrics/{metric_name}` endpoint, we additionally include `incompatible_druid_functions`, a list of Druid-incompatible functions in the metric expression. Note that this is not 100% accurate at the moment, because we haven't implemented support for all Druid SQL functions in our function registry. I'll leave that for a follow-up PR.

With this addition to the API, we can now display this information in the UI with a warning label:

<img width="786" alt="Screenshot 2024-04-29 at 6 55 17 PM" src="https://github.com/DataJunction/dj/assets/9524628/40a03e9c-8d14-4932-8f7d-a8da76408616">

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #975 
- [x] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
