### PR TITLE
Fix issue with lateral view explode sql rendering

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -4438,7 +4438,7 @@ class Unnest(TableFunction):
     It will generate a new row for each element in the specified column.
     """
 
-    dialects = [Dialect.SPARK, Dialect.DRUID]
+    dialects = [Dialect.TRINO, Dialect.DRUID]
 
 
 @Unnest.register

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2279,7 +2279,7 @@ class FunctionTable(FunctionTableExpression):
             if self.column_list
             else ""
         )
-        column_list_str = f"({cols})" if len(self.column_list) > 1 else str(cols)
+        column_list_str = f"{cols}"
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
         return f"{self.name}{args_str}{alias}{as_}{column_list_str}"
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2279,7 +2279,9 @@ class FunctionTable(FunctionTableExpression):
             if self.column_list
             else ""
         )
-        column_list_str = f"{cols}"
+        column_list_str = (
+            f"{cols}" if self.name.name.upper() != "UNNEST" else f"({cols})"
+        )
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
         return f"{self.name}{args_str}{alias}{as_}{column_list_str}"
 


### PR DESCRIPTION
### Summary

`LATERAL VIEW EXPLODE(...) abc AS a1, b1` should not have parentheses around `a1, b1`, but the current sql rendering does put parens around them, which results in an invalid Spark SQL query.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
