### PR TITLE
Require current_user everywhere, no longer optional

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=redefined-outer-name, import-outside-toplevel, too-many-lines
 import logging
+import os
 import platform
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict
@@ -177,15 +178,18 @@ class DJClient:
 
     def basic_login(
         self,
-        username: str,
-        password: str,
+        username: Optional[str],
+        password: Optional[str],
     ):
         """
         Login with basic authentication.
         """
         response = self._session.post(
             "/basic/login/",
-            data={"username": username, "password": password},
+            data={
+                "username": username or os.getenv("DJ_USER"),
+                "password": password or os.getenv("DJ_PWD"),
+            },
         )
         return response
 

--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock
 import pytest
 import pytest_asyncio
 from cachelib import SimpleCache
-from datajunction_server.api.access.authentication import basic
 from datajunction_server.api.main import app
 from datajunction_server.config import Settings
 from datajunction_server.database.base import Base
@@ -221,7 +220,6 @@ def server(  # pylint: disable=too-many-statements
         get_query_service_client
     ] = get_query_service_client_override
 
-    app.include_router(basic.router)
     with TestClient(app) as test_client:
 
         test_client.post(

--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -249,7 +249,17 @@ def builder_client(session_with_examples: TestClient):
     """
     Returns a DJ client instance
     """
-    return DJBuilder(requests_session=session_with_examples)  # type: ignore
+    client = DJBuilder(requests_session=session_with_examples)  # type: ignore
+    client.create_user(
+        email="dj@datajunction.io",
+        username="datajunction",
+        password="datajunction",
+    )
+    client.basic_login(
+        username="datajunction",
+        password="datajunction",
+    )
+    return client
 
 
 @pytest.fixture

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -42,7 +42,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         """
         # full list
         dims = client.list_dimensions()
-        assert dims == [
+        assert set(dims) == {
             "default.repair_order",
             "default.contractor",
             "default.hard_hat",
@@ -57,7 +57,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             "foo.bar.us_state",
             "foo.bar.dispatcher",
             "foo.bar.municipality_dim",
-        ]
+        }
 
         # partial list
         dims = client.list_dimensions(namespace="foo.bar")
@@ -112,7 +112,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         """
         # full list
         cubes = client.list_cubes()
-        assert cubes == ["foo.bar.cube_one", "default.cube_two"]
+        assert set(cubes) == {"foo.bar.cube_one", "default.cube_two"}
 
         # partial list
         cubes = client.list_cubes(namespace="foo.bar")
@@ -127,7 +127,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         """
         # full list
         nodes = client.list_sources()
-        assert nodes == [
+        assert set(nodes) == {
             "default.repair_orders",
             "default.repair_order_details",
             "default.repair_type",
@@ -152,7 +152,7 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             "foo.bar.hard_hat_state",
             "foo.bar.us_states",
             "foo.bar.us_region",
-        ]
+        }
 
         # partial list
         nodes = client.list_sources(namespace="foo.bar")
@@ -177,7 +177,10 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         """
         # full list
         nodes = client.list_transforms()
-        assert nodes == ["default.repair_orders_thin", "foo.bar.repair_orders_thin"]
+        assert set(nodes) == {
+            "default.repair_orders_thin",
+            "foo.bar.repair_orders_thin",
+        }
 
         # partial list
         nodes = client.list_transforms(namespace="foo.bar")

--- a/datajunction-server/datajunction_server/api/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/basic.py
@@ -18,7 +18,7 @@ from datajunction_server.internal.access.authentication.basic import (
     validate_user_password,
 )
 from datajunction_server.internal.access.authentication.tokens import create_token
-from datajunction_server.utils import get_session
+from datajunction_server.utils import Settings, get_session, get_settings
 
 router = APIRouter(tags=["Basic OAuth2"])
 
@@ -63,6 +63,7 @@ async def create_a_user(
 async def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
     session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
 ):
     """
     Get a JWT token and set it as an HTTP only cookie
@@ -75,7 +76,12 @@ async def login(
     response = Response(status_code=HTTPStatus.OK)
     response.set_cookie(
         AUTH_COOKIE,
-        create_token({"username": user.username}, expires_delta=timedelta(days=365)),
+        create_token(
+            {"username": user.username},
+            secret=settings.secret,
+            iss=settings.url,
+            expires_delta=timedelta(days=365),
+        ),
         httponly=True,
     )
     response.set_cookie(

--- a/datajunction-server/datajunction_server/api/access/authentication/google.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/google.py
@@ -99,7 +99,12 @@ async def get_access_token(
     response = RedirectResponse(url=urljoin(settings.frontend_host, state))  # type: ignore
     response.set_cookie(
         AUTH_COOKIE,
-        create_token({"username": user.email}, expires_delta=timedelta(days=365)),
+        create_token(
+            {"username": user.email},
+            secret=settings.secret,
+            iss=settings.url,
+            expires_delta=timedelta(days=365),
+        ),
         httponly=True,
         samesite="none",
         secure=True,

--- a/datajunction-server/datajunction_server/api/access/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/whoami.py
@@ -11,9 +11,12 @@ from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authentication.tokens import create_token
 from datajunction_server.models.user import UserOutput
-from datajunction_server.utils import get_and_update_current_user, get_settings
+from datajunction_server.utils import (
+    Settings,
+    get_and_update_current_user,
+    get_settings,
+)
 
-settings = get_settings()
 router = SecureAPIRouter(tags=["Who am I?"])
 
 
@@ -28,7 +31,10 @@ async def get_user(
 
 
 @router.get("/token/")
-async def get_short_lived_token(request: Request) -> JSONResponse:
+async def get_short_lived_token(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
     """
     Returns a token that expires in 24 hours
     """
@@ -38,7 +44,9 @@ async def get_short_lived_token(request: Request) -> JSONResponse:
         content={
             "token": create_token(
                 {"username": request.state.user.username},
-                expires_delta,
+                secret=settings.secret,
+                iss=settings.url,
+                expires_delta=expires_delta,
             ),
         },
     )

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.dimensions import build_dimensions_from_cube_query
 from datajunction_server.database.node import Node
+from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.internal.nodes import get_cube_revision_metadata
@@ -25,6 +26,7 @@ from datajunction_server.models.query import QueryCreate
 from datajunction_server.naming import from_amenable_name
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import (
+    get_and_update_current_user,
     get_query_service_client,
     get_session,
     get_settings,
@@ -60,6 +62,7 @@ async def get_cube_dimension_sql(
     ),
     include_counts: bool = False,
     session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=redefined-outer-name
         validate_access,
     ),
@@ -73,10 +76,11 @@ async def get_cube_dimension_sql(
         session,
         node_revision,
         dimensions,
+        current_user,
+        validate_access,
         filters,
         limit,
         include_counts,
-        validate_access=validate_access,
     )
 
 
@@ -101,6 +105,7 @@ async def get_cube_dimension_values(  # pylint: disable=too-many-locals
     cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=redefined-outer-name
         validate_access,
     ),
@@ -114,10 +119,11 @@ async def get_cube_dimension_values(  # pylint: disable=too-many-locals
         session,
         cube,
         dimensions,
+        current_user,
+        validate_access,
         filters,
         limit,
         include_counts,
-        validate_access,
     )
     if cube.availability:
         catalog = await get_catalog_by_name(  # pragma: no cover

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -53,7 +53,7 @@ async def add_availability_state(
     data: AvailabilityStateBase,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -147,7 +147,7 @@ async def add_availability_state(
             if old_availability
             else {},
             post=AvailabilityStateBase.from_orm(node_revision.availability).dict(),
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -177,7 +177,7 @@ async def get_data(  # pylint: disable=too-many-locals
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -248,7 +248,7 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -361,7 +361,7 @@ async def get_data_for_metrics(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -40,7 +40,7 @@ async def list_dimensions(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -71,7 +71,7 @@ async def find_nodes_with_dimension(
     *,
     node_type: List[NodeType] = Query([]),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -104,7 +104,7 @@ async def find_nodes_with_common_dimensions(
     node_type: List[NodeType] = Query([]),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -36,7 +36,7 @@ async def get_data_for_djsql(  # pylint: disable=R0914, R0913
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     )
@@ -87,7 +87,7 @@ async def get_data_stream_for_djsql(
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     )

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -248,7 +248,7 @@ def find_bound_dimensions(
 async def resolve_downstream_references(
     session: AsyncSession,
     node_revision: NodeRevision,
-    current_user: Optional[User] = None,
+    current_user: User,
 ) -> List[NodeRevision]:
     """
     Find all node revisions with missing parent references to `node` and resolve them

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -44,7 +44,7 @@ from datajunction_server.api import (
     tags,
     users,
 )
-from datajunction_server.api.access.authentication import whoami
+from datajunction_server.api.access.authentication import basic, whoami
 from datajunction_server.api.attributes import default_attribute_types
 from datajunction_server.api.catalogs import default_catalog
 from datajunction_server.api.graphql.main import graphql_app
@@ -111,6 +111,7 @@ app.include_router(dimensions.router)
 app.include_router(graphql_app, prefix="/graphql")
 app.include_router(whoami.router)
 app.include_router(users.router)
+app.include_router(basic.router)
 
 
 @app.on_event("startup")
@@ -141,12 +142,6 @@ async def dj_exception_handler(  # pylint: disable=unused-argument
         response.delete_cookie(LOGGED_IN_FLAG_COOKIE)
     return response
 
-
-# Only mount basic auth router if a server secret is configured
-if settings.secret:  # pragma: no cover
-    from datajunction_server.api.access.authentication import basic
-
-    app.include_router(basic.router)
 
 # Only mount github auth router if a github client id and secret are configured
 if all(

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -5,7 +5,7 @@ Node materialization related APIs.
 import logging
 from datetime import datetime
 from http import HTTPStatus
-from typing import List, Optional
+from typing import List
 
 from fastapi import Depends
 from fastapi.responses import JSONResponse
@@ -84,7 +84,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -119,6 +119,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
         current_revision,
         data,
         validate_access,
+        current_user=current_user,
     )
 
     # Check to see if a materialization for this engine already exists with the exact same config
@@ -140,7 +141,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
                     node=node.name,  # type: ignore
                     activity_type=ActivityType.RESTORE,
                     details={},
-                    user=current_user.username if current_user else None,
+                    user=current_user.username,
                 ),
             )
             await session.commit()
@@ -205,7 +206,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
                 "node": node.name,  # type: ignore
                 "materialization": new_materialization.name,
             },
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -277,7 +278,7 @@ async def deactivate_node_materializations(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> List[MaterializationConfigInfoUnified]:
     """
     Deactivate the node materialization with the provided name.
@@ -308,7 +309,7 @@ async def deactivate_node_materializations(
             node=node.name,  # type: ignore
             activity_type=ActivityType.DELETE,
             details={},
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -334,7 +335,7 @@ async def run_materialization_backfill(  # pylint: disable=too-many-locals
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> MaterializationInfo:
     """
     Start a backfill for a configured materialization.
@@ -412,7 +413,7 @@ async def run_materialization_backfill(  # pylint: disable=too-many-locals
                 backfill_partition.dict() for backfill_partition in backfill_partitions
             ],
         },
-        user=current_user.username if current_user else None,
+        user=current_user.username,
     )
     session.add(backfill_event)
     await session.commit()

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -65,7 +65,7 @@ async def list_metrics(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -48,7 +48,7 @@ async def create_node_namespace(
     namespace: str,
     include_parents: Optional[bool] = False,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Create a node namespace
@@ -79,9 +79,9 @@ async def create_node_namespace(
         )
     validate_namespace(namespace)
     created_namespaces = await create_namespace(
-        session,
-        namespace,
-        include_parents,  # type: ignore
+        session=session,
+        namespace=namespace,
+        include_parents=include_parents,  # type: ignore
         current_user=current_user,
     )
     return JSONResponse(
@@ -102,7 +102,7 @@ async def create_node_namespace(
 )
 async def list_namespaces(
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -160,7 +160,7 @@ async def deactivate_a_namespace(
         description="Cascade the deletion down to the nodes in the namespace",
     ),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Deactivates a node namespace
@@ -181,7 +181,12 @@ async def deactivate_a_namespace(
     node_names = [node.name for node in node_list]
     if len(node_names) == 0:
         message = f"Namespace `{namespace}` has been deactivated."
-        await mark_namespace_deactivated(session, node_namespace, message)  # type: ignore
+        await mark_namespace_deactivated(
+            session=session,
+            namespace=node_namespace,  # type: ignore
+            message=message,
+            current_user=current_user,
+        )
         return JSONResponse(
             status_code=HTTPStatus.OK,
             content={"message": message},
@@ -192,9 +197,9 @@ async def deactivate_a_namespace(
     if cascade:
         for node_name in node_names:
             await deactivate_node(
-                session,
-                node_name,
-                f"Cascaded from deactivating namespace `{namespace}`",
+                session=session,
+                name=node_name,
+                message=f"Cascaded from deactivating namespace `{namespace}`",
                 current_user=current_user,
             )
         message = (
@@ -202,9 +207,9 @@ async def deactivate_a_namespace(
             f" have also been deactivated: {','.join(node_names)}"
         )
         await mark_namespace_deactivated(
-            session,
-            node_namespace,  # type: ignore
-            message,
+            session=session,
+            namespace=node_namespace,  # type: ignore
+            message=message,
             current_user=current_user,
         )
 
@@ -232,7 +237,7 @@ async def restore_a_namespace(
         description="Cascade the restore down to the nodes in the namespace",
     ),
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Restores a node namespace
@@ -268,7 +273,12 @@ async def restore_a_namespace(
             f"Namespace `{namespace}` has been restored. The following nodes"
             f" have also been restored: {','.join(node_names)}"
         )
-        await mark_namespace_restored(session, node_namespace, message)
+        await mark_namespace_restored(
+            session=session,
+            namespace=node_namespace,
+            message=message,
+            current_user=current_user,
+        )
 
         return JSONResponse(
             status_code=HTTPStatus.CREATED,
@@ -280,9 +290,9 @@ async def restore_a_namespace(
     # Otherwise just restore this namespace
     message = f"Namespace `{namespace}` has been restored."
     await mark_namespace_restored(
-        session,
-        node_namespace,
-        message,
+        session=session,
+        namespace=node_namespace,
+        message=message,
         current_user=current_user,
     )
     return JSONResponse(
@@ -297,7 +307,7 @@ async def hard_delete_node_namespace(
     *,
     cascade: bool = False,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Hard delete a namespace, which will completely remove the namespace. Additionally,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -153,7 +153,7 @@ async def validate_node(
 async def revalidate(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> NodeStatusDetails:
     """
     Revalidate a single existing node and update its status appropriately
@@ -200,7 +200,7 @@ async def set_column_attributes(
     attributes: List[AttributeTypeIdentifier],
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> List[ColumnOutput]:
     """
     Set column attributes for the node.
@@ -228,7 +228,7 @@ async def list_nodes(
     prefix: Optional[str] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -259,7 +259,7 @@ async def list_all_nodes_with_details(
     node_type: Optional[NodeType] = None,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -333,12 +333,12 @@ async def delete_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ):
     """
     Delete (aka deactivate) the specified node.
     """
-    await deactivate_node(session, name, current_user=current_user)
+    await deactivate_node(session=session, name=name, current_user=current_user)
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={"message": f"Node `{name}` has been successfully deleted."},
@@ -349,7 +349,7 @@ async def delete_node(
 async def hard_delete(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
@@ -374,12 +374,12 @@ async def restore_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ):
     """
     Restore (aka re-activate) the specified node.
     """
-    await activate_node(session, name, current_user=current_user)
+    await activate_node(session=session, name=name, current_user=current_user)
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={"message": f"Node `{name}` has been successfully restored."},
@@ -409,7 +409,7 @@ async def create_source(
     data: CreateSourceNode,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -517,7 +517,7 @@ async def create_node(
     request: Request,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
@@ -615,7 +615,7 @@ async def create_cube(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -669,7 +669,7 @@ async def register_table(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     background_tasks: BackgroundTasks,
 ) -> NodeOutput:
     """
@@ -725,7 +725,7 @@ async def link_dimension(
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Add information to a node column
@@ -808,7 +808,7 @@ async def add_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_input: LinkDimensionInput,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Links a source, dimension, or transform node to a dimension with a custom join query.
@@ -841,7 +841,7 @@ async def remove_complex_dimension_link(  # pylint: disable=too-many-locals
     node_name: str,
     link_identifier: LinkDimensionIdentifier,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Removes a complex dimension link based on the dimension node and its role (if any).
@@ -861,7 +861,7 @@ async def delete_dimension_link(
     dimension: str,
     dimension_column: Optional[str] = None,  # pylint: disable=unused-argument
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Remove the link between a node column and a dimension node
@@ -885,7 +885,7 @@ async def tags_node(
     tag_names: Optional[List[str]] = Query(default=None),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> JSONResponse:
     """
     Add a tag to a node
@@ -906,7 +906,7 @@ async def tags_node(
             details={
                 "tags": tag_names,
             },
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -935,7 +935,7 @@ async def refresh_source_node(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> NodeOutput:
     """
     Refresh a source node with the latest columns from the query service.
@@ -1040,7 +1040,7 @@ async def refresh_source_node(
             node=source_node.name,  # type: ignore
             activity_type=ActivityType.REFRESH,
             details=refresh_details,
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -1064,7 +1064,7 @@ async def update_node(
     *,
     session: AsyncSession = Depends(get_session),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
@@ -1261,7 +1261,7 @@ async def set_column_display_name(
     node_name: str,
     column_name: str,
     display_name: str,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     *,
     session: AsyncSession = Depends(get_session),
 ) -> ColumnOutput:
@@ -1285,7 +1285,7 @@ async def set_column_display_name(
                 "column": column.name,
                 "display_name": display_name,
             },
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -1304,7 +1304,7 @@ async def set_column_partition(  # pylint: disable=too-many-locals
     input_partition: PartitionInput,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> ColumnOutput:
     """
     Add or update partition columns for the specified node.
@@ -1328,7 +1328,7 @@ async def set_column_partition(  # pylint: disable=too-many-locals
             "column": column_name,
             "partition": input_partition.dict(),
         },
-        user=current_user.username if current_user else None,
+        user=current_user.username,
     )
 
     if input_partition.type_ == PartitionType.TEMPORAL:
@@ -1374,7 +1374,7 @@ async def copy_node(
     *,
     new_name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> DAGNodeOutput:
     """
     Copy this node to a new name.

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -54,7 +54,7 @@ async def get_measures_sql_for_cube(
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -216,7 +216,7 @@ async def get_node_sql(  # pylint: disable=too-many-locals
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User],
+    current_user: User,
     validate_access: access.ValidateAccessFn,  # pylint: disable=redefined-outer-name
     background_tasks: BackgroundTasks,
 ) -> Tuple[TranslatedSQL, QueryRequest]:
@@ -226,7 +226,7 @@ async def get_node_sql(  # pylint: disable=too-many-locals
     dimensions = [dim for dim in dimensions if dim and dim != ""]
     access_control = access.AccessControlStore(
         validate_access=validate_access,
-        user=UserOutput.from_orm(current_user) if current_user else None,
+        user=UserOutput.from_orm(current_user),
         base_verb=access.ResourceRequestVerb.READ,
     )
 
@@ -304,7 +304,7 @@ async def get_sql(  # pylint: disable=too-many-locals
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
@@ -340,7 +340,7 @@ async def get_sql_for_metrics(
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -97,7 +97,7 @@ async def get_a_tag(
 async def create_a_tag(
     data: CreateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> TagOutput:
     """
     Create a tag.
@@ -121,7 +121,7 @@ async def create_a_tag(
             entity_type=EntityType.TAG,
             entity_name=tag.name,
             activity_type=ActivityType.CREATE,
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -134,7 +134,7 @@ async def update_a_tag(
     name: str,
     data: UpdateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: Optional[User] = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> TagOutput:
     """
     Update a tag.
@@ -159,7 +159,7 @@ async def update_a_tag(
             entity_name=tag.name,
             activity_type=ActivityType.UPDATE,
             details=data.dict(),
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -71,7 +71,7 @@ class Settings(
     sql_transpilation_library: Optional[str] = None
 
     # 128 bit DJ secret, used to encrypt passwords and JSON web tokens
-    secret: str
+    secret: str = "a-fake-secretkey"
 
     # GitHub OAuth application client ID
     github_oauth_client_id: Optional[str] = None

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -70,8 +70,8 @@ class Settings(
     # Library to use when transpiling SQL to other dialects
     sql_transpilation_library: Optional[str] = None
 
-    # DJ secret, used to encrypt passwords and JSON web tokens
-    secret: Optional[str] = None
+    # 128 bit DJ secret, used to encrypt passwords and JSON web tokens
+    secret: str
 
     # GitHub OAuth application client ID
     github_oauth_client_id: Optional[str] = None

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -1673,10 +1673,10 @@ async def get_measures_query(
     metrics: List[str],
     dimensions: List[str],
     filters: List[str],
+    current_user: User,
+    validate_access: access.ValidateAccessFn,
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
-    current_user: Optional[User] = None,
-    validate_access: access.ValidateAccessFn = None,
     cast_timestamp_to_ms: bool = False,
     include_all_columns: bool = False,
 ) -> TranslatedSQL:

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build import get_measures_query
 from datajunction_server.database.node import NodeRevision
+from datajunction_server.database.user import User
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models import access
 from datajunction_server.models.column import SemanticType
@@ -24,10 +25,11 @@ async def build_dimensions_from_cube_query(  # pylint: disable=too-many-argument
     session: AsyncSession,
     cube: NodeRevision,
     dimensions: List[str],
+    current_user: User,
+    validate_access: access.ValidateAccessFn,
     filters: Optional[str] = None,
     limit: Optional[int] = 50000,
     include_counts: bool = False,
-    validate_access: access.ValidateAccessFn = None,
 ) -> TranslatedSQL:
     """
     Builds a query for retrieving unique values of a dimension for the given cube.
@@ -98,6 +100,7 @@ async def build_dimensions_from_cube_query(  # pylint: disable=too-many-argument
             metrics=[metric.name for metric in cube.cube_metrics()],
             dimensions=dimensions,
             filters=[filters] if filters else [],
+            current_user=current_user,
             validate_access=validate_access,
         )
         measures_query_ast = parse(measures_query.sql)

--- a/datajunction-server/datajunction_server/internal/access/authentication/tokens.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/tokens.py
@@ -36,7 +36,12 @@ def decrypt(value: str) -> str:
     return jwe.decrypt(value, settings.secret).decode("utf-8")
 
 
-def create_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+def create_token(
+    data: dict,
+    secret: str,
+    iss: str,
+    expires_delta: Optional[timedelta] = None,
+) -> str:
     """
     Encode data into a signed JWT that's then encrypted using JWE.
 
@@ -46,17 +51,16 @@ def create_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     in any form other than an HTTP-only cookie, it's important that a reasonably
     small expires_delta is provided, such as 24 hours.
     """
-    settings = get_settings()
     to_encode = data.copy()
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:  # pragma: no cover
         expire = datetime.utcnow() + timedelta(minutes=15)
     to_encode.update({"exp": expire})
-    to_encode.update({"iss": settings.url})
+    to_encode.update({"iss": iss})
     encoded_jwt = jwt.encode(
         to_encode,
-        settings.secret,
+        secret,
         algorithm="HS256",
     )
     return encrypt(encoded_jwt)

--- a/datajunction-server/datajunction_server/internal/access/authorization.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization.py
@@ -1,7 +1,7 @@
 """
 Authorization related functionality
 """
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Union
 
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
@@ -16,7 +16,7 @@ from datajunction_server.models.user import UserOutput
 
 def validate_access_requests(
     validate_access: ValidateAccessFn,  # pylint: disable=W0621
-    user: Optional[User],
+    user: User,
     resource_requests: Iterable[ResourceRequest],
     raise_: bool = False,
 ) -> List[Union[NodeRevision, Node, ResourceRequest]]:

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -14,6 +14,7 @@ from datajunction_server.construction.build import (
 )
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import NodeRevision
+from datajunction_server.database.user import User
 from datajunction_server.errors import DJException, DJInvalidInputException
 from datajunction_server.materialization.jobs import MaterializationJob
 from datajunction_server.models import access
@@ -97,6 +98,7 @@ async def build_cube_materialization_config(
     current_revision: NodeRevision,
     upsert_input: UpsertMaterialization,
     validate_access: access.ValidateAccessFn,
+    current_user: User,
 ) -> DruidMeasuresCubeConfig:
     """
     Builds the materialization config for a cube.
@@ -147,6 +149,7 @@ async def build_cube_materialization_config(
             metrics=[node.name for node in current_revision.cube_metrics()],
             dimensions=current_revision.cube_dimensions(),
             filters=[],
+            current_user=current_user,
             validate_access=validate_access,
             cast_timestamp_to_ms=True,
         )
@@ -219,6 +222,7 @@ async def create_new_materialization(
     current_revision: NodeRevision,
     upsert: UpsertMaterialization,
     validate_access: access.ValidateAccessFn,
+    current_user: User,
 ) -> Materialization:
     """
     Create a new materialization based on the input values.
@@ -255,6 +259,7 @@ async def create_new_materialization(
             current_revision,
             upsert,
             validate_access,
+            current_user=current_user,
         )
     materialization_name = (
         f"{upsert.job.name.lower()}__{upsert.strategy.name.lower()}"

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -4,7 +4,7 @@ Helper methods for namespaces endpoints.
 import os
 import re
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -109,8 +109,8 @@ async def list_namespaces_in_hierarchy(  # pylint: disable=too-many-arguments
 async def mark_namespace_deactivated(
     session: AsyncSession,
     namespace: NodeNamespace,
+    current_user: User,
     message: str = None,
-    current_user: Optional[User] = None,
 ):
     """
     Deactivates the node namespace and updates history indicating so
@@ -131,7 +131,7 @@ async def mark_namespace_deactivated(
             node=None,
             activity_type=ActivityType.DELETE,
             details={"message": message or ""},
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -140,8 +140,8 @@ async def mark_namespace_deactivated(
 async def mark_namespace_restored(
     session: AsyncSession,
     namespace: NodeNamespace,
+    current_user: User,
     message: str = None,
-    current_user: Optional[User] = None,
 ):
     """
     Restores the node namespace and updates history indicating so
@@ -154,7 +154,7 @@ async def mark_namespace_restored(
             node=None,
             activity_type=ActivityType.RESTORE,
             details={"message": message or ""},
-            user=current_user.username if current_user else None,
+            user=current_user.username,
         ),
     )
     await session.commit()
@@ -188,8 +188,8 @@ def get_parent_namespaces(namespace: str):
 async def create_namespace(
     session: AsyncSession,
     namespace: str,
+    current_user: User,
     include_parents: bool = True,
-    current_user: Optional[User] = None,
 ) -> List[str]:
     """
     Creates a namespace entry in the database table.
@@ -213,7 +213,7 @@ async def create_namespace(
                     entity_name=namespace,
                     node=None,
                     activity_type=ActivityType.CREATE,
-                    user=current_user.username if current_user else None,
+                    user=current_user.username,
                 ),
             )
     await session.commit()
@@ -223,8 +223,8 @@ async def create_namespace(
 async def hard_delete_namespace(
     session: AsyncSession,
     namespace: str,
+    current_user: User,
     cascade: bool = False,
-    current_user: Optional[User] = None,
 ):
     """
     Hard delete a node namespace.

--- a/datajunction-server/datajunction_server/models/history.py
+++ b/datajunction-server/datajunction_server/models/history.py
@@ -38,8 +38,8 @@ def status_change_history(
     node_revision: "NodeRevision",
     start_status: "NodeStatus",
     end_status: "NodeStatus",
+    current_user: "User",
     parent_node: str = None,
-    current_user: Optional["User"] = None,
 ) -> History:
     """
     Returns a status change history activity entry
@@ -52,5 +52,5 @@ def status_change_history(
         pre={"status": start_status},
         post={"status": end_status},
         details={"upstream_node": parent_node if parent_node else None},
-        user=current_user.username if current_user else None,
+        user=current_user.username,
     )

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from functools import lru_cache
+from http import HTTPStatus
 
 # pylint: disable=line-too-long
 from typing import AsyncIterator, List, Optional
@@ -252,40 +253,42 @@ def get_namespace_from_name(name: str) -> str:
     return node_namespace
 
 
-async def get_current_user(request: Request) -> Optional["User"]:
+async def get_current_user(request: Request) -> "User":
     """
     Returns the current authenticated user
     """
-    if hasattr(request.state, "user"):
-        return request.state.user
-    return None  # pragma: no cover
+    if not hasattr(request.state, "user"):  # pragma: no cover
+        raise DJException(
+            message="Unauthorized, request state has no user",
+            http_status_code=HTTPStatus.UNAUTHORIZED,
+        )
+    return request.state.user
 
 
 async def get_and_update_current_user(
     session: AsyncSession = Depends(get_session),
-    current_user: Optional["User"] = Depends(get_current_user),
-) -> Optional["User"]:
+    current_user: "User" = Depends(get_current_user),
+) -> "User":
     """
     Wrapper for the get_current_user dependency that creates a DJ user object if required
     """
-    if current_user:
-        statement = insert(User).values(
-            username=current_user.username,
-            email=current_user.email,
-            name=current_user.name,
-            oauth_provider=current_user.oauth_provider,
-        )
-        update_dict = {
-            "email": current_user.email,
-            "name": current_user.name,
-            "oauth_provider": current_user.oauth_provider,
-        }
-        statement = statement.on_conflict_do_update(
-            index_elements=["username"],
-            set_=update_dict,
-        )
-        await session.execute(statement)
-        await session.commit()
+    statement = insert(User).values(
+        username=current_user.username,
+        email=current_user.email,
+        name=current_user.name,
+        oauth_provider=current_user.oauth_provider,
+    )
+    update_dict = {
+        "email": current_user.email,
+        "name": current_user.name,
+        "oauth_provider": current_user.oauth_provider,
+    }
+    statement = statement.on_conflict_do_update(
+        index_elements=["username"],
+        set_=update_dict,
+    )
+    await session.execute(statement)
+    await session.commit()
     return current_user
 
 

--- a/datajunction-server/requirements/docker.txt
+++ b/datajunction-server/requirements/docker.txt
@@ -2,8 +2,6 @@
 # Please do not edit it manually.
 
 accept-types==0.4.1
-aiohttp==3.9.0; python_version >= "3.11"
-aiosignal==1.3.1; python_version >= "3.11"
 aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
@@ -11,31 +9,27 @@ antlr4-python3-runtime==4.13.1
 anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
-astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
+async-timeout==4.0.3
 attrs==23.1.0
-backports-zoneinfo==0.2.1; python_version < "3.9"
 bcrypt==4.1.2
 billiard==4.2.0
 cachelib==0.12.0
 cachetools==5.3.3
 celery==5.3.6
 certifi==2023.7.22
-cffi==1.15.1; platform_python_implementation != "PyPy"
+cffi==1.15.1
 charset-normalizer==3.2.0
 click==8.1.6
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
-colorama==0.4.6; sys_platform == "win32" or platform_system == "Windows"
 cryptography==42.0.5
 deprecated==1.2.14
 ecdsa==0.18.0
-exceptiongroup==1.1.3; python_version < "3.11"
+exceptiongroup==1.1.3
 fastapi==0.110.0
 fastapi-cache2==0.2.1
 fastjsonschema==2.20.0
-frozenlist==1.4.0; python_version >= "3.11"
 google-api-core==2.12.0
 google-api-python-client==2.122.0
 google-auth==2.23.2
@@ -43,14 +37,13 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 googleapis-common-protos==1.60.0
 graphql-core==3.2.3
-greenlet==3.0.3; platform_machine == "win32" or platform_machine == "WIN32" or platform_machine == "AMD64" or platform_machine == "amd64" or platform_machine == "x86_64" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 h11==0.14.0
 httplib2==0.22.0
 httptools==0.6.0
 idna==3.4
 importlib-metadata==6.8.0
-importlib-resources==6.0.1; python_version < "3.9"
 iniconfig==2.0.0
+jinja2==3.1.4
 jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter-core==5.7.2
@@ -73,7 +66,6 @@ opentelemetry-util-http==0.38b0
 packaging==23.1
 passlib==1.7.4
 pendulum==2.1.2
-pkgutil-resolve-name==1.3.10; python_version < "3.9"
 platformdirs==3.10.0
 pluggy==1.4.0
 prompt-toolkit==3.0.39
@@ -81,10 +73,10 @@ protobuf==4.24.3
 psycopg==3.1.18
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
-pycparser==2.21; platform_python_implementation != "PyPy"
+pycparser==2.21
 pydantic==1.10.14
 pygments==2.16.1
-pyparsing==3.1.1; python_version > "3.0"
+pyparsing==3.1.1
 pytest==8.1.1
 pytest-asyncio==0.21.2
 python-dateutil==2.8.2
@@ -92,7 +84,6 @@ python-dotenv==0.21.1
 python-jose==3.3.0
 python-multipart==0.0.9
 pytzdata==2020.1
-pywin32==306; sys_platform == "win32" and platform_python_implementation != "PyPy"
 pyyaml==6.0.1
 redis==4.6.0
 referencing==0.35.1
@@ -111,7 +102,7 @@ sqlparse==0.4.4
 sse-starlette==2.0.0
 starlette==0.36.3
 strawberry-graphql==0.220.0
-tomli==2.0.1; python_version < "3.11"
+tomli==2.0.1
 traitlets==5.14.3
 types-cachetools==5.3.0.7
 typing-extensions==4.10.0
@@ -119,12 +110,11 @@ tzdata==2023.3
 uritemplate==4.1.1
 urllib3==1.26.16
 uvicorn==0.28.0
-uvloop==0.17.0; (sys_platform != "cygwin" and sys_platform != "win32") and platform_python_implementation != "PyPy"
+uvloop==0.17.0
 vine==5.1.0
 watchfiles==0.19.0
 wcwidth==0.2.6
 websockets==11.0.3
-wheel==0.41.1; python_version < "3.9"
 wrapt==1.15.0
 yarl==1.9.4
 zipp==3.16.2

--- a/datajunction-server/requirements/test.txt
+++ b/datajunction-server/requirements/test.txt
@@ -2,8 +2,6 @@
 # Please do not edit it manually.
 
 accept-types==0.4.1
-aiohttp==3.9.0; python_version >= "3.11"
-aiosignal==1.3.1; python_version >= "3.11"
 aiosqlite==0.20.0
 alembic==1.13.1
 amqp==5.1.1
@@ -12,17 +10,15 @@ anyio==3.7.1
 asciidag==0.2.0
 asgiref==3.7.2
 astroid==3.1.0
-astunparse==1.6.3; python_version < "3.9"
-async-timeout==4.0.3; python_full_version <= "3.11.2"
+async-timeout==4.0.3
 attrs==23.1.0
-backports-zoneinfo==0.2.1; python_version < "3.9"
 bcrypt==4.1.2
 billiard==4.2.0
 cachelib==0.12.0
 cachetools==5.3.3
 celery==5.3.6
 certifi==2023.7.22
-cffi==1.15.1; platform_python_implementation != "PyPy"
+cffi==1.15.1
 cfgv==3.4.0
 charset-normalizer==3.2.0
 click==8.1.6
@@ -30,7 +26,6 @@ click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
 codespell==2.2.6
-colorama==0.4.6; sys_platform == "win32" or platform_system == "Windows"
 coverage==7.3.0
 cryptography==42.0.5
 deprecated==1.2.14
@@ -40,14 +35,13 @@ distlib==0.3.7
 docker==7.0.0
 duckdb==0.8.1
 ecdsa==0.18.0
-exceptiongroup==1.1.3; python_version < "3.11"
+exceptiongroup==1.1.3
 execnet==2.0.2
 fastapi==0.110.0
 fastapi-cache2==0.2.1
 fastjsonschema==2.20.0
 filelock==3.12.2
 freezegun==1.4.0
-frozenlist==1.4.0; python_version >= "3.11"
 gevent==24.2.1
 google-api-core==2.12.0
 google-api-python-client==2.122.0
@@ -64,9 +58,9 @@ httpx==0.27.0
 identify==2.5.26
 idna==3.4
 importlib-metadata==6.8.0
-importlib-resources==6.0.1; python_version < "3.9"
 iniconfig==2.0.0
 isort==5.12.0
+jinja2==3.1.4
 jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter-core==5.7.2
@@ -91,7 +85,6 @@ opentelemetry-util-http==0.38b0
 packaging==23.1
 passlib==1.7.4
 pendulum==2.1.2
-pkgutil-resolve-name==1.3.10; python_version < "3.9"
 platformdirs==3.10.0
 pluggy==1.4.0
 pre-commit==3.5.0
@@ -100,11 +93,11 @@ protobuf==4.24.3
 psycopg==3.1.18
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
-pycparser==2.21; platform_python_implementation != "PyPy"
+pycparser==2.21
 pydantic==1.10.14
 pygments==2.16.1
 pylint==3.1.0
-pyparsing==3.1.1; python_version > "3.0"
+pyparsing==3.1.1
 pytest==8.1.1
 pytest-asyncio==0.21.2
 pytest-cov==4.1.0
@@ -116,7 +109,6 @@ python-dotenv==0.21.1
 python-jose==3.3.0
 python-multipart==0.0.9
 pytzdata==2020.1
-pywin32==306; sys_platform == "win32"
 pyyaml==6.0.1
 redis==4.6.0
 referencing==0.35.1
@@ -136,7 +128,7 @@ sse-starlette==2.0.0
 starlette==0.36.3
 strawberry-graphql==0.220.0
 testcontainers==3.7.1
-tomli==2.0.1; python_version < "3.11"
+tomli==2.0.1
 tomlkit==0.12.1
 traitlets==5.14.3
 types-cachetools==5.3.0.7
@@ -148,7 +140,6 @@ uvicorn==0.28.0
 vine==5.1.0
 virtualenv==20.24.3
 wcwidth==0.2.6
-wheel==0.41.1; python_version < "3.9"
 wrapt==1.15.0
 yarl==1.9.4
 zipp==3.16.2

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api import helpers
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import DJDoesNotExistException, DJException
 from datajunction_server.internal.nodes import propagate_valid_status
 from datajunction_server.models.node import NodeStatus
@@ -46,11 +47,20 @@ async def test_propagate_valid_status(module__session: AsyncSession):
         name="foo",
         status=NodeStatus.INVALID,
     )
+    example_user = User(
+        id=1,
+        username="userfoo",
+        password="passwordfoo",
+        name="djuser",
+        email="userfoo@datajunction.io",
+        oauth_provider=OAuthProvider.BASIC,
+    )
     with pytest.raises(DJException) as exc_info:
         await propagate_valid_status(
             session=module__session,
             valid_nodes=[invalid_node],
             catalog_id=1,
+            current_user=example_user,
         )
 
     assert "Cannot propagate valid status: Node `foo` is not valid" in str(

--- a/datajunction-server/tests/internal/authentication/token_test.py
+++ b/datajunction-server/tests/internal/authentication/token_test.py
@@ -12,6 +12,8 @@ def test_create_and_get_token():
     """
     jwe_string = tokens.create_token(
         data={"foo": "bar"},
+        secret="a-fake-secretkey",
+        iss="https://foo.bar",
         expires_delta=timedelta(minutes=30),
     )
     data = tokens.decode_token(jwe_string)

--- a/datajunction-server/tests/internal/authentication/token_test.py
+++ b/datajunction-server/tests/internal/authentication/token_test.py
@@ -13,7 +13,7 @@ def test_create_and_get_token():
     jwe_string = tokens.create_token(
         data={"foo": "bar"},
         secret="a-fake-secretkey",
-        iss="https://foo.bar",
+        iss="http://localhost:8000/",
         expires_delta=timedelta(minutes=30),
     )
     data = tokens.decode_token(jwe_string)

--- a/datajunction-server/tests/utils_test.py
+++ b/datajunction-server/tests/utils_test.py
@@ -168,7 +168,3 @@ async def test_get_and_update_current_user(session: AsyncSession):
     assert found_user.name == "djuser"
     assert found_user.email == "userfoo@datajunction.io"
     assert found_user.oauth_provider == "basic"
-
-    # Confirm that if current_user is None, this also returns None
-    current_user = await get_and_update_current_user(session=session, current_user=None)
-    assert current_user is None


### PR DESCRIPTION
### Summary

This changes the typing and some logic everywhere to make user required. After this PR, user is no longer optional and any auth implementation will at a minimum have to pass through a `User` instance.

Running DJ without auth will now require a custom override of the auth logic that injects a `User` instance. Also when you're using the client, if the server just uses basic auth you can either provided the username and password in the client code or optionally you can set `DJ_USER` and `DJ_PWD` as environment variables. This isn't too hard but I've opened issue #1118 #1119 to keep track of adding docs for both of these.

### Test Plan

Updated existing tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
