### PR TITLE
Disable status check for measures SQL generation 

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -383,16 +383,17 @@ async def validate_cube(  # pylint: disable=too-many-locals
             f"The following metric nodes were not found: {', '.join(not_found)}",
         )
 
-    # Verify that all metrics are in valid status
-    invalid_metrics = [
-        metric.name
-        for metric in metric_nodes
-        if metric.current.status == NodeStatus.INVALID
-    ]
-    if invalid_metrics:
-        raise DJInvalidInputException(
-            f"The following metric nodes are invalid: {', '.join(invalid_metrics)}",
-        )
+    # TODO: Removing for now until we fix the issue with status updates  # pylint: disable=fixme
+    # # Verify that all metrics are in valid status
+    # invalid_metrics = [
+    #     metric.name
+    #     for metric in metric_nodes
+    #     if metric.current.status == NodeStatus.INVALID
+    # ]
+    # if invalid_metrics:
+    #     raise DJInvalidInputException(
+    #         f"The following metric nodes are invalid: {', '.join(invalid_metrics)}",
+    #     )
 
     metrics: List[Column] = [metric.current.columns[0] for metric in metric_nodes]
     catalogs = [metric.current.catalog for metric in metric_nodes]

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -530,24 +530,25 @@ async def test_create_cube_failures(
     )
     assert response.status_code == 200
 
-    response = await client_with_roads.post(
-        "/nodes/cube/",
-        json={
-            "metrics": ["default.num_repair_orders"],
-            "dimensions": [
-                "default.hard_hat.country",
-                "default.hard_hat.postal_code",
-            ],
-            "description": "Cube with invalid metric",
-            "mode": "published",
-            "name": "default.bad_cube",
-        },
-    )
-    assert response.status_code == 422
-    assert (
-        response.json()["message"]
-        == "The following metric nodes are invalid: default.num_repair_orders"
-    )
+    # TODO: Removing for now until we fix the issue with status updates  # pylint: disable=fixme
+    # response = await client_with_roads.post(
+    #     "/nodes/cube/",
+    #     json={
+    #         "metrics": ["default.num_repair_orders"],
+    #         "dimensions": [
+    #             "default.hard_hat.country",
+    #             "default.hard_hat.postal_code",
+    #         ],
+    #         "description": "Cube with invalid metric",
+    #         "mode": "published",
+    #         "name": "default.bad_cube",
+    #     },
+    # )
+    # assert response.status_code == 422
+    # assert (
+    #     response.json()["message"]
+    #     == "The following metric nodes are invalid: default.num_repair_orders"
+    # )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Disable status check for metrics during measures SQL generation until we get to the bottom of why status checks are buggy

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
<!-- Any special instructions around deployment? -->
