### PR TITLE
Make tests/api/data_test.py use module scope.

### DIFF
--- a/datajunction-server/tests/api/access_test.py
+++ b/datajunction-server/tests/api/access_test.py
@@ -1,0 +1,39 @@
+"""
+Tests for the data API.
+"""
+import pytest
+
+from datajunction_server.api.main import app
+from datajunction_server.internal.access.authorization import validate_access
+from datajunction_server.models import access
+
+
+class TestDataAccessControl:  # pylint: disable=too-few-public-methods
+    """
+    Test the data access control.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_metric_data_unauthorized(
+        self,
+        module__client_with_basic,
+    ) -> None:
+        """
+        Test retrieving data for a metric
+        """
+
+        def validate_access_override():
+            def _validate_access(access_control: access.AccessControl):
+                access_control.deny_all()
+
+            return _validate_access
+
+        app.dependency_overrides[validate_access] = validate_access_override
+        response = await module__client_with_basic.get("/data/basic.num_comments/")
+        data = response.json()
+        assert data["message"] == (
+            "Authorization of User `dj` for this request failed."
+            "\nThe following requests were denied:\nread:node/basic.num_comments."
+        )
+        assert response.status_code == 403
+        app.dependency_overrides.clear()

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -236,7 +236,7 @@ async def test_export_namespace_as_notebook(
         response.headers["content-disposition"] == 'attachment; filename="export.ipynb"'
     )
     notebook = response.json()
-    assert len(notebook["cells"]) == 49
+    assert len(notebook["cells"]) == 51
     # Intro cell
     assert notebook["cells"][0]["cell_type"] == "markdown"
     assert (

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -29,6 +29,8 @@ async def test_list_dimension(client_with_roads: AsyncClient) -> None:
             {"indegree": 1, "name": "default.contractor"},
             {"indegree": 1, "name": "default.us_state"},
             {"indegree": 0, "name": "default.local_hard_hats"},
+            {"indegree": 0, "name": "default.local_hard_hats_1"},
+            {"indegree": 0, "name": "default.local_hard_hats_2"},
         ]
     }
 

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -26,7 +26,7 @@ async def test_list_all_namespaces(client_with_examples: AsyncClient) -> None:
         {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
         {"namespace": "dbt.source.stripe", "num_nodes": 1},
         {"namespace": "dbt.transform", "num_nodes": 1},
-        {"namespace": "default", "num_nodes": 56},
+        {"namespace": "default", "num_nodes": 61},
         {
             "namespace": "different.basic",
             "num_nodes": 2,
@@ -517,6 +517,11 @@ async def test_hard_delete_namespace(client_with_examples: AsyncClient):
             "foo.bar.repair_order": [
                 {
                     "effect": "broken link",
+                    "name": "foo.bar.total_repair_cost",
+                    "status": "valid",
+                },
+                {
+                    "effect": "broken link",
                     "name": "foo.bar.total_repair_order_discounts",
                     "status": "valid",
                 },
@@ -528,11 +533,6 @@ async def test_hard_delete_namespace(client_with_examples: AsyncClient):
                 {
                     "effect": "broken link",
                     "name": "foo.bar.repair_order_details",
-                    "status": "valid",
-                },
-                {
-                    "effect": "broken link",
-                    "name": "foo.bar.total_repair_cost",
                     "status": "valid",
                 },
             ],
@@ -575,7 +575,7 @@ async def test_hard_delete_namespace(client_with_examples: AsyncClient):
         {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
         {"namespace": "dbt.source.stripe", "num_nodes": 1},
         {"namespace": "dbt.transform", "num_nodes": 1},
-        {"namespace": "default", "num_nodes": 56},
+        {"namespace": "default", "num_nodes": 61},
         {"namespace": "different.basic", "num_nodes": 2},
         {"namespace": "different.basic.dimension", "num_nodes": 2},
         {"namespace": "different.basic.source", "num_nodes": 2},
@@ -704,6 +704,8 @@ async def test_export_namespaces(client_with_examples: AsyncClient):
         "contractor.dimension.yaml",
         "hard_hat.dimension.yaml",
         "local_hard_hats.dimension.yaml",
+        "local_hard_hats_1.dimension.yaml",
+        "local_hard_hats_2.dimension.yaml",
         "us_state.dimension.yaml",
         "dispatcher.dimension.yaml",
         "municipality_dim.dimension.yaml",
@@ -725,7 +727,10 @@ async def test_export_namespaces(client_with_examples: AsyncClient):
         "payment_type.dimension.yaml",
         "account_type.dimension.yaml",
         "large_revenue_payments_only.transform.yaml",
+        "large_revenue_payments_only_1.transform.yaml",
+        "large_revenue_payments_only_2.transform.yaml",
         "large_revenue_payments_and_business_only.transform.yaml",
+        "large_revenue_payments_and_business_only_1.transform.yaml",
         "number_of_account_types.metric.yaml",
         "event_source.source.yaml",
         "long_events.transform.yaml",

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -171,8 +171,11 @@ async def test_get_nodes_with_details(client_with_examples: AsyncClient):
         "basic.source.comments",
         "foo.bar.municipality_type",
         "default.large_revenue_payments_and_business_only",
+        "default.large_revenue_payments_and_business_only_1",
         "default.payment_type_table",
         "default.local_hard_hats",
+        "default.local_hard_hats_1",
+        "default.local_hard_hats_2",
         "default.dispatcher",
         "foo.bar.repair_orders",
         "basic.transform.country_agg",
@@ -250,6 +253,8 @@ async def test_get_nodes_with_details(client_with_examples: AsyncClient):
         "default.event_source",
         "foo.bar.repair_type",
         "default.large_revenue_payments_only",
+        "default.large_revenue_payments_only_1",
+        "default.large_revenue_payments_only_2",
         "default.repair_orders_fact",
     }
 

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -399,6 +399,32 @@ ROADS = (  # type: ignore
     (
         "/nodes/dimension/",
         {
+            "description": "Hard hat dimension #1",
+            "query": """
+                        SELECT hh.hard_hat_id
+                        FROM default.hard_hats hh
+                    """,
+            "mode": "published",
+            "name": "default.local_hard_hats_1",
+            "primary_key": ["hard_hat_id"],
+        },
+    ),
+    (
+        "/nodes/dimension/",
+        {
+            "description": "Hard hat dimension #2",
+            "query": """
+                        SELECT hh.hard_hat_id
+                        FROM default.hard_hats hh
+                    """,
+            "mode": "published",
+            "name": "default.local_hard_hats_2",
+            "primary_key": ["hard_hat_id"],
+        },
+    ),
+    (
+        "/nodes/dimension/",
+        {
             "description": "US state dimension",
             "query": """
                         SELECT
@@ -1400,6 +1426,30 @@ ACCOUNT_REVENUE = (  # type: ignore
         {
             "query": (
                 "SELECT payment_id, payment_amount, customer_id, account_type "
+                "FROM default.revenue WHERE payment_amount > 1000000"
+            ),
+            "description": "Only large revenue payments #1",
+            "mode": "published",
+            "name": "default.large_revenue_payments_only_1",
+        },
+    ),
+    (
+        "/nodes/transform/",
+        {
+            "query": (
+                "SELECT payment_id, payment_amount, customer_id, account_type "
+                "FROM default.revenue WHERE payment_amount > 1000000"
+            ),
+            "description": "Only large revenue payments #2",
+            "mode": "published",
+            "name": "default.large_revenue_payments_only_2",
+        },
+    ),
+    (
+        "/nodes/transform/",
+        {
+            "query": (
+                "SELECT payment_id, payment_amount, customer_id, account_type "
                 "FROM default.revenue WHERE "
                 "large_revenue_payments_and_business_only > 1000000 "
                 "AND account_type='BUSINESS'"
@@ -1407,6 +1457,20 @@ ACCOUNT_REVENUE = (  # type: ignore
             "description": "Only large revenue payments from business accounts",
             "mode": "published",
             "name": "default.large_revenue_payments_and_business_only",
+        },
+    ),
+    (
+        "/nodes/transform/",
+        {
+            "query": (
+                "SELECT payment_id, payment_amount, customer_id, account_type "
+                "FROM default.revenue WHERE "
+                "large_revenue_payments_and_business_only > 1000000 "
+                "AND account_type='BUSINESS'"
+            ),
+            "description": "Only large revenue payments from business accounts 1",
+            "mode": "published",
+            "name": "default.large_revenue_payments_and_business_only_1",
         },
     ),
     (


### PR DESCRIPTION
### Summary

What the title says... I had to take one unit test to a separate file cause it was breaking the rest "too much".

### Test Plan

pdm run pytest

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

n/a
