### PR TITLE
add update functionality to create_ methods

### DIFF
--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -297,8 +297,20 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert "default.account_type_table" in client.namespace("default").sources()
 
         # update it
-        account_type_table = client.source(node_name="default.account_type_table")
-        account_type_table.save(mode=NodeMode.PUBLISHED)
+        # ... should fail without changing the default update_if_exists = False
+        with pytest.raises(DJClientException):
+            account_type_table = client.create_source(
+                name="default.account_type_table",
+                description="New description",
+            )
+
+        # ... should work by setting update_if_exists = True
+        account_type_table = client.create_source(
+            name="default.account_type_table",
+            description="new description",
+            update_if_exists=True,
+        )
+        assert account_type_table.description == "new description"
 
     def test_create_nodes(self, client):  # pylint: disable=unused-argument
         """


### PR DESCRIPTION
### Summary

Add the ability to `update_if_exists` to `create_X` methods

### Questions

It seems that a Source node can't update its catalog, schema, or table. [code](https://github.com/DataJunction/dj/blob/897787fcf0cfde1a8998ce72cc9b9fd38963d983/datajunction-server/datajunction_server/internal/nodes.py#L1099). If that's true then there's the client Source's [UpdateNode](https://github.com/DataJunction/dj/blob/9a8c1263ce965b27254b666d490a80eedfd68d66/datajunction-clients/python/datajunction/nodes.py#L312) is incorrect

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
