### PR TITLE
Start using module scope fixtures.

### DIFF
--- a/datajunction-server/pdm.lock
+++ b/datajunction-server/pdm.lock
@@ -3,9 +3,10 @@
 
 [metadata]
 groups = ["default", "test", "uvicorn", "transpilation"]
-strategy = ["cross_platform"]
-lock_version = "4.4.1"
-content_hash = "sha256:32aabf6a0d1ea115acffb53468e9d15a0b77bd6d3a82d7dc7f9e548e4542f34f"
+cross_platform = true
+static_urls = false
+lock_version = "4.3"
+content_hash = "sha256:c178128a16ba8ae48a055e6415b410cd711267fe823eb55b2d6badc139f83b82"
 
 [[package]]
 name = "accept-types"
@@ -2046,15 +2047,15 @@ files = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.6"
-requires_python = ">=3.8"
+version = "0.21.2"
+requires_python = ">=3.7"
 summary = "Pytest support for asyncio"
 dependencies = [
-    "pytest<9,>=7.0.0",
+    "pytest>=7.0.0",
 ]
 files = [
-    {file = "pytest-asyncio-0.23.6.tar.gz", hash = "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"},
-    {file = "pytest_asyncio-0.23.6-py3-none-any.whl", hash = "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a"},
+    {file = "pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b"},
+    {file = "pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45"},
 ]
 
 [[package]]
@@ -2350,7 +2351,7 @@ version = "2.0.28"
 requires_python = ">=3.7"
 summary = "Database Abstraction Library"
 dependencies = [
-    "greenlet!=0.4.17; platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\"",
+    "greenlet!=0.4.17; platform_machine == \"aarch64\" or (platform_machine == \"ppc64le\" or (platform_machine == \"x86_64\" or (platform_machine == \"amd64\" or (platform_machine == \"AMD64\" or (platform_machine == \"win32\" or platform_machine == \"WIN32\")))))",
     "typing-extensions>=4.6.0",
 ]
 files = [
@@ -2587,7 +2588,7 @@ dependencies = [
     "python-dotenv>=0.13",
     "pyyaml>=5.1",
     "uvicorn==0.28.0",
-    "uvloop!=0.15.0,!=0.15.1,>=0.14.0; (sys_platform != \"cygwin\" and sys_platform != \"win32\") and platform_python_implementation != \"PyPy\"",
+    "uvloop!=0.15.0,!=0.15.1,>=0.14.0; sys_platform != \"win32\" and (sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\")",
     "watchfiles>=0.13",
     "websockets>=10.4",
 ]

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -16,7 +16,7 @@ test = [
     "freezegun>=1.2.2",
     "pre-commit>=3.2.2",
     "pylint>=3.0.3",
-    "pytest-asyncio>=0.23.6",
+    "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
     "pytest-integration>=0.2.2",
     "pytest-mock>=3.10.0",
@@ -83,6 +83,7 @@ dependencies = [
     "psycopg>=3.1.16",
     "pydantic<2",
     "aiosqlite>=0.20.0",
+    "pytest-asyncio==0.21.2",
 ]
 requires-python = ">=3.8,<4.0"
 readme = "README.md"

--- a/datajunction-server/requirements/docker.txt
+++ b/datajunction-server/requirements/docker.txt
@@ -2,8 +2,6 @@
 # Please do not edit it manually.
 
 accept-types==0.4.1
-aiohttp==3.9.0; python_version >= "3.11"
-aiosignal==1.3.1; python_version >= "3.11"
 aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
@@ -11,30 +9,25 @@ antlr4-python3-runtime==4.13.1
 anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
-astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
-attrs==23.1.0; python_version >= "3.11"
-backports-zoneinfo==0.2.1; python_version < "3.9"
+async-timeout==4.0.3
 bcrypt==4.1.2
 billiard==4.2.0
 cachelib==0.12.0
 cachetools==5.3.3
 celery==5.3.6
 certifi==2023.7.22
-cffi==1.15.1; platform_python_implementation != "PyPy"
+cffi==1.15.1
 charset-normalizer==3.2.0
 click==8.1.6
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
-colorama==0.4.6; sys_platform == "win32" or platform_system == "Windows"
 cryptography==42.0.5
 deprecated==1.2.14
 ecdsa==0.18.0
-exceptiongroup==1.1.3; python_version < "3.11"
+exceptiongroup==1.1.3
 fastapi==0.110.0
 fastapi-cache2==0.2.1
-frozenlist==1.4.0; python_version >= "3.11"
 google-api-core==2.12.0
 google-api-python-client==2.122.0
 google-auth==2.23.2
@@ -42,13 +35,12 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 googleapis-common-protos==1.60.0
 graphql-core==3.2.3
-greenlet==3.0.3; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 h11==0.14.0
 httplib2==0.22.0
 httptools==0.6.0
 idna==3.4
 importlib-metadata==6.8.0
-importlib-resources==6.0.1; python_version < "3.9"
+iniconfig==2.0.0
 kombu==5.3.5
 line-profiler==4.1.2
 Mako==1.2.4
@@ -64,17 +56,21 @@ opentelemetry-instrumentation-asgi==0.38b0
 opentelemetry-instrumentation-fastapi==0.38b0
 opentelemetry-semantic-conventions==0.38b0
 opentelemetry-util-http==0.38b0
+packaging==23.1
 passlib==1.7.4
 pendulum==2.1.2
+pluggy==1.4.0
 prompt-toolkit==3.0.39
 protobuf==4.24.3
 psycopg==3.1.18
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
-pycparser==2.21; platform_python_implementation != "PyPy"
+pycparser==2.21
 pydantic==1.10.14
 pygments==2.16.1
-pyparsing==3.1.1; python_version > "3.0"
+pyparsing==3.1.1
+pytest==8.1.1
+pytest-asyncio==0.21.2
 python-dateutil==2.8.2
 python-dotenv==0.21.1
 python-jose==3.3.0
@@ -96,18 +92,18 @@ sqlparse==0.4.4
 sse-starlette==2.0.0
 starlette==0.36.3
 strawberry-graphql==0.220.0
+tomli==2.0.1
 types-cachetools==5.3.0.7
 typing-extensions==4.10.0
 tzdata==2023.3
 uritemplate==4.1.1
 urllib3==1.26.16
 uvicorn==0.28.0
-uvloop==0.17.0; (sys_platform != "cygwin" and sys_platform != "win32") and platform_python_implementation != "PyPy"
+uvloop==0.17.0
 vine==5.1.0
 watchfiles==0.19.0
 wcwidth==0.2.6
 websockets==11.0.3
-wheel==0.41.1; python_version < "3.9"
 wrapt==1.15.0
 yarl==1.9.4
 zipp==3.16.2

--- a/datajunction-server/requirements/test.txt
+++ b/datajunction-server/requirements/test.txt
@@ -2,8 +2,6 @@
 # Please do not edit it manually.
 
 accept-types==0.4.1
-aiohttp==3.9.0; python_version >= "3.11"
-aiosignal==1.3.1; python_version >= "3.11"
 aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
@@ -12,17 +10,14 @@ anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
 astroid==3.1.0
-astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
-attrs==23.1.0; python_version >= "3.11"
-backports-zoneinfo==0.2.1; python_version < "3.9"
+async-timeout==4.0.3
 bcrypt==4.1.2
 billiard==4.2.0
 cachelib==0.12.0
 cachetools==5.3.3
 celery==5.3.6
 certifi==2023.7.22
-cffi==1.15.1; platform_python_implementation != "PyPy"
+cffi==1.15.1
 cfgv==3.4.0
 charset-normalizer==3.2.0
 click==8.1.6
@@ -30,7 +25,6 @@ click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
 codespell==2.2.6
-colorama==0.4.6; sys_platform == "win32" or platform_system == "Windows"
 coverage==7.3.0
 cryptography==42.0.5
 deprecated==1.2.14
@@ -40,13 +34,12 @@ distlib==0.3.7
 docker==7.0.0
 duckdb==0.8.1
 ecdsa==0.18.0
-exceptiongroup==1.1.3; python_version < "3.11"
+exceptiongroup==1.1.3
 execnet==2.0.2
 fastapi==0.110.0
 fastapi-cache2==0.2.1
 filelock==3.12.2
 freezegun==1.4.0
-frozenlist==1.4.0; python_version >= "3.11"
 gevent==24.2.1
 google-api-core==2.12.0
 google-api-python-client==2.122.0
@@ -63,7 +56,6 @@ httpx==0.27.0
 identify==2.5.26
 idna==3.4
 importlib-metadata==6.8.0
-importlib-resources==6.0.1; python_version < "3.9"
 iniconfig==2.0.0
 isort==5.12.0
 kombu==5.3.5
@@ -94,13 +86,13 @@ protobuf==4.24.3
 psycopg==3.1.18
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
-pycparser==2.21; platform_python_implementation != "PyPy"
+pycparser==2.21
 pydantic==1.10.14
 pygments==2.16.1
 pylint==3.1.0
-pyparsing==3.1.1; python_version > "3.0"
+pyparsing==3.1.1
 pytest==8.1.1
-pytest-asyncio==0.23.6
+pytest-asyncio==0.21.2
 pytest-cov==4.1.0
 pytest-integration==0.2.3
 pytest-mock==3.12.0
@@ -110,7 +102,6 @@ python-dotenv==0.21.1
 python-jose==3.3.0
 python-multipart==0.0.9
 pytzdata==2020.1
-pywin32==306; sys_platform == "win32"
 pyyaml==6.0.1
 redis==4.6.0
 requests==2.29.0
@@ -128,7 +119,7 @@ sse-starlette==2.0.0
 starlette==0.36.3
 strawberry-graphql==0.220.0
 testcontainers==3.7.1
-tomli==2.0.1; python_version < "3.11"
+tomli==2.0.1
 tomlkit==0.12.1
 types-cachetools==5.3.0.7
 typing-extensions==4.10.0
@@ -139,7 +130,6 @@ uvicorn==0.28.0
 vine==5.1.0
 virtualenv==20.24.3
 wcwidth==0.2.6
-wheel==0.41.1; python_version < "3.9"
 wrapt==1.15.0
 yarl==1.9.4
 zipp==3.16.2

--- a/datajunction-server/tests/api/attributes_test.py
+++ b/datajunction-server/tests/api/attributes_test.py
@@ -9,12 +9,12 @@ from httpx import AsyncClient
 
 @pytest.mark.asyncio
 async def test_adding_new_attribute(
-    client: AsyncClient,
+    module__client: AsyncClient,
 ) -> None:
     """
     Test adding an attribute.
     """
-    response = await client.post(
+    response = await module__client.post(
         "/attributes/",
         json={
             "namespace": "custom",
@@ -34,7 +34,7 @@ async def test_adding_new_attribute(
         "allowed_node_types": ["source"],
     }
 
-    response = await client.post(
+    response = await module__client.post(
         "/attributes/",
         json={
             "namespace": "custom",
@@ -51,7 +51,7 @@ async def test_adding_new_attribute(
         "warnings": [],
     }
 
-    response = await client.post(
+    response = await module__client.post(
         "/attributes/",
         json={
             "namespace": "system",
@@ -70,19 +70,20 @@ async def test_adding_new_attribute(
 
 
 @pytest.mark.asyncio
-async def test_list_attributes(
-    client: AsyncClient,
+async def test_list_system_attributes(
+    module__client: AsyncClient,
 ) -> None:
     """
     Test listing attributes. These should contain the default attributes.
     """
-    response = await client.get("/attributes/")
+    response = await module__client.get("/attributes/")
     assert response.status_code == 200
     data = response.json()
     data = {
         type_["name"]: {k: type_[k] for k in (type_.keys() - {"id"})} for type_ in data
     }
-    assert data == {
+    data_for_system = {k: v for k, v in data.items() if v["namespace"] == "system"}
+    assert data_for_system == {
         "primary_key": {
             "namespace": "system",
             "uniqueness_scope": [],

--- a/datajunction-server/tests/fixes_test.py
+++ b/datajunction-server/tests/fixes_test.py
@@ -1,3 +1,0 @@
-"""
-Tests for ``dj.fixes``.
-"""


### PR DESCRIPTION
### Summary

Our "unit tests" are too slow. We should start using the client/session fixtures at module scope, instead of function scope. This is a example PR that rewrites `metrics_test.py` to module scope. It will take some work to rewrite all the modules, but eventually these tests should take no longer than 10-15 min.

### Test Plan

`time pdm run pytest -vv -- tests/api/metrics_test.py` went from 3:30 min to 30 sec.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a
