### PR TITLE
Upgrade antlr4 runtime to match the generated antlr parsers

### DIFF
--- a/datajunction-server/pdm.lock
+++ b/datajunction-server/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "uvicorn", "transpilation"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:429aa30b49f46bc2476c7aae2978331722a4436222e91a1134e9857478b08664"
+content_hash = "sha256:32aabf6a0d1ea115acffb53468e9d15a0b77bd6d3a82d7dc7f9e548e4542f34f"
 
 [[package]]
 name = "accept-types"
@@ -165,11 +165,11 @@ files = [
 
 [[package]]
 name = "antlr4-python3-runtime"
-version = "4.12.0"
-summary = "ANTLR 4.12.0 runtime for Python 3"
+version = "4.13.1"
+summary = "ANTLR 4.13.1 runtime for Python 3"
 files = [
-    {file = "antlr4-python3-runtime-4.12.0.tar.gz", hash = "sha256:0a8b82f55032734f43ed6b60b8a48c25754721a75cd714eb1fe9ce6ed418b361"},
-    {file = "antlr4_python3_runtime-4.12.0-py3-none-any.whl", hash = "sha256:2c08f4dfbdc7dfd10f680681a96a55579c1e4f866f01d27099c9a54027923d70"},
+    {file = "antlr4-python3-runtime-4.13.1.tar.gz", hash = "sha256:3cd282f5ea7cfb841537fe01f143350fdb1c0b1ce7981443a2fa8513fddb6d1a"},
+    {file = "antlr4_python3_runtime-4.13.1-py3-none-any.whl", hash = "sha256:78ec57aad12c97ac039ca27403ad61cb98aaec8a3f9bb8144f889aa0fa28b943"},
 ]
 
 [[package]]

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "alembic>=1.10.3",
     "SQLAlchemy-Utils<1.0.0,>=0.40.0",
     "accept-types<1.0.0,>=0.4.1",
-    "antlr4-python3-runtime==4.12.0",
+    "antlr4-python3-runtime==4.13.1",
     "asciidag<1.0.0,>=0.2.0",
     "cachelib<1.0.0,>=0.10.2",
     "celery<6.0.0,>=5.2.7",

--- a/datajunction-server/requirements/docker.txt
+++ b/datajunction-server/requirements/docker.txt
@@ -7,7 +7,7 @@ aiosignal==1.3.1; python_version >= "3.11"
 aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
-antlr4-python3-runtime==4.12.0
+antlr4-python3-runtime==4.13.1
 anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2

--- a/datajunction-server/requirements/test.txt
+++ b/datajunction-server/requirements/test.txt
@@ -7,7 +7,7 @@ aiosignal==1.3.1; python_version >= "3.11"
 aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
-antlr4-python3-runtime==4.12.0
+antlr4-python3-runtime==4.13.1
 anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2


### PR DESCRIPTION
### Summary

In #1033 the new antlr parsers were generated with a different antlr version. This upgrades the antlr4 runtime to match the generated antlr parsers.

### Test Plan

Locally

- [x] PR has an associated issue: #1026 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
