### PR TITLE
Fixing greenlet spawn error when building metrics sql

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -757,6 +757,7 @@ async def add_filters_dimensions_orderby_limit_to_query_ast(
                         col,
                     )
                     if dj_node:  # pragma: no cover
+                        await session.refresh(node, ["columns"])
                         await session.refresh(node, ["dimension_links"])
                         rename_dimension_primary_keys_to_foreign_keys(
                             dj_node,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -149,7 +149,10 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         """
         response = self.requests_session.post(
             "/queries/",
-            headers={**self.requests_session.headers, **request_headers}
+            headers={
+                **self.requests_session.headers,
+                **QueryServiceClient.filtered_headers(request_headers),
+            }
             if request_headers
             else self.requests_session.headers,
             json=query_create.dict(),


### PR DESCRIPTION
### Summary

This fixes an issue where building metrics sql yields a greenlet spawn error due to the node's columns not being loaded.

### Test Plan

Tested locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
