### PR TITLE
Make add namespace popover less confusing 

### DIFF
--- a/datajunction-ui/src/app/icons/AddItemIcon.jsx
+++ b/datajunction-ui/src/app/icons/AddItemIcon.jsx
@@ -1,0 +1,16 @@
+const AddItemIcon = props => (
+  <svg
+    enable-background="new 0 0 512 512"
+    height="20px"
+    id="Layer_1"
+    version="1.1"
+    viewBox="0 0 512 512"
+    width="20px"
+    xmlSpace="preserve"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    <path d="M256,512C114.625,512,0,397.391,0,256C0,114.609,114.625,0,256,0c141.391,0,256,114.609,256,256  C512,397.391,397.391,512,256,512z M256,64C149.969,64,64,149.969,64,256s85.969,192,192,192c106.047,0,192-85.969,192-192  S362.047,64,256,64z M288,384h-64v-96h-96v-64h96v-96h64v96h96v64h-96V384z" />
+  </svg>
+);
+export default AddItemIcon;

--- a/datajunction-ui/src/app/pages/NamespacePage/AddNamespacePopover.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/AddNamespacePopover.jsx
@@ -2,9 +2,8 @@ import { useContext, useState } from 'react';
 import * as React from 'react';
 import DJClientContext from '../../providers/djclient';
 import { ErrorMessage, Field, Form, Formik } from 'formik';
-import { FormikSelect } from '../AddEditNodePage/FormikSelect';
-import EditIcon from '../../icons/EditIcon';
-import { displayMessageAfterSubmit, labelize } from '../../../utils/form';
+import AddItemIcon from '../../icons/AddItemIcon';
+import { displayMessageAfterSubmit } from '../../../utils/form';
 
 export default function AddNamespacePopover({ namespace }) {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
@@ -33,7 +32,7 @@ export default function AddNamespacePopover({ namespace }) {
           setPopoverAnchor(!popoverAnchor);
         }}
       >
-        <EditIcon />
+        <AddItemIcon />
       </button>
       <div
         className="popover"
@@ -48,7 +47,7 @@ export default function AddNamespacePopover({ namespace }) {
       >
         <Formik
           initialValues={{
-            namespace: '',
+            namespace: namespace + '.',
           }}
           onSubmit={addNamespace}
         >
@@ -64,6 +63,7 @@ export default function AddNamespacePopover({ namespace }) {
                     name="namespace"
                     id="namespace"
                     placeholder="New namespace"
+                    default={namespace}
                   />
                 </span>
                 <button

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
@@ -167,7 +167,7 @@ describe('NamespacePage', () => {
     });
     expect(mockDjClient.addNamespace).toHaveBeenCalled();
     expect(mockDjClient.addNamespace).toHaveBeenCalledWith(
-      'some.random.namespace',
+      'test.namespace.some.random.namespace',
     );
     expect(screen.getByText('Saved')).toBeInTheDocument();
     expect(window.location.reload).toHaveBeenCalled();

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -167,7 +167,7 @@ export function NamespacePage() {
                   padding: '1rem 1rem 1rem 0',
                 }}
               >
-                Namespaces <AddNamespacePopover />
+                Namespaces <AddNamespacePopover namespace={namespace}/>
               </span>
               {namespaceHierarchy
                 ? namespaceHierarchy.map(child => (


### PR DESCRIPTION
### Summary

This PR makes the add namespace popover less confusing with the following changes:
* Pre-populating the form field with the namespace that the user is currently in, if any
* Changing the icon from an edit icon to an add icon

<img width="252" alt="Screenshot 2024-07-10 at 8 01 49 PM" src="https://github.com/DataJunction/dj/assets/9524628/1724ab1a-bd8f-476f-b392-572f3716e22a">

### Test Plan

Locally

- [x] PR has an associated issue: #1097 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
