### PR TITLE
Add register_view as another way to create Source nodes.

### DIFF
--- a/datajunction-clients/python/README.md
+++ b/datajunction-clients/python/README.md
@@ -350,6 +350,7 @@ List of all available DJ builder methods:
   - source(self, node_name: str)
   - create_source( ..., mode: Optional[NodeMode] = NodeMode.PUBLISHED)
   - register_table( catalog: str, schema: str, table: str)
+  - register_view( catalog: str, schema: str, view: str, query: str, replace: bool = False)
 
   ### nodes: transform
   - transform(self, node_name: str)

--- a/datajunction-clients/python/datajunction/exceptions.py
+++ b/datajunction-clients/python/datajunction/exceptions.py
@@ -53,3 +53,16 @@ class DJTableAlreadyRegistered(DJClientException):
     def __init__(self, catalog: str, schema: str, table: str, *args) -> None:
         self.message = f"Table `{catalog}.{schema}.{table}` is already registered."
         super().__init__(self.message, *args)
+
+
+class DJViewAlreadyRegistered(DJClientException):
+    """
+    Raised when a view is already regsistered in DJ.
+    """
+
+    def __init__(self, catalog: str, schema: str, view: str, *args) -> None:
+        self.message = (
+            f"View `{catalog}.{schema}.{view}` is already registered, "
+            "use replace=True to force a refresh."
+        )
+        super().__init__(self.message, *args)

--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -165,6 +165,21 @@ def query_service_client(mocker: MockerFixture) -> Iterator[QueryServiceClient]:
         mock_submit_query,
     )
 
+    def mock_create_view(
+        view_name: str,
+        query_create: QueryCreate,  # pylint: disable=unused-argument
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
+    ) -> str:
+        return f"View {view_name} created successfully."
+
+    mocker.patch.object(
+        qs_client,
+        "create_view",
+        mock_create_view,
+    )
+
     mock_materialize = MagicMock()
     mock_materialize.return_value = MaterializationInfo(
         urls=["http://fake.url/job"],

--- a/datajunction-clients/python/tests/examples.py
+++ b/datajunction-clients/python/tests/examples.py
@@ -1135,6 +1135,12 @@ COLUMN_MAPPINGS = {
         Column(name="timestamp", type=TimestampType()),
         Column(name="text", type=StringType()),
     ],
+    "default.store.comments_view": [
+        Column(name="id", type=IntegerType()),
+        Column(name="user_id", type=IntegerType()),
+        Column(name="timestamp", type=TimestampType()),
+        Column(name="text", type=StringType()),
+    ],
 }
 
 QUERY_DATA_MAPPINGS: Dict[str, Union[DJException, QueryWithResults]] = {

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -685,12 +685,6 @@ class NodeRevision(
         """
         Extra validation for node data.
         """
-        if self.type in (NodeType.SOURCE,):
-            if self.query:
-                raise DJInvalidInputException(
-                    f"Node {self.name} of type {self.type} should not have a query",
-                )
-
         if self.type in {NodeType.TRANSFORM, NodeType.METRIC, NodeType.DIMENSION}:
             if not self.query:
                 raise DJInvalidInputException(

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -687,6 +687,8 @@ class CreateSourceNode(ImmutableNodeFields, MutableNodeFields, SourceNodeFields)
     A create object for source nodes
     """
 
+    query: Optional[str] = None
+
 
 class CreateCubeNode(ImmutableNodeFields, MutableNodeFields, CubeNodeFields):
     """

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -105,7 +105,10 @@ async def get_downstream_nodes(
 
     # Calculate the maximum depth for each node
     max_depths = (
-        select(paths.c.node_id, func.max(paths.c.depth).label("max_depth"))
+        select(
+            paths.c.node_id,
+            func.max(paths.c.depth).label("max_depth"),  # pylint: disable=not-callable
+        )
         .group_by(paths.c.node_id)
         .cte("max_depths")
     )

--- a/datajunction-server/tests/api/measures_test.py
+++ b/datajunction-server/tests/api/measures_test.py
@@ -212,14 +212,14 @@ async def test_edit_measure(
         "additive": "non-additive",
         "columns": [
             {
-                "name": "completed_repairs",
-                "node": "default.regional_level_agg",
-                "type": "bigint",
-            },
-            {
                 "name": "total_amount_nationwide",
                 "node": "default.national_level_agg",
                 "type": "double",
+            },
+            {
+                "name": "completed_repairs",
+                "node": "default.regional_level_agg",
+                "type": "bigint",
             },
         ],
         "description": "random description",

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -30,7 +30,7 @@ async def test_list_all_namespaces(
         {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
         {"namespace": "dbt.source.stripe", "num_nodes": 1},
         {"namespace": "dbt.transform", "num_nodes": 1},
-        {"namespace": "default", "num_nodes": 62},
+        {"namespace": "default", "num_nodes": 63},
         {
             "namespace": "different.basic",
             "num_nodes": 2,
@@ -666,6 +666,7 @@ async def test_export_namespaces(client_with_roads: AsyncClient):
         "us_region.source.yaml",
         "us_state.dimension.yaml",
         "us_states.source.yaml",
+        "repair_orders_view.source.yaml",
     }
     assert {d["directory"] for d in project_definition} == {""}
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -208,6 +208,7 @@ async def test_get_nodes_with_details(client_with_examples: AsyncClient):
         "default.contractor",
         "foo.bar.total_repair_order_discounts",
         "default.repair_orders",
+        "default.repair_orders_view",
         "basic.paint_colors_spark",
         "default.long_events",
         "default.items",
@@ -1572,7 +1573,9 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         """
         Trying to register a view without a query service set up should fail.
         """
-        response = await client.post("/register/view/foo/bar/baz/?query=SELECT+1")
+        response = await client.post(
+            "/register/view/foo/bar/baz/?query=SELECT+1&replace=True",
+        )
         data = response.json()
         assert data["message"] == (
             "Registering tables or views requires that a query "
@@ -1589,18 +1592,18 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         Registering a view with a query service set up should succeed.
         """
         response = await module__client_with_basic.post(
-            "/register/view/public/basic/view_foo?"
-            "query=SELECT+1+AS+one+,+'two'+AS+two&replace=True",
+            "/register/view/public/main/view_foo?"
+            "query=SELECT+1+AS+one+,+'two'+AS+two",
         )
         data = response.json()
-        assert data["name"] == "source.public.basic.view_foo"
+        assert data["name"] == "source.public.main.view_foo"
         assert data["type"] == "source"
-        assert data["display_name"] == "source.public.basic.view_foo"
+        assert data["display_name"] == "source.public.main.view_foo"
         assert data["version"] == "v1.0"
         assert data["status"] == "valid"
         assert data["mode"] == "published"
         assert data["catalog"]["name"] == "public"
-        assert data["schema_"] == "basic"
+        assert data["schema_"] == "main"
         assert data["table"] == "view_foo"
         assert data["columns"] == [
             {
@@ -1683,12 +1686,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
     @pytest.mark.asyncio
     async def test_refresh_source_node(
         self,
-        client_with_query_service_example_loader,
+        module__client_with_roads,
     ):
         """
         Refresh a source node with a query service
         """
-        custom_client = await client_with_query_service_example_loader(["ROADS"])
+        custom_client = module__client_with_roads
         response = await custom_client.post(
             "/nodes/default.repair_orders/refresh/",
         )
@@ -1818,20 +1821,19 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
     @pytest.mark.asyncio
     async def test_refresh_source_node_with_problems(
         self,
-        client_with_query_service_example_loader,
-        query_service_client: QueryServiceClient,
+        module__client_with_roads,
+        module__query_service_client: QueryServiceClient,
         mocker: MockerFixture,
     ):
         """
         Refresh a source node with a query service and find that no columns are returned.
         """
-        custom_client = await client_with_query_service_example_loader(["ROADS"])
-        response = await custom_client.post(
+        response = await module__client_with_roads.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data = response.json()
 
-        the_good_columns = query_service_client.get_columns_for_table(
+        the_good_columns = module__query_service_client.get_columns_for_table(
             "default",
             "roads",
             "repair_orders",
@@ -1845,7 +1847,9 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert data["status"] == "valid"
         assert data["missing_table"] is False
 
-        response = await custom_client.get("/history?node=default.repair_orders")
+        response = await module__client_with_roads.get(
+            "/history?node=default.repair_orders",
+        )
         history = response.json()
         assert [
             (activity["activity_type"], activity["entity_type"]) for activity in history
@@ -1858,11 +1862,11 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Refresh it again, but this time no columns are found
         mocker.patch.object(
-            query_service_client,
+            module__query_service_client,
             "get_columns_for_table",
             lambda *args: [],
         )
-        response = await custom_client.post(
+        response = await module__client_with_roads.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_second = response.json()
@@ -1874,13 +1878,13 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Refresh it again, but this time the table is missing
         mocker.patch.object(
-            query_service_client,
+            module__query_service_client,
             "get_columns_for_table",
             lambda *args: (_ for _ in ()).throw(
                 DJDoesNotExistException(message="Table not found: foo.bar.baz"),
             ),
         )
-        response = await custom_client.post(
+        response = await module__client_with_roads.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_third = response.json()
@@ -1892,11 +1896,11 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
 
         # Refresh it again, back to normal state
         mocker.patch.object(
-            query_service_client,
+            module__query_service_client,
             "get_columns_for_table",
             lambda *args: the_good_columns,
         )
-        response = await custom_client.post(
+        response = await module__client_with_roads.post(
             "/nodes/default.repair_orders/refresh/",
         )
         data_fourth = response.json()
@@ -1905,6 +1909,102 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         assert len(data_fourth["columns"]) == 8
         assert data_fourth["status"] == "valid"
         assert data_fourth["missing_table"] is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_source_node_with_query(
+        self,
+        module__client_with_roads,
+    ):
+        """
+        Refresh a source node based on a view.
+        """
+        custom_client = module__client_with_roads
+        response = await custom_client.post(
+            "/nodes/default.repair_orders_view/refresh/",
+        )
+        data = response.json()
+
+        # Columns have changed, so the new node revision should be bumped to a new
+        # version with an additional `ratings` column. Existing dimension links remain
+        new_columns = [
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Repair Order Id",
+                "name": "repair_order_id",
+                "type": "int",
+                "partition": None,
+            },
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Municipality Id",
+                "name": "municipality_id",
+                "type": "string",
+                "partition": None,
+            },
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Hard Hat Id",
+                "name": "hard_hat_id",
+                "type": "int",
+                "partition": None,
+            },
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Order Date",
+                "name": "order_date",
+                "type": "timestamp",
+                "partition": None,
+            },
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Required Date",
+                "name": "required_date",
+                "type": "timestamp",
+                "partition": None,
+            },
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Dispatched Date",
+                "name": "dispatched_date",
+                "type": "timestamp",
+                "partition": None,
+            },
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Dispatcher Id",
+                "name": "dispatcher_id",
+                "type": "int",
+                "partition": None,
+            },
+            {
+                "attributes": [],
+                "dimension": None,
+                "display_name": "Rating",
+                "name": "rating",
+                "type": "int",
+                "partition": None,
+            },
+        ]
+
+        assert data["version"] == "v2.0"
+        assert data["columns"] == new_columns
+        assert response.status_code == 201
+
+        response = await custom_client.get("/history?node=default.repair_orders_view")
+        history = response.json()
+        assert [
+            (activity["activity_type"], activity["entity_type"]) for activity in history
+        ] == [
+            ("refresh", "node"),
+            ("create", "node"),
+        ]
 
     @pytest.mark.asyncio
     async def test_create_update_source_node(

--- a/datajunction-server/tests/api/users_test.py
+++ b/datajunction-server/tests/api/users_test.py
@@ -18,7 +18,7 @@ class TestUsers:
         """
 
         response = await module__client_with_roads.get("/users?with_activity=true")
-        assert response.json() == [{"username": "dj", "count": 67}]
+        assert response.json() == [{"username": "dj", "count": 68}]
 
         response = await module__client_with_roads.get("/users")
         assert response.json() == ["dj"]
@@ -33,8 +33,9 @@ class TestUsers:
         """
 
         response = await module__client_with_roads.get("/users/dj")
-        assert [(node["name"], node["type"]) for node in response.json()] == [
+        assert {(node["name"], node["type"]) for node in response.json()} == {
             ("default.repair_orders", "source"),
+            ("default.repair_orders_view", "source"),
             ("default.repair_order_details", "source"),
             ("default.repair_type", "source"),
             ("default.contractors", "source"),
@@ -69,4 +70,4 @@ class TestUsers:
             ("default.total_repair_order_discounts", "metric"),
             ("default.avg_repair_order_discounts", "metric"),
             ("default.avg_time_to_dispatch", "metric"),
-        ]
+        }

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -244,6 +244,22 @@ def query_service_client(
         mock_submit_query,
     )
 
+    def mock_create_view(
+        view_name: str,
+        query_create: QueryCreate,
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
+    ) -> str:
+        duckdb_conn.sql(query_create.submitted_query)
+        return f"View {view_name} created successfully."
+
+    mocker.patch.object(
+        qs_client,
+        "create_view",
+        mock_create_view,
+    )
+
     def mock_get_query(
         query_id: str,
         request_headers: Optional[  # pylint: disable=unused-argument
@@ -919,6 +935,22 @@ def module__query_service_client(
         qs_client,
         "submit_query",
         mock_submit_query,
+    )
+
+    def mock_create_view(
+        view_name: str,
+        query_create: QueryCreate,
+        request_headers: Optional[  # pylint: disable=unused-argument
+            Dict[str, str]
+        ] = None,
+    ) -> str:
+        duckdb_conn.sql(query_create.submitted_query)
+        return f"View {view_name} created successfully."
+
+    module_mocker.patch.object(
+        qs_client,
+        "create_view",
+        mock_create_view,
     )
 
     def mock_get_query(

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -2428,6 +2428,10 @@ COLUMN_MAPPINGS = {
         Column(name="dispatcher_id", type=IntegerType(), order=6),
         Column(name="rating", type=IntegerType(), order=7),
     ],
+    "public.basic.view_foo": [
+        Column(name="one", type=IntegerType(), order=0),
+        Column(name="two", type=StringType(), order=1),
+    ],
 }
 
 QUERY_DATA_MAPPINGS = {

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -81,6 +81,27 @@ ROADS = (  # type: ignore
         {
             "columns": [
                 {"name": "repair_order_id", "type": "int"},
+                {"name": "municipality_id", "type": "string"},
+                {"name": "hard_hat_id", "type": "int"},
+                {"name": "order_date", "type": "timestamp"},
+                {"name": "required_date", "type": "timestamp"},
+                {"name": "dispatched_date", "type": "timestamp"},
+                {"name": "dispatcher_id", "type": "int"},
+            ],
+            "description": "All repair orders (view)",
+            "mode": "published",
+            "name": "default.repair_orders_view",
+            "catalog": "default",
+            "schema_": "roads",
+            "table": "repair_orders_view",
+            "query": "CREATE OR REPLACE VIEW roads.repair_orders_view AS SELECT * FROM roads.repair_orders",
+        },
+    ),
+    (
+        "/nodes/source/",
+        {
+            "columns": [
+                {"name": "repair_order_id", "type": "int"},
                 {"name": "repair_type_id", "type": "int"},
                 {"name": "price", "type": "float"},
                 {"name": "quantity", "type": "int"},
@@ -2428,7 +2449,17 @@ COLUMN_MAPPINGS = {
         Column(name="dispatcher_id", type=IntegerType(), order=6),
         Column(name="rating", type=IntegerType(), order=7),
     ],
-    "public.basic.view_foo": [
+    "default.roads.repair_orders_view": [
+        Column(name="repair_order_id", type=IntegerType(), order=0),
+        Column(name="municipality_id", type=StringType(), order=1),
+        Column(name="hard_hat_id", type=IntegerType(), order=2),
+        Column(name="order_date", type=TimestampType(), order=3),
+        Column(name="required_date", type=TimestampType(), order=4),
+        Column(name="dispatched_date", type=TimestampType(), order=5),
+        Column(name="dispatcher_id", type=IntegerType(), order=6),
+        Column(name="rating", type=IntegerType(), order=7),
+    ],
+    "public.main.view_foo": [
         Column(name="one", type=IntegerType(), order=0),
         Column(name="two", type=StringType(), order=1),
     ],

--- a/datajunction-server/tests/models/node_test.py
+++ b/datajunction-server/tests/models/node_test.py
@@ -47,18 +47,6 @@ def test_extra_validation() -> None:
     """
     Test ``extra_validation``.
     """
-    node = Node(name="A", type=NodeType.SOURCE, current_version="1")
-    node_revision = NodeRevision(
-        name=node.name,
-        type=node.type,
-        node=node,
-        version="1",
-        query="SELECT * FROM B",
-    )
-    with pytest.raises(Exception) as excinfo:
-        node_revision.extra_validation()
-    assert str(excinfo.value) == "Node A of type source should not have a query"
-
     node = Node(name="A", type=NodeType.METRIC, current_version="1")
     node_revision = NodeRevision(
         name=node.name,


### PR DESCRIPTION
### Summary

This adds the ability for DJ to create Source nodes based on database views, but with the extra option of creating the view first. This does not mean that DJ will maintain that view. Only that we use the query param verbatim to build a view and if it is successful we create a source node on top of it. DJ will also store the view SQL but will not do anything with it for now. The feature of allowing this query SQL to be updated could be a future feature.

### Test Plan

Unit tests.

- [x] PR has an associated issue: #1127 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

n/a
