### PR TITLE
Fix graphql findNodes bug when retrieving revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
     - types-requests
     - types-freezegun
     - types-python-dateutil
-    - types-pkg_resources
+    - types-setuptools
     - types-tabulate
 - repo: https://github.com/asottile/add-trailing-comma
   rev: v2.2.1

--- a/datajunction-clients/python/.pre-commit-config.yaml
+++ b/datajunction-clients/python/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     - types-requests
     - types-freezegun
     - types-python-dateutil
-    - types-pkg_resources
+    - types-setuptools
     - types-PyYAML
     - types-tabulate
 - repo: https://github.com/asottile/add-trailing-comma

--- a/datajunction-query/.pre-commit-config.yaml
+++ b/datajunction-query/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
     - types-requests
     - types-freezegun
     - types-python-dateutil
-    - types-pkg_resources
+    - types-setuptools
     - types-PyYAML
     - types-tabulate
     - types-toml

--- a/datajunction-reflection/.pre-commit-config.yaml
+++ b/datajunction-reflection/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
     - types-requests
     - types-freezegun
     - types-python-dateutil
-    - types-pkg_resources
+    - types-setuptools
     - types-PyYAML
     - types-tabulate
 - repo: https://github.com/asottile/add-trailing-comma

--- a/datajunction-server/.pre-commit-config.yaml
+++ b/datajunction-server/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
     - types-requests
     - types-freezegun
     - types-python-dateutil
-    - types-pkg_resources
+    - types-setuptools
     - types-PyYAML
     - types-tabulate
 - repo: https://github.com/asottile/add-trailing-comma

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -546,3 +546,98 @@ async def test_find_cubes(
             "type": "CUBE",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_find_node_with_revisions(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test finding nodes with revisions
+    """
+
+    query = """
+    {
+        findNodes(nodeTypes: [TRANSFORM]) {
+            name
+            type
+            revisions {
+                displayName
+                dimensionLinks {
+                    dimension {
+                        name
+                    }
+                    joinSql
+                }
+            }
+            currentVersion
+        }
+    }
+    """
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["findNodes"] == [
+        {
+            "currentVersion": "v1.0",
+            "name": "default.regional_level_agg",
+            "revisions": [
+                {
+                    "dimensionLinks": [],
+                    "displayName": "Default: Regional Level Agg",
+                },
+            ],
+            "type": "TRANSFORM",
+        },
+        {
+            "currentVersion": "v1.0",
+            "name": "default.national_level_agg",
+            "revisions": [
+                {
+                    "dimensionLinks": [],
+                    "displayName": "Default: National Level Agg",
+                },
+            ],
+            "type": "TRANSFORM",
+        },
+        {
+            "currentVersion": "v1.0",
+            "name": "default.repair_orders_fact",
+            "revisions": [
+                {
+                    "dimensionLinks": [
+                        {
+                            "dimension": {
+                                "name": "default.municipality_dim",
+                            },
+                            "joinSql": "default.repair_orders_fact.municipality_id = "
+                            "default.municipality_dim.municipality_id",
+                        },
+                        {
+                            "dimension": {
+                                "name": "default.hard_hat",
+                            },
+                            "joinSql": "default.repair_orders_fact.hard_hat_id = "
+                            "default.hard_hat.hard_hat_id",
+                        },
+                        {
+                            "dimension": {
+                                "name": "default.hard_hat_to_delete",
+                            },
+                            "joinSql": "default.repair_orders_fact.hard_hat_id = "
+                            "default.hard_hat_to_delete.hard_hat_id",
+                        },
+                        {
+                            "dimension": {
+                                "name": "default.dispatcher",
+                            },
+                            "joinSql": "default.repair_orders_fact.dispatcher_id = "
+                            "default.dispatcher.dispatcher_id",
+                        },
+                    ],
+                    "displayName": "Repair Orders Fact",
+                },
+            ],
+            "type": "TRANSFORM",
+        },
+    ]


### PR DESCRIPTION
### Summary

When using the GraphQL `findNodes` query, we should be able to request node revisions (along with any attribute on these revisions) without error. At the moment we get this error:

```
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)
```

due to sqlalchemy object not loading the right database attribute.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #https://github.com/DataJunction/dj/issues/1132
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
