### PR TITLE
Add created by and edited by fields to both the REST API and GraphQL query

### DIFF
--- a/datajunction-server/datajunction_server/api/collection.py
+++ b/datajunction-server/datajunction_server/api/collection.py
@@ -15,7 +15,7 @@ from datajunction_server.database.node import Node
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
-from datajunction_server.models.collection import CollectionInfo
+from datajunction_server.models.collection import CollectionDetails, CollectionInfo
 from datajunction_server.utils import (
     get_and_update_current_user,
     get_session,
@@ -97,7 +97,7 @@ async def get_collection(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-):
+) -> CollectionDetails:
     """
     Get a collection and its nodes
     """
@@ -106,7 +106,7 @@ async def get_collection(
         name=name,
         raise_if_not_exists=True,
     )
-    return collection
+    return collection  # type: ignore
 
 
 @router.post(

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -51,6 +51,8 @@ def load_node_options(fields):
         options.append(joinedload(DBNode.current).options(*node_revision_options))
     if "created_by" in fields:
         options.append(joinedload(DBNode.created_by))
+    if "edited_by" in fields:
+        options.append(selectinload(DBNode.history))
     if "tags" in fields:
         options.append(selectinload(DBNode.tags))
     return options

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -19,6 +19,7 @@ from datajunction_server.database.dimensionlink import (
     JoinCardinality as JoinCardinality_,
 )
 from datajunction_server.database.dimensionlink import JoinType as JoinType_
+from datajunction_server.database.node import Node as DBNode
 from datajunction_server.database.node import NodeRevision as DBNodeRevision
 from datajunction_server.models.node import NodeMode as NodeMode_
 from datajunction_server.models.node import NodeStatus as NodeStatus_
@@ -182,3 +183,10 @@ class Node:  # pylint: disable=too-few-public-methods
 
     tags: List[Tag]
     created_by: User
+
+    @strawberry.field
+    def edited_by(self, root: "DBNode") -> List[str]:
+        """
+        The users who edited this node
+        """
+        return list({entry.user for entry in root.history})

--- a/datajunction-server/datajunction_server/api/graphql/scalars/user.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/user.py
@@ -2,6 +2,7 @@
 User related scalars
 """
 from enum import Enum
+from typing import Optional
 
 import strawberry
 
@@ -25,9 +26,9 @@ class User:  # pylint: disable=too-few-public-methods
     A DataJunction User
     """
 
-    # id: BigInt
+    id: BigInt
     username: str
-    # email: Optional[str]
-    # name: Optional[str]
-    # oauth_provider: OAuthProvider
-    # is_admin: bool
+    email: Optional[str]
+    name: Optional[str]
+    oauth_provider: OAuthProvider
+    is_admin: bool

--- a/datajunction-server/datajunction_server/api/graphql/scalars/user.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/user.py
@@ -2,7 +2,6 @@
 User related scalars
 """
 from enum import Enum
-from typing import Optional
 
 import strawberry
 
@@ -26,9 +25,9 @@ class User:  # pylint: disable=too-few-public-methods
     A DataJunction User
     """
 
-    id: BigInt
+    # id: BigInt
     username: str
-    email: Optional[str]
-    name: Optional[str]
-    oauth_provider: OAuthProvider
-    is_admin: bool
+    # email: Optional[str]
+    # name: Optional[str]
+    # oauth_provider: OAuthProvider
+    # is_admin: bool

--- a/datajunction-server/datajunction_server/database/collection.py
+++ b/datajunction-server/datajunction_server/database/collection.py
@@ -28,6 +28,8 @@ class Collection(Base):  # pylint: disable=too-few-public-methods
     created_by: Mapped[User] = relationship(
         "User",
         back_populates="created_collections",
+        foreign_keys=[created_by_id],
+        lazy="selectin",
     )
     nodes: Mapped[List[Node]] = relationship(
         secondary="collectionnodes",

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -369,7 +369,7 @@ class Node(Base):  # pylint: disable=too-few-public-methods
         return node  # pragma: no cover
 
     @classmethod
-    async def find(
+    async def find(  # pylint: disable=keyword-arg-before-vararg
         cls,
         session: AsyncSession,
         prefix: Optional[str] = None,

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -179,7 +179,13 @@ class Node(Base):  # pylint: disable=too-few-public-methods
         ForeignKey("users.id"),
         nullable=False,
     )
-    created_by: Mapped[User] = relationship("User", back_populates="created_nodes")
+
+    created_by: Mapped[User] = relationship(
+        "User",
+        back_populates="created_nodes",
+        foreign_keys=[created_by_id],
+        lazy="selectin",
+    )
     namespace: Mapped[str] = mapped_column(String, default="default")
     current_version: Mapped[str] = mapped_column(
         String,
@@ -269,6 +275,7 @@ class Node(Base):  # pylint: disable=too-few-public-methods
                 *NodeRevision.default_load_options(),
             ),
             selectinload(Node.tags),
+            selectinload(Node.created_by),
         ]
         statement = statement.options(*options)
         if not include_inactive:
@@ -365,8 +372,8 @@ class Node(Base):  # pylint: disable=too-few-public-methods
     async def find(
         cls,
         session: AsyncSession,
-        prefix: Optional[str],
-        node_type: NodeType,
+        prefix: Optional[str] = None,
+        node_type: Optional[NodeType] = None,
         *options: ExecutableOption,
     ) -> List["Node"]:
         """
@@ -390,7 +397,7 @@ class Node(Base):  # pylint: disable=too-few-public-methods
         fragment: Optional[str] = None,
         node_types: Optional[List[NodeType]] = None,
         tags: Optional[List[str]] = None,
-        *options: ExecutableOption,
+        *options: ExecutableOption,  # pylint: disable=keyword-arg-before-vararg
     ) -> List["Node"]:
         """
         Finds a list of nodes by prefix
@@ -458,6 +465,8 @@ class NodeRevision(
     created_by: Mapped[User] = relationship(
         "User",
         back_populates="created_node_revisions",
+        foreign_keys=[created_by_id],
+        lazy="selectin",
     )
     query: Mapped[Optional[str]] = mapped_column(String)
     mode: Mapped[NodeMode] = mapped_column(

--- a/datajunction-server/datajunction_server/database/tag.py
+++ b/datajunction-server/datajunction_server/database/tag.py
@@ -32,7 +32,12 @@ class Tag(Base):  # pylint: disable=too-few-public-methods
         insert_default=lambda context: labelize(context.current_parameters.get("name")),
     )
     created_by_id: Mapped[int] = Column(Integer, ForeignKey("users.id"), nullable=False)
-    created_by: Mapped[User] = relationship("User", back_populates="created_tags")
+    created_by: Mapped[User] = relationship(
+        "User",
+        back_populates="created_tags",
+        foreign_keys=[created_by_id],
+        lazy="selectin",
+    )
     tag_metadata: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, default={})
 
     nodes: Mapped[List["Node"]] = relationship(

--- a/datajunction-server/datajunction_server/database/user.py
+++ b/datajunction-server/datajunction_server/database/user.py
@@ -43,20 +43,23 @@ class User(Base):  # pylint: disable=too-few-public-methods
     created_collections: Mapped[list["Collection"]] = relationship(
         "Collection",
         back_populates="created_by",
+        foreign_keys="Collection.created_by_id",
         lazy="joined",
     )
     created_nodes: Mapped[list["Node"]] = relationship(
         "Node",
         back_populates="created_by",
-        lazy="joined",
+        foreign_keys="Node.created_by_id",
+        lazy="selectin",
     )
     created_node_revisions: Mapped[list["NodeRevision"]] = relationship(
         "NodeRevision",
         back_populates="created_by",
-        lazy="joined",
+        foreign_keys="NodeRevision.created_by_id",
     )
     created_tags: Mapped[list["Tag"]] = relationship(
         "Tag",
         back_populates="created_by",
+        foreign_keys="Tag.created_by_id",
         lazy="joined",
     )

--- a/datajunction-server/datajunction_server/internal/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/basic.py
@@ -8,6 +8,7 @@ from passlib.context import CryptContext
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
+from sqlalchemy.sql.base import ExecutableOption
 
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJError, DJException, ErrorCode
@@ -30,21 +31,18 @@ def get_password_hash(password) -> str:
     return pwd_context.hash(password)
 
 
-async def get_user(username: str, session: AsyncSession) -> User:
+async def get_user(
+    username: str,
+    session: AsyncSession,
+    *options: ExecutableOption,
+) -> User:
     """
     Get a DJ user
     """
     user = (
         (
             await session.execute(
-                select(User)
-                .options(
-                    joinedload(User.created_collections),
-                    joinedload(User.created_nodes),
-                    joinedload(User.created_node_revisions),
-                    joinedload(User.created_tags),
-                )
-                .where(User.username == username),
+                select(User).options(*options).where(User.username == username),
             )
         )
         .unique()

--- a/datajunction-server/datajunction_server/internal/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/basic.py
@@ -7,7 +7,6 @@ from http import HTTPStatus
 from passlib.context import CryptContext
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.base import ExecutableOption
 
 from datajunction_server.database.user import User

--- a/datajunction-server/datajunction_server/models/collection.py
+++ b/datajunction-server/datajunction_server/models/collection.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from pydantic.main import BaseModel
 
+from datajunction_server.models.node import NodeNameOutput
+
 
 class CollectionInfo(BaseModel):
     """
@@ -14,6 +16,20 @@ class CollectionInfo(BaseModel):
     id: Optional[int]
     name: str
     description: str
+
+    class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
+        orm_mode = True
+
+
+class CollectionDetails(CollectionInfo):
+    """
+    Collection information with details
+    """
+
+    id: Optional[int]
+    name: str
+    description: str
+    nodes: list[NodeNameOutput]
 
     class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
         orm_mode = True

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -837,7 +837,6 @@ class NodeOutput(GenericNodeOutputModel):
     missing_table: Optional[bool] = False
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
-        # allow_population_by_field_name = True
         orm_mode = True
 
     @classmethod

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -27,6 +27,7 @@ from datajunction_server.models.materialization import MaterializationConfigOutp
 from datajunction_server.models.node_type import NodeNameOutput, NodeType
 from datajunction_server.models.partition import PartitionOutput
 from datajunction_server.models.tag import TagMinimum, TagOutput
+from datajunction_server.models.user import UserNameOnly
 from datajunction_server.sql.parsing.types import ColumnType
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import Version
@@ -753,6 +754,7 @@ class GenericNodeOutputModel(BaseModel):
             "catalog": values.get("catalog"),
             "missing_table": values.get("missing_table"),
             "tags": values.get("tags"),
+            "created_by": values.get("created_by").__dict__,
         }
         for k, v in current_dict.items():
             final_dict[k] = v
@@ -829,11 +831,13 @@ class NodeOutput(GenericNodeOutputModel):
     metric_metadata: Optional[MetricMetadataOutput] = None
     dimension_links: Optional[List[LinkDimensionOutput]]
     created_at: UTCDatetime
+    created_by: UserNameOnly
     tags: List[TagOutput] = []
     current_version: str
     missing_table: Optional[bool] = False
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        # allow_population_by_field_name = True
         orm_mode = True
 
     @classmethod
@@ -849,6 +853,7 @@ class NodeOutput(GenericNodeOutputModel):
         return [
             selectinload(Node.current).options(*NodeRevision.default_load_options()),
             joinedload(Node.tags),
+            selectinload(Node.created_by),
         ]
 
 

--- a/datajunction-server/datajunction_server/models/user.py
+++ b/datajunction-server/datajunction_server/models/user.py
@@ -51,6 +51,17 @@ class UserOutput(BaseModel):
         orm_mode = True
 
 
+class UserNameOnly(BaseModel):
+    """
+    Username only
+    """
+
+    username: str
+
+    class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
+        orm_mode = True
+
+
 class UserActivity(BaseModel):
     """
     User activity info

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -685,7 +685,9 @@ async def test_find_nodes_with_created_edited_by(
     {
         findNodes(names: ["default.repair_orders_fact"]) {
             name
-            createdBy
+            createdBy {
+              username
+            }
             editedBy
         }
     }
@@ -694,5 +696,9 @@ async def test_find_nodes_with_created_edited_by(
     assert response.status_code == 200
     data = response.json()
     assert data["data"]["findNodes"] == [
-        {"name": "default.repair_orders_fact", "createdBy": "dj", "editedBy": ["dj"]},
+        {
+            "name": "default.repair_orders_fact",
+            "createdBy": {"username": "dj"},
+            "editedBy": ["dj"],
+        },
     ]

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5608,7 +5608,7 @@ class TestCopyNode:
 
         # Copy all nodes to a node name with _copy appended
         nodes = (await client_with_roads.get("/nodes")).json()
-        for node in nodes:
+        for node in sorted(nodes):
             await client_with_roads.post(f"/nodes/{node}/copy?new_name={node}_copy")
 
         # Check that each node was successfully copied by comparing against the original


### PR DESCRIPTION
### Summary

This change exposes `created_by` and adds `edited_by` to both the REST API and the GraphQL findNodes query. For the GraphQL query, the join against the history table is only done when `edited_by` is requested, and the `created_by` attribute is only joined in when it is requested. 

There were a few issues with SQLAlchemy managing the join correctly without explicitly specifying the `foreign_keys` attribute on the ORM object. 

### Test Plan

Added a test

- [x] PR has an associated issue: #1144
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
