### PR TITLE
Fix a bug with updating existing materialization.

### DIFF
--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -182,6 +182,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
         existing_materialization.schedule = new_materialization.schedule
         new_materialization.node_revision = None  # type: ignore
         new_materialization = existing_materialization
+        new_materialization.deactivated_at = None
     else:
         unchanged_existing_materializations = [
             config


### PR DESCRIPTION
### Summary

When a materialization existed and was inactive. It was hard-to-impossible to recreate it because we were not cleaning up the old `deactivated_at` marker. Now we are.

### Test Plan

In the UI.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

auto