### PR TITLE
Allow docs dropdown in UI with .env configured urls

### DIFF
--- a/datajunction-ui/src/app/pages/Root/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/Root/__tests__/index.test.jsx
@@ -39,7 +39,7 @@ describe('<Root />', () => {
         'href',
         '/sql',
       );
-      expect(screen.getByText('Docs').closest('a')).toHaveAttribute(
+      expect(screen.getByText('Open-Source').closest('a')).toHaveAttribute(
         'href',
         'https://www.datajunction.io',
       );

--- a/datajunction-ui/src/app/pages/Root/index.tsx
+++ b/datajunction-ui/src/app/pages/Root/index.tsx
@@ -5,6 +5,21 @@ import { Helmet } from 'react-helmet-async';
 import DJClientContext from '../../providers/djclient';
 import Search from '../../components/Search';
 
+// Define the type for the docs sites
+type DocsSites = {
+  [key: string]: string;
+};
+
+// Default docs sites if REACT_APP_DOCS_SITES is not defined
+const defaultDocsSites: DocsSites = {
+  "Open-Source": "https://www.datajunction.io/"
+};
+
+// Parse the JSON map from the environment variable or use the default
+const docsSites: DocsSites = process.env.REACT_APP_DOCS_SITES
+  ? JSON.parse(process.env.REACT_APP_DOCS_SITES as string) as DocsSites
+  : defaultDocsSites;
+
 export function Root() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
 
@@ -12,14 +27,12 @@ export function Root() {
     await djClient.logout();
     window.location.reload();
   };
+
   return (
     <>
       <Helmet>
         <title>DataJunction</title>
-        <meta
-          name="description"
-          content="DataJunction Metrics Platform Webapp"
-        />
+        <meta name="description" content="DataJunction Metrics Platform Webapp" />
       </Helmet>
       <div className="container d-flex align-items-center justify-content-between">
         <div className="header">
@@ -53,13 +66,26 @@ export function Root() {
               </span>
               <span className="menu-link">
                 <span className="menu-title">
-                  <a
-                    href="https://www.datajunction.io"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Docs
-                  </a>
+                  <div className="dropdown">
+                    <a
+                      className="btn btn-link dropdown-toggle"
+                      href="#"
+                      id="docsDropdown"
+                      role="button"
+                      aria-expanded="false"
+                    >
+                      Docs
+                    </a>
+                    <ul className="dropdown-menu" aria-labelledby="docsDropdown">
+                      {Object.entries(docsSites).map(([key, value]) => (
+                        <li key={key}>
+                          <a className="dropdown-item" href={value} target="_blank" rel="noreferrer">
+                            {key}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 </span>
               </span>
             </div>

--- a/datajunction-ui/src/styles/index.css
+++ b/datajunction-ui/src/styles/index.css
@@ -1477,3 +1477,29 @@ table {
 .active {
   border-bottom: 2px solid #007acc;
 }
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  float: left;
+  min-width: 15rem;
+  padding: 0.5rem;
+  margin: 0;
+  font-size: 1rem;
+  color: #212529;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.175);
+}
+.dropdown {
+  position: relative;
+}
+.dropdown:hover .dropdown-menu {
+  display: block;
+}


### PR DESCRIPTION
### Summary

Small change to the UI to allow expanding the docs dropdown with additional custom URLs. The purpose of this is so that internal deployments can add additional links, like URLs to internal docs.

As an example, if you set this in the .env
```env
REACT_APP_DOCS_SITES='{"Open-Source": "https://www.datajunction.io/", "Red Button": "https://clicktheredbutton.com/"}'
```

The UI would look like this:

https://github.com/DataJunction/dj/assets/43911210/75f3bc52-36ef-4c86-accb-988a1648b1fa

If you do not set this variable at all, the dropdown will default to just having the "Open-Source" item that links to the OSS docs.

### Test Plan

Ran it locally.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
