### PR TITLE
Add depth filter when retrieving downstream nodes

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1150,12 +1150,13 @@ async def list_downstream_nodes(
     name: str,
     *,
     node_type: NodeType = None,
+    depth: int = -1,
     session: AsyncSession = Depends(get_session),
 ) -> List[DAGNodeOutput]:
     """
     List all nodes that are downstream from the given node, filterable by type.
     """
-    return await get_downstream_nodes(session, name, node_type)
+    return await get_downstream_nodes(session, name, node_type, depth=depth)
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1154,7 +1154,8 @@ async def list_downstream_nodes(
     session: AsyncSession = Depends(get_session),
 ) -> List[DAGNodeOutput]:
     """
-    List all nodes that are downstream from the given node, filterable by type.
+    List all nodes that are downstream from the given node, filterable by type and max depth.
+    Setting a max depth of -1 will include all downstream nodes.
     """
     return await get_downstream_nodes(session, name, node_type, depth=depth)
 

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -120,7 +120,7 @@ async def get_downstream_nodes(
         final_select = final_select.where(is_(Node.deactivated_at, None))
 
     # Add depth filter
-    if depth != -1:
+    if depth > -1:
         final_select = final_select.where(max_depths.c.max_depth < depth)
 
     statement = (

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -111,9 +111,9 @@ async def get_downstream_nodes(
     )
 
     # Select nodes with the maximum depth
-    final_select = (
-        select(Node, max_depths.c.max_depth)
-        .join(max_depths, max_depths.c.node_id == Node.id)
+    final_select = select(Node, max_depths.c.max_depth).join(
+        max_depths,
+        max_depths.c.node_id == Node.id,
     )
 
     if not include_deactivated:
@@ -123,10 +123,8 @@ async def get_downstream_nodes(
     if depth > -1:
         final_select = final_select.where(max_depths.c.max_depth < depth)
 
-    statement = (
-        final_select
-        .order_by(max_depths.c.max_depth, Node.id)
-        .options(*_node_output_options())
+    statement = final_select.order_by(max_depths.c.max_depth, Node.id).options(
+        *_node_output_options()
     )
     results = (await session.execute(statement)).unique().scalars().all()
     return [

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -4116,6 +4116,32 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             "default.country_dim",
         }
 
+        # Test depth limiting
+        response = await client_with_event.get(
+            "/nodes/default.event_source/downstream/?depth=2",
+        )
+        data = response.json()
+        assert {node["name"] for node in data} == {
+            "default.long_events_distinct_countries",
+            "default.device_ids_count",
+            "default.long_events",
+            "default.country_dim",
+        }
+        response = await client_with_event.get(
+            "/nodes/default.event_source/downstream/?depth=1",
+        )
+        data = response.json()
+        assert {node["name"] for node in data} == {
+            "default.long_events",
+            "default.country_dim",
+            "default.device_ids_count",
+        }
+        response = await client_with_event.get(
+            "/nodes/default.event_source/downstream/?depth=0",
+        )
+        data = response.json()
+        assert {node["name"] for node in data} == set()
+
         response = await client_with_event.get(
             "/nodes/default.device_ids_count/downstream/",
         )


### PR DESCRIPTION
### Summary

For the API endpoint that retrieves downstreams for a node, this adds the ability to filter by the maximum depth of the downstreams. Setting a max depth of -1 will include all downstream nodes (the default).

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
