### PR TITLE
Upsert users who are authenticated but not stored in the user table

### DIFF
--- a/datajunction-server/alembic/versions/2024_07_12_0348-34171c92dd6d_set_user_username_to_be_unique.py
+++ b/datajunction-server/alembic/versions/2024_07_12_0348-34171c92dd6d_set_user_username_to_be_unique.py
@@ -8,21 +8,21 @@ Create Date: 2024-07-12 03:48:53.609685+00:00
 # pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
 
 import sqlalchemy as sa
+
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
-revision = '34171c92dd6d'
-down_revision = '640a814db2d8'
+revision = "34171c92dd6d"
+down_revision = "640a814db2d8"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    with op.batch_alter_table('users', schema=None) as batch_op:
-        batch_op.create_unique_constraint(None, ['username'])
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.create_unique_constraint(None, ["username"])
 
 
 def downgrade():
-    with op.batch_alter_table('users', schema=None) as batch_op:
-        batch_op.drop_constraint(None, type_='unique')
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_="unique")

--- a/datajunction-server/alembic/versions/2024_07_12_0348-34171c92dd6d_set_user_username_to_be_unique.py
+++ b/datajunction-server/alembic/versions/2024_07_12_0348-34171c92dd6d_set_user_username_to_be_unique.py
@@ -1,0 +1,28 @@
+"""Set User.username to be unique
+
+Revision ID: 34171c92dd6d
+Revises: 640a814db2d8
+Create Date: 2024-07-12 03:48:53.609685+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '34171c92dd6d'
+down_revision = '640a814db2d8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.create_unique_constraint(None, ['username'])
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_='unique')

--- a/datajunction-server/datajunction_server/api/access/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/whoami.py
@@ -11,14 +11,16 @@ from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authentication.tokens import create_token
 from datajunction_server.models.user import UserOutput
-from datajunction_server.utils import get_current_user, get_settings
+from datajunction_server.utils import get_current_user_and_upsert, get_settings
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["Who am I?"])
 
 
 @router.get("/whoami/", response_model=UserOutput)
-async def get_user(current_user: User = Depends(get_current_user)) -> UserOutput:
+async def get_user(
+    current_user: User = Depends(get_current_user_and_upsert),
+) -> UserOutput:
     """
     Returns the current authenticated user
     """

--- a/datajunction-server/datajunction_server/api/access/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/whoami.py
@@ -11,7 +11,7 @@ from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authentication.tokens import create_token
 from datajunction_server.models.user import UserOutput
-from datajunction_server.utils import get_current_user_and_upsert, get_settings
+from datajunction_server.utils import get_and_update_current_user, get_settings
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["Who am I?"])
@@ -19,7 +19,7 @@ router = SecureAPIRouter(tags=["Who am I?"])
 
 @router.get("/whoami/", response_model=UserOutput)
 async def get_user(
-    current_user: User = Depends(get_current_user_and_upsert),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> UserOutput:
     """
     Returns the current authenticated user

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -37,7 +37,7 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate, QueryWithResults
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_query_service_client,
     get_session,
     get_settings,
@@ -53,7 +53,7 @@ async def add_availability_state(
     data: AvailabilityStateBase,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -177,7 +177,7 @@ async def get_data(  # pylint: disable=too-many-locals
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -248,7 +248,7 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -361,7 +361,7 @@ async def get_data_for_metrics(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -37,7 +37,7 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate, QueryWithResults
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import (
-    get_current_user,
+    get_current_user_and_upsert,
     get_query_service_client,
     get_session,
     get_settings,
@@ -53,7 +53,7 @@ async def add_availability_state(
     data: AvailabilityStateBase,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -177,7 +177,7 @@ async def get_data(  # pylint: disable=too-many-locals
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -248,7 +248,7 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -361,7 +361,7 @@ async def get_data_for_metrics(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -25,7 +25,7 @@ from datajunction_server.sql.dag import (
     get_nodes_with_dimension,
 )
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_session,
     get_settings,
 )
@@ -40,7 +40,7 @@ async def list_dimensions(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -71,7 +71,7 @@ async def find_nodes_with_dimension(
     *,
     node_type: List[NodeType] = Query([]),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -104,7 +104,7 @@ async def find_nodes_with_common_dimensions(
     node_type: List[NodeType] = Query([]),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -24,7 +24,11 @@ from datajunction_server.sql.dag import (
     get_nodes_with_common_dimensions,
     get_nodes_with_dimension,
 )
-from datajunction_server.utils import get_current_user, get_session, get_settings
+from datajunction_server.utils import (
+    get_current_user_and_upsert,
+    get_session,
+    get_settings,
+)
 
 settings = get_settings()
 _logger = logging.getLogger(__name__)
@@ -36,7 +40,7 @@ async def list_dimensions(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -67,7 +71,7 @@ async def find_nodes_with_dimension(
     *,
     node_type: List[NodeType] = Query([]),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -100,7 +104,7 @@ async def find_nodes_with_common_dimensions(
     node_type: List[NodeType] = Query([]),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -16,7 +16,7 @@ from datajunction_server.models import access
 from datajunction_server.models.query import QueryCreate, QueryWithResults
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_query_service_client,
     get_session,
     get_settings,
@@ -36,7 +36,7 @@ async def get_data_for_djsql(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     )
@@ -87,7 +87,7 @@ async def get_data_stream_for_djsql(
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     )

--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -16,7 +16,7 @@ from datajunction_server.models import access
 from datajunction_server.models.query import QueryCreate, QueryWithResults
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import (
-    get_current_user,
+    get_current_user_and_upsert,
     get_query_service_client,
     get_session,
     get_settings,
@@ -36,7 +36,7 @@ async def get_data_for_djsql(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     )
@@ -87,7 +87,7 @@ async def get_data_stream_for_djsql(
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     )

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -41,7 +41,7 @@ from datajunction_server.naming import amenable_name
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_query_service_client,
     get_session,
     get_settings,
@@ -84,7 +84,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -277,7 +277,7 @@ async def deactivate_node_materializations(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> List[MaterializationConfigInfoUnified]:
     """
     Deactivate the node materialization with the provided name.
@@ -334,7 +334,7 @@ async def run_materialization_backfill(  # pylint: disable=too-many-locals
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> MaterializationInfo:
     """
     Start a backfill for a configured materialization.

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -41,7 +41,7 @@ from datajunction_server.naming import amenable_name
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import (
-    get_current_user,
+    get_current_user_and_upsert,
     get_query_service_client,
     get_session,
     get_settings,
@@ -84,7 +84,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -277,7 +277,7 @@ async def deactivate_node_materializations(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> List[MaterializationConfigInfoUnified]:
     """
     Deactivate the node materialization with the provided name.
@@ -334,7 +334,7 @@ async def run_materialization_backfill(  # pylint: disable=too-many-locals
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> MaterializationInfo:
     """
     Start a backfill for a configured materialization.

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -28,7 +28,7 @@ from datajunction_server.models.node import (
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.dag import get_dimensions, get_shared_dimensions
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_session,
     get_settings,
 )
@@ -65,7 +65,7 @@ async def list_metrics(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -27,7 +27,11 @@ from datajunction_server.models.node import (
 )
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.dag import get_dimensions, get_shared_dimensions
-from datajunction_server.utils import get_current_user, get_session, get_settings
+from datajunction_server.utils import (
+    get_current_user_and_upsert,
+    get_session,
+    get_settings,
+)
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["metrics"])
@@ -61,7 +65,7 @@ async def list_metrics(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -32,7 +32,11 @@ from datajunction_server.internal.nodes import activate_node, deactivate_node
 from datajunction_server.models import access
 from datajunction_server.models.node import NamespaceOutput, NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
-from datajunction_server.utils import get_current_user, get_session, get_settings
+from datajunction_server.utils import (
+    get_current_user_and_upsert,
+    get_session,
+    get_settings,
+)
 
 _logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -44,7 +48,7 @@ async def create_node_namespace(
     namespace: str,
     include_parents: Optional[bool] = False,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Create a node namespace
@@ -98,7 +102,7 @@ async def create_node_namespace(
 )
 async def list_namespaces(
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -156,7 +160,7 @@ async def deactivate_a_namespace(
         description="Cascade the deletion down to the nodes in the namespace",
     ),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Deactivates a node namespace
@@ -228,7 +232,7 @@ async def restore_a_namespace(
         description="Cascade the restore down to the nodes in the namespace",
     ),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Restores a node namespace
@@ -293,7 +297,7 @@ async def hard_delete_node_namespace(
     *,
     cascade: bool = False,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Hard delete a namespace, which will completely remove the namespace. Additionally,

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -33,7 +33,7 @@ from datajunction_server.models import access
 from datajunction_server.models.node import NamespaceOutput, NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_session,
     get_settings,
 )
@@ -48,7 +48,7 @@ async def create_node_namespace(
     namespace: str,
     include_parents: Optional[bool] = False,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Create a node namespace
@@ -102,7 +102,7 @@ async def create_node_namespace(
 )
 async def list_namespaces(
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -160,7 +160,7 @@ async def deactivate_a_namespace(
         description="Cascade the deletion down to the nodes in the namespace",
     ),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Deactivates a node namespace
@@ -232,7 +232,7 @@ async def restore_a_namespace(
         description="Cascade the restore down to the nodes in the namespace",
     ),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Restores a node namespace
@@ -297,7 +297,7 @@ async def hard_delete_node_namespace(
     *,
     cascade: bool = False,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Hard delete a namespace, which will completely remove the namespace. Additionally,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -108,7 +108,7 @@ from datajunction_server.sql.dag import (
 from datajunction_server.sql.parsing.backends.antlr4 import parse, parse_rule
 from datajunction_server.utils import (
     Version,
-    get_current_user,
+    get_current_user_and_upsert,
     get_namespace_from_name,
     get_query_service_client,
     get_session,
@@ -153,7 +153,7 @@ async def validate_node(
 async def revalidate(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> NodeStatusDetails:
     """
     Revalidate a single existing node and update its status appropriately
@@ -200,7 +200,7 @@ async def set_column_attributes(
     attributes: List[AttributeTypeIdentifier],
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> List[ColumnOutput]:
     """
     Set column attributes for the node.
@@ -228,7 +228,7 @@ async def list_nodes(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -259,7 +259,7 @@ async def list_all_nodes_with_details(
     node_type: Optional[NodeType] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -333,7 +333,7 @@ async def delete_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ):
     """
     Delete (aka deactivate) the specified node.
@@ -349,7 +349,7 @@ async def delete_node(
 async def hard_delete(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
@@ -374,7 +374,7 @@ async def restore_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ):
     """
     Restore (aka re-activate) the specified node.
@@ -409,7 +409,7 @@ async def create_source(
     data: CreateSourceNode,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -517,7 +517,7 @@ async def create_node(
     request: Request,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
@@ -615,7 +615,7 @@ async def create_cube(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -669,7 +669,7 @@ async def register_table(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     background_tasks: BackgroundTasks,
 ) -> NodeOutput:
     """
@@ -725,7 +725,7 @@ async def link_dimension(
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Add information to a node column
@@ -808,7 +808,7 @@ async def add_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_input: LinkDimensionInput,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Links a source, dimension, or transform node to a dimension with a custom join query.
@@ -841,7 +841,7 @@ async def remove_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_identifier: LinkDimensionIdentifier,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Removes a complex dimension link based on the dimension node and its role (if any).
@@ -861,7 +861,7 @@ async def delete_dimension_link(
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Remove the link between a node column and a dimension node
@@ -885,7 +885,7 @@ async def tags_node(
     tag_names: Optional[List[str]] = Query(default=None),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> JSONResponse:
     """
     Add a tag to a node
@@ -935,7 +935,7 @@ async def refresh_source_node(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> NodeOutput:
     """
     Refresh a source node with the latest columns from the query service.
@@ -1064,7 +1064,7 @@ async def update_node(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -1261,7 +1261,7 @@ async def set_column_display_name(
     node_name: str,
     column_name: str,
     display_name: str,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     *,
     session: AsyncSession = Depends(get_session),
 ) -> ColumnOutput:
@@ -1304,7 +1304,7 @@ async def set_column_partition(  # pylint: disable=too-many-locals
     input_partition: PartitionInput,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> ColumnOutput:
     """
     Add or update partition columns for the specified node.
@@ -1374,7 +1374,7 @@ async def copy_node(
     *,
     new_name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> DAGNodeOutput:
     """
     Copy this node to a new name.

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -108,7 +108,7 @@ from datajunction_server.sql.dag import (
 from datajunction_server.sql.parsing.backends.antlr4 import parse, parse_rule
 from datajunction_server.utils import (
     Version,
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_namespace_from_name,
     get_query_service_client,
     get_session,
@@ -153,7 +153,7 @@ async def validate_node(
 async def revalidate(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> NodeStatusDetails:
     """
     Revalidate a single existing node and update its status appropriately
@@ -200,7 +200,7 @@ async def set_column_attributes(
     attributes: List[AttributeTypeIdentifier],
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> List[ColumnOutput]:
     """
     Set column attributes for the node.
@@ -228,7 +228,7 @@ async def list_nodes(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -259,7 +259,7 @@ async def list_all_nodes_with_details(
     node_type: Optional[NodeType] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -333,7 +333,7 @@ async def delete_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ):
     """
     Delete (aka deactivate) the specified node.
@@ -349,7 +349,7 @@ async def delete_node(
 async def hard_delete(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
@@ -374,7 +374,7 @@ async def restore_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ):
     """
     Restore (aka re-activate) the specified node.
@@ -409,7 +409,7 @@ async def create_source(
     data: CreateSourceNode,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -517,7 +517,7 @@ async def create_node(
     request: Request,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
@@ -615,7 +615,7 @@ async def create_cube(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -669,7 +669,7 @@ async def register_table(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     background_tasks: BackgroundTasks,
 ) -> NodeOutput:
     """
@@ -725,7 +725,7 @@ async def link_dimension(
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Add information to a node column
@@ -808,7 +808,7 @@ async def add_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_input: LinkDimensionInput,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Links a source, dimension, or transform node to a dimension with a custom join query.
@@ -841,7 +841,7 @@ async def remove_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_identifier: LinkDimensionIdentifier,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Removes a complex dimension link based on the dimension node and its role (if any).
@@ -861,7 +861,7 @@ async def delete_dimension_link(
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Remove the link between a node column and a dimension node
@@ -885,7 +885,7 @@ async def tags_node(
     tag_names: Optional[List[str]] = Query(default=None),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Add a tag to a node
@@ -935,7 +935,7 @@ async def refresh_source_node(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> NodeOutput:
     """
     Refresh a source node with the latest columns from the query service.
@@ -1064,7 +1064,7 @@ async def update_node(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -1261,7 +1261,7 @@ async def set_column_display_name(
     node_name: str,
     column_name: str,
     display_name: str,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     *,
     session: AsyncSession = Depends(get_session),
 ) -> ColumnOutput:
@@ -1304,7 +1304,7 @@ async def set_column_partition(  # pylint: disable=too-many-locals
     input_partition: PartitionInput,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> ColumnOutput:
     """
     Add or update partition columns for the specified node.
@@ -1374,7 +1374,7 @@ async def copy_node(
     *,
     new_name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> DAGNodeOutput:
     """
     Copy this node to a new name.

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -28,7 +28,7 @@ from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.user import UserOutput
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_session,
     get_settings,
 )
@@ -54,7 +54,7 @@ async def get_measures_sql_for_cube(
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -304,7 +304,7 @@ async def get_sql(  # pylint: disable=too-many-locals
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -340,7 +340,7 @@ async def get_sql_for_metrics(
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -27,7 +27,11 @@ from datajunction_server.models.access import AccessControlStore
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.user import UserOutput
-from datajunction_server.utils import get_current_user, get_session, get_settings
+from datajunction_server.utils import (
+    get_current_user_and_upsert,
+    get_session,
+    get_settings,
+)
 
 _logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -50,7 +54,7 @@ async def get_measures_sql_for_cube(
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -300,7 +304,7 @@ async def get_sql(  # pylint: disable=too-many-locals
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -336,7 +340,7 @@ async def get_sql_for_metrics(
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -19,7 +19,7 @@ from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.tag import CreateTag, TagOutput, UpdateTag
 from datajunction_server.utils import (
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_session,
     get_settings,
 )
@@ -97,7 +97,7 @@ async def get_a_tag(
 async def create_a_tag(
     data: CreateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> TagOutput:
     """
     Create a tag.
@@ -134,7 +134,7 @@ async def update_a_tag(
     name: str,
     data: UpdateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user_and_upsert),
+    current_user: Optional[User] = Depends(get_and_update_current_user),
 ) -> TagOutput:
     """
     Update a tag.

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -18,7 +18,11 @@ from datajunction_server.internal.access.authentication.http import SecureAPIRou
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.tag import CreateTag, TagOutput, UpdateTag
-from datajunction_server.utils import get_current_user, get_session, get_settings
+from datajunction_server.utils import (
+    get_current_user_and_upsert,
+    get_session,
+    get_settings,
+)
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["tags"])
@@ -93,7 +97,7 @@ async def get_a_tag(
 async def create_a_tag(
     data: CreateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> TagOutput:
     """
     Create a tag.
@@ -130,7 +134,7 @@ async def update_a_tag(
     name: str,
     data: UpdateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_current_user),
+    current_user: Optional[User] = Depends(get_current_user_and_upsert),
 ) -> TagOutput:
     """
     Update a tag.

--- a/datajunction-server/datajunction_server/database/user.py
+++ b/datajunction-server/datajunction_server/database/user.py
@@ -1,7 +1,7 @@
 """User database schema."""
 from typing import Optional
 
-from sqlalchemy import BigInteger, Enum, Integer
+from sqlalchemy import BigInteger, Enum, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from datajunction_server.database.base import Base
@@ -27,7 +27,7 @@ class User(Base):  # pylint: disable=too-few-public-methods
         BigInteger().with_variant(Integer, "sqlite"),
         primary_key=True,
     )
-    username: Mapped[str]
+    username: Mapped[str] = mapped_column(String, unique=True)
     password: Mapped[Optional[str]]
     email: Mapped[Optional[str]]
     name: Mapped[Optional[str]]

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -261,7 +261,7 @@ async def get_current_user(request: Request) -> Optional["User"]:
     return None  # pragma: no cover
 
 
-async def get_current_user_and_upsert(
+async def get_and_update_current_user(
     session: AsyncSession = Depends(get_session),
     current_user: Optional["User"] = Depends(get_current_user),
 ) -> Optional["User"]:

--- a/datajunction-server/tests/utils_test.py
+++ b/datajunction-server/tests/utils_test.py
@@ -18,7 +18,7 @@ from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import DJException
 from datajunction_server.utils import (
     Version,
-    get_current_user_and_upsert,
+    get_and_update_current_user,
     get_engine,
     get_issue_url,
     get_query_service_client,
@@ -137,7 +137,7 @@ def test_version_parse() -> None:
     assert str(excinfo.value) == "Unparseable version 0!"
 
 
-async def test_get_current_user_and_upsert(session: AsyncSession):
+async def test_get_and_update_current_user(session: AsyncSession):
     """
     Test upserting the current user
     """
@@ -151,7 +151,7 @@ async def test_get_current_user_and_upsert(session: AsyncSession):
     )
 
     # Confirm that the current user is returned after upserting
-    current_user = await get_current_user_and_upsert(
+    current_user = await get_and_update_current_user(
         session=session,
         current_user=example_user,
     )
@@ -170,5 +170,5 @@ async def test_get_current_user_and_upsert(session: AsyncSession):
     assert found_user.oauth_provider == "basic"
 
     # Confirm that if current_user is None, this also returns None
-    current_user = await get_current_user_and_upsert(session=session, current_user=None)
+    current_user = await get_and_update_current_user(session=session, current_user=None)
     assert current_user is None


### PR DESCRIPTION
### Summary

This adds a `get_current_user_and_upsert` dependable that is also a dependent that relies on the `get_current_user` dependable that already existed (Am I the only one confused by this terminology?). Essentially all of this dependency magic turns into a middleware chain where:
- First the `get_current_user` dependency runs as it does today. That means any internal deployments that have injected their own authentication middleware that overrides this dependency will still work exactly as it does today.
- Next on the chain is the `get_current_user_and_upsert` function which will do a simple upsert to insert the user into the DJ metadata `users` table, if it does not already exist (based on the username)

Below describes what will happen in a few of the typical auth scenarios:

#### Scenario 1: Basic Auth (no change)
- When a user goes through the basic auth signup flow, the user is inserted into the DJ metadata `users` table.
- When the user logs in, they're authenticated and the encrypted cookie is stored
- On authenticated requests, the cookie is processed by the backend and the user is retrieved from the `users` table
- The `get_current_user_and_upsert` is essentially a no-op since the user already exists in the `users` table

#### Scenario 2: Google OAuth (no change)
- A user signs in with google through the google oauth flow
- If it's the user's first time, they're inserted into the `users` table
- An encrypted cookie is stored on the client
- On authenticated requests, the cookie is processed by the backend and the user is retrieved from the `users` table
- The `get_current_user_and_upsert` is essentially a no-op since the user already exists in the `users` table

#### Scenario 3: `get_current_user` override to use custom auth managed by an external system (only setup impacted by this PR)
- `get_current_user` returns a `User` object instantiated from data retrieved from some system external to DJ
- `get_current_user_and_upsert` runs to guarantee the user is stored in the DJ deployments `users` table

It's true that in Scenario 3, the internal logic in the `get_current_user` override should handle the upsert on it's own, but there's no guarantee of that since the `User` instance could simply be constructed in memory based on the propagated user identity and never saved to the database. This PR makes it so that custom auth implementations never have to concern themselves with making sure they save the user to the DJ metadata database, the open source logic will automatically handle that, guaranteeing that we always have a DJ user entity to tie things to in the system.

### Test Plan

Added some tests and tested it in the local docker environment

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Shouldn't effect existing deployments nor require any changes
