### PR TITLE
Fix issue with null tag description

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -77,7 +77,7 @@ class Tag:  # pylint: disable=too-few-public-methods
     """
 
     name: str
-    description: str = ""
+    description: Optional[str]
     tag_type: str
     tag_metadata: JSON
 


### PR DESCRIPTION
### Summary

The GraphQL findNodes query should be able to return tags that have a null description successfully. It currently errors out because the output schema enforces that description is non-null, when the underlying tags' database schema allows for a null description value.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
