### PR TITLE
Add access for node and measures sql to the Python client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
           # Run tests
           export MODULE=${{ matrix.library == 'server' && 'datajunction_server' || matrix.library == 'client' && 'datajunction' || matrix.library == 'djqs' && 'djqs' || matrix.library == 'djrs' && 'datajunction_reflection'}}
-          pdm run pytest ${{ matrix.library == 'server' && '-n auto' || '' }} --cov-fail-under=100 --cov=$MODULE --cov-report term-missing -vv tests/ --doctest-modules $MODULE --without-integration --without-slow-integration
+          pdm run pytest ${{ (matrix.library == 'server' || matrix.library == 'client') && '-n auto' || '' }} --cov-fail-under=100 --cov=$MODULE --cov-report term-missing -vv tests/ --doctest-modules $MODULE --without-integration --without-slow-integration
 
       - uses: pre-commit/action@v3.0.0
         name: Force check of all pdm.lock files

--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -162,14 +162,45 @@ class DJClient(_internal.DJClient):
         filters: Optional[List[str]] = None,
         engine_name: Optional[str] = None,
         engine_version: Optional[str] = None,
+        measures: bool = False,
     ):
         """
-        Builds SQL for one or more metrics with the provided dimensions and filters.
+        Builds SQL for one or more metrics with the provided group by dimensions and filters.
         """
+        endpoint = "/sql/"
+        if measures:
+            endpoint = "/sql/measures/"
         response = self._session.get(
-            "/sql/",
+            endpoint,
             params={
                 "metrics": metrics,
+                "dimensions": dimensions or [],
+                "filters": filters or [],
+                "engine_name": engine_name or self.engine_name,
+                "engine_version": engine_version or self.engine_version,
+            },
+        )
+        if response.status_code == 200:
+            return response.json()["sql"]
+        return response.json()
+
+    #
+    # Get SQL for a node
+    #
+    def node_sql(  # pylint: disable=too-many-arguments
+        self,
+        node_name: str,
+        dimensions: Optional[List[str]] = None,
+        filters: Optional[List[str]] = None,
+        engine_name: Optional[str] = None,
+        engine_version: Optional[str] = None,
+    ):
+        """
+        Builds SQL for a node with the provided dimensions and filters.
+        """
+        response = self._session.get(
+            f"/sql/{node_name}",
+            params={
                 "dimensions": dimensions or [],
                 "filters": filters or [],
                 "engine_name": engine_name or self.engine_name,

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -387,6 +387,17 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         )
         assert isinstance(result, str)
 
+        # Retrieve sql for a node (error)
+        result = client.node_sql(
+            node_name="default.repair_order_details",
+            dimensions=["default.repair_order.repair_order_id1"],
+            filters=["default.repair_order.repair_order_id = 1222"],
+        )
+        assert result["message"] == (
+            "default.repair_order.repair_order_id1 are not available dimensions"
+            " on default.repair_order_details"
+        )
+
         # Retrieve measures sql for metrics
         result = client.sql(
             metrics=["default.avg_repair_price", "default.num_repair_orders"],

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -367,6 +367,35 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             )
         assert "Error response from query service" in str(exc_info)
 
+    def test_sql(self, client):
+        """
+        Test SQL retrieval
+        """
+        # Retrieve sql for metrics
+        result = client.sql(
+            metrics=["default.avg_repair_price", "default.num_repair_orders"],
+            dimensions=["default.hard_hat.city"],
+            filters=["default.hard_hat.state = 'NY'"],
+        )
+        assert isinstance(result, str)
+
+        # Retrieve sql for a node
+        result = client.node_sql(
+            node_name="default.repair_order_details",
+            dimensions=["default.hard_hat.city"],
+            filters=["default.hard_hat.state = 'NY'"],
+        )
+        assert isinstance(result, str)
+
+        # Retrieve measures sql for metrics
+        result = client.sql(
+            metrics=["default.avg_repair_price", "default.num_repair_orders"],
+            dimensions=["default.hard_hat.city"],
+            filters=["default.hard_hat.state = 'NY'"],
+            measures=True,
+        )
+        assert isinstance(result, str)
+
     #
     # Data Catalog and Engines
     #

--- a/docs/content/0.1.0/docs/getting-started/requesting-sql.md
+++ b/docs/content/0.1.0/docs/getting-started/requesting-sql.md
@@ -3,38 +3,47 @@ weight: 50
 title: "Requesting SQL"
 ---
 
-DJ can generate SQL for one or more metrics with a set of compatible
-filters and dimensions.
+## Metrics SQL
+
+DJ can generate SQL for one or more metrics with a set of compatible filters and group by dimensions.
 
 {{< tabs "retrieving sql multiple" >}}
-{{< tab "curl" >}}
-```sh
-curl -X 'GET' \
-  'http://localhost:8000/sql/?metrics=default.num_repair_orders&dimensions=default.all_dispatchers.company_name&filters=default.all_dispatchers.company_name%20IS%20NOT%20NULL' \
-  -H 'accept: application/json'
-```
-{{< /tab >}}
 {{< tab "python" >}}
 ```py
 dj.sql(
     metrics=[
+      "default.avg_repair_price",
       "default.num_repair_orders",
     ],
     dimensions=[
-      "default.all_dispatchers.company_name",
+      "default.hard_hat.city",
+      "default.hard_hat.state",
     ],
     filters=[
-      "default.all_dispatchers.company_name IS NOT NULL"
+      "default.hard_hat.state = 'NY'"
     ],
 )
+```
+{{< /tab >}}
+{{< tab "curl" >}}
+```sh
+curl -X 'GET' \
+  'http://localhost:8000/sql/?metrics=default.num_repair_orders&&metrics=default.avg_repair_price&dimensions=default.hard_hat.city&dimensions=default.hard_hat.state&filters=default.hard_hat.state%20%3D%20%27NY%27' \
+  -H 'accept: application/json'
 ```
 {{< /tab >}}
 {{< tab "javascript" >}}
 ```js
 dj.sql.get(
-  metrics=["default.num_repair_orders"],
-  dimensions=["default.all_dispatchers.company_name"],
-  filters=["default.all_dispatchers.company_name IS NOT NULL"]
+  metrics=[
+    "default.num_repair_orders",
+    "default.avg_repair_price",
+  ],
+  dimensions=[
+    "default.hard_hat.city",
+    "default.hard_hat.state",
+  ],
+  filters=["default.hard_hat.state = 'NY'"]
 ).then(data => console.log(data))
 ```
 {{< /tab >}}
@@ -43,3 +52,64 @@ dj.sql.get(
 {{< alert icon="👉" >}}
 You can optionally provide an `engine_name` and `engine_version`. A typical DataJunction query service will include a default engine.
 {{< /alert >}}
+
+## Node SQL
+DJ can generate SQL for a node with a compatible filters and dimensions.
+
+{{< tabs "retrieving node sql" >}}
+{{< tab "python" >}}
+```py
+dj.sql(
+    node_name=[
+      "default.repair_orders_fact",
+    ],
+    dimensions=[
+      "default.hard_hat.city",
+      "default.hard_hat.state",
+    ],
+    filters=[
+      "default.hard_hat.state = 'NY'"
+    ],
+)
+```
+{{< /tab >}}
+{{< tab "curl" >}}
+```sh
+curl -X 'GET' \
+  'http://localhost:8000/sql/default.repair_orders_fact?dimensions=default.hard_hat.city&dimensions=default.hard_hat.state&filters=default.hard_hat.state%20%3D%20%27NY%27' \
+  -H 'accept: application/json'
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+## Measures SQL
+
+DJ can also return the measures SQL for a set of metrics with group by dimensions and filters. This SQL can be used to produce an intermediate table with all the measures and dimensions needed for an analytics database (e.g., Druid).
+
+{{< tabs "retrieving measures sql" >}}
+{{< tab "python" >}}
+```py
+dj.sql(
+    metrics=[
+      "default.avg_repair_price",
+      "default.num_repair_orders",
+    ],
+    dimensions=[
+      "default.hard_hat.city",
+      "default.hard_hat.state",
+    ],
+    filters=[
+      "default.hard_hat.state = 'NY'"
+    ],
+    measures=True,
+)
+```
+{{< /tab >}}
+{{< tab "curl" >}}
+```sh
+curl -X 'GET' \
+  'http://localhost:8000/sql/measures?metrics=default.num_repair_orders&&metrics=default.avg_repair_price&dimensions=default.hard_hat.city&dimensions=default.hard_hat.state&filters=default.hard_hat.state%20%3D%20%27NY%27' \
+  -H 'accept: application/json'
+```
+{{< /tab >}}
+{{< /tabs >}}


### PR DESCRIPTION
### Summary

This adds the ability to retrieve node SQL and measures SQL using the Python client. This is helpful for anyone who is debugging their nodes.

### Test Plan

Added parallelism for the Python client tests by passing in `-n auto` when running client tests. This reduces the runtime of the client tests from 28min to 14min cc @agorajek 

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
