### PR TITLE
Fix query building bug for materialized dimension nodes

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -195,11 +195,12 @@ async def _build_joins_for_dimension_link(
         necessary_columns = selected_columns.union(join_columns).union(
             joinable_dim_columns,
         )
-        join_right.child.select.projection = [
-            col
-            for col in join_right.child.select.projection
-            if col.alias_or_name.name in necessary_columns
-        ]
+        if isinstance(join_right.child, ast.Query):
+            join_right.child.select.projection = [
+                col
+                for col in join_right.child.select.projection
+                if col.alias_or_name.name in necessary_columns  # type: ignore
+            ]
 
         # Replace the join right query
         join.right = join_right.child  # type: ignore


### PR DESCRIPTION
### Summary

This PR fixes a bug where building a query for a transform node that is linked to a dimension node with a materialized table will fail due to an attempt at accessing a select clause on a materialized table.

The specific error seen was:
```
AttributeError-'Table' object has no attribute 'select'
```
on
```
            join_right.child.select.projection = [
                col
                for col in join_right.child.select.projection
                if col.alias_or_name.name in necessary_columns
            ]
```

This is because `join_right` is now a single table and not a query clause.

### Test Plan

Will add unit tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
