### PR TITLE
Minor SQL build fixes

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -10,7 +10,7 @@ import re
 import time
 import uuid
 from http import HTTPStatus
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, cast
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -727,6 +727,9 @@ async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,
         assemble_column_metadata(col)  # type: ignore
         for col in query_ast.select.projection
     ]
+    upstream_tables = [tbl for tbl in query_ast.find_all(ast.Table) if tbl.dj_node]
+    for tbl in upstream_tables:
+        await session.refresh(tbl.dj_node, ["availability"])
     return (
         TranslatedSQL(
             sql=str(query_ast),
@@ -734,12 +737,11 @@ async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,
             dialect=engine.dialect if engine else None,
             upstream_tables=[
                 f"{leading_metric_node.current.catalog.name}.{tbl.identifier()}"  # type: ignore
-                for tbl in query_ast.find_all(ast.Table)
-                # If a table has a corresponding node, then we can use it as dependency.
-                # It must be either a Source node or some type of Materialized node.
-                # Even if there is no availability state for it right now, this qery may be built
-                # for future execution, so we don't need to check for availability state here.
-                if tbl.dj_node and tbl.dj_node.type == NodeType.SOURCE
+                for tbl in upstream_tables
+                # If a table has a corresponding node with an associated physical table (either
+                # a source node or a node with a materialized table).
+                if cast(NodeRevision, tbl.dj_node).type == NodeType.SOURCE
+                or cast(NodeRevision, tbl.dj_node).availability is not None
             ],
         ),
         engine,

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -739,7 +739,7 @@ async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,
                 # It must be either a Source node or some type of Materialized node.
                 # Even if there is no availability state for it right now, this qery may be built
                 # for future execution, so we don't need to check for availability state here.
-                if tbl.dj_node
+                if tbl.dj_node and tbl.dj_node.type == NodeType.SOURCE
             ],
         ),
         engine,

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -814,7 +814,7 @@ async def dimension_join_path(
         [(link, [link]) for link in node.dimension_links],
     )
     while processing_queue:
-        current_link, join_path = processing_queue.pop()
+        current_link, join_path = processing_queue.popleft()
         await session.refresh(current_link, ["dimension"])
         if current_link.dimension.name == dimension_attr.node_name:
             return join_path

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -503,7 +503,7 @@ SELECT
 FROM default_DOT_events
 LEFT JOIN default_DOT_users
   ON default_DOT_events.user_id = default_DOT_users.user_id
-  AND default_DOT_events.event_start_date BETWEEN default_DOT_users.snapshot_date AND CAST(DATE_ADD(CAST(default_DOT_users.snapshot_date AS DATE), 10) AS INT)
+  AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
 GROUP BY
   default_DOT_users.user_id,
   default_DOT_users.snapshot_date,
@@ -542,8 +542,7 @@ GROUP BY
     FROM default_DOT_events
     LEFT JOIN default_DOT_users
       ON default_DOT_events.user_id = default_DOT_users.user_id
-      AND default_DOT_events.event_start_date BETWEEN default_DOT_users.snapshot_date
-      AND CAST(DATE_ADD(CAST(default_DOT_users.snapshot_date AS DATE), 10) AS INT)
+      AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
     GROUP BY
       default_DOT_users.user_id,
       default_DOT_users.snapshot_date,
@@ -597,7 +596,7 @@ SELECT
 FROM default_DOT_events
 LEFT JOIN default_DOT_users
   ON default_DOT_events.user_id = default_DOT_users.user_id
-  AND default_DOT_events.event_start_date BETWEEN default_DOT_users.snapshot_date AND CAST(DATE_ADD(CAST(default_DOT_users.snapshot_date AS DATE), 10) AS INT)
+  AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
 INNER JOIN default_DOT_countries
   ON default_DOT_users.registration_country = default_DOT_countries.country_code
 GROUP BY
@@ -729,7 +728,7 @@ SELECT
 FROM default_DOT_events
 LEFT JOIN default_DOT_users
   ON default_DOT_events.user_id = default_DOT_users.user_id
-  AND default_DOT_events.event_start_date BETWEEN default_DOT_users.snapshot_date AND CAST(DATE_ADD(CAST(default_DOT_users.snapshot_date AS DATE), 10) AS INT)
+  AND default_DOT_events.event_start_date = default_DOT_users.snapshot_date
 INNER JOIN default_DOT_countries
   ON default_DOT_users.registration_country = default_DOT_countries.country_code"""
     assert str(parse(query)) == str(parse(expected))


### PR DESCRIPTION
### Summary

This PR has two fixes to the SQL building:
* The `upstream_tables` list for built SQL should only include source nodes. Including non-source-nodes leads to issues downstream when we try to search for the physical table.
* When searching the dimensions graph during SQL building, we should use breadth-first and not depth-first search. Otherwise we'll end up performing a more expensive join to pull in a dimension when we could've used the shortest path.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
