### PR TITLE
Reference links

### DIFF
--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -387,6 +387,29 @@ class DJClient:
         )
         return response.json()
 
+    def _add_reference_dimension_link(  # pylint: disable=too-many-arguments
+        self,
+        node_name: str,
+        node_column: str,
+        dimension_node: str,
+        dimension_column: str,
+        role: Optional[str] = None,
+    ):
+        """
+        Helper function to link a dimension to the node.
+        """
+        params = {
+            "dimension_node": dimension_node,
+            "dimension_column": dimension_column,
+            **({"role": role} if role else {}),
+        }
+        response = self._session.post(
+            f"/nodes/{node_name}/columns/{node_column}/link",
+            timeout=self._timeout,
+            params=params,
+        )
+        return response.json()
+
     def _link_complex_dimension_to_node(  # pylint: disable=too-many-arguments
         self,
         node_name: str,
@@ -448,6 +471,20 @@ class DJClient:
                 "dimension_node": dimension_node,
                 "role": role,
             },
+        )
+        return response.json()
+
+    def _remove_reference_dimension_link(
+        self,
+        node_name: str,
+        node_column: str,
+    ):
+        """
+        Helper function to remove a reference dimension link from a node column.
+        """
+        response = self._session.delete(
+            f"/nodes/{node_name}/columns/{node_column}/link",
+            timeout=self._timeout,
         )
         return response.json()
 

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -179,6 +179,27 @@ class Node(ClientEntity):  # pylint: disable=protected-access
         self.refresh()
         return link_response
 
+    def add_reference_dimension_link(
+        self,
+        node_column: str,
+        dimension_node: str,
+        dimension_column: str,
+        role: Optional[str] = None,
+    ):
+        """
+        Adds a reference dimension link from the node's `column` to the dimension node's
+        `dimension_column`
+        """
+        link_response = self.dj_client._add_reference_dimension_link(
+            self.name,
+            node_column,
+            dimension_node,
+            dimension_column,
+            role,
+        )
+        self.refresh()
+        return link_response
+
     def link_complex_dimension(  # pylint: disable=too-many-arguments
         self,
         dimension_node: str,
@@ -235,6 +256,20 @@ class Node(ClientEntity):  # pylint: disable=protected-access
         )
         self.refresh()
         return unlink_response
+
+    def remove_reference_dimension_link(
+        self,
+        node_column: str,
+    ):
+        """
+        Remove a reference dimension linkk from the node's `column`.
+        """
+        link_response = self.dj_client._remove_reference_dimension_link(
+            self.name,
+            node_column,
+        )
+        self.refresh()
+        return link_response
 
     def add_materialization(self, config: models.Materialization):
         """

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -683,6 +683,30 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
             "node foo.bar.repair_type has been removed."
         )
 
+    def test_add_remove_reference_dimension_link(self, client):
+        """
+        Check that adding a reference dimension link works as expected
+        """
+
+        repair_type = client.source("foo.bar.repair_type")
+        result = repair_type.add_reference_dimension_link(
+            node_column="contractor_id",
+            dimension_node="foo.bar.contractor",
+            dimension_column="contractor_id",
+        )
+        assert result["message"] == (
+            "foo.bar.repair_type.contractor_id has been successfully linked "
+            "to foo.bar.contractor.contractor_id"
+        )
+
+        # Unlink the dimension
+        result = repair_type.remove_reference_dimension_link(
+            node_column="contractor_id",
+        )
+        assert result["message"] == (
+            "The reference dimension link on foo.bar.repair_type.contractor_id has been removed."
+        )
+
     def test_sql(self, client):  # pylint: disable=unused-argument
         """
         Check that getting sql via the client works as expected.

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -926,7 +926,9 @@ async def add_reference_dimension_link(
     node = await Node.get_by_name(session, node_name, raise_if_not_exists=True)
     dim_node = await Node.get_by_name(session, dimension_node, raise_if_not_exists=True)
     if dim_node.type != NodeType.DIMENSION:  # type: ignore
-        raise DJException(message=f"Node {node.name} is not of type dimension!")  # type: ignore
+        raise DJInvalidInputException(
+            message=f"Node {node.name} is not of type dimension!",  # type: ignore
+        )
 
     # The target and dimension columns should both exist
     target_column = await get_column(session, node.current, node_column)  # type: ignore
@@ -936,7 +938,7 @@ async def add_reference_dimension_link(
     if not dim_column.type.is_compatible(target_column.type):
         raise DJInvalidInputException(
             f"The column {target_column.name} has type {target_column.type} "
-            f"and is being linked to the dimension {dim_node} "
+            f"and is being linked to the dimension {dimension_node} "
             f"via the dimension column {dimension_column}, which has "
             f"type {dim_column.type}. These column types are incompatible"
             " and the dimension cannot be linked",

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -570,6 +570,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
 
         # Find all dimension node joins necessary for the requested dimensions and filters
         dimension_node_joins = await self.find_dimension_node_joins()
+        print("dimension_node_joins", dimension_node_joins)
         for _, dimension_join in dimension_node_joins.items():
             join_path = dimension_join.join_path
             requested_dimensions = list(

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -570,7 +570,6 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
 
         # Find all dimension node joins necessary for the requested dimensions and filters
         dimension_node_joins = await self.find_dimension_node_joins()
-        print("dimension_node_joins", dimension_node_joins)
         for _, dimension_join in dimension_node_joins.items():
             join_path = dimension_join.join_path
             requested_dimensions = list(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -50,8 +50,8 @@ from datajunction_server.models.attribute import (
 from datajunction_server.models.base import labelize
 from datajunction_server.models.cube import CubeElementMetadata, CubeRevisionMetadata
 from datajunction_server.models.dimensionlink import (
+    JoinLinkInput,
     LinkDimensionIdentifier,
-    LinkDimensionInput,
 )
 from datajunction_server.models.history import status_change_history
 from datajunction_server.models.materialization import (
@@ -1486,7 +1486,7 @@ async def get_cube_revision_metadata(session: AsyncSession, name: str):
 async def upsert_complex_dimension_link(
     session: AsyncSession,
     node_name: str,
-    link_input: LinkDimensionInput,
+    link_input: JoinLinkInput,
     current_user: User,
 ) -> ActivityType:
     """

--- a/datajunction-server/datajunction_server/models/dimensionlink.py
+++ b/datajunction-server/datajunction_server/models/dimensionlink.py
@@ -7,6 +7,15 @@ from datajunction_server.enum import StrEnum
 from datajunction_server.models.node_type import NodeNameOutput
 
 
+class DimensionLinkType(StrEnum):
+    """
+    The type of dimension link
+    """
+
+    JOIN = "join"
+    REFERENCE = "reference"
+
+
 class JoinCardinality(StrEnum):
     """
     The version upgrade type
@@ -39,15 +48,26 @@ class LinkDimensionIdentifier(BaseModel):
     role: Optional[str]
 
 
-class LinkDimensionInput(BaseModel):
+class JoinLinkInput(BaseModel):
     """
-    Input for linking a dimension to a node
+    Input for creating a join link between a dimension node and node
     """
 
     dimension_node: str
     join_type: Optional[JoinType] = JoinType.LEFT
     join_on: str
     join_cardinality: Optional[JoinCardinality] = JoinCardinality.MANY_TO_ONE
+    role: Optional[str]
+
+
+class ReferenceLinkInput(BaseModel):
+    """
+    Input for creating a reference link between a dimension node column and a node column
+    """
+
+    node_column: str
+    dimension_node: str
+    dimension_column: str
     role: Optional[str]
 
 

--- a/datajunction-server/datajunction_server/models/dimensionlink.py
+++ b/datajunction-server/datajunction_server/models/dimensionlink.py
@@ -7,15 +7,6 @@ from datajunction_server.enum import StrEnum
 from datajunction_server.models.node_type import NodeNameOutput
 
 
-class DimensionLinkType(StrEnum):
-    """
-    The type of dimension link
-    """
-
-    JOIN = "join"
-    REFERENCE = "reference"
-
-
 class JoinCardinality(StrEnum):
     """
     The version upgrade type
@@ -57,17 +48,6 @@ class JoinLinkInput(BaseModel):
     join_type: Optional[JoinType] = JoinType.LEFT
     join_on: str
     join_cardinality: Optional[JoinCardinality] = JoinCardinality.MANY_TO_ONE
-    role: Optional[str]
-
-
-class ReferenceLinkInput(BaseModel):
-    """
-    Input for creating a reference link between a dimension node column and a node column
-    """
-
-    node_column: str
-    dimension_node: str
-    dimension_column: str
     role: Optional[str]
 
 

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -190,13 +190,13 @@ def reference_link_events_user_registration_country(
 
     async def _reference_link_events_user_registration_country() -> Response:
         response = await dimensions_link_client.post(
-            "/nodes/default.events/link?link_type=reference",
-            json={
-                "node_column": "user_registration_country",
+            "/nodes/default.events/columns/user_registration_country/link",
+            params={
                 "dimension_node": "default.users",
                 "dimension_column": "registration_country",
             },
         )
+        assert response.status_code == 201
         return response
 
     return _reference_link_events_user_registration_country

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -298,7 +298,8 @@ async def test_link_complex_dimension_without_role(
         default_DOT_events_table.user_id,
         default_DOT_events_table.event_start_date,
         default_DOT_events_table.event_end_date,
-        default_DOT_events_table.elapsed_secs
+        default_DOT_events_table.elapsed_secs,
+        default_DOT_events_table.user_registration_country
       FROM examples.events AS default_DOT_events_table
     ),
     default_DOT_users AS (
@@ -315,6 +316,7 @@ async def test_link_complex_dimension_without_role(
         default_DOT_events.event_start_date default_DOT_users_DOT_snapshot_date,
         default_DOT_events.event_end_date default_DOT_events_DOT_event_end_date,
         default_DOT_events.elapsed_secs default_DOT_events_DOT_elapsed_secs,
+        default_DOT_events.user_registration_country default_DOT_events_DOT_user_registration_country,
         default_DOT_users.registration_country default_DOT_users_DOT_registration_country
     FROM default_DOT_events
     LEFT JOIN default_DOT_users
@@ -481,7 +483,8 @@ async def test_link_complex_dimension_with_role(
     default_DOT_events_table.user_id,
     default_DOT_events_table.event_start_date,
     default_DOT_events_table.event_end_date,
-    default_DOT_events_table.elapsed_secs
+    default_DOT_events_table.elapsed_secs,
+    default_DOT_events_table.user_registration_country
   FROM examples.events AS default_DOT_events_table
 ), default_DOT_users AS (
   SELECT
@@ -519,7 +522,8 @@ GROUP BY
         default_DOT_events_table.user_id,
         default_DOT_events_table.event_start_date,
         default_DOT_events_table.event_end_date,
-        default_DOT_events_table.elapsed_secs
+        default_DOT_events_table.elapsed_secs,
+        default_DOT_events_table.user_registration_country
       FROM examples.events AS default_DOT_events_table
     ), default_DOT_users AS (
       SELECT
@@ -568,7 +572,8 @@ GROUP BY
     default_DOT_events_table.user_id,
     default_DOT_events_table.event_start_date,
     default_DOT_events_table.event_end_date,
-    default_DOT_events_table.elapsed_secs
+    default_DOT_events_table.elapsed_secs,
+    default_DOT_events_table.user_registration_country
   FROM examples.events AS default_DOT_events_table
 ), default_DOT_users AS (
   SELECT
@@ -700,7 +705,8 @@ async def test_measures_sql_with_dimension_roles(
     default_DOT_events_table.user_id,
     default_DOT_events_table.event_start_date,
     default_DOT_events_table.event_end_date,
-    default_DOT_events_table.elapsed_secs
+    default_DOT_events_table.elapsed_secs,
+    default_DOT_events_table.user_registration_country
   FROM examples.events AS default_DOT_events_table
 ), default_DOT_users AS (
   SELECT

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -826,13 +826,46 @@ async def test_measures_sql_with_reference_dimension_links(
     Test measures SQL generation with reference dimension links
     """
     await reference_link_events_user_registration_country()
+
+    response = await dimensions_link_client.get(
+        "/nodes/default.elapsed_secs/dimensions",
+    )
+    dimensions_data = response.json()
+    assert dimensions_data == [
+        {
+            "filter_only": False,
+            "is_primary_key": False,
+            "name": "default.users.registration_country",
+            "node_display_name": "Default: Users",
+            "node_name": "default.users",
+            "path": [
+                "default.events.user_registration_country",
+            ],
+            "type": "string",
+        },
+    ]
+
     await link_events_to_users_without_role()
+    response = await dimensions_link_client.get(
+        "/nodes/default.elapsed_secs/dimensions",
+    )
+    dimensions_data = response.json()
+    assert [dim["name"] for dim in dimensions_data] == [
+        "default.users.account_type",
+        "default.users.registration_country",
+        "default.users.registration_country",
+        "default.users.residence_country",
+        "default.users.snapshot_date",
+        "default.users.user_id",
+    ]
+
     sql_params = {
         "metrics": ["default.elapsed_secs"],
         "dimensions": [
             "default.users.registration_country",
         ],
     }
+
     response = await dimensions_link_client.get("/sql/measures/v2", params=sql_params)
     response_data = response.json()
     expected_sql = """WITH

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -2153,6 +2153,7 @@ COMPLEX_DIMENSION_LINK = (
                 {"name": "event_start_date", "type": "int"},
                 {"name": "event_end_date", "type": "int"},
                 {"name": "elapsed_secs", "type": "int"},
+                {"name": "user_registration_country", "type": "string"},
             ],
             "description": "Events table",
             "mode": "published",
@@ -2205,7 +2206,8 @@ COMPLEX_DIMENSION_LINK = (
             user_id,
             event_start_date,
             event_end_date,
-            elapsed_secs
+            elapsed_secs,
+            user_registration_country
         FROM default.events_table
     """,
             "mode": "published",


### PR DESCRIPTION
### Summary

This change adds support in the backend and Python client for reference links. We already have documentation on [reference links](https://datajunction.io/docs/0.1.0/data-modeling/dimension-links/#reference-link), so this PR brings us up-to-date with the docs.

The reference link implementation reuses our original dimension link database schema: on the `columns` table, we store reference dimension links using the table's `dimension_id` and `dimension_column` columns. This setup means that each column on a node is allowed a *single* reference dimension. 

The following features (from the checklist in #1050) are implemented:
- An API endpoint to create/update a reference link
- An API endpoint to remove a reference link
- Python client support for creating / updating / removing reference links
- Updates to the `get_dimensions` functionality based on the presence of reference links in the dimensions graph

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #1050 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
