### PR TITLE
Attempt to fix the comparison for struct types.

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -103,7 +103,7 @@ from datajunction_server.sql.dag import (
     get_downstream_nodes,
     get_upstream_nodes,
 )
-from datajunction_server.sql.parsing.backends.antlr4 import parse
+from datajunction_server.sql.parsing.backends.antlr4 import parse, parse_rule
 from datajunction_server.utils import (
     Version,
     get_current_user,
@@ -967,10 +967,9 @@ async def refresh_source_node(
     if new_columns:
         # check if any of the columns have changed (only continue with update if they have)
         column_changes = {col.identifier() for col in current_revision.columns} != {
-            col.identifier() for col in new_columns
+            (col.name, str(parse_rule(str(col.type), "dataType")))
+            for col in new_columns
         }
-
-        # FIXME: there is a bug with type translation (bigint != long) - fix it. # pylint: disable=fixme
 
         # if the columns haven't changed and the node has a table, we can skip the update
         if not column_changes:

--- a/datajunction-server/datajunction_server/sql/parsing/types.py
+++ b/datajunction-server/datajunction_server/sql/parsing/types.py
@@ -291,7 +291,7 @@ class NestedField(ColumnType):
             doc_string = "" if doc is None else f", doc={repr(doc)}"
             super().__init__(
                 (
-                    f"{name}: {field_type}"
+                    f"{name} {field_type}"
                     f"{' NOT NULL' if not is_optional else ''}"
                     + ("" if doc is None else f" {doc}")
                 ),
@@ -364,7 +364,7 @@ field_type=IntegerType(), is_optional=True, doc='an optional field'))
     def __init__(self, *fields: NestedField):
         if not self._initialized:
             super().__init__(
-                f"struct<{', '.join(map(str, fields))}>",
+                f"struct<{','.join(map(str, fields))}>",
                 f"StructType{repr(fields)}",
             )
             self._fields = fields

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2692,11 +2692,11 @@ GROUP BY
             "attributes": [],
             "dimension": None,
             "name": "measures",
-            "type": "struct<completed_repairs: bigint, "
-            "total_repairs_dispatched: bigint, "
-            "total_amount_in_region: double, "
-            "avg_repair_amount_in_region: double, "
-            "avg_dispatch_delay: double, unique_contractors: "
+            "type": "struct<completed_repairs bigint,"
+            "total_repairs_dispatched bigint,"
+            "total_amount_in_region double,"
+            "avg_repair_amount_in_region double,"
+            "avg_dispatch_delay double,unique_contractors "
             "bigint>",
             "display_name": "Measures",
             "partition": None,


### PR DESCRIPTION
### Summary

This fixes comparison for struct types that we ingest from our repo. Another way to fix it would be to try to match the other side but I'd like to move on for now since things seems to be working.

### Test Plan

Unit tests plus internal test on a mock source node:
```
create table olek.test_1 (a string, b int, c double, d map<string, string>, e array<int>, s struct<a int, b string>);
```

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan
n/a
