### PR TITLE
Better input validation on get_sql_for_metrics().

### DIFF
--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -282,7 +282,7 @@ class QueryRequest(Base):  # type: ignore  # pylint: disable=too-few-public-meth
     ) -> Dict[str, List[str]]:
         """
         Prepare for searching in saved query requests by appending version numbers to all nodes
-        being worked with, from the nodes we're retrieving the queries of to the
+        being worked with.
         """
         nodes_objs = [
             await Node.get_by_name(

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -2897,6 +2897,22 @@ async def test_get_sql_for_metrics_failures(module__client_with_examples: AsyncC
     )
     assert response.status_code == 200
 
+    # Getting sql for metric with non-metric node
+    response = await module__client_with_examples.get(
+        "/sql/",
+        params={
+            "metrics": ["default.repair_orders"],
+            "dimensions": [],
+            "filters": [],
+        },
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "message": "All nodes must be of metric type, but some are not: default.repair_orders (source) .",
+        "errors": [],
+        "warnings": [],
+    }
+
 
 @pytest.mark.asyncio
 async def test_get_sql_for_metrics_no_access(module__client_with_examples: AsyncClient):


### PR DESCRIPTION
### Summary

We did not properly check the input to `/sql` api. This PR does a better job, example:

1. When metrics arg has a non-existing node:
    - before: `'NoneType' object has no attribute 'current'`
    - after: `datajunction_server.errors.DJNodeNotFound: A node with name `foo.bar.baz` does not exist.`
2. When metrics argument has a non-metric node:
    - before: `{"message":"","errors":[{"code":204,"message":"","debug":null,"context":""}],"warnings":[]}`
    - after: `datajunction_server.errors.DJInvalidInputException: All nodes must be of metric type, but some are not: system.logs.cube (cube).`

### Test Plan

Locally.

- [x] PR has an associated issue: #1226 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

auto