### PR TITLE
Fix bug in pagination logic for edge case around empty list

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/__init__.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/__init__.py
@@ -125,10 +125,10 @@ class Connection(Generic[GenericItemNode]):  # pylint: disable=too-few-public-me
         Construct a Connection from a list of items.
         """
         has_next_page = len(items) > limit or (
-            before is not None and items[0] is not None
+            before is not None and len(items) > 0 and items[0] is not None
         )
         has_prev_page = (before is not None and len(items) > limit) or (
-            after is not None and items[0] is not None
+            after is not None and len(items) > 0 and items[0] is not None
         )
         start_cursor = encode_cursor(items[0]).encode() if items else None
         end_cursor = encode_cursor(items[-1]).encode() if items else None

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -883,3 +883,42 @@ async def test_find_nodes_with_created_edited_by(
             "editedBy": ["dj"],
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_paginated_empty_list(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test finding nodes with pagination when there are none
+    """
+
+    query = """
+    {
+        findNodesPaginated(names: ["default.repair_orders_fact111"], before: "eyJjcmVhdGVkX2F0IjogIjIwMjQtMTAtMjZUMTQ6Mzc6MjkuNzI4MzE3KzAwOjAwIiwgImlkIjogMjV9") {
+          edges {
+            node {
+              name
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPrevPage
+          }
+        }
+    }
+    """
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["findNodesPaginated"] == {
+        "edges": [],
+        "pageInfo": {
+            "startCursor": None,
+            "endCursor": None,
+            "hasNextPage": False,
+            "hasPrevPage": False,
+        },
+    }


### PR DESCRIPTION
### Summary

This PR fixes a bug when the pagination logic processes an empty list, which is now covered by the unit test `test_find_nodes_paginated_empty_list`. Previously this would fail to generate a value for `has_next_page` due to a list index out of range error, but it should return `false`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
