### PR TITLE
Refactor node query building v2 to use the builder pattern

### DIFF
--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -408,12 +408,12 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
             filters=["default.hard_hat.state = 'NY'"],
             measures=True,
         )
-        for upstream_key, translated_sql in result.items():
-            assert upstream_key in (
+        for generated_sql in result:
+            assert generated_sql["node"]["name"] in (
                 "default.repair_order_details",
                 "default.repair_orders",
             )
-            assert isinstance(translated_sql["sql"], str)
+            assert isinstance(generated_sql["sql"], str)
 
     #
     # Data Catalog and Engines

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -28,6 +28,7 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.sql import GeneratedSQL
 from datajunction_server.models.user import UserOutput
 from datajunction_server.utils import (
+    Settings,
     get_and_update_current_user,
     get_session,
     get_settings,
@@ -137,6 +138,7 @@ async def get_measures_sql_for_cube_v2(
             "for the metrics and dimensions in the cube"
         ),
     ),
+    settings: Settings = Depends(get_settings),  # pylint: disable=redefined-outer-name
     session: AsyncSession = Depends(get_session),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
@@ -170,6 +172,7 @@ async def get_measures_sql_for_cube_v2(
         current_user=current_user,
         validate_access=validate_access,
         include_all_columns=include_all_columns,
+        sql_transpilation_library=settings.sql_transpilation_library,
     )
     return measures_query
 

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -4,7 +4,7 @@ SQL related APIs.
 """
 import logging
 from collections import OrderedDict
-from typing import Dict, List, Optional, Tuple, cast
+from typing import List, Optional, Tuple, cast
 
 from fastapi import BackgroundTasks, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,6 +25,7 @@ from datajunction_server.models import access
 from datajunction_server.models.access import AccessControlStore
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.sql import GeneratedSQL
 from datajunction_server.models.user import UserOutput
 from datajunction_server.utils import (
     get_and_update_current_user,
@@ -121,7 +122,7 @@ async def get_measures_sql_for_cube(
 
 @router.get(
     "/sql/measures/v2/",
-    response_model=Dict[str, TranslatedSQL],
+    response_model=List[GeneratedSQL],
     name="Get Measures SQL",
 )
 async def get_measures_sql_for_cube_v2(
@@ -143,7 +144,7 @@ async def get_measures_sql_for_cube_v2(
     validate_access: access.ValidateAccessFn = Depends(  # pylint: disable=W0621
         validate_access,
     ),
-) -> Dict[str, TranslatedSQL]:
+) -> List[GeneratedSQL]:
     """
     Return measures SQL for a set of metrics with dimensions and filters.
 

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -80,6 +80,7 @@ async def get_measures_query(  # pylint: disable=too-many-locals
     validate_access: access.ValidateAccessFn = None,
     cast_timestamp_to_ms: bool = False,  # pylint: disable=unused-argument
     include_all_columns: bool = False,
+    sql_transpilation_library: Optional[str] = None,
 ) -> List[GeneratedSQL]:
     """
     Builds the measures SQL for a set of metrics with dimensions and filters.
@@ -186,10 +187,10 @@ async def get_measures_query(  # pylint: disable=too-many-locals
         dependencies, _ = await parent_ast.extract_dependencies(
             CompileContext(session, DJException()),
         )
-        print("Measures SQL!", parent_node.name, str(parent_ast))
         measures_queries.append(
             GeneratedSQL(
                 node=parent_node.current,
+                sql_transpilation_library=sql_transpilation_library,
                 sql=str(parent_ast),
                 columns=columns_metadata,
                 dialect=build_criteria.dialect,

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -966,6 +966,10 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
                 )
 
         for table in table_expressions:
+            # If the user has set an alias for the node reference, reuse the
+            # same alias for the built query
+            if table.alias and hasattr(query_ast, "alias"):
+                query_ast.alias = table.alias
             query.select.replace(
                 table,
                 query_ast,

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -264,11 +264,15 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes
             self.add_dimension(dimension)
         return self
 
-    def order_by(self, orderby: Optional[List[str]] = None):
+    def order_by(self, orderby: Optional[Union[str, List[str]]] = None):
         """Set order by for the query builder."""
-        for order in orderby or []:
-            if order not in self._orderby:
-                self._orderby.append(order)
+        if isinstance(orderby, str):
+            if orderby not in self._orderby:
+                self._orderby.append(orderby)
+        else:
+            for order in orderby or []:
+                if order not in self._orderby:
+                    self._orderby.append(order)
         return self
 
     def limit(self, limit: Optional[int] = None):
@@ -279,7 +283,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes
 
     def with_build_criteria(self, build_criteria: Optional[BuildCriteria] = None):
         """Set build criteria for the query builder."""
-        if build_criteria:
+        if build_criteria:  # pragma: no cover
             self._build_criteria = build_criteria
         return self
 
@@ -290,7 +294,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes
         """
         Set access control for the query builder.
         """
-        if access_control:
+        if access_control:  # pragma: no cover
             access_control.add_request_by_node(self.node_revision)
             self._access_control = access_control
         return self
@@ -601,23 +605,6 @@ def get_column_from_canonical_dimension(
             link.foreign_keys_reversed[dimension_attr.name],
         ).column_name
     return column_name
-
-
-async def get_necessary_dimensions(
-    session: AsyncSession,
-    node: NodeRevision,
-    dimensions: List[str],
-):
-    """
-    Returns the necessary dimensions for this node, which are a combination of the requested
-    dimensions and the node's required dimensions
-    """
-    await session.refresh(node, ["required_dimensions"])
-    return list(
-        dict.fromkeys(
-            dimensions or [] + [required.name for required in node.required_dimensions],
-        ),
-    )
 
 
 def to_filter_asts(filters: Optional[List[str]] = None):

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -294,13 +294,13 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
                 self._orderby.append(orderby)
         else:
             for order in orderby or []:
-                if order not in self._orderby:
+                if order not in self._orderby:  # pragma: no cover
                     self._orderby.append(order)
         return self
 
     def limit(self, limit: Optional[int] = None):
         """Set limit for the query builder."""
-        if limit:
+        if limit:  # pragma: no cover
             self._limit = limit
         return self
 
@@ -555,8 +555,11 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
 
     async def add_request_by_node_name(self, node_name):
         """Add a node request to the access control validator."""
-        if self._access_control:
-            await self._access_control.add_request_by_node_name(self.session, node_name)
+        if self._access_control:  # pragma: no cover
+            await self._access_control.add_request_by_node_name(  # pragma: no cover
+                self.session,
+                node_name,
+            )
 
     def validate_access(self):
         """Validates access"""
@@ -584,7 +587,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
             dim_node = dimension_attr.node_name
             if dim_node == self.node_revision.name:
                 continue
-            await self.add_request_by_node_name(dim_node)
+            self.add_request_by_node_name(dim_node)
             if dim_node not in dimension_node_joins:
                 join_path = await dimension_join_path(
                     self.session,
@@ -904,43 +907,83 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
 
     new_cte_mapping: Dict[str, ast.Query] = {}
     if ctes_mapping is None:
-        ctes_mapping = new_cte_mapping
+        ctes_mapping = new_cte_mapping  # pragma: no cover
 
     node_to_tables_mapping = get_dj_node_references_from_select(query.select)
     for referenced_node, reference_expressions in node_to_tables_mapping.items():
         await session.refresh(referenced_node, ["dimension_links"])
 
         for ref_expr in reference_expressions:
+
+            # Try to find a materialized table attached to this node, if one exists.
             physical_table = cast(
                 Optional[ast.Table],
-                get_table_for_node(referenced_node, build_criteria),
-            )
-            if physical_table:
-                query_ast = create_query_ast_with_table(
-                    physical_table,
+                get_table_for_node(
                     referenced_node,
-                    filters,
+                    build_criteria=build_criteria,
+                ),
+            )
+            if not physical_table:
+                # Build a new CTE with the query AST if there is no materialized table
+                if referenced_node.name not in ctes_mapping:
+                    node_query = parse(cast(str, referenced_node.query))
+                    query_ast = await build_ast(  # type: ignore
+                        session,
+                        referenced_node,
+                        node_query,
+                        filters=filters,
+                        memoized_queries=memoized_queries,
+                        build_criteria=build_criteria,
+                        access_control=access_control,
+                        ctes_mapping=ctes_mapping,
+                    )
+                    cte_name = ast.Name(amenable_name(referenced_node.name))
+                    query_ast = query_ast.to_cte(cte_name, parent_ast=query)
+                    if referenced_node.name not in new_cte_mapping:  # pragma: no cover
+                        new_cte_mapping[referenced_node.name] = query_ast
+
+                reference_cte = (
+                    ctes_mapping[referenced_node.name]
+                    if referenced_node.name in ctes_mapping
+                    else new_cte_mapping[referenced_node.name]
+                )
+                query_ast = ast.Table(  # type: ignore
+                    reference_cte.alias,  # type: ignore
+                    _columns=reference_cte._columns,  # pylint: disable=protected-access
+                    _dj_node=referenced_node,
                 )
             else:
-                query_ast = await create_query_ast_with_cte(
-                    session,
-                    referenced_node,
-                    query,
-                    filters,
-                    memoized_queries,
-                    build_criteria,
-                    access_control,
-                    ctes_mapping,
-                    new_cte_mapping,
+                # Otherwise use the materialized table and apply filters where possible
+                alias = amenable_name(referenced_node.name)
+                query_ast = ast.Query(
+                    select=ast.Select(
+                        projection=physical_table.columns,  # type: ignore
+                        from_=ast.From(relations=[ast.Relation(physical_table)]),
+                    ),
+                    alias=ast.Name(alias),
                 )
+                query_ast.parenthesized = True
+                apply_filters_to_node(
+                    referenced_node,
+                    query_ast,
+                    to_filter_asts(filters),
+                )
+                if not query_ast.select.where:
+                    query_ast = ast.Alias(  # type: ignore
+                        ast.Name(alias),
+                        child=physical_table,
+                        as_=True,
+                    )
 
             # If the user has set an alias for the node reference, reuse the
             # same alias for the built query
             if ref_expr.alias and hasattr(query_ast, "alias"):
                 query_ast.alias = ref_expr.alias
-
-            query.select.replace(ref_expr, query_ast, copy=False)
-
+            query.select.replace(
+                ref_expr,
+                query_ast,
+                copy=False,
+            )
             await query.select.compile(context)
             for col in query.select.find_all(ast.Column):
                 if (
@@ -958,77 +1001,9 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
         query.ctes.extend(cte.ctes)
         cte.ctes = []
         query.ctes.append(cte)
-
     query.select.add_aliases_to_unnamed_columns()
     ctes_mapping.update(new_cte_mapping)
     return query
-
-
-async def create_query_ast_with_cte(
-    session,
-    referenced_node,
-    query,
-    filters,
-    memoized_queries,
-    build_criteria,
-    access_control,
-    ctes_mapping,
-    new_cte_mapping,
-):
-    """
-    Build a new CTE with the query AST if there is no materialized table
-    """
-    if referenced_node.name not in ctes_mapping:
-        node_query = parse(cast(str, referenced_node.query))
-        query_ast = await build_ast(  # type: ignore
-            session,
-            referenced_node,
-            node_query,
-            filters=filters,
-            memoized_queries=memoized_queries,
-            build_criteria=build_criteria,
-            access_control=access_control,
-            ctes_mapping=ctes_mapping,
-        )
-        cte_name = ast.Name(amenable_name(referenced_node.name))
-        query_ast = query_ast.to_cte(cte_name, parent_ast=query)
-        new_cte_mapping[referenced_node.name] = query_ast
-
-    reference_cte = (
-        ctes_mapping[referenced_node.name]
-        if referenced_node.name in ctes_mapping
-        else new_cte_mapping[referenced_node.name]
-    )
-    query_ast = ast.Table(  # type: ignore
-        reference_cte.alias,  # type: ignore
-        _columns=reference_cte._columns,  # pylint: disable=protected-access
-        _dj_node=referenced_node,
-    )
-    return query_ast
-
-
-def create_query_ast_with_table(table_reference, referenced_node, filters):
-    """
-    Build query from the materialized table with filters.
-    """
-    alias = amenable_name(referenced_node.name)
-    query_ast = ast.Query(
-        select=ast.Select(
-            projection=table_reference.columns,
-            from_=ast.From(relations=[ast.Relation(table_reference)]),
-        ),
-        alias=ast.Name(alias),
-    )
-    query_ast.parenthesized = True
-    apply_filters_to_node(referenced_node, query_ast, to_filter_asts(filters))
-
-    if not query_ast.select.where:
-        query_ast = ast.Alias(
-            ast.Name(alias),
-            child=table_reference,
-            as_=True,
-        )
-    return query_ast
 
 
 def apply_filters_to_node(

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -447,7 +447,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
         """
         Initialize the final query AST structure
         """
-        node_ctes = remove_duplicates(
+        node_ctes = remove_duplicates(  # pragma: no cover
             node_ast.ctes,
             lambda cte: cte.alias_or_name.identifier(),
         )
@@ -664,7 +664,7 @@ def to_filter_asts(filters: Optional[List[str]] = None):
     ]
 
 
-def remove_duplicates(input_list, key_func=lambda x: x):
+def remove_duplicates(input_list, key_func=lambda x: x):  # pragma: no cover
     """
     Remove duplicates from the list by using the key_func on each element
     to determine the "key" used for identifying duplicates.
@@ -1003,6 +1003,7 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
             for col in query.select.find_all(ast.Column):
                 if (
                     col.table
+                    and not col.table.alias
                     and isinstance(col.table, ast.Table)
                     and col.table.dj_node
                     and col.table.dj_node.name == referenced_node.name

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -553,10 +553,10 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
             if node_col and new_alias not in self.final_ast.select.column_mapping:
                 node_col.set_alias(ast.Name(amenable_name(dim_name)))
 
-    def add_request_by_node_name(self, node_name):
+    async def add_request_by_node_name(self, node_name):
         """Add a node request to the access control validator."""
         if self._access_control:
-            self._access_control.add_request_by_node_name(self.session, node_name)
+            await self._access_control.add_request_by_node_name(self.session, node_name)
 
     def validate_access(self):
         """Validates access"""
@@ -983,7 +983,11 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
     # Apply pushdown filters if possible
     apply_filters_to_node(node, query, to_filter_asts(filters))
 
-    query.ctes.extend(new_cte_mapping.values())
+    for cte in new_cte_mapping.values():
+        if cte.ctes:
+            query.ctes.extend(cte.ctes)
+        query.ctes.append(cte)
+
     query.select.add_aliases_to_unnamed_columns()
     return query
 

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -389,6 +389,8 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
             self.final_ast = node_ast
         else:
             node_alias, node_ast = await self.build_current_node_ast(node_ast)
+            ctx = CompileContext(self.session, DJException())
+            await node_ast.compile(ctx)
             self.final_ast = self.initialize_final_query_ast(node_ast, node_alias)
             await self.build_dimension_node_joins(node_ast, node_alias)
             self.set_dimension_aliases()
@@ -431,7 +433,6 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
         ctx = CompileContext(self.session, DJException())
         await node_ast.compile(ctx)
         self.errors.extend(ctx.exception.errors)
-
         node_alias = ast.Name(amenable_name(self.node_revision.name))
         return node_alias, await build_ast(
             self.session,

--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -291,3 +291,15 @@ class DJPluginNotFoundException(DJException):
     """
     Exception raised when plugin is not found.
     """
+
+
+class DJQueryBuildException(DJException):
+    """
+    Exception raised when query building fails.
+    """
+
+
+class DJQueryBuildError(DJError):
+    """
+    Query build error
+    """

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -1,0 +1,55 @@
+"""
+Models for generated SQL
+"""
+from typing import List, Optional
+
+from pydantic.class_validators import root_validator
+from pydantic.main import BaseModel
+
+from datajunction_server.models.engine import Dialect
+from datajunction_server.models.query import ColumnMetadata
+from datajunction_server.transpilation import get_transpilation_plugin
+from datajunction_server.utils import get_settings
+
+
+class NodeNameVersion(BaseModel):
+    """
+    Node name and version
+    """
+
+    name: str
+    version: str
+
+    class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        orm_mode = True
+
+
+class GeneratedSQL(BaseModel):
+    """
+    Generated SQL for a given node, the output of a QueryBuilder(...).build() call.
+    """
+
+    node: NodeNameVersion
+    sql: str
+    columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover
+    dialect: Optional[Dialect] = None
+    upstream_tables: Optional[List[str]] = None
+
+    @root_validator(pre=False)
+    def transpile_sql(  # pylint: disable=no-self-argument
+        cls,
+        values,
+    ):
+        """
+        Transpiles SQL to the specified dialect with the configured transpilation plugin.
+        If no plugin is configured, it will just return the original generated query.
+        """
+        settings = get_settings()
+        if settings.sql_transpilation_library:
+            plugin = get_transpilation_plugin(settings.sql_transpilation_library)
+            values["sql"] = plugin.transpile_sql(
+                values["sql"],
+                input_dialect=Dialect.SPARK,
+                output_dialect=values["dialect"],
+            )
+        return values

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 from pydantic.class_validators import root_validator
 from pydantic.main import BaseModel
 
+from datajunction_server.errors import DJQueryBuildError
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.transpilation import get_transpilation_plugin
@@ -34,6 +35,7 @@ class GeneratedSQL(BaseModel):
     columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover
     dialect: Optional[Dialect] = None
     upstream_tables: Optional[List[str]] = None
+    errors: Optional[List[DJQueryBuildError]] = None
 
     @root_validator(pre=False)
     def transpile_sql(  # pylint: disable=no-self-argument

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -10,7 +10,6 @@ from datajunction_server.errors import DJQueryBuildError
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.transpilation import get_transpilation_plugin
-from datajunction_server.utils import get_settings
 
 
 class NodeNameVersion(BaseModel):
@@ -32,6 +31,7 @@ class GeneratedSQL(BaseModel):
 
     node: NodeNameVersion
     sql: str
+    sql_transpilation_library: Optional[str] = None
     columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover
     dialect: Optional[Dialect] = None
     upstream_tables: Optional[List[str]] = None
@@ -46,9 +46,8 @@ class GeneratedSQL(BaseModel):
         Transpiles SQL to the specified dialect with the configured transpilation plugin.
         If no plugin is configured, it will just return the original generated query.
         """
-        settings = get_settings()
-        if settings.sql_transpilation_library:
-            plugin = get_transpilation_plugin(settings.sql_transpilation_library)
+        if values.get("sql_transpilation_library"):
+            plugin = get_transpilation_plugin(values.get("sql_transpilation_library"))
             values["sql"] = plugin.transpile_sql(
                 values["sql"],
                 input_dialect=Dialect.SPARK,

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -47,8 +47,10 @@ class GeneratedSQL(BaseModel):
         If no plugin is configured, it will just return the original generated query.
         """
         if values.get("sql_transpilation_library"):
-            plugin = get_transpilation_plugin(values.get("sql_transpilation_library"))
-            values["sql"] = plugin.transpile_sql(
+            plugin = get_transpilation_plugin(  # pragma: no cover
+                values.get("sql_transpilation_library"),
+            )
+            values["sql"] = plugin.transpile_sql(  # pragma: no cover
                 values["sql"],
                 input_dialect=Dialect.SPARK,
                 output_dialect=values["dialect"],

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -931,7 +931,9 @@ class Column(Aliasable, Named, Expression):
         if isinstance(alpha_query, Query) and alpha_query.ctes:
             for cte in alpha_query.ctes:
                 cte_name = cte.alias_or_name.identifier(False)
-                if cte_name == namespace or cte_name in direct_table_names:
+                if cte_name == namespace or (
+                    not namespace and cte_name in direct_table_names
+                ):
                     if await cte.add_ref_column(self, ctx):
                         found.append(cte)
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -925,11 +925,15 @@ class Column(Aliasable, Named, Expression):
 
         # Check for ctes
         alpha_query = self.get_furthest_parent()
+        direct_table_names = {
+            direct_table.alias_or_name.identifier() for direct_table in direct_tables
+        }
         if isinstance(alpha_query, Query) and alpha_query.ctes:
-            for table in alpha_query.ctes:
-                if table.alias_or_name.identifier(False) == namespace:
-                    if await table.add_ref_column(self, ctx):
-                        found.append(table)
+            for cte in alpha_query.ctes:
+                cte_name = cte.alias_or_name.identifier(False)
+                if cte_name == namespace or cte_name in direct_table_names:
+                    if await cte.add_ref_column(self, ctx):
+                        found.append(cte)
 
         # If nothing was found in the initial AST, traverse through dimensions graph
         # to find another table in DJ that could be its origin

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -75,11 +75,11 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                AS default_DOT_dispatcher_DOT_dispatcher_id,
+                default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                AS default_DOT_repair_orders_fact_DOT_discount,
+                default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                AS default_DOT_repair_orders_fact_DOT_price
+                default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -167,11 +167,11 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                AS default_DOT_dispatcher_DOT_dispatcher_id,
+                default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                AS default_DOT_repair_orders_fact_DOT_discount,
+                default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                AS default_DOT_repair_orders_fact_DOT_price
+                default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -300,15 +300,15 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.total_repair_cost
-                AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
+                default_DOT_repair_orders_fact_DOT_total_repair_cost,
               default_DOT_repair_orders_fact.time_to_dispatch
-                AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+                default_DOT_repair_orders_fact_DOT_time_to_dispatch,
               default_DOT_us_state.state_name
-                AS default_DOT_us_state_DOT_state_name,
+                default_DOT_us_state_DOT_state_name,
               default_DOT_dispatcher.company_name
-                AS default_DOT_dispatcher_DOT_company_name,
+                default_DOT_dispatcher_DOT_company_name,
               default_DOT_hard_hat.last_name
-                AS default_DOT_hard_hat_DOT_last_name
+                default_DOT_hard_hat_DOT_last_name
             FROM default_DOT_repair_orders_fact
             INNER JOIN default_DOT_hard_hat
               ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
@@ -478,23 +478,23 @@ async def test_measures_sql_include_all_columns(
         default_DOT_dispatchers.phone
      FROM roads.dispatchers AS default_DOT_dispatchers
     )
-    SELECT  default_DOT_repair_orders_fact.repair_order_id AS default_DOT_repair_orders_fact_DOT_repair_order_id,
-        default_DOT_repair_orders_fact.municipality_id AS default_DOT_repair_orders_fact_DOT_municipality_id,
-        default_DOT_repair_orders_fact.hard_hat_id AS default_DOT_repair_orders_fact_DOT_hard_hat_id,
-        default_DOT_repair_orders_fact.dispatcher_id AS default_DOT_repair_orders_fact_DOT_dispatcher_id,
-        default_DOT_repair_orders_fact.order_date AS default_DOT_repair_orders_fact_DOT_order_date,
-        default_DOT_repair_orders_fact.dispatched_date AS default_DOT_repair_orders_fact_DOT_dispatched_date,
-        default_DOT_repair_orders_fact.required_date AS default_DOT_repair_orders_fact_DOT_required_date,
-        default_DOT_repair_orders_fact.discount AS default_DOT_repair_orders_fact_DOT_discount,
-        default_DOT_repair_orders_fact.price AS default_DOT_repair_orders_fact_DOT_price,
-        default_DOT_repair_orders_fact.quantity AS default_DOT_repair_orders_fact_DOT_quantity,
-        default_DOT_repair_orders_fact.repair_type_id AS default_DOT_repair_orders_fact_DOT_repair_type_id,
-        default_DOT_repair_orders_fact.total_repair_cost AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
-        default_DOT_repair_orders_fact.time_to_dispatch AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
-        default_DOT_repair_orders_fact.dispatch_delay AS default_DOT_repair_orders_fact_DOT_dispatch_delay,
-        default_DOT_us_state.state_name AS default_DOT_us_state_DOT_state_name,
-        default_DOT_dispatcher.company_name AS default_DOT_dispatcher_DOT_company_name,
-        default_DOT_hard_hat.last_name AS default_DOT_hard_hat_DOT_last_name
+    SELECT  default_DOT_repair_orders_fact.repair_order_id default_DOT_repair_orders_fact_DOT_repair_order_id,
+        default_DOT_repair_orders_fact.municipality_id default_DOT_repair_orders_fact_DOT_municipality_id,
+        default_DOT_repair_orders_fact.hard_hat_id default_DOT_repair_orders_fact_DOT_hard_hat_id,
+        default_DOT_repair_orders_fact.dispatcher_id default_DOT_repair_orders_fact_DOT_dispatcher_id,
+        default_DOT_repair_orders_fact.order_date default_DOT_repair_orders_fact_DOT_order_date,
+        default_DOT_repair_orders_fact.dispatched_date default_DOT_repair_orders_fact_DOT_dispatched_date,
+        default_DOT_repair_orders_fact.required_date default_DOT_repair_orders_fact_DOT_required_date,
+        default_DOT_repair_orders_fact.discount default_DOT_repair_orders_fact_DOT_discount,
+        default_DOT_repair_orders_fact.price default_DOT_repair_orders_fact_DOT_price,
+        default_DOT_repair_orders_fact.quantity default_DOT_repair_orders_fact_DOT_quantity,
+        default_DOT_repair_orders_fact.repair_type_id default_DOT_repair_orders_fact_DOT_repair_type_id,
+        default_DOT_repair_orders_fact.total_repair_cost default_DOT_repair_orders_fact_DOT_total_repair_cost,
+        default_DOT_repair_orders_fact.time_to_dispatch default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+        default_DOT_repair_orders_fact.dispatch_delay default_DOT_repair_orders_fact_DOT_dispatch_delay,
+        default_DOT_us_state.state_name default_DOT_us_state_DOT_state_name,
+        default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name,
+        default_DOT_hard_hat.last_name default_DOT_hard_hat_DOT_last_name
      FROM default_DOT_repair_orders_fact INNER JOIN default_DOT_hard_hat ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
     INNER JOIN default_DOT_us_state ON default_DOT_hard_hat.state = default_DOT_us_state.state_short
     LEFT JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -77,11 +77,11 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                AS default_DOT_dispatcher_DOT_dispatcher_id,
+                default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                AS default_DOT_repair_orders_fact_DOT_discount,
+                default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                AS default_DOT_repair_orders_fact_DOT_price
+                default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -173,11 +173,11 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                AS default_DOT_dispatcher_DOT_dispatcher_id,
+                default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                AS default_DOT_repair_orders_fact_DOT_discount,
+                default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                AS default_DOT_repair_orders_fact_DOT_price
+                default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -307,15 +307,15 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.total_repair_cost
-                AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
+                default_DOT_repair_orders_fact_DOT_total_repair_cost,
               default_DOT_repair_orders_fact.time_to_dispatch
-                AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+                default_DOT_repair_orders_fact_DOT_time_to_dispatch,
               default_DOT_us_state.state_name
-                AS default_DOT_us_state_DOT_state_name,
+                default_DOT_us_state_DOT_state_name,
               default_DOT_dispatcher.company_name
-                AS default_DOT_dispatcher_DOT_company_name,
+                default_DOT_dispatcher_DOT_company_name,
               default_DOT_hard_hat.last_name
-                AS default_DOT_hard_hat_DOT_last_name
+                default_DOT_hard_hat_DOT_last_name
             FROM default_DOT_repair_orders_fact
             INNER JOIN default_DOT_hard_hat
               ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
@@ -485,24 +485,23 @@ async def test_measures_sql_include_all_columns(
         default_DOT_dispatchers.phone
      FROM roads.dispatchers AS default_DOT_dispatchers
     )
-    SELECT
-        default_DOT_repair_orders_fact.repair_order_id AS default_DOT_repair_orders_fact_DOT_repair_order_id,
-        default_DOT_repair_orders_fact.municipality_id AS default_DOT_repair_orders_fact_DOT_municipality_id,
-        default_DOT_repair_orders_fact.hard_hat_id AS default_DOT_repair_orders_fact_DOT_hard_hat_id,
-        default_DOT_repair_orders_fact.dispatcher_id AS default_DOT_repair_orders_fact_DOT_dispatcher_id,
-        default_DOT_repair_orders_fact.order_date AS default_DOT_repair_orders_fact_DOT_order_date,
-        default_DOT_repair_orders_fact.dispatched_date AS default_DOT_repair_orders_fact_DOT_dispatched_date,
-        default_DOT_repair_orders_fact.required_date AS default_DOT_repair_orders_fact_DOT_required_date,
-        default_DOT_repair_orders_fact.discount AS default_DOT_repair_orders_fact_DOT_discount,
-        default_DOT_repair_orders_fact.price AS default_DOT_repair_orders_fact_DOT_price,
-        default_DOT_repair_orders_fact.quantity AS default_DOT_repair_orders_fact_DOT_quantity,
-        default_DOT_repair_orders_fact.repair_type_id AS default_DOT_repair_orders_fact_DOT_repair_type_id,
-        default_DOT_repair_orders_fact.total_repair_cost AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
-        default_DOT_repair_orders_fact.time_to_dispatch AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
-        default_DOT_repair_orders_fact.dispatch_delay AS default_DOT_repair_orders_fact_DOT_dispatch_delay,
-        default_DOT_us_state.state_name AS default_DOT_us_state_DOT_state_name,
-        default_DOT_dispatcher.company_name AS default_DOT_dispatcher_DOT_company_name,
-        default_DOT_hard_hat.last_name AS default_DOT_hard_hat_DOT_last_name
+    SELECT  default_DOT_repair_orders_fact.repair_order_id default_DOT_repair_orders_fact_DOT_repair_order_id,
+        default_DOT_repair_orders_fact.municipality_id default_DOT_repair_orders_fact_DOT_municipality_id,
+        default_DOT_repair_orders_fact.hard_hat_id default_DOT_repair_orders_fact_DOT_hard_hat_id,
+        default_DOT_repair_orders_fact.dispatcher_id default_DOT_repair_orders_fact_DOT_dispatcher_id,
+        default_DOT_repair_orders_fact.order_date default_DOT_repair_orders_fact_DOT_order_date,
+        default_DOT_repair_orders_fact.dispatched_date default_DOT_repair_orders_fact_DOT_dispatched_date,
+        default_DOT_repair_orders_fact.required_date default_DOT_repair_orders_fact_DOT_required_date,
+        default_DOT_repair_orders_fact.discount default_DOT_repair_orders_fact_DOT_discount,
+        default_DOT_repair_orders_fact.price default_DOT_repair_orders_fact_DOT_price,
+        default_DOT_repair_orders_fact.quantity default_DOT_repair_orders_fact_DOT_quantity,
+        default_DOT_repair_orders_fact.repair_type_id default_DOT_repair_orders_fact_DOT_repair_type_id,
+        default_DOT_repair_orders_fact.total_repair_cost default_DOT_repair_orders_fact_DOT_total_repair_cost,
+        default_DOT_repair_orders_fact.time_to_dispatch default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+        default_DOT_repair_orders_fact.dispatch_delay default_DOT_repair_orders_fact_DOT_dispatch_delay,
+        default_DOT_us_state.state_name default_DOT_us_state_DOT_state_name,
+        default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name,
+        default_DOT_hard_hat.last_name default_DOT_hard_hat_DOT_last_name
      FROM default_DOT_repair_orders_fact INNER JOIN default_DOT_hard_hat ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
     INNER JOIN default_DOT_us_state ON default_DOT_hard_hat.state = default_DOT_us_state.state_short
     LEFT JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -400,11 +400,13 @@ async def test_measures_sql_with_filters__v2(  # pylint: disable=too-many-argume
         params=sql_params,
     )
     data = response.json()
-    translated_sql = data["default.repair_orders_fact"]
-    assert str(parse(str(sql))) == str(parse(str(translated_sql["sql"])))
-    result = duckdb_conn.sql(translated_sql["sql"])
+    generated_sql = data[0]
+    assert generated_sql["node"]["name"] == "default.repair_orders_fact"
+    assert generated_sql["node"]["version"] == "v1.0"
+    assert str(parse(str(sql))) == str(parse(str(generated_sql["sql"])))
+    result = duckdb_conn.sql(generated_sql["sql"])
     assert set(result.fetchall()) == set(rows)
-    assert translated_sql["columns"] == columns
+    assert generated_sql["columns"] == columns
 
 
 @pytest.mark.asyncio
@@ -434,7 +436,9 @@ async def test_measures_sql_include_all_columns(
         },
     )
     data = response.json()
-    translated_sql = data["default.repair_orders_fact"]
+    generated_sql = data[0]
+    assert generated_sql["node"]["name"] == "default.repair_orders_fact"
+    assert generated_sql["node"]["version"] == "v1.0"
 
     expected_sql = """
     WITH default_DOT_repair_orders_fact AS (
@@ -506,6 +510,6 @@ async def test_measures_sql_include_all_columns(
     INNER JOIN default_DOT_us_state ON default_DOT_hard_hat.state = default_DOT_us_state.state_short
     LEFT JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id
     """
-    assert str(parse(str(expected_sql))) == str(parse(str(translated_sql["sql"])))
-    result = duckdb_conn.sql(translated_sql["sql"])
+    assert str(parse(str(expected_sql))) == str(parse(str(generated_sql["sql"])))
+    result = duckdb_conn.sql(generated_sql["sql"])
     assert len(result.fetchall()) == 4

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -53,35 +53,33 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             """
             WITH default_DOT_repair_orders_fact AS (
               SELECT
-                default_DOT_repair_orders.repair_order_id,
-                default_DOT_repair_orders.municipality_id,
-                default_DOT_repair_orders.hard_hat_id,
-                default_DOT_repair_orders.dispatcher_id,
-                default_DOT_repair_orders.order_date,
-                default_DOT_repair_orders.dispatched_date,
-                default_DOT_repair_orders.required_date,
-                default_DOT_repair_order_details.discount,
-                default_DOT_repair_order_details.price,
-                default_DOT_repair_order_details.quantity,
-                default_DOT_repair_order_details.repair_type_id,
-                default_DOT_repair_order_details.price *
-                  default_DOT_repair_order_details.quantity AS total_repair_cost,
-                default_DOT_repair_orders.dispatched_date -
-                  default_DOT_repair_orders.order_date AS time_to_dispatch,
-                default_DOT_repair_orders.dispatched_date -
-                  default_DOT_repair_orders.required_date AS dispatch_delay
-              FROM roads.repair_orders AS default_DOT_repair_orders
-              JOIN roads.repair_order_details AS default_DOT_repair_order_details
-                ON default_DOT_repair_orders.repair_order_id =
-                  default_DOT_repair_order_details.repair_order_id
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price *
+                  repair_order_details.quantity AS total_repair_cost,
+                repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+                repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+              FROM roads.repair_orders AS repair_orders
+              JOIN roads.repair_order_details AS repair_order_details
+                ON repair_orders.repair_order_id =
+                  repair_order_details.repair_order_id
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                default_DOT_dispatcher_DOT_dispatcher_id,
+                AS default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                default_DOT_repair_orders_fact_DOT_discount,
+                AS default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                default_DOT_repair_orders_fact_DOT_price
+                AS default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -149,35 +147,31 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             """
             WITH default_DOT_repair_orders_fact AS (
               SELECT
-                default_DOT_repair_orders.repair_order_id,
-                default_DOT_repair_orders.municipality_id,
-                default_DOT_repair_orders.hard_hat_id,
-                default_DOT_repair_orders.dispatcher_id,
-                default_DOT_repair_orders.order_date,
-                default_DOT_repair_orders.dispatched_date,
-                default_DOT_repair_orders.required_date,
-                default_DOT_repair_order_details.discount,
-                default_DOT_repair_order_details.price,
-                default_DOT_repair_order_details.quantity,
-                default_DOT_repair_order_details.repair_type_id,
-                default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity
-                  AS total_repair_cost,
-                default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.order_date
-                  AS time_to_dispatch,
-                default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.required_date
-                  AS dispatch_delay
-              FROM roads.repair_orders AS default_DOT_repair_orders
-              JOIN roads.repair_order_details AS default_DOT_repair_order_details
-                ON default_DOT_repair_orders.repair_order_id =
-                  default_DOT_repair_order_details.repair_order_id
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+                repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+                repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+              FROM roads.repair_orders AS repair_orders
+              JOIN roads.repair_order_details AS repair_order_details
+                ON repair_orders.repair_order_id = repair_order_details.repair_order_id
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                default_DOT_dispatcher_DOT_dispatcher_id,
+                AS default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                default_DOT_repair_orders_fact_DOT_discount,
+                AS default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                default_DOT_repair_orders_fact_DOT_price
+                AS default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -249,27 +243,26 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             """
             WITH default_DOT_repair_orders_fact AS (
               SELECT
-                default_DOT_repair_orders.repair_order_id,
-                default_DOT_repair_orders.municipality_id,
-                default_DOT_repair_orders.hard_hat_id,
-                default_DOT_repair_orders.dispatcher_id,
-                default_DOT_repair_orders.order_date,
-                default_DOT_repair_orders.dispatched_date,
-                default_DOT_repair_orders.required_date,
-                default_DOT_repair_order_details.discount,
-                default_DOT_repair_order_details.price,
-                default_DOT_repair_order_details.quantity,
-                default_DOT_repair_order_details.repair_type_id,
-                default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price * repair_order_details.quantity
                   AS total_repair_cost,
-                default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.order_date
+                repair_orders.dispatched_date - repair_orders.order_date
                   AS time_to_dispatch,
-                default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.required_date
+                repair_orders.dispatched_date - repair_orders.required_date
                   AS dispatch_delay
-              FROM roads.repair_orders AS default_DOT_repair_orders
-              JOIN roads.repair_order_details AS default_DOT_repair_order_details
-              ON default_DOT_repair_orders.repair_order_id =
-                default_DOT_repair_order_details.repair_order_id
+              FROM roads.repair_orders AS repair_orders
+              JOIN roads.repair_order_details AS repair_order_details
+              ON repair_orders.repair_order_id = repair_order_details.repair_order_id
             ),
             default_DOT_hard_hat AS (
               SELECT
@@ -291,12 +284,12 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             ),
             default_DOT_us_state AS (
               SELECT
-                default_DOT_us_states.state_id,
-                default_DOT_us_states.state_name,
-                default_DOT_us_states.state_abbr AS state_short,
-                default_DOT_us_states.state_region
-              FROM roads.us_states AS default_DOT_us_states
-              WHERE  default_DOT_us_states.state_name = 'New Jersey'
+                s.state_id,
+                s.state_name,
+                s.state_abbr AS state_short,
+                s.state_region
+              FROM roads.us_states AS s
+              WHERE  s.state_name = 'New Jersey'
             ),
             default_DOT_dispatcher AS (
               SELECT
@@ -307,15 +300,15 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.total_repair_cost
-                default_DOT_repair_orders_fact_DOT_total_repair_cost,
+                AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
               default_DOT_repair_orders_fact.time_to_dispatch
-                default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+                AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
               default_DOT_us_state.state_name
-                default_DOT_us_state_DOT_state_name,
+                AS default_DOT_us_state_DOT_state_name,
               default_DOT_dispatcher.company_name
-                default_DOT_dispatcher_DOT_company_name,
+                AS default_DOT_dispatcher_DOT_company_name,
               default_DOT_hard_hat.last_name
-                default_DOT_hard_hat_DOT_last_name
+                AS default_DOT_hard_hat_DOT_last_name
             FROM default_DOT_repair_orders_fact
             INNER JOIN default_DOT_hard_hat
               ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
@@ -438,21 +431,21 @@ async def test_measures_sql_include_all_columns(
 
     expected_sql = """
     WITH default_DOT_repair_orders_fact AS (
-    SELECT  default_DOT_repair_orders.repair_order_id,
-        default_DOT_repair_orders.municipality_id,
-        default_DOT_repair_orders.hard_hat_id,
-        default_DOT_repair_orders.dispatcher_id,
-        default_DOT_repair_orders.order_date,
-        default_DOT_repair_orders.dispatched_date,
-        default_DOT_repair_orders.required_date,
-        default_DOT_repair_order_details.discount,
-        default_DOT_repair_order_details.price,
-        default_DOT_repair_order_details.quantity,
-        default_DOT_repair_order_details.repair_type_id,
-        default_DOT_repair_order_details.price * default_DOT_repair_order_details.quantity AS total_repair_cost,
-        default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.order_date AS time_to_dispatch,
-        default_DOT_repair_orders.dispatched_date - default_DOT_repair_orders.required_date AS dispatch_delay
-     FROM roads.repair_orders AS default_DOT_repair_orders JOIN roads.repair_order_details AS default_DOT_repair_order_details ON default_DOT_repair_orders.repair_order_id = default_DOT_repair_order_details.repair_order_id
+    SELECT  repair_orders.repair_order_id,
+        repair_orders.municipality_id,
+        repair_orders.hard_hat_id,
+        repair_orders.dispatcher_id,
+        repair_orders.order_date,
+        repair_orders.dispatched_date,
+        repair_orders.required_date,
+        repair_order_details.discount,
+        repair_order_details.price,
+        repair_order_details.quantity,
+        repair_order_details.repair_type_id,
+        repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+        repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+        repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+     FROM roads.repair_orders AS repair_orders JOIN roads.repair_order_details AS repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
     ),
     default_DOT_hard_hat AS (
     SELECT  default_DOT_hard_hats.hard_hat_id,
@@ -472,12 +465,12 @@ async def test_measures_sql_include_all_columns(
      WHERE  default_DOT_hard_hats.last_name IN ('Brian')
     ),
     default_DOT_us_state AS (
-    SELECT  default_DOT_us_states.state_id,
-        default_DOT_us_states.state_name,
-        default_DOT_us_states.state_abbr AS state_short,
-        default_DOT_us_states.state_region
-     FROM roads.us_states AS default_DOT_us_states
-     WHERE  default_DOT_us_states.state_name = 'New Jersey'
+    SELECT  s.state_id,
+        s.state_name,
+        s.state_abbr AS state_short,
+        s.state_region
+     FROM roads.us_states AS s
+     WHERE  s.state_name = 'New Jersey'
     ),
     default_DOT_dispatcher AS (
     SELECT  default_DOT_dispatchers.dispatcher_id,
@@ -485,23 +478,23 @@ async def test_measures_sql_include_all_columns(
         default_DOT_dispatchers.phone
      FROM roads.dispatchers AS default_DOT_dispatchers
     )
-    SELECT  default_DOT_repair_orders_fact.repair_order_id default_DOT_repair_orders_fact_DOT_repair_order_id,
-        default_DOT_repair_orders_fact.municipality_id default_DOT_repair_orders_fact_DOT_municipality_id,
-        default_DOT_repair_orders_fact.hard_hat_id default_DOT_repair_orders_fact_DOT_hard_hat_id,
-        default_DOT_repair_orders_fact.dispatcher_id default_DOT_repair_orders_fact_DOT_dispatcher_id,
-        default_DOT_repair_orders_fact.order_date default_DOT_repair_orders_fact_DOT_order_date,
-        default_DOT_repair_orders_fact.dispatched_date default_DOT_repair_orders_fact_DOT_dispatched_date,
-        default_DOT_repair_orders_fact.required_date default_DOT_repair_orders_fact_DOT_required_date,
-        default_DOT_repair_orders_fact.discount default_DOT_repair_orders_fact_DOT_discount,
-        default_DOT_repair_orders_fact.price default_DOT_repair_orders_fact_DOT_price,
-        default_DOT_repair_orders_fact.quantity default_DOT_repair_orders_fact_DOT_quantity,
-        default_DOT_repair_orders_fact.repair_type_id default_DOT_repair_orders_fact_DOT_repair_type_id,
-        default_DOT_repair_orders_fact.total_repair_cost default_DOT_repair_orders_fact_DOT_total_repair_cost,
-        default_DOT_repair_orders_fact.time_to_dispatch default_DOT_repair_orders_fact_DOT_time_to_dispatch,
-        default_DOT_repair_orders_fact.dispatch_delay default_DOT_repair_orders_fact_DOT_dispatch_delay,
-        default_DOT_us_state.state_name default_DOT_us_state_DOT_state_name,
-        default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name,
-        default_DOT_hard_hat.last_name default_DOT_hard_hat_DOT_last_name
+    SELECT  default_DOT_repair_orders_fact.repair_order_id AS default_DOT_repair_orders_fact_DOT_repair_order_id,
+        default_DOT_repair_orders_fact.municipality_id AS default_DOT_repair_orders_fact_DOT_municipality_id,
+        default_DOT_repair_orders_fact.hard_hat_id AS default_DOT_repair_orders_fact_DOT_hard_hat_id,
+        default_DOT_repair_orders_fact.dispatcher_id AS default_DOT_repair_orders_fact_DOT_dispatcher_id,
+        default_DOT_repair_orders_fact.order_date AS default_DOT_repair_orders_fact_DOT_order_date,
+        default_DOT_repair_orders_fact.dispatched_date AS default_DOT_repair_orders_fact_DOT_dispatched_date,
+        default_DOT_repair_orders_fact.required_date AS default_DOT_repair_orders_fact_DOT_required_date,
+        default_DOT_repair_orders_fact.discount AS default_DOT_repair_orders_fact_DOT_discount,
+        default_DOT_repair_orders_fact.price AS default_DOT_repair_orders_fact_DOT_price,
+        default_DOT_repair_orders_fact.quantity AS default_DOT_repair_orders_fact_DOT_quantity,
+        default_DOT_repair_orders_fact.repair_type_id AS default_DOT_repair_orders_fact_DOT_repair_type_id,
+        default_DOT_repair_orders_fact.total_repair_cost AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
+        default_DOT_repair_orders_fact.time_to_dispatch AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+        default_DOT_repair_orders_fact.dispatch_delay AS default_DOT_repair_orders_fact_DOT_dispatch_delay,
+        default_DOT_us_state.state_name AS default_DOT_us_state_DOT_state_name,
+        default_DOT_dispatcher.company_name AS default_DOT_dispatcher_DOT_company_name,
+        default_DOT_hard_hat.last_name AS default_DOT_hard_hat_DOT_last_name
      FROM default_DOT_repair_orders_fact INNER JOIN default_DOT_hard_hat ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
     INNER JOIN default_DOT_us_state ON default_DOT_hard_hat.state = default_DOT_us_state.state_short
     LEFT JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -77,11 +77,11 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                default_DOT_dispatcher_DOT_dispatcher_id,
+                AS default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                default_DOT_repair_orders_fact_DOT_discount,
+                AS default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                default_DOT_repair_orders_fact_DOT_price
+                AS default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -173,11 +173,11 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.dispatcher_id
-                default_DOT_dispatcher_DOT_dispatcher_id,
+                AS default_DOT_dispatcher_DOT_dispatcher_id,
               default_DOT_repair_orders_fact.discount
-                default_DOT_repair_orders_fact_DOT_discount,
+                AS default_DOT_repair_orders_fact_DOT_discount,
               default_DOT_repair_orders_fact.price
-                default_DOT_repair_orders_fact_DOT_price
+                AS default_DOT_repair_orders_fact_DOT_price
             FROM default_DOT_repair_orders_fact
             """,
             [
@@ -307,15 +307,15 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
             )
             SELECT
               default_DOT_repair_orders_fact.total_repair_cost
-                default_DOT_repair_orders_fact_DOT_total_repair_cost,
+                AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
               default_DOT_repair_orders_fact.time_to_dispatch
-                default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+                AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
               default_DOT_us_state.state_name
-                default_DOT_us_state_DOT_state_name,
+                AS default_DOT_us_state_DOT_state_name,
               default_DOT_dispatcher.company_name
-                default_DOT_dispatcher_DOT_company_name,
+                AS default_DOT_dispatcher_DOT_company_name,
               default_DOT_hard_hat.last_name
-                default_DOT_hard_hat_DOT_last_name
+                AS default_DOT_hard_hat_DOT_last_name
             FROM default_DOT_repair_orders_fact
             INNER JOIN default_DOT_hard_hat
               ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
@@ -400,13 +400,11 @@ async def test_measures_sql_with_filters__v2(  # pylint: disable=too-many-argume
         params=sql_params,
     )
     data = response.json()
-    generated_sql = data[0]
-    assert generated_sql["node"]["name"] == "default.repair_orders_fact"
-    assert generated_sql["node"]["version"] == "v1.0"
-    assert str(parse(str(sql))) == str(parse(str(generated_sql["sql"])))
-    result = duckdb_conn.sql(generated_sql["sql"])
+    translated_sql = data[0]
+    assert str(parse(str(sql))) == str(parse(str(translated_sql["sql"])))
+    result = duckdb_conn.sql(translated_sql["sql"])
     assert set(result.fetchall()) == set(rows)
-    assert generated_sql["columns"] == columns
+    assert translated_sql["columns"] == columns
 
 
 @pytest.mark.asyncio
@@ -436,9 +434,7 @@ async def test_measures_sql_include_all_columns(
         },
     )
     data = response.json()
-    generated_sql = data[0]
-    assert generated_sql["node"]["name"] == "default.repair_orders_fact"
-    assert generated_sql["node"]["version"] == "v1.0"
+    translated_sql = data[0]
 
     expected_sql = """
     WITH default_DOT_repair_orders_fact AS (
@@ -489,27 +485,28 @@ async def test_measures_sql_include_all_columns(
         default_DOT_dispatchers.phone
      FROM roads.dispatchers AS default_DOT_dispatchers
     )
-    SELECT  default_DOT_repair_orders_fact.repair_order_id default_DOT_repair_orders_fact_DOT_repair_order_id,
-        default_DOT_repair_orders_fact.municipality_id default_DOT_repair_orders_fact_DOT_municipality_id,
-        default_DOT_repair_orders_fact.hard_hat_id default_DOT_repair_orders_fact_DOT_hard_hat_id,
-        default_DOT_repair_orders_fact.dispatcher_id default_DOT_repair_orders_fact_DOT_dispatcher_id,
-        default_DOT_repair_orders_fact.order_date default_DOT_repair_orders_fact_DOT_order_date,
-        default_DOT_repair_orders_fact.dispatched_date default_DOT_repair_orders_fact_DOT_dispatched_date,
-        default_DOT_repair_orders_fact.required_date default_DOT_repair_orders_fact_DOT_required_date,
-        default_DOT_repair_orders_fact.discount default_DOT_repair_orders_fact_DOT_discount,
-        default_DOT_repair_orders_fact.price default_DOT_repair_orders_fact_DOT_price,
-        default_DOT_repair_orders_fact.quantity default_DOT_repair_orders_fact_DOT_quantity,
-        default_DOT_repair_orders_fact.repair_type_id default_DOT_repair_orders_fact_DOT_repair_type_id,
-        default_DOT_repair_orders_fact.total_repair_cost default_DOT_repair_orders_fact_DOT_total_repair_cost,
-        default_DOT_repair_orders_fact.time_to_dispatch default_DOT_repair_orders_fact_DOT_time_to_dispatch,
-        default_DOT_repair_orders_fact.dispatch_delay default_DOT_repair_orders_fact_DOT_dispatch_delay,
-        default_DOT_us_state.state_name default_DOT_us_state_DOT_state_name,
-        default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name,
-        default_DOT_hard_hat.last_name default_DOT_hard_hat_DOT_last_name
+    SELECT
+        default_DOT_repair_orders_fact.repair_order_id AS default_DOT_repair_orders_fact_DOT_repair_order_id,
+        default_DOT_repair_orders_fact.municipality_id AS default_DOT_repair_orders_fact_DOT_municipality_id,
+        default_DOT_repair_orders_fact.hard_hat_id AS default_DOT_repair_orders_fact_DOT_hard_hat_id,
+        default_DOT_repair_orders_fact.dispatcher_id AS default_DOT_repair_orders_fact_DOT_dispatcher_id,
+        default_DOT_repair_orders_fact.order_date AS default_DOT_repair_orders_fact_DOT_order_date,
+        default_DOT_repair_orders_fact.dispatched_date AS default_DOT_repair_orders_fact_DOT_dispatched_date,
+        default_DOT_repair_orders_fact.required_date AS default_DOT_repair_orders_fact_DOT_required_date,
+        default_DOT_repair_orders_fact.discount AS default_DOT_repair_orders_fact_DOT_discount,
+        default_DOT_repair_orders_fact.price AS default_DOT_repair_orders_fact_DOT_price,
+        default_DOT_repair_orders_fact.quantity AS default_DOT_repair_orders_fact_DOT_quantity,
+        default_DOT_repair_orders_fact.repair_type_id AS default_DOT_repair_orders_fact_DOT_repair_type_id,
+        default_DOT_repair_orders_fact.total_repair_cost AS default_DOT_repair_orders_fact_DOT_total_repair_cost,
+        default_DOT_repair_orders_fact.time_to_dispatch AS default_DOT_repair_orders_fact_DOT_time_to_dispatch,
+        default_DOT_repair_orders_fact.dispatch_delay AS default_DOT_repair_orders_fact_DOT_dispatch_delay,
+        default_DOT_us_state.state_name AS default_DOT_us_state_DOT_state_name,
+        default_DOT_dispatcher.company_name AS default_DOT_dispatcher_DOT_company_name,
+        default_DOT_hard_hat.last_name AS default_DOT_hard_hat_DOT_last_name
      FROM default_DOT_repair_orders_fact INNER JOIN default_DOT_hard_hat ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
     INNER JOIN default_DOT_us_state ON default_DOT_hard_hat.state = default_DOT_us_state.state_short
     LEFT JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id
     """
-    assert str(parse(str(expected_sql))) == str(parse(str(generated_sql["sql"])))
-    result = duckdb_conn.sql(generated_sql["sql"])
+    assert str(parse(str(expected_sql))) == str(parse(str(translated_sql["sql"])))
+    result = duckdb_conn.sql(translated_sql["sql"])
     assert len(result.fetchall()) == 4

--- a/datajunction-server/tests/construction/build_v2_test.py
+++ b/datajunction-server/tests/construction/build_v2_test.py
@@ -1241,15 +1241,15 @@ async def test_build_transform_with_multijoin_dimensions_filters(
         ),
         shared_DOT_manufacturers AS (
           SELECT
-            CAST(source_DOT_manufacturers.manufacturer_name AS STRING) name,
-            CAST(source_DOT_manufacturers.company_name AS STRING) company_name,
-            source_DOT_manufacturers.created_on AS created_at,
-            COUNT( DISTINCT shared_DOT_devices.device_id) AS devices_produced
-          FROM test.manufacturers AS source_DOT_manufacturers
-          JOIN shared_DOT_devices
-            ON source_DOT_manufacturers.manufacturer_name =
-               shared_DOT_devices.device_manufacturer
-          WHERE  CAST(source_DOT_manufacturers.company_name AS STRING) = 'Apple'
+            CAST(manufacturers.manufacturer_name AS STRING) name,
+            CAST(manufacturers.company_name AS STRING) company_name,
+            manufacturers.created_on AS created_at,
+            COUNT( DISTINCT devices.device_id) AS devices_produced
+          FROM test.manufacturers AS manufacturers
+          JOIN shared_DOT_devices devices
+            ON manufacturers.manufacturer_name =
+               devices.device_manufacturer
+          WHERE  CAST(manufacturers.company_name AS STRING) = 'Apple'
         )
         SELECT
           agg_DOT_events.user_id,
@@ -1410,29 +1410,29 @@ async def test_build_transform_with_multijoin_dimensions_with_extra_ctes(
         FROM test.regions AS source_DOT_regions
     ),
     shared_DOT_countries AS (
-    SELECT  source_DOT_countries.country_code,
-        source_DOT_countries.country_name,
+    SELECT  countries.country_code,
+        countries.country_name,
         shared_DOT_regions.region_code,
         shared_DOT_regions.region_name,
-        source_DOT_countries.population
-        FROM test.countries AS source_DOT_countries
+        countries.population
+        FROM test.countries AS countries
         JOIN shared_DOT_regions
-          ON source_DOT_countries.region_code = shared_DOT_regions.region_code
+          ON countries.region_code = shared_DOT_regions.region_code
         WHERE
           shared_DOT_regions.region_name = 'APAC'
     ),
     shared_DOT_manufacturers AS (
       SELECT
-        CAST(source_DOT_manufacturers.manufacturer_name AS STRING) name,
-        CAST(source_DOT_manufacturers.company_name AS STRING) company_name,
-        source_DOT_manufacturers.created_on AS created_at,
-        COUNT( DISTINCT shared_DOT_devices.device_id) AS devices_produced
-      FROM test.manufacturers AS source_DOT_manufacturers
-      JOIN shared_DOT_devices ON source_DOT_manufacturers.manufacturer_name =
-        shared_DOT_devices.device_manufacturer
+        CAST(manufacturers.manufacturer_name AS STRING) name,
+        CAST(manufacturers.company_name AS STRING) company_name,
+        manufacturers.created_on AS created_at,
+        COUNT( DISTINCT devices.device_id) AS devices_produced
+      FROM test.manufacturers AS manufacturers
+      JOIN shared_DOT_devices devices ON manufacturers.manufacturer_name =
+        devices.device_manufacturer
       WHERE
-        CAST(source_DOT_manufacturers.company_name AS STRING) = 'Apple'
-        AND source_DOT_manufacturers.created_on > 20240101
+        CAST(manufacturers.company_name AS STRING) = 'Apple'
+        AND manufacturers.created_on > 20240101
     )
 
     SELECT  agg_DOT_events.user_id,

--- a/datajunction-server/tests/construction/build_v2_test.py
+++ b/datajunction-server/tests/construction/build_v2_test.py
@@ -1023,11 +1023,11 @@ async def test_build_transform_w_cte_and_pushdown_dimensions_filters(
     expected = """
     WITH agg_DOT_events_complex AS (
       SELECT
-        CAST(user_id AS BIGINT) user_id,
-        CAST(utc_date AS BIGINT) utc_date,
-        CAST(device_id AS BIGINT) device_id,
-        CAST(country_code AS STRING) country_code,
-        CAST(total_latency AS BIGINT) total_latency
+        CAST(complexity.user_id AS BIGINT) user_id,
+        CAST(complexity.utc_date AS BIGINT) utc_date,
+        CAST(complexity.device_id AS BIGINT) device_id,
+        CAST(complexity.country_code AS STRING) country_code,
+        CAST(complexity.total_latency AS BIGINT) total_latency
       FROM (
         SELECT
           source_DOT_events.user_id,
@@ -1052,7 +1052,7 @@ async def test_build_transform_w_cte_and_pushdown_dimensions_filters(
           source_DOT_events.device_id,
           source_DOT_events.country_code
       ) AS complexity
-      WHERE CAST(device_id AS BIGINT) = 111 AND CAST(device_id AS BIGINT) = 222
+      WHERE CAST(complexity.device_id AS BIGINT) = 111 AND CAST(complexity.device_id AS BIGINT) = 222
     )
     SELECT
       agg_DOT_events_complex.user_id,

--- a/datajunction-server/tests/construction/build_v2_test.py
+++ b/datajunction-server/tests/construction/build_v2_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name,too-many-lines
 """Tests for building nodes"""
+from typing import List, Tuple
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -339,6 +340,64 @@ async def manufacturers_dim(
     await session.refresh(manufacturers_source_node, ["current"])
     await session.refresh(manufacturers_dim_node, ["current"])
     return manufacturers_dim_node
+
+
+async def create_source(
+    session: AsyncSession, 
+    name: str,
+    display_name: str,
+    schema_: str,
+    table: str,
+    columns: List[Column],
+) -> Tuple[Node, NodeRevision]:
+    source_node = Node(
+        name=name,
+        display_name=display_name,
+        type=NodeType.SOURCE,
+        current_version="1",
+    )
+    source_node_revision = NodeRevision(
+        node=source_node,
+        name=name,
+        display_name=display_name,
+        type=NodeType.SOURCE,
+        version="1",
+        schema_=schema_,
+        table=table,
+        columns=columns,
+    )
+    session.add(source_node_revision)
+    await session.commit()
+    await session.refresh(source_node, ["current"])
+    return source_node, source_node_revision
+
+
+async def create_transform(
+    session: AsyncSession, 
+    name: str,
+    display_name: str,
+    query: str,
+    columns: List[Column],
+) -> Tuple[Node, NodeRevision]:
+    node = Node(
+        name=name,
+        display_name=display_name,
+        type=NodeType.SOURCE,
+        current_version="1",
+    )
+    node_revision = NodeRevision(
+        node=node,
+        name=name,
+        display_name=display_name,
+        type=NodeType.TRANSFORM,
+        version="1",
+        query=query,
+        columns=columns,
+    )
+    session.add(node_revision)
+    await session.commit()
+    await session.refresh(node, ["current"])
+    return node, node_revision
 
 
 @pytest_asyncio.fixture

--- a/datajunction-server/tests/transpilation_test.py
+++ b/datajunction-server/tests/transpilation_test.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 from datajunction_server.errors import DJPluginNotFoundException
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.metric import TranslatedSQL
+from datajunction_server.models.sql import GeneratedSQL, NodeNameVersion
 from datajunction_server.transpilation import get_transpilation_plugin
 
 
@@ -55,6 +56,13 @@ def test_translated_sql(mocker: MockerFixture) -> None:
         dialect=Dialect.SPARK,
     )
     assert translated_sql.sql == "1"
+    generated_sql = GeneratedSQL(
+        node=NodeNameVersion(name="a", version="v1.0"),
+        sql="1",
+        columns=[],
+        dialect=Dialect.SPARK,
+    )
+    assert generated_sql.sql == "1"
 
 
 def test_druid_sql(mocker: MockerFixture) -> None:
@@ -70,3 +78,10 @@ def test_druid_sql(mocker: MockerFixture) -> None:
         dialect=Dialect.DRUID,
     )
     assert translated_sql.sql == "SELECT 1"
+    generated_sql = GeneratedSQL(
+        node=NodeNameVersion(name="a", version="v1.0"),
+        sql="SELECT 1",
+        columns=[],
+        dialect=Dialect.DRUID,
+    )
+    assert generated_sql.sql == "SELECT 1"


### PR DESCRIPTION
### Summary

This change refactors node query building v2 to use the builder pattern. We create a `QueryBuilder` class, which is designed to:
* Allow for chaining of method calls to layer in requests for filters, dimensions, order by clauses etc in an incremental manner.
* Incorporate a validation process to check the feasibility of the query based on requested dimensions and filters, as well as access controls. All errors encountered during query construction are collected and raised in the final stage of the build process.

I've also changed the output of the measures SQL endpoint to include both the node name and its version, so that there is no ambiguity about what the generated SQL was for. This output model is captured by the new `GeneratedSQL` class.

```
The changes are actually quite minimal, but the github diffs don't seem able to reflect them properly.
Indenting makes it go haywire...
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
