### PR TITLE
change create_ methods into upsert_

### DIFF
--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -107,7 +107,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
     #
     # Nodes: SOURCE
     #
-    def create_source(  # pylint: disable=too-many-arguments
+    def upsert_source(  # pylint: disable=too-many-arguments
         self,
         name: str,
         catalog: str,
@@ -119,6 +119,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         primary_key: Optional[List[str]] = None,
         tags: Optional[List[Tag]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+        if_exists: Optional[str] = "update",
     ) -> "Source":
         """
         Creates a new Source node with given parameters.
@@ -135,7 +136,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
             table=table,
             columns=columns,
         )
-        self._create_node(node=new_node, mode=mode)
+        new_node.save(if_exists=if_exists)
         new_node.refresh()
         return new_node
 

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -278,7 +278,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         Verifies that creating nodes works.
         """
         # create it
-        account_type_table = client.create_source(
+        account_type_table = client.upsert_source(
             name="default.account_type_table",
             description="A source table for account type data",
             display_name="Default: Account Type Table",
@@ -302,10 +302,10 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
 
     def test_create_nodes(self, client):  # pylint: disable=unused-argument
         """
-        Verifies that creating nodes works.
+        Verifies that upserting nodes works.
         """
         # source nodes
-        account_type_table = client.create_source(
+        account_type_table = client.upsert_source(
             name="default.account_type_table",
             description="A source table for account type data",
             display_name="Default: Account Type Table",
@@ -323,7 +323,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert account_type_table.name == "default.account_type_table"
         assert "default.account_type_table" in client.namespace("default").sources()
 
-        payment_type_table = client.create_source(
+        payment_type_table = client.upsert_source(
             name="default.payment_type_table",
             description="A source table for payment type data",
             display_name="Default: Payment Type Table",
@@ -340,7 +340,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert payment_type_table.name == "default.payment_type_table"
         assert "default.payment_type_table" in client.namespace("default").sources()
 
-        revenue = client.create_source(
+        revenue = client.upsert_source(
             name="default.revenue",
             description="Record of payments",
             display_name="Default: Payment Records",

--- a/datajunction-clients/python/tests/test_integration.py
+++ b/datajunction-clients/python/tests/test_integration.py
@@ -30,7 +30,7 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
     assert matching_namespace
 
     # Create a sources
-    dj.create_source(
+    dj.upsert_source(
         name=f"{namespace}.repair_orders",
         description="Repair orders",
         catalog="warehouse",
@@ -47,7 +47,7 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
         ],
     )
 
-    repair_order_details = dj.create_source(
+    repair_order_details = dj.upsert_source(
         name=f"{namespace}.repair_order_details",
         description="Details on repair orders",
         display_name="Default: Repair Order Details",
@@ -111,7 +111,7 @@ def test_integration():  # pylint: disable=too-many-statements,too-many-locals,l
     dj.transform(f"{namespace}.repair_orders_w_dispatchers")
 
     # Create a source and dimension nodes
-    dj.create_source(
+    dj.upsert_source(
         name=f"{namespace}.dispatchers",
         description="Different third party dispatcher companies that coordinate repairs",
         catalog="warehouse",

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -39,7 +39,7 @@ async def test_generated_python_client_code_new_source(client_with_roads: AsyncC
         response.json()
         == """dj = DJBuilder(DJ_URL)
 
-repair_order_details = dj.create_source(
+repair_order_details = dj.upsert_source(
     description="Details on repair orders",
     display_name="default.roads.repair_order_details",
     mode="published",


### PR DESCRIPTION
### Summary

This PR changes the `create_somenode` methods into `upsert_somenode`, which create if a node doesn't exist and update if it does exist.

This is useful because users just want to "make the nodes this way" without having to first check for existence. An example use case is writing a notebook with a bunch of upsert, which would be reproducible and idempotent.

The commit so far only changes `create_source` into `upsert_source`. If the approach makes sense I'll make the same changes to other nodes types & and add tests.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
