### PR TITLE
FIX python client error not propagating

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -109,7 +109,7 @@ class RequestsSessionWithEndpoint(requests.Session):  # pragma: no cover
             if exc.response.headers.get("Content-Type") == "application/json":
                 error_message = exc.response.json().get("message")
             else:
-                error_message = f"Request failed with status code {exc.response.status_code}: {str(exc)}"
+                error_message = f"Request failed {exc.response.status_code}: {str(exc)}"
             raise DJClientException(error_message) from exc
 
     def prepare_request(self, request, *args, **kwargs):

--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -106,19 +106,10 @@ class RequestsSessionWithEndpoint(requests.Session):  # pragma: no cover
             response.raise_for_status()
             return response
         except requests.exceptions.RequestException as exc:
-            error_message = None
-            if not exc.response:
-                error_message = str(exc)
-                print(error_message)
-            if (
-                exc.response
-                and exc.response.headers.get("Content-Type") == "application/json"
-            ):
+            if exc.response.headers.get("Content-Type") == "application/json":
                 error_message = exc.response.json().get("message")
-            if not error_message:
-                error_message = (
-                    f"Request failed with status code {exc.response.status_code}"
-                )
+            else:
+                error_message = f"Request failed with status code {exc.response.status_code}: {str(exc)}"
             raise DJClientException(error_message) from exc
 
     def prepare_request(self, request, *args, **kwargs):


### PR DESCRIPTION
### Summary

Current code checks for the existence of response with `if exc.response`, which is a semantic bug because 400 responses are actually Falsy.

This PR removes this check (since exc.response should always exist anyway), ultimately allowing the error message to be propagated

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x ] `make check` passes
- [x ] `make test` shows 100% unit test coverage