### PR TITLE
Add `created_by_id` for `Node`, `NodeRevision`, `Collection`, and `Tag`

### DIFF
--- a/datajunction-server/alembic/versions/2024_08_18_0036-f3c9b40deb6f_add_create_by_to_nodes_node_revisions_.py
+++ b/datajunction-server/alembic/versions/2024_08_18_0036-f3c9b40deb6f_add_create_by_to_nodes_node_revisions_.py
@@ -1,0 +1,89 @@
+"""add create_by to nodes, node revisions, collections, and tags
+
+Revision ID: f3c9b40deb6f
+Revises: 34171c92dd6d
+Create Date: 2024-08-18 00:36:51.859475+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f3c9b40deb6f"
+down_revision = "34171c92dd6d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("created_by_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, "users", ["created_by_id"], ["id"])
+
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("created_by_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, "users", ["created_by_id"], ["id"])
+
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("created_by_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, "users", ["created_by_id"], ["id"])
+
+    with op.batch_alter_table("tag", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("created_by_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, "users", ["created_by_id"], ["id"])
+
+    # Backfill created by columns with user id 1
+    op.execute("UPDATE collection SET created_by_id = 1 WHERE created_by_id IS NULL")
+    op.execute("UPDATE node SET created_by_id = 1 WHERE created_by_id IS NULL")
+    op.execute("UPDATE noderevision SET created_by_id = 1 WHERE created_by_id IS NULL")
+    op.execute("UPDATE tag SET created_by_id = 1 WHERE created_by_id IS NULL")
+
+    # After the created by column is backfilled, make it required going forward
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.alter_column(
+            "created_by_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.alter_column(
+            "created_by_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.alter_column(
+            "created_by_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+
+    with op.batch_alter_table("tag", schema=None) as batch_op:
+        batch_op.alter_column(
+            "created_by_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("tag", schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_="foreignkey")
+        batch_op.drop_column("created_by_id")
+
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_="foreignkey")
+        batch_op.drop_column("created_by_id")
+
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_="foreignkey")
+        batch_op.drop_column("created_by_id")
+
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_="foreignkey")
+        batch_op.drop_column("created_by_id")

--- a/datajunction-server/alembic/versions/2024_08_18_0036-f3c9b40deb6f_add_create_by_to_nodes_node_revisions_.py
+++ b/datajunction-server/alembic/versions/2024_08_18_0036-f3c9b40deb6f_add_create_by_to_nodes_node_revisions_.py
@@ -19,6 +19,13 @@ depends_on = None
 
 
 def upgrade():
+    """This upgrades adds the created_by_id field to Collection, Node, NodeRevision, and Tag
+
+    Deployments prior to this upgrade will not have easily accessible information for who created
+    these objects in the past. Therefore, this upgrade backfills all existing objects as created by
+    the user with ID=1. If creation information can be gathered elsewhere, it's recommended that you
+    manually backfill the correct created_by_id after the database is upgraded.
+    """
     with op.batch_alter_table("collection", schema=None) as batch_op:
         batch_op.add_column(sa.Column("created_by_id", sa.Integer(), nullable=True))
         batch_op.create_foreign_key(None, "users", ["created_by_id"], ["id"])

--- a/datajunction-server/datajunction_server/api/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/basic.py
@@ -34,7 +34,7 @@ async def create_a_user(
     Create a new user
     """
     user_result = await session.execute(select(User).where(User.username == username))
-    if user_result.scalar_one_or_none():
+    if user_result.unique().scalar_one_or_none():
         raise DJException(
             http_status_code=HTTPStatus.CONFLICT,
             errors=[

--- a/datajunction-server/datajunction_server/api/access/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/whoami.py
@@ -20,10 +20,10 @@ from datajunction_server.utils import (
 router = SecureAPIRouter(tags=["Who am I?"])
 
 
-@router.get("/whoami/", response_model=UserOutput)
-async def get_user(
+@router.get("/whoami/")
+async def whoami(
     current_user: User = Depends(get_and_update_current_user),
-) -> UserOutput:
+):
     """
     Returns the current authenticated user
     """

--- a/datajunction-server/datajunction_server/api/collection.py
+++ b/datajunction-server/datajunction_server/api/collection.py
@@ -12,10 +12,15 @@ from sqlalchemy.sql.operators import is_
 
 from datajunction_server.database.collection import Collection
 from datajunction_server.database.node import Node
+from datajunction_server.database.user import User
 from datajunction_server.errors import DJException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.models.collection import CollectionInfo
-from datajunction_server.utils import get_session, get_settings
+from datajunction_server.utils import (
+    get_and_update_current_user,
+    get_session,
+    get_settings,
+)
 
 _logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -31,6 +36,7 @@ async def create_a_collection(
     data: CollectionInfo,
     *,
     session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> CollectionInfo:
     """
     Create a Collection
@@ -48,6 +54,7 @@ async def create_a_collection(
     collection = Collection(
         name=data.name,
         description=data.description,
+        created_by_id=current_user.id,
     )
     session.add(collection)
     await session.commit()

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -49,7 +49,8 @@ def load_node_options(fields):
     if fields.get("current"):
         node_revision_options = load_node_revision_options(fields["current"])
         options.append(joinedload(DBNode.current).options(*node_revision_options))
-
+    if "created_by" in fields:
+        options.append(joinedload(DBNode.created_by))
     if "tags" in fields:
         options.append(selectinload(DBNode.tags))
     return options

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -14,6 +14,7 @@ from datajunction_server.api.graphql.scalars.materialization import (
     MaterializationConfig,
 )
 from datajunction_server.api.graphql.scalars.metricmetadata import MetricMetadata
+from datajunction_server.api.graphql.scalars.user import User
 from datajunction_server.database.dimensionlink import (
     JoinCardinality as JoinCardinality_,
 )
@@ -180,3 +181,4 @@ class Node:  # pylint: disable=too-few-public-methods
     revisions: List[NodeRevision]
 
     tags: List[Tag]
+    created_by: User

--- a/datajunction-server/datajunction_server/api/graphql/scalars/user.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/user.py
@@ -1,3 +1,6 @@
+"""
+User related scalars
+"""
 from enum import Enum
 from typing import Optional
 
@@ -11,15 +14,18 @@ class OAuthProvider(Enum):
     """
     An oauth implementation provider
     """
+
     BASIC = "basic"
     GITHUB = "github"
     GOOGLE = "google"
-    
+
+
 @strawberry.type
-class User:
+class User:  # pylint: disable=too-few-public-methods
     """
     A DataJunction User
     """
+
     id: BigInt
     username: str
     email: Optional[str]

--- a/datajunction-server/datajunction_server/api/graphql/scalars/user.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/user.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from typing import Optional
+
+import strawberry
+
+from datajunction_server.api.graphql.scalars import BigInt
+
+
+@strawberry.enum
+class OAuthProvider(Enum):
+    """
+    An oauth implementation provider
+    """
+    BASIC = "basic"
+    GITHUB = "github"
+    GOOGLE = "google"
+    
+@strawberry.type
+class User:
+    """
+    A DataJunction User
+    """
+    id: BigInt
+    username: str
+    email: Optional[str]
+    name: Optional[str]
+    oauth_provider: OAuthProvider
+    is_admin: bool

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -114,6 +114,7 @@ async def create_a_tag(
         description=data.description,
         display_name=data.display_name,
         tag_metadata=data.tag_metadata,
+        created_by_id=current_user.id,
     )
     session.add(tag)
     session.add(

--- a/datajunction-server/datajunction_server/database/attributetype.py
+++ b/datajunction-server/datajunction_server/database/attributetype.py
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
     from datajunction_server.database.column import Column
 
 
-class AttributeType(Base):  # pylint: disable=too-few-public-methods
+class AttributeType(
+    Base,
+):  # pylint: disable=too-few-public-methods,unsubscriptable-object
     """
     Available attribute types for column metadata.
     """

--- a/datajunction-server/datajunction_server/database/availabilitystate.py
+++ b/datajunction-server/datajunction_server/database/availabilitystate.py
@@ -1,4 +1,6 @@
 """Availability state database schema."""
+# pylint: disable=unsubscriptable-object
+
 from datetime import datetime, timezone
 from functools import partial
 from typing import List, Optional

--- a/datajunction-server/datajunction_server/database/collection.py
+++ b/datajunction-server/datajunction_server/database/collection.py
@@ -3,12 +3,13 @@ from datetime import datetime, timezone
 from functools import partial
 from typing import List, Optional
 
-from sqlalchemy import DateTime, ForeignKey, String, select
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
 from datajunction_server.database.node import Node
+from datajunction_server.database.user import User
 from datajunction_server.errors import DJDoesNotExistException
 from datajunction_server.typing import UTCDatetime
 
@@ -23,6 +24,11 @@ class Collection(Base):  # pylint: disable=too-few-public-methods
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[Optional[str]] = mapped_column(String, default=None, unique=True)
     description: Mapped[Optional[str]] = mapped_column(String, default=None)
+    created_by_id: Mapped[int] = Column(Integer, ForeignKey("users.id"))
+    created_by: Mapped[User] = relationship(
+        "User",
+        back_populates="created_collections",
+    )
     nodes: Mapped[List[Node]] = relationship(
         secondary="collectionnodes",
         primaryjoin="Collection.id==CollectionNodes.collection_id",

--- a/datajunction-server/datajunction_server/database/collection.py
+++ b/datajunction-server/datajunction_server/database/collection.py
@@ -24,7 +24,7 @@ class Collection(Base):  # pylint: disable=too-few-public-methods
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[Optional[str]] = mapped_column(String, default=None, unique=True)
     description: Mapped[Optional[str]] = mapped_column(String, default=None)
-    created_by_id: Mapped[int] = Column(Integer, ForeignKey("users.id"))
+    created_by_id: Mapped[int] = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_by: Mapped[User] = relationship(
         "User",
         back_populates="created_collections",

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -175,7 +175,9 @@ class Node(Base):  # pylint: disable=too-few-public-methods
     type: Mapped[NodeType] = mapped_column(Enum(NodeType))
     display_name: Mapped[Optional[str]]
     created_by_id: int = SqlalchemyColumn(
-        Integer, ForeignKey("users.id"), nullable=False,
+        Integer,
+        ForeignKey("users.id"),
+        nullable=False,
     )
     created_by: Mapped[User] = relationship("User", back_populates="created_nodes")
     namespace: Mapped[str] = mapped_column(String, default="default")
@@ -449,7 +451,9 @@ class NodeRevision(
     type: Mapped[NodeType] = mapped_column(Enum(NodeType))
     description: Mapped[str] = mapped_column(String, default="")
     created_by_id: int = SqlalchemyColumn(
-        Integer, ForeignKey("users.id"), nullable=False,
+        Integer,
+        ForeignKey("users.id"),
+        nullable=False,
     )
     created_by: Mapped[User] = relationship(
         "User",

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -174,7 +174,9 @@ class Node(Base):  # pylint: disable=too-few-public-methods
     name: Mapped[str] = mapped_column(String, unique=True)
     type: Mapped[NodeType] = mapped_column(Enum(NodeType))
     display_name: Mapped[Optional[str]]
-    created_by_id: int = SqlalchemyColumn(Integer, ForeignKey("users.id"))
+    created_by_id: int = SqlalchemyColumn(
+        Integer, ForeignKey("users.id"), nullable=False,
+    )
     created_by: Mapped[User] = relationship("User", back_populates="created_nodes")
     namespace: Mapped[str] = mapped_column(String, default="default")
     current_version: Mapped[str] = mapped_column(
@@ -446,7 +448,9 @@ class NodeRevision(
     )
     type: Mapped[NodeType] = mapped_column(Enum(NodeType))
     description: Mapped[str] = mapped_column(String, default="")
-    created_by_id: int = SqlalchemyColumn(Integer, ForeignKey("users.id"))
+    created_by_id: int = SqlalchemyColumn(
+        Integer, ForeignKey("users.id"), nullable=False,
+    )
     created_by: Mapped[User] = relationship(
         "User",
         back_populates="created_node_revisions",

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -6,11 +6,13 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import sqlalchemy as sa
 from pydantic import Extra
+from sqlalchemy import JSON
+from sqlalchemy import Column as SqlalchemyColumn
 from sqlalchemy import (
-    JSON,
     DateTime,
     Enum,
     ForeignKey,
+    Integer,
     String,
     UniqueConstraint,
     select,
@@ -30,6 +32,7 @@ from datajunction_server.database.history import History
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.metricmetadata import MetricMetadata
 from datajunction_server.database.tag import Tag
+from datajunction_server.database.user import User
 from datajunction_server.errors import DJInvalidInputException, DJNodeNotFound
 from datajunction_server.models.base import labelize
 from datajunction_server.models.node import (
@@ -171,6 +174,8 @@ class Node(Base):  # pylint: disable=too-few-public-methods
     name: Mapped[str] = mapped_column(String, unique=True)
     type: Mapped[NodeType] = mapped_column(Enum(NodeType))
     display_name: Mapped[Optional[str]]
+    created_by_id: int = SqlalchemyColumn(Integer, ForeignKey("users.id"))
+    created_by: Mapped[User] = relationship("User", back_populates="created_nodes")
     namespace: Mapped[str] = mapped_column(String, default="default")
     current_version: Mapped[str] = mapped_column(
         String,
@@ -441,6 +446,11 @@ class NodeRevision(
     )
     type: Mapped[NodeType] = mapped_column(Enum(NodeType))
     description: Mapped[str] = mapped_column(String, default="")
+    created_by_id: int = SqlalchemyColumn(Integer, ForeignKey("users.id"))
+    created_by: Mapped[User] = relationship(
+        "User",
+        back_populates="created_node_revisions",
+    )
     query: Mapped[Optional[str]] = mapped_column(String)
     mode: Mapped[NodeMode] = mapped_column(
         Enum(NodeMode),

--- a/datajunction-server/datajunction_server/database/tag.py
+++ b/datajunction-server/datajunction_server/database/tag.py
@@ -2,10 +2,11 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, ForeignKey, String
+from sqlalchemy import JSON, Column, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
+from datajunction_server.database.user import User
 from datajunction_server.models.base import labelize
 
 if TYPE_CHECKING:
@@ -30,6 +31,8 @@ class Tag(Base):  # pylint: disable=too-few-public-methods
         String,
         insert_default=lambda context: labelize(context.current_parameters.get("name")),
     )
+    created_by_id: Mapped[int] = Column(Integer, ForeignKey("users.id"))
+    created_by: Mapped[User] = relationship("User", back_populates="created_tags")
     tag_metadata: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, default={})
 
     nodes: Mapped[List["Node"]] = relationship(

--- a/datajunction-server/datajunction_server/database/tag.py
+++ b/datajunction-server/datajunction_server/database/tag.py
@@ -31,7 +31,7 @@ class Tag(Base):  # pylint: disable=too-few-public-methods
         String,
         insert_default=lambda context: labelize(context.current_parameters.get("name")),
     )
-    created_by_id: Mapped[int] = Column(Integer, ForeignKey("users.id"))
+    created_by_id: Mapped[int] = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_by: Mapped[User] = relationship("User", back_populates="created_tags")
     tag_metadata: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, default={})
 

--- a/datajunction-server/datajunction_server/database/user.py
+++ b/datajunction-server/datajunction_server/database/user.py
@@ -1,11 +1,16 @@
 """User database schema."""
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import BigInteger, Enum, Integer, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
 from datajunction_server.enum import StrEnum
+
+if TYPE_CHECKING:
+    from datajunction_server.database.collection import Collection
+    from datajunction_server.database.node import Node, NodeRevision
+    from datajunction_server.database.tag import Tag
 
 
 class OAuthProvider(StrEnum):
@@ -35,3 +40,23 @@ class User(Base):  # pylint: disable=too-few-public-methods
         Enum(OAuthProvider),
     )
     is_admin: Mapped[bool] = mapped_column(default=False)
+    created_collections: Mapped[list["Collection"]] = relationship(
+        "Collection",
+        back_populates="created_by",
+        lazy="joined",
+    )
+    created_nodes: Mapped[list["Node"]] = relationship(
+        "Node",
+        back_populates="created_by",
+        lazy="joined",
+    )
+    created_node_revisions: Mapped[list["NodeRevision"]] = relationship(
+        "NodeRevision",
+        back_populates="created_by",
+        lazy="joined",
+    )
+    created_tags: Mapped[list["Tag"]] = relationship(
+        "Tag",
+        back_populates="created_by",
+        lazy="joined",
+    )

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -611,7 +611,7 @@ async def update_node_with_query(
     new_revision = await create_new_revision_from_existing(
         session=session,
         old_revision=old_revision,
-        node=node,  # type: ignorec
+        node=node,  # type: ignore
         current_user=current_user,
         data=data,
     )

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -609,10 +609,11 @@ async def update_node_with_query(
     )
     old_revision = node.current  # type: ignore
     new_revision = await create_new_revision_from_existing(
-        session,
-        old_revision,
-        node,  # type: ignore
-        data,
+        session=session,
+        old_revision=old_revision,
+        node=node,  # type: ignorec
+        current_user=current_user,
+        data=data,
     )
 
     if not new_revision:

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -215,6 +215,7 @@ async def create_node_revision(
     data: CreateNode,
     node_type: NodeType,
     session: AsyncSession,
+    current_user: User,
 ) -> NodeRevision:
     """
     Create a non-source node revision.
@@ -228,6 +229,7 @@ async def create_node_revision(
         query=data.query,
         mode=data.mode,
         required_dimensions=data.required_dimensions or [],
+        created_by_id=current_user.id,
     )
     node_validator = await validate_node_data(node_revision, session)
     if node_validator.status == NodeStatus.INVALID:
@@ -293,6 +295,7 @@ async def create_node_revision(
 async def create_cube_node_revision(  # pylint: disable=too-many-locals
     session: AsyncSession,
     data: CreateCubeNode,
+    current_user: User,
 ) -> NodeRevision:
     """
     Create a cube node revision.
@@ -356,6 +359,7 @@ async def create_cube_node_revision(  # pylint: disable=too-many-locals
         parents=list(set(dimension_nodes + metric_nodes)),
         status=status,
         catalog=catalog,
+        created_by_id=current_user.id,
     )
     return node_revision
 
@@ -438,6 +442,7 @@ async def copy_to_new_node(
         deactivated_at=node.deactivated_at,  # type: ignore
         tags=node.tags,  # type: ignore
         missing_table=node.missing_table,  # type: ignore
+        created_by_id=current_user.id,
     )
     new_revision = NodeRevision(
         name=new_name,
@@ -463,6 +468,7 @@ async def copy_to_new_node(
         columns=[col.copy() for col in old_revision.columns],
         # TODO: availability and materializations are missing here  # pylint: disable=fixme
         lineage=old_revision.lineage,
+        created_by_id=current_user.id,
     )
 
     # Assemble new dimension links, where each link will need to have their join SQL rewritten
@@ -777,7 +783,11 @@ async def update_cube_node(  # pylint: disable=too-many-locals
     if not major_changes and not minor_changes:
         return None
 
-    new_cube_revision = await create_cube_node_revision(session, create_cube)
+    new_cube_revision = await create_cube_node_revision(
+        session,
+        create_cube,
+        current_user,
+    )
 
     old_version = Version.parse(node_revision.version)
     if major_changes:
@@ -939,7 +949,7 @@ async def propagate_update_downstream(  # pylint: disable=too-many-locals
         await session.commit()
 
 
-def copy_existing_node_revision(old_revision: NodeRevision):
+def copy_existing_node_revision(old_revision: NodeRevision, current_user: User):
     """
     Create an exact copy of the node revision
     """
@@ -970,6 +980,7 @@ def copy_existing_node_revision(old_revision: NodeRevision):
             )
             for link in old_revision.dimension_links
         ],
+        created_by_id=current_user.id,
     )
 
 
@@ -1063,6 +1074,7 @@ async def create_new_revision_from_existing(  # pylint: disable=too-many-locals,
     session: AsyncSession,
     old_revision: NodeRevision,
     node: Node,
+    current_user: User,
     data: UpdateNode = None,
     version_upgrade: VersionUpgrade = None,
 ) -> Optional[NodeRevision]:
@@ -1166,6 +1178,7 @@ async def create_new_revision_from_existing(  # pylint: disable=too-many-locals,
             )
             for link in old_revision.dimension_links
         ],
+        created_by_id=current_user.id,
     )
     if data.required_dimensions:  # type: ignore
         new_revision.required_dimensions = data.required_dimensions  # type: ignore
@@ -1934,7 +1947,7 @@ async def revalidate_node(  # pylint: disable=too-many-locals,too-many-statement
 
     # Only create a new revision if the columns have been updated
     if updated_columns:  # type: ignore
-        new_revision = copy_existing_node_revision(node.current)  # type: ignore
+        new_revision = copy_existing_node_revision(node.current, current_user)  # type: ignore
         new_revision.version = str(
             Version.parse(node.current.version).next_major_version(),  # type: ignore
         )

--- a/datajunction-server/datajunction_server/models/collection.py
+++ b/datajunction-server/datajunction_server/models/collection.py
@@ -1,6 +1,7 @@
 """
 Models for collections
 """
+from typing import Optional
 
 from pydantic.main import BaseModel
 
@@ -10,6 +11,7 @@ class CollectionInfo(BaseModel):
     Class for a collection information
     """
 
+    id: Optional[int]
     name: str
     description: str
 

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -26,7 +26,7 @@ from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import MaterializationConfigOutput
 from datajunction_server.models.node_type import NodeNameOutput, NodeType
 from datajunction_server.models.partition import PartitionOutput
-from datajunction_server.models.tag import TagOutput
+from datajunction_server.models.tag import TagMinimum, TagOutput
 from datajunction_server.sql.parsing.types import ColumnType
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import Version
@@ -534,6 +534,8 @@ class NodeMinimumDetail(BaseModel):
     status: NodeStatus
     mode: NodeMode
     updated_at: UTCDatetime
+    tags: Optional[List[TagMinimum]]
+    edited_by: Optional[List[str]]
 
     class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
         orm_mode = True

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -26,7 +26,7 @@ from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import MaterializationConfigOutput
 from datajunction_server.models.node_type import NodeNameOutput, NodeType
 from datajunction_server.models.partition import PartitionOutput
-from datajunction_server.models.tag import TagMinimum, TagOutput
+from datajunction_server.models.tag import TagOutput
 from datajunction_server.sql.parsing.types import ColumnType
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import Version
@@ -534,8 +534,6 @@ class NodeMinimumDetail(BaseModel):
     status: NodeStatus
     mode: NodeMode
     updated_at: UTCDatetime
-    tags: Optional[List[TagMinimum]]
-    edited_by: Optional[List[str]]
 
     class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
         orm_mode = True

--- a/datajunction-server/datajunction_server/models/user.py
+++ b/datajunction-server/datajunction_server/models/user.py
@@ -1,11 +1,37 @@
 """
 Models for users and auth
 """
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel
 
 from datajunction_server.database.user import OAuthProvider
+from datajunction_server.models.catalog import CatalogInfo
+from datajunction_server.models.collection import CollectionInfo
+from datajunction_server.models.node import NodeType
+from datajunction_server.models.tag import TagOutput
+from datajunction_server.typing import UTCDatetime
+
+
+class CreatedNode(BaseModel):
+    """
+    A node created by a user
+    """
+
+    namespace: str
+    type: NodeType
+    name: str
+    catalog: Optional[CatalogInfo]
+    schema_: Optional[str]
+    table: Optional[str]
+    description: str = ""
+    query: Optional[str] = None
+    created_at: UTCDatetime
+    current_version: str
+    missing_table: Optional[bool] = False
+
+    class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
+        orm_mode = True
 
 
 class UserOutput(BaseModel):
@@ -17,6 +43,9 @@ class UserOutput(BaseModel):
     name: Optional[str]
     oauth_provider: OAuthProvider
     is_admin: bool = False
+    created_collections: Optional[List[CollectionInfo]] = []
+    created_nodes: Optional[List[CreatedNode]] = []
+    created_tags: Optional[List[TagOutput]] = []
 
     class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
         orm_mode = True

--- a/datajunction-server/tests/api/collections_test.py
+++ b/datajunction-server/tests/api/collections_test.py
@@ -38,6 +38,7 @@ class TestCollections:
         data = response.json()
         assert data == [
             {
+                "id": 1,
                 "name": "Accounting",
                 "description": "This is a collection that contains accounting related nodes",
             },

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -571,6 +571,14 @@ async def test_find_node_with_revisions(
                 }
             }
             currentVersion
+            createdBy {
+                email
+                id
+                isAdmin
+                name
+                oauthProvider
+                username
+            }
         }
     }
     """

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -1,6 +1,8 @@
 """
 Tests for the engine API.
 """
+
+# pylint: disable=line-too-long
 import pytest
 from httpx import AsyncClient
 
@@ -587,65 +589,71 @@ async def test_find_node_with_revisions(
     data = response.json()
     assert data["data"]["findNodes"] == [
         {
-            "currentVersion": "v1.0",
             "name": "default.regional_level_agg",
-            "revisions": [
-                {
-                    "dimensionLinks": [],
-                    "displayName": "Default: Regional Level Agg",
-                },
-            ],
             "type": "TRANSFORM",
+            "revisions": [
+                {"displayName": "Default: Regional Level Agg", "dimensionLinks": []},
+            ],
+            "currentVersion": "v1.0",
+            "createdBy": {
+                "email": None,
+                "id": 1,
+                "isAdmin": False,
+                "name": None,
+                "oauthProvider": "BASIC",
+                "username": "dj",
+            },
         },
         {
-            "currentVersion": "v1.0",
             "name": "default.national_level_agg",
-            "revisions": [
-                {
-                    "dimensionLinks": [],
-                    "displayName": "Default: National Level Agg",
-                },
-            ],
             "type": "TRANSFORM",
+            "revisions": [
+                {"displayName": "Default: National Level Agg", "dimensionLinks": []},
+            ],
+            "currentVersion": "v1.0",
+            "createdBy": {
+                "email": None,
+                "id": 1,
+                "isAdmin": False,
+                "name": None,
+                "oauthProvider": "BASIC",
+                "username": "dj",
+            },
         },
         {
-            "currentVersion": "v1.0",
             "name": "default.repair_orders_fact",
+            "type": "TRANSFORM",
             "revisions": [
                 {
+                    "displayName": "Repair Orders Fact",
                     "dimensionLinks": [
                         {
-                            "dimension": {
-                                "name": "default.municipality_dim",
-                            },
-                            "joinSql": "default.repair_orders_fact.municipality_id = "
-                            "default.municipality_dim.municipality_id",
+                            "dimension": {"name": "default.municipality_dim"},
+                            "joinSql": "default.repair_orders_fact.municipality_id = default.municipality_dim.municipality_id",
                         },
                         {
-                            "dimension": {
-                                "name": "default.hard_hat",
-                            },
-                            "joinSql": "default.repair_orders_fact.hard_hat_id = "
-                            "default.hard_hat.hard_hat_id",
+                            "dimension": {"name": "default.hard_hat"},
+                            "joinSql": "default.repair_orders_fact.hard_hat_id = default.hard_hat.hard_hat_id",
                         },
                         {
-                            "dimension": {
-                                "name": "default.hard_hat_to_delete",
-                            },
-                            "joinSql": "default.repair_orders_fact.hard_hat_id = "
-                            "default.hard_hat_to_delete.hard_hat_id",
+                            "dimension": {"name": "default.hard_hat_to_delete"},
+                            "joinSql": "default.repair_orders_fact.hard_hat_id = default.hard_hat_to_delete.hard_hat_id",
                         },
                         {
-                            "dimension": {
-                                "name": "default.dispatcher",
-                            },
-                            "joinSql": "default.repair_orders_fact.dispatcher_id = "
-                            "default.dispatcher.dispatcher_id",
+                            "dimension": {"name": "default.dispatcher"},
+                            "joinSql": "default.repair_orders_fact.dispatcher_id = default.dispatcher.dispatcher_id",
                         },
                     ],
-                    "displayName": "Repair Orders Fact",
                 },
             ],
-            "type": "TRANSFORM",
+            "currentVersion": "v1.0",
+            "createdBy": {
+                "email": None,
+                "id": 1,
+                "isAdmin": False,
+                "name": None,
+                "oauthProvider": "BASIC",
+                "username": "dj",
+            },
         },
     ]

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -11,6 +11,7 @@ from datajunction_server.database.attributetype import AttributeType, ColumnAttr
 from datajunction_server.database.column import Column
 from datajunction_server.database.database import Database
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import User
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.parsing.types import FloatType, IntegerType, StringType
 
@@ -415,6 +416,7 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
 async def test_read_metric(
     module__session: AsyncSession,
     module__client: AsyncClient,
+    module__current_user: User,
 ) -> None:
     """
     Test ``GET /metric/{node_id}/``.
@@ -449,12 +451,14 @@ async def test_read_metric(
                 order=3,
             ),
         ],
+        created_by_id=module__current_user.id,
     )
     parent_node = Node(
         name=parent_rev.name,
         namespace="default",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=module__current_user.id,
     )
     parent_rev.node = parent_node
 
@@ -463,6 +467,7 @@ async def test_read_metric(
         namespace="default",
         type=NodeType.METRIC,
         current_version="1",
+        created_by_id=module__current_user.id,
     )
     child_rev = NodeRevision(
         name=child_node.name,
@@ -471,6 +476,7 @@ async def test_read_metric(
         version="1",
         query="SELECT COUNT(*) FROM parent",
         parents=[parent_node],
+        created_by_id=module__current_user.id,
     )
 
     module__session.add(child_rev)
@@ -517,6 +523,7 @@ async def test_read_metric(
 async def test_read_metrics_errors(
     module__session: AsyncSession,
     module__client: AsyncClient,
+    module__current_user: User,
 ) -> None:
     """
     Test errors on ``GET /metrics/{node_id}/``.
@@ -527,6 +534,7 @@ async def test_read_metrics_errors(
         namespace="default",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=module__current_user.id,
     )
     node_revision = NodeRevision(
         name=node.name,
@@ -534,6 +542,7 @@ async def test_read_metrics_errors(
         node=node,
         version="1",
         query="SELECT 1 AS col",
+        created_by_id=module__current_user.id,
     )
     module__session.add(database)
     module__session.add(node_revision)

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -76,7 +76,11 @@ async def test_read_node(client_with_roads: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_read_nodes(session: AsyncSession, client: AsyncClient) -> None:
+async def test_read_nodes(
+    session: AsyncSession,
+    client: AsyncClient,
+    current_user: User,
+) -> None:
     """
     Test ``GET /nodes/``.
     """
@@ -84,17 +88,20 @@ async def test_read_nodes(session: AsyncSession, client: AsyncClient) -> None:
         name="not-a-metric",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=current_user.id,
     )
     node_rev1 = NodeRevision(
         node=node1,
         version="1",
         name=node1.name,
         type=node1.type,
+        created_by_id=current_user.id,
     )
     node2 = Node(
         name="also-not-a-metric",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=current_user.id,
     )
     node_rev2 = NodeRevision(
         name=node2.name,
@@ -105,8 +112,14 @@ async def test_read_nodes(session: AsyncSession, client: AsyncClient) -> None:
         columns=[
             Column(name="answer", type=IntegerType(), order=0),
         ],
+        created_by_id=current_user.id,
     )
-    node3 = Node(name="a-metric", type=NodeType.METRIC, current_version="1")
+    node3 = Node(
+        name="a-metric",
+        type=NodeType.METRIC,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
     node_rev3 = NodeRevision(
         name=node3.name,
         node=node3,
@@ -116,6 +129,7 @@ async def test_read_nodes(session: AsyncSession, client: AsyncClient) -> None:
             Column(name="_col0", type=IntegerType(), order=0),
         ],
         type=node3.type,
+        created_by_id=current_user.id,
     )
     session.add(node_rev1)
     session.add(node_rev2)
@@ -4569,7 +4583,11 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
 
 
 @pytest.mark.asyncio
-async def test_node_similarity(session: AsyncSession, client: AsyncClient):
+async def test_node_similarity(
+    session: AsyncSession,
+    client: AsyncClient,
+    current_user: User,
+):
     """
     Test determining node similarity based on their queries
     """
@@ -4577,17 +4595,20 @@ async def test_node_similarity(session: AsyncSession, client: AsyncClient):
         name="source_data",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=current_user.id,
     )
     source_data_rev = NodeRevision(
         node=source_data,
         version="1",
         name=source_data.name,
         type=source_data.type,
+        created_by_id=current_user.id,
     )
     a_transform = Node(
         name="a_transform",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=current_user.id,
     )
     a_transform_rev = NodeRevision(
         name=a_transform.name,
@@ -4598,11 +4619,13 @@ async def test_node_similarity(session: AsyncSession, client: AsyncClient):
         columns=[
             Column(name="num", type=IntegerType()),
         ],
+        created_by_id=current_user.id,
     )
     another_transform = Node(
         name="another_transform",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=current_user.id,
     )
     another_transform_rev = NodeRevision(
         name=another_transform.name,
@@ -4613,11 +4636,13 @@ async def test_node_similarity(session: AsyncSession, client: AsyncClient):
         columns=[
             Column(name="num", type=IntegerType()),
         ],
+        created_by_id=current_user.id,
     )
     yet_another_transform = Node(
         name="yet_another_transform",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=current_user.id,
     )
     yet_another_transform_rev = NodeRevision(
         name=yet_another_transform.name,
@@ -4628,6 +4653,7 @@ async def test_node_similarity(session: AsyncSession, client: AsyncClient):
         columns=[
             Column(name="num", type=IntegerType()),
         ],
+        created_by_id=current_user.id,
     )
     session.add(source_data_rev)
     session.add(a_transform_rev)

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -14,6 +14,7 @@ from datajunction_server.database.column import Column
 from datajunction_server.database.database import Database
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.queryrequest import QueryBuildType, QueryRequest
+from datajunction_server.database.user import User
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.models import access
 from datajunction_server.models.node_type import NodeType
@@ -26,6 +27,7 @@ from tests.sql.utils import assert_query_strings_equal, compare_query_strings
 async def test_sql(
     session: AsyncSession,
     client: AsyncClient,
+    current_user: User,
 ) -> None:
     """
     Test ``GET /sql/{name}/``.
@@ -36,6 +38,7 @@ async def test_sql(
         name="default.my_table",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=current_user.id,
     )
     source_node_rev = NodeRevision(
         name=source_node.name,
@@ -45,15 +48,22 @@ async def test_sql(
         table="my_table",
         columns=[Column(name="one", type=StringType(), order=0)],
         type=NodeType.SOURCE,
+        created_by_id=current_user.id,
     )
 
-    node = Node(name="default.a_metric", type=NodeType.METRIC, current_version="1")
+    node = Node(
+        name="default.a_metric",
+        type=NodeType.METRIC,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
     node_revision = NodeRevision(
         name=node.name,
         node=node,
         version="1",
         query="SELECT COUNT(*) FROM default.my_table",
         type=NodeType.METRIC,
+        created_by_id=current_user.id,
     )
     node_revision.parents = [source_node]
     session.add(database)

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -1,6 +1,8 @@
 """
 Fixtures for testing.
 """
+
+# pylint: disable=too-many-lines
 import asyncio
 import os
 import re
@@ -992,3 +994,51 @@ async def module__client_with_all_examples(
     Provides a DJ client fixture with all examples
     """
     return await module__client_example_loader(None)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def module__current_user(module__session: AsyncSession) -> User:
+    """
+    A user fixture.
+    """
+
+    new_user = User(
+        username="datajunction",
+        password="datajunction",
+        email="dj@datajunction.io",
+        name="DJ",
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=False,
+    )
+    existing_user = await module__session.get(User, new_user.id)
+    if not existing_user:
+        module__session.add(new_user)
+        await module__session.commit()
+        user = new_user
+    else:
+        user = existing_user
+    return user
+
+
+@pytest_asyncio.fixture
+async def current_user(session: AsyncSession) -> User:
+    """
+    A user fixture.
+    """
+
+    new_user = User(
+        username="datajunction",
+        password="datajunction",
+        email="dj@datajunction.io",
+        name="DJ",
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=False,
+    )
+    existing_user = await session.get(User, new_user.id)
+    if not existing_user:
+        session.add(new_user)
+        await session.commit()
+        user = new_user
+    else:
+        user = existing_user
+    return user

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -62,11 +62,11 @@ from .examples import COLUMN_MAPPINGS, EXAMPLES, QUERY_DATA_MAPPINGS, SERVICE_SE
 
 
 EXAMPLE_TOKEN = (
-    "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..pMoQFVS0VMSAFsG5X0itfw.Lc"
-    "8mo22qxeD1NQROlHkjFnmLiDXJGuhlSPcBOoQVlpQGbovHRHT7EJ9_vFGBqDGihul1"
-    "BcABiJT7kJtO6cZCJNkykHx-Cbz7GS_6ZQs1_kR5FzsvrJt5_X-dqehVxCFATjv64-"
-    "Lokgj9ciOudO2YoBW61UWoLdpmzX1A_OPgv9PlAX23owZrFbPcptcXSJPJQVwvvy8h"
-    "DgZ1M6YtqZt_T7o0G2QmFukk.e0ZFTP0H5zP4_wZA3sIrxw"
+    "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..SxGbG0NRepMY4z9-2-ZZdg.ug"
+    "0FvJUoybiGGpUItL4VbM1O_oinX7dMBUM1V3OYjv30fddn9m9UrrXxv3ERIyKu2zVJ"
+    "xx1gSoM5k8petUHCjatFQqA-iqnvjloFKEuAmxLdCHKUDgfKzCIYtbkDcxtzXLuqlj"
+    "B0-ConD6tpjMjFxNrp2KD4vwaS0oGsDJGqXlMo0MOhe9lHMLraXzOQ6xDgDFHiFert"
+    "Fc0T_9jYkcpmVDPl9pgPf55R.sKF18rttq1OZ_EjZqw8Www"
 )
 
 

--- a/datajunction-server/tests/construction/build_test.py
+++ b/datajunction-server/tests/construction/build_test.py
@@ -17,6 +17,7 @@ from datajunction_server.construction.build import (
 from datajunction_server.database.attributetype import AttributeType, ColumnAttribute
 from datajunction_server.database.column import Column
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import User
 from datajunction_server.errors import DJException
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.node_type import NodeType
@@ -135,6 +136,7 @@ async def test_build_metric_with_required_dimensions(
 @pytest.mark.asyncio
 async def test_raise_on_build_without_required_dimension_column(
     construction_session: AsyncSession,
+    current_user: User,
 ):
     """
     Test building a node that has a dimension reference without a column and a compound PK
@@ -148,6 +150,7 @@ async def test_raise_on_build_without_required_dimension_column(
         name="basic.dimension.compound_countries",
         type=NodeType.DIMENSION,
         current_version="1",
+        created_by_id=current_user.id,
     )
     NodeRevision(
         name=countries_dim_ref.name,
@@ -176,8 +179,14 @@ async def test_raise_on_build_without_required_dimension_column(
             ),
             Column(name="user_cnt", type=ct.IntegerType(), order=2),
         ],
+        created_by_id=current_user.id,
     )
-    node_foo_ref = Node(name="basic.foo", type=NodeType.TRANSFORM, current_version="1")
+    node_foo_ref = Node(
+        name="basic.foo",
+        type=NodeType.TRANSFORM,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
     node_foo = NodeRevision(
         name=node_foo_ref.name,
         type=node_foo_ref.type,
@@ -197,10 +206,16 @@ async def test_raise_on_build_without_required_dimension_column(
                 order=1,
             ),
         ],
+        created_by_id=current_user.id,
     )
     construction_session.add(node_foo)
 
-    node_bar_ref = Node(name="basic.bar", type=NodeType.TRANSFORM, current_version="1")
+    node_bar_ref = Node(
+        name="basic.bar",
+        type=NodeType.TRANSFORM,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
     node_bar = NodeRevision(
         name=node_bar_ref.name,
         type=node_bar_ref.type,
@@ -211,6 +226,7 @@ async def test_raise_on_build_without_required_dimension_column(
         columns=[
             Column(name="num_users", type=ct.IntegerType(), order=0),
         ],
+        created_by_id=current_user.id,
     )
     construction_session.add(node_bar)
     await construction_session.commit()
@@ -256,7 +272,10 @@ async def test_build_metric_with_dimensions_filters(construction_session: AsyncS
 
 
 @pytest.mark.asyncio
-async def test_build_node_with_unnamed_column(construction_session: AsyncSession):
+async def test_build_node_with_unnamed_column(
+    construction_session: AsyncSession,
+    current_user: User,
+):
     """
     Test building a node that has an unnamed column (so defaults to col<n>)
     """
@@ -265,6 +284,7 @@ async def test_build_node_with_unnamed_column(construction_session: AsyncSession
         display_name="foo",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=current_user.id,
     )
     node_foo = NodeRevision(
         node=node_foo_ref,
@@ -276,6 +296,7 @@ async def test_build_node_with_unnamed_column(construction_session: AsyncSession
         columns=[
             Column(name="col1", type=ct.IntegerType(), order=0),
         ],
+        created_by_id=current_user.id,
     )
     construction_session.add(node_foo)
     await construction_session.commit()

--- a/datajunction-server/tests/construction/fixtures.py
+++ b/datajunction-server/tests/construction/fixtures.py
@@ -12,6 +12,7 @@ from datajunction_server.database.attributetype import AttributeType, ColumnAttr
 from datajunction_server.database.column import Column
 from datajunction_server.database.database import Database
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import User
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.parsing.types import (
     DateType,
@@ -194,6 +195,7 @@ def build_expectation() -> Dict[str, Dict[Optional[int], Tuple[bool, str]]]:
 @pytest_asyncio.fixture
 async def construction_session(  # pylint: disable=too-many-locals
     session: AsyncSession,
+    current_user: User,
 ) -> AsyncSession:
     """
     Add some source nodes and transform nodes to facilitate testing of extracting dependencies
@@ -207,6 +209,7 @@ async def construction_session(  # pylint: disable=too-many-locals
         name="basic.dimension.countries",
         type=NodeType.DIMENSION,
         current_version="1",
+        created_by_id=current_user.id,
     )
     countries_dim = NodeRevision(
         name=countries_dim_ref.name,
@@ -228,12 +231,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             ),
             Column(name="user_cnt", type=IntegerType(), order=1),
         ],
+        created_by_id=current_user.id,
     )
 
     user_dim_ref = Node(
         name="basic.dimension.users",
         type=NodeType.DIMENSION,
         current_version="1",
+        created_by_id=current_user.id,
     )
     user_dim = NodeRevision(
         name=user_dim_ref.name,
@@ -264,12 +269,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="preferred_language", type=StringType(), order=5),
             Column(name="secret_number", type=FloatType(), order=6),
         ],
+        created_by_id=current_user.id,
     )
 
     country_agg_tfm_ref = Node(
         name="basic.transform.country_agg",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=current_user.id,
     )
     country_agg_tfm = NodeRevision(
         name=country_agg_tfm_ref.name,
@@ -292,12 +299,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             ),
             Column(name="num_users", type=IntegerType(), order=1),
         ],
+        created_by_id=current_user.id,
     )
 
     users_src_ref = Node(
         name="basic.source.users",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=current_user.id,
     )
     users_src = NodeRevision(
         name=users_src_ref.name,
@@ -332,12 +341,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="preferred_language", type=StringType(), order=7),
             Column(name="secret_number", type=FloatType(), order=8),
         ],
+        created_by_id=current_user.id,
     )
 
     comments_src_ref = Node(
         name="basic.source.comments",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=current_user.id,
     )
     comments_src = NodeRevision(
         name=comments_src_ref.name,
@@ -355,12 +366,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="timestamp", type=TimestampType(), order=2),
             Column(name="text", type=StringType(), order=3),
         ],
+        created_by_id=current_user.id,
     )
 
     num_comments_mtc_ref = Node(
         name="basic.num_comments",
         type=NodeType.METRIC,
         current_version="1",
+        created_by_id=current_user.id,
     )
     num_comments_mtc = NodeRevision(
         name=num_comments_mtc_ref.name,
@@ -375,12 +388,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="cnt", type=IntegerType(), order=0),
         ],
         parents=[comments_src_ref],
+        created_by_id=current_user.id,
     )
 
     num_comments_mtc_bnd_dims_ref = Node(
         name="basic.num_comments_bnd",
         type=NodeType.METRIC,
         current_version="1",
+        created_by_id=current_user.id,
     )
     num_comments_mtc_bnd_dims = NodeRevision(
         name=num_comments_mtc_bnd_dims_ref.name,
@@ -399,12 +414,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             comments_src.columns[0],  # pylint: disable=E1136
             comments_src.columns[-1],  # pylint: disable=E1136
         ],
+        created_by_id=current_user.id,
     )
 
     num_users_mtc_ref = Node(
         name="basic.num_users",
         type=NodeType.METRIC,
         current_version="1",
+        created_by_id=current_user.id,
     )
     num_users_mtc = NodeRevision(
         name=num_users_mtc_ref.name,
@@ -419,11 +436,13 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="col0", type=IntegerType(), order=0),
         ],
         parents=[country_agg_tfm_ref],
+        created_by_id=current_user.id,
     )
     num_users_us_join_mtc_ref = Node(
         name="basic.num_users_us",
         type=NodeType.METRIC,
         current_version="1",
+        created_by_id=current_user.id,
     )
     num_users_us_join_mtc = NodeRevision(
         name=num_users_us_join_mtc_ref.name,
@@ -445,11 +464,13 @@ async def construction_session(  # pylint: disable=too-many-locals
             ),
         ],
         parents=[country_agg_tfm_ref, users_src_ref],
+        created_by_id=current_user.id,
     )
     customers_dim_ref = Node(
         name="dbt.dimension.customers",
         type=NodeType.DIMENSION,
         current_version="1",
+        created_by_id=current_user.id,
     )
     customers_dim = NodeRevision(
         name=customers_dim_ref.name,
@@ -472,12 +493,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="first_name", type=StringType(), order=1),
             Column(name="last_name", type=StringType(), order=2),
         ],
+        created_by_id=current_user.id,
     )
 
     customers_agg_tfm_ref = Node(
         name="dbt.transform.customer_agg",
         type=NodeType.TRANSFORM,
         current_version="1",
+        created_by_id=current_user.id,
     )
     customers_agg_tfm = NodeRevision(
         name=customers_agg_tfm_ref.name,
@@ -501,12 +524,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="last_name", type=StringType(), order=2),
             Column(name="order_cnt", type=IntegerType(), order=3),
         ],
+        created_by_id=current_user.id,
     )
 
     orders_src_ref = Node(
         name="dbt.source.jaffle_shop.orders",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=current_user.id,
     )
     orders_src = NodeRevision(
         name=orders_src_ref.name,
@@ -526,12 +551,14 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="status", type=StringType(), order=3),
             Column(name="_etl_loaded_at", type=TimestampType(), order=4),
         ],
+        created_by_id=current_user.id,
     )
 
     customers_src_ref = Node(
         name="dbt.source.jaffle_shop.customers",
         type=NodeType.SOURCE,
         current_version="1",
+        created_by_id=current_user.id,
     )
     customers_src = NodeRevision(
         name=customers_src_ref.name,
@@ -543,6 +570,7 @@ async def construction_session(  # pylint: disable=too-many-locals
             Column(name="first_name", type=StringType(), order=1),
             Column(name="last_name", type=StringType(), order=2),
         ],
+        created_by_id=current_user.id,
     )
 
     session.add(postgres)

--- a/datajunction-server/tests/internal/authentication/basic_test.py
+++ b/datajunction-server/tests/internal/authentication/basic_test.py
@@ -161,4 +161,7 @@ async def test_whoami(client: AsyncClient):
         "name": None,
         "oauth_provider": "basic",
         "is_admin": False,
+        "created_collections": [],
+        "created_nodes": [],
+        "created_tags": [],
     }

--- a/datajunction-server/tests/internal/authentication/http_test.py
+++ b/datajunction-server/tests/internal/authentication/http_test.py
@@ -11,11 +11,11 @@ from datajunction_server.internal.access.authentication.http import DJHTTPBearer
 from datajunction_server.models.user import OAuthProvider, UserOutput
 
 EXAMPLE_TOKEN = (
-    "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..pMoQFVS0VMSAFsG5X0itfw.Lc"
-    "8mo22qxeD1NQROlHkjFnmLiDXJGuhlSPcBOoQVlpQGbovHRHT7EJ9_vFGBqDGihul1"
-    "BcABiJT7kJtO6cZCJNkykHx-Cbz7GS_6ZQs1_kR5FzsvrJt5_X-dqehVxCFATjv64-"
-    "Lokgj9ciOudO2YoBW61UWoLdpmzX1A_OPgv9PlAX23owZrFbPcptcXSJPJQVwvvy8h"
-    "DgZ1M6YtqZt_T7o0G2QmFukk.e0ZFTP0H5zP4_wZA3sIrxw"
+    "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..SxGbG0NRepMY4z9-2-ZZdg.ug"
+    "0FvJUoybiGGpUItL4VbM1O_oinX7dMBUM1V3OYjv30fddn9m9UrrXxv3ERIyKu2zVJ"
+    "xx1gSoM5k8petUHCjatFQqA-iqnvjloFKEuAmxLdCHKUDgfKzCIYtbkDcxtzXLuqlj"
+    "B0-ConD6tpjMjFxNrp2KD4vwaS0oGsDJGqXlMo0MOhe9lHMLraXzOQ6xDgDFHiFert"
+    "Fc0T_9jYkcpmVDPl9pgPf55R.sKF18rttq1OZ_EjZqw8Www"
 )
 
 
@@ -86,6 +86,9 @@ def test_dj_http_bearer_w_cookie():
         "name": None,
         "oauth_provider": OAuthProvider.BASIC,
         "is_admin": False,
+        "created_collections": [],
+        "created_nodes": [],
+        "created_tags": [],
     }
 
 
@@ -105,6 +108,9 @@ def test_dj_http_bearer_w_auth_headers():
         "name": None,
         "oauth_provider": OAuthProvider.BASIC,
         "is_admin": False,
+        "created_collections": [],
+        "created_nodes": [],
+        "created_tags": [],
     }
 
 

--- a/datajunction-server/tests/utils_test.py
+++ b/datajunction-server/tests/utils_test.py
@@ -159,7 +159,7 @@ async def test_get_and_update_current_user(session: AsyncSession):
 
     # Confirm that the user was upserted
     result = await session.execute(select(User).where(User.username == "userfoo"))
-    found_user = result.scalar_one_or_none()
+    found_user = result.unique().scalar_one_or_none()
     assert found_user.id == 1
     assert found_user.username == "userfoo"
     assert (


### PR DESCRIPTION
### Summary

Now that the current authenticated user is required and reliably available, this adds a `created_by_id` attribute for `Node`, `NodeRevision`, `Collection`, and `Tag` that stores the ID of the user that created that entity. The database change is pretty minimal, just adding that column and updating the sqlalchemy models to configure the back populates so that you can do `user.created_nodes -> List[Node]`, `user.created_collections -> List[Collection]`, etc. A good chunk of this PR is addressing two side effects from this:

- Instantiating any of these models now require that you include `created_by_id`, so I had to make that change everywhere and make sure `current_user` is passed into all of the places this happens
- The alembic upgrade has to deal with the fact that existing deployments have not been tracking this directly up until this change. What I do there is I just backfill `created_by_id=1` everywhere (since it's required) and then that allows a manual backfill later if the creating user can be figured out through other means like scanning the history table.

One other thing I did is add a `User` scalar for the graphql endpoint and updated the resolver for `findNode` so that it also can pull in the information of the creating user via a `createdBy` field.

```gql
{
  findNodes(names: ["users.sredai.a_test_transform"]) {
    name
    createdAt
    currentVersion
    deactivatedAt
    id
    createdBy {
      email
      id
      isAdmin
      name
      oauthProvider
      username
    }
  }
}
```
### Test Plan

Updated all of the relevant tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
