### PR TITLE
Support filtering on dimensions available on upstream source nodes

### DIFF
--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -611,6 +611,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
                 "foo.bar.repair_order_details",
                 "foo.bar.repair_order",
             ],
+            "filter_only": False,
         } in result
 
     def test_create_namespace(self, client):

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -397,7 +397,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         result = num_repair_orders.get_downstreams()
         assert result == ["default.cube_two"]
         result = num_repair_orders.get_dimensions()
-        assert len(result) == 28
+        assert len(result) == 31
 
         hard_hat = client.dimension("default.hard_hat")
         result = hard_hat.get_upstreams()

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -102,6 +102,7 @@ from datajunction_server.sql.dag import (
     _node_output_options,
     get_dimensions,
     get_downstream_nodes,
+    get_filter_only_dimensions,
     get_upstream_nodes,
 )
 from datajunction_server.sql.parsing.backends.antlr4 import parse, parse_rule
@@ -1214,7 +1215,9 @@ async def list_all_dimension_attributes(
             ],
         )
     )
-    return await get_dimensions(session, node, with_attributes=True)  # type: ignore
+    dimensions = await get_dimensions(session, node, with_attributes=True)  # type: ignore
+    filter_only_dimensions = await get_filter_only_dimensions(session, name)
+    return dimensions + filter_only_dimensions
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -573,6 +573,7 @@ class DimensionAttributeOutput(BaseModel):
     is_primary_key: bool
     type: str
     path: List[str]
+    filter_only: bool = False
 
 
 class ColumnOutput(BaseModel):

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2504,6 +2504,28 @@ class SelectExpression(Aliasable, Expression):
                 projection.append(expression)
         self.projection = projection
 
+    def where_clause_expressions_list(self) -> Optional[List[Expression]]:
+        """
+        Converts the WHERE clause to a list of expressions separated by AND operators
+        """
+        if not self.where:
+            return self.where
+
+        filters = []
+        processing = collections.deque([self.where])
+        while processing:
+            current_clause = processing.pop()
+            if current_clause:
+                if (
+                    isinstance(current_clause, BinaryOp)
+                    and current_clause.op == BinaryOpKind.And
+                ):
+                    processing.append(current_clause.left)
+                    processing.append(current_clause.right)
+                else:
+                    filters.append(current_clause)
+        return filters
+
 
 class Select(SelectExpression):
     """

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -345,7 +345,6 @@ async def test_druid_measures_cube_full(
         "for node `default.repairs_cube`"
     )
     args, _ = query_service_client.materialize.call_args_list[0]  # type: ignore
-    print("args[0].query", args[0].query)
     assert str(parse(args[0].query)) == str(
         parse(load_expected_file("druid_measures_cube.full.query.sql")),
     )
@@ -571,7 +570,6 @@ WHERE repair_orders.order_date = DJ_LOGICAL_TIMESTAMP()""",
         "for node `default.repairs_cube`"
     )
     args, _ = query_service_client.materialize.call_args_list[2]  # type: ignore
-    print("args[0]", args[0].query)
     assert str(
         parse(
             args[0]

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -127,6 +127,7 @@ async def test_read_metric(
             "node_name": "parent",
             "path": [],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -135,6 +136,7 @@ async def test_read_metric(
             "node_name": "parent",
             "path": [],
             "type": "float",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -143,6 +145,7 @@ async def test_read_metric(
             "node_name": "parent",
             "path": [],
             "type": "int",
+            "filter_only": False,
         },
     ]
 
@@ -206,6 +209,7 @@ async def test_common_dimensions(
             "node_name": "default.dispatcher",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -214,6 +218,7 @@ async def test_common_dimensions(
             "node_name": "default.dispatcher",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -222,6 +227,7 @@ async def test_common_dimensions(
             "node_name": "default.dispatcher",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -230,6 +236,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -238,6 +245,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "timestamp",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -246,6 +254,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -254,6 +263,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -262,6 +272,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -270,6 +281,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -278,6 +290,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -286,6 +299,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "timestamp",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -294,6 +308,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -302,6 +317,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -310,6 +326,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -318,6 +335,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -326,6 +344,7 @@ async def test_common_dimensions(
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -334,6 +353,7 @@ async def test_common_dimensions(
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -342,6 +362,7 @@ async def test_common_dimensions(
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -350,6 +371,7 @@ async def test_common_dimensions(
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -358,6 +380,7 @@ async def test_common_dimensions(
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -366,6 +389,7 @@ async def test_common_dimensions(
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -374,6 +398,7 @@ async def test_common_dimensions(
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -382,6 +407,7 @@ async def test_common_dimensions(
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -393,6 +419,7 @@ async def test_common_dimensions(
                 "default.hard_hat",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -404,6 +431,7 @@ async def test_common_dimensions(
                 "default.hard_hat",
             ],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -415,6 +443,7 @@ async def test_common_dimensions(
                 "default.hard_hat",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -426,6 +455,7 @@ async def test_common_dimensions(
                 "default.hard_hat",
             ],
             "type": "string",
+            "filter_only": False,
         },
     ]
 
@@ -529,6 +559,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.dispatcher",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -537,6 +568,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.dispatcher",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -545,6 +577,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.dispatcher",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -553,6 +586,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -561,6 +595,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "timestamp",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -569,6 +604,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -577,6 +613,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -585,6 +622,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -593,6 +631,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -601,6 +640,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -609,6 +649,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "timestamp",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -617,6 +658,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -625,6 +667,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -633,6 +676,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -641,6 +685,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -649,6 +694,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.hard_hat",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -657,6 +703,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -665,6 +712,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -673,6 +721,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -681,6 +730,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -689,6 +739,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -697,6 +748,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -705,6 +757,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
             "node_name": "default.municipality_dim",
             "path": ["default.repair_orders_fact"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -716,6 +769,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
                 "default.hard_hat",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -727,6 +781,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
                 "default.hard_hat",
             ],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -738,6 +793,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
                 "default.hard_hat",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -749,6 +805,7 @@ async def test_get_dimensions(module__client_with_roads: AsyncClient):
                 "default.hard_hat",
             ],
             "type": "string",
+            "filter_only": False,
         },
     ]
 
@@ -776,6 +833,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -787,6 +845,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -798,6 +857,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -809,6 +869,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -820,6 +881,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -831,6 +893,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -842,6 +905,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -853,6 +917,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -864,6 +929,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -875,6 +941,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -886,6 +953,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -897,6 +965,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -908,6 +977,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -919,6 +989,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -930,6 +1001,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.formation_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -941,6 +1013,7 @@ async def test_get_multi_link_dimensions(
                 "default.special_country_dim.last_election_date",
             ],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -949,6 +1022,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.birth_country"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -957,6 +1031,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.residence_country"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -965,6 +1040,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.birth_country"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -973,6 +1049,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.residence_country"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -981,6 +1058,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.birth_country"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -989,6 +1067,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.residence_country"],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -997,6 +1076,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.birth_country"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -1005,6 +1085,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.special_country_dim",
             "path": ["default.user_dim.residence_country"],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -1013,6 +1094,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.user_dim",
             "path": [],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -1021,6 +1103,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.user_dim",
             "path": [],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": False,
@@ -1029,6 +1112,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.user_dim",
             "path": [],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -1037,6 +1121,7 @@ async def test_get_multi_link_dimensions(
             "node_name": "default.user_dim",
             "path": [],
             "type": "int",
+            "filter_only": False,
         },
     ]
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -953,6 +953,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "int",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -961,6 +962,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -969,6 +971,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "timestamp",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -977,6 +980,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -985,6 +989,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": True,
@@ -993,6 +998,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "int",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1001,6 +1007,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "timestamp",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1009,6 +1016,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1017,6 +1025,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "float",
+                "filter_only": False,
             },
         ]
 
@@ -1060,6 +1069,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "int",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1068,6 +1078,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1076,6 +1087,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "timestamp",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1084,6 +1096,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1092,6 +1105,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": True,
@@ -1100,6 +1114,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "int",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1108,6 +1123,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "timestamp",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1116,6 +1132,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "string",
+                "filter_only": False,
             },
             {
                 "is_primary_key": False,
@@ -1124,6 +1141,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
                 "node_name": "default.us_users",
                 "path": ["default.messages"],
                 "type": "float",
+                "filter_only": False,
             },
         ]
         # The metric should still be VALID
@@ -4865,6 +4883,7 @@ async def test_list_dimension_attributes(client_with_roads: AsyncClient) -> None
             "node_name": "default.regional_level_agg",
             "path": [],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -4873,6 +4892,7 @@ async def test_list_dimension_attributes(client_with_roads: AsyncClient) -> None
             "node_name": "default.regional_level_agg",
             "path": [],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -4881,6 +4901,7 @@ async def test_list_dimension_attributes(client_with_roads: AsyncClient) -> None
             "node_name": "default.regional_level_agg",
             "path": [],
             "type": "int",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -4889,6 +4910,7 @@ async def test_list_dimension_attributes(client_with_roads: AsyncClient) -> None
             "node_name": "default.regional_level_agg",
             "path": [],
             "type": "string",
+            "filter_only": False,
         },
         {
             "is_primary_key": True,
@@ -4897,6 +4919,43 @@ async def test_list_dimension_attributes(client_with_roads: AsyncClient) -> None
             "node_name": "default.regional_level_agg",
             "path": [],
             "type": "int",
+            "filter_only": False,
+        },
+        {
+            "filter_only": True,
+            "is_primary_key": False,
+            "name": "default.repair_order.repair_order_id",
+            "node_display_name": "default.roads.repair_orders",
+            "node_name": "default.repair_orders",
+            "path": [],
+            "type": "source",
+        },
+        {
+            "filter_only": True,
+            "is_primary_key": False,
+            "name": "default.dispatcher.dispatcher_id",
+            "node_display_name": "default.roads.repair_orders",
+            "node_name": "default.repair_orders",
+            "path": [],
+            "type": "source",
+        },
+        {
+            "filter_only": True,
+            "is_primary_key": False,
+            "name": "default.repair_order.repair_order_id",
+            "node_display_name": "default.roads.repair_order_details",
+            "node_name": "default.repair_order_details",
+            "path": [],
+            "type": "source",
+        },
+        {
+            "filter_only": True,
+            "is_primary_key": False,
+            "name": "default.contractor.contractor_id",
+            "node_display_name": "default.roads.repair_type",
+            "node_name": "default.repair_type",
+            "path": [],
+            "type": "source",
         },
     ]
 

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -853,7 +853,7 @@ async def test_saving_metrics_sql_requests(  # pylint: disable=too-many-statemen
                 FROM logs.log_events AS default_DOT_event_source
                 WHERE  default_DOT_event_source.country = 'ABCD' AND default_DOT_event_source.event_latency > 1000000)
                 AS default_DOT_long_events
-                WHERE  default_DOT_long_events.country = 'ABCD' AND default_DOT_long_events.country = 'ABCD'
+                WHERE  default_DOT_long_events.country = 'ABCD'
                 """,
             [
                 {
@@ -1079,7 +1079,7 @@ async def test_saving_metrics_sql_requests(  # pylint: disable=too-many-statemen
                 default_DOT_hard_hats.state
              FROM roads.hard_hats AS default_DOT_hard_hats)
              AS default_DOT_hard_hat ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
-             WHERE  default_DOT_repair_orders_fact.dispatcher_id = 1 AND default_DOT_hard_hat.state = 'AZ'
+             WHERE  default_DOT_hard_hat.state = 'AZ' AND default_DOT_repair_orders_fact.dispatcher_id = 1
              GROUP BY  default_DOT_hard_hat.state
             """,
             [
@@ -1155,7 +1155,7 @@ async def test_saving_metrics_sql_requests(  # pylint: disable=too-many-statemen
              FROM roads.municipality AS m LEFT JOIN roads.municipality_municipality_type AS mmt ON m.municipality_id = mmt.municipality_id
             LEFT JOIN roads.municipality_type AS mt ON mmt.municipality_type_id = mt.municipality_type_desc)
              AS default_DOT_municipality_dim ON default_DOT_repair_orders_fact.municipality_id = default_DOT_municipality_dim.municipality_id
-             WHERE  default_DOT_repair_orders_fact.dispatcher_id = 1 AND default_DOT_repair_orders_fact.dispatcher_id = 1 AND default_DOT_hard_hat.state != 'AZ' AND default_DOT_dispatcher.phone = '4082021022' AND default_DOT_repair_orders_fact.order_date >= '2020-01-01'
+             WHERE  default_DOT_repair_orders_fact.order_date >= '2020-01-01' AND default_DOT_dispatcher.phone = '4082021022' AND default_DOT_hard_hat.state != 'AZ' AND default_DOT_repair_orders_fact.dispatcher_id = 1
              GROUP BY  default_DOT_hard_hat.city, default_DOT_hard_hat.last_name, default_DOT_dispatcher.company_name, default_DOT_municipality_dim.local_region
             """,
             [
@@ -1579,7 +1579,7 @@ async def test_sql_with_filters(  # pylint: disable=too-many-arguments
         params={"dimensions": dimensions, "filters": filters},
     )
     data = response.json()
-    assert_query_strings_equal(data["sql"], sql)
+    assert str(parse(str(data["sql"]))) == str(parse(str(sql)))
     assert data["columns"] == columns
 
     # Run the query against local duckdb file if it's part of the roads model
@@ -1672,7 +1672,7 @@ async def test_sql_with_filters(  # pylint: disable=too-many-arguments
                 foo_DOT_bar_DOT_hard_hats.state
              FROM roads.hard_hats AS foo_DOT_bar_DOT_hard_hats)
              AS foo_DOT_bar_DOT_hard_hat ON foo_DOT_bar_DOT_repair_order.hard_hat_id = foo_DOT_bar_DOT_hard_hat.hard_hat_id
-             WHERE  foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1 AND foo_DOT_bar_DOT_hard_hat.state = 'AZ'
+             WHERE  foo_DOT_bar_DOT_hard_hat.state = 'AZ' AND foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1
              GROUP BY  foo_DOT_bar_DOT_hard_hat.state
             """,
         ),
@@ -1719,7 +1719,7 @@ async def test_sql_with_filters(  # pylint: disable=too-many-arguments
              FROM roads.municipality AS m LEFT JOIN roads.municipality_municipality_type AS mmt ON m.municipality_id = mmt.municipality_id
             LEFT JOIN roads.municipality_type AS mt ON mmt.municipality_type_id = mt.municipality_type_desc)
              AS foo_DOT_bar_DOT_municipality_dim ON foo_DOT_bar_DOT_repair_order.municipality_id = foo_DOT_bar_DOT_municipality_dim.municipality_id
-             WHERE  foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1 AND foo_DOT_bar_DOT_hard_hat.state != 'AZ' AND foo_DOT_bar_DOT_dispatcher.phone = '4082021022' AND foo_DOT_bar_DOT_repair_orders.order_date >= '2020-01-01'
+             WHERE  foo_DOT_bar_DOT_repair_orders.order_date >= '2020-01-01' AND foo_DOT_bar_DOT_dispatcher.phone = '4082021022' AND foo_DOT_bar_DOT_hard_hat.state != 'AZ' AND foo_DOT_bar_DOT_repair_orders.dispatcher_id = 1
              GROUP BY  foo_DOT_bar_DOT_hard_hat.city, foo_DOT_bar_DOT_hard_hat.last_name, foo_DOT_bar_DOT_dispatcher.company_name, foo_DOT_bar_DOT_municipality_dim.local_region
             ORDER BY foo_DOT_bar_DOT_hard_hat.last_name
             """,
@@ -1862,7 +1862,6 @@ async def test_union_all(
     assert response.status_code == 201
 
     response = await client_with_roads.get("/sql/default.union_all_test")
-    print("SQLLL", response.json()["sql"])
     assert str(parse(response.json()["sql"])) == str(
         parse(
             """
@@ -3468,7 +3467,7 @@ async def test_measures_sql_with_filters(  # pylint: disable=too-many-arguments
     }
     response = await client_with_roads.get("/sql/measures", params=sql_params)
     data = response.json()
-    assert_query_strings_equal(data["sql"], sql)
+    assert str(parse(str(data["sql"]))) == str(parse(str(sql)))
     result = duckdb_conn.sql(data["sql"])
     assert result.fetchall() == rows
     assert data["columns"] == columns
@@ -3524,9 +3523,6 @@ async def test_filter_pushdowns(
               FROM roads.repair_orders AS repair_orders
             ) AS default_DOT_repair_orders_fact
             WHERE  default_DOT_repair_orders_fact.hh_id IN (123, 13)
-              AND default_DOT_repair_orders_fact.hh_id = 123
-              OR default_DOT_repair_orders_fact.hh_id = 13
-              AND default_DOT_repair_orders_fact.hh_id IN (123, 13)
               AND default_DOT_repair_orders_fact.hh_id = 123
               OR default_DOT_repair_orders_fact.hh_id = 13
             """,
@@ -3616,3 +3612,132 @@ SELECT  default_DOT_repair_orders_fact.default_DOT_repair_orders_fact_DOT_repair
  FROM default_DOT_repair_orders_fact
     """
     assert str(parse(expected_sql)) == str(parse(response["sql"]))
+
+
+@pytest.mark.asyncio
+async def test_filter_on_source_nodes(
+    client_with_basic: AsyncClient,
+):
+    """
+    Verify that filtering using dimensions that are available on a given node's upstream
+    source nodes works, even if these dimensions are not available on the node itself.
+    """
+    # Create a dimension node: `default.event_date`
+    response = await client_with_basic.post(
+        "/nodes/dimension",
+        json={
+            "name": "default.event_date",
+            "description": "",
+            "display_name": "Event Date",
+            "query": """
+              SELECT
+                20240101 AS dateint,
+                '2024-01-01' AS date
+            """,
+            "mode": "published",
+            "primary_key": ["dateint"],
+        },
+    )
+    assert response.status_code == 201
+
+    # Create a source node: `default.events`
+    response = await client_with_basic.post(
+        "/nodes/source",
+        json={
+            "name": "default.events",
+            "description": "",
+            "display_name": "Events",
+            "catalog": "default",
+            "schema_": "example",
+            "table": "events",
+            "columns": [
+                {"name": "event_id", "type": "int"},
+                {"name": "event_date", "type": "int"},
+                {"name": "user_id", "type": "int"},
+                {"name": "duration_ms", "type": "int"},
+            ],
+            "primary_key": ["event_id"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 200
+
+    # Link `default.events` transform to the `default.event_date` dimension node on `dateint`
+    response = await client_with_basic.post(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.event_date",
+            "join_type": "left",
+            "join_on": "default.events.event_date = default.event_date.dateint",
+        },
+    )
+    assert response.status_code == 201
+
+    # Create a transform on `default.events` that aggregates it to the user level
+    response = await client_with_basic.post(
+        "/nodes/transform",
+        json={
+            "name": "default.events_agg",
+            "description": "",
+            "display_name": "Events Agg",
+            "query": """
+              SELECT
+                user_id,
+                SUM(duration_ms) AS duration_ms
+              FROM default.events
+            """,
+            "primary_key": ["user_id"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201
+
+    # Request the available dimensions for `default.events_agg`
+    response = await client_with_basic.get("/nodes/default.events_agg/dimensions")
+    assert response.json() == [
+        {
+            "is_primary_key": True,
+            "name": "default.events_agg.user_id",
+            "node_display_name": "Events Agg",
+            "node_name": "default.events_agg",
+            "path": [],
+            "type": "int",
+            "filter_only": False,
+        },
+        {
+            "is_primary_key": False,
+            "name": "default.event_date.dateint",
+            "node_display_name": "Events",
+            "node_name": "default.events",
+            "path": [],
+            "type": "source",
+            "filter_only": True,
+        },
+    ]
+
+    # Request SQL for default.events_agg with filters on `default.event_date`
+    response = await client_with_basic.get(
+        "/sql/default.events_agg",
+        params={
+            "filters": ["default.event_date.dateint BETWEEN 20240101 AND 20240201"],
+        },
+    )
+
+    # Check that the filters have propagated to the upstream nodes
+    assert str(parse(response.json()["sql"])) == str(
+        parse(
+            """
+            SELECT
+              default_DOT_events_agg.user_id default_DOT_events_agg_DOT_user_id,
+              default_DOT_events_agg.duration_ms default_DOT_events_agg_DOT_duration_ms
+            FROM (
+              SELECT
+                default_DOT_events.user_id,
+                SUM(default_DOT_events.duration_ms) AS duration_ms
+              FROM example.events AS default_DOT_events
+              WHERE
+                default_DOT_events.event_date BETWEEN 20240101 AND 20240201
+            ) AS default_DOT_events_agg
+            """,
+        ),
+    )

--- a/datajunction-server/tests/construction/build_test.py
+++ b/datajunction-server/tests/construction/build_test.py
@@ -37,13 +37,15 @@ async def test_build_node(
         Dict[Optional[int], Tuple[bool, str]],
     ] = request.getfixturevalue("build_expectation")
     succeeds, expected = build_expectation[node_name][db_id]
-    node = await Node.get_by_name(construction_session, node_name)
+    node = await Node.get_by_name(
+        construction_session,
+        node_name,
+    )
     if succeeds:
         ast = await build_node(
             construction_session,
             node.current,  # type: ignore
         )
-        print("QUERYY", str(ast))
         assert compare_query_strings(str(ast), expected)
     else:
         with pytest.raises(Exception) as exc:
@@ -106,8 +108,8 @@ async def test_build_metric_with_required_dimensions(
     expected = """
         SELECT
           COUNT(1) AS basic_DOT_num_comments_bnd,
-          basic_DOT_source_DOT_comments.id,
           basic_DOT_source_DOT_comments.text,
+          basic_DOT_source_DOT_comments.id,
           basic_DOT_dimension_DOT_users.country,
           basic_DOT_dimension_DOT_users.gender
         FROM basic.source.comments AS basic_DOT_source_DOT_comments
@@ -119,7 +121,7 @@ async def test_build_metric_with_required_dimensions(
           FROM basic.source.users AS basic_DOT_source_DOT_users
         ) AS basic_DOT_dimension_DOT_users ON basic_DOT_source_DOT_comments.user_id = basic_DOT_dimension_DOT_users.id
          GROUP BY
-           basic_DOT_source_DOT_comments.id, basic_DOT_source_DOT_comments.text, basic_DOT_dimension_DOT_users.country, basic_DOT_dimension_DOT_users.gender
+           basic_DOT_source_DOT_comments.text, basic_DOT_source_DOT_comments.id, basic_DOT_dimension_DOT_users.country, basic_DOT_dimension_DOT_users.gender
     """
     assert str(parse(str(query))) == str(parse(str(expected)))
 
@@ -241,10 +243,10 @@ async def test_build_metric_with_dimensions_filters(construction_session: AsyncS
     ) AS basic_DOT_dimension_DOT_users
       ON basic_DOT_source_DOT_comments.user_id = basic_DOT_dimension_DOT_users.id
     WHERE
-      basic_DOT_dimension_DOT_users.age >= 25
-      AND basic_DOT_dimension_DOT_users.age < 50
+      basic_DOT_dimension_DOT_users.age < 50
+      AND basic_DOT_dimension_DOT_users.age >= 25
     """
-    assert compare_query_strings(str(query), expected)
+    assert str(parse(str(query))) == str(parse(expected))
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/construction/fixtures.py
+++ b/datajunction-server/tests/construction/fixtures.py
@@ -374,6 +374,7 @@ async def construction_session(  # pylint: disable=too-many-locals
         columns=[
             Column(name="cnt", type=IntegerType(), order=0),
         ],
+        parents=[comments_src_ref],
     )
 
     num_comments_mtc_bnd_dims_ref = Node(
@@ -390,6 +391,7 @@ async def construction_session(  # pylint: disable=too-many-locals
         SELECT COUNT(1) AS cnt
         FROM basic.source.comments
         """,
+        parents=[comments_src_ref],
         columns=[
             Column(name="cnt", type=IntegerType(), order=0),
         ],
@@ -416,6 +418,7 @@ async def construction_session(  # pylint: disable=too-many-locals
         columns=[
             Column(name="col0", type=IntegerType(), order=0),
         ],
+        parents=[country_agg_tfm_ref],
     )
     num_users_us_join_mtc_ref = Node(
         name="basic.num_users_us",
@@ -441,6 +444,7 @@ async def construction_session(  # pylint: disable=too-many-locals
                 order=0,
             ),
         ],
+        parents=[country_agg_tfm_ref, users_src_ref],
     )
     customers_dim_ref = Node(
         name="dbt.dimension.customers",

--- a/datajunction-server/tests/sql/dag_test.py
+++ b/datajunction-server/tests/sql/dag_test.py
@@ -76,6 +76,7 @@ async def test_get_dimensions(session: AsyncSession) -> None:
             is_primary_key=False,
             type="string",
             path=["A.b_id"],
+            filter_only=False,
         ),
         DimensionAttributeOutput(
             name="B.id",
@@ -84,6 +85,7 @@ async def test_get_dimensions(session: AsyncSession) -> None:
             is_primary_key=False,
             type="int",
             path=["A.b_id"],
+            filter_only=False,
         ),
     ]
 


### PR DESCRIPTION
### Summary

This PR adds support for filtering on dimensions available on upstream source nodes, even if these dimensions aren't available on the requested node. This is to support use cases where performant queries require partition pruning on the upstream source nodes.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
