### PR TITLE
Revert "Fix SQL building with filters"

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -214,7 +214,6 @@ async def get_query(  # pylint: disable=too-many-arguments
         limit=limit,
         build_criteria=build_criteria,
         access_control=access_control,
-        top_level=True,
     )
     query_ast = rename_columns(query_ast, node.current)  # type: ignore
     return query_ast

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1481,23 +1481,6 @@ class BinaryOp(Operation):
             (left, right, *rest),
         )
 
-    def split(self, op: BinaryOpKind) -> List[Expression]:
-        """
-        Splits the expression by the operator into a list of expressions.
-        """
-        if self.op == op:
-            if not isinstance(self.left, BinaryOp) and isinstance(self.right, BinaryOp):
-                return [self.left] + self.right.split(op)
-            if not isinstance(self.right, BinaryOp) and isinstance(self.left, BinaryOp):
-                return self.left.split(op) + [self.right]
-            if not isinstance(self.right, BinaryOp) and not isinstance(
-                self.left,
-                BinaryOp,
-            ):
-                return [self.left, self.right]
-            return self.left.split(op) + self.right.split(op)
-        return [self]
-
     @classmethod
     def Eq(  # pylint: disable=invalid-name
         cls,

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -3444,8 +3444,7 @@ async def test_filter_pushdowns(
         "/nodes/default.repair_orders_fact",
         json={
             "query": "SELECT repair_orders.hard_hat_id AS hh_id "
-            "FROM default.repair_orders repair_orders "
-            "WHERE repair_orders.hard_hat_id IN (1, 2, 3)",
+            "FROM default.repair_orders repair_orders",
         },
     )
     assert response.status_code == 200
@@ -3462,7 +3461,6 @@ async def test_filter_pushdowns(
     )
     assert response.status_code == 201
 
-    # All of the filters can push down
     response = await module__client_with_examples.get(
         "/sql/default.repair_orders_fact",
         params={
@@ -3483,50 +3481,10 @@ async def test_filter_pushdowns(
               SELECT
                 repair_orders.hard_hat_id AS hh_id
               FROM roads.repair_orders AS repair_orders
-              WHERE  repair_orders.hard_hat_id IN (1, 2, 3)
-                AND repair_orders.hard_hat_id IN (123, 13)
-                AND repair_orders.hard_hat_id = 123
-                OR repair_orders.hard_hat_id = 13
             ) AS default_DOT_repair_orders_fact
-            WHERE
-              default_DOT_repair_orders_fact.hh_id IN (123, 13) AND default_DOT_repair_orders_fact.hh_id = 123 OR default_DOT_repair_orders_fact.hh_id = 13
-            """,
-        ),
-    )
-
-    # One of the filters cannot push down
-    response = await module__client_with_examples.get(
-        "/sql/default.repair_orders_fact",
-        params={
-            "dimensions": ["default.hard_hat.hard_hat_id"],
-            "filters": [
-                "default.hard_hat.hard_hat_id IN (123, 13)",
-                "default.hard_hat.state IN ('CA')",
-            ],
-        },
-    )
-    assert str(parse(response.json()["sql"])) == str(
-        parse(
-            """
-            SELECT
-              default_DOT_repair_orders_fact.hh_id default_DOT_repair_orders_fact_DOT_hh_id,
-              default_DOT_repair_orders_fact.hh_id default_DOT_hard_hat_DOT_hard_hat_id
-            FROM (
-              SELECT
-                repair_orders.hard_hat_id AS hh_id
-              FROM roads.repair_orders AS repair_orders
-              WHERE
-                repair_orders.hard_hat_id IN (1, 2, 3)
-            ) AS default_DOT_repair_orders_fact LEFT JOIN (
-              SELECT
-                default_DOT_hard_hats.hard_hat_id,
-                default_DOT_hard_hats.state
-              FROM roads.hard_hats AS default_DOT_hard_hats
-            ) AS default_DOT_hard_hat
-            ON default_DOT_repair_orders_fact.hh_id = default_DOT_hard_hat.hard_hat_id
-            WHERE
-              default_DOT_hard_hat.state IN ('CA')
-              AND default_DOT_repair_orders_fact.hh_id IN (123, 13)
+            WHERE  default_DOT_repair_orders_fact.hh_id IN (123, 13)
+              AND default_DOT_repair_orders_fact.hh_id = 123
+              OR default_DOT_repair_orders_fact.hh_id = 13
             """,
         ),
     )


### PR DESCRIPTION
### Summary

This reverts https://github.com/DataJunction/dj/pull/1109, which causes unexpected issues with actually applying filters. It's very important that we get this revert in before doing any backend DJ deploys.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
