### PR TITLE
Fix bug with handling inline table queries

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2283,17 +2283,11 @@ class InlineTable(TableExpression, Named):
             if self.alias_or_name and self.alias_or_name.name.strip() != "AS"
             else ""
         )
-        print(
-            "self.columns",
-            [col.alias_or_name.name for col in self.columns],
-            inline_alias,
-        )
         alias = inline_alias + (
             f"({', '.join([col.alias_or_name.name for col in self.columns])})"
             if self.explicit_columns
             else ""
         )
-        print(f"ALIAS {alias}")
         return f"{values} AS {alias}" if alias else values
 
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2270,15 +2270,31 @@ class InlineTable(TableExpression, Named):
     explicit_columns: bool = False
 
     def __str__(self) -> str:
-        values = "VALUES " + ",\n\t".join(
-            [f'({", ".join([str(col) for col in row])})' for row in self.values],
+        row_values = (
+            self.values
+            if isinstance(self.values[0], list)
+            else [[row] for row in self.values]
         )
-        alias = f"{self.alias_or_name.name}" + (
+        values = "VALUES " + ",\n\t".join(
+            [f'({", ".join([str(col) for col in row])})' for row in row_values],
+        )
+        inline_alias = (
+            self.alias_or_name.name
+            if self.alias_or_name and self.alias_or_name.name.strip() != "AS"
+            else ""
+        )
+        print(
+            "self.columns",
+            [col.alias_or_name.name for col in self.columns],
+            inline_alias,
+        )
+        alias = inline_alias + (
             f"({', '.join([col.alias_or_name.name for col in self.columns])})"
             if self.explicit_columns
             else ""
         )
-        return f"{values} AS {alias}"
+        print(f"ALIAS {alias}")
+        return f"{values} AS {alias}" if alias else values
 
 
 @dataclass(eq=False)

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2270,19 +2270,10 @@ class InlineTable(TableExpression, Named):
     explicit_columns: bool = False
 
     def __str__(self) -> str:
-        row_values = (
-            self.values
-            if isinstance(self.values[0], list)
-            else [[row] for row in self.values]
-        )
         values = "VALUES " + ",\n\t".join(
-            [f'({", ".join([str(col) for col in row])})' for row in row_values],
+            [f'({", ".join([str(col) for col in row])})' for row in self.values],
         )
-        inline_alias = (
-            self.alias_or_name.name
-            if self.alias_or_name and self.alias_or_name.name.strip() != "AS"
-            else ""
-        )
+        inline_alias = self.alias_or_name.name if self.alias_or_name else ""
         alias = inline_alias + (
             f"({', '.join([col.alias_or_name.name for col in self.columns])})"
             if self.explicit_columns

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -293,13 +293,13 @@ def _(ctx: sbp.InlineTableContext):
     alias, columns = visit(ctx.tableAlias())
 
     # Generate default column aliases if they weren't specified
-    args = args[0] if isinstance(args[0], list) else args
+    col_args = args[0] if isinstance(args[0], list) else args
     inline_table_columns = (
-        [ast.Column(col, _type=value.type) for col, value in zip(columns, args)]
+        [ast.Column(col, _type=value.type) for col, value in zip(columns, col_args)]
         if columns
         else [
             ast.Column(ast.Name(f"col{idx + 1}"), _type=value.type)
-            for idx, value in enumerate(args)
+            for idx, value in enumerate(col_args)
         ]
     )
     return ast.InlineTable(

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -291,7 +291,6 @@ def _(ctx: sbp.RowConstructorContext):
 def _(ctx: sbp.InlineTableContext):
     args = visit(ctx.expression())
     alias, columns = visit(ctx.tableAlias())
-    print("args, alias, columns", args, alias, columns)
 
     # Generate default column aliases if they weren't specified
     args = args[0] if isinstance(args[0], list) else args
@@ -480,9 +479,7 @@ def _(ctx: sbp.QueryPrimaryContext):
 @visit.register
 def _(ctx: sbp.RegularQuerySpecificationContext):
     quantifier, projection, hints = visit(ctx.selectClause())
-    print("quantifier, projection, hints", quantifier, projection, hints)
     from_ = visit(ctx.fromClause()) if ctx.fromClause() else None
-    print("from_", from_)
     laterals = visit(ctx.lateralView())
     group_by = visit(ctx.aggregationClause()) if ctx.aggregationClause() else []
     where = None

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -271,6 +271,12 @@ def _(ctx: sbp.StatementDefaultContext):
 
 
 @visit.register
+def _(ctx: sbp.InlineTableDefault1Context):
+    print("got here after")
+    return visit(ctx.inlineTable())
+
+
+@visit.register
 def _(ctx: sbp.InlineTableDefault2Context):
     return visit(ctx.inlineTable())
 
@@ -285,14 +291,16 @@ def _(ctx: sbp.RowConstructorContext):
 def _(ctx: sbp.InlineTableContext):
     args = visit(ctx.expression())
     alias, columns = visit(ctx.tableAlias())
+    print("args, alias, columns", args, alias, columns)
 
     # Generate default column aliases if they weren't specified
+    args = args[0] if isinstance(args[0], list) else args
     inline_table_columns = (
-        [ast.Column(col, _type=value.type) for col, value in zip(columns, args[0])]
+        [ast.Column(col, _type=value.type) for col, value in zip(columns, args)]
         if columns
         else [
             ast.Column(ast.Name(f"col{idx + 1}"), _type=value.type)
-            for idx, value in enumerate(args[0])
+            for idx, value in enumerate(args)
         ]
     )
     return ast.InlineTable(
@@ -472,7 +480,9 @@ def _(ctx: sbp.QueryPrimaryContext):
 @visit.register
 def _(ctx: sbp.RegularQuerySpecificationContext):
     quantifier, projection, hints = visit(ctx.selectClause())
+    print("quantifier, projection, hints", quantifier, projection, hints)
     from_ = visit(ctx.fromClause()) if ctx.fromClause() else None
+    print("from_", from_)
     laterals = visit(ctx.lateralView())
     group_by = visit(ctx.aggregationClause()) if ctx.aggregationClause() else []
     where = None

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -272,7 +272,6 @@ def _(ctx: sbp.StatementDefaultContext):
 
 @visit.register
 def _(ctx: sbp.InlineTableDefault1Context):
-    print("got here after")
     return visit(ctx.inlineTable())
 
 
@@ -306,7 +305,7 @@ def _(ctx: sbp.InlineTableContext):
         name=alias,
         _columns=inline_table_columns,
         explicit_columns=len(columns) > 0,
-        values=[value for value in args],
+        values=[[value] if not isinstance(value, list) else value for value in args],
     )
 
 

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1083,7 +1083,7 @@ FROM VALUES
         (col.alias_or_name.name, col.type) for col in query.select.projection  # type: ignore
     ] == [("source", types.StringType())]
     assert [
-        val.value for val in query.select.from_.relations[0].primary.values  # type: ignore
+        val[0].value for val in query.select.from_.relations[0].primary.values  # type: ignore
     ] == ["'a'", "'b'", "'c'"]
     assert query.columns[0].table.alias_or_name == ast.Name(  # type: ignore
         name="tab",
@@ -1103,7 +1103,7 @@ FROM VALUES
         (col.alias_or_name.name, col.type) for col in query.select.projection  # type: ignore
     ] == [("col1", types.StringType())]
     assert [
-        val.value for val in query.select.from_.relations[0].primary.values  # type: ignore
+        val[0].value for val in query.select.from_.relations[0].primary.values  # type: ignore
     ] == ["'a'", "'b'", "'c'"]
     assert query.columns[0].table.alias_or_name == ast.Name(  # type: ignore
         name="tab",

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1071,6 +1071,46 @@ FROM VALUES
     assert query.select.from_.relations[0].primary.values == expected_values  # type: ignore
     assert query.columns[0].table.alias_or_name == expected_table_name  # type: ignore
 
+    query_str = """SELECT tab.source FROM VALUES ('a'), ('b'), ('c') AS tab(source)"""
+    query = parse(query_str)
+    exc = DJException()
+    assert not exc.errors
+    assert str(parse(str(query))) == str(parse(query_str))
+
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert [
+        (col.alias_or_name.name, col.type) for col in query.select.projection  # type: ignore
+    ] == [("source", types.StringType())]
+    assert [
+        val.value for val in query.select.from_.relations[0].primary.values  # type: ignore
+    ] == ["'a'", "'b'", "'c'"]
+    assert query.columns[0].table.alias_or_name == ast.Name(  # type: ignore
+        name="tab",
+        quote_style="",
+        namespace=None,
+    )
+
+    query_str = """SELECT tab.col1 FROM VALUES ('a'), ('b'), ('c') AS tab"""
+    query = parse(query_str)
+    exc = DJException()
+    assert not exc.errors
+    assert str(parse(str(query))) == str(parse(query_str))
+
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert [
+        (col.alias_or_name.name, col.type) for col in query.select.projection  # type: ignore
+    ] == [("col1", types.StringType())]
+    assert [
+        val.value for val in query.select.from_.relations[0].primary.values  # type: ignore
+    ] == ["'a'", "'b'", "'c'"]
+    assert query.columns[0].table.alias_or_name == ast.Name(  # type: ignore
+        name="tab",
+        quote_style="",
+        namespace=None,
+    )
+
 
 @pytest.mark.asyncio
 async def test_ast_subscript_handling(session: AsyncSession):


### PR DESCRIPTION
### Summary

This PR fixes an issue with queries that use inline tables, where they aren't parsed properly into the query AST. An example of such a query:
```
SELECT
  tab.source 
FROM 
  VALUES ('a'), ('b'), ('c') AS tab(source)
```

While other inline table queries were working, those with only one column per row, like the example above, were failing. This is due to the way the parsed structure would return a nested list in the cases where there was more than one column per row, but an unnested list for the example above. This change handles the special case.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
