### PR TITLE
Make sure that we detect cycles in the dimensions traversal queries

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1337,7 +1337,10 @@ async def list_node_dag(
     name="List All Dimension Attributes",
 )
 async def list_all_dimension_attributes(
-    name: str, *, session: AsyncSession = Depends(get_session)
+    name: str,
+    *, 
+    depth: int = 30,
+    session: AsyncSession = Depends(get_session)
 ) -> List[DimensionAttributeOutput]:
     """
     List all available dimension attributes for the given node.
@@ -1353,7 +1356,12 @@ async def list_all_dimension_attributes(
             ],
         )
     )
-    dimensions = await get_dimensions(session, node, with_attributes=True)  # type: ignore
+    dimensions = await get_dimensions(
+        session,
+        node,  # type: ignore
+        with_attributes=True,
+        depth=depth,
+    )
     filter_only_dimensions = await get_filter_only_dimensions(session, name)
     return dimensions + filter_only_dimensions
 

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1337,10 +1337,7 @@ async def list_node_dag(
     name="List All Dimension Attributes",
 )
 async def list_all_dimension_attributes(
-    name: str,
-    *, 
-    depth: int = 30,
-    session: AsyncSession = Depends(get_session)
+    name: str, *, depth: int = 30, session: AsyncSession = Depends(get_session)
 ) -> List[DimensionAttributeOutput]:
     """
     List all available dimension attributes for the given node.

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -303,7 +303,9 @@ async def get_dimensions_dag(  # pylint: disable=too-many-locals
         )
         .where(initial_node.id == node_revision.id)
     ).cte("dimensions_graph", recursive=True)
-    dimensions_graph = dimensions_graph.suffix_with("CYCLE node_revision_id SET is_cycle USING path")
+    dimensions_graph = dimensions_graph.suffix_with(
+        "CYCLE node_revision_id SET is_cycle USING path",
+    )
 
     paths = dimensions_graph.union_all(
         select(
@@ -323,7 +325,8 @@ async def get_dimensions_dag(  # pylint: disable=too-many-locals
             next_rev.id.label("node_revision_id"),
             next_rev.display_name.label("node_display_name"),
             (dimensions_graph.c.depth + literal(1)).label("depth"),
-        ).select_from(
+        )
+        .select_from(
             dimensions_graph.join(
                 current_node,
                 dimensions_graph.c.path_end == current_node.id,
@@ -511,7 +514,12 @@ async def get_dimensions(
         )
     else:
         await session.refresh(node, attribute_names=["current"])
-        dag = await get_dimensions_dag(session, node.current, with_attributes, depth=depth)
+        dag = await get_dimensions_dag(
+            session,
+            node.current,
+            with_attributes,
+            depth=depth,
+        )
     return dag
 
 

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -312,7 +312,7 @@ async def get_dimensions_dag(  # pylint: disable=too-many-locals
         .where(initial_node.id == node_revision.id)
     ).cte("dimensions_graph", recursive=True)
     dimensions_graph = dimensions_graph.suffix_with(
-        "CYCLE path_start SET is_cycle USING path",
+        "CYCLE node_revision_id SET is_cycle USING path",
     )
 
     paths = dimensions_graph.union_all(

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -312,7 +312,7 @@ async def get_dimensions_dag(  # pylint: disable=too-many-locals
         .where(initial_node.id == node_revision.id)
     ).cte("dimensions_graph", recursive=True)
     dimensions_graph = dimensions_graph.suffix_with(
-        "CYCLE node_revision_id SET is_cycle USING path",
+        "CYCLE path_start SET is_cycle USING path",
     )
 
     paths = dimensions_graph.union_all(

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -86,7 +86,9 @@ async def get_downstream_nodes(
     )
     if not include_cubes:
         initial_dag = initial_dag.where((NodeRevision.type != NodeType.CUBE))
-    dag = initial_dag.cte("downstreams", recursive=True)
+    dag = initial_dag.cte("downstreams", recursive=True).suffix_with(
+        "CYCLE node_id SET is_cycle USING path",
+    )
 
     next_layer = (
         select(
@@ -178,7 +180,9 @@ async def get_upstream_nodes(
             (Node.id == NodeRevision.node_id)
             & (Node.current_version == NodeRevision.version),
         )
-    ).cte("upstreams", recursive=True)
+    ).cte("upstreams", recursive=True).suffix_with(
+        "CYCLE node_id SET is_cycle USING path",
+    )
 
     paths = dag.union_all(
         select(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5323,7 +5323,9 @@ async def test_cycle_detection_dimensions_graph(client_with_roads: AsyncClient) 
         " -> ".join(dim["path"] + [""]) + dim["name"] for dim in response.json()
     ] == [
         "default.user -> default.country.country_id",
+        "default.user -> default.country -> default.user -> default.country.country_id",
         "default.user -> default.country.user_id",
+        "default.user -> default.country -> default.user -> default.country.user_id",
         "default.user.birth_country",
         "default.user -> default.country -> default.user.birth_country",
         "default.user.user_id",
@@ -5337,7 +5339,9 @@ async def test_cycle_detection_dimensions_graph(client_with_roads: AsyncClient) 
         "default.events -> default.user -> default.country.user_id",
         "default.events.event_id",
         "default.events -> default.user.birth_country",
+        "default.events -> default.user -> default.country -> default.user.birth_country",
         "default.events -> default.user.user_id",
+        "default.events -> default.user -> default.country -> default.user.user_id",
     ]
 
 


### PR DESCRIPTION
### Summary

This change adds cycle detection to the recursive queries used to traverse the dimensions graph. We do so by adding `CYCLE node_revision_id SET is_cycle USING path` to the recursive CTE, which is recommended in [the Postgres docs](https://www.postgresql.org/docs/16/queries-with.html#QUERIES-WITH-CYCLE).

We also add a `depth` parameter to the API call, so that clients can make less expensive queries if they only need a few levels and not the entire graph. The default `depth` is set to 30, which is reasonable for the vast majority of cases. Note that if we actually have circular loops, keeping the cycle detection from above will make it significantly faster for the query to return, since it will stop traversing immediately after detecting a cycle.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
