### PR TITLE
Support dimension links with `CROSS JOIN` 

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -1389,6 +1389,8 @@ def build_join_for_link(
     dimension_node_columns = join_right.select.column_mapping
     join_left = cte_mapping.get(link.node_revision.name)
     node_columns = join_left.select.column_mapping  # type: ignore
+    if not join_ast.criteria:
+        return join_ast
     for col in join_ast.criteria.find_all(ast.Column):  # type: ignore
         full_column = FullColumnName(col.identifier())
         is_dimension_node = full_column.node_name == link.dimension.name

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -51,6 +51,7 @@ from datajunction_server.models.base import labelize
 from datajunction_server.models.cube import CubeElementMetadata, CubeRevisionMetadata
 from datajunction_server.models.dimensionlink import (
     JoinLinkInput,
+    JoinType,
     LinkDimensionIdentifier,
 )
 from datajunction_server.models.history import status_change_history

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """
 Dimension linking related tests.
 
@@ -961,6 +962,9 @@ FROM default_DOT_events"""
     """
     assert str(parse(response_data[0]["sql"])) == str(parse(expected_sql))
     assert response_data[0]["errors"] == []
+
+
+@pytest.mark.asyncio
 async def test_dimension_link_cross_join(
     dimensions_link_client: AsyncClient,  # pylint: disable=redefined-outer-name
 ):
@@ -995,3 +999,36 @@ async def test_dimension_link_cross_join(
         "default.areas.area",
         "default.areas.area_rep",
     ]
+
+    response = await dimensions_link_client.get(
+        "/sql/default.events?dimensions=default.areas.area&dimensions=default.areas.area_rep",
+    )
+    expected = """WITH
+    default_DOT_events AS (
+      SELECT
+        default_DOT_events_table.user_id,
+        default_DOT_events_table.event_start_date,
+        default_DOT_events_table.event_end_date,
+        default_DOT_events_table.elapsed_secs,
+        default_DOT_events_table.user_registration_country
+      FROM examples.events AS default_DOT_events_table
+    ),
+    default_DOT_areas AS (
+      SELECT
+        tab.area,
+      1 AS area_rep
+      FROM VALUES ('A'),
+      ('B'),
+      ('C') AS tab(area)
+    )
+    SELECT
+      default_DOT_events.user_id default_DOT_events_DOT_user_id,
+      default_DOT_events.event_start_date default_DOT_events_DOT_event_start_date,
+      default_DOT_events.event_end_date default_DOT_events_DOT_event_end_date,
+      default_DOT_events.elapsed_secs default_DOT_events_DOT_elapsed_secs,
+      default_DOT_events.user_registration_country default_DOT_events_DOT_user_registration_country,
+      default_DOT_areas.area default_DOT_areas_DOT_area,
+      default_DOT_areas.area_rep default_DOT_areas_DOT_area_rep
+    FROM default_DOT_events CROSS JOIN default_DOT_areas
+    """
+    assert str(parse(response.json()["sql"])) == str(parse(expected))


### PR DESCRIPTION
### Summary

This change supports using `CROSS JOIN` as the join type when creating a dimension join link. While we allow the `CROSS` join type to be passed in when creating dimension links, we don't actually support this join type because we don't allow for the join ON clause to be empty (typical in cross joins).

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1178 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
