### PR TITLE
Fix the node history UI when it displays certain event types

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
@@ -57,7 +57,7 @@ export default function NodeHistory({ node, djClient }) {
         </div>
       );
     }
-    if (event.activity_type === 'create' && event.entity_type === 'link') {
+    if (['create', 'update', 'delete'].includes(event.activity_type) && event.entity_type === 'link') {
       return (
         <div className="history-left">
           <b style={{ textTransform: 'capitalize' }}>{event.activity_type}</b>{' '}
@@ -166,7 +166,7 @@ export default function NodeHistory({ node, djClient }) {
     ) {
       return (
         <div className="history-left">
-          Materialized table{' '}
+          <b>Materialized</b> table{' '}
           <code>
             {event.post.catalog}.{event.post.schema_}.{event.post.table}
           </code>{' '}
@@ -180,10 +180,10 @@ export default function NodeHistory({ node, djClient }) {
     if (event.activity_type === 'create' && event.entity_type === 'backfill') {
       return (
         <div className="history-left">
-          Backfill created for materialization {event.details.materialization}{' '}
-          for partition {event.details.partition.column_name} from{' '}
-          {event.details.partition.range[0]} to{' '}
-          {event.details.partition.range[1]}
+          <b>Backfill</b> created for materialization {event.details.materialization}{' '}
+          for partition {event.details.partition[0].column_name} from{' '}
+          {event.details.partition[0].range[0]} to{' '}
+          {event.details.partition[0].range[1]}
         </div>
       );
     }

--- a/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
@@ -182,6 +182,8 @@ export default function RevisionDiff() {
                             {prevRevision[0].query}
                           </SyntaxHighlighter>
                         </>
+                      ) : field === 'columns' ? (
+                        <div>{prevRevision[0][field].map(col => <>{col.name}<br /></>)}</div>
                       ) : (
                         prevRevision[0][field].toString()
                       )

--- a/datajunction-ui/src/mocks/mockNodes.jsx
+++ b/datajunction-ui/src/mocks/mockNodes.jsx
@@ -422,11 +422,11 @@ export const mocks = {
       post: { status: 'invalid' },
       details: {
         materialization: 'druid_metrics_cube__incremental_time__xyz',
-        partition: {
+        partition: [{
           column_name: 'xyz.abc',
           values: null,
           range: ['20240201', '20240301'],
-        },
+        }],
       },
       created_at: '2023-08-21T16:48:56.950482+00:00',
     },


### PR DESCRIPTION
### Summary

The node history UI is sometimes broken when it needs to display certain event types. This PR fixes a number of those edge cases.

### Test Plan

Locally

- [ ] PR has an associated issue: #624 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
