### PR TITLE
Add default catalog setting for DJ nodes 

### DIFF
--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -91,6 +91,8 @@ class Settings(
     # Interval in seconds with which to expire caching of any indexes
     index_cache_expire = 60
 
+    default_catalog_id: int = 0
+
     # SQLAlchemy engine config
     db_pool_size = 20
     db_max_overflow = 20

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -83,9 +83,11 @@ from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.typing import UTCDatetime
-from datajunction_server.utils import SEPARATOR, Version, VersionUpgrade
+from datajunction_server.utils import SEPARATOR, Version, VersionUpgrade, get_settings
 
 _logger = logging.getLogger(__name__)
+
+settings = get_settings()
 
 
 def get_node_column(node: Node, column_name: str) -> Column:
@@ -260,7 +262,7 @@ async def create_node_revision(
         raise DJException(
             f"Cannot create nodes with multi-catalog dependencies: {set(catalog_ids)}",
         )
-    catalog_id = next(iter(catalog_ids), 0)
+    catalog_id = next(iter(catalog_ids), settings.default_catalog_id)
     parent_refs = (
         (
             await session.execute(


### PR DESCRIPTION
### Summary

In some cases, DJ nodes are created (in draft mode) that don't have any valid upstream nodes, thus making it so that we can't infer an appropriate catalog for the node. We seem to default to `catalog_id = 0` for these invalid nodes, which causes issues since this catalog is never updated after the node becomes valid. This PR adds a default catalog for nodes that don't have an inferrable catalog at creation time.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
