### PR TITLE
Sort dimensions by order of usage when displaying them in the link dimensions popover

### DIFF
--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -260,7 +260,7 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
     query, query_request = await get_node_sql(
         node_name,
         dimensions,
-        filters,
+        [filter_ for filter_ in filters if filter_],
         orderby,
         limit,
         session=session,

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -941,3 +941,12 @@ class NamespaceOutput(BaseModel):
 
     namespace: str
     num_nodes: int
+
+
+class NodeIndegreeOutput(BaseModel):
+    """
+    Node indegree output
+    """
+
+    name: str
+    indegree: int

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -18,7 +18,18 @@ async def test_list_dimension(client_with_roads: AsyncClient) -> None:
     data = response.json()
 
     assert response.status_code == 200
-    assert len(data) > 5
+    assert {(dim["name"], dim["indegree"]) for dim in data} == {
+        (dim["name"], dim["indegree"])
+        for dim in [
+            {"indegree": 3, "name": "default.dispatcher"},
+            {"indegree": 2, "name": "default.repair_order"},
+            {"indegree": 2, "name": "default.hard_hat"},
+            {"indegree": 2, "name": "default.municipality_dim"},
+            {"indegree": 1, "name": "default.contractor"},
+            {"indegree": 1, "name": "default.us_state"},
+            {"indegree": 0, "name": "default.local_hard_hats"},
+        ]
+    }
 
 
 @pytest.mark.asyncio

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import ClientCodePopover from './ClientCodePopover';
 import * as React from 'react';
 import EditColumnPopover from './EditColumnPopover';
 import LinkDimensionPopover from './LinkDimensionPopover';
@@ -35,8 +34,11 @@ export default function NodeColumnTab({ node, djClient }) {
   useEffect(() => {
     const fetchData = async () => {
       const dimensions = await djClient.dimensions();
-      const options = dimensions.map(name => {
-        return { value: name, label: name };
+      const options = dimensions.map(dim => {
+        return {
+          value: dim.name,
+          label: `${dim.name} (${dim.indegree} links)`,
+        };
       });
       setDimensions(options);
     };


### PR DESCRIPTION
### Summary

This PR sorts dimensions by order of usage (with "usage" defined as the number of dimension links a given dimension node has) when displaying them in the list of available dimensions in the link dimensions popover:

<img width="240" alt="Screenshot 2024-05-27 at 10 26 53 AM" src="https://github.com/DataJunction/dj/assets/9524628/710e1de4-0cb5-41b9-b95d-a398c70266bc">

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
