### PR TITLE
Show source node refreshes in the node history tab

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
@@ -74,6 +74,17 @@ export default function NodeHistory({ node, djClient }) {
         </div>
       );
     }
+    if (event.activity_type === 'refresh') {
+      return (
+        <div className="history-left">
+          <b style={{ textTransform: 'capitalize' }}>{event.activity_type}</b>{' '}
+          {event.entity_type}{' '}
+          <b>
+            <a href={'/nodes/' + event.entity_name}>{event.entity_name}</a>
+          </b>
+        </div>
+      );
+    }
     if (event.activity_type === 'update' && event.entity_type === 'node') {
       return (
         <div className="history-left">


### PR DESCRIPTION
### Summary

This change makes it so that the source node refreshes actually show up in the node history tab.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
