### PR TITLE
Add loading stage to various parts of the UI

### DIFF
--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -164,7 +164,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 89,
+        "statements": 87,
         "branches": 75,
         "lines": 80,
         "functions": 85

--- a/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
@@ -1,10 +1,11 @@
 import { useContext, useEffect, useRef, useState } from 'react';
 import * as React from 'react';
 import DJClientContext from '../../providers/djclient';
-import { Form, Formik } from 'formik';
+import { Field, Form, Formik } from 'formik';
 import { FormikSelect } from '../AddEditNodePage/FormikSelect';
 import EditIcon from '../../icons/EditIcon';
 import { displayMessageAfterSubmit } from '../../../utils/form';
+import LoadingIcon from '../../icons/LoadingIcon';
 
 export default function LinkDimensionPopover({
   column,
@@ -35,11 +36,17 @@ export default function LinkDimensionPopover({
     { node, column, dimension },
     { setSubmitting, setStatus },
   ) => {
-    setSubmitting(false);
     if (referencedDimensionNode && dimension === 'Remove') {
-      await unlinkDimension(node, column, referencedDimensionNode, setStatus);
+      await unlinkDimension(
+        node,
+        column,
+        referencedDimensionNode,
+        setStatus,
+      ).then(_ => setSubmitting(false));
     } else {
-      await linkDimension(node, column, dimension, setStatus);
+      await linkDimension(node, column, dimension, setStatus).then(_ =>
+        setSubmitting(false),
+      );
     }
     onSubmit();
   };
@@ -137,8 +144,9 @@ export default function LinkDimensionPopover({
                   type="submit"
                   aria-label="SaveLinkDimension"
                   aria-hidden="false"
+                  disabled={isSubmitting}
                 >
-                  Save
+                  {isSubmitting ? <LoadingIcon /> : 'Save'}
                 </button>
               </Form>
             );

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/LinkDimensionPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/LinkDimensionPopover.test.jsx
@@ -58,7 +58,6 @@ describe('<LinkDimensionPopover />', () => {
     fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
     fireEvent.click(screen.getByText('Dimension 1'));
     fireEvent.click(getByText('Save'));
-    getByText('Save').click();
 
     // Expect linkDimension to be called
     await waitFor(() => {
@@ -74,7 +73,6 @@ describe('<LinkDimensionPopover />', () => {
     fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
     fireEvent.click(screen.getByText('[Remove dimension link]'));
     fireEvent.click(getByText('Save'));
-    getByText('Save').click();
 
     // Expect unlinkDimension to be called
     await waitFor(() => {
@@ -133,7 +131,6 @@ describe('<LinkDimensionPopover />', () => {
     fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
     fireEvent.click(screen.getByText('Dimension 1'));
     fireEvent.click(getByText('Save'));
-    getByText('Save').click();
 
     // Expect linkDimension to be called
     await waitFor(() => {
@@ -151,7 +148,6 @@ describe('<LinkDimensionPopover />', () => {
     fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
     fireEvent.click(screen.getByText('[Remove Dimension]'));
     fireEvent.click(getByText('Save'));
-    getByText('Save').click();
 
     // Expect unlinkDimension to be called
     await waitFor(() => {

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
@@ -706,9 +706,11 @@ describe('<NodePage />', () => {
       expect(screen.getByText('Add Filters')).toBeInTheDocument();
       expect(screen.getByText('Generated Query')).toBeInTheDocument();
       expect(screen.getByText('Results')).toBeInTheDocument();
+    });
+    // Click on the 'Validate' tab
+    fireEvent.click(screen.getByRole('button', { name: '► Validate' }));
 
-      // Click on the 'Validate' tab
-      fireEvent.click(screen.getByRole('button', { name: '► Validate' }));
+    await waitFor(() => {
       expect(djClient.DataJunctionAPI.node).toHaveBeenCalledWith(
         mocks.mockMetricNode.name,
       );
@@ -719,35 +721,41 @@ describe('<NodePage />', () => {
       expect(djClient.DataJunctionAPI.nodeDimensions).toHaveBeenCalledWith(
         mocks.mockMetricNode.name,
       );
+    });
 
-      // Click on 'Run' to run the node query
-      const runButton = screen.getByText('► Run');
-      fireEvent.click(runButton);
+    // Click on 'Run' to run the node query
+    const runButton = screen.getByText('► Run');
+    fireEvent.click(runButton);
 
+    await waitFor(() => {
       expect(djClient.DataJunctionAPI.streamNodeData).toHaveBeenCalledWith(
         mocks.mockMetricNode.name,
         { dimensions: [], filters: [] },
       );
       expect(streamNodeData.onmessage).toBeDefined();
       expect(streamNodeData.onerror).toBeDefined();
+    });
 
-      const infoTab = screen.getByRole('button', { name: 'QueryInfo' });
-      const resultsTab = screen.getByText('Results');
+    const infoTab = screen.getByRole('button', { name: 'QueryInfo' });
+    const resultsTab = screen.getByText('Results');
 
-      // Initially, the Results tab should be active
-      expect(resultsTab).toHaveClass('active');
-      expect(infoTab).not.toHaveClass('active');
+    // Initially, the Results tab should be active
+    expect(resultsTab).toHaveClass('active');
+    expect(infoTab).not.toHaveClass('active');
 
-      // Click on the Info tab first
-      fireEvent.click(infoTab);
+    // Click on the Info tab first
+    fireEvent.click(infoTab);
 
+    await waitFor(() => {
       // Now, the Info tab should be active
       expect(infoTab).toHaveClass('active');
       expect(resultsTab).not.toHaveClass('active');
+    });
 
-      // Click on the Results tab
-      fireEvent.click(resultsTab);
+    // Click on the Results tab
+    fireEvent.click(resultsTab);
 
+    await waitFor(() => {
       // Now, the Results tab should be active again
       expect(resultsTab).toHaveClass('active');
       expect(infoTab).not.toHaveClass('active');


### PR DESCRIPTION
### Summary

This PR adds a loading stage to various parts of the UI so that users know DJ is doing something when they click a button: 
* Link dimensions popover
* Node validation query run

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
