### PR TITLE
Add users endpoints for retrieving nodes by user

### DIFF
--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -42,6 +42,7 @@ from datajunction_server.api import (
     nodes,
     sql,
     tags,
+    users,
 )
 from datajunction_server.api.access.authentication import whoami
 from datajunction_server.api.attributes import default_attribute_types
@@ -109,6 +110,7 @@ app.include_router(client.router)
 app.include_router(dimensions.router)
 app.include_router(graphql_app, prefix="/graphql")
 app.include_router(whoami.router)
+app.include_router(users.router)
 
 
 @app.on_event("startup")

--- a/datajunction-server/datajunction_server/api/users.py
+++ b/datajunction-server/datajunction_server/api/users.py
@@ -1,0 +1,62 @@
+"""
+User related APIs.
+"""
+
+from typing import List
+
+from fastapi import Depends, Query
+from sqlalchemy import distinct, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
+
+from datajunction_server.database.column import Column
+from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.models.node import NodeMinimumDetail
+from datajunction_server.utils import get_session, get_settings
+
+settings = get_settings()
+router = SecureAPIRouter(tags=["users"])
+
+
+@router.get("/users/{username}", response_model=List[NodeMinimumDetail])
+async def list_nodes_by_username(
+    username: str,
+    *,
+    session: AsyncSession = Depends(get_session),
+    activity_types: List[str] = Query([ActivityType.CREATE, ActivityType.UPDATE]),
+) -> List[NodeMinimumDetail]:
+    """
+    List all nodes created by the user
+    """
+    statement = select(distinct(History.entity_name)).where(
+        (History.user == username)
+        & (History.entity_type == EntityType.NODE)
+        & (History.activity_type.in_(activity_types)),
+    )
+    result = await session.execute(statement)
+    nodes = await Node.get_by_names(
+        session=session,
+        names=list(set(result.scalars().all())),
+        options=[
+            joinedload(Node.current).options(
+                selectinload(NodeRevision.cube_elements)
+                .selectinload(Column.node_revisions)
+                .options(
+                    selectinload(NodeRevision.node),
+                ),
+            ),
+        ],
+    )
+    return [node.current for node in nodes]
+
+
+@router.get("/users", response_model=List[str])
+async def list_users(session: AsyncSession = Depends(get_session)) -> List[str]:
+    """
+    List all users
+    """
+    statement = select(distinct(History.user))
+    result = await session.execute(statement)
+    return list({user for user in result.scalars().all() if user})

--- a/datajunction-server/tests/api/users_test.py
+++ b/datajunction-server/tests/api/users_test.py
@@ -1,0 +1,68 @@
+"""
+Tests for users API endpoints
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestUsers:
+    """
+    Test users API endpoints.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_users(self, module__client_with_roads: AsyncClient) -> None:
+        """
+        Test ``POST /tags`` and ``GET /tags/{name}``
+        """
+
+        response = await module__client_with_roads.get("/users")
+        assert response.json() == ["dj"]
+
+    @pytest.mark.asyncio
+    async def test_list_nodes_by_user(
+        self, module__client_with_roads: AsyncClient,
+    ) -> None:
+        """
+        Test ``POST /tags`` and ``GET /tags/{name}``
+        """
+
+        response = await module__client_with_roads.get("/users/dj")
+        assert [(node["name"], node["type"]) for node in response.json()] == [
+            ("default.repair_orders", "source"),
+            ("default.repair_order_details", "source"),
+            ("default.repair_type", "source"),
+            ("default.contractors", "source"),
+            ("default.municipality_municipality_type", "source"),
+            ("default.municipality_type", "source"),
+            ("default.municipality", "source"),
+            ("default.dispatchers", "source"),
+            ("default.hard_hats", "source"),
+            ("default.hard_hat_state", "source"),
+            ("default.us_states", "source"),
+            ("default.us_region", "source"),
+            ("default.repair_order", "dimension"),
+            ("default.contractor", "dimension"),
+            ("default.hard_hat", "dimension"),
+            ("default.hard_hat_2", "dimension"),
+            ("default.hard_hat_to_delete", "dimension"),
+            ("default.local_hard_hats", "dimension"),
+            ("default.local_hard_hats_1", "dimension"),
+            ("default.local_hard_hats_2", "dimension"),
+            ("default.us_state", "dimension"),
+            ("default.dispatcher", "dimension"),
+            ("default.municipality_dim", "dimension"),
+            ("default.regional_level_agg", "transform"),
+            ("default.national_level_agg", "transform"),
+            ("default.repair_orders_fact", "transform"),
+            ("default.regional_repair_efficiency", "metric"),
+            ("default.num_repair_orders", "metric"),
+            ("default.avg_repair_price", "metric"),
+            ("default.total_repair_cost", "metric"),
+            ("default.avg_length_of_employment", "metric"),
+            ("default.discounted_orders_rate", "metric"),
+            ("default.total_repair_order_discounts", "metric"),
+            ("default.avg_repair_order_discounts", "metric"),
+            ("default.avg_time_to_dispatch", "metric"),
+        ]

--- a/datajunction-server/tests/api/users_test.py
+++ b/datajunction-server/tests/api/users_test.py
@@ -22,7 +22,8 @@ class TestUsers:
 
     @pytest.mark.asyncio
     async def test_list_nodes_by_user(
-        self, module__client_with_roads: AsyncClient,
+        self,
+        module__client_with_roads: AsyncClient,
     ) -> None:
         """
         Test ``POST /tags`` and ``GET /tags/{name}``


### PR DESCRIPTION
### Summary

This PR adds two `/users` endpoints, one for retrieving all users and the other for retrieving nodes for a given user.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
