### PR TITLE
fastapi cache on dimension dag endpoints

### DIFF
--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from typing import List, Optional
 
 from fastapi import Depends, HTTPException, Query
+from fastapi_cache.decorator import cache
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -95,6 +96,7 @@ async def list_metric_metadata() -> MetricMetadataOptions:
 
 
 @router.get("/metrics/{name}/", response_model=Metric)
+@cache(expire=settings.index_cache_expire)
 async def get_a_metric(
     name: str, *, session: AsyncSession = Depends(get_session)
 ) -> Metric:

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1336,6 +1336,7 @@ async def list_node_dag(
     response_model=List[DimensionAttributeOutput],
     name="List All Dimension Attributes",
 )
+@cache(expire=settings.index_cache_expire)
 async def list_all_dimension_attributes(
     name: str, *, session: AsyncSession = Depends(get_session)
 ) -> List[DimensionAttributeOutput]:

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -89,7 +89,7 @@ class Settings(
     google_oauth_client_secret_file: Optional[str] = None
 
     # Interval in seconds with which to expire caching of any indexes
-    index_cache_expire = 60
+    index_cache_expire = 180
 
     default_catalog_id: int = 0
 

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -174,6 +174,7 @@ def link_users_to_countries_with_role_registration(
                 "join_cardinality": "one_to_one",
                 "role": "registration_country",
             },
+            headers={"Cache-Control": "no-cache"},
         )
         return response
 
@@ -602,6 +603,7 @@ async def test_remove_dimension_link(
             "dimension_node": "default.users",
             "role": "user_direct",
         },
+        headers={"Cache-Control": "no-cache"},
     )
     assert response.json() == {
         "message": "Dimension link default.users (role user_direct) to node "

--- a/docs/content/0.1.0/docs/deploying-dj/caching.md
+++ b/docs/content/0.1.0/docs/deploying-dj/caching.md
@@ -1,0 +1,26 @@
+---
+weight: 50
+title: Caching
+---
+
+In DataJunction, caching is a crucial component that helps optimize performance by storing and reusing results of expensive operations, such as computing the dimension DAG (Directed Acyclic Graph). This section discusses how caching is used within DataJunction and how you can implement a custom caching solution using `fastapi-cache`.
+
+### How Caching is Used
+
+DataJunction employs caching in multiple areas to enhance performance and reduce the load on the database. One of the primary use cases is caching the results of expensive operations like computing the dimension DAG. By caching these results, DataJunction can quickly return previously computed results without having to recompute them, thereby saving time and resources.
+
+### Default Caching Implementation
+
+Out of the box, DataJunction uses the in-memory backend that comes packaged with `fastapi-cache`. This library is straightforward and efficient for development and small-scale deployments, however `fastapi-cache` makes it easy to use your own custom caching implementation.
+
+### Custom Caching Implementation
+
+You can implement a custom cache by using `fastapi-cache`'s `Backend` interface. The custom cache must implement the methods such as `get`, `set`, and `delete`.
+
+For detailed information on how to implement a custom `Backend`, please refer to the [fastapi-cache documentation](https://fastapi-cache.readthedocs.io/en/latest/).
+
+### Respecting the `no-cache` Header
+
+The `fastapi-cache` library respects the `no-cache` header in requests. This means that if a request contains the `Cache-Control: no-cache` header, the cache will be bypassed, and fresh data will be fetched.
+
+For more information on how to configure and use `fastapi-cache`, please refer to the [fastapi-cache documentation](https://fastapi-cache.readthedocs.io/en/latest/).


### PR DESCRIPTION
### Summary

This is a much less complex alternative to PR #1180 that uses `fastapi-cache` (which was already setup) and avoids any granular cache invalidation, doing a blanket cache on the endpoints instead. The tradeoff here is that users could hit cached data if they're bouncing between "builder" operations and calling any of the cached endpoints that perform the expensive dimension dag generation.

I really do like the idea of avoiding the web of complexity that comes with cache invalidation in a graph system and so I'm really scratching my head here trying to figure out if this PR and maybe a follow-up PR that adds modest rate limiting is all we need to provide the performance boost we need without degrading the user experience in any meaningful way.

### Test Plan

Updated tests, mainly to set cache-control headers.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
