### PR TITLE
Fix column attribution by making sure it only comes from the same parent

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2682,7 +2682,11 @@ class Query(TableExpression, UnNamed):
             for cte in (nearest_query.ctes if nearest_query else [])
         }
         table_options = (
-            list(self.select.from_.find_all(TableExpression))
+            [
+                tbl
+                for tbl in self.select.from_.find_all(TableExpression)
+                if tbl.get_nearest_parent_of_type(Query) is self
+            ]
             if self.select.from_
             else []
         )


### PR DESCRIPTION
### Summary

There is a bug where the column's table source should be restricted to those whose parent query matches the table source's parent query.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP