### PR TITLE
Speed up sql building by short-circuiting the compilation for CAST(...)

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2404,6 +2404,17 @@ class Cast(Expression):
         """
         return self.data_type
 
+    async def compile(self, ctx: CompileContext):
+        """
+        In most cases we can short-circuit the CAST expression's compilation, since the output
+        type is determined directly by `data_type`, so evaluating the expression is unnecessary.
+        """
+        for child in self.find_all(Column):
+            await child.compile(ctx)
+
+        if self.data_type:
+            return
+
 
 @dataclass(eq=False)
 class SortItem(Node):
@@ -2532,7 +2543,6 @@ class Select(SelectExpression):
                     context=str(self),
                 ),
             )
-
         await super().compile(ctx)
 
 

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -128,7 +128,11 @@ async def test_aggregate(session: AsyncSession):
       aggregate(items, '', (acc, x) -> (case
         when acc = '' then element_at(split(x, '::'), 1)
         when acc = 'a' then acc
-        else element_at(split(x, '::'), 1) end)) as item
+        else element_at(split(x, '::'), 1) end)) as item,
+      aggregate(items, '', (acc, x) -> (case
+        when acc = '' then element_at(split(x, '::'), 1)
+        when acc = 'a' then acc
+        else element_at(split(x, '::'), 1) end), acc -> acc) as item1
     from (
       select 1 as id, ARRAY('b', 'c', 'a', 'x', 'g', 'z') AS items
     )


### PR DESCRIPTION
### Summary

We can speed up node SQL building for some cases by short-circuiting the compilation process for `CAST(...)` expressions, since the type of the expression is clearly determined by what the cast data type is set to.

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A