### PR TITLE
Adding 'use_materialized' flag to sql endpoints

### DIFF
--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -163,6 +163,7 @@ class DJClient(_internal.DJClient):
         engine_name: Optional[str] = None,
         engine_version: Optional[str] = None,
         measures: bool = False,
+        use_materialized: bool = True,
     ):
         """
         Builds SQL for one or more metrics with the provided group by dimensions and filters.
@@ -178,6 +179,7 @@ class DJClient(_internal.DJClient):
                 "filters": filters or [],
                 "engine_name": engine_name or self.engine_name,
                 "engine_version": engine_version or self.engine_version,
+                "use_materialized": use_materialized,
             },
         )
         if response.status_code != 200:
@@ -196,6 +198,7 @@ class DJClient(_internal.DJClient):
         filters: Optional[List[str]] = None,
         engine_name: Optional[str] = None,
         engine_version: Optional[str] = None,
+        use_materialized: bool = True,
     ):
         """
         Builds SQL for a node with the provided dimensions and filters.
@@ -207,6 +210,7 @@ class DJClient(_internal.DJClient):
                 "filters": filters or [],
                 "engine_name": engine_name or self.engine_name,
                 "engine_version": engine_version or self.engine_version,
+                "use_materialized": use_materialized,
             },
         )
         if response.status_code == 200:

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -198,6 +198,7 @@ async def get_query(  # pylint: disable=too-many-arguments
     limit: Optional[int] = None,
     engine: Optional[Engine] = None,
     access_control: Optional[access.AccessControlStore] = None,
+    use_materialized: bool = True,
 ) -> ast.Query:
     """
     Get a query for a metric, dimensions, and filters
@@ -208,7 +209,11 @@ async def get_query(  # pylint: disable=too-many-arguments
 
     node = await Node.get_by_name(session, node_name, raise_if_not_exists=True)
     build_criteria = get_default_criteria(node.current, engine)  # type: ignore
-    query_builder = await QueryBuilder.create(session, node.current)  # type: ignore
+    query_builder = await QueryBuilder.create(
+        session,
+        node.current,  # type: ignore
+        use_materialized=use_materialized,
+    )
     query_ast = await (
         query_builder.ignore_errors()
         .with_access_control(access_control)
@@ -598,8 +603,8 @@ async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
     access_control: Optional[access.AccessControlStore] = None,
-    use_materialized: bool = True,
     ignore_errors: bool = True,
+    use_materialized: bool = True,
 ) -> Tuple[TranslatedSQL, Engine, Catalog]:
     """
     Build SQL for multiple metrics. Used by both /sql and /data endpoints

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -991,14 +991,19 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
         for ref_expr in reference_expressions:
 
             # Try to find a materialized table attached to this node, if one exists.
-            physical_table = cast(
-                Optional[ast.Table],
-                get_table_for_node(
-                    referenced_node,
-                    build_criteria=build_criteria,
-                ),
-            )
-            if not physical_table or not use_materialized:
+            physical_table = None
+            if use_materialized:
+                print(f"Checking for physical node: {referenced_node.name}")
+                physical_table = cast(
+                    Optional[ast.Table],
+                    get_table_for_node(
+                        referenced_node,
+                        build_criteria=build_criteria,
+                    ),
+                )
+
+            if not physical_table:
+                print(f"No physical node for {referenced_node.name}")
                 # Build a new CTE with the query AST if there is no materialized table
                 if referenced_node.name not in ctes_mapping:
                     node_query = parse(cast(str, referenced_node.query))

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -993,7 +993,7 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
             # Try to find a materialized table attached to this node, if one exists.
             physical_table = None
             if use_materialized:
-                print(f"Checking for physical node: {referenced_node.name}")
+                logger.debug("Checking for physical node: %s", referenced_node.name)
                 physical_table = cast(
                     Optional[ast.Table],
                     get_table_for_node(
@@ -1003,7 +1003,7 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
                 )
 
             if not physical_table:
-                print(f"No physical node for {referenced_node.name}")
+                logger.debug("Didn't find physical node: %s", referenced_node.name)
                 # Build a new CTE with the query AST if there is no materialized table
                 if referenced_node.name not in ctes_mapping:
                     node_query = parse(cast(str, referenced_node.query))

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -101,6 +101,7 @@ async def get_measures_query(  # pylint: disable=too-many-locals
     cast_timestamp_to_ms: bool = False,  # pylint: disable=unused-argument
     include_all_columns: bool = False,
     sql_transpilation_library: Optional[str] = None,
+    use_materialized: bool = True,
 ) -> List[GeneratedSQL]:
     """
     Builds the measures SQL for a set of metrics with dimensions and filters.
@@ -158,7 +159,11 @@ async def get_measures_query(  # pylint: disable=too-many-locals
     measures_queries = []
     for parent_node, _ in common_parents.items():  # type: ignore
         measure_columns, dimensional_columns = [], []
-        query_builder = await QueryBuilder.create(session, parent_node.current)
+        query_builder = await QueryBuilder.create(
+            session,
+            parent_node.current,
+            use_materialized=use_materialized,
+        )
         parent_ast = await (
             query_builder.ignore_errors()
             .with_access_control(access_control)
@@ -233,9 +238,15 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
     validation, allowing for dynamic node query generation based on runtime conditions.
     """
 
-    def __init__(self, session: AsyncSession, node_revision: NodeRevision):
+    def __init__(
+        self,
+        session: AsyncSession,
+        node_revision: NodeRevision,
+        use_materialized: bool = True,
+    ):
         self.session = session
         self.node_revision = node_revision
+        self.use_materialized = use_materialized
 
         self._filters: List[str] = []
         self._required_dimensions: List[str] = [
@@ -262,12 +273,13 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
         cls,
         session: AsyncSession,
         node_revision: NodeRevision,
+        use_materialized: bool = True,
     ) -> "QueryBuilder":
         """
         Create a QueryBuilder instance for the node revision.
         """
         await session.refresh(node_revision, ["required_dimensions", "dimension_links"])
-        instance = cls(session, node_revision)
+        instance = cls(session, node_revision, use_materialized=use_materialized)
         return instance
 
     def ignore_errors(self):
@@ -464,6 +476,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
             filters=self._filters,
             build_criteria=self._build_criteria,
             ctes_mapping=self.cte_mapping,
+            use_materialized=self.use_materialized,
         )
 
     def initialize_final_query_ast(self, node_ast, node_alias):
@@ -523,6 +536,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
                     link,
                     self._filters,
                     self.cte_mapping,
+                    use_materialized=self.use_materialized,
                 )
                 dimension_join.node_query = convert_to_cte(
                     dimension_node_query,
@@ -751,6 +765,7 @@ async def build_dimension_node_query(
     link: DimensionLink,
     filters: List[str],
     cte_mapping: Dict[str, ast.Query],
+    use_materialized: bool = True,
 ):
     """
     Builds a dimension node query with the requested filters
@@ -778,6 +793,7 @@ async def build_dimension_node_query(
         filters=filters,  # type: ignore
         build_criteria=build_criteria,
         ctes_mapping=cte_mapping,
+        use_materialized=use_materialized,
     )
     return dimension_node_query
 
@@ -949,6 +965,7 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
     build_criteria: Optional[BuildCriteria] = None,
     access_control=None,
     ctes_mapping: Dict[str, ast.Query] = None,
+    use_materialized: bool = True,
 ) -> ast.Query:
     """
     Recursively replaces DJ node references with query ASTs. These are replaced with
@@ -981,7 +998,7 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
                     build_criteria=build_criteria,
                 ),
             )
-            if not physical_table:
+            if not physical_table or not use_materialized:
                 # Build a new CTE with the query AST if there is no materialized table
                 if referenced_node.name not in ctes_mapping:
                     node_query = parse(cast(str, referenced_node.query))
@@ -994,6 +1011,7 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals
                         build_criteria=build_criteria,
                         access_control=access_control,
                         ctes_mapping=ctes_mapping,
+                        use_materialized=use_materialized,
                     )
                     cte_name = ast.Name(amenable_name(referenced_node.name))
                     query_ast = query_ast.to_cte(cte_name, parent_ast=query)


### PR DESCRIPTION
### Summary

To address https://github.com/DataJunction/dj/issues/1158 this adds an `use_materialized` flag to the `sql` endpoints so that clients can set to `False` and request SQL that bypasses any materialized data. By default, no behavior is changing, the default value is still `True` for this flag.

### Test Plan

Unit tests cover this code already, focus is on making sure

- [x] PR has an associated issue: #1158
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan
Nothing special.