### PR TITLE
Always refresh the user object after getting current user from th…

### DIFF
--- a/datajunction-server/datajunction_server/database/user.py
+++ b/datajunction-server/datajunction_server/database/user.py
@@ -1,12 +1,11 @@
 """User database schema."""
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import BigInteger, Enum, Integer, String, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
-from sqlalchemy.sql.base import ExecutableOption
 from datajunction_server.enum import StrEnum
 
 if TYPE_CHECKING:

--- a/datajunction-server/datajunction_server/database/user.py
+++ b/datajunction-server/datajunction_server/database/user.py
@@ -1,10 +1,12 @@
 """User database schema."""
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import BigInteger, Enum, Integer, String
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import BigInteger, Enum, Integer, String, select
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
+from sqlalchemy.sql.base import ExecutableOption
 from datajunction_server.enum import StrEnum
 
 if TYPE_CHECKING:
@@ -63,3 +65,16 @@ class User(Base):  # pylint: disable=too-few-public-methods
         foreign_keys="Tag.created_by_id",
         lazy="joined",
     )
+
+    @classmethod
+    async def get_by_username(
+        cls,
+        session: AsyncSession,
+        username: str,
+    ) -> Optional["User"]:
+        """
+        Find a user by username
+        """
+        statement = select(User).where(User.username == username)
+        result = await session.execute(statement)
+        return result.unique().scalar_one_or_none()

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -289,7 +289,8 @@ async def get_and_update_current_user(
     )
     await session.execute(statement)
     await session.commit()
-    return current_user
+    refreshed_user = await User.get_by_username(session, current_user.username)
+    return refreshed_user
 
 
 SEPARATOR = "."

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -290,7 +290,7 @@ async def get_and_update_current_user(
     await session.execute(statement)
     await session.commit()
     refreshed_user = await User.get_by_username(session, current_user.username)
-    return refreshed_user
+    return refreshed_user  # type: ignore
 
 
 SEPARATOR = "."

--- a/datajunction-server/tests/utils_test.py
+++ b/datajunction-server/tests/utils_test.py
@@ -137,6 +137,7 @@ def test_version_parse() -> None:
     assert str(excinfo.value) == "Unparseable version 0!"
 
 
+@pytest.mark.asyncio
 async def test_get_and_update_current_user(session: AsyncSession):
     """
     Test upserting the current user
@@ -155,7 +156,8 @@ async def test_get_and_update_current_user(session: AsyncSession):
         session=session,
         current_user=example_user,
     )
-    assert current_user == example_user
+    assert current_user.id == example_user.id
+    assert current_user.username == example_user.username
 
     # Confirm that the user was upserted
     result = await session.execute(select(User).where(User.username == "userfoo"))


### PR DESCRIPTION
### Summary

There's a bug where because we don't refresh the user object after retrieving the current user from the request, we don't have an updated `User` object with the right `id` value, causing node edits to fail.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A