### PR TITLE
Don't use materialized tables in their own materialization job.

### DIFF
--- a/datajunction-clients/python/Makefile
+++ b/datajunction-clients/python/Makefile
@@ -5,7 +5,7 @@ lint:
 	make check
 
 test:
-	pdm run pytest -n auto --cov=datajunction --cov-report=html -vv tests/ --doctest-modules datajunction --without-integration --without-slow-integration ${PYTEST_ARGS}
+	pdm run pytest -n auto --cov=datajunction -vv tests/ --doctest-modules datajunction --without-integration --without-slow-integration ${PYTEST_ARGS}
 
 dev-release:
 	hatch version dev

--- a/datajunction-server/Makefile
+++ b/datajunction-server/Makefile
@@ -18,7 +18,7 @@ docker-run:
 	docker compose up
 
 test:
-	pdm run pytest -n auto --cov=datajunction_server --cov-report=html -vv tests/ --doctest-modules datajunction_server --without-integration --without-slow-integration ${PYTEST_ARGS}
+	pdm run pytest -n auto --cov=datajunction_server -vv tests/ --doctest-modules datajunction_server --without-integration --without-slow-integration ${PYTEST_ARGS}
 
 integration:
 	pdm run pytest --cov=dj -vv tests/ --doctest-modules datajunction_server --with-integration --with-slow-integration

--- a/datajunction-server/datajunction_server/database/availabilitystate.py
+++ b/datajunction-server/datajunction_server/database/availabilitystate.py
@@ -70,7 +70,8 @@ class AvailabilityState(Base):  # pylint: disable=too-few-public-methods
         """
         Determine whether an availability state is useable given criteria
         """
-        # Criteria to determine if an availability state should be used needs to be added
+        # TODO: we should evaluate this availability state against the criteria. # pylint: disable=fixme
+        #       Remember that VTTS can be also evaluated at runtime dependency.
         return True
 
 

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -7,7 +7,11 @@ from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import build_sql_for_multiple_metrics
-from datajunction_server.construction.build import build_node, get_measures_query
+from datajunction_server.construction.build import (
+    build_node,
+    get_default_criteria,
+    get_measures_query,
+)
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import NodeRevision
 from datajunction_server.errors import DJException, DJInvalidInputException
@@ -183,11 +187,15 @@ async def build_non_cube_materialization_config(
     """
     Build materialization config for non-cube nodes (transforms and dimensions).
     """
+    build_criteria = get_default_criteria(
+        node=current_revision,
+    )
     materialization_ast = await build_node(
         session=session,
         node=current_revision,
         dimensions=[],
         orderby=[],
+        build_criteria=build_criteria,
     )
     generic_config = GenericMaterializationConfig(
         lookback_window=upsert.config.lookback_window,

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -45,7 +45,7 @@ class BuildCriteria:
 
     timestamp: Optional[UTCDatetime] = None
     dialect: Dialect = Dialect.SPARK
-    for_materialization: bool = False
+    target_node_name: Optional[str] = None
 
 
 class NodeMode(StrEnum):

--- a/datajunction-server/tests/construction/build_test.py
+++ b/datajunction-server/tests/construction/build_test.py
@@ -7,11 +7,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import datajunction_server.sql.parsing.types as ct
-from datajunction_server.construction.build import build_node
+from datajunction_server.construction.build import build_node, get_default_criteria
 from datajunction_server.database.attributetype import AttributeType, ColumnAttribute
 from datajunction_server.database.column import Column
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.errors import DJException
+from datajunction_server.models.engine import Dialect
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.naming import amenable_name
 from datajunction_server.sql.parsing.backends.antlr4 import parse
@@ -278,3 +279,10 @@ async def test_build_node_with_unnamed_column(construction_session: AsyncSession
 def test_amenable_name():
     """testing for making an amenable name"""
     assert amenable_name("hello.名") == "hello_DOT__UNK"
+
+
+def test_get_default_criteria():
+    """Test getting default criteria for a node revision"""
+    result = get_default_criteria(node=NodeRevision(type=NodeType.TRANSFORM))
+    assert result.dialect == Dialect.SPARK
+    assert result.target_node_name is None

--- a/datajunction-ui/src/app/pages/Root/index.tsx
+++ b/datajunction-ui/src/app/pages/Root/index.tsx
@@ -70,7 +70,9 @@ export function Root() {
         ) : (
           <span className="menu-link">
             <span className="menu-title">
-              <a onClick={handleLogout}>Logout</a>
+              <a href={'/'} onClick={handleLogout}>
+                Logout
+              </a>
             </span>
           </span>
         )}


### PR DESCRIPTION
### Summary

Main thing here is to use the `for_materialization` flag to indicate that we want to build a node SQL for the purposes of materialization jobs so we don't really want to use any pre-materialized tables. This is potentially risky because it means that we won't use any materialized parent nodes and will go straight the "sources". But this is only for `build_non_cube_materialization_config` so the risk is lower. We can optimize that aspect later.

Minor stuff:
1. Deleted `--cov-report=html` from test commands cause we didn't see the coverage automatically at the end of the run. Now we do.
2. Fixed a lint warning on the Logout button.

### Test Plan

Generated a Spark job for a node and made sure that the full query goes into the workflow even when availability state was present.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

nah
