### PR TITLE
Fix cube dimensions

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -458,11 +458,12 @@ async def validate_cube(  # pylint: disable=too-many-locals
         )
 
     dimension_mapping: Dict[str, Node] = {
-        attr: dimension_nodes[node_name] for node_name, attr in dimension_attributes
+        f"{node_name}{SEPARATOR}{attr}": dimension_nodes[node_name]
+        for node_name, attr in dimension_attributes
     }
     dimensions: List[Column] = []
     for node_name, column_name in dimension_attributes:
-        dimension_node = dimension_mapping[column_name]
+        dimension_node = dimension_mapping[f"{node_name}{SEPARATOR}{column_name}"]
         columns = {col.name: col for col in dimension_node.current.columns}  # type: ignore
 
         column_name_without_role = column_name

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -588,6 +588,42 @@ async def test_create_cube_failures(
 
 
 @pytest.mark.asyncio
+async def test_create_cube_similar_dimensions(
+    module__client_with_roads: AsyncClient,
+):
+    """
+    Tests cube creation for dimension attributes with the same name
+    but from different dimension nodes.
+    """
+
+    metrics_list = [
+        "default.num_repair_orders",
+        "default.avg_repair_price",
+        "default.total_repair_cost",
+    ]
+
+    await module__client_with_roads.post("/nodes/default.repair_order_fact/")
+    # Should succeed
+    response = await module__client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": metrics_list,
+            "dimensions": [
+                "default.hard_hat.country",
+                "default.hard_hat.postal_code",
+                "default.hard_hat_to_delete.postal_code",
+            ],
+            "filters": ["default.hard_hat.state='AZ'"],
+            "description": "Cube of various metrics related to repairs",
+            "mode": "published",
+            "name": "default.repairs_cube2",
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["version"] == "v1.0"
+
+
+@pytest.mark.asyncio
 async def test_create_cube(
     client_with_repairs_cube: AsyncClient,
 ):


### PR DESCRIPTION
### Summary

There's a bug with creating cubes that have dimension attributes that share the same column name but come from different dimension nodes. This is due to a "group by" we do on the column name that shouldn't be done.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A