### PR TITLE
Add regexp_[extract|replace] and align node list to the top.

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1395,13 +1395,23 @@ def infer_type(arg: Union[ct.StringType, ct.TimestampType]) -> ct.ColumnType:
 
 class DateAdd(Function):
     """
-    Adds a specified number of days to a date.
+    date_add(date|timestamp|str, int) - Adds a specified number of days to a date.
     """
+
+    dialects = [Dialect.SPARK]
 
 
 @DateAdd.register  # type: ignore
 def infer_type(
     start_date: ct.DateType,
+    days: ct.IntegerBase,
+) -> ct.DateType:
+    return ct.DateType()
+
+
+@DateAdd.register  # type: ignore
+def infer_type(
+    start_date: ct.TimestampType,
     days: ct.IntegerBase,
 ) -> ct.DateType:
     return ct.DateType()
@@ -3686,6 +3696,24 @@ def infer_type(_: ct.ColumnType) -> ct.IntegerType:
     return ct.IntegerType()
 
 
+class RegexpExtract(Function):
+    """
+    regexp_extract(str, regexp[, idx]) - Extract the first string in the str that
+    match the regexp expression and corresponding to the regex group index.
+    """
+
+    dialects = [Dialect.SPARK, Dialect.DRUID]
+
+
+@RegexpExtract.register
+def infer_type(  # type: ignore
+    str_: ct.StringType,
+    regexp: ct.StringType,
+    idx: Optional[ct.IntegerType] = 1,
+) -> ct.StringType:
+    return ct.StringType()
+
+
 class RegexpLike(Function):
     """
     regexp_like(str, regexp) - Returns true if str matches regexp, or false otherwise
@@ -3700,6 +3728,25 @@ def infer_type(  # type: ignore
     arg2: ct.StringType,
 ) -> ct.BooleanType:
     return ct.BooleanType()
+
+
+class RegexpReplace(Function):
+    """
+    regexp_replace(str, regexp, rep[, position]) - Replaces all substrings of str that
+    match regexp with rep.
+    """
+
+    dialects = [Dialect.SPARK, Dialect.DRUID]
+
+
+@RegexpReplace.register
+def infer_type(  # type: ignore
+    str_: ct.StringType,
+    regexp: ct.StringType,
+    rep: ct.StringType,
+    position: Optional[ct.IntegerType] = 1,
+) -> ct.StringType:
+    return ct.StringType()
 
 
 class Replace(Function):

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -3104,6 +3104,27 @@ async def test_rank(session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_regexp_extract(session: AsyncSession):
+    """
+    Test `regexp_extract`
+    """
+    # w/o position arg
+    query = parse("SELECT regexp_replace('100-200', '(\\d+)', 'num')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    # w/ position arg
+    query = parse("SELECT regexp_replace('100-200', '(\\d+)', 'num', 42)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
+@pytest.mark.asyncio
 async def test_regexp_like(session: AsyncSession):
     """
     Test `regexp_like`
@@ -3116,6 +3137,61 @@ async def test_regexp_like(session: AsyncSession):
     await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_regexp_replace(session: AsyncSession):
+    """
+    Test `regexp_replace`
+    """
+    # w/o position arg
+    query = parse("SELECT regexp_replace('100-200', '(\\d+)', 'num')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+    # w/ position arg
+    query = parse("SELECT regexp_replace('100-200', '(\\d+)', 'num', 42)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.StringType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_date_add(session: AsyncSession):
+    """
+    Test `date_add`
+    """
+    # first arg: date
+    query = parse(
+        "SELECT date_add(CURRENT_DATE(), 42)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+    # first arg: timestamp
+    query = parse(
+        "SELECT date_add(CURRENT_TIMESTAMP(), 42)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+    # first arg: string
+    query = parse(
+        "SELECT date_add('2020-01-01', 42)",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -3109,14 +3109,14 @@ async def test_regexp_extract(session: AsyncSession):
     Test `regexp_extract`
     """
     # w/o position arg
-    query = parse("SELECT regexp_replace('100-200', '(\\d+)', 'num')")
+    query = parse("SELECT regexp_extract('100-200', '(\\d+)')")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.StringType()  # type: ignore
     # w/ position arg
-    query = parse("SELECT regexp_replace('100-200', '(\\d+)', 'num', 42)")
+    query = parse("SELECT regexp_extract('100-200', '(\\d+)', 42)")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.compile(ctx)

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -6,6 +6,7 @@ import DJClientContext from '../../providers/djclient';
 import Explorer from '../NamespacePage/Explorer';
 import NodeListActions from '../../components/NodeListActions';
 import AddNamespacePopover from './AddNamespacePopover';
+import 'styles/node-list.css';
 
 export function NamespacePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;

--- a/datajunction-ui/src/styles/node-list.css
+++ b/datajunction-ui/src/styles/node-list.css
@@ -1,0 +1,4 @@
+table {
+  width: 100%;
+  height: min-content;
+}


### PR DESCRIPTION
### Summary

Because it was hard to see them when the list of namespaces was getting long. Now its all good.

Minor: added 3rd version of DATE_ADD udf (with timestamp arg) cause it was missing.

### Test Plan

1. UDFs tested with unit tests.
2. Node alignment tested visually.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
