### PR TITLE
Use the queryrequest cache to serve /data requests + bug fixes

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -359,7 +359,7 @@ async def validate_cube(  # pylint: disable=too-many-locals
     session: AsyncSession,
     metric_names: List[str],
     dimension_names: List[str],
-    require_dimensions: bool = True,
+    require_dimensions: bool = False,
 ) -> Tuple[List[Column], List[Node], List[Node], List[Column], Optional[Catalog]]:
     """
     Validate that a set of metrics and dimensions can be built together.

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -131,6 +131,7 @@ async def get_sql(  # pylint: disable=too-many-locals
     """
     Return SQL for a node.
     """
+    dimensions = [dim for dim in dimensions if dim and dim != ""]
     access_control = access.AccessControlStore(
         validate_access=validate_access,
         user=UserOutput.from_orm(current_user) if current_user else None,

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -463,9 +463,14 @@ async def _build_tables_on_select(
                                 if (  # pragma: no cover
                                     col.alias_or_name.name in foreign_keys_alias_map
                                 ):
-                                    col.name = foreign_keys_alias_map[  # type: ignore
+                                    key = foreign_keys_alias_map[  # type: ignore
                                         col.alias_or_name.name
-                                    ].name
+                                    ]
+                                    col.name = (
+                                        key.name
+                                        if isinstance(key, ast.Named)
+                                        else key.alias_or_name
+                                    )
                             filter_asts.append(
                                 temp_select.where,  # type:ignore
                             )

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -469,10 +469,10 @@ async def _build_tables_on_select(
                                     col.name = (
                                         key.name
                                         if isinstance(key, ast.Named)
-                                        else key.alias_or_name
+                                        else key.alias_or_name  # type: ignore
                                     )
                             filter_asts.append(
-                                temp_select.where,  # type:ignore
+                                temp_select.where,  # type: ignore
                             )
                     if filter_asts:
                         node_query.select.where = ast.BinaryOp.And(*filter_asts)

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -319,7 +319,7 @@ class QueryRequest(Base):  # type: ignore  # pylint: disable=too-few-public-meth
         invalid_dimensions = sorted(
             list(set(dimensions).difference(available_dimensions)),
         )
-        if invalid_dimensions:
+        if dimensions and invalid_dimensions:
             raise DJInvalidInputException(
                 f"{', '.join(invalid_dimensions)} are not available "
                 f"dimensions on {', '.join(nodes)}",

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -305,6 +305,7 @@ async def create_cube_node_revision(  # pylint: disable=too-many-locals
         session,
         data.metrics,
         data.dimensions,
+        require_dimensions=True,
     )
     status = (
         NodeStatus.VALID

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -40,8 +40,11 @@ class TestDataForNode:
             },
         )
         data = response.json()
-        assert response.status_code == 500
-        assert "Cannot resolve type of column something" in data["message"]
+        assert response.status_code == 422
+        assert (
+            "something are not available dimensions on default.payment_type"
+            in data["message"]
+        )
 
     @pytest.mark.asyncio
     async def test_get_dimension_data(
@@ -467,7 +470,7 @@ class TestDataForNode:
         data = response.json()
         assert data["message"] == (
             "Authorization of User `dj` for this request failed."
-            "\nThe following requests were denied:\nexecute:node/basic.num_comments."
+            "\nThe following requests were denied:\nread:node/basic.num_comments."
         )
         assert response.status_code == 403
         app.dependency_overrides.clear()

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -1516,6 +1516,45 @@ async def test_saving_metrics_sql_requests(  # pylint: disable=too-many-statemen
                 ],
             ],
         ),
+        # metric without any dimensions or filters should return single aggregate value
+        (
+            ["ROADS"],
+            "default.num_repair_orders",
+            [],
+            [],
+            """
+                SELECT  count(default_DOT_repair_orders_fact.repair_order_id) default_DOT_num_repair_orders
+                 FROM (SELECT  default_DOT_repair_orders.repair_order_id,
+                    default_DOT_repair_orders.municipality_id,
+                    default_DOT_repair_orders.hard_hat_id,
+                    default_DOT_repair_orders.dispatcher_id,
+                    default_DOT_repair_orders.order_date,
+                    default_DOT_repair_orders.dispatched_date,
+                    default_DOT_repair_orders.required_date,
+                    default_DOT_repair_order_details.discount,
+                    default_DOT_repair_order_details.price,
+                    default_DOT_repair_order_details.quantity,
+                    default_DOT_repair_order_details.repair_type_id,
+                    default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity AS total_repair_cost,
+                    default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.order_date AS time_to_dispatch,
+                    default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.required_date AS dispatch_delay
+                 FROM roads.repair_orders AS default_DOT_repair_orders JOIN roads.repair_order_details AS default_DOT_repair_order_details ON default_DOT_repair_orders.repair_order_id = default_DOT_repair_order_details.repair_order_id)
+                 AS default_DOT_repair_orders_fact
+                """,
+            [
+                {
+                    "column": "default_DOT_num_repair_orders",
+                    "name": "default_DOT_num_repair_orders",
+                    "node": "default.num_repair_orders",
+                    "type": "bigint",
+                    "semantic_type": None,
+                    "semantic_entity": "default.num_repair_orders.default_DOT_num_repair_orders",
+                },
+            ],
+            [
+                [25],
+            ],
+        ),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

The `/data` endpoints also need to build SQL before they can send off requests to the query service for data. These endpoints should also use the `queryrequest` cache where possible.

This PR also fixes some additional issues, including 
* Requiring dimensions when metrics SQL is requested. While we can continue to keep this "at least one dimension" requirement when someone is creating a cube, it should be possible to just request metrics without any dimensions, resulting in a single aggregate value for the metric.
* Not filtering out empty dimensions (arguably this is user error, but easier for the server-side to just filter out these rather than raising an error)
* Fix a bug with defaulting to `name` on the foreign key mapping during sql building when this attribute doesn't exist.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
