### PR TITLE
Do not pass on encoding-related headers to the query service

### DIFF
--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -84,6 +84,17 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             retry_strategy=retry_strategy,
         )
 
+    @staticmethod
+    def filtered_headers(request_headers: Dict[str, str]):
+        """
+        The request headers with the headers to ignore filtered out.
+        """
+        return {
+            key: value
+            for key, value in request_headers.items()
+            if key.lower() not in QueryServiceClient.HEADERS_TO_IGNORE
+        }
+
     def get_columns_for_table(
         self,
         catalog: str,
@@ -105,11 +116,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             else {},
             headers={
                 **self.requests_session.headers,
-                **{
-                    key: value
-                    for key, value in request_headers.items()
-                    if key.lower() not in self.HEADERS_TO_IGNORE
-                },
+                **QueryServiceClient.filtered_headers(request_headers),
             }
             if request_headers
             else self.requests_session.headers,
@@ -197,7 +204,10 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         response = self.requests_session.post(
             "/materialization/",
             json=materialization_input.dict(),
-            headers={**self.requests_session.headers, **request_headers}
+            headers={
+                **self.requests_session.headers,
+                **QueryServiceClient.filtered_headers(request_headers),
+            }
             if request_headers
             else self.requests_session.headers,
         )
@@ -217,7 +227,10 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         """
         response = self.requests_session.delete(
             f"/materialization/{node_name}/{materialization_name}/",
-            headers={**self.requests_session.headers, **request_headers}
+            headers={
+                **self.requests_session.headers,
+                **QueryServiceClient.filtered_headers(request_headers),
+            }
             if request_headers
             else self.requests_session.headers,
         )
@@ -239,7 +252,10 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         response = self.requests_session.get(
             f"/materialization/{node_name}/{node_version}/{materialization_name}/",
             timeout=3,
-            headers={**self.requests_session.headers, **request_headers}
+            headers={
+                **self.requests_session.headers,
+                **QueryServiceClient.filtered_headers(request_headers),
+            }
             if request_headers
             else self.requests_session.headers,
         )
@@ -258,7 +274,10 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         response = self.requests_session.post(
             f"/materialization/run/{node_name}/{materialization_name}/",
             json=[partition.dict() for partition in partitions],
-            headers={**self.requests_session.headers, **request_headers}
+            headers={
+                **self.requests_session.headers,
+                **QueryServiceClient.filtered_headers(request_headers),
+            }
             if request_headers
             else self.requests_session.headers,
             timeout=20,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -69,6 +69,8 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
     Client for the query service.
     """
 
+    HEADERS_TO_IGNORE = ("accept-encoding",)
+
     def __init__(self, uri: str, retries: int = 0):
         self.uri = uri
         retry_strategy = Retry(
@@ -101,7 +103,14 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             }
             if engine
             else {},
-            headers={**self.requests_session.headers, **request_headers}
+            headers={
+                **self.requests_session.headers,
+                **{
+                    key: value
+                    for key, value in request_headers.items()
+                    if key.lower() not in self.HEADERS_TO_IGNORE
+                },
+            }
             if request_headers
             else self.requests_session.headers,
         )

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -585,3 +585,28 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             timeout=20,
             headers=ANY,
         )
+
+    def test_filtered_headers(self):
+        """
+        We should filter out certain headers.
+        """
+        assert QueryServiceClient.filtered_headers(
+            {
+                "User-Agent": "python-requests/2.29.0",
+                "Accept-Encoding": "gzip, deflate",
+                "Accept": "*/*",
+            },
+        ) == {
+            "User-Agent": "python-requests/2.29.0",
+            "Accept": "*/*",
+        }
+        assert QueryServiceClient.filtered_headers(
+            {
+                "User-Agent": "python-requests/2.29.0",
+                "accept-encoding": "gzip, deflate",
+                "Accept": "*/*",
+            },
+        ) == {
+            "User-Agent": "python-requests/2.29.0",
+            "Accept": "*/*",
+        }


### PR DESCRIPTION
### Summary

We should not pass on encoding-related headers to the query service. 

If we pass a header like:
```
Accept-Encoding: gzip, deflate
```
The DJ core API will need to be able to process a gzipped response from the query service. Given that we're not ready to do this, this change just ignores those headers when doing a headers pass-through.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
