### PR TITLE
Added cache interface and cachelib + noop implementations

### DIFF
--- a/datajunction-server/datajunction_server/internal/caching/cachelib_cache.py
+++ b/datajunction-server/datajunction_server/internal/caching/cachelib_cache.py
@@ -1,0 +1,43 @@
+"""
+Cachelib-based cache implementation
+"""
+from typing import Any, Optional
+
+from cachelib import SimpleCache
+from fastapi import Request
+
+from datajunction_server.internal.caching.interface import Cache, CacheInterface
+from datajunction_server.internal.caching.noop_cache import noop_cache
+
+
+class CachelibCache(Cache):
+    """A standard implementation of CacheInterface that uses cachelib"""
+
+    def __init__(self):
+        super().__init__()
+        self.cache = SimpleCache()
+
+    def get(self, key: str) -> Optional[Any]:
+        """Get a cached value from the simple cache"""
+        super().get(key)
+        return self.cache.get(key)
+
+    def set(self, key: str, value: Any, timeout: int = 3600) -> None:
+        """Cache a value in the simple cache"""
+        super().set(key, value, timeout)
+        self.cache.set(key, value, timeout=timeout)
+
+    def delete(self, key: str) -> None:
+        """Delete a key in the simple cache"""
+        super().delete(key)
+        self.cache.delete(key)
+
+
+cachelib_cache = CachelibCache()
+
+
+def get_cache(request: Request) -> Optional[CacheInterface]:
+    """Dependency for retrieving a cachelib-based cache implementation"""
+    cache_control = request.headers.get("Cache-Control", "")
+    skip_cache = "no-cache" in cache_control
+    return noop_cache if skip_cache else cachelib_cache

--- a/datajunction-server/datajunction_server/internal/caching/cachelib_cache.py
+++ b/datajunction-server/datajunction_server/internal/caching/cachelib_cache.py
@@ -1,6 +1,7 @@
 """
 Cachelib-based cache implementation
 """
+
 from typing import Any, Optional
 
 from cachelib import SimpleCache

--- a/datajunction-server/datajunction_server/internal/caching/interface.py
+++ b/datajunction-server/datajunction_server/internal/caching/interface.py
@@ -1,6 +1,7 @@
 """
 Caching interface and logging wrapper
 """
+
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Optional

--- a/datajunction-server/datajunction_server/internal/caching/interface.py
+++ b/datajunction-server/datajunction_server/internal/caching/interface.py
@@ -1,0 +1,50 @@
+"""
+Caching interface and logging wrapper
+"""
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+
+class CacheInterface(ABC):
+    """Cache interface"""
+
+    @abstractmethod
+    def get(self, key: str) -> Optional[Any]:
+        """Get a cached value"""
+
+    @abstractmethod
+    def set(self, key: str, value: Any, timeout: int = 300) -> None:
+        """Cache a value"""
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Delete a cache key"""
+
+
+class Cache(CacheInterface):
+    """A wrapper for the cache interface to ensure standardized logging"""
+
+    def __init__(self):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def get(self, key: str) -> Optional[Any]:  # type: ignore
+        """Log the cache check and then use the implemented cache"""
+        self.logger.info(
+            "%s: Getting cached value for key %s",
+            self.__class__.__name__,
+            key,
+        )
+
+    def set(self, key: str, value: Any, timeout: int = 300) -> None:
+        """Log the cache attempt and then use the implemented cache"""
+        self.logger.info(
+            "%s: Setting value for key %s with timeout: %s",
+            self.__class__.__name__,
+            key,
+            timeout,
+        )
+
+    def delete(self, key: str) -> None:
+        """Log the cache deletion attempt and then use the implemented cache"""
+        self.logger.info("%s: Deleting key %s", self.__class__.__name__, key)

--- a/datajunction-server/datajunction_server/internal/caching/noop_cache.py
+++ b/datajunction-server/datajunction_server/internal/caching/noop_cache.py
@@ -1,0 +1,12 @@
+"""
+NoOp cache implementation
+"""
+
+from datajunction_server.internal.caching.interface import Cache
+
+
+class NoOpCache(Cache):
+    """A NoOp implementation of CacheInterface that returns None for get and set"""
+
+
+noop_cache = NoOpCache()

--- a/datajunction-server/tests/internal/caching/cachelib_cache_test.py
+++ b/datajunction-server/tests/internal/caching/cachelib_cache_test.py
@@ -1,6 +1,7 @@
 """
 Tests for cachelib cache implementation
 """
+
 from starlette.requests import Headers, Request
 
 from datajunction_server.internal.caching.cachelib_cache import CachelibCache, get_cache

--- a/datajunction-server/tests/internal/caching/cachelib_cache_test.py
+++ b/datajunction-server/tests/internal/caching/cachelib_cache_test.py
@@ -1,0 +1,61 @@
+"""
+Tests for cachelib cache implementation
+"""
+from starlette.requests import Headers, Request
+
+from datajunction_server.internal.caching.cachelib_cache import CachelibCache, get_cache
+from datajunction_server.internal.caching.noop_cache import NoOpCache
+
+
+def test_cachelib_cache():
+    """
+    Test getting, setting, and deleting using the cachelib implementation
+    """
+    cache = CachelibCache()
+    assert cache.set(key="foo", value="bar", timeout=300) is None
+    assert cache.get(key="foo") == "bar"
+    assert cache.delete(key="foo") is None
+    assert cache.get(key="foo") is None
+
+
+def test_cachelib_cache_nocache_headers():
+    """Test cachelib cache with various request headers"""
+
+    # Test with "no-cache" in headers
+    nocache_request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": Headers({"Cache-Control": "no-cache"}).raw,
+            "query_string": b"",
+        },
+    )
+    get_cache(nocache_request)
+    assert isinstance(get_cache(nocache_request), NoOpCache)
+
+    # Test without "no-cache" in headers
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": Headers({"Cache-Control": "max-age=3600"}).raw,
+            "query_string": b"",
+        },
+    )
+    get_cache(request)
+    assert isinstance(get_cache(request), CachelibCache)
+
+    # Test with no headers at all
+    headerless_request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "query_string": b"",
+        },
+    )
+
+    assert isinstance(get_cache(headerless_request), CachelibCache)

--- a/datajunction-server/tests/internal/caching/noop_cache_test.py
+++ b/datajunction-server/tests/internal/caching/noop_cache_test.py
@@ -1,6 +1,7 @@
 """
 Tests for noop cache
 """
+
 from datajunction_server.internal.caching.noop_cache import NoOpCache
 
 

--- a/datajunction-server/tests/internal/caching/noop_cache_test.py
+++ b/datajunction-server/tests/internal/caching/noop_cache_test.py
@@ -1,0 +1,16 @@
+"""
+Tests for noop cache
+"""
+from datajunction_server.internal.caching.noop_cache import NoOpCache
+
+
+def test_noop_cache():
+    """
+    Test getting, setting, and deleting using a NoOpCache implementation
+    """
+    cache = NoOpCache()
+    assert cache.set(key="foo", value="bar") is None
+    assert (
+        cache.get(key="foo") is None
+    )  # Returns None because NoOp doesn't actually cache
+    assert cache.delete(key="foo") is None

--- a/docs/content/0.1.0/docs/deploying-dj/caching.md
+++ b/docs/content/0.1.0/docs/deploying-dj/caching.md
@@ -1,0 +1,124 @@
+---
+weight: 50
+title: Caching
+---
+
+In DataJunction, caching is a crucial component that helps optimize performance by storing and reusing results of expensive operations, such as computing the dimension DAG (Directed Acyclic Graph). This section discusses how caching is used within DataJunction and how you can implement a custom caching solution using FastAPI's dependency injection.
+
+### How Caching is Used
+
+DataJunction employs caching in multiple areas to enhance performance and reduce the load on the database. One of the primary use cases is caching the results of expensive operations like computing the dimension DAG. By caching these results, DataJunction can quickly return previously computed results without having to recompute them, thereby saving time and resources.
+
+### Default Caching Implementation
+
+Out of the box, DataJunction comes with a simple in-memory cache that uses `SimpleCache` from the `cachelib` library. This implementation is straightforward and efficient for development and small-scale deployments.
+
+Here's a brief look at the default caching implementation:
+
+```py
+from cachelib import SimpleCache
+
+class CachelibCache(Cache):
+    """A standard implementation of CacheInterface that uses cachelib"""
+
+    def __init__(self):
+        super().__init__()
+        self.cache = SimpleCache()
+
+    def get(self, key: str) -> Optional[Any]:
+        """Get a cached value from the simple cache"""
+        super().get(key)
+        return self.cache.get(key)
+
+    def set(self, key: str, value: Any, timeout: int = 3600) -> None:
+        """Cache a value in the simple cache"""
+        super().set(key, value, timeout)
+        self.cache.set(key, value, timeout=timeout)
+
+    def delete(self, key: str) -> None:
+        """Delete a key in the simple cache"""
+        super().delete(key)
+        self.cache.delete(key)
+```
+
+### Custom Caching Implementation
+
+You can implement a custom cache by using FastAPI's dependency injection and injecting a `get_cache` dependency.
+The custom cache must implement the `CacheInterface`, which includes the `get` and `set` methods.
+
+Here's the `CacheInterface` definition:
+
+```py
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+class CacheInterface(ABC):
+    """Cache interface"""
+
+    @abstractmethod
+    def get(self, key: str) -> Optional[Any]:
+        """Get a cached value"""
+
+    @abstractmethod
+    def set(self, key: str, value: Any, timeout: int = 300) -> None:
+        """Cache a value"""
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Delete a cache key"""
+```
+
+#### Implementing a Custom Cache
+
+To implement a custom cache, create a class that extends `CacheInterface` and override the `get` and `set` methods. Then, use FastAPI's dependency injection to inject your custom cache.
+
+Here's an example of a custom cache implementation:
+
+```py
+from fastapi import Request
+from datajunction_server.internal.caching.noop_cache import noop_cache
+
+class MyCustomCache(CacheInterface):
+    """A custom cache implementation"""
+
+    def __init__(self):
+        # Initialize your custom cache here
+        ...
+
+    def get(self, key: str) -> Optional[Any]:
+        # Implement the logic to retrieve a cached value
+        ...
+
+    def set(self, key: str, value: Any, timeout: int = 300) -> None:
+        # Implement the logic to cache a value
+        ...
+
+    def delete(self, key: str) -> None:
+        # Implement the logic to delete a cache key
+        ...
+
+def get_cache(request: Request) -> Optional[CacheInterface]:
+    """Dependency for retrieving a custom cache implementation"""
+    cache_control = request.headers.get("Cache-Control", "")
+    skip_cache = "no-cache" in cache_control
+    return noop_cache if skip_cache else MyCustomCache()
+```
+
+### Respecting the `no-cache` Header
+
+The open-source `get_cache` dependency respects the `no-cache` header in requests. This means that if a request contains
+the `Cache-Control: no-cache` header, the cache will be bypassed, and fresh data will be fetched. This is done by
+returning an instance of `NoOpCache` which simply wraps the base `Cache` implementation that logs caching activity.
+It is recommended that custom cache implementations also respect this header to ensure consistency. "Turning off the
+cache" when a `no-cache` header is detected is as simple as making sure the dependency injected function returns the
+`NoOpCache` instance that can be imported from `datajunction_server.internal.caching.noop_cache`.
+
+Here's the open-source `get_cache` dependency for reference:
+
+```py
+def get_cache(request: Request) -> Optional[CacheInterface]:
+    """Dependency for retrieving a cachelib-based cache implementation"""
+    cache_control = request.headers.get("Cache-Control", "")
+    skip_cache = "no-cache" in cache_control
+    return noop_cache if skip_cache else cachelib_cache
+```

--- a/docs/content/0.1.0/docs/deploying-dj/caching.md
+++ b/docs/content/0.1.0/docs/deploying-dj/caching.md
@@ -44,7 +44,7 @@ class CachelibCache(Cache):
 ### Custom Caching Implementation
 
 You can implement a custom cache by using FastAPI's dependency injection and injecting a `get_cache` dependency.
-The custom cache must implement the `CacheInterface`, which includes the `get` and `set` methods.
+The custom cache must implement the `CacheInterface`, which includes the `get`, `set` and `delete` methods.
 
 Here's the `CacheInterface` definition:
 
@@ -70,7 +70,8 @@ class CacheInterface(ABC):
 
 #### Implementing a Custom Cache
 
-To implement a custom cache, create a class that extends `CacheInterface` and override the `get` and `set` methods. Then, use FastAPI's dependency injection to inject your custom cache.
+To implement a custom cache, create a class that extends `CacheInterface` and override the `get`, `set`, and `delete`
+methods. Then, use FastAPI's dependency injection to inject your custom cache.
 
 Here's an example of a custom cache implementation:
 
@@ -112,13 +113,3 @@ returning an instance of `NoOpCache` which simply wraps the base `Cache` impleme
 It is recommended that custom cache implementations also respect this header to ensure consistency. "Turning off the
 cache" when a `no-cache` header is detected is as simple as making sure the dependency injected function returns the
 `NoOpCache` instance that can be imported from `datajunction_server.internal.caching.noop_cache`.
-
-Here's the open-source `get_cache` dependency for reference:
-
-```py
-def get_cache(request: Request) -> Optional[CacheInterface]:
-    """Dependency for retrieving a cachelib-based cache implementation"""
-    cache_control = request.headers.get("Cache-Control", "")
-    skip_cache = "no-cache" in cache_control
-    return noop_cache if skip_cache else cachelib_cache
-```


### PR DESCRIPTION
### Summary

This breaks out just the cache interface from #1180 and leaves out any use of the dependency injection anywhere. I've also added a `NoOpCache` implementation of the `CacheInterface` which makes it nicer to use the dependency while also keeping it optional (A `NoOpCache` has the same methods so no need to do a null check for the cache everywhere).

I also added the caching docs page that describes how this works and how someone can implement their own custom cache dependency.

### Test Plan

Wrote some tests to get full coverage.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Deploying this has no effect because it's not used anywhere yet.
