### PR TITLE
Adds lookback window support to cube materializations

### DIFF
--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -122,6 +122,7 @@ async def build_cube_materialization_config(
                 use_materialized=False,
             )
             generic_config = DruidMetricsCubeConfig(
+                lookback_window=upsert_input.config.lookback_window,
                 node_name=current_revision.name,
                 query=metrics_query.sql,
                 dimensions=[


### PR DESCRIPTION
### Summary

This PR adds lookback window support to cube materialization jobs. Not only were we failing to save the lookback window for cube materialization, but it was also failing to use this window when generating the materialization SQL. 

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1055 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
