### PR TITLE
Adding '/data/{node_name}' path to fetch data for a single node

### DIFF
--- a/datajunction-clients/python/README.md
+++ b/datajunction-clients/python/README.md
@@ -130,7 +130,18 @@ List of all available DJ client methods:
         filters: Optional[List[str]],
         engine_name: Optional[str],
         engine_version: Optional[str])
+  - node_sql( node_name: str,
+        dimensions: Optional[List[str]],
+        filters: Optional[List[str]],
+        engine_name: Optional[str],
+        engine_version: Optional[str])
   - data( metrics: List[str],
+        dimensions: Optional[List[str]],
+        filters: Optional[List[str]],
+        engine_name: Optional[str],
+        engine_version: Optional[str],
+        async_: bool = True)
+  - node_data( node_name: str,
         dimensions: Optional[List[str]],
         filters: Optional[List[str]],
         engine_name: Optional[str],

--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -298,8 +298,10 @@ class DJClient(_internal.DJClient):
 
             if node_name:
                 path = f"{path}{node_name}"
-            elif metrics:
-                params["metrics"] = metrics
+            elif metrics:  # pragma: no cover
+                params["metrics"] = metrics  # pragma: no cover
+
+            print(f"Fetching data for '{node_name}' or '{metrics}'")  # pragma: no cover
 
             while job_state not in models.END_JOB_STATES:
                 progress_bar()  # pylint: disable=not-callable

--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -226,7 +226,50 @@ class DJClient(_internal.DJClient):
         async_: bool = True,
     ):
         """
+        Retrieves the data for one or more metrics with the provided dimensions and filters.
+        """
+        return self._data(
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=filters,
+            engine_name=engine_name,
+            engine_version=engine_version,
+            async_=async_,
+        )
+
+    def node_data(  # pylint: disable=too-many-arguments,too-many-locals
+        self,
+        node_name: str,
+        dimensions: Optional[List[str]] = None,
+        filters: Optional[List[str]] = None,
+        engine_name: Optional[str] = None,
+        engine_version: Optional[str] = None,
+        async_: bool = True,
+    ):
+        """
         Retrieves the data for the node with the provided dimensions and filters.
+        """
+        return self._data(
+            node_name=node_name,
+            dimensions=dimensions,
+            filters=filters,
+            engine_name=engine_name,
+            engine_version=engine_version,
+            async_=async_,
+        )
+
+    def _data(  # pylint: disable=too-many-arguments,too-many-locals
+        self,
+        node_name: Optional[str] = None,
+        metrics: Optional[List[str]] = None,
+        dimensions: Optional[List[str]] = None,
+        filters: Optional[List[str]] = None,
+        engine_name: Optional[str] = None,
+        engine_version: Optional[str] = None,
+        async_: bool = True,
+    ):
+        """
+        Fetch data for a node or a set of metrics with dimensions and filters.
         """
         printed_links = False
         with alive_bar(
@@ -239,18 +282,30 @@ class DJClient(_internal.DJClient):
             poll_interval = 1  # Initial polling interval in seconds
             job_state = models.QueryState.UNKNOWN
             results = None
+            path = "/data/"
+            params = {
+                "dimensions": dimensions or [],
+                "filters": filters or [],
+                "engine_name": engine_name or self.engine_name,
+                "engine_version": engine_version or self.engine_version,
+                "async_": async_,
+            }
+
+            if (node_name and metrics) or not (node_name or metrics):
+                raise DJClientException(
+                    "Must supply either 'node_name' or 'metrics' to fetch data.",
+                )
+
+            if node_name:
+                path = f"{path}{node_name}"
+            elif metrics:
+                params["metrics"] = metrics
+
             while job_state not in models.END_JOB_STATES:
                 progress_bar()  # pylint: disable=not-callable
                 response = self._session.get(
-                    "/data/",
-                    params={
-                        "metrics": metrics,
-                        "dimensions": dimensions or [],
-                        "filters": filters or [],
-                        "engine_name": engine_name or self.engine_name,
-                        "engine_version": engine_version or self.engine_version,
-                        "async_": async_,
-                    },
+                    path,
+                    params=params,
                 )
                 results = response.json()
 

--- a/datajunction-clients/python/tests/examples.py
+++ b/datajunction-clients/python/tests/examples.py
@@ -1207,4 +1207,34 @@ QUERY_DATA_MAPPINGS: Dict[str, Union[DJException, QueryWithResults]] = {
             "errors": [],
         }
     ),
+    "SELECTavg(default_DOT_repair_order_details.price)ASdefault_DOT_avg_repair_price,\tdefault"
+    "_DOT_hard_hat.citydefault_DOT_hard_hat_DOT_cityFROMroads.repair_order_detailsASdefault_"
+    "DOT_repair_order_detailsLEFTJOIN(SELECTdefault_DOT_repair_orders.repair_order_id,\tdefault_"
+    "DOT_repair_orders.municipality_id,\tdefault_DOT_repair_orders.hard_hat_id,\tdefault_DOT_"
+    "repair_orders.dispatcher_idFROMroads.repair_ordersASdefault_DOT_repair_orders)ASdefault_"
+    "DOT_repair_orderONdefault_DOT_repair_order_details.repair_order_id=default_DOT_repair_order"
+    ".repair_order_idLEFTJOIN(SELECTdefault_DOT_hard_hats.hard_hat_id,\tdefault_DOT_hard_hats."
+    "city,\tdefault_DOT_hard_hats.stateFROMroads.hard_hatsASdefault_DOT_hard_hats)ASdefault_DOT_"
+    "hard_hatONdefault_DOT_repair_order.hard_hat_id=default_DOT_hard_hat.hard_hat_idGROUPBY"
+    "default_DOT_hard_hat.city": QueryWithResults(
+        **{
+            "id": "bd98d6be-e2d2-413e-94c7-96d9411ddee2",
+            "submitted_query": "...",
+            "state": QueryState.FINISHED,
+            "results": [
+                {
+                    "columns": [
+                        {"name": "default_DOT_avg_repair_price", "type": "float"},
+                        {"name": "default_DOT_hard_hat_DOT_city", "type": "str"},
+                    ],
+                    "rows": [
+                        (1.0, "Foo"),
+                        (2.0, "Bar"),
+                    ],
+                    "sql": "",
+                },
+            ],
+            "errors": [],
+        }
+    ),
 }

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -340,17 +340,31 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         """
         Test data retreval for a metric and dimension(s)
         """
-        # Retrieve data for a single metric
-        result = client.data(
-            metrics=["default.avg_repair_price"],
-            dimensions=["default.hard_hat.city"],
-        )
+        # Should throw error when no name or metrics are passed in
+        with pytest.raises(DJClientException):
+            client.node_data("")
 
+        with pytest.raises(DJClientException):
+            client.data([])
+
+        # Retrieve data for a single metric
         expected_df = pandas.DataFrame.from_dict(
             {
                 "default_DOT_avg_repair_price": [1.0, 2.0],
                 "default_DOT_hard_hat_DOT_city": ["Foo", "Bar"],
             },
+        )
+
+        result = client.data(
+            metrics=["default.avg_repair_price"],
+            dimensions=["default.hard_hat.city"],
+        )
+        pandas.testing.assert_frame_equal(result, expected_df)
+
+        # Retrieve data for a single node
+        result = client.node_data(
+            node_name="default.avg_repair_price",
+            dimensions=["default.hard_hat.city"],
         )
         pandas.testing.assert_frame_equal(result, expected_df)
 

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -429,7 +429,7 @@ async def get_data_stream_for_metrics(  # pylint: disable=R0914, R0913
     engine_version: Optional[str] = None,
 ) -> QueryWithResults:
     """
-    Return data for a set of metrics with dimensions and filters using server side events
+    Return data for a set of metrics with dimensions and filters using server sent events
     """
     request_headers = dict(request.headers)
     translated_sql, engine, catalog = await build_sql_for_multiple_metrics(


### PR DESCRIPTION
### Summary
The `.data()` method in the client currently only supports fetching a set of metrics by name, with dimensions and filters attached. However, there are cases where fetching an entire node works better, but that endpoint wasn't supported in the client until now.

### Test Plan
Unit tests updated.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan
Normal release.