### PR TITLE
Add a get node function to the DJ client 

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -254,14 +254,18 @@ class DJClient:
         )
         return response.json()
 
-    def _verify_node_exists(self, node_name: str, type_: str) -> Dict[str, Any]:
+    def _verify_node_exists(
+        self,
+        node_name: str,
+        type_: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Retrieves a node and verifies that it exists and has the expected node type.
         """
         node = self._get_node(node_name)
         if "name" not in node:
             raise DJClientException(f"No node with name {node_name} exists!")
-        if "name" in node and node["type"] != type_:
+        if type_ and "name" in node and node["type"] != type_:
             raise DJClientException(
                 f"A node with name {node_name} exists, but it is not a {type_} node!",
             )

--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -112,7 +112,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
 
         try:
             existing_node_dict = self._get_node(name)
-            if type_ == models.NodeType.CUBE:
+            if type_ == models.NodeType.CUBE.value:
                 cube_dict = self._get_cube(name)
                 # This check is for the unit tests, which don't raise an exception
                 # for >= 400 status codes

--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -368,7 +368,7 @@ class DJClient(_internal.DJClient):
                 node_cls = Transform
             case models.NodeType.METRIC.value:
                 node_cls = Metric
-            case models.NodeType.CUBE.value:
+            case models.NodeType.CUBE.value:  # pragma: no cover
                 return self.cube(node_name)
 
         node = node_cls(

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 
 from datajunction import DJClient
 from datajunction.exceptions import DJClientException
+from datajunction.nodes import Cube, Dimension, Metric, Source, Transform
 
 
 class TestDJClient:  # pylint: disable=too-many-public-methods
@@ -406,3 +407,30 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         assert result == []
         result = hard_hat.get_dimensions()
         assert len(result) == 18
+
+    def test_get_node(self, client):
+        """
+        Verifies that retrieving a node (of any type) works with:
+            dj.node(<node_name>)
+        """
+        hard_hat = client.node("default.hard_hat")
+        assert isinstance(hard_hat, Dimension)
+        assert hard_hat.name == "default.hard_hat"
+
+        num_repair_orders = client.node("default.num_repair_orders")
+        assert isinstance(num_repair_orders, Metric)
+        assert num_repair_orders.name == "default.num_repair_orders"
+
+        repair_orders_thin = client.node("default.repair_orders_thin")
+        assert isinstance(repair_orders_thin, Transform)
+        assert repair_orders_thin.name == "default.repair_orders_thin"
+
+        repair_orders = client.node("default.repair_orders")
+        assert isinstance(repair_orders, Source)
+        assert repair_orders.name == "default.repair_orders"
+
+        cube_two = client.node("default.cube_two")
+        assert isinstance(cube_two, Cube)
+        assert cube_two.name == "default.cube_two"
+        assert cube_two.metrics == ["default.num_repair_orders"]
+        assert cube_two.dimensions == ["default.municipality_dim.local_region"]


### PR DESCRIPTION
### Summary

There are a few changes in this PR:
* Adds a get node function (`dj.node(<node_name>)`) to the client that is agnostic to the node type. This is useful when someone has a list of node names and needs to call the client to retrieve a node (if one exists) for each name.
* Fixes a bug with the metrics returned by the client's cube node retrieval (it was returning the metric node name + the metric column name, but the column name doesn't need to be there).
* Fixes a bug where cube node updates don't work because we were comparing a string with an enum and not its value

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
