### PR TITLE
Improve node status display and fix status update bugs

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks,too-many-branches,R0401
 # pylint: disable=too-many-lines,protected-access
-"""Functions to add to an ast DJ node queries"""
+"""Functions for building DJ node queries"""
 import collections
 import logging
 import re
@@ -14,7 +14,12 @@ from datajunction_server.construction.utils import to_namespaced_name
 from datajunction_server.database.column import Column
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJException, DJInvalidInputException
+from datajunction_server.errors import (
+    DJError,
+    DJException,
+    DJInvalidInputException,
+    ErrorCode,
+)
 from datajunction_server.internal.engines import get_engine
 from datajunction_server.models import access
 from datajunction_server.models.column import SemanticType
@@ -1013,9 +1018,13 @@ async def validate_shared_dimensions(
     ]
     for dimension_attribute in dimensions:
         if dimension_attribute not in shared_dimensions:
-            raise DJInvalidInputException(
+            message = (
                 f"The dimension attribute `{dimension_attribute}` is not "
-                "available on every metric and thus cannot be included.",
+                "available on every metric and thus cannot be included."
+            )
+            raise DJInvalidInputException(
+                message,
+                errors=[DJError(code=ErrorCode.INVALID_DIMENSION, message=message)],
             )
 
     for filter_ in filters:
@@ -1032,10 +1041,14 @@ async def validate_shared_dimensions(
                     if str(col) in dims_without_prefix
                     else ""
                 )
-                raise DJInvalidInputException(
+                message = (
                     f"The filter `{filter_}` references the dimension attribute "
                     f"`{col}`, which is not available on every"
-                    f" metric and thus cannot be included.{potential_dimension_match}",
+                    f" metric and thus cannot be included.{potential_dimension_match}"
+                )
+                raise DJInvalidInputException(
+                    message,
+                    errors=[DJError(code=ErrorCode.INVALID_DIMENSION, message=message)],
                 )
 
 

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -234,6 +234,7 @@ class QueryRequest(Base):  # type: ignore  # pylint: disable=too-few-public-meth
             engine_version=engine_version,
             limit=limit,
             orderby=orderby,
+            other_args=other_args,
         )
         if query_request:  # pragma: no cover
             query_request.query = query

--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -49,6 +49,11 @@ class ErrorCode(IntEnum):
     UNAUTHORIZED_ACCESS = 500
     INCOMPLETE_AUTHORIZATION = 501
 
+    # Node validation
+    INVALID_PARENT = 600
+    INVALID_DIMENSION = 601
+    INVALID_METRIC = 602
+
 
 class DebugType(TypedDict, total=False):
     """

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1,10 +1,10 @@
 # pylint: disable=too-many-lines,too-many-arguments
 """Nodes endpoint helper functions"""
 import logging
-from collections import defaultdict, deque
+from collections import defaultdict
 from datetime import datetime
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 from fastapi import BackgroundTasks
 from fastapi.responses import JSONResponse
@@ -31,15 +31,17 @@ from datajunction_server.database.partition import Partition
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJDoesNotExistException,
+    DJError,
     DJException,
     DJInvalidInputException,
     DJNodeNotFound,
+    ErrorCode,
 )
 from datajunction_server.internal.materializations import (
     create_new_materialization,
     schedule_materialization_jobs,
 )
-from datajunction_server.internal.validation import validate_node_data
+from datajunction_server.internal.validation import NodeValidator, validate_node_data
 from datajunction_server.models import access
 from datajunction_server.models.attribute import (
     AttributeTypeIdentifier,
@@ -70,7 +72,11 @@ from datajunction_server.models.node import (
 )
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.service_clients import QueryServiceClient
-from datajunction_server.sql.dag import get_downstream_nodes, get_nodes_with_dimension
+from datajunction_server.sql.dag import (
+    get_downstream_nodes,
+    get_nodes_with_dimension,
+    topological_sort,
+)
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import parse
@@ -640,7 +646,7 @@ async def update_node_with_query(
         session.add(new_revision)
         await session.commit()
 
-    if background_tasks:
+    if background_tasks:  # pragma: no cover
         background_tasks.add_task(
             save_column_level_lineage,
             session=session,
@@ -662,16 +668,14 @@ async def update_node_with_query(
             if col.name not in old_columns_map or old_columns_map[col.name] != col.type
         ],
     }
-    await propagate_update_downstream(
-        session,
-        node,  # type: ignore
-        history_events,
-        query_service_client=query_service_client,
-        current_user=current_user,
-        background_tasks=background_tasks,
-        validate_access=validate_access,
-    )
 
+    background_tasks.add_task(
+        propagate_update_downstream,
+        session,
+        node,
+        current_user=current_user,
+    )
+    await session.refresh(node, ["current"])
     await session.refresh(node.current, ["materializations"])  # type: ignore
     return node  # type: ignore
 
@@ -717,7 +721,7 @@ async def update_cube_node(  # pylint: disable=too-many-locals
     *,
     query_service_client: QueryServiceClient,
     current_user: Optional[User] = None,
-    background_tasks: BackgroundTasks,
+    background_tasks: BackgroundTasks = None,
     validate_access: access.ValidateAccessFn,
 ) -> Optional[NodeRevision]:
     """
@@ -798,11 +802,17 @@ async def update_cube_node(  # pylint: disable=too-many-locals
                     user=current_user.username if current_user else None,
                 ),
             )
-        background_tasks.add_task(
-            schedule_materialization_jobs,
-            materializations=new_cube_revision.materializations,
-            query_service_client=query_service_client,
-        )
+        if background_tasks:
+            background_tasks.add_task(
+                schedule_materialization_jobs,
+                materializations=new_cube_revision.materializations,
+                query_service_client=query_service_client,
+            )
+        else:
+            schedule_materialization_jobs(  # pragma: no cover
+                materializations=new_cube_revision.materializations,
+                query_service_client=query_service_client,
+            )
     session.add(new_cube_revision)
     session.add(new_cube_revision.node)
     await session.commit()
@@ -816,12 +826,8 @@ async def update_cube_node(  # pylint: disable=too-many-locals
 async def propagate_update_downstream(  # pylint: disable=too-many-locals
     session: AsyncSession,
     node: Node,
-    history_events: Dict[str, Any],
     *,
-    query_service_client: QueryServiceClient,
     current_user: Optional[User] = None,
-    background_tasks: BackgroundTasks,
-    validate_access: access.ValidateAccessFn,
 ):
     """
     Propagate the updated node's changes to all of its downstream children.
@@ -830,138 +836,60 @@ async def propagate_update_downstream(  # pylint: disable=too-many-locals
     - altered column types: may invalidate downstream nodes
     - new columns: won't affect downstream nodes
     """
-    processed = set()
+    _logger.info("Propagating update of node %s downstream", node.name)
+    downstreams = await get_downstream_nodes(
+        session,
+        node.name,
+        include_deactivated=False,
+        include_cubes=False,
+    )
+    downstreams = topological_sort(downstreams)
+    _logger.info(
+        "Revalidating the following downstreams %s",
+        [downstream.name for downstream in downstreams],
+    )
 
-    # Each entry being processed is a list that represents the changelog of affected nodes
-    # The last entry in the list is the current node that's being processed
-    await session.refresh(node, ["current", "children"])
-    to_process = deque([[node.current, child] for child in node.children])
+    # The downstreams need to be sorted topologically in order for the updates to be done
+    # in the right order. Otherwise it is possible for a leaf node like a metric to be updated
+    # before its upstreams are updated.
+    for downstream in downstreams:
+        original_node_revision = downstream.current
+        previous_status = original_node_revision.status
+        node_validator = await revalidate_node(downstream.name, session)
 
-    while to_process:
-        changelog = to_process.popleft()
-        child = changelog[-1]
-
-        # Only process if it hasn't already been processed before
-        if child.name not in processed:
-            await session.refresh(child)
-            processed.add(child.name)
-
-            if child.type == NodeType.CUBE:
-                child_node = await Node.get_by_name(
-                    session,
-                    child.name,
-                    options=[
-                        joinedload(Node.current).options(
-                            selectinload(NodeRevision.columns).options(
-                                selectinload(Column.node_revisions).options(
-                                    selectinload(NodeRevision.node),
-                                ),
-                            ),
-                            selectinload(NodeRevision.cube_elements).options(
-                                selectinload(Column.node_revisions).options(
-                                    selectinload(NodeRevision.node),
-                                ),
-                            ),
-                        ),
-                    ],
-                )
-                if child_node:
-                    await update_cube_node(
-                        session,
-                        child_node.current,  # type: ignore
-                        UpdateNode(
-                            metrics=[
-                                metric.name for metric in child_node.current.cube_metrics()  # type: ignore  # pylint: disable=line-too-long
-                            ],
-                            dimensions=child_node.current.cube_dimensions(),  # type: ignore
-                        ),
-                        query_service_client=query_service_client,
-                        background_tasks=background_tasks,
-                        validate_access=validate_access,
-                    )
-                continue
-
-            node_validator = await validate_node_data(
-                data=child,
-                session=session,
-            )
-            result = await Node.get_by_name(
-                session,
-                child.name,
-                options=[
-                    joinedload(Node.current).options(
-                        *NodeRevision.default_load_options()
-                    ),
-                ],
-            )
-            if not result:
-                continue
-            child = result.current  # type: ignore
-            # Update the child with a new node revision if its columns or status have changed
-            if node_validator.differs_from(child):
-                await session.refresh(child, ["required_dimensions"])
-                new_revision = copy_existing_node_revision(child)
-                new_revision.version = str(
-                    Version.parse(child.version).next_major_version(),
-                )
-
-                new_revision.status = node_validator.status
-                new_revision.lineage = [
-                    lineage.dict()
-                    for lineage in await get_column_level_lineage(session, new_revision)
-                ]
-
-                # Save which columns were modified and update the columns with the changes
-                updated_columns = node_validator.modified_columns(new_revision)
-                new_revision.columns = node_validator.columns
-
-                # Save the new revision of the child
-                new_revision.node_id = child.node_id
-                session.add(new_revision)
-                await session.commit()
-                await session.refresh(new_revision, ["node"])
-                new_revision.node.current_version = new_revision.version
-                session.add(new_revision.node)
-
-                # Add grandchildren for processing
-                await session.refresh(child, ["node"])
-                await session.refresh(child.node, ["children"])
-
-                for grandchild in child.node.children:
-                    new_changelog = changelog + [grandchild]
-                    to_process.append(new_changelog)
-
-                # Record history event
-                history_events[child.name] = {
-                    "name": child.name,
-                    "current_version": new_revision.version,
-                    "previous_version": child.version,
-                    "updated_columns": sorted(list(updated_columns)),
-                }
-                for entry in changelog:
-                    await session.refresh(entry)
-                event = History(
-                    entity_type=EntityType.NODE,
-                    entity_name=child.name,
-                    node=child.name,
-                    activity_type=ActivityType.STATUS_CHANGE,
-                    details={
-                        "upstreams": [
-                            history_events[entry.name]
-                            for entry in changelog
-                            if entry.name in history_events
-                        ],
-                        "reason": f"Caused by update of `{node.name}` to "
-                        f"{node.current_version}",
+        # Record history event
+        if (
+            original_node_revision.version != downstream.current_version
+            or previous_status != node_validator.status
+        ):
+            event = History(
+                entity_type=EntityType.NODE,
+                entity_name=downstream.name,
+                node=downstream.name,
+                activity_type=ActivityType.UPDATE,
+                details={
+                    "changes": {
+                        "updated_columns": sorted(list(node_validator.updated_columns)),
                     },
-                    pre={"status": child.status},
-                    post={"status": node_validator.status},
-                    user=current_user.username if current_user else None,
-                )
-                session.add(event)
-                await session.commit()
-                await session.refresh(new_revision)
-                await session.refresh(new_revision.node)
+                    "upstream": {
+                        "node": node.name,
+                        "version": node.current_version,
+                    },
+                    "reason": f"Caused by update of `{node.name}` to "
+                    f"{node.current_version}",
+                },
+                pre={
+                    "status": previous_status,
+                    "version": original_node_revision.version,
+                },
+                post={
+                    "status": node_validator.status,
+                    "version": downstream.current_version,
+                },
+                user=current_user.username if current_user else None,
+            )
+            session.add(event)
+        await session.commit()
 
 
 def copy_existing_node_revision(old_revision: NodeRevision):
@@ -1830,12 +1758,11 @@ async def activate_node(
     await session.commit()
 
 
-async def revalidate_node(
+async def revalidate_node(  # pylint: disable=too-many-locals,too-many-statements
     name: str,
     session: AsyncSession,
-    parent_node: str = None,
     current_user: Optional[User] = None,
-):
+) -> NodeValidator:
     """
     Revalidate a single existing node and update its status appropriately
     """
@@ -1849,6 +1776,8 @@ async def revalidate_node(
         raise_if_not_exists=True,
     )
     current_node_revision = node.current  # type: ignore
+
+    # Revalidate source node
     if current_node_revision.type == NodeType.SOURCE:
         if current_node_revision.status != NodeStatus.VALID:  # pragma: no cover
             current_node_revision.status = NodeStatus.VALID
@@ -1863,13 +1792,18 @@ async def revalidate_node(
             session.add(current_node_revision)
             await session.commit()
             await session.refresh(current_node_revision)
-        return NodeStatus.VALID
+        return NodeValidator(
+            status=node.current.status,  # type: ignore
+            columns=node.current.columns,  # type: ignore
+        )
 
+    # Revalidate cube node
     if current_node_revision.type == NodeType.CUBE:
         cube_node = await Node.get_cube_by_name(session, name)
         current_node_revision = cube_node.current  # type: ignore
         cube_metrics = [metric.name for metric in current_node_revision.cube_metrics()]
         cube_dimensions = current_node_revision.cube_dimensions()
+        errors = []
         try:
             await validate_cube(
                 session,
@@ -1878,39 +1812,68 @@ async def revalidate_node(
                 require_dimensions=True,
             )
             current_node_revision.status = NodeStatus.VALID
-        except DJException:  # pragma: no cover
+        except DJException as exc:  # pragma: no cover
             current_node_revision.status = NodeStatus.INVALID
+            if exc.errors:
+                errors.extend(exc.errors)
+            else:
+                errors.append(
+                    DJError(code=ErrorCode.INVALID_DIMENSION, message=exc.message),
+                )
         session.add(current_node_revision)
         await session.commit()
-        return current_node_revision.status
-    previous_status = current_node_revision.status
+        return NodeValidator(
+            status=current_node_revision.status,
+            columns=current_node_revision.columns,
+            errors=errors,
+        )
+
+    # Revalidate all other node types
     node_validator = await validate_node_data(current_node_revision, session)
 
-    node = await Node.get_by_name(
-        session,
-        name,
-        options=[
-            joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            joinedload(Node.tags),
-        ],
-        raise_if_not_exists=True,
-    )
+    # Update the status
     node.current.status = node_validator.status  # type: ignore
-    if previous_status != node.current.status:  # type: ignore  # pragma: no cover
-        session.add(node)
-        session.add(
-            status_change_history(
-                node.current,  # type: ignore
-                previous_status,
-                node.current.status,  # type: ignore
-                parent_node=parent_node,
-                current_user=current_user,
-            ),
+
+    # Check if any columns have been updated
+    existing_columns = {col.name: col for col in node.current.columns}  # type: ignore
+    updated_columns = False
+    for col in node_validator.columns:
+        if existing_col := existing_columns.get(col.name):
+            if existing_col.type != col.type:
+                existing_col.type = col.type
+                updated_columns = True
+        else:
+            node.current.columns.append(col)  # type: ignore
+            updated_columns = True
+
+    # Only create a new revision if the columns have been updated
+    if updated_columns:  # type: ignore
+        new_revision = copy_existing_node_revision(node.current)  # type: ignore
+        new_revision.version = str(
+            Version.parse(node.current.version).next_major_version(),  # type: ignore
         )
-        await session.commit()
+
+        new_revision.status = node_validator.status
+        new_revision.lineage = [
+            lineage.dict()
+            for lineage in await get_column_level_lineage(session, new_revision)
+        ]
+
+        # Save which columns were modified and update the columns with the changes
+        node_validator.updated_columns = node_validator.modified_columns(
+            new_revision,  # type: ignore
+        )
+        new_revision.columns = node_validator.columns
+
+        # Save the new revision of the child
+        node.current_version = new_revision.version  # type: ignore
+        new_revision.node_id = node.id  # type: ignore
+        session.add(node)
+        session.add(new_revision)
+    await session.commit()
     await session.refresh(node.current)  # type: ignore
     await session.refresh(node, ["current"])
-    return node.current.status  # type: ignore
+    return node_validator
 
 
 async def hard_delete_node(
@@ -1953,16 +1916,15 @@ async def hard_delete_node(
                 user=current_user.username if current_user else None,
             ),
         )
-        status = await revalidate_node(
+        node_validator = await revalidate_node(
             name=node.name,
             session=session,
-            parent_node=name,
             current_user=current_user,
         )
         impact.append(
             {
                 "name": node.name,
-                "status": status,
+                "status": node_validator.status,
                 "effect": "downstream node is now invalid",
             },
         )
@@ -1978,7 +1940,7 @@ async def hard_delete_node(
                 user=current_user.username if current_user else None,
             ),
         )
-        status = await revalidate_node(
+        node_validator = await revalidate_node(
             name=node.name,
             session=session,
             current_user=current_user,
@@ -1986,7 +1948,7 @@ async def hard_delete_node(
         impact.append(
             {
                 "name": node.name,
-                "status": status,
+                "status": node_validator.status,
                 "effect": "broken link",
             },
         )

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1843,8 +1843,8 @@ async def revalidate_node(  # pylint: disable=too-many-locals,too-many-statement
                 existing_col.type = col.type
                 updated_columns = True
         else:
-            node.current.columns.append(col)  # type: ignore
-            updated_columns = True
+            node.current.columns.append(col)  # type: ignore  # pragma: no cover
+            updated_columns = True  # pragma: no cover
 
     # Only create a new revision if the columns have been updated
     if updated_columns:  # type: ignore

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -76,6 +76,24 @@ class NodeStatus(StrEnum):
     INVALID = "invalid"
 
 
+class NodeValidationError(BaseModel):
+    """
+    Validation error
+    """
+
+    type: str
+    message: str
+
+
+class NodeStatusDetails(BaseModel):
+    """
+    Node status details. Contains a list of node errors or an empty list of the node status is valid
+    """
+
+    status: NodeStatus
+    errors: List[NodeValidationError]
+
+
 class NodeYAML(TypedDict, total=False):
     """
     Schema of a node in the YAML file.

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -118,7 +118,15 @@ async def test_create_invalid_cube(client_with_account_revenue: AsyncClient):
     assert data == {
         "message": "Node default.account_type of type dimension cannot be added to a cube. "
         "Did you mean to add a dimension attribute?",
-        "errors": [],
+        "errors": [
+            {
+                "code": 204,
+                "context": "",
+                "debug": None,
+                "message": "Node default.account_type of type dimension cannot be added to a "
+                "cube. Did you mean to add a dimension attribute?",
+            },
+        ],
         "warnings": [],
     }
 
@@ -138,7 +146,15 @@ async def test_create_invalid_cube(client_with_account_revenue: AsyncClient):
     assert data == {
         "message": "The dimension attribute `default.payment_type.payment_type_name` "
         "is not available on every metric and thus cannot be included.",
-        "errors": [],
+        "errors": [
+            {
+                "code": 601,
+                "context": "",
+                "debug": None,
+                "message": "The dimension attribute `default.payment_type.payment_type_name` "
+                "is not available on every metric and thus cannot be included.",
+            },
+        ],
         "warnings": [],
     }
 
@@ -517,7 +533,15 @@ async def test_create_cube_failures(
     assert response.status_code == 404
     assert response.json() == {
         "message": "The following metric nodes were not found: default.metric_that_doesnt_exist",
-        "errors": [],
+        "errors": [
+            {
+                "code": 203,
+                "context": "",
+                "debug": None,
+                "message": "The following metric nodes were not found: "
+                "default.metric_that_doesnt_exist",
+            },
+        ],
         "warnings": [],
     }
 

--- a/datajunction-server/tests/api/node_update_test.py
+++ b/datajunction-server/tests/api/node_update_test.py
@@ -45,165 +45,93 @@ async def test_update_source_node(
     node_history_events = {
         "default.national_level_agg": [
             {
-                "activity_type": "status_change",
+                "activity_type": "update",
                 "created_at": mock.ANY,
                 "details": {
+                    "changes": {"updated_columns": []},
                     "reason": "Caused by update of `default.repair_order_details` to "
                     "v2.0",
-                    "upstreams": [
-                        {
-                            "current_version": "v2.0",
-                            "name": "default.repair_order_details",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "repair_order_id",
-                                "price",
-                                "quantity_v2",
-                            ],
-                        },
-                        {
-                            "current_version": "v2.0",
-                            "name": "default.national_level_agg",
-                            "previous_version": "v1.0",
-                            "updated_columns": ["total_amount_nationwide"],
-                        },
-                    ],
+                    "upstream": {
+                        "node": "default.repair_order_details",
+                        "version": "v2.0",
+                    },
                 },
                 "entity_name": "default.national_level_agg",
                 "entity_type": "node",
                 "id": mock.ANY,
                 "node": "default.national_level_agg",
-                "post": {"status": "invalid"},
-                "pre": {"status": "valid"},
-                "user": "dj",
+                "post": {"status": "invalid", "version": "v1.0"},
+                "pre": {"status": "valid", "version": "v1.0"},
+                "user": mock.ANY,
             },
         ],
         "default.regional_level_agg": [
             {
-                "activity_type": "status_change",
+                "activity_type": "update",
                 "created_at": mock.ANY,
                 "details": {
-                    "reason": "Caused by update of `default.repair_order_details` to "
-                    "v2.0",
-                    "upstreams": [
-                        {
-                            "current_version": "v2.0",
-                            "name": "default.repair_order_details",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "repair_order_id",
-                                "price",
-                                "quantity_v2",
-                            ],
-                        },
-                        {
-                            "current_version": "v2.0",
-                            "name": "default.regional_level_agg",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "avg_repair_amount_in_region",
-                                "total_amount_in_region",
-                            ],
-                        },
-                    ],
+                    "changes": {
+                        "updated_columns": [],
+                    },
+                    "reason": "Caused by update of `default.repair_order_details` to v2.0",
+                    "upstream": {
+                        "node": "default.repair_order_details",
+                        "version": "v2.0",
+                    },
                 },
                 "entity_name": "default.regional_level_agg",
                 "entity_type": "node",
                 "id": mock.ANY,
                 "node": "default.regional_level_agg",
-                "post": {"status": "invalid"},
-                "pre": {"status": "valid"},
-                "user": "dj",
+                "post": {"status": "invalid", "version": "v1.0"},
+                "pre": {"status": "valid", "version": "v1.0"},
+                "user": mock.ANY,
             },
         ],
         "default.avg_repair_price": [
             {
-                "activity_type": "status_change",
+                "activity_type": "update",
                 "created_at": mock.ANY,
                 "details": {
+                    "changes": {"updated_columns": []},
                     "reason": "Caused by update of `default.repair_order_details` to "
                     "v2.0",
-                    "upstreams": [
-                        {
-                            "current_version": "v2.0",
-                            "name": "default.repair_order_details",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "repair_order_id",
-                                "price",
-                                "quantity_v2",
-                            ],
-                        },
-                        {
-                            "current_version": "v2.0",
-                            "name": "default.repair_orders_fact",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "price",
-                                "quantity",
-                                "total_repair_cost",
-                            ],
-                        },
-                        {
-                            "current_version": "v2.0",
-                            "name": "default.avg_repair_price",
-                            "previous_version": "v1.0",
-                            "updated_columns": ["default_DOT_avg_repair_price"],
-                        },
-                    ],
+                    "upstream": {
+                        "node": "default.repair_order_details",
+                        "version": "v2.0",
+                    },
                 },
                 "entity_name": "default.avg_repair_price",
                 "entity_type": "node",
                 "id": mock.ANY,
                 "node": "default.avg_repair_price",
-                "post": {"status": "invalid"},
-                "pre": {"status": "valid"},
-                "user": "dj",
+                "post": {"status": "invalid", "version": "v1.0"},
+                "pre": {"status": "valid", "version": "v1.0"},
+                "user": mock.ANY,
             },
         ],
         "default.regional_repair_efficiency": [
             {
-                "id": mock.ANY,
-                "entity_type": "node",
-                "entity_name": "default.regional_repair_efficiency",
-                "node": "default.regional_repair_efficiency",
-                "activity_type": "status_change",
-                "user": "dj",
-                "pre": {"status": "valid"},
-                "post": {"status": "invalid"},
-                "details": {
-                    "upstreams": [
-                        {
-                            "name": "default.repair_order_details",
-                            "current_version": "v2.0",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "repair_order_id",
-                                "price",
-                                "quantity_v2",
-                            ],
-                        },
-                        {
-                            "name": "default.regional_level_agg",
-                            "current_version": "v2.0",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "avg_repair_amount_in_region",
-                                "total_amount_in_region",
-                            ],
-                        },
-                        {
-                            "name": "default.regional_repair_efficiency",
-                            "current_version": "v2.0",
-                            "previous_version": "v1.0",
-                            "updated_columns": [
-                                "default_DOT_regional_repair_efficiency",
-                            ],
-                        },
-                    ],
-                    "reason": "Caused by update of `default.repair_order_details` to v2.0",
-                },
+                "activity_type": "update",
                 "created_at": mock.ANY,
+                "details": {
+                    "changes": {
+                        "updated_columns": [],
+                    },
+                    "reason": "Caused by update of `default.repair_order_details` to "
+                    "v2.0",
+                    "upstream": {
+                        "node": "default.repair_order_details",
+                        "version": "v2.0",
+                    },
+                },
+                "entity_name": "default.regional_repair_efficiency",
+                "entity_type": "node",
+                "id": mock.ANY,
+                "node": "default.regional_repair_efficiency",
+                "post": {"status": "invalid", "version": "v1.0"},
+                "pre": {"status": "valid", "version": "v1.0"},
+                "user": mock.ANY,
             },
         ],
     }
@@ -220,5 +148,26 @@ async def test_update_source_node(
                 assert [
                     event
                     for event in response.json()
-                    if event["activity_type"] == "status_change"
+                    if event["activity_type"] == "update"
                 ] == node_history_events.get(affected)
+
+    await client_with_roads.patch(
+        "/nodes/default.national_level_agg/",
+        json={
+            "query": "SELECT SUM(cast(rd.price AS float) * rd.quantity_v2) AS total_amount "
+            "FROM default.repair_order_details rd",
+        },
+    )
+    response = await client_with_roads.get("/nodes/default.national_level_agg")
+    data = response.json()
+    assert data["status"] == "valid"
+    assert data["columns"] == [
+        {
+            "attributes": [],
+            "dimension": None,
+            "display_name": "Total Amount",
+            "name": "total_amount",
+            "partition": None,
+            "type": "double",
+        },
+    ]

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1382,8 +1382,9 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         # Hard deleting a dimension creates broken links
         response = await client_with_roads.delete("/nodes/default.repair_order/hard/")
         assert response.status_code in (200, 201)
-        assert response.json() == {
-            "impact": [
+        data = response.json()
+        assert sorted(data["impact"], key=lambda x: x["name"]) == sorted(
+            [
                 {
                     "effect": "broken link",
                     "name": "default.repair_order_details",
@@ -1445,8 +1446,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                     "status": "invalid",
                 },
             ],
-            "message": "The node `default.repair_order` has been completely removed.",
-        }
+            key=lambda x: x["name"],
+        )
+        assert (
+            data["message"]
+            == "The node `default.repair_order` has been completely removed."
+        )
 
         # Hard deleting an unlinked node has no impact
         response = await client_with_roads.delete(
@@ -2013,27 +2018,18 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data == {
             "message": (
-                "Unable to infer type for some columns on node "
-                "`default.avg_length_of_employment_plus_one`.\n\n"
-                "\t* Incompatible types in binary operation NOW() - "
-                "foo.bar.hard_hats.hire_date + 1. Got left timestamp, rig"
+                "Incompatible types in binary operation NOW() - "
+                "foo.bar.hard_hats.hire_date + 1. Got left timestamp, right int."
             ),
             "errors": [
                 {
                     "code": 302,
                     "message": (
-                        "Unable to infer type for some columns on node "
-                        "`default.avg_length_of_employment_plus_one`.\n\n"
-                        "\t* Incompatible types in binary operation NOW() - "
-                        "foo.bar.hard_hats.hire_date + 1. Got left timestamp, rig"
+                        "Incompatible types in binary operation NOW() - "
+                        "foo.bar.hard_hats.hire_date + 1. Got left timestamp, right int."
                     ),
                     "debug": {
-                        "columns": {
-                            "default_DOT_avg_length_of_employment_plus_one": (
-                                "Incompatible types in binary operation NOW() - "
-                                "foo.bar.hard_hats.hire_date + 1. Got left timestamp, right int."
-                            ),
-                        },
+                        "columns": ["default_DOT_avg_length_of_employment_plus_one"],
                         "errors": [],
                     },
                     "context": "",

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -3245,7 +3245,6 @@ async def test_measures_sql_with_filters(  # pylint: disable=too-many-arguments
     }
     response = await client_with_roads.get("/sql/measures", params=sql_params)
     data = response.json()
-    print("data", data)
     assert str(parse(str(data["sql"]))) == str(parse(str(sql)))
     result = duckdb_conn.sql(data["sql"])
     assert result.fetchall() == rows

--- a/datajunction-server/tests/sql/dag_test.py
+++ b/datajunction-server/tests/sql/dag_test.py
@@ -7,8 +7,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.database.column import Column
 from datajunction_server.database.database import Database
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.errors import DJException
 from datajunction_server.models.node import DimensionAttributeOutput, NodeType
-from datajunction_server.sql.dag import get_dimensions
+from datajunction_server.sql.dag import get_dimensions, topological_sort
 from datajunction_server.sql.parsing.types import IntegerType, StringType
 
 
@@ -85,3 +86,83 @@ async def test_get_dimensions(session: AsyncSession) -> None:
             path=["A.b_id"],
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_topological_sort(session: AsyncSession) -> None:
+    """
+    Test ``topological_sort``.
+    """
+    node_a = Node(name="test.A", type=NodeType.TRANSFORM)
+    node_rev_a = NodeRevision(
+        node=node_a,
+        name=node_a.name,
+        parents=[],
+    )
+    node_a.current = node_rev_a
+    session.add(node_a)
+    session.add(node_rev_a)
+
+    node_b = Node(name="test.B", type=NodeType.TRANSFORM)
+    node_rev_b = NodeRevision(
+        node=node_b,
+        name=node_b.name,
+        parents=[node_a],
+    )
+    node_b.current = node_rev_b
+    session.add(node_b)
+    session.add(node_rev_b)
+
+    node_c = Node(name="test.C", type=NodeType.TRANSFORM)
+    node_rev_c = NodeRevision(
+        node=node_c,
+        name=node_c.name,
+        parents=[],
+    )
+    node_c.current = node_rev_c
+    session.add(node_c)
+    session.add(node_rev_c)
+
+    node_d = Node(name="test.D", type=NodeType.TRANSFORM)
+    node_rev_c.parents = [node_b, node_d]
+    node_rev_d = NodeRevision(
+        node=node_d,
+        name=node_d.name,
+        parents=[node_a],
+    )
+    node_d.current = node_rev_d
+    session.add(node_d)
+    session.add(node_rev_d)
+
+    node_e = Node(name="test.E", type=NodeType.TRANSFORM)
+    node_rev_e = NodeRevision(
+        node=node_e,
+        name=node_e.name,
+        parents=[node_c, node_b],
+    )
+    node_e.current = node_rev_e
+    session.add(node_e)
+    session.add(node_rev_e)
+
+    node_f = Node(name="test.F", type=NodeType.TRANSFORM)
+    node_rev_d.parents.append(node_f)
+    node_rev_f = NodeRevision(
+        node=node_f,
+        name=node_f.name,
+        parents=[node_e],
+    )
+    node_f.current = node_rev_f
+    session.add(node_f)
+    session.add(node_rev_f)
+
+    ordering = topological_sort([node_a, node_b, node_c, node_d, node_e])
+    assert [node.name for node in ordering] == [
+        node_a.name,
+        node_d.name,
+        node_b.name,
+        node_c.name,
+        node_e.name,
+    ]
+    with pytest.raises(DJException) as exc_info:
+        topological_sort([node_a, node_b, node_c, node_d, node_e, node_f])
+    assert "Graph has at least one cycle" in str(exc_info)

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -94,7 +94,7 @@ export function NamespacePage() {
         </span>
       </td>
       <td>
-        <NodeStatus node={node} />
+        <NodeStatus node={node} revalidate={false} />
       </td>
       <td>
         <span className="status">{node.mode}</span>

--- a/datajunction-ui/src/app/pages/NodePage/NodeStatus.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeStatus.jsx
@@ -1,28 +1,101 @@
-import { Component } from 'react';
+import { Component, useContext, useEffect, useRef, useState } from 'react';
 import ValidIcon from '../../icons/ValidIcon';
 import InvalidIcon from '../../icons/InvalidIcon';
+import DJClientContext from '../../providers/djclient';
+import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import markdown from 'react-syntax-highlighter/dist/cjs/languages/hljs/markdown';
+import * as React from 'react';
+import { AlertMessage } from '../AddEditNodePage/AlertMessage';
+import AlertIcon from '../../icons/AlertIcon';
+import { labelize } from '../../../utils/form';
 
-export default class NodeStatus extends Component {
-  render() {
-    const { node } = this.props;
-    return (
+SyntaxHighlighter.registerLanguage('markdown', markdown);
+
+export default function NodeStatus({ node, revalidate = true }) {
+  const MAX_ERROR_LENGTH = 200;
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const [validation, setValidation] = useState([]);
+
+  const [codeAnchor, setCodeAnchor] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (revalidate) {
+      const fetchData = async () => {
+        setValidation(await djClient.revalidate(node.name));
+      };
+      fetchData().catch(console.error);
+    }
+  }, [djClient, node, revalidate]);
+
+  const displayValidation =
+    revalidate && validation?.errors?.length > 0 ? (
       <>
-        {node?.status === 'valid' ? (
-          <span
-            className="status__valid status"
-            style={{ alignContent: 'center' }}
-          >
-            <ValidIcon />
-          </span>
-        ) : (
-          <span
-            className="status__invalid status"
-            style={{ alignContent: 'center' }}
-          >
-            <InvalidIcon />
-          </span>
-        )}
+        <button
+          className="badge"
+          style={{
+            backgroundColor: '#b34b00',
+            fontSize: '15px',
+            outline: '0',
+            border: '0',
+            cursor: 'pointer',
+          }}
+          onClick={() => setCodeAnchor(!codeAnchor)}
+        >
+          ⚠ {validation?.errors?.length} error
+          {validation?.errors?.length > 1 ? 's' : ''}
+        </button>
+        <div
+          className="popover"
+          ref={ref}
+          style={{
+            display: codeAnchor === false ? 'none' : 'block',
+            border: 'none',
+            paddingTop: '0px !important',
+            marginTop: '0px',
+            backgroundColor: 'transparent',
+          }}
+        >
+          {validation?.errors?.map((error, idx) => (
+            <div className="validation_error">
+              <b
+                style={{
+                  color: '#b34b00',
+                }}
+              >
+                {labelize(error.type.toLowerCase())}:
+              </b>{' '}
+              {error.message.length > MAX_ERROR_LENGTH
+                ? error.message.slice(0, MAX_ERROR_LENGTH - 1) + '...'
+                : error.message}
+            </div>
+          ))}
+        </div>
       </>
+    ) : (
+      <></>
     );
-  }
+
+  return (
+    <>
+      {revalidate && validation?.errors?.length > 0 ? (
+        displayValidation
+      ) : validation?.status === 'valid' || node?.status === 'valid' ? (
+        <span
+          className="status__valid status"
+          style={{ alignContent: 'center' }}
+        >
+          <ValidIcon />
+        </span>
+      ) : (
+        <span
+          className="status__invalid status"
+          style={{ alignContent: 'center' }}
+        >
+          <InvalidIcon />
+        </span>
+      )}
+    </>
+  );
 }

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -844,4 +844,15 @@ export const DataJunctionAPI = {
       })
     ).json();
   },
+  revalidate: async function (node) {
+    return await (
+      await fetch(`${DJ_URL}/nodes/${node}/validate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      })
+    ).json();
+  },
 };

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -1202,3 +1202,18 @@ pre {
   text-transform: uppercase;
   padding-left: 10px;
 }
+
+.validation_error {
+  border: #b34b0025 1px solid;
+  border-left: #b34b00 5px solid;
+  padding-left: 20px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: small;
+  width: 600px;
+  word-wrap: break-word;
+  margin-top: 3px;
+  background-color: #ffffff;
+  margin-bottom: 3px;
+  margin-left: -20px;
+}


### PR DESCRIPTION
### Summary

This PR makes a number of improvements related to node status.

#### Fix node update status propagation bug

We were seeing an issue with node update propagation, where after a node is updated, its downstreams' statuses were often not updated to the right status. 

The primary cause of this issue is that we weren't updating the downstreams in the right order. We need to **topologically sort** the downstreams, such that if node A queries from node B, B always comes before A in the ordering. We were instead sorting by level order, which is the wrong ordering and may lead to children being processed before parents.

A secondary issue is that we were only updating statuses and not columns. If a node's query changes, it may cause changes to downstream nodes' columns, which also needs to be saved in order for downstream nodes to pick up on them.

#### Display detailed node status

This change modifies the node validation endpoint to include a list of errors if the node's status is invalid.

We update the node info UI to (a) always revalidate the node (this can be changed later), and (b) show detailed status information. If a node is valid, we continue to display just the checkmark, but if a node is invalid, we additionally display a list of errors that explain why the node is invalid. This allows users to understand why a node's status is what it is, so that they can fix issues to correct it.

<img width="1181" alt="Screenshot 2024-05-04 at 10 38 06 AM" src="https://github.com/DataJunction/dj/assets/9524628/7d81f48c-b655-483f-8f32-658b08a3bd3a">

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #911 #621 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
