### PR TITLE
Raise error if a temporal partition was not specified for a Druid materialization

### DIFF
--- a/datajunction-query/docker/druid_spec.json
+++ b/datajunction-query/docker/druid_spec.json
@@ -24,7 +24,7 @@
         "type": "uniform",
         "queryGranularity": "HOUR",
         "rollup": true,
-        "segmentGranularity": "DAY"
+        "segmentGranularity": "day"
       },
       "timestampSpec": {
         "column": "timestamp",

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -9,6 +9,7 @@ from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import (
     BackfillOutput,
+    Granularity,
     PartitionColumnOutput,
     PartitionType,
 )
@@ -360,11 +361,11 @@ class DruidMeasuresCubeConfig(DruidCubeConfigInput, GenericCubeConfig):
                 "metricsSpec": metrics_spec,
                 "granularitySpec": {
                     "type": "uniform",
-                    "segmentGranularity": (
+                    "segmentGranularity": str(
                         user_defined_temporal_partition.partition.granularity
                         if user_defined_temporal_partition
-                        else "DAY"
-                    ),
+                        else Granularity.DAY,
+                    ).upper(),
                     "intervals": [],  # this should be set at runtime
                 },
             },

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1107,7 +1107,7 @@ async def test_druid_cube_agg_materialization(
             ],
             "granularitySpec": {
                 "type": "uniform",
-                "segmentGranularity": "day",
+                "segmentGranularity": "DAY",
                 "intervals": [],
             },
         },

--- a/datajunction-server/tests/api/files/materializations_test/druid_measures_cube.full.druid_spec.json
+++ b/datajunction-server/tests/api/files/materializations_test/druid_measures_cube.full.druid_spec.json
@@ -32,8 +32,8 @@
                 },
                 "format":"parquet",
                 "timestampSpec":{
-                    "column":"timestamp_column",
-                    "format":"millis"
+                    "column":"default_DOT_repair_orders_fact_DOT_order_date",
+                    "format":"yyyyMMdd"
                 }
             }
         }

--- a/datajunction-server/tests/api/files/materializations_test/druid_measures_cube.full.partition.druid_spec.json
+++ b/datajunction-server/tests/api/files/materializations_test/druid_measures_cube.full.partition.druid_spec.json
@@ -5,7 +5,7 @@
             "intervals":[
 
             ],
-            "segmentGranularity":"day",
+            "segmentGranularity":"DAY",
             "type":"uniform"
         },
         "metricsSpec":[

--- a/datajunction-server/tests/api/files/materializations_test/druid_measures_cube.incremental.druid_spec.json
+++ b/datajunction-server/tests/api/files/materializations_test/druid_measures_cube.incremental.druid_spec.json
@@ -5,7 +5,7 @@
             "intervals":[
 
             ],
-            "segmentGranularity":"day",
+            "segmentGranularity":"DAY",
             "type":"uniform"
         },
         "metricsSpec":[

--- a/datajunction-server/tests/api/files/materializations_test/druid_metrics_cube.incremental.druid_spec.json
+++ b/datajunction-server/tests/api/files/materializations_test/druid_metrics_cube.incremental.druid_spec.json
@@ -32,7 +32,7 @@
       ],
       "granularitySpec":{
          "type":"uniform",
-         "segmentGranularity":"day",
+         "segmentGranularity":"DAY",
          "intervals":[
 
          ]


### PR DESCRIPTION
### Summary

When someone sets up Druid materialization for a cube node, we need a timestamp column to use for ingestion to Druid. We can use the user-specified temporal partition for this, and if this is not supplied by the user, we should raise an error instead of silently failing.

Additionally, we were previously falling back to any timestamp column on the cube node (if one was available), but I think this behavior is confusing and removed it. It's better for users to be explicit about which timestamp column they want to use.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
