### PR TITLE
Unify the update_if_exists param in DJ client.

### DIFF
--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -234,7 +234,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         primary_key: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
-        update_if_exists: bool = True,
+        update_if_exists: bool = False,
     ) -> "Source":
         """
         Creates a new Source node with given parameters.
@@ -348,7 +348,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         primary_key: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
-        update_if_exists: bool = True,
+        update_if_exists: bool = False,
     ) -> "Transform":
         """
         Creates or update a Transform node with given parameters.
@@ -380,7 +380,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         display_name: Optional[str] = None,
         tags: Optional[List[str]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
-        update_if_exists: bool = True,
+        update_if_exists: bool = False,
     ) -> "Dimension":
         """
         Creates or update a Dimension node with given parameters.
@@ -414,7 +414,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         unit: Optional[models.MetricUnit] = None,
         tags: Optional[List[str]] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
-        update_if_exists: bool = True,
+        update_if_exists: bool = False,
     ) -> "Metric":
         """
         Creates or update a Metric node with given parameters.
@@ -457,7 +457,7 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
         display_name: Optional[str] = None,
         mode: Optional[models.NodeMode] = models.NodeMode.PUBLISHED,
         tags: Optional[List[str]] = None,
-        update_if_exists: bool = True,
+        update_if_exists: bool = False,
     ) -> "Cube":
         """
         Create or update a cube with the given parameters.

--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -152,24 +152,24 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
                 # This check is for the unit tests, which don't raise an exception
                 # for >= 400 status codes
                 if "name" in cube_dict:
-                    data["metrics"] = cube_dict["cube_node_metrics"]
-                    data["dimensions"] = cube_dict["cube_node_dimensions"]
+                    existing_node_dict["metrics"] = cube_dict["cube_node_metrics"]
+                    existing_node_dict["dimensions"] = cube_dict["cube_node_dimensions"]
         except DJClientException as e:  # pragma: no cover # pytest fixture doesn't raise
             if re.search(r"node .* does not exist", str(e)):
                 existing_node_dict = None
             else:
                 raise
 
-        # pylint: disable=fixme
-        # TODO: checking for "name" in existing_node_dict is a workaround
+        # Checking for "name" in existing_node_dict is a workaround
         #   to accommodate pytest mock client, which return a error message dict (no "name")
         #   instead of raising like the real client.
         if existing_node_dict and "name" in existing_node_dict:
             # update
             if update_if_exists:
+                existing_node_dict.update(data)
                 new_node = self.make_node_of_type(
                     type_=type_,
-                    data=data,
+                    data=existing_node_dict,
                 )
                 new_node._update_tags()
                 new_node._update()

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -383,9 +383,8 @@ class Source(Node):
         When `catalog` is a dictionary, parse out the catalog's
         name, otherwise just return the string.
         """
-        if self.catalog:
-            if isinstance(self.catalog, dict):
-                self.catalog = self.catalog["name"]
+        if self.catalog and isinstance(self.catalog, dict):
+            self.catalog = self.catalog["name"]
 
     def _update(self) -> requests.Response:
         """

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -367,6 +367,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         account_type_table = client.create_source(
             name="default.account_type_table",
             description="new description",
+            update_if_exists=True,
         )
         assert account_type_table.description == "new description"
 
@@ -398,6 +399,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
             ],
             mode=NodeMode.DRAFT,
             tags=["foo"],
+            update_if_exists=True,
         )
         assert account_type_table.name == "default.account_type_table"
         assert account_type_table.display_name == "Default: Account Type Table"

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -359,11 +359,11 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         with pytest.raises(DJClientException):
             account_type_table = client.create_source(
                 name="default.account_type_table",
-                description="New description",
+                description="new description",
                 update_if_exists=False,
             )
 
-        # ... should work since update_if_exists is set to True by default
+        # ... should work since update_if_exists is set to True
         account_type_table = client.create_source(
             name="default.account_type_table",
             description="new description",


### PR DESCRIPTION
### Summary

Because `create_<comething>()` should fail by default if `<something>` already exists.

Piggyback: a bug fix for a problem I introduced in an earlier PR.

### Test Plan

Unit tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Auto.