### PR TITLE
Add derived measures to GraphQL 

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
@@ -5,8 +5,10 @@ from typing import Optional
 import strawberry
 
 from datajunction_server.models.node import MetricDirection as MetricDirection_
+from datajunction_server.sql.decompose import Aggregability as Aggregability_
 
 MetricDirection = strawberry.enum(MetricDirection_)
+Aggregability = strawberry.enum(Aggregability_)
 
 
 @strawberry.type
@@ -19,6 +21,49 @@ class Unit:  # pylint: disable=too-few-public-methods
     label: Optional[str]
     category: Optional[str]
     abbreviation: Optional[str]
+
+
+@strawberry.type
+class AggregationRule:
+    """
+    The aggregation rule for the measure. If the Aggregability type is LIMITED, the `level` should
+    be specified to highlight the level at which the measure needs to be aggregated in order to
+    support the specified aggregation function.
+
+    For example, consider a metric like COUNT(DISTINCT user_id). It can be decomposed into a
+    single measure with LIMITED aggregability, i.e., it is only aggregatable if the measure is
+    calculated at the `user_id` level:
+    - name: num_users
+      expression: DISTINCT user_id
+      aggregation: COUNT
+      rule:
+        type: LIMITED
+        level: ["user_id"]
+    """
+
+    type: Aggregability = Aggregability.NONE  # type: ignore
+    level: list[str] | None = None
+
+
+@strawberry.type
+class Measure:  # pylint: disable=too-few-public-methods
+    """
+    Measure output
+    """
+
+    name: str
+    expression: str  # A SQL expression for defining the measure
+    aggregation: str
+    rule: AggregationRule
+
+
+@strawberry.type
+class ExtractedMeasures:  # pylint: disable=too-few-public-methods
+    """
+    extracted measures from metric
+    """
+    measures: list[Measure]
+    derived_sql: str
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
@@ -26,12 +26,12 @@ class Unit:  # pylint: disable=too-few-public-methods
 
 
 @strawberry.experimental.pydantic.type(model=AggregationRule_, all_fields=True)
-class AggregationRule:
+class AggregationRule:  # pylint: disable=missing-class-docstring,too-few-public-methods
     ...
 
 
 @strawberry.experimental.pydantic.type(model=Measure_, all_fields=True)
-class Measure:
+class Measure:  # pylint: disable=missing-class-docstring,too-few-public-methods
     ...
 
 

--- a/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
@@ -6,6 +6,8 @@ import strawberry
 
 from datajunction_server.models.node import MetricDirection as MetricDirection_
 from datajunction_server.sql.decompose import Aggregability as Aggregability_
+from datajunction_server.sql.decompose import AggregationRule as AggregationRule_
+from datajunction_server.sql.decompose import Measure as Measure_
 
 MetricDirection = strawberry.enum(MetricDirection_)
 Aggregability = strawberry.enum(Aggregability_)
@@ -23,26 +25,14 @@ class Unit:  # pylint: disable=too-few-public-methods
     abbreviation: Optional[str]
 
 
-@strawberry.type
+@strawberry.experimental.pydantic.type(model=AggregationRule_, all_fields=True)
 class AggregationRule:
-    """
-    The aggregation rule for the measure.
-    """
-
-    type: Aggregability = Aggregability.NONE  # type: ignore
-    level: list[str] | None = None
+    ...
 
 
-@strawberry.type
-class Measure:  # pylint: disable=too-few-public-methods
-    """
-    Measure output
-    """
-
-    name: str
-    expression: str  # A SQL expression for defining the measure
-    aggregation: str
-    rule: AggregationRule
+@strawberry.experimental.pydantic.type(model=Measure_, all_fields=True)
+class Measure:
+    ...
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
@@ -42,7 +42,8 @@ class ExtractedMeasures:  # pylint: disable=too-few-public-methods
     """
 
     measures: list[Measure]
-    derived_sql: str
+    derived_query: str
+    derived_expression: str
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
@@ -26,19 +26,7 @@ class Unit:  # pylint: disable=too-few-public-methods
 @strawberry.type
 class AggregationRule:
     """
-    The aggregation rule for the measure. If the Aggregability type is LIMITED, the `level` should
-    be specified to highlight the level at which the measure needs to be aggregated in order to
-    support the specified aggregation function.
-
-    For example, consider a metric like COUNT(DISTINCT user_id). It can be decomposed into a
-    single measure with LIMITED aggregability, i.e., it is only aggregatable if the measure is
-    calculated at the `user_id` level:
-    - name: num_users
-      expression: DISTINCT user_id
-      aggregation: COUNT
-      rule:
-        type: LIMITED
-        level: ["user_id"]
+    The aggregation rule for the measure.
     """
 
     type: Aggregability = Aggregability.NONE  # type: ignore
@@ -62,6 +50,7 @@ class ExtractedMeasures:  # pylint: disable=too-few-public-methods
     """
     extracted measures from metric
     """
+
     measures: list[Measure]
     derived_sql: str
 

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -14,7 +14,6 @@ from datajunction_server.api.graphql.scalars.materialization import (
 )
 from datajunction_server.api.graphql.scalars.metricmetadata import (
     ExtractedMeasures,
-    Measure,
     MetricMetadata,
 )
 from datajunction_server.api.graphql.scalars.user import User

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -128,8 +128,12 @@ class NodeRevision:
         """
         if root.type != NodeType.METRIC:
             return None
-        measures, derived_sql = extractor.extract_measures(root.query)
-        return ExtractedMeasures(measures=measures, derived_sql=derived_sql)  # type: ignore
+        measures, derived_ast = extractor.extract_measures(root.query)
+        return ExtractedMeasures(  # type: ignore
+            measures=measures,
+            derived_query=str(derived_ast),
+            derived_expression=str(derived_ast.select.projection[0]),
+        )
 
     # Only cubes will have these fields
     @strawberry.field

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 import strawberry
 from strawberry.scalars import JSON
 
-from datajunction_server.sql.decompose import extractor
 from datajunction_server.api.graphql.scalars import BigInt
 from datajunction_server.api.graphql.scalars.availabilitystate import AvailabilityState
 from datajunction_server.api.graphql.scalars.catalog_engine import Catalog
@@ -13,7 +12,11 @@ from datajunction_server.api.graphql.scalars.column import Column, NodeName, Par
 from datajunction_server.api.graphql.scalars.materialization import (
     MaterializationConfig,
 )
-from datajunction_server.api.graphql.scalars.metricmetadata import ExtractedMeasures, Measure, MetricMetadata
+from datajunction_server.api.graphql.scalars.metricmetadata import (
+    ExtractedMeasures,
+    Measure,
+    MetricMetadata,
+)
 from datajunction_server.api.graphql.scalars.user import User
 from datajunction_server.database.dimensionlink import (
     JoinCardinality as JoinCardinality_,
@@ -24,6 +27,7 @@ from datajunction_server.database.node import NodeRevision as DBNodeRevision
 from datajunction_server.models.node import NodeMode as NodeMode_
 from datajunction_server.models.node import NodeStatus as NodeStatus_
 from datajunction_server.models.node import NodeType as NodeType_
+from datajunction_server.sql.decompose import extractor
 
 NodeType = strawberry.enum(NodeType_)
 NodeStatus = strawberry.enum(NodeStatus_)
@@ -118,7 +122,6 @@ class NodeRevision:
     metric_metadata: Optional[MetricMetadata] = None
     required_dimensions: Optional[List[Column]] = None
 
-    # Only metrics will have these fields
     @strawberry.field
     def extracted_measures(self, root: "DBNodeRevision") -> ExtractedMeasures | None:
         """
@@ -127,7 +130,7 @@ class NodeRevision:
         if root.type != NodeType.METRIC:
             return None
         measures, derived_sql = extractor.extract_measures(root.query)
-        return ExtractedMeasures(measures=measures, derived_sql=derived_sql)
+        return ExtractedMeasures(measures=measures, derived_sql=derived_sql)  # type: ignore
 
     # Only cubes will have these fields
     @strawberry.field

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -45,7 +45,8 @@ class Metric(BaseModel):
     incompatible_druid_functions: List[str]
 
     measures: List[Measure]
-    derived_sql: str
+    derived_query: str
+    derived_expression: str
 
     @classmethod
     def parse_node(cls, node: Node, dims: List[DimensionAttributeOutput]) -> "Metric":
@@ -76,7 +77,8 @@ class Metric(BaseModel):
             required_dimensions=[dim.name for dim in node.current.required_dimensions],
             incompatible_druid_functions=incompatible_druid_functions,
             measures=measures,
-            derived_sql=str(derived_sql).strip(),
+            derived_query=str(derived_sql).strip(),
+            derived_expression=str(derived_sql.select.projection[0]).strip(),
         )
 
 

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -608,7 +608,8 @@ async def test_find_metric(
                             type
                         }
                     }
-                    derivedSql
+                    derivedQuery
+                    derivedExpression
                 }
             }
         }
@@ -666,13 +667,17 @@ async def test_find_metric(
                             },
                         },
                     ],
-                    "derivedSql": "SELECT  (SUM(rm.completed_repairs_sum_0) * 1.0 / "
+                    "derivedQuery": "SELECT  (SUM(rm.completed_repairs_sum_0) * 1.0 / "
                     "SUM(rm.total_repairs_dispatched_sum_1)) * "
                     "(SUM(rm.total_amount_in_region_sum_2) * 1.0 / "
                     "SUM(na.total_amount_nationwide_sum_3)) * 100 \n"
                     " FROM default.regional_level_agg rm CROSS JOIN "
                     "default.national_level_agg na\n"
                     "\n",
+                    "derivedExpression": "(SUM(rm.completed_repairs_sum_0) * 1.0 / "
+                    "SUM(rm.total_repairs_dispatched_sum_1)) * "
+                    "(SUM(rm.total_amount_in_region_sum_2) * 1.0 / "
+                    "SUM(na.total_amount_nationwide_sum_3)) * 100",
                 },
             },
             "name": "default.regional_repair_efficiency",

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -537,6 +537,11 @@ async def test_find_transform(
                 cubeDimensions {
                     name
                 }
+                extractedMeasures {
+                    measures {
+                        name
+                    }
+                }
             }
         }
     }
@@ -560,6 +565,7 @@ async def test_find_transform(
                         "name": "default.repair_order_details",
                     },
                 ],
+                "extractedMeasures": None,
             },
             "name": "default.repair_orders_fact",
             "type": "TRANSFORM",

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -593,6 +593,17 @@ async def test_find_metric(
                 requiredDimensions {
                     name
                 }
+                extractedMeasures {
+                    measures {
+                        name
+                        expression
+                        aggregation
+                        rule {
+                            type
+                        }
+                    }
+                    derivedSql
+                }
             }
         }
     }
@@ -614,6 +625,49 @@ async def test_find_metric(
                     },
                 ],
                 "requiredDimensions": [],
+                "extractedMeasures": {
+                    "measures": [
+                        {
+                            "aggregation": "SUM",
+                            "expression": "rm.completed_repairs",
+                            "name": "rm.completed_repairs_sum_0",
+                            "rule": {
+                                "type": "FULL",
+                            },
+                        },
+                        {
+                            "aggregation": "SUM",
+                            "expression": "rm.total_repairs_dispatched",
+                            "name": "rm.total_repairs_dispatched_sum_1",
+                            "rule": {
+                                "type": "FULL",
+                            },
+                        },
+                        {
+                            "aggregation": "SUM",
+                            "expression": "rm.total_amount_in_region",
+                            "name": "rm.total_amount_in_region_sum_2",
+                            "rule": {
+                                "type": "FULL",
+                            },
+                        },
+                        {
+                            "aggregation": "SUM",
+                            "expression": "na.total_amount_nationwide",
+                            "name": "na.total_amount_nationwide_sum_3",
+                            "rule": {
+                                "type": "FULL",
+                            },
+                        },
+                    ],
+                    "derivedSql": "SELECT  (SUM(rm.completed_repairs_sum_0) * 1.0 / "
+                    "SUM(rm.total_repairs_dispatched_sum_1)) * "
+                    "(SUM(rm.total_amount_in_region_sum_2) * 1.0 / "
+                    "SUM(na.total_amount_nationwide_sum_3)) * 100 \n"
+                    " FROM default.regional_level_agg rm CROSS JOIN "
+                    "default.national_level_agg na\n"
+                    "\n",
+                },
             },
             "name": "default.regional_repair_efficiency",
             "type": "METRIC",

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -410,6 +410,33 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
     )
     data = response.json()
     assert data["incompatible_druid_functions"] == ["IF"]
+    assert data["measures"] == [
+        {
+            "aggregation": "SUM",
+            "expression": "if(discount > 0.0, 1, 0)",
+            "name": "discount_sum_0",
+            "rule": {
+                "level": None,
+                "type": "full",
+            },
+        },
+        {
+            "aggregation": "COUNT",
+            "expression": "*",
+            "name": "count_1",
+            "rule": {
+                "level": None,
+                "type": "full",
+            },
+        },
+    ]
+    assert data["derived_query"] == (
+        "SELECT  CAST(sum(discount_sum_0) AS DOUBLE) / SUM(count_1) AS "
+        "default_DOT_discounted_orders_rate \n FROM default.repair_orders_fact"
+    )
+    assert data["derived_expression"] == (
+        "CAST(sum(discount_sum_0) AS DOUBLE) / SUM(count_1) AS default_DOT_discounted_orders_rate"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This change makes the derived measures metadata from #1234 available to query via GraphQL. For example:
```
query ListNodes($namespace: String, $nodeTypes: [NodeType!], $tags: [String!], $editedBy: String, $after: String, $limit: Int) {
  findNodesPaginated(
    namespace: $namespace
    nodeTypes: $nodeTypes
    tags: $tags
    editedBy: $editedBy
    limit: $limit
    after: $after
  ) {
    edges {
      node {
        name
        type
        current {
          extractedMeasures {
            measures {
              name
              expression
              aggregation
              rule {
                type
              }
            }
            derivedQuery
            derivedExpression
          }
        }
      }
    }
    pageInfo {
      startCursor
      endCursor
      hasNextPage
      hasPrevPage
    }
  }
}
```

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1223 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
