### PR TITLE
After a node's query is updated, we should revalidate dimension links

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -941,7 +941,7 @@ def build_join_for_link(
         if full_column.column_name not in (
             dimension_node_columns if is_dimension_node else node_columns
         ):
-            raise DJQueryBuildException(
+            raise DJQueryBuildException(  # pragma: no cover
                 f"The requested column {full_column.column_name} does not exist"
                 f" on {full_column.node_name}",
             )

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1950,8 +1950,8 @@ async def revalidate_node(  # pylint: disable=too-many-locals,too-many-statement
     to_remove = set()
     for link in node.current.dimension_links:  # type: ignore
         if not link.foreign_key_column_names.intersection(set(existing_columns)):
-            to_remove.add(link)
-            await session.delete(link)
+            to_remove.add(link)  # pragma: no cover
+            await session.delete(link)  # pragma: no cover
 
     # Check if any columns have been updated
     updated_columns = False

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -3984,6 +3984,18 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
                 """,
             },
         )
+        response = await client_with_roads.get("/nodes/default.hard_hat/dimensions")
+        dimensions = response.json()
+        assert [dim["name"] for dim in dimensions] == [
+            "default.hard_hat.hard_hat_id",
+            "default.hard_hat.state",
+            "default.hard_hat.title",
+            "default.us_state.state_id",
+            "default.us_state.state_name",
+            "default.us_state.state_region",
+            "default.us_state.state_short",
+        ]
+
         response = await client_with_roads.get("/history?node=default.hard_hat")
         history = response.json()
         assert [
@@ -4037,6 +4049,24 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             ("create", "link"),
             ("set_attribute", "column_attribute"),
             ("create", "node"),
+        ]
+
+        response = await client_with_roads.patch(
+            "/nodes/default.hard_hat/",
+            json={
+                "query": """
+                SELECT
+                    hard_hat_id,
+                    title
+                FROM default.hard_hats
+                """,
+            },
+        )
+        response = await client_with_roads.get("/nodes/default.hard_hat/dimensions")
+        dimensions = response.json()
+        assert [dim["name"] for dim in dimensions] == [
+            "default.hard_hat.hard_hat_id",
+            "default.hard_hat.title",
         ]
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -207,6 +207,50 @@ def update_transform_node(client_with_roads: AsyncClient):
         ON repair_orders.repair_order_id = repair_order_details.repair_order_id""",
             },
         )
+
+        response = await client_with_roads.post(
+            "/nodes/default.repair_orders_fact/link",
+            json={
+                "dimension_node": "default.municipality_dim",
+                "join_type": "inner",
+                "join_on": (
+                    "default.repair_orders_fact.municipality_id = default.municipality_dim.municipality_id"
+                ),
+            },
+        )
+
+        response = await client_with_roads.post(
+            "/nodes/default.repair_orders_fact/link",
+            json={
+                "dimension_node": "default.hard_hat",
+                "join_type": "inner",
+                "join_on": (
+                    "default.repair_orders_fact.hard_hat_id = default.hard_hat.hard_hat_id"
+                ),
+            },
+        )
+
+        response = await client_with_roads.post(
+            "/nodes/default.repair_orders_fact/link",
+            json={
+                "dimension_node": "default.hard_hat_to_delete",
+                "join_type": "left",
+                "join_on": (
+                    "default.repair_orders_fact.hard_hat_id = default.hard_hat_to_delete.hard_hat_id"
+                ),
+            },
+        )
+
+        response = await client_with_roads.post(
+            "/nodes/default.repair_orders_fact/link",
+            json={
+                "dimension_node": "default.dispatcher",
+                "join_type": "inner",
+                "join_on": (
+                    "default.repair_orders_fact.dispatcher_id = default.dispatcher.dispatcher_id"
+                ),
+            },
+        )
         return response
 
     return _make_request
@@ -286,13 +330,13 @@ async def test_saving_node_sql_requests(  # pylint: disable=too-many-statements
     # This should now trigger error messages when requesting SQL
     response = await transform_node_sql_request()
     assert (
-        "The requested column dispatcher_id does not exist on default.repair_orders"
+        "are not available dimensions on default.repair_orders_fact"
         in response.json()["message"]
     )
 
     # Update the transform node with a new query
     response = await update_transform_node()
-    assert response.status_code == 200
+    assert response.status_code == 201
 
     response = (await transform_node_sql_request()).json()
 


### PR DESCRIPTION
### Summary

When any node with a query is updated, we should revalidate the node's dimension links, as some of them may have become invalidated due to the updated query. For example, if a transform's query gets updated to remove a column that has a dimension link defined on it, we should also remove the dimension link.

To fix it for existing nodes, I've added some changes to the `POST /nodes/{node}/validate` endpoint so that it does the same logic of cleaning up unneeded dimension links. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
