### PR TITLE
FIX create_cube doesn't hit the right end point to retrieve existing cube node

### DIFF
--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -1,4 +1,5 @@
 """DataJunction builder client module."""
+
 # pylint: disable=protected-access
 import re
 from http import HTTPStatus
@@ -115,7 +116,9 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
                 existing_node_dict = self._get_cube(name)
             else:
                 existing_node_dict = self._get_node(name)
-        except DJClientException as e:  # pragma: no cover # pytest fixture doesn't raise
+        except (
+            DJClientException
+        ) as e:  # pragma: no cover # pytest fixture doesn't raise
             if re.search(r"node .* does not exist", str(e)):
                 existing_node_dict = None
             else:
@@ -136,7 +139,8 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
                         dj_client=self,
                         metrics=existing_node_dict.get("cube_node_metrics"),
                         dimensions=existing_node_dict.get("cube_node_dimensions"),
-                        **existing_node_dict)
+                        **existing_node_dict,
+                    )
                 else:
                     existing_node = node_cls(dj_client=self, **existing_node_dict)
                 new_node = existing_node.copy(update=data)

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -75,6 +75,17 @@ class NodeType(str, enum.Enum):
     CUBE = "cube"
 
 
+class Column(BaseModel):
+    """
+    Represents a column
+    """
+
+    name: str
+    type: str
+    display_name: Optional[str]
+    attributes: Optional[List]
+
+
 class ColumnAttribute(BaseModel):
     """
     Represents a column attribute
@@ -110,7 +121,7 @@ class UpdateNode(BaseModel):
     catalog: Optional[str]
     schema_: Optional[str]
     table: Optional[str]
-    columns: Optional[List[SourceColumn]] = []
+    columns: Optional[List[Column]] = []
 
     # cube nodes only
     metrics: Optional[List[str]]
@@ -162,17 +173,6 @@ class AvailabilityState(BaseModel):
     schema_: Optional[str]
     table: str
     valid_through_ts: int
-
-
-class Column(BaseModel):
-    """
-    Represents a column
-    """
-
-    name: str
-    type: str
-    display_name: Optional[str]
-    attributes: Optional[List]
 
 
 END_JOB_STATES = [QueryState.FINISHED, QueryState.CANCELED, QueryState.FAILED]


### PR DESCRIPTION
### Summary

`create_cube` should hit the `/cubes/` endpoint, which returns the `metrics` and `dimensions` fields that are required to instantiate a `Cube` instance.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
