### PR TITLE
FIX Remove fields from Source's UpdateNode that aren't actually update-able

### DIFF
--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -309,9 +309,6 @@ class Source(Node):
             description=self.description,
             mode=self.mode,
             primary_key=self.primary_key,
-            catalog=self.catalog,
-            schema_=self.schema_,
-            table=self.table,
             columns=self.columns,
         )
         return self.dj_client._update_node(self.name, update_node)


### PR DESCRIPTION
### Summary

Fixing the bug discussed/discovered in #1001 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
