### PR TITLE
Node Query Validation / Testing

### DIFF
--- a/datajunction-server/alembic/versions/2024_05_21_0012-57fc93ef6947_add_query_id_to_queryrequest.py
+++ b/datajunction-server/alembic/versions/2024_05_21_0012-57fc93ef6947_add_query_id_to_queryrequest.py
@@ -1,0 +1,28 @@
+"""Add query_id to queryrequest
+
+Revision ID: 57fc93ef6947
+Revises: 9b1227ff17f4
+Create Date: 2024-05-21 00:12:11.303914+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "57fc93ef6947"
+down_revision = "9b1227ff17f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("queryrequest", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("query_id", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("queryrequest", schema=None) as batch_op:
+        batch_op.drop_column("query_id")

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -15,7 +15,7 @@ from datajunction_server.api.helpers import (
     build_sql_for_multiple_metrics,
     query_event_stream,
 )
-from datajunction_server.api.sql import get_sql, get_node_sql
+from datajunction_server.api.sql import get_node_sql
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.node import Node, NodeRevision
@@ -185,7 +185,7 @@ async def get_data(  # pylint: disable=too-many-locals
     """
     Gets data for a node
     """
-    query = await get_sql(
+    query, query_request = await get_node_sql(
         node_name,
         dimensions,
         filters,
@@ -225,7 +225,7 @@ async def get_data(  # pylint: disable=too-many-locals
 
     # Inject column info if there are results
     if result.results.__root__:  # pragma: no cover
-        result.results.__root__[0].columns = query.columns
+        result.results.__root__[0].columns = query.columns  # type: ignore
     return result
 
 
@@ -252,7 +252,7 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
     ),
 ) -> QueryWithResults:
     """
-    Return data for a set of metrics with dimensions and filters using server side events
+    Return data for a node using server side events
     """
     query, query_request = await get_node_sql(
         node_name,
@@ -266,7 +266,7 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
         current_user=current_user,
         validate_access=validate_access,
     )
-    if query_request.query_id:
+    if query_request and query_request.query_id:
         return EventSourceResponse(
             query_event_stream(
                 query=QueryWithResults(

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -3,7 +3,7 @@
 SQL related APIs.
 """
 import logging
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from fastapi import Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -108,12 +108,7 @@ async def get_measures_sql_for_cube(
     return measures_query
 
 
-@router.get(
-    "/sql/{node_name}/",
-    response_model=TranslatedSQL,
-    name="Get SQL For A Node",
-)
-async def get_sql(  # pylint: disable=too-many-locals
+async def get_node_sql(
     node_name: str,
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
@@ -123,11 +118,9 @@ async def get_sql(  # pylint: disable=too-many-locals
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
-    validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
-        validate_access,
-    ),
-) -> TranslatedSQL:
+    current_user: Optional[User],
+    validate_access: access.ValidateAccessFn,
+) -> Tuple[TranslatedSQL, QueryRequest]:
     """
     Return SQL for a node.
     """
@@ -160,7 +153,7 @@ async def get_sql(  # pylint: disable=too-many-locals
             sql=query_request.query,
             columns=query_request.columns,
             dialect=engine.dialect if engine else None,
-        )
+        ), query_request
 
     query_ast = await get_query(
         session=session,
@@ -194,7 +187,38 @@ async def get_sql(  # pylint: disable=too-many-locals
         sql=query,
         columns=columns,
         dialect=engine.dialect if engine else None,
+    ), query_request
+
+
+@router.get(
+    "/sql/{node_name}/",
+    response_model=TranslatedSQL,
+    name="Get SQL For A Node",
+)
+async def get_sql(  # pylint: disable=too-many-locals
+    node_name: str,
+    dimensions: List[str] = Query([]),
+    filters: List[str] = Query([]),
+    orderby: List[str] = Query([]),
+    limit: Optional[int] = None,
+    *,
+    session: AsyncSession = Depends(get_session),
+    engine_name: Optional[str] = None,
+    engine_version: Optional[str] = None,
+    current_user: Optional[User] = Depends(get_current_user),
+    validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
+        validate_access,
+    ),
+) -> TranslatedSQL:
+    """
+    Return SQL for a node.
+    """
+    translated_sql, query_request = await get_node_sql(
+        node_name, dimensions, filters, orderby, limit,
+        session=session, engine_name=engine_name, engine_version=engine_version, current_user=current_user,
+        validate_access=validate_access,
     )
+    return translated_sql
 
 
 @router.get("/sql/", response_model=TranslatedSQL, name="Get SQL For Metrics")

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from functools import partial
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional
+from uuid import UUID, uuid4
 
 from sqlalchemy import (
     JSON,
@@ -13,6 +14,7 @@ from sqlalchemy import (
     and_,
     select,
     text,
+    ForeignKey,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,7 +32,8 @@ from datajunction_server.sql.dag import (
 )
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
-from datajunction_server.typing import UTCDatetime
+from datajunction_server.sql.parsing.types import UUIDType
+from datajunction_server.typing import UTCDatetime, QueryState
 
 
 class QueryBuildType(StrEnum):
@@ -159,6 +162,8 @@ class QueryRequest(Base):  # type: ignore  # pylint: disable=too-few-public-meth
         DateTime(timezone=True),
         default=partial(datetime.now, timezone.utc),
     )
+    # External identifier for the query
+    query_id: Mapped[Optional[str]]
 
     @classmethod
     async def get_query_request(

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -3,7 +3,6 @@ from datetime import datetime, timezone
 from functools import partial
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional
-from uuid import UUID, uuid4
 
 from sqlalchemy import (
     JSON,
@@ -14,7 +13,6 @@ from sqlalchemy import (
     and_,
     select,
     text,
-    ForeignKey,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,8 +30,7 @@ from datajunction_server.sql.dag import (
 )
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
-from datajunction_server.sql.parsing.types import UUIDType
-from datajunction_server.typing import UTCDatetime, QueryState
+from datajunction_server.typing import UTCDatetime
 
 
 class QueryBuildType(StrEnum):
@@ -225,7 +222,7 @@ class QueryRequest(Base):  # type: ignore  # pylint: disable=too-few-public-meth
         query: str,
         columns: List[Dict[str, Any]],
         other_args: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> "QueryRequest":
         """
         Retrieves saved query for a node SQL request
         """
@@ -271,6 +268,7 @@ class QueryRequest(Base):  # type: ignore  # pylint: disable=too-few-public-meth
             )
             session.add(query_request)
             await session.commit()
+        return query_request
 
     @classmethod
     async def to_versioned_query_request(  # pylint: disable=too-many-locals

--- a/datajunction-ui/src/app/components/QueryInfo.jsx
+++ b/datajunction-ui/src/app/components/QueryInfo.jsx
@@ -1,3 +1,7 @@
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { solarizedDark } from 'react-syntax-highlighter/src/styles/hljs';
+import React from 'react';
+
 export default function QueryInfo({
   id,
   state,
@@ -8,6 +12,7 @@ export default function QueryInfo({
   output_table,
   scheduled,
   started,
+  finished,
   numRows,
   isList = false,
 }) {
@@ -78,35 +83,64 @@ export default function QueryInfo({
     <div className="rightbottom">
       <ul style={{ padding: '20px' }}>
         <li className={'query-info'}>
-          <label>Query ID:</label>{' '}
-          <span className="rounded-pill badge bg-secondary-soft">{id}</span>
+          <label>Query ID</label>{' '}
+          <span className="tag_value rounded-pill badge">
+            {links?.length ? (
+              <a
+                href={links[links.length - 1]}
+                target={'_blank'}
+                rel="noreferrer"
+              >
+                {id}
+              </a>
+            ) : (
+              id
+            )}
+          </span>
         </li>
         <li className={'query-info'}>
-          <label>Engine:</label>{' '}
-          <span className="rounded-pill badge bg-secondary-soft">
+          <label>State</label>
+          <span className="tag_value rounded-pill badge">{state}</span>
+        </li>
+        <li className={'query-info'}>
+          <label>Engine</label>{' '}
+          <span className="tag_value rounded-pill badge">
             {engine_name}
             {' - '}
             {engine_version}
           </span>
         </li>
         <li className={'query-info'}>
-          <label>State:</label> {state}
+          <label>Scheduled</label> {scheduled}
         </li>
         <li className={'query-info'}>
-          <label>Scheduled:</label> {scheduled}
+          <label>Started</label> {started}
         </li>
         <li className={'query-info'}>
-          <label>Started:</label> {started}
+          <label>Finished</label> {finished}
         </li>
         <li className={'query-info'}>
-          <label>Errors:</label>{' '}
+          <label>Logs</label>{' '}
           {errors?.length ? (
-            errors.map((e, idx) => (
-              <p key={`error-${idx}`}>
-                <span className="rounded-pill badge bg-secondary-error">
-                  {e}
-                </span>
-              </p>
+            errors.map(error => (
+              <div
+                style={{
+                  height: '800px',
+                  width: '80%',
+                  overflow: 'scroll',
+                  borderRadius: '0',
+                  border: '1px solid #ccc',
+                }}
+                className="queryrunner-query"
+              >
+                <SyntaxHighlighter
+                  language="javascript"
+                  style={solarizedDark}
+                  wrapLines={true}
+                >
+                  {error}
+                </SyntaxHighlighter>
+              </div>
             ))
           ) : (
             <></>

--- a/datajunction-ui/src/app/components/QueryInfo.jsx
+++ b/datajunction-ui/src/app/components/QueryInfo.jsx
@@ -9,8 +9,9 @@ export default function QueryInfo({
   scheduled,
   started,
   numRows,
+  isList = false,
 }) {
-  return (
+  return isList === false ? (
     <div className="table-responsive">
       <table className="card-inner-table table">
         <thead className="fs-7 fw-bold text-gray-400 border-bottom-0">
@@ -72,6 +73,66 @@ export default function QueryInfo({
           </tr>
         </tbody>
       </table>
+    </div>
+  ) : (
+    <div className="rightbottom">
+      <ul style={{ padding: '20px' }}>
+        <li className={'query-info'}>
+          <label>Query ID:</label>{' '}
+          <span className="rounded-pill badge bg-secondary-soft">{id}</span>
+        </li>
+        <li className={'query-info'}>
+          <label>Engine:</label>{' '}
+          <span className="rounded-pill badge bg-secondary-soft">
+            {engine_name}
+            {' - '}
+            {engine_version}
+          </span>
+        </li>
+        <li className={'query-info'}>
+          <label>State:</label> {state}
+        </li>
+        <li className={'query-info'}>
+          <label>Scheduled:</label> {scheduled}
+        </li>
+        <li className={'query-info'}>
+          <label>Started:</label> {started}
+        </li>
+        <li className={'query-info'}>
+          <label>Errors:</label>{' '}
+          {errors?.length ? (
+            errors.map((e, idx) => (
+              <p key={`error-${idx}`}>
+                <span className="rounded-pill badge bg-secondary-error">
+                  {e}
+                </span>
+              </p>
+            ))
+          ) : (
+            <></>
+          )}
+        </li>
+        <li className={'query-info'}>
+          <label>Links:</label>{' '}
+          {links?.length ? (
+            links.map((link, idx) => (
+              <p key={idx}>
+                <a href={link} target="_blank" rel="noreferrer">
+                  {link}
+                </a>
+              </p>
+            ))
+          ) : (
+            <></>
+          )}
+        </li>
+        <li className={'query-info'}>
+          <label>Output Table:</label> {output_table}
+        </li>
+        <li className={'query-info'}>
+          <label>Rows:</label> {numRows}
+        </li>
+      </ul>
     </div>
   );
 }

--- a/datajunction-ui/src/app/icons/LoadingIcon.jsx
+++ b/datajunction-ui/src/app/icons/LoadingIcon.jsx
@@ -3,7 +3,7 @@ import '../../styles/loading.css';
 export default function LoadingIcon() {
   return (
     <center>
-      <div class="lds-ring">
+      <div className="lds-ring">
         <div></div>
         <div></div>
         <div></div>

--- a/datajunction-ui/src/app/pages/NodePage/DimensionFilter.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/DimensionFilter.jsx
@@ -1,0 +1,101 @@
+import { useContext, useEffect, useState } from 'react';
+import * as React from 'react';
+import DJClientContext from '../../providers/djclient';
+import CreatableSelect from 'react-select/creatable';
+import { Field } from 'formik';
+import EditIcon from '../../icons/EditIcon';
+
+export default function DimensionFilter({ dimension, onChange }) {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const [dimensionValues, setDimensionValues] = useState([]);
+  const [selected, setSelected] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const dimensionNode = await djClient.node(dimension.metadata.node_name);
+      if (dimensionNode && dimensionNode.type === 'dimension') {
+        const primaryKey =
+          dimensionNode.name +
+          '.' +
+          dimensionNode.columns
+            .filter(col =>
+              col.attributes.some(
+                attr => attr.attribute_type.name === 'primary_key',
+              ),
+            )
+            .map(col => col.name);
+        const label =
+          dimensionNode.name +
+          '.' +
+          dimensionNode.columns
+            .filter(col =>
+              col.attributes.some(attr => attr.attribute_type.name === 'label'),
+            )
+            .map(col => col.name);
+        const data = { results: [] }; //await djClient.nodeData(dimension.metadata.node_name);
+        if (dimensionNode && data.results && data.results.length > 0) {
+          const columnNames = data.results[0].columns.map(
+            column => column.semantic_entity,
+          );
+          const dimValues = data.results[0].rows.map(row => {
+            const rowData = { value: '', label: '' };
+            row.forEach((value, index) => {
+              if (columnNames[index] === primaryKey) {
+                rowData.value = value;
+                if (rowData.label === '') {
+                  rowData.label = value;
+                }
+              } else if (columnNames[index] === label) {
+                rowData.label = value;
+              }
+            });
+            return rowData;
+          });
+          console.log('dimensionValues', dimValues);
+          setDimensionValues(dimValues);
+        }
+      }
+    };
+    fetchData().catch(console.error);
+  }, [dimension.metadata.node_name, djClient]);
+
+  return (
+    <div>
+      {dimension.label.split('[').slice(0)[0]} (
+      {
+        <a href={`/nodes/${dimension.metadata.node_name}`}>
+          {dimension.metadata.node_display_name}
+        </a>
+      }
+      ){/*<code className="DimensionAttribute">{dimension.value}</code>*/}
+      {/*{*/}
+      {/*  <div className="tooltip">*/}
+      {/*    <EditIcon />*/}
+      {/*    <span className="tooltiptext">*/}
+      {/*      <code className="DimensionAttribute">*/}
+      {/*      {dimension.value}*/}
+      {/*      </code>*/}
+      {/*      comes from the dimension link on{' '}*/}
+      {/*      {dimension.metadata.path.map(path => {*/}
+      {/*        return <a href={`/nodes/${path}`}>{path}</a>;*/}
+      {/*      })}*/}
+      {/*      /!*{console.log('metadata', dimension.metadata)}*!/*/}
+      {/*    </span>*/}
+      {/*  </div>*/}
+      {/*}*/}
+      <CreatableSelect
+        name="dimensions"
+        options={dimensionValues}
+        isMulti
+        isClearable
+        onChange={event => {
+          setSelected(event);
+          onChange({
+            dimension: dimension.value,
+            values: event,
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/pages/NodePage/NodeSQLTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeSQLTab.jsx
@@ -1,82 +1,357 @@
-import { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Select from 'react-select';
-import DJClientContext from '../../providers/djclient';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import { labelize } from '../../../utils/form';
+import { Form, Formik } from 'formik';
+import DimensionFilter from './DimensionFilter';
+import QueryInfo from '../../components/QueryInfo';
+import LoadingIcon from '../../icons/LoadingIcon';
 
-const NodeSQLTab = djNode => {
-  const djClient = useContext(DJClientContext).DataJunctionAPI;
+export default function NodeSQLTab({ node, djClient }) {
   const [query, setQuery] = useState('');
+  const [lookup, setLookup] = useState([]);
+
+  const [dimensions, setDimensions] = useState([]);
+  const [selectedDimensions, setSelectedDimensions] = useState([]);
+  const [selectedFilters, setSelectedFilters] = useState({});
 
   const [selection, setSelection] = useState({
     dimensions: [],
     filters: [],
   });
 
+  const [queryInfo, setQueryInfo] = useState({});
+  const [data, setData] = useState(null);
+  const [displayedRows, setDisplayedRows] = useState(<></>);
+
+  // Set number of rows to display
   useEffect(() => {
+    if (data) {
+      setDisplayedRows(
+        data[0]?.rows.slice(0, 100).map((rowData, index) => (
+          <tr key={`data-row:${index}`}>
+            {rowData.map(rowValue => (
+              <td key={rowValue}>{rowValue}</td>
+            ))}
+          </tr>
+        )),
+      );
+    }
+  }, [data]);
+
+  // Get data for the current selection of metrics and dimensions
+  const getData = () => {
+    // setLoadingData(true);
+    setQueryInfo({});
     const fetchData = async () => {
-      const query = await djClient.sql(djNode.djNode.name, selection);
-      setQuery(query.sql);
+      const response = await djClient.nodeData(node.name, selection);
+      setQueryInfo(response);
+      console.log('respon!!!', response);
+      if (response.results) {
+        // setLoadingData(false);
+        setData(response.results);
+        response.numRows = response.results?.length
+          ? response.results[0].rows.length
+          : [];
+        // setViewData(true);
+        // setShowNumRows(DEFAULT_NUM_ROWS);
+      }
     };
     fetchData().catch(console.error);
-  }, [djClient, djNode.djNode.name, selection]);
-  const dimensionsList = djNode.djNode.dimensions
-    ? djNode.djNode.dimensions.map(dim => ({
-        value: dim.name,
-        label: dim.name + ` (${dim.type})`,
-      }))
-    : [''];
+  };
 
-  const handleSubmit = event => {
-    event.preventDefault();
+  useEffect(() => {
+    const fetchData = async () => {
+      if (node) {
+        const dimensions = await djClient.nodeDimensions(node.name);
+
+        const lookup = {};
+        dimensions.forEach(dimension => {
+          lookup[dimension.name] = dimension;
+        });
+        setLookup(lookup);
+
+        const grouped = Object.entries(
+          dimensions.reduce((group, dimension) => {
+            group[dimension.node_name + dimension.path] =
+              group[dimension.node_name + dimension.path] ?? [];
+            group[dimension.node_name + dimension.path].push(dimension);
+            return group;
+          }, {}),
+        );
+        setDimensions(grouped);
+
+        console.log('selection', selection);
+        const query = await djClient.sql(node.name, selection);
+        setQuery(query.sql);
+      }
+    };
+    fetchData().catch(console.error);
+  }, [djClient, node, selection]);
+
+  const dimensionsList = dimensions.flatMap(grouping => {
+    const dimensionsInGroup = grouping[1];
+    return dimensionsInGroup
+      .filter(dim => dim.is_primary_key === true)
+      .map(dim => {
+        return {
+          value: dim.name,
+          label: (
+            <span>
+              {labelize(dim.name.split('.').slice(-1)[0])}{' '}
+              <small>{dim.name}</small>
+            </span>
+          ),
+        };
+      });
+  });
+
+  const runQuery = async (values, setStatus) => {
+    const response = await djClient.nodeData(node.name, selection);
+    setQueryInfo(response);
+    console.log('respon!!!', response);
+    if (response.results) {
+      // setLoadingData(false);
+      setData(response.results);
+      response.numRows = response.results?.length
+        ? response.results[0].rows.length
+        : [];
+      // setViewData(true);
+      // setShowNumRows(DEFAULT_NUM_ROWS);
+    }
+  };
+
+  const handleSubmit = async (values, { setSubmitting, setStatus }) => {
+    await runQuery(values, setStatus).then(_ => {
+      window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+      setSubmitting(false);
+    });
   };
 
   const handleChange = event => {
-    setSelection({ filters: [], dimensions: event.map(dim => dim.value) });
+    // handle filters change
+    const updatedFilters = selectedFilters;
+    if (event.dimension in updatedFilters) {
+      updatedFilters[event.dimension].operator = event.operator;
+      updatedFilters[event.dimension].values = event.values;
+    } else {
+      updatedFilters[event.dimension] = {
+        operator: event.operator,
+        values: event.values,
+      };
+    }
+    setSelectedFilters(updatedFilters);
+    const updatedDimensions = selection.dimensions.concat([event.dimension]);
+    setSelection({
+      filters: Object.entries(updatedFilters).map(obj =>
+        obj[1].values
+          ? `${obj[0]} IN (${obj[1].values
+              .map(val =>
+                ['int', 'bigint', 'float', 'double', 'long'].includes(
+                  lookup[obj[0]].type,
+                )
+                  ? val.value
+                  : "'" + val.value + "'",
+              )
+              .join(', ')})`
+          : '',
+      ),
+      dimensions: updatedDimensions,
+    });
+  };
+
+  const filters = dimensions.map(grouping => {
+    const dimensionsInGroup = grouping[1];
+    const dimensionGroupOptions = dimensionsInGroup
+      .filter(dim => dim.is_primary_key === true)
+      .map(dim => {
+        return {
+          value: dim.name,
+          label: labelize(dim.name.split('.').slice(-1)[0]),
+          metadata: dim,
+        };
+      });
+    return (
+      <>
+        <div className="dimensionsList">
+          {dimensionGroupOptions.map(dimension => {
+            return (
+              <DimensionFilter dimension={dimension} onChange={handleChange} />
+            );
+          })}
+        </div>
+      </>
+    );
+  });
+
+  const initialValues = {};
+
+  const [state, setState] = useState({
+    selectedTab: 'results',
+  });
+
+  const switchTab = (event, tabName) => {
+    setState({ selectedTab: tabName });
   };
 
   return (
-    <form
-      id="retrieve-sql"
-      name="retrieve-sql"
-      onSubmit={handleSubmit.bind(this)}
+    // <form
+    //   id="retrieve-sql"
+    //   name="retrieve-sql"
+    //   onSubmit={handleSubmit.bind(this)}
+    // >
+
+    <Formik
+      initialValues={initialValues}
+      // validate={validator}
+      onSubmit={handleSubmit}
     >
-      <div>
-        <h4>Group By</h4>
-        <Select
-          name="dimensions"
-          options={dimensionsList}
-          isMulti
-          isClearable
-          onChange={handleChange}
-        />
-        {/*<h4>Filters</h4>*/}
-        {/*<Select*/}
-        {/*  name="filter_name"*/}
-        {/*  options={dimensionsList}*/}
-        {/*  className="filters_attribute"*/}
-        {/*/>*/}
-        {/*<Select*/}
-        {/*  name="filter_operator"*/}
-        {/*  options={options}*/}
-        {/*  className="filters_attribute"*/}
-        {/*/>*/}
-        {/*<textarea name="filter_value" className="filters_attribute" />*/}
+      {function Render({ isSubmitting, status, setFieldValue }) {
+        return (
+          <Form>
+            {/*<h2 style={{ display: 'inline-flex', paddingRight: '20px' }}>*/}
+            {/*  Test Query*/}
+            {/*</h2>*/}
 
-        <div
-          style={{
-            width: window.innerWidth * 0.8,
-            marginTop: '2rem',
-          }}
-        >
-          <h6 className="mb-0 w-100">Query</h6>
-          <SyntaxHighlighter language="sql" style={foundation}>
-            {query}
-          </SyntaxHighlighter>
-        </div>
-      </div>
-    </form>
+            {/*<button*/}
+            {/*  type="submit"*/}
+            {/*  disabled={isSubmitting}*/}
+            {/*  className="button-3 execute-button"*/}
+            {/*>*/}
+            {/*  {isSubmitting ? <LoadingIcon /> : 'ⓘ Explain'}*/}
+            {/*</button>*/}
+            <div className={'queryrunner'}>
+              <div className="queryrunner-filters left">
+                {node?.type === 'metric' ? (
+                  <>
+                    <span>
+                      <label>Group By</label>
+                    </span>
+                    <Select
+                      name="dimensions"
+                      options={dimensionsList}
+                      isMulti
+                      isClearable
+                      onChange={handleChange}
+                    />
+                    <br />
+                  </>
+                ) : null}
+                <span>
+                  <label>Add Filters</label>
+                </span>
+                {filters}
+              </div>
+              <div className={'righttop'}>
+                {/*<h6 className="mb-0 w-100">Query</h6>*/}
+                <label>Generated Query</label>
+                <div
+                  style={{
+                    height: '200px',
+                    width: '80%',
+                    overflow: 'scroll',
+                    borderRadius: '0',
+                    border: '1px solid #ccc',
+                  }}
+                  className="queryrunner-query"
+                >
+                  <SyntaxHighlighter language="sql" style={foundation}>
+                    {query}
+                  </SyntaxHighlighter>
+                </div>
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="button-3 execute-button"
+                  style={{ marginTop: '1rem' }}
+                >
+                  {isSubmitting ? <LoadingIcon /> : '► Run'}
+                </button>
+              </div>
+              <div
+                style={{
+                  width: window.innerWidth * 0.8,
+                  marginTop: '1rem',
+                  marginLeft: '0.5rem',
+                  height: 'calc(70% - 5.5px)',
+                }}
+                className={'rightbottom'}
+              >
+                <div
+                  className={'align-items-center row'}
+                  style={{
+                    borderBottom: '1px solid #dddddd',
+                    width: '86%',
+                  }}
+                >
+                  <div
+                    className={
+                      'tab-item' +
+                      (state.selectedTab === 'results' ? ' active' : '')
+                    }
+                    onClick={ev => switchTab(ev, 'results')}
+                  >
+                    Results
+                  </div>
+                  <div
+                    className={
+                      'tab-item' +
+                      (state.selectedTab === 'info' ? ' active' : '')
+                    }
+                    onClick={ev => switchTab(ev, 'info')}
+                  >
+                    Info
+                  </div>
+                </div>
+                {state.selectedTab === 'info' ? (
+                  <div>
+                    {queryInfo && queryInfo.id ? (
+                      <QueryInfo {...queryInfo} isList={true} />
+                    ) : (
+                      <></>
+                    )}
+                  </div>
+                ) : null}
+                {state.selectedTab === 'results' ? (
+                  <div>
+                    {data ? (
+                      <div
+                        className="table-responsive"
+                        style={{
+                          gridGap: '0',
+                          width: '86%',
+                          padding: '0',
+                          maxHeight: '50%',
+                        }}
+                      >
+                        <table
+                          style={{ marginTop: '0 !important' }}
+                          className="table"
+                        >
+                          <thead className="fs-7 fw-bold text-gray-400 border-bottom-0">
+                            <tr>
+                              {data[0]?.columns.map(columnName => (
+                                <th key={columnName.name}>
+                                  {columnName.column}
+                                </th>
+                              ))}
+                            </tr>
+                          </thead>
+                          <tbody>{displayedRows}</tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <></>
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            {/*</form>*/}
+          </Form>
+        );
+      }}
+    </Formik>
   );
-};
-
-export default NodeSQLTab;
+}

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/DimensionFilter.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/DimensionFilter.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DJClientContext from '../../../providers/djclient';
+import DimensionFilter from '../DimensionFilter';
+
+// Mock DJClientContext
+const mockDJClient = {
+  DataJunctionAPI: {
+    node: jest.fn(),
+    nodeData: jest.fn(),
+  },
+};
+
+const mockDimension = {
+  label: 'Dimension Label [Test]',
+  value: 'dimension_value',
+  metadata: {
+    node_name: 'test_node',
+    node_display_name: 'Test Node',
+  },
+};
+
+const getByTextStartsWith = (container, text) => {
+  return Array.from(container.querySelectorAll('*')).find(element => {
+    return element.textContent.trim().startsWith(text);
+  });
+};
+
+describe('DimensionFilter', () => {
+  it('fetches dimension data and renders correctly', async () => {
+    // Mock node response
+    const mockNodeResponse = {
+      type: 'dimension',
+      name: 'test_node',
+      columns: [
+        {
+          name: 'id',
+          attributes: [{ attribute_type: { name: 'primary_key' } }],
+        },
+        { name: 'name', attributes: [{ attribute_type: { name: 'label' } }] },
+      ],
+    };
+    mockDJClient.DataJunctionAPI.node.mockResolvedValue(mockNodeResponse);
+
+    // Mock node data response
+    const mockNodeDataResponse = {
+      results: [
+        {
+          columns: [{ semantic_entity: 'id' }, { semantic_entity: 'name' }],
+          rows: [
+            [1, 'Value 1'],
+            [2, 'Value 2'],
+          ],
+        },
+      ],
+    };
+    mockDJClient.DataJunctionAPI.nodeData.mockResolvedValue(
+      mockNodeDataResponse,
+    );
+
+    const { container } = render(
+      <DJClientContext.Provider value={mockDJClient}>
+        <DimensionFilter dimension={mockDimension} onChange={jest.fn()} />
+      </DJClientContext.Provider>,
+    );
+
+    // Check if the dimension label and node display name are rendered
+    expect(
+      getByTextStartsWith(container, 'Dimension Label'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Node')).toBeInTheDocument();
+  });
+});

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
@@ -247,7 +247,7 @@ exports[`<NodePage /> renders the NodeMaterialization tab with materializations 
                       <div
                         class="cm-line"
                       >
-                            "spark.executor.memory":
+                            "spark.executor.memory": 
                         <span
                           class="ͼe"
                         >
@@ -258,7 +258,7 @@ exports[`<NodePage /> renders the NodeMaterialization tab with materializations 
                       <div
                         class="cm-line"
                       >
-                            "spark.memory.fraction":
+                            "spark.memory.fraction": 
                         <span
                           class="ͼe"
                         >
@@ -285,7 +285,7 @@ exports[`<NodePage /> renders the NodeMaterialization tab with materializations 
               </div>
             </div>
           </details>
-
+           
         </div>
         <button
           aria-hidden="false"

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/__snapshots__/NodePage.test.jsx.snap
@@ -247,7 +247,7 @@ exports[`<NodePage /> renders the NodeMaterialization tab with materializations 
                       <div
                         class="cm-line"
                       >
-                            "spark.executor.memory": 
+                            "spark.executor.memory":
                         <span
                           class="ͼe"
                         >
@@ -258,7 +258,7 @@ exports[`<NodePage /> renders the NodeMaterialization tab with materializations 
                       <div
                         class="cm-line"
                       >
-                            "spark.memory.fraction": 
+                            "spark.memory.fraction":
                         <span
                           class="ͼe"
                         >
@@ -285,7 +285,7 @@ exports[`<NodePage /> renders the NodeMaterialization tab with materializations 
               </div>
             </div>
           </details>
-           
+
         </div>
         <button
           aria-hidden="false"

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -93,8 +93,8 @@ export function NodePage() {
       },
       {
         id: 'sql',
-        name: 'SQL',
-        display: node?.type !== 'dimension' && node?.type !== 'source',
+        name: 'Run',
+        display: node?.type !== 'source',
       },
       {
         id: 'materializations',
@@ -135,8 +135,7 @@ export function NodePage() {
       tabToDisplay = <NodeHistory node={node} djClient={djClient} />;
       break;
     case 'sql':
-      tabToDisplay =
-        node?.type === 'metric' ? <NodeSQLTab djNode={node} /> : <br />;
+      tabToDisplay = <NodeSQLTab node={node} djClient={djClient} />;
       break;
     case 'materializations':
       tabToDisplay = <NodeMaterializationTab node={node} djClient={djClient} />;

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -8,7 +8,7 @@ import NodeColumnTab from './NodeColumnTab';
 import NodeLineage from './NodeGraphTab';
 import NodeHistory from './NodeHistory';
 import DJClientContext from '../../providers/djclient';
-import NodeSQLTab from './NodeSQLTab';
+import NodeValidateTab from './NodeValidateTab';
 import NodeMaterializationTab from './NodeMaterializationTab';
 import ClientCodePopover from './ClientCodePopover';
 import NodesWithDimension from './NodesWithDimension';
@@ -92,8 +92,8 @@ export function NodePage() {
         display: true,
       },
       {
-        id: 'sql',
-        name: 'Run',
+        id: 'validate',
+        name: '► Validate',
         display: node?.type !== 'source',
       },
       {
@@ -134,8 +134,8 @@ export function NodePage() {
     case 'history':
       tabToDisplay = <NodeHistory node={node} djClient={djClient} />;
       break;
-    case 'sql':
-      tabToDisplay = <NodeSQLTab node={node} djClient={djClient} />;
+    case 'validate':
+      tabToDisplay = <NodeValidateTab node={node} djClient={djClient} />;
       break;
     case 'materializations':
       tabToDisplay = <NodeMaterializationTab node={node} djClient={djClient} />;

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -475,6 +475,28 @@ export const DataJunctionAPI = {
     );
   },
 
+  streamNodeData: async function (nodeName, selection = null) {
+    if (selection === null) {
+      selection = {
+        dimensions: [],
+        filters: [],
+      };
+    }
+    const params = new URLSearchParams(selection);
+    for (const [key, value] of Object.entries(selection)) {
+      if (Array.isArray(value)) {
+        params.delete(key);
+        value.forEach(v => params.append(key, v));
+      }
+    }
+    params.append('limit', '1000');
+    params.append('async_', 'true');
+
+    return new EventSource(`${DJ_URL}/stream/${nodeName}?${params}`, {
+      withCredentials: true,
+    });
+  },
+
   lineage: async function (node) {},
 
   compiledSql: async function (node) {
@@ -845,7 +867,6 @@ export const DataJunctionAPI = {
     return { status: response.status, json: await response.json() };
   },
   deleteMaterialization: async function (nodeName, materializationName) {
-    console.log('deleting materialization', nodeName, materializationName);
     const response = await fetch(
       `${DJ_URL}/nodes/${nodeName}/materializations?materialization_name=${materializationName}`,
       {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -363,13 +363,18 @@ export const DataJunctionAPI = {
   },
 
   sql: async function (metric_name, selection) {
+    const params = new URLSearchParams(selection);
+    for (const [key, value] of Object.entries(selection)) {
+      if (Array.isArray(value)) {
+        params.delete(key);
+        value.forEach(v => params.append(key, v));
+      }
+    }
+
     return await (
-      await fetch(
-        `${DJ_URL}/sql/${metric_name}?` + new URLSearchParams(selection),
-        {
-          credentials: 'include',
-        },
-      )
+      await fetch(`${DJ_URL}/sql/${metric_name}?${params}`, {
+        credentials: 'include',
+      })
     ).json();
   },
 
@@ -428,6 +433,31 @@ export const DataJunctionAPI = {
     return await (
       await fetch(`${DJ_URL}/data/?` + params + '&limit=10000', {
         credentials: 'include',
+      })
+    ).json();
+  },
+
+  nodeData: async function (nodeName, selection = null) {
+    if (selection === null) {
+      selection = {
+        dimensions: [],
+        filters: [],
+      };
+    }
+    const params = new URLSearchParams(selection);
+    for (const [key, value] of Object.entries(selection)) {
+      if (Array.isArray(value)) {
+        params.delete(key);
+        value.forEach(v => params.append(key, v));
+      }
+    }
+    params.append('limit', '1000');
+    params.append('async_', 'true');
+
+    return await (
+      await fetch(`${DJ_URL}/data/${nodeName}?${params}`, {
+        credentials: 'include',
+        headers: { 'Cache-Control': 'max-age=86400' },
       })
     ).json();
   },

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -605,6 +605,50 @@ describe('DataJunctionAPI', () => {
     );
   });
 
+  it('calls streamNodeData correctly', () => {
+    const nodes = ['transform1'];
+    const dimensionSelection = ['dimension1', 'dimension2'];
+    const filters = 'sampleFilter';
+
+    DataJunctionAPI.streamNodeData(nodes[0], {
+      dimensions: dimensionSelection,
+      filters: filters,
+    });
+
+    const params = new URLSearchParams();
+    params.append('dimensions', dimensionSelection, 'filters', filters);
+
+    expect(global.EventSource).toHaveBeenCalledWith(
+      `${DJ_URL}/stream/transform1?filters=sampleFilter&dimensions=dimension1&dimensions=dimension2&limit=1000&async_=true`,
+      { withCredentials: true },
+    );
+  });
+
+  it('calls nodeData correctly', () => {
+    const nodes = ['transform1'];
+    const dimensionSelection = ['dimension1', 'dimension2'];
+    const filters = 'sampleFilter';
+    fetch.mockResponseOnce(JSON.stringify({}));
+
+    DataJunctionAPI.nodeData(nodes[0], {
+      dimensions: dimensionSelection,
+      filters: filters,
+    });
+
+    const params = new URLSearchParams();
+    params.append('dimensions', dimensionSelection, 'filters', filters);
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${DJ_URL}/data/transform1?filters=sampleFilter&dimensions=dimension1&dimensions=dimension2&limit=1000&async_=true`,
+      {
+        credentials: 'include',
+        headers: {
+          'Cache-Control': 'max-age=86400',
+        },
+      },
+    );
+  });
+
   it('calls dag correctly and processes response', async () => {
     const mockResponse = [
       {
@@ -1013,6 +1057,24 @@ describe('DataJunctionAPI', () => {
       {
         credentials: 'include',
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  });
+
+  it('calls deleteMaterialization correctly', () => {
+    const nodeName = 'transform1';
+    const materializationName = 'sampleMaterialization';
+    fetch.mockResponseOnce(JSON.stringify({}));
+
+    DataJunctionAPI.deleteMaterialization(nodeName, materializationName);
+    expect(fetch).toHaveBeenCalledWith(
+      `${DJ_URL}/nodes/${nodeName}/materializations?materialization_name=${materializationName}`,
+      {
+        method: 'DELETE',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/datajunction-ui/src/mocks/mockNodes.jsx
+++ b/datajunction-ui/src/mocks/mockNodes.jsx
@@ -962,6 +962,9 @@ export const mocks = {
     dimensions: [
       {
         name: 'default.date_dim.dateint',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: true,
         type: 'timestamp',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -971,6 +974,9 @@ export const mocks = {
       },
       {
         name: 'default.date_dim.dateint',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: true,
         type: 'timestamp',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -980,6 +986,9 @@ export const mocks = {
       },
       {
         name: 'default.date_dim.day',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -989,6 +998,9 @@ export const mocks = {
       },
       {
         name: 'default.date_dim.day',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -998,6 +1010,9 @@ export const mocks = {
       },
       {
         name: 'default.date_dim.month',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1007,6 +1022,9 @@ export const mocks = {
       },
       {
         name: 'default.date_dim.month',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1016,6 +1034,9 @@ export const mocks = {
       },
       {
         name: 'default.date_dim.year',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1025,6 +1046,9 @@ export const mocks = {
       },
       {
         name: 'default.date_dim.year',
+        node_name: 'default.date_dim',
+        node_display_name: 'Date Dim',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1034,6 +1058,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.address',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1042,6 +1069,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.birth_date',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'date',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1050,6 +1080,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.city',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1058,6 +1091,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.contractor_id',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1066,6 +1102,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.country',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1074,6 +1113,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.first_name',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1082,6 +1124,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.hard_hat_id',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: true,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1090,6 +1135,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.hire_date',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'date',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1098,6 +1146,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.last_name',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1106,6 +1157,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.manager',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'int',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1114,6 +1168,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.postal_code',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1122,6 +1179,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.state',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',
@@ -1130,6 +1190,9 @@ export const mocks = {
       },
       {
         name: 'default.hard_hat.title',
+        node_name: 'default.hard_hat',
+        node_display_name: 'Hard hat',
+        is_primary_key: false,
         type: 'string',
         path: [
           'default.repair_order_details.repair_order_id',

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -1319,3 +1319,151 @@ pre {
   display: table-cell;
   padding: 8px;
 }
+
+.operator {
+  background-color: #efefef;
+  border-radius: 2px;
+  border-style: none;
+  padding: 0.4rem;
+  font-family: Lato, "sans-serif";
+  font-size: 110%;
+  border-right: 16px solid transparent;
+  margin-left: 0.4rem;
+}
+
+.backfills summary::marker,
+.backfills summary::-webkit-details-marker{
+  display : none;
+}
+
+.backfills summary:focus{
+  outline : none;
+}
+
+.backfills summary:focus-visible{
+  outline : 1px dotted #000;
+}
+
+.backfills summary::before{
+  z-index    : 1;
+  /*background : #696 url('expand-collapse.svg') 0 0;*/
+}
+
+.backfills details[open] > summary::before{
+  background-position : calc(-2 * var(--radius)) 0;
+}
+
+.backfills_header {
+  font-size: 16px;
+  margin-left: 18px;
+  border-left: 2px solid #ddd;
+  padding-left: 40px;
+  margin-bottom: 10px;
+}
+
+.tr {
+  display: inline-flex;
+}
+.tr li {
+  padding-right: 10px;
+}
+.td {
+  display: table-cell;
+  padding: 8px;
+}
+
+table {
+  width: 100%;
+  height: min-content;
+}
+
+.queryrunner-filters {
+  background-color: #fff;
+  padding-right: 20px;
+}
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 15px;
+  position: absolute;
+  z-index: 1;
+
+    top: -5px;
+    left: 125%;
+  /*bottom: 125%;*/
+  /*left: 50%;*/
+  margin-left: -60px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip .tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}
+
+.queryrunner {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  grid-template-rows: 250px 1fr;
+  gap: 20px;
+  grid-template-areas:
+    "left righttop"
+    "left rightbottom";
+  margin-top: 1rem;
+}
+.left { grid-area: left; }
+.righttop { grid-area: righttop; }
+.rightbottom { grid-area: rightbottom; }
+
+.queryrunner-query pre {
+  border-radius: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 1rem !important;
+}
+
+.tab-item {
+  align-items: center;
+  background: #0000;
+  border: 0;
+  cursor: pointer;
+  margin: 0 32px 0 0;
+  outline: none;
+  padding: 12px 0;
+  text-transform: uppercase;
+  user-select: none;
+  width: fit-content !important;
+}
+.query-info {
+  list-style-type: none;
+  padding-bottom: 10px;
+}
+.query-info label {
+  margin-left: -10px;
+}
+.active {
+  border-bottom: 2px solid #007acc;
+}

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -51,6 +51,7 @@ button.nav-link {
   font: inherit;
   cursor: pointer;
   outline: inherit;
+  width: max-content;
 }
 code {
   font-family: Consolas, source-code-pro, Menlo, Monaco, Consolas, 'Courier New',


### PR DESCRIPTION
### Summary

#### UI Changes

This PR adds a Validation tab to the node page, allowing users to validate their node queries by running them. They can view the generated SQL in the top pane, and the left sidebar includes an optional set of configurable filters, along with group-by dimensions if the node is a metric. 

#### Backend Changes

We add a new SSE stream endpoint for getting node data, which is used by the above interface when a user kicks off a query execution. This also adds a change to the `queryrequest` table to store `query_id`, an external query reference that we can keep track of server-side, which helps with picking up on in-progress queries after a connection is closed.

#### Preview

Here is a transform node's Validation tab, shortly after clicking "Run":

<img width="1689" alt="Screenshot 2024-05-20 at 10 22 35 PM" src="https://github.com/DataJunction/dj/assets/9524628/a65b929f-0e40-4b02-a44b-354e7031abac">
<br/><br/>
As the query is running, there's the option to look at info on the query:
<br/><br/>
<img width="1137" alt="Screenshot 2024-05-20 at 10 34 15 PM" src="https://github.com/DataJunction/dj/assets/9524628/d7ee8ad1-5f27-45f3-8a5c-5107dfac96f5">
<br/><br/>
After the query finishes, the tab displays results:
<br/><br/>
<img width="1690" alt="Screenshot 2024-05-20 at 10 33 57 PM" src="https://github.com/DataJunction/dj/assets/9524628/e74ae121-2816-4172-b3f2-3e74e6292d89">

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #968 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
