### PR TITLE
include sql_columns output in /cube/{cube_name} endpoint

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -72,7 +72,7 @@ from datajunction_server.models.node import (
     UpdateNode,
 )
 from datajunction_server.models.node_type import NodeType
-from datajunction_server.naming import from_amenable_name
+from datajunction_server.naming import amenable_name, from_amenable_name
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
     get_downstream_nodes,
@@ -1399,11 +1399,8 @@ async def derive_sql_column(
     if cube_element.type == "metric":
         query_column_name = cube_element.name
     elif cube_element.type == "dimension":
-        query_column_name = (
-            f"{cube_element.node_name}{SEPARATOR}{cube_element.name}".replace(
-                SEPARATOR,
-                "_DOT_",
-            )
+        query_column_name = amenable_name(
+            f"{cube_element.node_name}{SEPARATOR}{cube_element.name}",
         )
     return ColumnOutput(
         name=query_column_name,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1389,7 +1389,7 @@ async def column_lineage(
     return lineage_column
 
 
-async def determine_query_column_name(
+async def derive_sql_column(
     cube_element: CubeElementMetadata,
 ) -> ColumnOutput:
     """
@@ -1457,8 +1457,7 @@ async def get_cube_revision_metadata(session: AsyncSession, name: str):
     cube_metadata = CubeRevisionMetadata.from_orm(cube)
     cube_metadata.tags = cube.node.tags
     cube_metadata.sql_columns = [
-        await determine_query_column_name(element)
-        for element in cube_metadata.cube_elements
+        await derive_sql_column(element) for element in cube_metadata.cube_elements
     ]
     return cube_metadata
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1395,13 +1395,13 @@ async def derive_sql_column(
     """
     Derives the column name in the generated Cube SQL based on the CubeElement
     """
-    query_column_name = None
-    if cube_element.type == "metric":
-        query_column_name = cube_element.name
-    elif cube_element.type == "dimension":
-        query_column_name = amenable_name(
+    query_column_name = (
+        cube_element.name
+        if cube_element.type == "metric"
+        else amenable_name(
             f"{cube_element.node_name}{SEPARATOR}{cube_element.name}",
         )
+    )
     return ColumnOutput(
         name=query_column_name,
         display_name=cube_element.display_name,

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -70,6 +70,7 @@ class CubeRevisionMetadata(BaseModel):
     cube_node_dimensions: List[str]
     query: Optional[str]
     columns: List[ColumnOutput]
+    sql_columns: Optional[List[ColumnOutput]]
     updated_at: UTCDatetime
     materializations: List[MaterializationConfigOutput]
     tags: Optional[List[TagOutput]]


### PR DESCRIPTION
### Summary

This adds a `sql_columns` attribute that derives the names that will be found in the SQL generated for a cube. This will let you know the schema when calling `/cube/{cube_name}` (without calling `/sql/{cube_name}` to find that out).

There is an existing `columns` field but that pulls the actual column entities as defined on those base nodes. It's a small nuanced difference where with metrics we automatically alias metric expression with the `_DOT_` notation, so the name matches the column in the final dataset, however for dimensions, the column entity is the name as it exists on the actual dimension node which is fully determined by the SQL contained in that node (as it should be). It didn't seem right to change any of that so I added this `sql_columns` that gets right to the point of providing the columns that will be found in the SQL projection.

### Test Plan

Added a test for the new function to make sure the names are being derived properly.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
