### PR TITLE
Fix python client model class hydration issue

### DIFF
--- a/datajunction-clients/python/datajunction/_base.py
+++ b/datajunction-clients/python/datajunction/_base.py
@@ -20,7 +20,6 @@ class DeserializableMixin:  # pylint: disable=too-few-public-methods
         Create an instance of the given dataclass `cls` from a dictionary `data`.
         This will handle nested dataclasses and optional types.
         """
-        print("from_dict", cls, data)
         if not is_dataclass(cls):
             return cls(**data)
 

--- a/datajunction-clients/python/datajunction/_base.py
+++ b/datajunction-clients/python/datajunction/_base.py
@@ -1,4 +1,4 @@
-"""Base mixins for client dataclasses."""
+"""Base client dataclasses."""
 from dataclasses import fields, is_dataclass
 from typing import TYPE_CHECKING, Any, Dict, Type, TypeVar, Union, get_args, get_origin
 
@@ -9,9 +9,9 @@ if TYPE_CHECKING:  # pragma: no cover
 T = TypeVar("T")
 
 
-class DeserializableMixin:  # pylint: disable=too-few-public-methods
+class SerializableMixin:  # pylint: disable=too-few-public-methods
     """
-    Mixin for deserializing dictionaries to dataclasses
+    Mixin for serializing dictionaries to dataclasses
     """
 
     @classmethod
@@ -32,7 +32,7 @@ class DeserializableMixin:  # pylint: disable=too-few-public-methods
 
             # For optional field types, look at the inner type
             if get_origin(field_type) is Union and type(None) in get_args(field_type):
-                field_type = next(
+                field_type = next(  # pragma: no cover
                     t for t in get_args(field_type) if t is not type(None)  # noqa: E721
                 )
 

--- a/datajunction-clients/python/datajunction/_base.py
+++ b/datajunction-clients/python/datajunction/_base.py
@@ -1,0 +1,49 @@
+from dataclasses import fields, is_dataclass
+from typing import TYPE_CHECKING, Any, Dict, Type, TypeVar, Union, get_args, get_origin
+
+if TYPE_CHECKING:  # pragma: no cover
+    from datajunction.client import DJClient
+
+
+T = TypeVar("T")
+
+
+class DeserializableMixin:
+    @classmethod
+    def from_dict(cls: Type[T], dj_client: "DJClient", data: Dict[str, Any]) -> T:
+        """
+        Create an instance of the given dataclass `cls` from a dictionary `data`.
+        This will handle nested dataclasses and optional types.
+        """
+        if not is_dataclass(cls):
+            return cls(**data)
+
+        field_values = {}
+        for field in fields(cls):
+            if field.name == "dj_client":
+                continue
+            field_type = field.type
+            field_value = data.get(field.name)
+
+            # For optional field types, look at the inner type
+            if get_origin(field_type) is Union and type(None) in get_args(field_type):
+                field_type = next(
+                    t for t in get_args(field_type) if t is not type(None)
+                )
+
+            if get_origin(field_type) is list:
+                list_inner_type = get_args(field_type)[0]
+                if is_dataclass(list_inner_type) and isinstance(field_value, list):
+                    field_values[field.name] = [
+                        list_inner_type.from_dict(dj_client, item)
+                        if isinstance(item, dict)
+                        else item
+                        for item in field_value
+                    ]
+            elif is_dataclass(field_type) and isinstance(field_value, dict):
+                field_values[field.name] = field_type.from_dict(dj_client, field_value)
+            else:
+                field_values[field.name] = field_value  # type: ignore
+        if is_dataclass(cls) and "dj_client" in cls.__dataclass_fields__.keys():  # type: ignore
+            return cls(dj_client=dj_client, **field_values)  # type: ignore
+        return cls(**field_values)

--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -23,7 +23,7 @@ import requests
 from requests.adapters import CaseInsensitiveDict, HTTPAdapter
 
 from datajunction import models
-from datajunction._base import DeserializableMixin
+from datajunction._base import SerializableMixin
 from datajunction.exceptions import (
     DJClientException,
     DJTagAlreadyExists,
@@ -648,7 +648,7 @@ class DJClient:
 
 
 @dataclass
-class ClientEntity(DeserializableMixin):
+class ClientEntity(SerializableMixin):
     """
     Any entity that uses the DJ client.
     """

--- a/datajunction-clients/python/datajunction/_internal.py
+++ b/datajunction-clients/python/datajunction/_internal.py
@@ -23,6 +23,7 @@ import requests
 from requests.adapters import CaseInsensitiveDict, HTTPAdapter
 
 from datajunction import models
+from datajunction._base import DeserializableMixin
 from datajunction.exceptions import (
     DJClientException,
     DJTagAlreadyExists,
@@ -647,7 +648,7 @@ class DJClient:
 
 
 @dataclass
-class ClientEntity:
+class ClientEntity(DeserializableMixin):
     """
     Any entity that uses the DJ client.
     """

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -1,9 +1,12 @@
 """Models used by the DJ client."""
 import enum
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from datajunction._base import DeserializableMixin
+
+if TYPE_CHECKING:  # pragma: no cover
+    from datajunction.client import DJClient
 
 
 @dataclass
@@ -136,6 +139,18 @@ class ColumnAttribute(DeserializableMixin):
 
     name: str
     namespace: Optional[str] = "system"
+
+    @classmethod
+    def from_dict(
+        cls,
+        dj_client: "DJClient",
+        data: Dict[str, Any],
+    ) -> "ColumnAttribute":
+        """
+        Create an instance of the given dataclass `cls` from a dictionary `data`.
+        This will handle nested dataclasses and optional types.
+        """
+        return ColumnAttribute(**data["attribute_type"])
 
 
 @dataclass

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -3,9 +3,11 @@ import enum
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from datajunction._base import DeserializableMixin
+
 
 @dataclass
-class Engine:
+class Engine(DeserializableMixin):
     """
     Represents an engine
     """
@@ -44,7 +46,7 @@ class MetricUnit(str, enum.Enum):
 
 
 @dataclass
-class MetricMetadata:
+class MetricMetadata(DeserializableMixin):
     """
     Metric metadata output
     """
@@ -74,7 +76,7 @@ class MaterializationStrategy(str, enum.Enum):
 
 
 @dataclass
-class Materialization:
+class Materialization(DeserializableMixin):
     """
     A node's materialization config
     """
@@ -127,7 +129,7 @@ class NodeType(str, enum.Enum):
 
 
 @dataclass
-class ColumnAttribute:
+class ColumnAttribute(DeserializableMixin):
     """
     Represents a column attribute
     """
@@ -137,7 +139,7 @@ class ColumnAttribute:
 
 
 @dataclass
-class Column:
+class Column(DeserializableMixin):
     """
     Represents a column
     """
@@ -150,7 +152,7 @@ class Column:
 
 
 @dataclass
-class UpdateNode:  # pylint: disable=too-many-instance-attributes
+class UpdateNode(DeserializableMixin):  # pylint: disable=too-many-instance-attributes
     """
     Fields for updating a node
     """
@@ -180,7 +182,7 @@ class UpdateNode:  # pylint: disable=too-many-instance-attributes
 
 
 @dataclass
-class UpdateTag:
+class UpdateTag(DeserializableMixin):
     """
     Model for a tag update
     """
@@ -211,7 +213,7 @@ class QueryState(str, enum.Enum):
 
 
 @dataclass
-class AvailabilityState:
+class AvailabilityState(DeserializableMixin):
     """
     Represents the availability state for a node.
     """

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -3,14 +3,14 @@ import enum
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from datajunction._base import DeserializableMixin
+from datajunction._base import SerializableMixin
 
 if TYPE_CHECKING:  # pragma: no cover
     from datajunction.client import DJClient
 
 
 @dataclass
-class Engine(DeserializableMixin):
+class Engine(SerializableMixin):
     """
     Represents an engine
     """
@@ -49,7 +49,7 @@ class MetricUnit(str, enum.Enum):
 
 
 @dataclass
-class MetricMetadata(DeserializableMixin):
+class MetricMetadata(SerializableMixin):
     """
     Metric metadata output
     """
@@ -79,7 +79,7 @@ class MaterializationStrategy(str, enum.Enum):
 
 
 @dataclass
-class Materialization(DeserializableMixin):
+class Materialization(SerializableMixin):
     """
     A node's materialization config
     """
@@ -132,7 +132,7 @@ class NodeType(str, enum.Enum):
 
 
 @dataclass
-class ColumnAttribute(DeserializableMixin):
+class ColumnAttribute(SerializableMixin):
     """
     Represents a column attribute
     """
@@ -154,7 +154,7 @@ class ColumnAttribute(DeserializableMixin):
 
 
 @dataclass
-class Column(DeserializableMixin):
+class Column(SerializableMixin):
     """
     Represents a column
     """
@@ -167,7 +167,7 @@ class Column(DeserializableMixin):
 
 
 @dataclass
-class UpdateNode(DeserializableMixin):  # pylint: disable=too-many-instance-attributes
+class UpdateNode(SerializableMixin):  # pylint: disable=too-many-instance-attributes
     """
     Fields for updating a node
     """
@@ -197,7 +197,7 @@ class UpdateNode(DeserializableMixin):  # pylint: disable=too-many-instance-attr
 
 
 @dataclass
-class UpdateTag(DeserializableMixin):
+class UpdateTag(SerializableMixin):
     """
     Model for a tag update
     """
@@ -228,7 +228,7 @@ class QueryState(str, enum.Enum):
 
 
 @dataclass
-class AvailabilityState(DeserializableMixin):
+class AvailabilityState(SerializableMixin):
     """
     Represents the availability state for a node.
     """

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -520,29 +520,6 @@ class Transform(NodeWithQuery):
 
     type: str = "transform"
 
-    @classmethod
-    def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Transform":
-        """
-        Create a new transform node from a dictionary
-        """
-        return cls(
-            dj_client=dj_client,
-            name=data["name"],
-            description=data.get("description"),
-            mode=data.get("mode"),
-            status=data.get("status"),
-            display_name=data.get("display_name"),
-            availability=data.get("availability"),
-            tags=data.get("tags"),
-            primary_key=data.get("primary_key"),
-            materializations=data.get("materializations"),
-            version=data.get("version"),
-            deactivated_at=data.get("deactivated_at"),
-            current_version=data.get("current_version"),
-            query=data["query"],
-            columns=data.get("columns"),
-        )
-
 
 @dataclass
 class Metric(NodeWithQuery):
@@ -564,30 +541,6 @@ class Metric(NodeWithQuery):
             asdict(self.metric_metadata) if self.metric_metadata else None
         )
         return dict_
-
-    @classmethod
-    def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Metric":
-        """
-        Create a new metric node from a dictionary
-        """
-        return cls(
-            dj_client=dj_client,
-            name=data["name"],
-            description=data.get("description"),
-            mode=data.get("mode"),
-            status=data.get("status"),
-            display_name=data.get("display_name"),
-            availability=data.get("availability"),
-            tags=data.get("tags"),
-            primary_key=data.get("primary_key"),
-            materializations=data.get("materializations"),
-            version=data.get("version"),
-            deactivated_at=data.get("deactivated_at"),
-            current_version=data.get("current_version"),
-            query=data["query"],
-            required_dimensions=data.get("required_dimensions"),
-            metric_metadata=data.get("metric_metadata"),
-        )
 
     def dimensions(self):
         """
@@ -650,6 +603,32 @@ class Cube(Node):  # pylint: disable=abstract-method
         dict_["dimensions"] = self.dimensions
         dict_["filters"] = self.filters
         return dict_
+
+    # @classmethod
+    # def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Cube":
+    #     """
+    #     Create a new cube node from a dictionary
+    #     """
+    #     return cls(
+    #         dj_client=dj_client,
+    #         name=data["name"],
+    #         description=data.get("description"),
+    #         mode=data.get("mode"),
+    #         status=data.get("status"),
+    #         display_name=data.get("display_name"),
+    #         availability=data.get("availability"),
+    #         tags=data.get("tags"),
+    #         primary_key=data.get("primary_key"),
+    #         materializations=data.get("materializations"),
+    #         version=data.get("version"),
+    #         deactivated_at=data.get("deactivated_at"),
+    #         current_version=data.get("current_version"),
+    #         query=data.get("query"),
+    #         metrics=data.get("metrics"),
+    #         dimensions=data.get("dimensions"),
+    #         filters=data.get("filters"),
+    #         columns=data.get("columns"),
+    #     )
 
     def _update(self):  # pragma: no cover
         update_node = models.UpdateNode(

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -388,32 +388,6 @@ class Source(Node):
         dict_["table"] = self.table
         return dict_
 
-    # @classmethod
-    # def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Source":
-    #     """
-    #     Create a new source node from a dictionary
-    #     """
-    #     ClientEntity.from_dict(data)
-    #     return cls(
-    #         dj_client=dj_client,
-    #         name=data["name"],
-    #         description=data.get("description"),
-    #         mode=data.get("mode"),
-    #         status=data.get("status"),
-    #         display_name=data.get("display_name"),
-    #         availability=data.get("availability"),
-    #         tags=data.get("tags"),
-    #         primary_key=data.get("primary_key"),
-    #         materializations=data.get("materializations"),
-    #         version=data.get("version"),
-    #         deactivated_at=data.get("deactivated_at"),
-    #         current_version=data.get("current_version"),
-    #         catalog=data.get("catalog"),
-    #         schema_=data.get("schema_"),
-    #         table=data.get("table"),
-    #         columns=data.get("columns"),
-    #     )
-
     def __post_init__(self):
         """
         When `catalog` is a dictionary, parse out the catalog's
@@ -603,32 +577,6 @@ class Cube(Node):  # pylint: disable=abstract-method
         dict_["dimensions"] = self.dimensions
         dict_["filters"] = self.filters
         return dict_
-
-    # @classmethod
-    # def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Cube":
-    #     """
-    #     Create a new cube node from a dictionary
-    #     """
-    #     return cls(
-    #         dj_client=dj_client,
-    #         name=data["name"],
-    #         description=data.get("description"),
-    #         mode=data.get("mode"),
-    #         status=data.get("status"),
-    #         display_name=data.get("display_name"),
-    #         availability=data.get("availability"),
-    #         tags=data.get("tags"),
-    #         primary_key=data.get("primary_key"),
-    #         materializations=data.get("materializations"),
-    #         version=data.get("version"),
-    #         deactivated_at=data.get("deactivated_at"),
-    #         current_version=data.get("current_version"),
-    #         query=data.get("query"),
-    #         metrics=data.get("metrics"),
-    #         dimensions=data.get("dimensions"),
-    #         filters=data.get("filters"),
-    #         columns=data.get("columns"),
-    #     )
 
     def _update(self):  # pragma: no cover
         update_node = models.UpdateNode(

--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -388,30 +388,31 @@ class Source(Node):
         dict_["table"] = self.table
         return dict_
 
-    @classmethod
-    def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Source":
-        """
-        Create a new source node from a dictionary
-        """
-        return cls(
-            dj_client=dj_client,
-            name=data["name"],
-            description=data.get("description"),
-            mode=data.get("mode"),
-            status=data.get("status"),
-            display_name=data.get("display_name"),
-            availability=data.get("availability"),
-            tags=data.get("tags"),
-            primary_key=data.get("primary_key"),
-            materializations=data.get("materializations"),
-            version=data.get("version"),
-            deactivated_at=data.get("deactivated_at"),
-            current_version=data.get("current_version"),
-            catalog=data.get("catalog"),
-            schema_=data.get("schema_"),
-            table=data.get("table"),
-            columns=data.get("columns"),
-        )
+    # @classmethod
+    # def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Source":
+    #     """
+    #     Create a new source node from a dictionary
+    #     """
+    #     ClientEntity.from_dict(data)
+    #     return cls(
+    #         dj_client=dj_client,
+    #         name=data["name"],
+    #         description=data.get("description"),
+    #         mode=data.get("mode"),
+    #         status=data.get("status"),
+    #         display_name=data.get("display_name"),
+    #         availability=data.get("availability"),
+    #         tags=data.get("tags"),
+    #         primary_key=data.get("primary_key"),
+    #         materializations=data.get("materializations"),
+    #         version=data.get("version"),
+    #         deactivated_at=data.get("deactivated_at"),
+    #         current_version=data.get("current_version"),
+    #         catalog=data.get("catalog"),
+    #         schema_=data.get("schema_"),
+    #         table=data.get("table"),
+    #         columns=data.get("columns"),
+    #     )
 
     def __post_init__(self):
         """
@@ -518,7 +519,6 @@ class Transform(NodeWithQuery):
     """
 
     type: str = "transform"
-    # columns: Optional[List[models.Column]] = None
 
     @classmethod
     def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Transform":
@@ -619,30 +619,6 @@ class Dimension(NodeWithQuery):
     """
 
     type: str = "dimension"
-    # columns: Optional[List[models.Column]] = None
-
-    @classmethod
-    def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Dimension":
-        """
-        Create a new dimension node from a dictionary
-        """
-        return cls(
-            dj_client=dj_client,
-            name=data["name"],
-            description=data.get("description"),
-            mode=data.get("mode"),
-            status=data.get("status"),
-            display_name=data.get("display_name"),
-            availability=data.get("availability"),
-            tags=data.get("tags"),
-            primary_key=data.get("primary_key"),
-            materializations=data.get("materializations"),
-            version=data.get("version"),
-            deactivated_at=data.get("deactivated_at"),
-            current_version=data.get("current_version"),
-            query=data["query"],
-            columns=data.get("columns"),
-        )
 
     def linked_nodes(self):
         """
@@ -674,32 +650,6 @@ class Cube(Node):  # pylint: disable=abstract-method
         dict_["dimensions"] = self.dimensions
         dict_["filters"] = self.filters
         return dict_
-
-    @classmethod
-    def from_dict(cls, dj_client: "DJClient", data: Dict[str, Any]) -> "Cube":
-        """
-        Create a new cube node from a dictionary
-        """
-        return cls(
-            dj_client=dj_client,
-            name=data["name"],
-            description=data.get("description"),
-            mode=data.get("mode"),
-            status=data.get("status"),
-            display_name=data.get("display_name"),
-            availability=data.get("availability"),
-            tags=data.get("tags"),
-            primary_key=data.get("primary_key"),
-            materializations=data.get("materializations"),
-            version=data.get("version"),
-            deactivated_at=data.get("deactivated_at"),
-            current_version=data.get("current_version"),
-            query=data.get("query"),
-            metrics=data.get("metrics"),
-            dimensions=data.get("dimensions"),
-            filters=data.get("filters"),
-            columns=data.get("columns"),
-        )
 
     def _update(self):  # pragma: no cover
         update_node = models.UpdateNode(

--- a/datajunction-clients/python/tests/test_base.py
+++ b/datajunction-clients/python/tests/test_base.py
@@ -6,12 +6,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Optional
 
-from datajunction._internal import DJClient
 from datajunction._base import SerializableMixin
+from datajunction._internal import DJClient
 
 
 @dataclass
 class DataClassSimple(SerializableMixin):
+    """Simple dataclass"""
+
     name: str
     version: str
     other: Optional[int]
@@ -20,6 +22,8 @@ class DataClassSimple(SerializableMixin):
 
 @dataclass
 class DataClassNested(SerializableMixin):
+    """Nested dataclass"""
+
     name: str
     dj_client: Optional[DJClient]
     dc_list: List[DataClassSimple]
@@ -28,7 +32,9 @@ class DataClassNested(SerializableMixin):
     dc_str_list: List[str]
 
 
-class OtherClass(SerializableMixin):
+class OtherClass(SerializableMixin):  # pylint: disable=too-few-public-methods
+    """Non-dataclass test case"""
+
     def __init__(self, name: str, version: Optional[str]):
         self.name = name
         self.version = version
@@ -38,7 +44,11 @@ class TestSerializableMixin:
     """
     Tests for the SerializableMixin base class
     """
+
     def test_non_dataclass(self):
+        """
+        Test the mixin with non-dataclasses
+        """
         other_class = OtherClass.from_dict(
             dj_client=None,
             data={"name": "Name", "version": "v1"},
@@ -67,7 +77,7 @@ class TestSerializableMixin:
 
     def test_serialize_nested(self):
         """
-        Serialize simple dataclass
+        Serialize nested dataclass
         """
         now = datetime.now()
         dj_client = DJClient()
@@ -82,7 +92,12 @@ class TestSerializableMixin:
                 "dc_list_optional": [
                     {"name": "N1", "version": "v1", "other": 123, "created": now},
                 ],
-                "dc_optional": {"name": "N1", "version": "v1", "other": 123, "created": now},
+                "dc_optional": {
+                    "name": "N1",
+                    "version": "v1",
+                    "other": 123,
+                    "created": now,
+                },
                 "dc_str_list": ["a", "b", "c"],
             },
         )

--- a/datajunction-clients/python/tests/test_base.py
+++ b/datajunction-clients/python/tests/test_base.py
@@ -1,0 +1,155 @@
+"""
+Test serializable mixin for dict to dataclass conversion
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+from datajunction._internal import DJClient
+from datajunction._base import SerializableMixin
+
+
+@dataclass
+class DataClassSimple(SerializableMixin):
+    name: str
+    version: str
+    other: Optional[int]
+    created: datetime
+
+
+@dataclass
+class DataClassNested(SerializableMixin):
+    name: str
+    dj_client: Optional[DJClient]
+    dc_list: List[DataClassSimple]
+    dc_list_optional: Optional[List[DataClassSimple]]
+    dc_optional: Optional[DataClassSimple]
+    dc_str_list: List[str]
+
+
+class OtherClass(SerializableMixin):
+    def __init__(self, name: str, version: Optional[str]):
+        self.name = name
+        self.version = version
+
+
+class TestSerializableMixin:
+    """
+    Tests for the SerializableMixin base class
+    """
+    def test_non_dataclass(self):
+        other_class = OtherClass.from_dict(
+            dj_client=None,
+            data={"name": "Name", "version": "v1"},
+        )
+        assert other_class.name == "Name"
+        assert other_class.version == "v1"
+
+    def test_serialize_simple(self):
+        """
+        Serialize simple dataclass
+        """
+        now = datetime.now()
+        dc_simple = DataClassSimple.from_dict(
+            dj_client=None,
+            data={
+                "name": "Name",
+                "version": "v1",
+                "other": 123,
+                "created": now,
+            },
+        )
+        assert dc_simple.name == "Name"
+        assert dc_simple.version == "v1"
+        assert dc_simple.other == 123
+        assert dc_simple.created == now
+
+    def test_serialize_nested(self):
+        """
+        Serialize simple dataclass
+        """
+        now = datetime.now()
+        dj_client = DJClient()
+        dc_nested = DataClassNested.from_dict(
+            dj_client=dj_client,
+            data={
+                "name": "Name",
+                "dc_list": [
+                    {"name": "N1", "version": "v1", "other": 123, "created": now},
+                    {"name": "N2", "version": "v2", "other": None, "created": now},
+                ],
+                "dc_list_optional": [
+                    {"name": "N1", "version": "v1", "other": 123, "created": now},
+                ],
+                "dc_optional": {"name": "N1", "version": "v1", "other": 123, "created": now},
+                "dc_str_list": ["a", "b", "c"],
+            },
+        )
+        assert dc_nested == DataClassNested(
+            name="Name",
+            dj_client=dj_client,
+            dc_list=[
+                DataClassSimple(
+                    name="N1",
+                    version="v1",
+                    other=123,
+                    created=now,
+                ),
+                DataClassSimple(
+                    name="N2",
+                    version="v2",
+                    other=None,
+                    created=now,
+                ),
+            ],
+            dc_list_optional=[
+                DataClassSimple(
+                    name="N1",
+                    version="v1",
+                    other=123,
+                    created=now,
+                ),
+            ],
+            dc_optional=DataClassSimple(
+                name="N1",
+                version="v1",
+                other=123,
+                created=now,
+            ),
+            dc_str_list=["a", "b", "c"],
+        )
+        dc_nested = DataClassNested.from_dict(
+            dj_client=None,
+            data={
+                "name": "Name",
+                "dc_list": [
+                    {"name": "N1", "version": "v1", "other": 123, "created": now},
+                    {"name": "N2", "version": "v2", "other": None, "created": now},
+                ],
+                "dc_list_optional": None,
+                "dc_optional": None,
+                "dc_str_list": ["a", "b", "c"],
+            },
+        )
+        assert dc_nested == DataClassNested(
+            name="Name",
+            dj_client=None,
+            dc_list=[
+                DataClassSimple(
+                    name="N1",
+                    version="v1",
+                    other=123,
+                    created=now,
+                ),
+                DataClassSimple(
+                    name="N2",
+                    version="v2",
+                    other=None,
+                    created=now,
+                ),
+            ],
+            dc_list_optional=None,
+            dc_optional=None,
+            dc_str_list=["a", "b", "c"],
+        )

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -288,9 +288,9 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert cube_two.dimensions == ["default.municipality_dim.local_region"]
         assert cube_two.filters is None
         assert cube_two.columns[0] == Column(
-            name="repair_order_id",
-            type="int",
-            display_name="Repair Order Id",
+            name="default.num_repair_orders",
+            type="bigint",
+            display_name="Default: Num Repair Orders",
             attributes=[],
             dimension=None,
         )

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -172,6 +172,17 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert repair_orders.schema_ == "roads"
         assert repair_orders.table == "repair_orders"
         assert repair_orders.type == "source"
+        assert repair_orders.description == "All repair orders"
+        assert repair_orders.tags == []
+        assert repair_orders.primary_key == []
+        assert repair_orders.current_version == "v1.0"
+        assert repair_orders.columns[0] == Column(
+            name="repair_order_id",
+            type="int",
+            display_name="Repair Order Id",
+            attributes=[],
+            dimension=None,
+        )
 
         # dimensions (all)
         all_dimensions = client.list_dimensions()
@@ -207,10 +218,37 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert "FROM default.repair_orders" in repair_order_dim.query
         assert repair_order_dim.type == "dimension"
         assert repair_order_dim.primary_key == ["repair_order_id"]
+        assert repair_order_dim.description == "Repair order dimension"
+        assert repair_order_dim.tags == []
+        assert repair_order_dim.primary_key == ["repair_order_id"]
+        assert repair_order_dim.current_version == "v1.0"
+        assert repair_order_dim.columns[0] == Column(
+            name="repair_order_id",
+            type="int",
+            display_name="Repair Order Id",
+            attributes=[ColumnAttribute(name=None, namespace=None)],
+            dimension=None,
+        )
 
         # transforms
         result = client.namespace("default").transforms()
         assert result == ["default.repair_orders_thin"]
+        thin = client.transform("default.repair_orders_thin")
+        assert thin.name == "default.repair_orders_thin"
+        assert "FROM default.repair_orders" in thin.query
+        assert thin.type == "dimension"
+        assert thin.primary_key == ["repair_order_id"]
+        assert thin.description == "Repair order dimension"
+        assert thin.tags == []
+        assert thin.primary_key == ["repair_order_id"]
+        assert thin.current_version == "v1.0"
+        assert thin.columns[0] == Column(
+            name="repair_order_id",
+            type="int",
+            display_name="Repair Order Id",
+            attributes=[ColumnAttribute(name=None, namespace=None)],
+            dimension=None,
+        )
 
         # metrics
         result_names_only = client.list_metrics(namespace="default")
@@ -1131,7 +1169,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         node.tags.append(tag)
         node.save()
         repull_node = client.source("default.repair_orders")
-        assert repull_node.tags == [tag.to_dict()]
+        assert [tag.to_dict() for tag in repull_node.tags] == [tag.to_dict()]
 
     def test_list_nodes_with_tags(self, client):
         """

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -501,6 +501,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
             ],
             tags=[foo_tag],
             mode=NodeMode.PUBLISHED,
+            update_if_exists=True,
         )
         assert account_type_table.name == "default.account_type_table"
         assert [tag["name"] for tag in account_type_table.tags] == ["foo"]


### PR DESCRIPTION
### Summary

This fixes an issue where the python client's model classes weren't hydrating as dataclasses, but as dictionaries. For example, the expected type of `type(col)` here should be `Column`:
```
source_node = dj.source("source.node")
[type(col) for col in source_node.columns]
```

This fixes things by adding a custom serializer from dictionaries to DJ model dataclasses: `SerializableMixin`. This mixin includes a `from_dict` method that will examine the structure of the dataclass and recursively convert a dictionary to the dataclass.

### Test Plan

- [x] PR has an associated issue: #1220
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
