### PR TITLE
Allow deletion of materializations and fix few bugs.

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -728,7 +728,11 @@ async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,
             upstream_tables=[
                 f"{leading_metric_node.current.catalog.name}.{tbl.identifier()}"  # type: ignore
                 for tbl in query_ast.find_all(ast.Table)
-                if tbl.dj_node and tbl.dj_node.type == NodeType.SOURCE
+                # If a table has a corresponding node, then we can use it as dependency.
+                # It must be either a Source node or some type of Materialized node.
+                # Even if there is no availability state for it right now, this qery may be built
+                # for future execution, so we don't need to check for availability state here.
+                if tbl.dj_node
             ],
         ),
         engine,

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -149,6 +149,13 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
             current_revision.version,  # type: ignore
             new_materialization.name,  # type: ignore
         )
+        # refresh existing materialization job
+        await schedule_materialization_jobs(
+            session,
+            node_revision_id=current_revision.id,
+            materialization_names=[new_materialization.name],
+            query_service_client=query_service_client,
+        )
         return JSONResponse(
             status_code=HTTPStatus.CREATED,
             content={

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -192,11 +192,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         Deactivates the specified node materialization
         """
         response = self.requests_session.delete(
-            "/materialization/",
-            params={
-                "node_name": node_name,
-                "materialization_name": materialization_name,
-            },
+            f"/materialization/{node_name}/{materialization_name}/",
         )
         if response.status_code not in (200, 201):  # pragma: no cover
             return MaterializationInfo(urls=[], output_tables=[])

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -332,11 +332,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         )
 
         mock_request.assert_called_with(
-            "/materialization/",
-            params={
-                "node_name": "default.hard_hat",
-                "materialization_name": "default",
-            },
+            "/materialization/default.hard_hat/default/",
         )
 
     def test_query_service_client_raising_error(self, mocker: MockerFixture) -> None:

--- a/datajunction-ui/Makefile
+++ b/datajunction-ui/Makefile
@@ -2,3 +2,8 @@ dev-release:
 	yarn version --prerelease --preid dev --no-git-tag-version
 	npm publish
 
+test:
+	yarn test --coverage --watchAll --runInBand
+
+lint:
+	npm run lint

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -166,7 +166,7 @@
       "global": {
         "statements": 89,
         "branches": 75,
-        "lines": 90,
+        "lines": 80,
         "functions": 85
       }
     }

--- a/datajunction-ui/src/app/components/NodeMaterializationDelete.jsx
+++ b/datajunction-ui/src/app/components/NodeMaterializationDelete.jsx
@@ -1,0 +1,80 @@
+import DJClientContext from '../providers/djclient';
+import * as React from 'react';
+import DeleteIcon from '../icons/DeleteIcon';
+import { Form, Formik } from 'formik';
+import { useContext } from 'react';
+import { displayMessageAfterSubmit } from '../../utils/form';
+
+export default function NodeMaterializationDelete({
+  nodeName,
+  materializationName,
+}) {
+  const [deleteButton, setDeleteButton] = React.useState(<DeleteIcon />);
+
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const deleteNode = async (values, { setStatus }) => {
+    if (
+      !window.confirm(
+        'Deleting materialization job ' +
+          values.materializationName +
+          '. Are you sure?',
+      )
+    ) {
+      return;
+    }
+    const { status, json } = await djClient.deleteMaterialization(
+      values.nodeName,
+      values.materializationName,
+    );
+    if (status === 200 || status === 201 || status === 204) {
+      window.location.reload();
+      setStatus({
+        success: (
+          <>
+            Successfully deleted materialization job:{' '}
+            {values.materializationName}
+          </>
+        ),
+      });
+      setDeleteButton(''); // hide the Delete button
+    } else {
+      setStatus({
+        failure: `${json.message}`,
+      });
+    }
+  };
+
+  const initialValues = {
+    nodeName: nodeName,
+    materializationName: materializationName,
+  };
+
+  return (
+    <div>
+      <Formik initialValues={initialValues} onSubmit={deleteNode}>
+        {function Render({ status, setFieldValue }) {
+          return (
+            <Form className="deleteNode">
+              {displayMessageAfterSubmit(status)}
+              {
+                <>
+                  <button
+                    type="submit"
+                    style={{
+                      marginLeft: 0,
+                      all: 'unset',
+                      color: '#005c72',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {deleteButton}
+                  </button>
+                </>
+              }
+            </Form>
+          );
+        }}
+      </Formik>
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/pages/NodePage/AddBackfillPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddBackfillPopover.jsx
@@ -88,7 +88,7 @@ export default function AddBackfillPopover({
           setPopoverAnchor(!popoverAnchor);
         }}
       >
-        <span className="add_button">+ Run Backfill</span>
+        <span className="add_button">+ Run</span>
       </button>
       <div
         className="fade modal-backdrop in"

--- a/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
@@ -51,6 +51,7 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
     );
     if (status === 200 || status === 201) {
       setStatus({ success: json.message });
+      window.location.reload();
     } else {
       setStatus({
         failure: `${json.message}`,

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -4,6 +4,7 @@ import AddMaterializationPopover from './AddMaterializationPopover';
 import * as React from 'react';
 import AddBackfillPopover from './AddBackfillPopover';
 import { labelize } from '../../../utils/form';
+import NodeMaterializationDelete from '../../components/NodeMaterializationDelete';
 
 const cronstrue = require('cronstrue');
 
@@ -48,7 +49,12 @@ export default function NodeMaterializationTab({ node, djClient }) {
                 .match(/[A-Z][a-z]+/g)
                 .join(' ')}
             </div>
-
+            <div className="td">
+              <NodeMaterializationDelete
+                nodeName={node.name}
+                materializationName={materialization.name}
+              />
+            </div>
             <div className="td">
               <span className={`badge cron`}>{materialization.schedule}</span>
               <div className={`cron-description`}>{cron(materialization)} </div>
@@ -93,8 +99,13 @@ export default function NodeMaterializationTab({ node, djClient }) {
                         className="partitionLink"
                         style={{ fontSize: 'revert' }}
                       >
-                        <a href={url} key={`url-${idx}`} className="">
-                          {idx === 0 ? 'scheduled' : 'adhoc'}
+                        <a
+                          href={url}
+                          key={`url-${idx}`}
+                          className=""
+                          target="blank"
+                        >
+                          {idx === 0 ? 'main' : 'backfill'}
                         </a>
                       </div>
                     </li>
@@ -111,7 +122,7 @@ export default function NodeMaterializationTab({ node, djClient }) {
                   <summary>
                     <span className="backfills_header">Backfills</span>{' '}
                   </summary>
-                  {materializations[0].strategy === 'incremental_time' ? (
+                  {materialization.strategy === 'incremental_time' ? (
                     <ul>
                       <li>
                         <AddBackfillPopover
@@ -163,7 +174,9 @@ export default function NodeMaterializationTab({ node, djClient }) {
                       ))}
                     </ul>
                   ) : (
-                    <></>
+                    <ul>
+                      <li>N/A</li>
+                    </ul>
                   )}
                 </details>
               </li>

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -12,7 +12,7 @@ export const DataJunctionAPI = {
   },
 
   logout: async function () {
-    await await fetch(`${DJ_URL}/logout/`, {
+    return await fetch(`${DJ_URL}/logout/`, {
       credentials: 'include',
       method: 'POST',
     });
@@ -809,6 +809,20 @@ export const DataJunctionAPI = {
             };
           }),
         ),
+        credentials: 'include',
+      },
+    );
+    return { status: response.status, json: await response.json() };
+  },
+  deleteMaterialization: async function (nodeName, materializationName) {
+    console.log('deleting materialization', nodeName, materializationName);
+    const response = await fetch(
+      `${DJ_URL}/nodes/${nodeName}/materializations?materialization_name=${materializationName}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
         credentials: 'include',
       },
     );


### PR DESCRIPTION
### Summary

Changes:
1. Added ability to delete materializations in the UI.
2. Adjusted the display of materialization urls and the backfill feature.

Fixed:
1. When materialization was re-created we missed to refresh the ETL jobs for it.
2. When we create the list upstream table dependencies we missed to include the DJ materialized tables .

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a
