### PR TITLE
Bugfix, make sure EXPLODE includes parenthesis around column list

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2296,11 +2296,15 @@ class FunctionTable(FunctionTableExpression):
             if self.column_list
             else ""
         )
-        column_list_str = (
-            f"({cols})"
-            if self.name.name.upper() in ("UNNEST", "EXPLODE")
-            else f"{cols}"
-        )
+
+        column_parens = False
+        if self.name.name.upper() == "UNNEST" or (
+            self.name.name.upper() == "EXPLODE"
+            and not isinstance(self.parent, LateralView)
+        ):
+            column_parens = True
+
+        column_list_str = f"({cols})" if column_parens else f"{cols}"
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
         return f"{self.name}{args_str}{alias}{as_}{column_list_str}"
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2297,7 +2297,7 @@ class FunctionTable(FunctionTableExpression):
             else ""
         )
         column_list_str = (
-            f"{cols}" if self.name.name.upper() != "UNNEST" else f"({cols})"
+            f"({cols})" if self.name.name.upper() in ("UNNEST", "EXPLODE") else f"{cols}"
         )
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
         return f"{self.name}{args_str}{alias}{as_}{column_list_str}"

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2297,7 +2297,9 @@ class FunctionTable(FunctionTableExpression):
             else ""
         )
         column_list_str = (
-            f"({cols})" if self.name.name.upper() in ("UNNEST", "EXPLODE") else f"{cols}"
+            f"({cols})"
+            if self.name.name.upper() in ("UNNEST", "EXPLODE")
+            else f"{cols}"
         )
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
         return f"{self.name}{args_str}{alias}{as_}{column_list_str}"


### PR DESCRIPTION
### Summary

This fixes a bug where EXPLODE would not surround columns lists when rendering. For example, it would render in the projection as `EXPLODE(my_map) AS col1, col2` when it should actually be `EXPLODE(my_map) AS (col1, col2)`. Thanks to @anhqle for catching this.

### Test Plan
Added a test that explicitly checks for this syntax when using `EXPLODE`.

- [x] PR has an associated issue: #1111 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
