### PR TITLE
Various Python client features

### DIFF
--- a/datajunction-clients/python/datajunction/__init__.py
+++ b/datajunction-clients/python/datajunction/__init__.py
@@ -14,6 +14,9 @@ from datajunction.models import (
     Materialization,
     MaterializationJobType,
     MaterializationStrategy,
+    MetricDirection,
+    MetricMetadata,
+    MetricUnit,
     NodeMode,
 )
 from datajunction.nodes import (
@@ -50,6 +53,8 @@ __all__ = [
     "MaterializationJobType",
     "MaterializationStrategy",
     "Metric",
+    "MetricDirection",
+    "MetricUnit",
     "Cube",
     "Node",
     "NodeMode",

--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -149,6 +149,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
             # create
             new_node = node_cls(dj_client=self, **data)
             self._create_node(node=new_node, mode=data.get("mode"))
+            new_node._update_tags()
         new_node.refresh()
         return new_node
 
@@ -314,7 +315,9 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         query: Optional[str] = None,
         description: Optional[str] = None,
         display_name: Optional[str] = None,
-        primary_key: Optional[List[str]] = None,
+        required_dimensions: Optional[List[str]] = None,
+        direction: Optional[models.MetricDirection] = None,
+        unit: Optional[models.MetricUnit] = None,
         tags: Optional[List[Tag]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
         update_if_exists: bool = True,
@@ -330,7 +333,17 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
                 "query": query,
                 "description": description,
                 "display_name": display_name,
-                "primary_key": primary_key,
+                "required_dimensions": required_dimensions,
+                **(
+                    {
+                        "metric_metadata": models.MetricMetadata(
+                            direction=direction,
+                            unit=unit,
+                        ),
+                    }
+                    if direction or unit
+                    else {}
+                ),
                 "tags": tags,
                 "mode": mode,
             },

--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -349,6 +349,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         description: Optional[str] = None,
         display_name: Optional[str] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
+        tags: Optional[List[Tag]] = None,
         update_if_exists: bool = True,
     ) -> "Cube":
         """
@@ -365,6 +366,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
                 "description": description,
                 "display_name": display_name,
                 "mode": mode,
+                "tags": tags,
             },
             update_if_exists=update_if_exists,
         )

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -1,6 +1,6 @@
 """Models used by the DJ client."""
 import enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -12,6 +12,44 @@ class Engine(BaseModel):
 
     name: str
     version: Optional[str]
+
+
+class MetricDirection(str, enum.Enum):
+    """
+    The direction of the metric that's considered good, i.e., higher is better
+    """
+
+    HIGHER_IS_BETTER = "higher_is_better"
+    LOWER_IS_BETTER = "lower_is_better"
+    NEUTRAL = "neutral"
+
+
+class MetricUnit(str, enum.Enum):
+    """
+    Unit
+    """
+
+    UNKNOWN = "unknown"
+    UNITLESS = "unitless"
+    PERCENTAGE = "percentage"
+    PROPORTION = "proportion"
+    DOLLAR = "dollar"
+    SECOND = "second"
+    MINUTE = "minute"
+    HOUR = "hour"
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+    YEAR = "year"
+
+
+class MetricMetadata(BaseModel):
+    """
+    Metric metadata output
+    """
+
+    direction: Optional[MetricDirection]
+    unit: Optional[MetricUnit]
 
 
 class MaterializationJobType(str, enum.Enum):
@@ -118,6 +156,10 @@ class UpdateNode(BaseModel):
     filters: Optional[List[str]]
     orderby: Optional[List[str]]
     limit: Optional[int]
+
+    # metric nodes only
+    required_dimensions: Optional[List[str]]
+    metric_metadata: Optional[Dict[str, Any]]
 
 
 class UpdateTag(BaseModel):


### PR DESCRIPTION
### Summary

There are several Python client-related features in this PR, including:
* A small fix to allow for setting tags when creating a cube
* The ability to set required dimensions when creating or updating a metric node
* The ability to set metric metadata (unit, direction) when creating or updating a metric node

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
