### PR TITLE
fix basic login demanding json body

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -188,7 +188,7 @@ class DJClient:
             "/basic/login/",
             data={"username": username, "password": password},
         )
-        return response.json()
+        return response
 
     @staticmethod
     def _primary_key_from_columns(columns) -> List[str]:

--- a/datajunction-clients/python/tests/test__internal.py
+++ b/datajunction-clients/python/tests/test__internal.py
@@ -42,13 +42,8 @@ class TestDJClient:  # pylint: disable=too-many-public-methods, protected-access
         """
         Check that `client.basic_login()` works as expected.
         """
-        client._session.post = MagicMock(
-            return_value=MagicMock(
-                json=MagicMock(return_value={"text": "User created."}),
-            ),
-        )
-        response = client.basic_login(username="bar", password="baz")
-        assert response == {"text": "User created."}
+        client._session.post = MagicMock()
+        client.basic_login(username="bar", password="baz")
         assert client._session.post.call_args == call(
             "/basic/login/",
             data={"username": "bar", "password": "baz"},


### PR DESCRIPTION
### Summary

The [server](https://github.com/DataJunction/dj/blob/d730a76155adc79124b8442e4dd1d336210a098f/datajunction-server/datajunction_server/api/access/authentication/basic.py#L62) only returns a response with no JSON body, so this method has been returning a JSON decode error

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
