### PR TITLE
Enable dimension values dropdown

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/DimensionFilter.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/DimensionFilter.jsx
@@ -33,14 +33,7 @@ export default function DimensionFilter({ dimension, onChange }) {
             )
             .map(col => col.name);
 
-        // TODO: we're disabling this for now because it's unclear how performant the dimensions node
-        // data endpoints are. To re-enable, uncomment the following line:
-        // const data = await djClient.nodeData(dimension.metadata.node_name);
-        const data = { results: [] };
-
-        // TODO: when the above is enabled, this will use each dimension node's 'Label' column
-        // to build the display label for the dropdown, while continuing to pass the primary
-        // key in for filtering
+        const data = await djClient.nodeData(dimension.metadata.node_name);
         /* istanbul ignore if */
         if (dimensionNode && data.results && data.results.length > 0) {
           const columnNames = data.results[0].columns.map(


### PR DESCRIPTION
### Summary

This change enables a dimension values dropdown for each dimension in the "Add Filters" left pane. This makes it easier for users to figure out what some valid values they can input into each filter field are. Note that we had this feature all along, but it was disabled due to potential performance issues. This doesn't seem to be the case assuming cached dimension nodes.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
