### PR TITLE
Add a dictionary of links to AvailabilityState.

### DIFF
--- a/datajunction-server/alembic/versions/2024_10_24_0015-4d6ab789e456_add_a_map_of_links_to_availability_state.py
+++ b/datajunction-server/alembic/versions/2024_10_24_0015-4d6ab789e456_add_a_map_of_links_to_availability_state.py
@@ -1,0 +1,28 @@
+"""Add a map of links to availability state.
+
+Revision ID: 4d6ab789e456
+Revises: f3c9b40deb6f
+Create Date: 2024-10-24 00:15:17.022358+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4d6ab789e456"
+down_revision = "f3c9b40deb6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("availabilitystate", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("links", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("availabilitystate", schema=None) as batch_op:
+        batch_op.drop_column("links")

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -134,6 +134,7 @@ async def add_availability_state(
         ],
         categorical_partitions=data.categorical_partitions,
         temporal_partitions=data.temporal_partitions,
+        links=data.links,
     )
     if node_revision.availability and not node_revision.availability.partitions:
         node_revision.availability.partitions = []

--- a/datajunction-server/datajunction_server/database/availabilitystate.py
+++ b/datajunction-server/datajunction_server/database/availabilitystate.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime, timezone
 from functools import partial
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import sqlalchemy as sa
 from sqlalchemy import JSON, DateTime, ForeignKey
@@ -31,6 +31,7 @@ class AvailabilityState(Base):  # pylint: disable=too-few-public-methods
     table: Mapped[str]
     valid_through_ts: Mapped[int] = mapped_column(sa.BigInteger())
     url: Mapped[Optional[str]]
+    links: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, default=dict)
 
     # An ordered list of categorical partitions like ["country", "group_id"]
     # or ["region_id", "age_group"]

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -265,6 +265,7 @@ class AvailabilityStateBase(TemporalPartitionRange):
     table: str
     valid_through_ts: int
     url: Optional[str]
+    links: Optional[Dict[str, Any]] = Field(default={})
 
     # An ordered list of categorical partitions like ["country", "group_id"]
     # or ["region_id", "age_group"]

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -702,6 +702,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                     "url": "http://some.catalog.com/default.accounting.pmts",
+                    "links": {},
                 },
                 "pre": {},
                 "user": "dj",
@@ -726,6 +727,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "categorical_partitions": [],
             "temporal_partitions": [],
             "url": "http://some.catalog.com/default.accounting.pmts",
+            "links": {},
         }
 
     @pytest.mark.asyncio
@@ -839,6 +841,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                     "url": None,
+                    "links": {},
                 },
                 "pre": {
                     "catalog": "default",
@@ -851,6 +854,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                     "url": None,
+                    "links": {},
                 },
                 "user": "dj",
             },
@@ -873,6 +877,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                     "url": None,
+                    "links": {},
                 },
                 "pre": {
                     "catalog": "default",
@@ -885,6 +890,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                     "url": None,
+                    "links": {},
                 },
                 "user": "dj",
             },
@@ -907,6 +913,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
                     "temporal_partitions": [],
                     "valid_through_ts": 20230125,
                     "url": None,
+                    "links": {},
                 },
                 "pre": {},
                 "user": "dj",
@@ -931,6 +938,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "categorical_partitions": [],
             "temporal_partitions": [],
             "url": None,
+            "links": {},
         }
 
     @pytest.mark.asyncio
@@ -1070,6 +1078,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "categorical_partitions": [],
             "temporal_partitions": ["payment_id"],
             "url": None,
+            "links": {},
         }
 
     @pytest.fixture
@@ -1141,6 +1150,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "table": "local_hard_hats",
             "valid_through_ts": 20230101,
             "url": None,
+            "links": {},
         }
 
     @pytest.mark.asyncio
@@ -1187,6 +1197,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "table": "local_hard_hats",
             "valid_through_ts": 20230101,
             "url": None,
+            "links": {},
         }
 
     @pytest.mark.asyncio
@@ -1540,6 +1551,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "schema_": "accounting",
             "partitions": [],
             "url": None,
+            "links": {},
         }
 
     @pytest.mark.asyncio
@@ -1612,6 +1624,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "categorical_partitions": [],
             "temporal_partitions": [],
             "url": None,
+            "links": {},
         }
 
     @pytest.mark.asyncio
@@ -1657,6 +1670,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
             "categorical_partitions": [],
             "temporal_partitions": [],
             "url": None,
+            "links": {},
         }
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/models/node_test.py
+++ b/datajunction-server/tests/models/node_test.py
@@ -168,6 +168,7 @@ def test_merging_availability_simple_no_partitions() -> None:
         "temporal_partitions": [],
         "partitions": [],
         "url": None,
+        "links": {},
     }
 
 
@@ -208,6 +209,7 @@ def test_merging_availability_complex_no_partitions() -> None:
         "temporal_partitions": [],
         "partitions": [],
         "url": None,
+        "links": {},
     }
 
 
@@ -288,4 +290,5 @@ def test_merging_availability_complex_with_partitions() -> None:
             },
         ],
         "url": None,
+        "links": {},
     }

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -256,6 +256,7 @@ export default function NodeMaterializationTab({ node, djClient }) {
                   <th className="text-start">Output Dataset</th>
                   <th>Valid Through</th>
                   <th>Partitions</th>
+                  <th>Links</th>
                 </tr>
               </thead>
               <tbody>
@@ -298,6 +299,21 @@ export default function NodeMaterializationTab({ node, djClient }) {
                         {node.availability.max_temporal_partition}
                       </span>
                     </span>
+                  </td>
+                  <td>
+                    {node.availability.links !== null ? (
+                      Object.entries(node.availability.links).map(
+                        ([key, value]) => (
+                          <div key={key}>
+                            <a href={value} target="_blank" rel="noreferrer">
+                              {key}
+                            </a>
+                          </div>
+                        ),
+                      )
+                    ) : (
+                      <></>
+                    )}
                   </td>
                 </tr>
               </tbody>

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodeMaterializationTab.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodeMaterializationTab.test.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+import NodeMaterializationTab from '../NodeMaterializationTab';
+
+describe('<NodeMaterializationTab />', () => {
+  const mockDjClient = {
+    node: jest.fn(),
+    materializations: jest.fn(),
+  };
+
+  const mockMaterializations = [
+    {
+      name: 'mat_one',
+      config: {},
+      schedule: '@daily',
+      job: 'SparkSqlMaterializationJob',
+      backfills: [
+        {
+          spec: [
+            {
+              column_name: 'date',
+              values: ['20200101'],
+              range: ['20201010'],
+            },
+          ],
+          urls: ['https://example.com/'],
+        },
+      ],
+      strategy: 'full',
+      output_tables: ['table1'],
+      urls: ['https://example.com/'],
+    },
+  ];
+
+  const mockNode = {
+    node_revision_id: 1,
+    node_id: 1,
+    type: 'source',
+    name: 'default.repair_orders',
+    display_name: 'Default: Repair Orders',
+    version: 'v1.0',
+    status: 'valid',
+    mode: 'published',
+    catalog: {
+      id: 1,
+      uuid: '0fc18295-e1a2-4c3c-b72a-894725c12488',
+      created_at: '2023-08-21T16:48:51.146121+00:00',
+      updated_at: '2023-08-21T16:48:51.146122+00:00',
+      extra_params: {},
+      name: 'warehouse',
+    },
+    schema_: 'roads',
+    table: 'repair_orders',
+    description: 'Repair orders',
+    query: null,
+    availability: {
+      catalog: 'default',
+      categorical_partitions: [],
+      max_temporal_partition: ['2023', '01', '25'],
+      min_temporal_partition: ['2022', '01', '01'],
+      partitions: [],
+      schema_: 'foo',
+      table: 'bar',
+      temporal_partitions: [],
+      valid_through_ts: 1729667463,
+      url: 'https://www.table.com',
+      links: { dashboard: 'https://www.foobar.com/dashboard' },
+    },
+    columns: [
+      {
+        name: 'repair_order_id',
+        type: 'int',
+        attributes: [],
+        dimension: null,
+        partition: {
+          type_: 'temporal',
+          format: 'YYYYMMDD',
+          granularity: 'day',
+        },
+      },
+      {
+        name: 'municipality_id',
+        type: 'string',
+        attributes: [],
+        dimension: null,
+        partition: null,
+      },
+      {
+        name: 'hard_hat_id',
+        type: 'int',
+        attributes: [],
+        dimension: null,
+        partition: null,
+      },
+    ],
+    updated_at: '2023-08-21T16:48:52.880498+00:00',
+    materializations: [
+      {
+        name: 'mat1',
+        config: {},
+        schedule: 'string',
+        job: 'string',
+        backfills: [
+          {
+            spec: [
+              {
+                column_name: 'string',
+                values: ['string'],
+                range: ['string'],
+              },
+            ],
+            urls: ['string'],
+          },
+        ],
+        strategy: 'string',
+        output_tables: ['string'],
+        urls: ['https://example.com/'],
+      },
+    ],
+    parents: [],
+    dimension_links: [
+      {
+        dimension: {
+          name: 'default.contractor',
+        },
+        join_type: 'left',
+        join_sql:
+          'default.contractor.contractor_id = default.repair_orders.contractor_id',
+        join_cardinality: 'one_to_one',
+        role: 'contractor',
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    mockDjClient.materializations.mockReset();
+  });
+
+  it('renders NodeMaterializationTab tab correctly', async () => {
+    mockDjClient.materializations.mockReturnValue(mockMaterializations);
+
+    render(<NodeMaterializationTab node={mockNode} djClient={mockDjClient} />);
+    await waitFor(() => {
+      const link = screen.getByText('dashboard').closest('a');
+      expect(link).toHaveAttribute('href', `https://www.foobar.com/dashboard`);
+    });
+  });
+});


### PR DESCRIPTION
### Summary

This feature allows to integrate our AvailabilityStates with external tools, such as data visualizations. For example... when a new availability state is added or updated, we can submit additional urls that can be shown on the Materialization tab of the node.

This PR adds:
- the API call to save the additional links information,
- the adjustment to the UI to show the `links` together with the Materialized Datasets

Example:
![Screenshot 2024-10-24 at 10 55 16 AM](https://github.com/user-attachments/assets/61b69f4f-cd52-4cd9-9fe4-6c5d73413bfd)

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
