### PR TITLE
Move node-related functions to the internal/nodes module

### DIFF
--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -9,11 +9,7 @@ from fastapi import Depends, Query
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from datajunction_server.api.helpers import (
-    activate_node,
-    deactivate_node,
-    get_node_namespace,
-)
+from datajunction_server.api.helpers import get_node_namespace
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJAlreadyExistsException
@@ -32,6 +28,7 @@ from datajunction_server.internal.namespaces import (
     mark_namespace_restored,
     validate_namespace,
 )
+from datajunction_server.internal.nodes import activate_node, deactivate_node
 from datajunction_server.models import access
 from datajunction_server.models.node import NamespaceOutput, NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -17,16 +17,11 @@ from sqlalchemy.sql.operators import is_
 from starlette.requests import Request
 
 from datajunction_server.api.helpers import (
-    activate_node,
-    deactivate_node,
     get_catalog_by_name,
     get_column,
     get_node_by_name,
     get_node_namespace,
-    hard_delete_node,
     raise_if_node_exists,
-    revalidate_node,
-    validate_node_data,
 )
 from datajunction_server.api.namespaces import create_node_namespace
 from datajunction_server.api.tags import get_tags_by_name
@@ -51,18 +46,23 @@ from datajunction_server.internal.access.authorization import (
 )
 from datajunction_server.internal.nodes import (
     _create_node_from_inactive,
+    activate_node,
     copy_to_new_node,
     create_cube_node_revision,
     create_node_revision,
+    deactivate_node,
     get_column_level_lineage,
     get_node_column,
+    hard_delete_node,
     remove_dimension_link,
+    revalidate_node,
     save_column_level_lineage,
     save_node,
     set_node_column_attributes,
     update_any_node,
     upsert_complex_dimension_link,
 )
+from datajunction_server.internal.validation import validate_node_data
 from datajunction_server.models import access
 from datajunction_server.models.attribute import AttributeTypeIdentifier
 from datajunction_server.models.dimensionlink import (

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -1,11 +1,10 @@
+# pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks,too-many-branches,R0401
+# pylint: disable=too-many-lines,protected-access
 """Functions to add to an ast DJ node queries"""
 import collections
 import logging
 import re
 import time
-
-# pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks,too-many-branches,R0401
-# pylint: disable=too-many-lines,protected-access
 from typing import DefaultDict, Deque, Dict, List, Optional, Set, Tuple, Union, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -10,7 +10,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from datajunction_server.api.helpers import get_node_namespace, hard_delete_node
+from datajunction_server.api.helpers import get_node_namespace
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import Node, NodeRevision
@@ -20,7 +20,10 @@ from datajunction_server.errors import (
     DJDoesNotExistException,
     DJInvalidInputException,
 )
-from datajunction_server.internal.nodes import get_cube_revision_metadata
+from datajunction_server.internal.nodes import (
+    get_cube_revision_metadata,
+    hard_delete_node,
+)
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.typing import UTCDatetime

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -1,0 +1,226 @@
+"""Node validation functions."""
+from dataclasses import dataclass, field
+from typing import Dict, List, Union
+
+from sqlalchemy.exc import MissingGreenlet
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.api.helpers import find_bound_dimensions
+from datajunction_server.database import Column, Node, NodeRevision
+from datajunction_server.errors import DJError, DJException, ErrorCode
+from datajunction_server.models.base import labelize
+from datajunction_server.models.node import NodeRevisionBase, NodeStatus
+from datajunction_server.models.node_type import NodeType
+from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.backends.antlr4 import SqlSyntaxError, parse
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
+
+
+@dataclass
+class NodeValidator:
+    """
+    Node validation
+    """
+
+    status: NodeStatus = NodeStatus.VALID
+    columns: List[Column] = field(default_factory=list)
+    required_dimensions: List[Column] = field(default_factory=list)
+    dependencies_map: Dict[NodeRevision, List[ast.Table]] = field(default_factory=dict)
+    missing_parents_map: Dict[str, List[ast.Table]] = field(default_factory=dict)
+    type_inference_failures: List[str] = field(default_factory=list)
+    errors: List[DJError] = field(default_factory=list)
+
+    def differs_from(self, node_revision: NodeRevision):
+        """
+        Compared to the provided node revision, returns whether the validation
+        indicates that the nodes differ.
+        """
+        if node_revision.status != self.status:
+            return True
+        existing_columns_map = {col.name: col for col in self.columns}
+        for col in node_revision.columns:
+            if col.name not in existing_columns_map:
+                return True  # pragma: no cover
+            if existing_columns_map[col.name].type != col.type:
+                return True  # pragma: no cover
+        return False
+
+    def modified_columns(self, node_revision: NodeRevision):
+        """
+        Compared to the provided node revision, returns the modified columns
+        """
+        initial_node_columns = {col.name: col for col in node_revision.columns}
+        updated_columns = set(initial_node_columns.keys()).difference(
+            {n.name for n in self.columns},
+        )
+        for column in self.columns:
+            if column.name in initial_node_columns:
+                if initial_node_columns[column.name].type != column.type:
+                    updated_columns.add(column.name)  # pragma: no cover
+            else:  # pragma: no cover
+                updated_columns.add(column.name)  # pragma: no cover
+        return updated_columns
+
+
+async def validate_node_data(  # pylint: disable=too-many-locals,too-many-statements
+    data: Union[NodeRevisionBase, NodeRevision],
+    session: AsyncSession,
+) -> NodeValidator:
+    """
+    Validate a node. This function should never raise any errors.
+    It will build the lists of issues (including errors) and return them all
+    for the caller to decide what to do.
+    """
+    node_validator = NodeValidator()
+
+    if isinstance(data, NodeRevision):
+        validated_node = data
+    else:
+        node = Node(name=data.name, type=data.type)
+        validated_node = NodeRevision(**data.dict())
+        validated_node.node = node
+
+    ctx = ast.CompileContext(session=session, exception=DJException())
+
+    # Try to parse the node's query, extract dependencies and missing parents
+    try:
+        formatted_query = (
+            NodeRevision.format_metric_alias(
+                validated_node.query,  # type: ignore
+                validated_node.name,
+            )
+            if validated_node.type == NodeType.METRIC
+            else validated_node.query
+        )
+        query_ast = parse(formatted_query)  # type: ignore
+        (
+            dependencies_map,
+            missing_parents_map,
+        ) = await query_ast.bake_ctes().extract_dependencies(ctx)
+        node_validator.dependencies_map = dependencies_map
+        node_validator.missing_parents_map = missing_parents_map
+    except (DJParseException, ValueError, SqlSyntaxError) as raised_exceptions:
+        node_validator.status = NodeStatus.INVALID
+        node_validator.errors.append(
+            DJError(code=ErrorCode.INVALID_SQL_QUERY, message=str(raised_exceptions)),
+        )
+        return node_validator
+
+    # Add aliases for any unnamed columns and confirm that all column types can be inferred
+    query_ast.select.add_aliases_to_unnamed_columns()
+
+    # Invalid parents will invalidate this node
+    # Note: we include source nodes here because they sometimes appear to be invalid, but
+    # this is a bug that needs to be fixed
+    invalid_parents = {
+        parent.name
+        for parent in node_validator.dependencies_map
+        if parent.type != NodeType.SOURCE and parent.status == NodeStatus.INVALID
+    }
+    if invalid_parents:
+        node_validator.status = NodeStatus.INVALID
+
+    try:
+        column_mapping = {col.name: col for col in validated_node.columns}
+    except MissingGreenlet:
+        column_mapping = {}
+    node_validator.columns = []
+    type_inference_failures = {}
+    for idx, col in enumerate(query_ast.select.projection):
+        column = None
+        column_name = col.alias_or_name.name  # type: ignore
+        existing_column = column_mapping.get(column_name)
+        try:
+            column_type = str(col.type)  # type: ignore
+            column = Column(
+                name=column_name,
+                display_name=labelize(column_name),
+                type=column_type,
+                attributes=existing_column.attributes if existing_column else [],
+                dimension=existing_column.dimension if existing_column else None,
+                order=idx,
+            )
+        except DJParseException as parse_exc:
+            type_inference_failures[column_name] = parse_exc.message
+            node_validator.status = NodeStatus.INVALID
+        except TypeError:  # pragma: no cover
+            type_inference_failures[
+                column_name
+            ] = f"Unknown TypeError on column {column_name}."
+            node_validator.status = NodeStatus.INVALID
+        if column:
+            node_validator.columns.append(column)
+
+    # check that bound dimensions are from parent nodes
+    try:
+        invalid_required_dimensions, matched_bound_columns = find_bound_dimensions(
+            validated_node,
+            dependencies_map,
+        )
+        node_validator.required_dimensions = matched_bound_columns
+    except MissingGreenlet:
+        invalid_required_dimensions = set()
+        node_validator.required_dimensions = []
+
+    if missing_parents_map or type_inference_failures or invalid_required_dimensions:
+        # update status
+        node_validator.status = NodeStatus.INVALID
+        # build errors
+        missing_parents_error = (
+            [
+                DJError(
+                    code=ErrorCode.MISSING_PARENT,
+                    message=f"Node definition contains references to nodes that do not "
+                    f"exist: {','.join(missing_parents_map.keys())}",
+                    debug={"missing_parents": list(missing_parents_map.keys())},
+                ),
+            ]
+            if missing_parents_map
+            else []
+        )
+        type_inference_error = (
+            [
+                DJError(
+                    code=ErrorCode.TYPE_INFERENCE,
+                    message=(
+                        f"Unable to infer type for some columns on node `{data.name}`.\n"
+                        + ("\n\t* " if type_inference_failures else "")
+                        + "\n\t* ".join(
+                            [val[:103] for val in type_inference_failures.values()],
+                        )
+                    ),
+                    debug={
+                        "columns": type_inference_failures,
+                        "errors": ctx.exception.errors,
+                    },
+                ),
+            ]
+            if type_inference_failures
+            else []
+        )
+        invalid_required_dimensions_error = (
+            [
+                DJError(
+                    code=ErrorCode.INVALID_COLUMN,
+                    message=(
+                        "Node definition contains references to columns as "
+                        "required dimensions that are not on parent nodes."
+                    ),
+                    debug={
+                        "invalid_required_dimensions": list(
+                            invalid_required_dimensions,
+                        ),
+                    },
+                ),
+            ]
+            if invalid_required_dimensions
+            else []
+        )
+        errors = (
+            missing_parents_error
+            + type_inference_error
+            + invalid_required_dimensions_error
+        )
+        node_validator.errors.extend(errors)
+
+    return node_validator

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.api import helpers
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.errors import DJException
+from datajunction_server.internal.nodes import propagate_valid_status
 from datajunction_server.models.node import NodeStatus
 
 
@@ -40,7 +41,7 @@ async def test_propagate_valid_status(session: AsyncSession):
         status=NodeStatus.INVALID,
     )
     with pytest.raises(DJException) as exc_info:
-        await helpers.propagate_valid_status(
+        await propagate_valid_status(
             session=session,
             valid_nodes=[invalid_node],
             catalog_id=1,


### PR DESCRIPTION
### Summary

This PR is a precursor to the node status PR, which should hopefully make that one easier to read. It moves a number of node-related functions to the internal/nodes module rather than keeping them in helpers, and moves the node validation-related functions to a separate `validation` module. I made no changes to the functions other than moving them.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A