### PR TITLE
Add 'hidden' as a column attribute type

### DIFF
--- a/datajunction-server/datajunction_server/api/attributes.py
+++ b/datajunction-server/datajunction_server/api/attributes.py
@@ -85,6 +85,16 @@ async def default_attribute_types(session: AsyncSession = Depends(get_session)):
             uniqueness_scope=[],
             allowed_node_types=[NodeType.SOURCE, NodeType.TRANSFORM],
         ),
+        AttributeType(
+            namespace=RESERVED_ATTRIBUTE_NAMESPACE,
+            name="hidden",
+            description=(
+                "Points to a dimension column that's not useful "
+                "for end users and should be hidden"
+            ),
+            uniqueness_scope=[],
+            allowed_node_types=[NodeType.DIMENSION],
+        ),
     ]
     default_attribute_type_names = {type_.name: type_ for type_ in defaults}
 

--- a/datajunction-server/tests/api/attributes_test.py
+++ b/datajunction-server/tests/api/attributes_test.py
@@ -1,6 +1,7 @@
 """
 Tests for the attributes API.
 """
+
 from unittest.mock import ANY
 
 import pytest
@@ -97,5 +98,15 @@ async def test_list_system_attributes(
             "allowed_node_types": ["source", "transform"],
             "name": "dimension",
             "description": "Points to a dimension attribute column",
+        },
+        "hidden": {
+            "namespace": "system",
+            "uniqueness_scope": [],
+            "allowed_node_types": ["dimension"],
+            "name": "hidden",
+            "description": (
+                "Points to a dimension column that's not useful "
+                "for end users and should be hidden"
+            ),
         },
     }


### PR DESCRIPTION
### Summary

Add a `hidden` attribute type for columns on **dimension** nodes that are not useful for end users. For example, timestamp is technically a dimension of a fact, but it's rare that end users would want to filter or group by a timestamp.

Client application can use this `hidden` attribute to skip surfacing certain columns.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
