### PR TITLE
Add datajunction-community google group to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ metrics logic, and even selections of metrics, dimensions, and filters (**cube n
 By parsing each node's SQL into an AST and through dimensional links between columns,
 DJ can infer a graph of dependencies between nodes, which allows it to find the
 appropriate join paths between nodes to generate queries for metrics.
+
+## The Community
+
+To get involved, feel free to join the DataJunction open-source community sync that's held ever two weeks--all are welcome! For an invite to the sync, simply join the [datajunction-community](https://groups.google.com/g/datajunction-community) google group.


### PR DESCRIPTION
### Summary

I've created a datajunction-community google group to make it easier for people to join the community sync. This PR adds it to the readme.
