### PR TITLE
Update users endpoint to only pull users with activity when requested

### DIFF
--- a/datajunction-server/datajunction_server/api/users.py
+++ b/datajunction-server/datajunction_server/api/users.py
@@ -61,7 +61,8 @@ async def list_users_with_activity(
     with_activity: bool = False,
 ) -> List[Union[str, UserActivity]]:
     """
-    List all users ordered by activity count
+    Lists all users. The endpoint will include user activity counts if the
+    `with_activity` flag is set to true.
     """
     if not with_activity:
         statement = select(User.username)
@@ -86,13 +87,3 @@ async def list_users_with_activity(
         UserActivity(username=user_activity[0], count=user_activity[1])
         for user_activity in result.all()
     ]
-
-
-@router.get("/users", response_model=List[str])
-async def list_users(session: AsyncSession = Depends(get_session)) -> List[str]:
-    """
-    List all users
-    """
-    statement = select(User.username)
-    result = await session.execute(statement)
-    return result.scalars().all()

--- a/datajunction-server/datajunction_server/api/users.py
+++ b/datajunction-server/datajunction_server/api/users.py
@@ -80,7 +80,7 @@ async def list_users_with_activity(
             isouter=True,
         )
         .group_by(User.username)
-        .order_by(func.count(History.created_at).desc())  # pylint: disable=not-callable
+        .order_by(func.count(History.id).desc())  # pylint: disable=not-callable
     )
     result = await session.execute(statement)
     return [

--- a/datajunction-server/datajunction_server/api/users.py
+++ b/datajunction-server/datajunction_server/api/users.py
@@ -2,7 +2,7 @@
 User related APIs.
 """
 
-from typing import List, Optional
+from typing import List, Union
 
 from fastapi import Depends, Query
 from sqlalchemy import distinct, func, select
@@ -15,23 +15,11 @@ from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.models.node import NodeMinimumDetail
-from datajunction_server.models.user import UserActivity, UserOutput
-from datajunction_server.utils import get_current_user, get_session, get_settings
+from datajunction_server.models.user import UserActivity
+from datajunction_server.utils import get_session, get_settings
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["users"])
-
-
-@router.get("/users/me", response_model=UserOutput)
-async def current_user(
-    current_user: Optional[User] = Depends(  # pylint: disable=redefined-outer-name
-        get_current_user,
-    ),
-) -> UserOutput:
-    """
-    Returns info on the current authenticated user, if any
-    """
-    return current_user  # type: ignore
 
 
 @router.get("/users/{username}", response_model=List[NodeMinimumDetail])
@@ -66,11 +54,20 @@ async def list_nodes_by_username(
     return [node.current for node in nodes]
 
 
-@router.get("/users", response_model=List[UserActivity])
-async def list_users(session: AsyncSession = Depends(get_session)) -> List[str]:
+@router.get("/users", response_model=List[Union[str, UserActivity]])
+async def list_users_with_activity(
+    session: AsyncSession = Depends(get_session),
+    *,
+    with_activity: bool = False,
+) -> List[Union[str, UserActivity]]:
     """
     List all users ordered by activity count
     """
+    if not with_activity:
+        statement = select(User.username)
+        result = await session.execute(statement)
+        return result.scalars().all()
+
     statement = (
         select(
             User.username,
@@ -82,10 +79,20 @@ async def list_users(session: AsyncSession = Depends(get_session)) -> List[str]:
             isouter=True,
         )
         .group_by(User.username)
-        .order_by(func.count(History.id).desc())  # pylint: disable=not-callable
+        .order_by(func.count(History.created_at).desc())  # pylint: disable=not-callable
     )
     result = await session.execute(statement)
     return [
         UserActivity(username=user_activity[0], count=user_activity[1])
         for user_activity in result.all()
     ]
+
+
+@router.get("/users", response_model=List[str])
+async def list_users(session: AsyncSession = Depends(get_session)) -> List[str]:
+    """
+    List all users
+    """
+    statement = select(User.username)
+    result = await session.execute(statement)
+    return result.scalars().all()

--- a/datajunction-server/tests/api/users_test.py
+++ b/datajunction-server/tests/api/users_test.py
@@ -14,30 +14,14 @@ class TestUsers:
     @pytest.mark.asyncio
     async def test_get_users(self, module__client_with_roads: AsyncClient) -> None:
         """
-        Test ``POST /tags`` and ``GET /tags/{name}``
+        Test ``GET /users``
         """
 
-        response = await module__client_with_roads.get("/users")
+        response = await module__client_with_roads.get("/users?with_activity=true")
         assert response.json() == [{"username": "dj", "count": 67}]
 
-    @pytest.mark.asyncio
-    async def test_get_current_user(
-        self,
-        module__client_with_roads: AsyncClient,
-    ) -> None:
-        """
-        Test ``POST /tags`` and ``GET /tags/{name}``
-        """
-
-        response = await module__client_with_roads.get("/users/me")
-        assert response.json() == {
-            "id": 1,
-            "username": "dj",
-            "email": None,
-            "name": None,
-            "oauth_provider": "basic",
-            "is_admin": False,
-        }
+        response = await module__client_with_roads.get("/users")
+        assert response.json() == ["dj"]
 
     @pytest.mark.asyncio
     async def test_list_nodes_by_user(
@@ -45,7 +29,7 @@ class TestUsers:
         module__client_with_roads: AsyncClient,
     ) -> None:
         """
-        Test ``POST /tags`` and ``GET /tags/{name}``
+        Test ``GET /users/{username}``
         """
 
         response = await module__client_with_roads.get("/users/dj")


### PR DESCRIPTION
### Summary

This PR updates the `GET /users` endpoint to only pull users with activity when requested with `with_activity=true`.

It also removes `/users/me` since this is already covered by `/whoami`

Followup to https://github.com/DataJunction/dj/pull/1096

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
