### PR TITLE
Increase NODE_LIST_MAX to 10000 and set cache expiration to every 3m

### DIFF
--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -89,7 +89,7 @@ class Settings(
     google_oauth_client_secret_file: Optional[str] = None
 
     # Interval in seconds with which to expire caching of any indexes
-    index_cache_expire = 60
+    index_cache_expire = 180
 
     # SQLAlchemy engine config
     db_pool_size = 20

--- a/datajunction-server/datajunction_server/constants.py
+++ b/datajunction-server/datajunction_server/constants.py
@@ -20,4 +20,4 @@ AUTH_COOKIE = "__dj"
 LOGGED_IN_FLAG_COOKIE = "__djlif"
 
 # Maximum amount of nodes to return for requests to list all nodes
-NODE_LIST_MAX = 1000
+NODE_LIST_MAX = 10000


### PR DESCRIPTION
### Summary

This improves the DJ search to allow for more nodes to be included in the index (10,000 instead of 1,000) which should be performant enough now that the index endpoint is cached. I also set the cache interval for that endpoint to 3 minutes.

### Test Plan

Ran everything locally with `docker compose --profile=demo up` and test the search with a few thousand nodes.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
