### PR TITLE
forward request headers when requests are made to query service

### DIFF
--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -127,6 +127,9 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         schema: str,
         table: str,
         engine: Optional[Engine] = None,  # pylint: disable=unused-argument
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> List[Column]:
         return COLUMN_MAPPINGS[f"{catalog}.{schema}.{table}"]
 
@@ -138,7 +141,9 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
 
     def mock_submit_query(
         query_create: QueryCreate,
-        headers: Optional[Dict[str, str]] = None,  # pylint: disable=unused-argument
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> QueryWithResults:
         results = QUERY_DATA_MAPPINGS[
             query_create.submitted_query.strip()

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -3,9 +3,9 @@
 Cube related APIs.
 """
 import logging
-from typing import Annotated, List, Optional
+from typing import List, Optional
 
-from fastapi import Depends, Header, Query, Request
+from fastapi import Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_catalog_by_name
@@ -102,7 +102,6 @@ async def get_cube_dimension_values(  # pylint: disable=too-many-locals
     ),
     include_counts: bool = False,
     async_: bool = False,
-    cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
@@ -141,7 +140,6 @@ async def get_cube_dimension_values(  # pylint: disable=too-many-locals
         submitted_query=translated_sql.sql,
         async_=async_,
     )
-    request_headers.update({"Cache-Control": cache_control})
     result = query_service_client.submit_query(
         query_create,
         request_headers=request_headers,

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -3,9 +3,9 @@
 Data related APIs.
 """
 from http import HTTPStatus
-from typing import Annotated, Dict, List, Optional
+from typing import Dict, List, Optional
 
-from fastapi import BackgroundTasks, Depends, Header, Query, Request
+from fastapi import BackgroundTasks, Depends, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
@@ -172,7 +172,6 @@ async def get_data(  # pylint: disable=too-many-locals
         default=False,
         description="Whether to run the query async or wait for results from the query engine",
     ),
-    cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
@@ -221,7 +220,6 @@ async def get_data(  # pylint: disable=too-many-locals
         submitted_query=query.sql,
         async_=async_,
     )
-    request_headers.update({"Cache-Control": cache_control})
     result = query_service_client.submit_query(
         query_create,
         request_headers=request_headers,
@@ -245,7 +243,6 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
         None,
         description="Number of rows to limit the data retrieved to",
     ),
-    cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
@@ -310,7 +307,6 @@ async def get_data_stream_for_node(  # pylint: disable=R0914, R0913
         submitted_query=query.sql,
         async_=True,
     )
-    request_headers.update({"Cache-Control": cache_control or "max-age=86400"})
     initial_query_info = query_service_client.submit_query(
         query_create,
         request_headers=request_headers,
@@ -368,7 +364,6 @@ async def get_data_for_metrics(  # pylint: disable=R0914, R0913
     limit: Optional[int] = None,
     async_: bool = False,
     *,
-    cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
@@ -408,7 +403,6 @@ async def get_data_for_metrics(  # pylint: disable=R0914, R0913
         submitted_query=translated_sql.sql,
         async_=async_,
     )
-    request_headers.update({"Cache-Control": cache_control})
     result = query_service_client.submit_query(
         query_create,
         request_headers=request_headers,
@@ -428,7 +422,6 @@ async def get_data_stream_for_metrics(  # pylint: disable=R0914, R0913
     orderby: List[str] = Query([]),
     limit: Optional[int] = None,
     *,
-    cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
@@ -458,7 +451,6 @@ async def get_data_stream_for_metrics(  # pylint: disable=R0914, R0913
         async_=True,
     )
     # Submits the query, equivalent to calling POST /data/ directly
-    request_headers.update({"Cache-Control": cache_control})
     initial_query_info = query_service_client.submit_query(
         query_create,
         request_headers=request_headers,

--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -2,9 +2,9 @@
 Data related APIs.
 """
 
-from typing import Annotated, Optional
+from typing import Optional
 
-from fastapi import Depends, Header, Request
+from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
@@ -31,7 +31,6 @@ async def get_data_for_djsql(  # pylint: disable=R0914, R0913
     query: str,
     async_: bool = False,
     *,
-    cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
@@ -67,7 +66,6 @@ async def get_data_for_djsql(  # pylint: disable=R0914, R0913
         async_=async_,
     )
 
-    request_headers.update({"Cache-Control": cache_control})
     result = query_service_client.submit_query(
         query_create,
         request_headers=request_headers,
@@ -84,7 +82,6 @@ async def get_data_for_djsql(  # pylint: disable=R0914, R0913
 async def get_data_stream_for_djsql(
     query: str,
     *,
-    cache_control: Annotated[str, Header()] = "",
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
@@ -121,7 +118,6 @@ async def get_data_stream_for_djsql(
     )
 
     # Submits the query, equivalent to calling POST /data/ directly
-    request_headers.update({"Cache-Control": cache_control})
     initial_query_info = query_service_client.submit_query(
         query_create,
         request_headers=request_headers,

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -732,6 +732,7 @@ async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,
 
 async def query_event_stream(  # pylint: disable=too-many-arguments
     query: QueryWithResults,
+    request_headers: Optional[Dict[str, str]],
     query_service_client: QueryServiceClient,
     columns: List[Column],
     request,
@@ -763,6 +764,7 @@ async def query_event_stream(  # pylint: disable=too-many-arguments
         # Check the current state of the query
         query_next = query_service_client.get_query(  # type: ignore # pragma: no cover
             query_id=query_id,
+            request_headers=request_headers,
         )
         if query_next.state in END_JOB_STATES:  # pragma: no cover
             _logger.info(  # pragma: no cover

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from http import HTTPStatus
 from typing import List
 
-from fastapi import Depends
+from fastapi import Depends, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
@@ -83,6 +83,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     data: UpsertMaterialization,
     *,
     session: AsyncSession = Depends(get_session),
+    request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: User = Depends(get_and_update_current_user),
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
@@ -93,6 +94,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     Add or update a materialization of the specified node. If a node_name is specified
     for the materialization config, it will always update that named config.
     """
+    request_headers = dict(request.headers)
     node = await Node.get_by_name(session, node_name)
     if node.type == NodeType.SOURCE:  # type: ignore
         raise DJException(
@@ -150,6 +152,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
             node_name,
             current_revision.version,  # type: ignore
             new_materialization.name,  # type: ignore
+            request_headers=request_headers,
         )
         # refresh existing materialization job
         await schedule_materialization_jobs(
@@ -157,6 +160,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
             node_revision_id=current_revision.id,
             materialization_names=[new_materialization.name],
             query_service_client=query_service_client,
+            request_headers=request_headers,
         )
         return JSONResponse(
             status_code=HTTPStatus.CREATED,
@@ -216,6 +220,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
         node_revision_id=current_revision.id,
         materialization_names=[new_materialization.name],
         query_service_client=query_service_client,
+        request_headers=request_headers,
     )
     return JSONResponse(
         status_code=200,
@@ -239,12 +244,14 @@ async def list_node_materializations(
     show_deleted: bool = False,
     *,
     session: AsyncSession = Depends(get_session),
+    request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
 ) -> List[MaterializationConfigInfoUnified]:
     """
     Show all materializations configured for the node, with any associated metadata
     like urls from the materialization service, if available.
     """
+    request_headers = dict(request.headers)
     node = await Node.get_by_name(session, node_name)
     materializations = []
     for materialization in node.current.materializations:  # type: ignore
@@ -253,6 +260,7 @@ async def list_node_materializations(
                 node_name,
                 node.current.version,  # type: ignore
                 materialization.name,  # type: ignore
+                request_headers=request_headers,
             )
             if materialization.strategy != MaterializationStrategy.INCREMENTAL_TIME:
                 info.urls = [info.urls[0]]
@@ -277,6 +285,7 @@ async def deactivate_node_materializations(
     materialization_name: str,
     *,
     session: AsyncSession = Depends(get_session),
+    request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: User = Depends(get_and_update_current_user),
 ) -> List[MaterializationConfigInfoUnified]:
@@ -284,8 +293,13 @@ async def deactivate_node_materializations(
     Deactivate the node materialization with the provided name.
     Also calls the query service to deactivate the associated scheduled jobs.
     """
+    request_headers = dict(request.headers)
     node = await Node.get_by_name(session, node_name)
-    query_service_client.deactivate_materialization(node_name, materialization_name)
+    query_service_client.deactivate_materialization(
+        node_name,
+        materialization_name,
+        request_headers=request_headers,
+    )
     for materialization in node.current.materializations:  # type: ignore
         if (
             materialization.name == materialization_name
@@ -334,12 +348,14 @@ async def run_materialization_backfill(  # pylint: disable=too-many-locals
     backfill_partitions: List[PartitionBackfill],
     *,
     session: AsyncSession = Depends(get_session),
+    request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     current_user: User = Depends(get_and_update_current_user),
 ) -> MaterializationInfo:
     """
     Start a backfill for a configured materialization.
     """
+    request_headers = dict(request.headers)
     node = await Node.get_by_name(
         session,
         node_name,
@@ -395,6 +411,7 @@ async def run_materialization_backfill(  # pylint: disable=too-many-locals
         materialization,
         backfill_partitions,
         query_service_client,
+        request_headers=request_headers,
     )
     backfill = Backfill(
         materialization=materialization,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -1,6 +1,6 @@
 """Node materialization helper functions"""
 import zlib
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from pydantic import ValidationError
 from sqlalchemy.exc import InvalidRequestError
@@ -282,6 +282,7 @@ async def schedule_materialization_jobs(
     node_revision_id: int,
     materialization_names: List[str],
     query_service_client: QueryServiceClient,
+    request_headers: Optional[Dict[str, str]] = None,
 ) -> Dict[str, MaterializationInfo]:
     """
     Schedule recurring materialization jobs
@@ -301,6 +302,7 @@ async def schedule_materialization_jobs(
             materialization_to_output[materialization.name] = clazz().schedule(  # type: ignore
                 materialization,
                 query_service_client,
+                request_headers=request_headers,
             )
     return materialization_to_output
 

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -1,6 +1,8 @@
 """
 Cube materialization jobs
 """
+from typing import Dict, Optional
+
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import NodeRevision
 from datajunction_server.errors import DJInvalidInputException
@@ -51,6 +53,7 @@ class DruidMaterializationJob(MaterializationJob):
         self,
         materialization: Materialization,
         query_service_client: QueryServiceClient,
+        request_headers: Optional[Dict[str, str]] = None,
     ) -> MaterializationInfo:
         """
         Use the query service to kick off the materialization setup.
@@ -90,6 +93,7 @@ class DruidMaterializationJob(MaterializationJob):
                 job=materialization.job,
                 strategy=materialization.strategy,
             ),
+            request_headers=request_headers,
         )
 
 

--- a/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
@@ -2,7 +2,7 @@
 Available materialization jobs.
 """
 import abc
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.models.engine import Dialect
@@ -37,6 +37,7 @@ class MaterializationJob(abc.ABC):  # pylint: disable=too-few-public-methods
         materialization: Materialization,
         partitions: List[PartitionBackfill],
         query_service_client: QueryServiceClient,
+        request_headers: Optional[Dict[str, str]] = None,
     ) -> MaterializationInfo:
         """
         Kicks off a backfill based on the spec using the query service
@@ -45,6 +46,7 @@ class MaterializationJob(abc.ABC):  # pylint: disable=too-few-public-methods
             materialization.node_revision.name,
             materialization.name,  # type: ignore
             partitions,
+            request_headers=request_headers,
         )
 
     @abc.abstractmethod
@@ -72,6 +74,7 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
         self,
         materialization: Materialization,
         query_service_client: QueryServiceClient,
+        request_headers: Optional[Dict[str, str]] = None,
     ) -> MaterializationInfo:
         """
         Placeholder for the actual implementation.
@@ -177,5 +180,6 @@ class SparkSqlMaterializationJob(  # pylint: disable=too-few-public-methods # pr
                     )
                 ),
             ),
+            request_headers=request_headers,
         )
         return result

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -131,8 +131,6 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         """
         Submit a query to the query service
         """
-        if not request_headers:
-            request_headers = {"Cache-Control": ""}
         response = self.requests_session.post(
             "/queries/",
             headers={**self.requests_session.headers, **request_headers}

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -3,7 +3,6 @@
 import json
 import os
 from pathlib import Path
-from unittest.mock import call
 
 import pytest
 import pytest_asyncio
@@ -829,19 +828,17 @@ async def test_spark_sql_full(
             },
         ],
     )
-    assert module__query_service_client.run_backfill.call_args_list == [  # type: ignore
-        call(
-            "default.hard_hat",
-            "spark_sql__full__birth_date__country",
-            [
-                PartitionBackfill(
-                    column_name="birth_date",
-                    values=None,
-                    range=["20230101", "20230201"],
-                ),
-            ],
-        ),
-    ]
+    assert module__query_service_client.run_backfill.call_args_list[0].args == (  # type: ignore
+        "default.hard_hat",
+        "spark_sql__full__birth_date__country",
+        [
+            PartitionBackfill(
+                column_name="birth_date",
+                values=None,
+                range=["20230101", "20230201"],
+            ),
+        ],
+    )
     assert response.json() == {"output_tables": [], "urls": ["http://fake.url/job"]}
 
 
@@ -941,7 +938,7 @@ async def test_spark_sql_incremental(
             },
         ],
     )
-    assert module__query_service_client.run_backfill.call_args_list[-1] == call(  # type: ignore
+    assert module__query_service_client.run_backfill.call_args_list[-1].args == (  # type: ignore
         "default.hard_hat_2",
         "spark_sql__incremental_time__birth_date",
         [

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1737,6 +1737,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
             "default",
             "roads",
             "repair_orders",
+            request_headers={},
         )
 
         # Columns have changed, so the new node revision should be bumped to a new version

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -199,6 +199,9 @@ def query_service_client(
         schema: str,
         table: str,
         engine: Optional[Engine] = None,  # pylint: disable=unused-argument
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> List[Column]:
         return COLUMN_MAPPINGS[f"{catalog}.{schema}.{table}"]
 
@@ -210,7 +213,9 @@ def query_service_client(
 
     def mock_submit_query(
         query_create: QueryCreate,
-        headers: Optional[Dict[str, str]] = None,  # pylint: disable=unused-argument
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> QueryWithResults:
         result = duckdb_conn.sql(query_create.submitted_query)
         columns = [
@@ -239,6 +244,9 @@ def query_service_client(
 
     def mock_get_query(
         query_id: str,
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> Collection[Collection[str]]:
         if query_id == "foo-bar-baz":
             raise DJQueryServiceClientException("Query foo-bar-baz not found.")
@@ -868,6 +876,9 @@ def module__query_service_client(
         schema: str,
         table: str,
         engine: Optional[Engine] = None,  # pylint: disable=unused-argument
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> List[Column]:
         return COLUMN_MAPPINGS[f"{catalog}.{schema}.{table}"]
 
@@ -879,7 +890,9 @@ def module__query_service_client(
 
     def mock_submit_query(
         query_create: QueryCreate,
-        headers: Optional[Dict[str, str]] = None,  # pylint: disable=unused-argument
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> QueryWithResults:
         result = duckdb_conn.sql(query_create.submitted_query)
         columns = [
@@ -908,6 +921,9 @@ def module__query_service_client(
 
     def mock_get_query(
         query_id: str,
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
     ) -> Collection[Collection[str]]:
         if query_id == "foo-bar-baz":
             raise DJQueryServiceClientException("Query foo-bar-baz not found.")

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -52,7 +52,6 @@ class TestRequestsSessionWithEndpoint:
             "GET",
             f"{self.example_endpoint}/pies/?flavor=blueberry",
             data=None,
-            headers=ANY,
         )
         prepped = requests_session.prepare_request(req)
         assert prepped.headers["Connection"] == "keep-alive"

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -1,7 +1,7 @@
 """
 Tests for ``datajunction_server.service_clients``.
 """
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -52,7 +52,7 @@ class TestRequestsSessionWithEndpoint:
             "GET",
             f"{self.example_endpoint}/pies/?flavor=blueberry",
             data=None,
-            headers=None,
+            headers=ANY,
         )
         prepped = requests_session.prepare_request(req)
         assert prepped.headers["Connection"] == "keep-alive"
@@ -107,6 +107,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "http://queryservice:8001/table/hive.test.pies/columns/",
             params={},
             allow_redirects=True,
+            headers=ANY,
         )
 
         query_service_client.get_columns_for_table(
@@ -120,6 +121,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "http://queryservice:8001/table/hive.test.pies/columns/",
             params={"engine": "spark", "engine_version": "2.4.4"},
             allow_redirects=True,
+            headers=ANY,
         )
 
         # failed request with unknown reason
@@ -198,7 +200,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
 
         mock_request.assert_called_with(
             "/queries/",
-            headers={"Cache-Control": ""},
+            headers=ANY,
             json={
                 "catalog_name": "default",
                 "engine_name": "postgres",
@@ -252,6 +254,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
 
         mock_request.assert_called_with(
             "/queries/ef209eef-c31a-4089-aae6-833259a08e22/",
+            headers=ANY,
         )
 
     def test_query_service_client_materialize(self, mocker: MockerFixture) -> None:
@@ -304,6 +307,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 "upstream_tables": ["default.hard_hats"],
                 "columns": [],
             },
+            headers=ANY,
         )
 
     def test_query_service_client_deactivate_materialization(
@@ -333,6 +337,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
 
         mock_request.assert_called_with(
             "/materialization/default.hard_hat/default/",
+            headers=ANY,
         )
 
     def test_query_service_client_raising_error(self, mocker: MockerFixture) -> None:
@@ -370,7 +375,6 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         with pytest.raises(DJQueryServiceClientException) as exc_info:
             query_service_client.submit_query(
                 query_create,
-                headers={"Cache-Control": "no-cache"},
             )
         assert "Error response from query service" in str(exc_info.value)
         assert exc_info.value.errors == [
@@ -437,6 +441,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 "partitions": [],
                 "columns": [],
             },
+            headers=ANY,
         )
         assert response == {
             "urls": ["http://fake.url/job"],
@@ -468,6 +473,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         mock_request.assert_called_with(
             "/materialization/default.hard_hat/v3.1/default/",
             timeout=3,
+            headers=ANY,
         )
         assert response == {
             "urls": ["http://fake.url/job"],
@@ -539,6 +545,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 },
             ],
             timeout=20,
+            headers=ANY,
         )
 
         mocked_call.reset_mock()
@@ -577,4 +584,5 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
                 },
             ],
             timeout=20,
+            headers=ANY,
         )


### PR DESCRIPTION
### Summary

This updates every query service client request to include the headers that came in with the request to the main server. It also updates all usage of the query service client to make sure the headers are passed in.

cc: @sadath-12

### Test Plan

Updated tests

- [ ] PR has an associated issue: #1092 #1064
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
