### PR TITLE
Use module-level fixtures for sql tests

### DIFF
--- a/datajunction-server/tests/api/access_test.py
+++ b/datajunction-server/tests/api/access_test.py
@@ -17,7 +17,7 @@ class TestDataAccessControl:  # pylint: disable=too-few-public-methods
     @pytest.mark.asyncio
     async def test_get_metric_data_unauthorized(
         self,
-        module__client_with_basic,
+        module__client_with_examples: AsyncClient,
     ) -> None:
         """
         Test retrieving data for a metric
@@ -30,7 +30,7 @@ class TestDataAccessControl:  # pylint: disable=too-few-public-methods
             return _validate_access
 
         app.dependency_overrides[validate_access] = validate_access_override
-        response = await module__client_with_basic.get("/data/basic.num_comments/")
+        response = await module__client_with_examples.get("/data/basic.num_comments/")
         data = response.json()
         assert data["message"] == (
             "Authorization of User `dj` for this request failed."

--- a/datajunction-server/tests/api/access_test.py
+++ b/datajunction-server/tests/api/access_test.py
@@ -2,6 +2,7 @@
 Tests for the data API.
 """
 import pytest
+from httpx import AsyncClient
 
 from datajunction_server.api.main import app
 from datajunction_server.internal.access.authorization import validate_access
@@ -36,4 +37,52 @@ class TestDataAccessControl:  # pylint: disable=too-few-public-methods
             "\nThe following requests were denied:\nread:node/basic.num_comments."
         )
         assert response.status_code == 403
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_sql_with_filters_orderby_no_access(
+        self,
+        module__client_with_examples: AsyncClient,
+    ):
+        """
+        Test ``GET /sql/{node_name}/`` with various filters and dimensions using a
+        version of the DJ roads database with namespaces.
+        """
+
+        def validate_access_override():
+            def _validate_access(access_control: access.AccessControl):
+                access_control.deny_all()
+
+            return _validate_access
+
+        app.dependency_overrides[validate_access] = validate_access_override
+
+        node_name = "foo.bar.num_repair_orders"
+        dimensions = [
+            "foo.bar.hard_hat.city",
+            "foo.bar.hard_hat.last_name",
+            "foo.bar.dispatcher.company_name",
+            "foo.bar.municipality_dim.local_region",
+        ]
+        filters = [
+            "foo.bar.repair_orders.dispatcher_id=1",
+            "foo.bar.hard_hat.state != 'AZ'",
+            "foo.bar.dispatcher.phone = '4082021022'",
+            "foo.bar.repair_orders.order_date >= '2020-01-01'",
+        ]
+        orderby = ["foo.bar.hard_hat.last_name"]
+        response = await module__client_with_examples.get(
+            f"/sql/{node_name}/",
+            params={"dimensions": dimensions, "filters": filters, "orderby": orderby},
+        )
+        data = response.json()
+        assert sorted(list(data["message"])) == sorted(
+            list(
+                "Authorization of User `dj` for this request failed."
+                "\nThe following requests were denied:\nread:node/foo.bar.dispatcher, "
+                "read:node/foo.bar.repair_orders, read:node/foo.bar.municipality_dim, "
+                "read:node/foo.bar.num_repair_orders, read:node/foo.bar.hard_hat.",
+            ),
+        )
+        assert data["errors"][0]["code"] == 500
         app.dependency_overrides.clear()

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -10,7 +10,6 @@ from httpx import AsyncClient, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from datajunction_server.api.main import app
 from datajunction_server.database.column import Column
 from datajunction_server.database.database import Database
 from datajunction_server.database.node import Node, NodeRevision
@@ -1772,54 +1771,6 @@ async def test_sql_with_filters_on_namespaced_nodes(  # pylint: disable=R0913
     )
     data = response.json()
     assert str(parse(str(data["sql"]))) == str(parse(str(sql)))
-
-
-@pytest.mark.asyncio
-async def test_sql_with_filters_orderby_no_access(  # pylint: disable=R0913
-    module__client_with_examples: AsyncClient,
-):
-    """
-    Test ``GET /sql/{node_name}/`` with various filters and dimensions using a
-    version of the DJ roads database with namespaces.
-    """
-
-    def validate_access_override():
-        def _validate_access(access_control: access.AccessControl):
-            access_control.deny_all()
-
-        return _validate_access
-
-    app.dependency_overrides[validate_access] = validate_access_override
-
-    node_name = "foo.bar.num_repair_orders"
-    dimensions = [
-        "foo.bar.hard_hat.city",
-        "foo.bar.hard_hat.last_name",
-        "foo.bar.dispatcher.company_name",
-        "foo.bar.municipality_dim.local_region",
-    ]
-    filters = [
-        "foo.bar.repair_orders.dispatcher_id=1",
-        "foo.bar.hard_hat.state != 'AZ'",
-        "foo.bar.dispatcher.phone = '4082021022'",
-        "foo.bar.repair_orders.order_date >= '2020-01-01'",
-    ]
-    orderby = ["foo.bar.hard_hat.last_name"]
-    response = await module__client_with_examples.get(
-        f"/sql/{node_name}/",
-        params={"dimensions": dimensions, "filters": filters, "orderby": orderby},
-    )
-    data = response.json()
-    assert sorted(list(data["message"])) == sorted(
-        list(
-            "Authorization of User `dj` for this request failed."
-            "\nThe following requests were denied:\nread:node/foo.bar.dispatcher, "
-            "read:node/foo.bar.repair_orders, read:node/foo.bar.municipality_dim, "
-            "read:node/foo.bar.num_repair_orders, read:node/foo.bar.hard_hat.",
-        ),
-    )
-    assert data["errors"][0]["code"] == 500
-    app.dependency_overrides[validate_access] = validate_access
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -718,12 +718,15 @@ async def module__session(
 
 
 @pytest_asyncio.fixture(scope="module")
-def module__settings(module_mocker: MockerFixture) -> Iterator[Settings]:
+def module__settings(
+    module_mocker: MockerFixture,
+    module__postgres_container: PostgresContainer,
+) -> Iterator[Settings]:
     """
     Custom settings for unit tests.
     """
     settings = Settings(
-        index="sqlite+aiosqlite://",
+        index=module__postgres_container.get_connection_url(),
         repository="/path/to/repository",
         results_backend=SimpleCache(default_timeout=0),
         celery_broker=None,
@@ -808,6 +811,16 @@ async def module__client_with_both_basics(
     Provides a DJ client fixture with account revenue examples
     """
     return await module__client_example_loader(["BASIC", "BASIC_IN_DIFFERENT_CATALOG"])
+
+
+@pytest_asyncio.fixture(scope="module")
+async def module__client_with_examples(
+    module__client_example_loader: Callable[[Optional[List[str]]], AsyncClient],
+) -> AsyncClient:
+    """
+    Provides a DJ client fixture with all examples
+    """
+    return await module__client_example_loader(None)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Summary

Switch to using module-level fixtures for sql tests. There were a few tests in here that made significant modifications to nodes, which I left on the non-module-level fixtures, as resetting them was not easy. 

### Test Plan

- [ ] PR has an associated issue
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
