### PR TITLE
Only refresh SQLAlchemy ORM objects when needed

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -59,7 +59,7 @@ from datajunction_server.naming import LOOKUP_CHARS
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.parsing import ast
 from datajunction_server.typing import END_JOB_STATES
-from datajunction_server.utils import SEPARATOR
+from datajunction_server.utils import SEPARATOR, refresh_if_needed
 
 _logger = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ async def get_column(
     Get a column from a node revision
     """
     requested_column = None
-    await session.refresh(node, ["columns"])
+    await refresh_if_needed(session, node, ["columns"])
     for node_column in node.columns:
         if node_column.name == column_name:
             requested_column = node_column
@@ -737,7 +737,7 @@ async def build_sql_for_multiple_metrics(  # pylint: disable=too-many-arguments,
     ]
     upstream_tables = [tbl for tbl in query_ast.find_all(ast.Table) if tbl.dj_node]
     for tbl in upstream_tables:
-        await session.refresh(tbl.dj_node, ["availability"])
+        await refresh_if_needed(session, tbl.dj_node, ["availability"])
     return (
         TranslatedSQL(
             sql=str(query_ast),


### PR DESCRIPTION
### Summary

This helps speed up the SQL building process by only refreshing SQLAlchemy ORM objects when the attribute is not already loaded. After the migration to async database requests, we had to explicitly load attributes when they were needed. However, we were overdoing this by consistently calling `session.refresh(...)` on attributes that had already been loaded, thereby reloading attributes unnecessarily and making many calls to the database. This change will reduce calls to the database during SQL building, making it faster.

### Test Plan

No additional tests, but existing ones should pass.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
