### PR TITLE
Fix SQL building with filters

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -214,6 +214,7 @@ async def get_query(  # pylint: disable=too-many-arguments
         limit=limit,
         build_criteria=build_criteria,
         access_control=access_control,
+        top_level=True,
     )
     query_ast = rename_columns(query_ast, node.current)  # type: ignore
     return query_ast

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -460,7 +460,10 @@ def push_down_direct_ref_filter(
         for filter_dim in referenced_filter_dims:
             if filter_dim.identifier() in node_columns_lookup:  # pragma: no cover
                 filter_dim_ref = node_columns_lookup[filter_dim.identifier()].copy()
-                filter_dim_ref.alias = None
+                if isinstance(filter_dim_ref, ast.Alias):
+                    filter_dim_ref = filter_dim_ref.child  # pragma: no cover
+                else:
+                    filter_dim_ref.alias = None  # pragma: no cover
                 cast(ast.Node, filter_dim.parent).replace(filter_dim, filter_dim_ref)
         if isinstance(query_ast.select.where, ast.BinaryOp):
             existing_filters = (

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -435,9 +435,10 @@ def build_filters(
                 dim.name = ast.Name(name=col_name)
                 if node_table:  # pragma: no cover
                     dim.add_table(node_table)
-            filter_asts.append(
-                temp_select.where,  # type: ignore
-            )
+            if temp_select.where:
+                filter_asts.append(
+                    temp_select.where,  # type: ignore
+                )
     return filter_asts
 
 

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -441,6 +441,45 @@ def build_filters(
     return filter_asts
 
 
+def push_down_direct_ref_filter(
+    filter_ast: ast.Expression,
+    query_ast: ast.Query,
+    node_columns_lookup: Dict[str, ast.Node],
+) -> bool:
+    """
+    Pushes down a filter to the query AST if it is a direct reference
+    to an output column on the query. Returns True if the pushdown was
+    successful and False otherwise.
+    """
+    referenced_filter_dims = list(filter_ast.find_all(ast.Column))
+    if all(
+        filter_dim.identifier() in node_columns_lookup
+        for filter_dim in referenced_filter_dims
+    ):
+        for filter_dim in referenced_filter_dims:
+            if filter_dim.identifier() in node_columns_lookup:
+                filter_dim_ref = node_columns_lookup[filter_dim.identifier()].copy()
+                filter_dim_ref.alias = None
+                cast(ast.Node, filter_dim.parent).replace(filter_dim, filter_dim_ref)
+        existing_filters = (
+            cast(ast.BinaryOp, query_ast.select.where).split(
+                ast.BinaryOpKind.And,
+            )
+            if query_ast.select.where
+            else None
+        )
+        if not existing_filters or filter_ast not in existing_filters:
+            if query_ast.select.where:
+                query_ast.select.where = ast.BinaryOp.And(
+                    query_ast.select.where,
+                    filter_ast,
+                )
+            else:
+                query_ast.select.where = filter_ast
+        return True
+    return False
+
+
 async def _build_tables_on_select(
     session: AsyncSession,
     select: ast.SelectExpression,
@@ -490,13 +529,22 @@ async def _build_tables_on_select(
                 alias = amenable_name(node.name)
                 node_ast = ast.Alias(ast.Name(alias), child=query_ast, as_=True)  # type: ignore
                 query_ast.parenthesized = True  # type: ignore
-
+                node_columns_lookup = get_node_columns_lookup(node, query_ast)
                 filter_asts = build_filters(node, node_ast, filters)  # type: ignore
+                remaining = []
+                for filter_ast in filter_asts:
+                    push_down_success = push_down_direct_ref_filter(
+                        filter_ast,
+                        query_ast,
+                        node_columns_lookup,
+                    )
+                    if not push_down_success:
+                        remaining.append(filter_ast)
+                filter_asts = remaining
             else:
                 alias = amenable_name(node.name)
                 node_ast = ast.Alias(ast.Name(alias), child=physical_table, as_=True)  # type: ignore
                 filter_asts = build_filters(node, physical_table, filters)
-
             # Remove columns that are not part of the table expression reference
             if (
                 isinstance(node_ast, ast.Alias)
@@ -667,6 +715,17 @@ def rename_dimension_primary_keys_to_foreign_keys(
     return col
 
 
+def get_node_columns_lookup(node: "Node", query: ast.Query):
+    """
+    Returns a lookup dictionary that maps the node columns as they would be referenced by
+    in a filter expression or dimension request to the column expression itself.
+    """
+    return {
+        node.name + SEPARATOR + node_col.alias_or_name.name: node_col  # type: ignore
+        for node_col in query.select.projection
+    }
+
+
 # pylint: disable=R0915
 async def add_filters_dimensions_orderby_limit_to_query_ast(
     session: AsyncSession,
@@ -679,6 +738,7 @@ async def add_filters_dimensions_orderby_limit_to_query_ast(
     limit: Optional[int] = None,
     include_dimensions_in_groupby: bool = True,
     access_control: Optional[access.AccessControlStore] = None,
+    top_level: bool = False,
 ):
     """
     Add filters and dimensions to a query ast
@@ -763,10 +823,20 @@ async def add_filters_dimensions_orderby_limit_to_query_ast(
                             node,
                             col,
                         )
-            filter_asts.append(
-                temp_select.where,  # type:ignore
-            )
-        query.select.where = ast.BinaryOp.And(*filter_asts)
+
+            node_columns_lookup = get_node_columns_lookup(node, query)
+            if (
+                not all(
+                    filter_dim.identifier() in node_columns_lookup
+                    for filter_dim in temp_select.find_all(ast.Column)
+                )
+                or top_level
+            ):
+                filter_asts.append(
+                    temp_select.where,  # type:ignore
+                )
+        if filter_asts:
+            query.select.where = ast.BinaryOp.And(*filter_asts)
 
     if not query.select.organization:
         query.select.organization = ast.Organization([])
@@ -912,6 +982,7 @@ async def build_node(  # pylint: disable=too-many-arguments
     build_criteria: Optional[BuildCriteria] = None,
     access_control: Optional[access.AccessControlStore] = None,
     include_dimensions_in_groupby: bool = None,
+    top_level: bool = False,
 ) -> ast.Query:
     """
     Determines the optimal way to build the Node and does so
@@ -974,6 +1045,7 @@ async def build_node(  # pylint: disable=too-many-arguments
         limit,
         include_dimensions_in_groupby=include_dimensions_in_groupby,
         access_control=access_control,
+        top_level=top_level,
     )
 
     if access_control:
@@ -1220,6 +1292,7 @@ async def build_metric_nodes(
             build_criteria=build_criteria,
             include_dimensions_in_groupby=True,
             access_control=access_control,
+            top_level=True,
         )
 
         # Select only columns that were one of the chosen dimensions

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1481,6 +1481,23 @@ class BinaryOp(Operation):
             (left, right, *rest),
         )
 
+    def split(self, op: BinaryOpKind) -> List[Expression]:
+        """
+        Splits the expression by the operator into a list of expressions.
+        """
+        if self.op == op:
+            if not isinstance(self.left, BinaryOp) and isinstance(self.right, BinaryOp):
+                return [self.left] + self.right.split(op)
+            if not isinstance(self.right, BinaryOp) and isinstance(self.left, BinaryOp):
+                return self.left.split(op) + [self.right]
+            if not isinstance(self.right, BinaryOp) and not isinstance(
+                self.left,
+                BinaryOp,
+            ):
+                return [self.left, self.right]
+            return self.left.split(op) + self.right.split(op)
+        return [self]
+
     @classmethod
     def Eq(  # pylint: disable=invalid-name
         cls,

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -3481,10 +3481,12 @@ async def test_filter_pushdowns(
               SELECT
                 repair_orders.hard_hat_id AS hh_id
               FROM roads.repair_orders AS repair_orders
+              WHERE  repair_orders.hard_hat_id IN (123, 13)
+                AND repair_orders.hard_hat_id = 123
+                OR repair_orders.hard_hat_id = 13
             ) AS default_DOT_repair_orders_fact
-            WHERE  default_DOT_repair_orders_fact.hh_id IN (123, 13)
-              AND default_DOT_repair_orders_fact.hh_id = 123
-              OR default_DOT_repair_orders_fact.hh_id = 13
+            WHERE
+              default_DOT_repair_orders_fact.hh_id IN (123, 13) AND default_DOT_repair_orders_fact.hh_id = 123 OR default_DOT_repair_orders_fact.hh_id = 13
             """,
         ),
     )


### PR DESCRIPTION
### Summary

This fixes an issue where building SQL for a transform with filters turns any linked dimensions into an `INNER JOIN`.
For example, when we request SQL for a transform node with a filter, the generated SQL looks like this:
```
SELECT ...
FROM transform
LEFT JOIN dimension ON ...
WHERE transform.colA = 1 AND transform.colB = 'b'
```

Instead, we should see if the particular filters can be pushed down to the transform subquery and apply them there if possible. Only in cases where it's not possible to apply filters within the transform subquery should we pull it back into the outer layer. The new query structure looks like this:

```
(
SELECT ...
FROM transform
WHERE transform.colA = 1 AND transform.colB = 'b'
)
LEFT JOIN dimension ON ...
```

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1102 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
