### PR TITLE
Add measures metadata for metrics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          predicate-quantifier: 'every'
           filters: |
             client:
               - 'datajunction-clients/python/**'

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -1,0 +1,98 @@
+from pydantic import BaseModel
+from datajunction_server.sql import functions as dj_functions
+from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
+
+
+class Measure(BaseModel):
+    """
+    Measures are components used to build metrics (e.g., sales_amount, revenue, user_count).
+    """
+
+    name: str
+    expression: str  # A SQL expression for defining the measure
+    aggregation: str
+
+
+class MeasureExtractor:
+    def __init__(self):
+        """Register handlers for aggregation functions"""
+        self.handlers = {
+            dj_functions.Sum: self._generic_additive_agg,
+            dj_functions.Count: self._generic_additive_agg,
+            dj_functions.Max: self._generic_additive_agg,
+            dj_functions.Min: self._generic_additive_agg,
+            dj_functions.Avg: self._avg,
+        }
+
+    def extract_measures(self, metric_query: str) -> tuple[list[Measure], ast.Query]:
+        """
+        Decomposes the metric query into its constituent aggregatable measures and
+        constructs a SQL query derived from those measures.
+        """
+        query_ast = parse(metric_query)
+        measures = []
+
+        for func in query_ast.find_all(ast.Function):
+            handler = self.handlers.get(func.function())
+            if handler:
+                func_measures = handler(func)
+                if func_measures:
+                    self._update_ast(func, func_measures)
+                measures.extend(func_measures)
+
+        return measures, query_ast
+
+    def _generic_additive_agg(self, func) -> list[Measure]:
+        arg = func.args[0]
+        measure_name = "_".join([str(col) for col in arg.find_all(ast.Column)])
+        return [
+            Measure(
+                name=measure_name,
+                expression=str(arg),
+                aggregation=func.name.name,
+            ),
+        ]
+
+    def _avg(self, func) -> list[Measure]:
+        arg = func.args[0]
+        measure_name = "_".join([str(col) for col in arg.find_all(ast.Column)])
+        return [
+            Measure(
+                name=measure_name,
+                expression=str(arg),
+                aggregation=dj_functions.Sum,
+            ),
+            Measure(
+                name="count",
+                expression="1",
+                aggregation=dj_functions.Count,
+            ),
+        ]
+
+    def _update_ast(self, func, measures: list[Measure]):
+        """
+        Updates the query AST based on the measures derived from the function.
+        """
+        if func.function() == dj_functions.Avg:
+            func.parent.replace(
+                from_=func,
+                to=ast.BinaryOp(
+                    op=ast.BinaryOpKind.Divide,
+                    left=ast.Function(
+                        ast.Name("SUM"),
+                        args=[ast.Column(ast.Name(measures[0].name))],
+                    ),
+                    right=ast.Function(
+                        ast.Name("COUNT"),
+                        args=[ast.Column(ast.Name(measures[1].name))],
+                    ),
+                ),
+            )
+        elif func.function() == dj_functions.Count:
+            func.name.name = "SUM"
+            func.args = [ast.Column(ast.Name(measure.name)) for measure in measures]
+        else:
+            func.args = [ast.Column(ast.Name(measure.name)) for measure in measures]
+
+
+extractor = MeasureExtractor()

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -77,8 +77,8 @@ class MeasureExtractor:
         for idx, func in enumerate(query_ast.find_all(ast.Function)):
             dj_function = func.function()
             handler = self.handlers.get(dj_function)
-            if handler:
-                if (func_measures := handler(func, idx)) and dj_function.is_aggregation:
+            if handler and dj_function.is_aggregation:
+                if func_measures := handler(func, idx):  # pragma: no cover
                     MeasureExtractor.update_ast(func, func_measures)
                 measures.extend(func_measures)
 

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -75,10 +75,10 @@ class MeasureExtractor:
         measures = []
 
         for idx, func in enumerate(query_ast.find_all(ast.Function)):
-            handler = self.handlers.get(func.function())
+            dj_function = func.function()
+            handler = self.handlers.get(dj_function)
             if handler:
-                func_measures = handler(func, idx)
-                if func_measures:
+                if (func_measures := handler(func, idx)) and dj_function.is_aggregation:
                     MeasureExtractor.update_ast(func, func_measures)
                 measures.extend(func_measures)
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1679,6 +1679,19 @@ class Over(Expression):
         return f"OVER ({consolidated_by}{window_frame})"
 
 
+# pylint: disable=C0103
+class SetQuantifier(DJEnum):
+    """
+    The accepted set quantifiers
+    """
+
+    All = "ALL"
+    Distinct = "DISTINCT"
+
+    def __str__(self):
+        return self.value
+
+
 @dataclass(eq=False)
 class Function(Named, Operation):
     """
@@ -1686,7 +1699,7 @@ class Function(Named, Operation):
     """
 
     args: List[Expression] = field(default_factory=list)
-    quantifier: str = ""
+    quantifier: SetQuantifier | None = None
     over: Optional[Over] = None
     args_compiled: bool = False
 

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -659,7 +659,9 @@ def _(ctx: sbp.DereferenceContext):
 @visit.register
 def _(ctx: sbp.FunctionCallContext):
     name = visit(ctx.functionName())
-    quantifier = visit(ctx.setQuantifier()) if ctx.setQuantifier() else ""
+    quantifier = (
+        ast.SetQuantifier(visit(ctx.setQuantifier())) if ctx.setQuantifier() else None
+    )
     over = visit(ctx.windowSpec()) if ctx.windowSpec() else None
     args = visit(ctx.argument)
     return ast.Function(name, args, quantifier=quantifier, over=over)

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -1,0 +1,265 @@
+"""
+Tests for ``datajunction_server.sql.decompose``.
+"""
+import pytest
+
+from datajunction_server.sql.decompose import Measure, extractor
+from datajunction_server.sql.parsing.backends.antlr4 import parse
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
+
+
+def test_simple_sum():
+    """
+    Test decomposition for a metric definition that is a simple sum.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT SUM(sales_amount) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_0",
+            expression="sales_amount",
+            aggregation="SUM",
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT SUM(sales_amount_sum_0) FROM parent_node"),
+    )
+
+
+def test_nested_functions():
+    """
+    Test behavior with deeply nested functions inside aggregations.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT SUM(ROUND(COALESCE(sales_amount, 0) * 1.1)) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_0",
+            expression="ROUND(COALESCE(sales_amount, 0) * 1.1)",
+            aggregation="SUM",
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT SUM(sales_amount_sum_0) FROM parent_node"),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT LN(SUM(COALESCE(sales_amount, 0)) + 1) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_1",
+            expression="COALESCE(sales_amount, 0)",
+            aggregation="SUM",
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT LN(SUM(sales_amount_sum_1) + 1) FROM parent_node"),
+    )
+
+
+def test_average():
+    """
+    Test decomposition for a metric definition that uses AVG.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT AVG(sales_amount) FROM parent_node",
+    )
+
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_0",
+            expression="sales_amount",
+            aggregation="SUM",
+        ),
+        Measure(name="count", expression="1", aggregation="COUNT"),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT SUM(sales_amount_sum_0) / COUNT(count) FROM parent_node"),
+    )
+
+
+def test_rate():
+    """
+    Test decomposition for a metric definition that is a ratio
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT SUM(clicks) / SUM(impressions) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(name="clicks_sum_0", expression="clicks", aggregation="SUM"),
+        Measure(name="impressions_sum_1", expression="impressions", aggregation="SUM"),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT SUM(clicks_sum_0) / SUM(impressions_sum_1) FROM parent_node"),
+    )
+
+
+def test_has_ever():
+    """
+    Test decomposition for a metric definition that uses MAX.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT MAX(IF(condition, 1, 0)) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="condition_max_0",
+            expression="IF(condition, 1, 0)",
+            aggregation="MAX",
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT MAX(condition_max_0) FROM parent_node"),
+    )
+
+
+def test_fraction_with_if():
+    """
+    Test decomposition for a rate metric with complex numerator and denominators.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT IF(SUM(COALESCE(action, 0)) > 0, "
+        "CAST(SUM(COALESCE(action_two, 0)) AS DOUBLE) / "
+        "CAST(SUM(COALESCE(action, 0)) AS DOUBLE), NULL) FROM parent_node",
+    )
+
+    expected_measures = [
+        Measure(
+            name="action_sum_1",
+            expression="COALESCE(action, 0)",
+            aggregation="SUM",
+        ),
+        Measure(
+            name="action_two_sum_2",
+            expression="COALESCE(action_two, 0)",
+            aggregation="SUM",
+        ),
+        Measure(
+            name="action_sum_3",
+            expression="COALESCE(action, 0)",
+            aggregation="SUM",
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT IF(SUM(action_sum_1) > 0, "
+            "CAST(SUM(action_two_sum_2) AS DOUBLE) / "
+            "CAST(SUM(action_sum_3) AS DOUBLE), NULL) FROM parent_node",
+        ),
+    )
+
+
+def test_count():
+    """
+    Test decomposition for a count metric.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT COUNT(IF(action = 1, action_event_ts, 0)) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="action_action_event_ts_count_0",
+            expression="IF(action = 1, action_event_ts, 0)",
+            aggregation="COUNT",
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT SUM(action_action_event_ts_count_0) FROM parent_node"),
+    )
+
+
+def test_count_distinct_rate():
+    """
+    Test decomposition for a metric that uses count distinct.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT COUNT(DISTINCT user_id) / COUNT(action) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="user_id_count_0",
+            expression="DISTINCT user_id",
+            aggregation="COUNT",
+        ),
+        Measure(name="action_count_1", expression="action", aggregation="COUNT"),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT COUNT( DISTINCT user_id_count_0) / SUM(action_count_1) FROM parent_node",
+        ),
+    )
+
+
+def test_no_aggregation():
+    """
+    Test behavior when there is no aggregation function in the metric query.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT sales_amount FROM parent_node",
+    )
+    expected_measures = []
+    assert measures == expected_measures
+    assert str(derived_sql) == str(parse("SELECT sales_amount FROM parent_node"))
+
+
+def test_multiple_aggregations_with_conditions():
+    """
+    Test behavior with conditional aggregations in the metric query.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT SUM(IF(region = 'US', sales_amount, 0)) + "
+        "COUNT(DISTINCT IF(region = 'US', account_id, NULL)) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="region_sales_amount_sum_0",
+            expression="IF(region = 'US', sales_amount, 0)",
+            aggregation="SUM",
+        ),
+        Measure(
+            name="region_account_id_count_1",
+            expression="DISTINCT IF(region = 'US', account_id, NULL)",
+            aggregation="COUNT",
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT  SUM(region_sales_amount_sum_0) + COUNT("
+            "DISTINCT region_account_id_count_1) FROM parent_node",
+        ),
+    )
+
+
+def test_empty_query():
+    """
+    Test behavior when the metric query is empty.
+    """
+    with pytest.raises(DJParseException, match="Empty query provided!"):
+        extractor.extract_measures("")
+
+
+def test_unsupported_aggregation_function():
+    """
+    Test behavior when the query contains unsupported aggregation functions.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT MEDIAN(sales_amount) FROM parent_node",
+    )
+    expected_measures = []
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT MEDIAN(sales_amount) FROM parent_node"),
+    )

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -3,7 +3,12 @@ Tests for ``datajunction_server.sql.decompose``.
 """
 import pytest
 
-from datajunction_server.sql.decompose import Measure, extractor
+from datajunction_server.sql.decompose import (
+    Aggregability,
+    AggregationRule,
+    Measure,
+    extractor,
+)
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 
@@ -20,11 +25,111 @@ def test_simple_sum():
             name="sales_amount_sum_0",
             expression="sales_amount",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse("SELECT SUM(sales_amount_sum_0) FROM parent_node"),
+    )
+
+
+def test_sum_with_cast():
+    """
+    Test decomposition for a metric definition that has a sum with a cast.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT CAST(SUM(sales_amount) AS DOUBLE) * 100.0 FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_0",
+            expression="sales_amount",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT CAST(SUM(sales_amount_sum_0) AS DOUBLE) * 100.0 FROM parent_node",
+        ),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT 100.0 * SUM(sales_amount) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_0",
+            expression="sales_amount",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT 100.0 * SUM(sales_amount_sum_0) FROM parent_node"),
+    )
+
+
+def test_sum_with_coalesce():
+    """
+    Test decomposition for a metric definition that has a sum with coalesce.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT COALESCE(SUM(sales_amount), 0) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_1",
+            expression="sales_amount",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT COALESCE(SUM(sales_amount_sum_1), 0) FROM parent_node"),
+    )
+
+
+def test_multiple_sums():
+    """
+    Test decomposition for a metric definition that has multiple sums.
+    """
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT SUM(sales_amount) + SUM(fraud_sales) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="sales_amount_sum_0",
+            expression="sales_amount",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="fraud_sales_sum_1",
+            expression="fraud_sales",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT SUM(sales_amount_sum_0) + SUM(fraud_sales_sum_1) FROM parent_node",
+        ),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT SUM(sales_amount) - SUM(fraud_sales) FROM parent_node",
+    )
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT SUM(sales_amount_sum_0) - SUM(fraud_sales_sum_1) FROM parent_node",
+        ),
     )
 
 
@@ -40,6 +145,7 @@ def test_nested_functions():
             name="sales_amount_sum_0",
             expression="ROUND(COALESCE(sales_amount, 0) * 1.1)",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
     ]
     assert measures == expected_measures
@@ -55,6 +161,7 @@ def test_nested_functions():
             name="sales_amount_sum_1",
             expression="COALESCE(sales_amount, 0)",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
     ]
     assert measures == expected_measures
@@ -76,8 +183,14 @@ def test_average():
             name="sales_amount_sum_0",
             expression="sales_amount",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
-        Measure(name="count", expression="1", aggregation="COUNT"),
+        Measure(
+            name="count",
+            expression="1",
+            aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
@@ -87,18 +200,142 @@ def test_average():
 
 def test_rate():
     """
-    Test decomposition for a metric definition that is a ratio
+    Test decomposition for a rate metric definition.
     """
     measures, derived_sql = extractor.extract_measures(
         "SELECT SUM(clicks) / SUM(impressions) FROM parent_node",
     )
+    expected_measures0 = [
+        Measure(
+            name="clicks_sum_0",
+            expression="clicks",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="impressions_sum_1",
+            expression="impressions",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures0
+    assert str(derived_sql) == str(
+        parse("SELECT SUM(clicks_sum_0) / SUM(impressions_sum_1) FROM parent_node"),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT 1.0 * SUM(clicks) / NULLIF(SUM(impressions), 0) FROM parent_node",
+    )
     expected_measures = [
-        Measure(name="clicks_sum_0", expression="clicks", aggregation="SUM"),
-        Measure(name="impressions_sum_1", expression="impressions", aggregation="SUM"),
+        Measure(
+            name="clicks_sum_0",
+            expression="clicks",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="impressions_sum_2",
+            expression="impressions",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT SUM(clicks_sum_0) / SUM(impressions_sum_1) FROM parent_node"),
+        parse(
+            "SELECT 1.0 * SUM(clicks_sum_0) / NULLIF(SUM(impressions_sum_2), 0) FROM parent_node",
+        ),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT CAST(CAST(SUM(clicks) AS INT) AS DOUBLE) / "
+        "CAST(SUM(impressions) AS DOUBLE) FROM parent_node",
+    )
+    assert measures == expected_measures0
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT CAST(CAST(SUM(clicks_sum_0) AS INT) AS DOUBLE) / "
+            "CAST(SUM(impressions_sum_1) AS DOUBLE) FROM parent_node",
+        ),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT COALESCE(SUM(clicks) / SUM(impressions), 0) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="clicks_sum_1",
+            expression="clicks",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="impressions_sum_2",
+            expression="impressions",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT COALESCE(SUM(clicks_sum_1) / SUM(impressions_sum_2), 0) FROM parent_node",
+        ),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT IF(SUM(clicks) > 0, CAST(SUM(impressions) AS DOUBLE) "
+        "/ CAST(SUM(clicks) AS DOUBLE), NULL) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="clicks_sum_1",
+            expression="clicks",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="impressions_sum_2",
+            expression="impressions",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="clicks_sum_3",
+            expression="clicks",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT IF(SUM(clicks_sum_1) > 0, CAST(SUM(impressions_sum_2) AS DOUBLE)"
+            " / CAST(SUM(clicks_sum_3) AS DOUBLE), NULL) FROM parent_node",
+        ),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT ln(sum(clicks) + 1) / sum(views) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="clicks_sum_1",
+            expression="clicks",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="views_sum_2",
+            expression="views",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT ln(sum(clicks_sum_1) + 1) / sum(views_sum_2) FROM parent_node"),
     )
 
 
@@ -114,6 +351,7 @@ def test_has_ever():
             name="condition_max_0",
             expression="IF(condition, 1, 0)",
             aggregation="MAX",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
     ]
     assert measures == expected_measures
@@ -137,16 +375,19 @@ def test_fraction_with_if():
             name="action_sum_1",
             expression="COALESCE(action, 0)",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
         Measure(
             name="action_two_sum_2",
             expression="COALESCE(action_two, 0)",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
         Measure(
             name="action_sum_3",
             expression="COALESCE(action, 0)",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
     ]
     assert measures == expected_measures
@@ -171,6 +412,7 @@ def test_count():
             name="action_action_event_ts_count_0",
             expression="IF(action = 1, action_event_ts, 0)",
             aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
     ]
     assert measures == expected_measures
@@ -191,8 +433,14 @@ def test_count_distinct_rate():
             name="user_id_count_0",
             expression="DISTINCT user_id",
             aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.LIMITED),
         ),
-        Measure(name="action_count_1", expression="action", aggregation="COUNT"),
+        Measure(
+            name="action_count_1",
+            expression="action",
+            aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
@@ -227,11 +475,13 @@ def test_multiple_aggregations_with_conditions():
             name="region_sales_amount_sum_0",
             expression="IF(region = 'US', sales_amount, 0)",
             aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
         ),
         Measure(
             name="region_account_id_count_1",
             expression="DISTINCT IF(region = 'US', account_id, NULL)",
             aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.LIMITED),
         ),
     ]
     assert measures == expected_measures
@@ -239,6 +489,44 @@ def test_multiple_aggregations_with_conditions():
         parse(
             "SELECT  SUM(region_sales_amount_sum_0) + COUNT("
             "DISTINCT region_account_id_count_1) FROM parent_node",
+        ),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT cast(coalesce(max(a), max(b), 0) as double) + "
+        "cast(coalesce(max(a), max(b)) as double) FROM parent_node",
+    )
+    expected_measures = [
+        Measure(
+            name="a_max_1",
+            expression="a",
+            aggregation="MAX",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="b_max_2",
+            expression="b",
+            aggregation="MAX",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="a_max_4",
+            expression="a",
+            aggregation="MAX",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="b_max_5",
+            expression="b",
+            aggregation="MAX",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT CAST(coalesce(max(a_max_1), max(b_max_2), 0) AS DOUBLE) + "
+            "CAST(coalesce(max(a_max_4), max(b_max_5)) AS DOUBLE) FROM parent_node",
         ),
     )
 
@@ -253,7 +541,8 @@ def test_empty_query():
 
 def test_unsupported_aggregation_function():
     """
-    Test behavior when the query contains unsupported aggregation functions.
+    Test behavior when the query contains unsupported aggregation functions. We just return an
+    empty list of measures in this case, because there are no pre-aggregatable measures.
     """
     measures, derived_sql = extractor.extract_measures(
         "SELECT MEDIAN(sales_amount) FROM parent_node",
@@ -262,4 +551,15 @@ def test_unsupported_aggregation_function():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse("SELECT MEDIAN(sales_amount) FROM parent_node"),
+    )
+
+    measures, derived_sql = extractor.extract_measures(
+        "SELECT approx_percentile(duration_ms, 1.0, 0.9) / 1000 FROM parent_node",
+    )
+    expected_measures = []
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT approx_percentile(duration_ms, 1.0, 0.9) / 1000 FROM parent_node",
+        ),
     )


### PR DESCRIPTION
### Summary

The detailed context and explanation of the broader problem we're trying to solve is in [the issue](https://github.com/DataJunction/dj/issues/1223). To briefly summarize here:

For any set of metrics and dimensions, we can generate measures SQL, which is used to materialize a dataset that can serve those metrics and dimensions in a more efficient manner. Today, the generated measures SQL is non-optimized - the measures are computed at the level of the metrics' upstream transforms, without considering any downstream aggregation or grain optimizations.

We can make the generated measures SQL significantly more efficient by breaking down metrics into pre-aggregated (but still further aggregatable) **measures**. This PR provides appropriate appropriate metadata for a given metric on its measures, as a first step towards better measures SQL.

![image](https://github.com/user-attachments/assets/c5880acc-0b4e-4c4c-9a47-92cabd10aef5)

* **Metrics** are combinations of one or more measures with various aggregation or formulas applied (e.g., `SUM(sales_amount) * 100.0`, `AVG(revenue)`, `SUM(clicks) / SUM(impressions)`).
* **Measures** are components used to build metrics (e.g., `sales_amount`, `revenue`, `user_count`), along with aggregation and other metadata:
```
measures:
- name: sales_amount_sum
  expression: amount
  aggregation: SUM
  rule: FULL
- name: user_id_count_distinct
  expression: "distinct user_id"
  aggregation: COUNT
  rule: LIMITED
```

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1223
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
