### PR TITLE
Fix from_json function to parse the specified schema

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2185,20 +2185,22 @@ class FromJson(Function):  # pragma: no cover
 
 
 @FromJson.register  # type: ignore
-def infer_type(  # pragma: no cover
+def infer_type(
     json: ct.StringType,
     schema: ct.StringType,
     options: Optional[Function] = None,
 ) -> ct.StructType:
-    # TODO: Handle options?  # pylint: disable=fixme
     # pylint: disable=import-outside-toplevel
     from datajunction_server.sql.parsing.backends.antlr4 import (
-        parse_rule,  # pragma: no cover
+        parse_rule,
     )
-
-    return ct.StructType(
-        *parse_rule(schema.value, "complexColTypeList")
-    )  # pragma: no cover
+    schema_type = re.sub(r"^'(.*)'$", r"\1", schema.value)
+    try:
+        return parse_rule(schema_type, "dataType")
+    except DJParseException:
+        return ct.StructType(
+            *parse_rule(schema_type, "complexColTypeList")
+        )
 
 
 class FromUnixtime(Function):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2191,16 +2191,13 @@ def infer_type(
     options: Optional[Function] = None,
 ) -> ct.StructType:
     # pylint: disable=import-outside-toplevel
-    from datajunction_server.sql.parsing.backends.antlr4 import (
-        parse_rule,
-    )
+    from datajunction_server.sql.parsing.backends.antlr4 import parse_rule
+
     schema_type = re.sub(r"^'(.*)'$", r"\1", schema.value)
     try:
         return parse_rule(schema_type, "dataType")
     except DJParseException:
-        return ct.StructType(
-            *parse_rule(schema_type, "complexColTypeList")
-        )
+        return ct.StructType(*parse_rule(schema_type, "complexColTypeList"))
 
 
 class FromUnixtime(Function):

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -3,9 +3,9 @@
 Tests for ``datajunction_server.sql.functions``.
 """
 
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-from typing import Union
 
 import datajunction_server.sql.functions as F
 import datajunction_server.sql.parsing.types as ct
@@ -1828,7 +1828,9 @@ async def test_from_json_func(session: AsyncSession):
     """
     Test the `from_json` function
     """
-    query = parse("SELECT from_json('1,2,3', 'a INT, b INT, c INT'), from_json('[\"a\",\"b\"]', 'ARRAY<STRING>')")
+    query = parse(
+        "SELECT from_json('1,2,3', 'a INT, b INT, c INT'), from_json('[\"a\",\"b\"]', 'ARRAY<STRING>')",
+    )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.compile(ctx)

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -5,6 +5,7 @@ Tests for ``datajunction_server.sql.functions``.
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Union
 
 import datajunction_server.sql.functions as F
 import datajunction_server.sql.parsing.types as ct
@@ -1822,19 +1823,18 @@ async def test_format_string_func(session: AsyncSession):
 #     assert isinstance(query.select.projection[1].type, ct.StructType)  # type: ignore
 
 
-# TODO: Fix these two  # pylint: disable=fixme
-# @pytest.mark.asyncio
-# async def test_from_json_func(session: AsyncSession):
-#     """
-#     Test the `from_json` function
-#     """
-#     query = parse("SELECT from_json('1,2,3', 'a INT, b INT, c INT'), from_json('4,5,6', 'x INT, y INT, z INT')")
-#     exc = DJException()
-#     ctx = ast.CompileContext(session=session, exception=exc)
-#     await query.compile(ctx)
-#     assert not exc.errors
-#     assert isinstance(query.select.projection[0].type, Union[ct.StructType, ct.ListType])  # type: ignore
-#     assert isinstance(query.select.projection[1].type, Union[ct.StructType, ct.ListType])
+@pytest.mark.asyncio
+async def test_from_json_func(session: AsyncSession):
+    """
+    Test the `from_json` function
+    """
+    query = parse("SELECT from_json('1,2,3', 'a INT, b INT, c INT'), from_json('[\"a\",\"b\"]', 'ARRAY<STRING>')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert isinstance(query.select.projection[0].type, ct.StructType)  # type: ignore
+    assert isinstance(query.select.projection[1].type, ct.ListType)
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1836,7 +1836,7 @@ async def test_from_json_func(session: AsyncSession):
     await query.compile(ctx)
     assert not exc.errors
     assert isinstance(query.select.projection[0].type, ct.StructType)  # type: ignore
-    assert isinstance(query.select.projection[1].type, ct.ListType)
+    assert isinstance(query.select.projection[1].type, ct.ListType)  # type: ignore
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

The `from_json` function doesn't actually parse the specified schema correctly:
* It needs to strip out the beginning and end quotes
* There are two potential ways it can parse the schema, one for structs and one for arrays, both of which need to be handled here

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
