### PR TITLE
chore remove try/except in client methods

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -24,7 +24,6 @@ from requests.adapters import CaseInsensitiveDict, HTTPAdapter
 from datajunction import models
 from datajunction.exceptions import (
     DJClientException,
-    DJNodeAlreadyExists,
     DJTagAlreadyExists,
     DJTagDoesNotExist,
 )
@@ -290,9 +289,6 @@ class DJClient:
         Helper function to create a node.
         Raises an error if node already exists and is active.
         """
-        existing_node = self._get_node(node_name=node.name)
-        if "name" in existing_node:
-            raise DJNodeAlreadyExists(node_name=node.name)
         node.mode = mode
         response = self._session.post(
             f"/nodes/{node.type}/",
@@ -318,41 +314,29 @@ class DJClient:
         """
         Retrieves a node.
         """
-        try:
-            response = self._session.get(f"/nodes/{node_name}/")
-            return response.json()
-        except DJClientException as exc:  # pragma: no cover
-            return exc.__dict__
+        response = self._session.get(f"/nodes/{node_name}/")
+        return response.json()
 
     def _get_node_upstreams(self, node_name: str):
         """
         Retrieves a node's upstreams
         """
-        try:
-            response = self._session.get(f"/nodes/{node_name}/upstream")
-            return response.json()
-        except DJClientException as exc:  # pragma: no cover
-            return exc.__dict__
+        response = self._session.get(f"/nodes/{node_name}/upstream")
+        return response.json()
 
     def _get_node_downstreams(self, node_name: str):
         """
         Retrieves a node's downstreams
         """
-        try:
-            response = self._session.get(f"/nodes/{node_name}/downstream")
-            return response.json()
-        except DJClientException as exc:  # pragma: no cover
-            return exc.__dict__
+        response = self._session.get(f"/nodes/{node_name}/downstream")
+        return response.json()
 
     def _get_node_dimensions(self, node_name: str):
         """
         Retrieves a node's dimensions
         """
-        try:
-            response = self._session.get(f"/nodes/{node_name}/dimensions")
-            return response.json()
-        except DJClientException as exc:  # pragma: no cover
-            return exc.__dict__
+        response = self._session.get(f"/nodes/{node_name}/dimensions")
+        return response.json()
 
     def _get_cube(self, node_name: str):
         """

--- a/datajunction-clients/python/datajunction/exceptions.py
+++ b/datajunction-clients/python/datajunction/exceptions.py
@@ -34,16 +34,6 @@ class DJTagDoesNotExist(DJClientException):
         super().__init__(self.message, *args)
 
 
-class DJNodeAlreadyExists(DJClientException):
-    """
-    Raised when a node to be created already exists.
-    """
-
-    def __init__(self, node_name: str, *args) -> None:
-        self.message = f"Node `{node_name}` already exists."
-        super().__init__(self.message, *args)
-
-
 class DJDeploymentFailure(DJClientException):
     """
     Raised when a deployment of a project includes any errors

--- a/datajunction-clients/python/tests/test__internal.py
+++ b/datajunction-clients/python/tests/test__internal.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 from datajunction._internal import DJClient
-from datajunction.exceptions import DJTagDoesNotExist
+from datajunction.exceptions import DJClientException, DJTagDoesNotExist
 
 
 class TestDJClient:  # pylint: disable=too-many-public-methods, protected-access
@@ -48,6 +48,18 @@ class TestDJClient:  # pylint: disable=too-many-public-methods, protected-access
             "/basic/login/",
             data={"username": "bar", "password": "baz"},
         )
+
+    def test__verify_node_exists(self, client):
+        """
+        Check that `client._verify_node_exists()` works as expected.
+        """
+        client._session.get = MagicMock(
+            return_value=MagicMock(
+                json=MagicMock(return_value={"name": "_", "type": "foo"}),
+            ),
+        )
+        with pytest.raises(DJClientException):
+            client._verify_node_exists(node_name="_", type_="bar")
 
     def test__list_nodes_with_tag(self, client):
         """

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -8,7 +8,6 @@ from datajunction import DJBuilder
 from datajunction.exceptions import (
     DJClientException,
     DJNamespaceAlreadyExists,
-    DJNodeAlreadyExists,
     DJTableAlreadyRegistered,
     DJTagAlreadyExists,
 )
@@ -360,26 +359,6 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert revenue.name == "default.revenue"
         assert "default.revenue" in client.namespace("default").sources()
 
-        # make sure we get a failure if we try to create same node again
-        with pytest.raises(DJNodeAlreadyExists) as exc_info:
-            revenue = client.create_source(
-                name="default.revenue",
-                description="Record of payments",
-                display_name="Default: Payment Records",
-                catalog="default",
-                schema="accounting",
-                table="revenue",
-                columns=[
-                    Column(name="payment_id", type="int"),
-                    Column(name="payment_amount", type="float"),
-                    Column(name="payment_type", type="int"),
-                    Column(name="customer_id", type="int"),
-                    Column(name="account_type", type="string"),
-                ],
-                mode=NodeMode.PUBLISHED,
-            )
-        assert "Node `default.revenue` already exists." in str(exc_info.value)
-
         # dimension nodes
         payment_type_dim = client.create_dimension(
             name="default.payment_type",
@@ -621,23 +600,6 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
                 "foo.bar.repair_order",
             ],
         } in result
-
-    def test_failure_modes(self, client):
-        """
-        Test some client failure modes when retrieving nodes.
-        """
-        with pytest.raises(DJClientException) as excinfo:
-            client.transform(node_name="default.fruit")
-        assert "No node with name default.fruit exists!" in str(excinfo)
-
-        with pytest.raises(DJClientException) as excinfo:
-            client.transform(node_name="foo.bar.avg_repair_price")
-        assert (
-            "A node with name foo.bar.avg_repair_price exists, but it is not a transform node!"
-            in str(
-                excinfo,
-            )
-        )
 
     def test_create_namespace(self, client):
         """

--- a/datajunction-clients/python/tests/test_compile.py
+++ b/datajunction-clients/python/tests/test_compile.py
@@ -249,6 +249,24 @@ def test_compile_raising_on_invalid_file_name(
     ) in str(exc_info.value)
 
 
+def test_compile_error_on_invalid_dimension_link(
+    change_to_project_dir: Callable,
+    builder_client: DJBuilder,
+):
+    """
+    Test compiling and receiving an error on a dimension link
+    """
+    change_to_project_dir("project7")
+    project = Project.load_current()
+    compiled_project = project.compile()
+    with pytest.raises(DJDeploymentFailure) as exc_info:
+        compiled_project.deploy(client=builder_client)
+
+    assert str("Node definition contains references to nodes that do not exist") in str(
+        exc_info.value.errors[0],
+    )
+
+
 def test_compile_deeply_nested_namespace(
     change_to_project_dir: Callable,
     builder_client: DJBuilder,
@@ -270,24 +288,6 @@ def test_compile_error_on_individual_node(
     Test compiling and receiving an error on an individual node definition
     """
     change_to_project_dir("project6")
-    project = Project.load_current()
-    compiled_project = project.compile()
-    with pytest.raises(DJDeploymentFailure) as exc_info:
-        compiled_project.deploy(client=builder_client)
-
-    assert str("Node definition contains references to nodes that do not exist") in str(
-        exc_info.value.errors[0],
-    )
-
-
-def test_compile_error_on_invalid_dimension_link(
-    change_to_project_dir: Callable,
-    builder_client: DJBuilder,
-):
-    """
-    Test compiling and receiving an error on a dimension link
-    """
-    change_to_project_dir("project7")
     project = Project.load_current()
     compiled_project = project.compile()
     with pytest.raises(DJDeploymentFailure) as exc_info:


### PR DESCRIPTION
### Summary

Since the `djclient._session` already try/except to propagates any error returned by server, the client methods don't need to

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage