### PR TITLE
A get_notifier dependency for sending notifications

### DIFF
--- a/datajunction-server/datajunction_server/api/notification.py
+++ b/datajunction-server/datajunction_server/api/notification.py
@@ -1,0 +1,29 @@
+"""Dependency for notifications"""
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Message:
+    """A message for use in a notification"""
+
+    recipients: list[str]
+    subject: str
+    body: str
+    metadata: Optional[Dict[str, str]] = None
+
+
+def get_notifier():
+    """Returns a method for processing notifications"""
+
+    def notify(message: Message):
+        """Notify the recipients"""
+        _logger.debug("Sending notification to %s", message.recipients)
+        _logger.debug("Subject: %s", message.subject)
+        _logger.debug("Body: %s", message.body)
+        _logger.debug("Metadata: %s", message.metadata)
+
+    return notify

--- a/datajunction-server/datajunction_server/api/notification.py
+++ b/datajunction-server/datajunction_server/api/notification.py
@@ -1,29 +1,16 @@
 """Dependency for notifications"""
 import logging
-from dataclasses import dataclass
-from typing import Dict, Optional
+
+from datajunction_server.database.history import History
 
 _logger = logging.getLogger(__name__)
 
 
-@dataclass
-class Message:
-    """A message for use in a notification"""
-
-    recipients: list[str]
-    subject: str
-    body: str
-    metadata: Optional[Dict[str, str]] = None
-
-
 def get_notifier():
-    """Returns a method for processing notifications"""
+    """Returns a method for sending notifications for an event"""
 
-    def notify(message: Message):
-        """Notify the recipients"""
-        _logger.debug("Sending notification to %s", message.recipients)
-        _logger.debug("Subject: %s", message.subject)
-        _logger.debug("Body: %s", message.body)
-        _logger.debug("Metadata: %s", message.metadata)
+    def notify(event: History):
+        """Send a notification for an event"""
+        _logger.debug("Sending notification for event %s", event)
 
     return notify

--- a/datajunction-server/tests/api/notification_test.py
+++ b/datajunction-server/tests/api/notification_test.py
@@ -2,7 +2,8 @@
 import unittest
 from unittest.mock import patch
 
-from datajunction_server.api.notification import Message, get_notifier
+from datajunction_server.api.notification import get_notifier
+from datajunction_server.database.history import ActivityType, EntityType, History
 
 
 class TestNotification(unittest.TestCase):
@@ -12,20 +13,15 @@ class TestNotification(unittest.TestCase):
     def test_notify(self, mock_logger):
         """Test the get_notifier dependency"""
         notify = get_notifier()
-        message = Message(
-            recipients=["alice@example.com", "bob@example.com"],
-            subject="Test Subject",
-            body="This is a test body.",
-            metadata={"key1": "value1", "key2": "value2"},
+        event = History(
+            id=1,
+            entity_name="bar",
+            entity_type=EntityType.NODE,
+            activity_type=ActivityType.CREATE,
         )
-        notify(message)
+        notify(event)
 
         mock_logger.debug.assert_any_call(
-            "Sending notification to %s",
-            message.recipients,
-        )
-        mock_logger.debug.assert_any_call("Subject: %s", message.subject)
-        mock_logger.debug.assert_any_call(
-            "Sending notification to %s",
-            message.recipients,
+            "Sending notification for event %s",
+            event,
         )

--- a/datajunction-server/tests/api/notification_test.py
+++ b/datajunction-server/tests/api/notification_test.py
@@ -1,0 +1,31 @@
+"""Tests for notification dependency injection"""
+import unittest
+from unittest.mock import patch
+
+from datajunction_server.api.notification import Message, get_notifier
+
+
+class TestNotification(unittest.TestCase):
+    """Test sending notifications"""
+
+    @patch("datajunction_server.api.notification._logger")
+    def test_notify(self, mock_logger):
+        """Test the get_notifier dependency"""
+        notify = get_notifier()
+        message = Message(
+            recipients=["alice@example.com", "bob@example.com"],
+            subject="Test Subject",
+            body="This is a test body.",
+            metadata={"key1": "value1", "key2": "value2"},
+        )
+        notify(message)
+
+        mock_logger.debug.assert_any_call(
+            "Sending notification to %s",
+            message.recipients,
+        )
+        mock_logger.debug.assert_any_call("Subject: %s", message.subject)
+        mock_logger.debug.assert_any_call(
+            "Sending notification to %s",
+            message.recipients,
+        )

--- a/docs/content/0.1.0/docs/deploying-dj/notifications.md
+++ b/docs/content/0.1.0/docs/deploying-dj/notifications.md
@@ -1,0 +1,93 @@
+---
+weight: 60
+title: Notifications
+---
+
+In DataJunction, notifications play a vital role in keeping users informed about various activity, such as changes in
+the availability state of nodes. This section discusses how notifications are managed within DataJunction and how you
+can implement a custom notification solution using FastAPI's dependency injection.
+
+### How Notifications are Used
+
+DataJunction uses notifications to alert users about significant events, such as updates to nodes or changes in their
+availability state. By handling notifications within the OSS project, DataJunction provides an opinionated take on where
+and when notifications should be sent.
+
+### Default Notification Implementation
+
+Out of the box, DataJunction includes a simple placeholder dependecny that simply logs notifications.
+
+Here's a brief look at this placeholder notification implementation:
+
+```py
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+_logger = logging.getLogger(__name__)
+
+@dataclass
+class Message:
+    """A message for use in a notification"""
+
+    recipients: list[str]
+    subject: str
+    body: str
+    metadata: Optional[Dict[str, str]] = None
+
+def get_notifier():
+    """Returns a method for processing notifications"""
+
+    def notify(message: Message):
+        """Notify the recipients"""
+        _logger.debug("Sending notification to %s", message.recipients)
+        _logger.debug("Subject: %s", message.subject)
+        _logger.debug("Body: %s", message.body)
+        _logger.debug("Metadata: %s", message.metadata)
+
+    return notify
+```
+
+### Custom Notification Implementation
+
+You can implement a custom notification system by using FastAPI's dependency injection and injecting a `get_notifier`
+dependency. The custom notifier must handle the `notify` method, which processes the notification messages.
+
+#### Implementing a Custom Notifier
+
+To implement a custom notifier, create a function that processes notification messages and use FastAPI's dependency
+injection to inject your custom notifier.
+
+Here's an example of a custom notifier implementation:
+
+```py
+from fastapi import Request
+
+def custom_notify(message: Message):
+    """Custom logic to send notifications"""
+    # Implement the logic to send notifications, e.g., via email or a messaging service
+    ...
+
+def get_notifier(request: Request) -> callable:
+    """Dependency for retrieving a custom notifier implementation"""
+    # You can even add logic to choose between different notifiers based on request headers or other criteria
+    return custom_notify
+```
+
+### Example Usage
+
+Here's how the `get_notifier` dependency is used within the application to send a notification:
+
+```py
+notify = Depends(get_notifier())
+notify(
+    Message(
+        recipients=["dj@datajunction.io"],
+        subject="A new availability state has been published",
+        body="A new availability state has been published for node foo",
+    )
+)
+```
+
+By customizing the `get_notifier` dependency, you can tailor the notification system to suit your specific needs, such
+as integrating with third-party services or implementing advanced notification configuration or logic.

--- a/docs/content/0.1.0/docs/deploying-dj/notifications.md
+++ b/docs/content/0.1.0/docs/deploying-dj/notifications.md
@@ -15,7 +15,7 @@ and when notifications should be sent.
 
 ### Default Notification Implementation
 
-Out of the box, DataJunction includes a simple placeholder dependecny that simply logs notifications.
+Out of the box, DataJunction includes a simple placeholder dependency that simply logs notifications.
 
 Here's a brief look at this placeholder notification implementation:
 

--- a/docs/content/0.1.0/docs/deploying-dj/notifications.md
+++ b/docs/content/0.1.0/docs/deploying-dj/notifications.md
@@ -68,10 +68,13 @@ def custom_notify(message: Message):
     # Implement the logic to send notifications, e.g., via email or a messaging service
     ...
 
-def get_notifier(request: Request) -> callable:
+def get_custom_notifier(request: Request) -> callable:
     """Dependency for retrieving a custom notifier implementation"""
     # You can even add logic to choose between different notifiers based on request headers or other criteria
     return custom_notify
+
+# Override the built-in get_notifier with your custom one
+app.dependency_overrides[get_notifier] = get_custom_notifier
 ```
 
 ### Example Usage


### PR DESCRIPTION
### Summary

This adds a `get_notifier` dependency for plugging in a custom notification mechanism.

### Test Plan

Wrote a test to test the default dependency which just logs the message.

- [x] PR has an associated issue: #830 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
