### PR TITLE
Fix cube elements ordering bug

### DIFF
--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -380,102 +380,99 @@ def repairs_cube_elements():
     """
     Fixture of repairs cube elements
     """
-    return sorted(
-        [
-            {
-                "display_name": "City",
-                "name": "city",
-                "node_name": "default.hard_hat",
-                "type": "dimension",
-                "partition": None,
-            },
-            {
-                "display_name": "Company Name",
-                "name": "company_name",
-                "node_name": "default.dispatcher",
-                "type": "dimension",
-                "partition": None,
-            },
-            {
-                "display_name": "Country",
-                "name": "country",
-                "node_name": "default.hard_hat",
-                "type": "dimension",
-                "partition": None,
-            },
-            {
-                "display_name": "Hire Date",
-                "name": "hire_date",
-                "node_name": "default.hard_hat",
-                "partition": None,
-                "type": "dimension",
-            },
-            {
-                "display_name": "Default: Avg Repair Price",
-                "name": "default_DOT_avg_repair_price",
-                "node_name": "default.avg_repair_price",
-                "type": "metric",
-                "partition": None,
-            },
-            {
-                "display_name": "Default: Discounted Orders Rate",
-                "name": "default_DOT_discounted_orders_rate",
-                "node_name": "default.discounted_orders_rate",
-                "type": "metric",
-                "partition": None,
-            },
-            {
-                "display_name": "Default: Double Total Repair Cost",
-                "name": "default_DOT_double_total_repair_cost",
-                "node_name": "default.double_total_repair_cost",
-                "type": "metric",
-                "partition": None,
-            },
-            {
-                "display_name": "Default: Num Repair Orders",
-                "name": "default_DOT_num_repair_orders",
-                "node_name": "default.num_repair_orders",
-                "type": "metric",
-                "partition": None,
-            },
-            {
-                "display_name": "Default: Total Repair Cost",
-                "name": "default_DOT_total_repair_cost",
-                "node_name": "default.total_repair_cost",
-                "type": "metric",
-                "partition": None,
-            },
-            {
-                "display_name": "Default: Total Repair Order Discounts",
-                "name": "default_DOT_total_repair_order_discounts",
-                "node_name": "default.total_repair_order_discounts",
-                "type": "metric",
-                "partition": None,
-            },
-            {
-                "display_name": "Local Region",
-                "name": "local_region",
-                "node_name": "default.municipality_dim",
-                "type": "dimension",
-                "partition": None,
-            },
-            {
-                "display_name": "Postal Code",
-                "name": "postal_code",
-                "node_name": "default.hard_hat",
-                "type": "dimension",
-                "partition": None,
-            },
-            {
-                "display_name": "State",
-                "name": "state",
-                "node_name": "default.hard_hat",
-                "type": "dimension",
-                "partition": None,
-            },
-        ],
-        key=lambda x: x["name"],
-    )
+    return [
+        {
+            "display_name": "Default: Discounted Orders Rate",
+            "name": "default_DOT_discounted_orders_rate",
+            "node_name": "default.discounted_orders_rate",
+            "partition": None,
+            "type": "metric",
+        },
+        {
+            "display_name": "Company Name",
+            "name": "company_name",
+            "node_name": "default.dispatcher",
+            "partition": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Local Region",
+            "name": "local_region",
+            "node_name": "default.municipality_dim",
+            "partition": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Hire Date",
+            "name": "hire_date",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "City",
+            "name": "city",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "State",
+            "name": "state",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Postal Code",
+            "name": "postal_code",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Country",
+            "name": "country",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Default: Num Repair Orders",
+            "name": "default_DOT_num_repair_orders",
+            "node_name": "default.num_repair_orders",
+            "partition": None,
+            "type": "metric",
+        },
+        {
+            "display_name": "Default: Avg Repair Price",
+            "name": "default_DOT_avg_repair_price",
+            "node_name": "default.avg_repair_price",
+            "partition": None,
+            "type": "metric",
+        },
+        {
+            "display_name": "Default: Total Repair Cost",
+            "name": "default_DOT_total_repair_cost",
+            "node_name": "default.total_repair_cost",
+            "partition": None,
+            "type": "metric",
+        },
+        {
+            "display_name": "Default: Total Repair Order Discounts",
+            "name": "default_DOT_total_repair_order_discounts",
+            "node_name": "default.total_repair_order_discounts",
+            "partition": None,
+            "type": "metric",
+        },
+        {
+            "display_name": "Default: Double Total Repair Cost",
+            "name": "default_DOT_double_total_repair_cost",
+            "node_name": "default.double_total_repair_cost",
+            "partition": None,
+            "type": "metric",
+        },
+    ]
 
 
 @pytest.mark.asyncio
@@ -589,6 +586,10 @@ async def test_create_cube(
     assert results["display_name"] == "Default: Repairs Cube"
     assert results["description"] == "Cube of various metrics related to repairs"
 
+    response = await client_with_repairs_cube.get("/cubes/default.repairs_cube")
+    cube = response.json()
+
+    # Make sure it matches the original metrics order
     metrics = [
         "default.discounted_orders_rate",
         "default.num_repair_orders",
@@ -597,6 +598,11 @@ async def test_create_cube(
         "default.total_repair_order_discounts",
         "default.double_total_repair_cost",
     ]
+    assert cube["cube_node_metrics"] == metrics
+    assert [
+        elem["node_name"] for elem in cube["cube_elements"] if elem["type"] == "metric"
+    ] == metrics
+
     metrics_query = "&".join([f"metrics={metric}" for metric in metrics])
     dimensions = [
         "default.hard_hat.country",
@@ -739,9 +745,7 @@ async def test_cube_materialization_sql_and_measures(
     """
     response = await client_with_repairs_cube.get("/cubes/default.repairs_cube/")
     data = response.json()
-    assert (
-        sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
-    )
+    assert data["cube_elements"] == repairs_cube_elements
     expected_materialization_query = """WITH
 default_DOT_repair_orders_fact AS (SELECT  default_DOT_repair_orders_fact.repair_order_id default_DOT_repair_orders_fact_DOT_repair_order_id,
     default_DOT_repair_orders_fact.discount default_DOT_repair_orders_fact_DOT_discount,
@@ -1454,9 +1458,7 @@ async def test_changing_node_upstream_from_cube(
 
     response = await client_with_repairs_cube.get("/cubes/default.repairs_cube/")
     data = response.json()
-    assert (
-        sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
-    )
+    assert data["cube_elements"] == repairs_cube_elements
 
     # Verify effects on cube after updating a node upstream from the cube
     await client_with_repairs_cube.patch(
@@ -1473,9 +1475,7 @@ FROM default.repair_order_details""",
 
     response = await client_with_repairs_cube.get("/cubes/default.repairs_cube/")
     data = response.json()
-    assert (
-        sorted(data["cube_elements"], key=lambda x: x["name"]) == repairs_cube_elements
-    )
+    assert data["cube_elements"] == repairs_cube_elements
 
 
 def assert_updated_repairs_cube(data):


### PR DESCRIPTION
### Summary

Fixes an issue where the metrics in a cube don't follow the order specified when they're passed in. For consistency, we should keep track of the ordering of metrics in a cube and use that ordering when returning a list of metrics for the cube.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
