### PR TITLE
Generate measures SQL pre-aggregated to the requested dimensions

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -26,7 +26,7 @@ from datajunction_server.database.node import NodeRevision as DBNodeRevision
 from datajunction_server.models.node import NodeMode as NodeMode_
 from datajunction_server.models.node import NodeStatus as NodeStatus_
 from datajunction_server.models.node import NodeType as NodeType_
-from datajunction_server.sql.decompose import extractor
+from datajunction_server.sql.decompose import MeasureExtractor
 
 NodeType = strawberry.enum(NodeType_)
 NodeStatus = strawberry.enum(NodeStatus_)
@@ -128,7 +128,8 @@ class NodeRevision:
         """
         if root.type != NodeType.METRIC:
             return None
-        measures, derived_ast = extractor.extract_measures(root.query)
+        extractor = MeasureExtractor.from_query_string(root.query)
+        measures, derived_ast = extractor.extract()
         return ExtractedMeasures(  # type: ignore
             measures=measures,
             derived_query=str(derived_ast),

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -91,7 +91,7 @@ async def get_measures_sql_for_cube_v2(
         get_measures_query,
     )
 
-    metrics = list(OrderedDict.fromkeys(set(metrics)))
+    metrics = list(OrderedDict.fromkeys(metrics))
     measures_query = await get_measures_query(
         session=session,
         metrics=metrics,

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -51,7 +51,13 @@ async def get_measures_sql_for_cube_v2(
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
     orderby: List[str] = Query([]),
-    preagg: bool = False,
+    preaggregate: bool = Query(
+        False,
+        description=(
+            "Whether to pre-aggregate to the requested dimensions so that "
+            "subsequent queries are more efficient."
+        ),
+    ),
     *,
     include_all_columns: bool = Query(
         False,
@@ -99,7 +105,7 @@ async def get_measures_sql_for_cube_v2(
         include_all_columns=include_all_columns,
         sql_transpilation_library=settings.sql_transpilation_library,
         use_materialized=use_materialized,
-        preagg=preagg,
+        preaggregate=preaggregate,
     )
     return measures_query
 

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -51,6 +51,7 @@ async def get_measures_sql_for_cube_v2(
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
     orderby: List[str] = Query([]),
+    preagg: bool = False,
     *,
     include_all_columns: bool = Query(
         False,
@@ -98,6 +99,7 @@ async def get_measures_sql_for_cube_v2(
         include_all_columns=include_all_columns,
         sql_transpilation_library=settings.sql_transpilation_library,
         use_materialized=use_materialized,
+        preagg=preagg,
     )
     return measures_query
 

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -22,6 +22,7 @@ from datajunction_server.models.materialization import GenericCubeConfig
 from datajunction_server.models.node import BuildCriteria
 from datajunction_server.naming import LOOKUP_CHARS, amenable_name, from_amenable_name
 from datajunction_server.sql.dag import get_shared_dimensions
+from datajunction_server.sql.decompose import extractor
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
 from datajunction_server.sql.parsing.types import ColumnType
@@ -54,7 +55,11 @@ def get_default_criteria(
     )
 
 
-def rename_columns(built_ast: ast.Query, node: NodeRevision):
+def rename_columns(
+    built_ast: ast.Query,
+    node: NodeRevision,
+    preaggregate: bool = False,
+):
     """
     Rename columns in the built ast to fully qualified column names.
     """
@@ -74,7 +79,8 @@ def rename_columns(built_ast: ast.Query, node: NodeRevision):
                 alias_name = node.name + SEPARATOR + expression.alias_or_name.name  # type: ignore
             expression = expression.copy()
             expression.set_semantic_entity(alias_name)  # type: ignore
-            expression.set_alias(ast.Name(amenable_name(alias_name)))
+            if not preaggregate:
+                expression.set_alias(ast.Name(amenable_name(alias_name)))
             projection.append(expression)
         else:
             expression = expression.copy()
@@ -349,14 +355,14 @@ async def metrics_to_measures(
     metric_to_measures = collections.defaultdict(set)
     parents_to_measures = collections.defaultdict(set)
     for metric_node in metric_nodes:
+        metric_to_measures[metric_node.name] = extractor.extract_measures(
+            metric_node.current.query,
+        )
         metric_ast = parse(metric_node.current.query)
         await metric_ast.compile(ctx)
         for col in metric_ast.find_all(ast.Column):
             if col.table:  # pragma: no cover
                 parents_to_measures[col.table.dj_node.name].add(  # type: ignore
-                    col.alias_or_name.name,
-                )
-                metric_to_measures[metric_node.name].add(
                     col.alias_or_name.name,
                 )
     return parents_to_measures, metric_to_measures

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -90,23 +90,6 @@ class DimensionJoin:
     node_query: Optional[ast.Query] = None
 
 
-def async_profile(func):
-    from functools import wraps
-
-    @wraps(func)
-    async def wrapper(*args, **kwds):
-        from line_profiler import LineProfiler
-
-        prof = LineProfiler()
-        try:
-            return await prof(func)(*args, **kwds)
-        finally:
-            prof.print_stats()
-
-    return wrapper
-
-
-@async_profile
 async def get_measures_query(  # pylint: disable=too-many-locals
     session: AsyncSession,
     metrics: List[str],
@@ -117,7 +100,6 @@ async def get_measures_query(  # pylint: disable=too-many-locals
     engine_version: Optional[str] = None,
     current_user: Optional[User] = None,
     validate_access: access.ValidateAccessFn = None,
-    cast_timestamp_to_ms: bool = False,  # pylint: disable=unused-argument
     include_all_columns: bool = False,
     sql_transpilation_library: Optional[str] = None,
     use_materialized: bool = True,

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -514,6 +514,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
             if not self.physical_table
             else self.create_query_from_physical_table(self.physical_table)
         )
+
         if self.physical_table and not self._filters and not self.dimensions:
             self.final_ast = node_ast
         else:

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -146,7 +146,6 @@ async def get_measures_query(  # pylint: disable=too-many-locals
         dimensions,
     )
     metrics_sorting_order = {val: idx for idx, val in enumerate(metrics)}
-    print("metrics_sorting_order',", metrics, metrics_sorting_order)
     metric_nodes = sorted(
         metric_nodes,
         key=lambda x: metrics_sorting_order.get(x.name, 0),
@@ -223,7 +222,6 @@ async def get_measures_query(  # pylint: disable=too-many-locals
             if preaggregate
             else parent_ast
         )
-        print("final_query", final_query)
 
         # Build translated SQL object
         columns_metadata = [
@@ -281,7 +279,6 @@ def build_preaggregate_query(
     )
 
     added_measures = set()
-    print("children", [c.name for c in children])
     for metric in children:
         for measure in metrics2measures[metric.name][0]:
             if measure.name in added_measures:

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -150,7 +150,6 @@ async def build_cube_materialization_config(
             filters=[],
             current_user=current_user,
             validate_access=validate_access,
-            cast_timestamp_to_ms=True,
         )
         for measures_query in measures_queries:
             metrics_expressions = await rewrite_metrics_expressions(

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -13,7 +13,7 @@ from datajunction_server.models.node import (
     MetricMetadataOutput,
 )
 from datajunction_server.models.query import ColumnMetadata
-from datajunction_server.sql.decompose import Measure, extractor
+from datajunction_server.sql.decompose import Measure, MeasureExtractor
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
 from datajunction_server.transpilation import get_transpilation_plugin
 from datajunction_server.typing import UTCDatetime
@@ -60,7 +60,8 @@ class Metric(BaseModel):
             for func in functions
             if Dialect.DRUID not in func.dialects
         ]
-        measures, derived_sql = extractor.extract_measures(node.current.query)
+        extractor = MeasureExtractor.from_query_string(node.current.query)
+        measures, derived_sql = extractor.extract()
         return cls(
             id=node.id,
             name=node.name,

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -75,12 +75,14 @@ class MeasureExtractor:
     @classmethod
     @lru_cache(maxsize=128)
     def from_query_string(cls, metric_query: str):
+        """Create measures extractor from query string"""
         query_ast = parse(metric_query)
         return MeasureExtractor(query_ast=query_ast)
 
     @classmethod
-    def from_query_ast(cls, query_ast: ast.Query):
-        return MeasureExtractor(query_ast=query_ast)
+    def from_query_ast(cls, query_ast: ast.Query):  # pragma: no cover
+        """Create measures extractor from query AST"""
+        return MeasureExtractor(query_ast=query_ast)  # pragma: no cover
 
     def extract(self) -> tuple[list[Measure], ast.Query]:
         """

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -847,8 +847,10 @@ class Column(Aliasable, Named, Expression):
         return column_namespace, column_name, subscript_name
 
     @classmethod
-    def from_existing(cls, col: "Column"):
-        """Build a column from an existing one"""
+    def from_existing(cls, col: Aliasable | Expression):
+        """
+        Build a selectable column from an existing one
+        """
         return Column(
             col.alias_or_name,
             _type=col.type,

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -846,6 +846,16 @@ class Column(Aliasable, Named, Expression):
             column_namespace = self.namespace[0].name
         return column_namespace, column_name, subscript_name
 
+    @classmethod
+    def from_existing(cls, col: "Column"):
+        """Build a column from an existing one"""
+        return Column(
+            col.alias_or_name,
+            _type=col.type,
+            semantic_entity=col.semantic_entity,
+            semantic_type=col.semantic_type,
+        )
+
     async def find_table_sources(
         self,
         ctx: CompileContext,
@@ -2417,6 +2427,21 @@ class From(Node):
         parts += ",\n".join([str(r) for r in self.relations])
 
         return "".join(parts)
+
+    @classmethod
+    def Table(cls, table_name: str):
+        """
+        Create a FROM clause sourcing from this table name
+        """
+        return From(
+            relations=[
+                Relation(
+                    primary=Table(
+                        Name(table_name),
+                    ),
+                ),
+            ],
+        )
 
 
 @dataclass(eq=False)

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -959,7 +959,7 @@ class Column(Aliasable, Named, Expression):
                 not namespace
                 or current_table.alias_or_name.identifier(False) == namespace
             ):
-                if current_table.add_ref_column(self, ctx):
+                if await current_table.add_ref_column(self, ctx):
                     found.append(current_table)
                     return found
 

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -636,24 +636,24 @@ async def test_find_metric(
                     "measures": [
                         {
                             "aggregation": "SUM",
-                            "expression": "rm.completed_repairs",
-                            "name": "rm.completed_repairs_sum_0",
+                            "expression": "completed_repairs",
+                            "name": "completed_repairs_sum_0",
                             "rule": {
                                 "type": "FULL",
                             },
                         },
                         {
                             "aggregation": "SUM",
-                            "expression": "rm.total_repairs_dispatched",
-                            "name": "rm.total_repairs_dispatched_sum_1",
+                            "expression": "total_repairs_dispatched",
+                            "name": "total_repairs_dispatched_sum_1",
                             "rule": {
                                 "type": "FULL",
                             },
                         },
                         {
                             "aggregation": "SUM",
-                            "expression": "rm.total_amount_in_region",
-                            "name": "rm.total_amount_in_region_sum_2",
+                            "expression": "total_amount_in_region",
+                            "name": "total_amount_in_region_sum_2",
                             "rule": {
                                 "type": "FULL",
                             },
@@ -667,16 +667,16 @@ async def test_find_metric(
                             },
                         },
                     ],
-                    "derivedQuery": "SELECT  (SUM(rm.completed_repairs_sum_0) * 1.0 / "
-                    "SUM(rm.total_repairs_dispatched_sum_1)) * "
-                    "(SUM(rm.total_amount_in_region_sum_2) * 1.0 / "
+                    "derivedQuery": "SELECT  (SUM(completed_repairs_sum_0) * 1.0 / "
+                    "SUM(total_repairs_dispatched_sum_1)) * "
+                    "(SUM(total_amount_in_region_sum_2) * 1.0 / "
                     "SUM(na.total_amount_nationwide_sum_3)) * 100 \n"
-                    " FROM default.regional_level_agg rm CROSS JOIN "
+                    " FROM default.regional_level_agg CROSS JOIN "
                     "default.national_level_agg na\n"
                     "\n",
-                    "derivedExpression": "(SUM(rm.completed_repairs_sum_0) * 1.0 / "
-                    "SUM(rm.total_repairs_dispatched_sum_1)) * "
-                    "(SUM(rm.total_amount_in_region_sum_2) * 1.0 / "
+                    "derivedExpression": "(SUM(completed_repairs_sum_0) * 1.0 / "
+                    "SUM(total_repairs_dispatched_sum_1)) * "
+                    "(SUM(total_amount_in_region_sum_2) * 1.0 / "
                     "SUM(na.total_amount_nationwide_sum_3)) * 100",
                 },
             },

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -534,6 +534,495 @@ async def test_measures_sql_with_filters__v2(  # pylint: disable=too-many-argume
         assert translated_sql["columns"] == columns
 
 
+@pytest.mark.parametrize(
+    "metrics, dimensions, filters, orderby, sql, columns, rows",
+    [
+        # One metric with two measures + one local dimension. Both referenced measures should
+        # show up in the generated measures SQL
+        (
+            ["default.total_repair_order_discounts"],
+            ["default.dispatcher.dispatcher_id"],
+            [],
+            [],
+            """
+            WITH default_DOT_repair_orders_fact AS (
+              SELECT
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+                repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+                repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+              FROM roads.repair_orders AS repair_orders JOIN roads.repair_order_details AS repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+            ),
+            default_DOT_repair_orders_fact_built AS (
+              SELECT
+                default_DOT_repair_orders_fact.dispatcher_id default_DOT_dispatcher_DOT_dispatcher_id,
+                default_DOT_repair_orders_fact.discount,
+                default_DOT_repair_orders_fact.price
+              FROM default_DOT_repair_orders_fact
+            )
+            SELECT
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id,
+              SUM(price * discount) AS price_discount_sum_0
+            FROM default_DOT_repair_orders_fact_built
+            GROUP BY default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id
+            """,
+            [
+                {
+                    "column": "dispatcher_id",
+                    "name": "default_DOT_dispatcher_DOT_dispatcher_id",
+                    "node": "default.dispatcher",
+                    "semantic_entity": "default.dispatcher.dispatcher_id",
+                    "semantic_type": "dimension",
+                    "type": "int",
+                },
+                {
+                    "column": "price_discount_sum_0",
+                    "name": "price_discount_sum_0",
+                    "node": "default.total_repair_order_discounts",
+                    "semantic_entity": "default.total_repair_order_discounts.price_discount_sum_0",
+                    "semantic_type": "measure",
+                    "type": "double",
+                },
+            ],
+            [
+                (1, 11350.47006225586),
+                (2, 20297.260345458984),
+                (3, 9152.770111083984),
+            ],
+        ),
+        # Two metrics with overlapping measures + one joinable dimension
+        (
+            [
+                "default.total_repair_order_discounts",
+                "default.avg_repair_order_discounts",
+            ],
+            ["default.dispatcher.dispatcher_id"],
+            [],
+            [],
+            """
+            WITH default_DOT_repair_orders_fact AS (
+              SELECT
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+                repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+                repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+              FROM roads.repair_orders AS repair_orders JOIN roads.repair_order_details AS repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+            ),
+            default_DOT_repair_orders_fact_built AS (
+              SELECT
+                default_DOT_repair_orders_fact.dispatcher_id default_DOT_dispatcher_DOT_dispatcher_id,
+                default_DOT_repair_orders_fact.discount,
+                default_DOT_repair_orders_fact.price
+              FROM default_DOT_repair_orders_fact
+            )
+            SELECT
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id,
+              SUM(price * discount) AS price_discount_sum_0,
+              COUNT(1) AS count
+            FROM default_DOT_repair_orders_fact_built
+            GROUP BY  default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id
+            """,
+            [
+                {
+                    "column": "dispatcher_id",
+                    "name": "default_DOT_dispatcher_DOT_dispatcher_id",
+                    "node": "default.dispatcher",
+                    "semantic_entity": "default.dispatcher.dispatcher_id",
+                    "semantic_type": "dimension",
+                    "type": "int",
+                },
+                {
+                    "column": "price_discount_sum_0",
+                    "name": "price_discount_sum_0",
+                    "node": mock.ANY,
+                    "semantic_entity": mock.ANY,
+                    "semantic_type": "measure",
+                    "type": "double",
+                },
+                {
+                    "column": "count",
+                    "name": "count",
+                    "node": "default.avg_repair_order_discounts",
+                    "semantic_entity": "default.avg_repair_order_discounts.count",
+                    "semantic_type": "measure",
+                    "type": "bigint",
+                },
+            ],
+            [
+                (2, 20297.260345458984, 8),
+                (1, 11350.47006225586, 8),
+                (3, 9152.770111083984, 9),
+            ],
+        ),
+        # Two metrics with different measures + two dimensions from different sources
+        (
+            ["default.avg_time_to_dispatch", "default.total_repair_cost"],
+            [
+                "default.us_state.state_name",
+                "default.dispatcher.company_name",
+                "default.hard_hat.last_name",
+            ],
+            [
+                "default.us_state.state_name = 'New Jersey'",
+                "default.hard_hat.last_name IN ('Brian')",
+            ],
+            [],
+            """
+            WITH default_DOT_repair_orders_fact AS (
+              SELECT
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+                repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+                repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+              FROM roads.repair_orders AS repair_orders
+              JOIN roads.repair_order_details AS repair_order_details
+              ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+            ),
+            default_DOT_hard_hat AS (
+              SELECT
+                default_DOT_hard_hats.hard_hat_id,
+                default_DOT_hard_hats.last_name,
+                default_DOT_hard_hats.first_name,
+                default_DOT_hard_hats.title,
+                default_DOT_hard_hats.birth_date,
+                default_DOT_hard_hats.hire_date,
+                default_DOT_hard_hats.address,
+                default_DOT_hard_hats.city,
+                default_DOT_hard_hats.state,
+                default_DOT_hard_hats.postal_code,
+                default_DOT_hard_hats.country,
+                default_DOT_hard_hats.manager,
+                default_DOT_hard_hats.contractor_id
+              FROM roads.hard_hats AS default_DOT_hard_hats
+              WHERE  default_DOT_hard_hats.last_name IN ('Brian')
+            ),
+            default_DOT_us_state AS (
+              SELECT
+                s.state_id,
+                s.state_name,
+                s.state_abbr AS state_short,
+                s.state_region
+              FROM roads.us_states AS s
+              WHERE s.state_name = 'New Jersey'
+            ),
+            default_DOT_dispatcher AS (
+              SELECT
+                default_DOT_dispatchers.dispatcher_id,
+                default_DOT_dispatchers.company_name,
+                default_DOT_dispatchers.phone
+              FROM roads.dispatchers AS default_DOT_dispatchers
+            ),
+            default_DOT_repair_orders_fact_built AS (
+              SELECT
+                default_DOT_repair_orders_fact.total_repair_cost,
+                default_DOT_repair_orders_fact.time_to_dispatch,
+                default_DOT_us_state.state_name default_DOT_us_state_DOT_state_name,
+                default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name,
+                default_DOT_hard_hat.last_name default_DOT_hard_hat_DOT_last_name
+              FROM default_DOT_repair_orders_fact
+              INNER JOIN default_DOT_hard_hat
+                ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              INNER JOIN default_DOT_us_state
+                ON default_DOT_hard_hat.state = default_DOT_us_state.state_short
+              LEFT JOIN default_DOT_dispatcher
+                ON default_DOT_repair_orders_fact.dispatcher_id =
+                   default_DOT_dispatcher.dispatcher_id
+            )
+            SELECT
+              default_DOT_repair_orders_fact_built.default_DOT_us_state_DOT_state_name,
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
+              default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name,
+              COUNT(1) AS count,
+              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_0,
+              SUM(total_repair_cost) AS total_repair_cost_sum_0
+            FROM default_DOT_repair_orders_fact_built
+            GROUP BY
+              default_DOT_repair_orders_fact_built.default_DOT_us_state_DOT_state_name,
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
+              default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name
+            """,
+            [
+                {
+                    "column": "state_name",
+                    "name": "default_DOT_us_state_DOT_state_name",
+                    "node": "default.us_state",
+                    "semantic_entity": "default.us_state.state_name",
+                    "semantic_type": "dimension",
+                    "type": "string",
+                },
+                {
+                    "column": "company_name",
+                    "name": "default_DOT_dispatcher_DOT_company_name",
+                    "node": "default.dispatcher",
+                    "semantic_entity": "default.dispatcher.company_name",
+                    "semantic_type": "dimension",
+                    "type": "string",
+                },
+                {
+                    "column": "last_name",
+                    "name": "default_DOT_hard_hat_DOT_last_name",
+                    "node": "default.hard_hat",
+                    "semantic_entity": "default.hard_hat.last_name",
+                    "semantic_type": "dimension",
+                    "type": "string",
+                },
+                {
+                    "column": "count",
+                    "name": "count",
+                    "node": "default.avg_time_to_dispatch",
+                    "semantic_entity": "default.avg_time_to_dispatch.count",
+                    "semantic_type": "measure",
+                    "type": "bigint",
+                },
+                {
+                    "column": "time_to_dispatch_sum_0",
+                    "name": "time_to_dispatch_sum_0",
+                    "node": "default.avg_time_to_dispatch",
+                    "semantic_entity": "default.avg_time_to_dispatch.time_to_dispatch_sum_0",
+                    "semantic_type": "measure",
+                    "type": "bigint",
+                },
+                {
+                    "column": "total_repair_cost_sum_0",
+                    "name": "total_repair_cost_sum_0",
+                    "node": "default.total_repair_cost",
+                    "semantic_entity": "default.total_repair_cost.total_repair_cost_sum_0",
+                    "semantic_type": "measure",
+                    "type": "double",
+                },
+            ],
+            [
+                ("New Jersey", "Federal Roads Group", "Brian", 1, 150, 63708.0),
+                ("New Jersey", "Pothole Pete", "Brian", 3, 546, 154983.0),
+            ],
+        ),
+        (
+            ["default.avg_time_to_dispatch"],
+            ["default.dispatcher.company_name", "default.hard_hat.last_name"],
+            ["default.hard_hat.last_name IN ('Brian')"],
+            ["default.dispatcher.company_name"],
+            """
+            WITH default_DOT_repair_orders_fact AS (
+              SELECT
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+                repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+                repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+              FROM roads.repair_orders AS repair_orders JOIN roads.repair_order_details AS repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+            ),
+            default_DOT_dispatcher AS (
+              SELECT
+                default_DOT_dispatchers.dispatcher_id,
+                default_DOT_dispatchers.company_name,
+                default_DOT_dispatchers.phone
+              FROM roads.dispatchers AS default_DOT_dispatchers
+            ),
+            default_DOT_hard_hat AS (
+              SELECT
+                default_DOT_hard_hats.hard_hat_id,
+                default_DOT_hard_hats.last_name,
+                default_DOT_hard_hats.first_name,
+                default_DOT_hard_hats.title,
+                default_DOT_hard_hats.birth_date,
+                default_DOT_hard_hats.hire_date,
+                default_DOT_hard_hats.address,
+                default_DOT_hard_hats.city,
+                default_DOT_hard_hats.state,
+                default_DOT_hard_hats.postal_code,
+                default_DOT_hard_hats.country,
+                default_DOT_hard_hats.manager,
+                default_DOT_hard_hats.contractor_id
+              FROM roads.hard_hats AS default_DOT_hard_hats
+              WHERE default_DOT_hard_hats.last_name IN ('Brian')
+            ),
+            default_DOT_repair_orders_fact_built AS (
+              SELECT
+                default_DOT_repair_orders_fact.time_to_dispatch,
+                default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name,
+                default_DOT_hard_hat.last_name default_DOT_hard_hat_DOT_last_name
+              FROM default_DOT_repair_orders_fact
+              LEFT JOIN default_DOT_dispatcher
+                ON default_DOT_repair_orders_fact.dispatcher_id =
+                   default_DOT_dispatcher.dispatcher_id
+              INNER JOIN default_DOT_hard_hat
+                ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              ORDER BY default_DOT_dispatcher.company_name
+            )
+            SELECT
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
+              default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name,
+              COUNT(1) AS count,
+              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_0
+            FROM default_DOT_repair_orders_fact_built
+            GROUP BY
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
+              default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name
+            """,
+            [],
+            [
+                ("Federal Roads Group", "Brian", 1, 150),
+                ("Pothole Pete", "Brian", 3, 546),
+            ],
+        ),
+        (
+            ["default.avg_time_to_dispatch"],
+            ["default.dispatcher.company_name", "default.hard_hat.last_name"],
+            ["default.hard_hat.last_name IN ('Brian')"],
+            ["default.dispatcher.company_name DESC"],
+            """
+            WITH default_DOT_repair_orders_fact AS (
+              SELECT
+                repair_orders.repair_order_id,
+                repair_orders.municipality_id,
+                repair_orders.hard_hat_id,
+                repair_orders.dispatcher_id,
+                repair_orders.order_date,
+                repair_orders.dispatched_date,
+                repair_orders.required_date,
+                repair_order_details.discount,
+                repair_order_details.price,
+                repair_order_details.quantity,
+                repair_order_details.repair_type_id,
+                repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+                repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+                repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+              FROM roads.repair_orders AS repair_orders
+              JOIN roads.repair_order_details AS repair_order_details
+                ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+            ),
+            default_DOT_dispatcher AS (
+              SELECT
+                default_DOT_dispatchers.dispatcher_id,
+                default_DOT_dispatchers.company_name,
+                default_DOT_dispatchers.phone
+              FROM roads.dispatchers AS default_DOT_dispatchers
+            ),
+            default_DOT_hard_hat AS (
+              SELECT
+                default_DOT_hard_hats.hard_hat_id,
+                default_DOT_hard_hats.last_name,
+                default_DOT_hard_hats.first_name,
+                default_DOT_hard_hats.title,
+                default_DOT_hard_hats.birth_date,
+                default_DOT_hard_hats.hire_date,
+                default_DOT_hard_hats.address,
+                default_DOT_hard_hats.city,
+                default_DOT_hard_hats.state,
+                default_DOT_hard_hats.postal_code,
+                default_DOT_hard_hats.country,
+                default_DOT_hard_hats.manager,
+                default_DOT_hard_hats.contractor_id
+              FROM roads.hard_hats AS default_DOT_hard_hats
+              WHERE  default_DOT_hard_hats.last_name IN ('Brian')
+            ),
+            default_DOT_repair_orders_fact_built AS (
+              SELECT
+                default_DOT_repair_orders_fact.time_to_dispatch,
+                default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name,
+                default_DOT_hard_hat.last_name default_DOT_hard_hat_DOT_last_name
+              FROM default_DOT_repair_orders_fact
+              LEFT JOIN default_DOT_dispatcher
+                ON default_DOT_repair_orders_fact.dispatcher_id =
+                   default_DOT_dispatcher.dispatcher_id
+              INNER JOIN default_DOT_hard_hat
+                ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
+              ORDER BY default_DOT_dispatcher.company_name DESC
+            )
+            SELECT
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
+              default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name,
+              COUNT(1) AS count,
+              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_0
+            FROM default_DOT_repair_orders_fact_built
+            GROUP BY
+              default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
+              default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name
+            """,
+            [],
+            [
+                ("Pothole Pete", "Brian", 3, 546),
+                ("Federal Roads Group", "Brian", 1, 150),
+            ],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_measures_sql_preaggregate(  # pylint: disable=too-many-arguments
+    metrics,
+    dimensions,
+    filters,
+    orderby,
+    sql,
+    columns,
+    rows,
+    module__client_with_roads: AsyncClient,
+    duckdb_conn: duckdb.DuckDBPyConnection,  # pylint: disable=c-extension-no-member
+):
+    """
+    Test ``GET /sql/measures`` with various metrics, filters, and dimensions.
+    """
+    await fix_dimension_links(module__client_with_roads)
+    sql_params = {
+        "metrics": metrics,
+        "dimensions": dimensions,
+        "filters": filters,
+        **({"orderby": orderby} if orderby else {}),
+        "preaggregate": True,
+    }
+    response = await module__client_with_roads.get(
+        "/sql/measures/v2",
+        params=sql_params,
+    )
+    data = response.json()
+    translated_sql = data[0]
+    print("translated_sql", translated_sql["sql"])
+    assert str(parse(str(sql))) == str(parse(str(translated_sql["sql"])))
+    result = duckdb_conn.sql(translated_sql["sql"])
+    assert set(result.fetchall()) == set(rows)
+    if columns:
+        assert translated_sql["columns"] == columns
+
+
 @pytest.mark.asyncio
 async def test_measures_sql_include_all_columns(
     module__client_with_roads: AsyncClient,

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -1015,7 +1015,6 @@ async def test_measures_sql_preaggregate(  # pylint: disable=too-many-arguments
     )
     data = response.json()
     translated_sql = data[0]
-    print("translated_sql", translated_sql["sql"])
     assert str(parse(str(sql))) == str(parse(str(translated_sql["sql"])))
     result = duckdb_conn.sql(translated_sql["sql"])
     assert set(result.fetchall()) == set(rows)

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -189,15 +189,15 @@ def test_average():
 
     expected_measures = [
         Measure(
-            name="sales_amount_sum_0",
-            expression="sales_amount",
-            aggregation="SUM",
-            rule=AggregationRule(type=Aggregability.FULL),
-        ),
-        Measure(
             name="count",
             expression="1",
             aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        Measure(
+            name="sales_amount_sum_0",
+            expression="sales_amount",
+            aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
     ]
@@ -602,15 +602,15 @@ def test_metric_query_with_aliases():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
-            name="time_to_dispatch_sum_0",
-            expression="CAST(time_to_dispatch AS INT)",
-            aggregation="SUM",
-            rule=AggregationRule(type=Aggregability.FULL, level=None),
-        ),
-        Measure(
             name="count",
             expression="1",
             aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+        Measure(
+            name="time_to_dispatch_sum_0",
+            expression="CAST(time_to_dispatch AS INT)",
+            aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL, level=None),
         ),
     ]

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -7,7 +7,7 @@ from datajunction_server.sql.decompose import (
     Aggregability,
     AggregationRule,
     Measure,
-    extractor,
+    MeasureExtractor,
 )
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
@@ -17,9 +17,10 @@ def test_simple_sum():
     """
     Test decomposition for a metric definition that is a simple sum.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT SUM(sales_amount) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="sales_amount_sum_0",
@@ -38,9 +39,10 @@ def test_sum_with_cast():
     """
     Test decomposition for a metric definition that has a sum with a cast.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT CAST(SUM(sales_amount) AS DOUBLE) * 100.0 FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="sales_amount_sum_0",
@@ -56,9 +58,10 @@ def test_sum_with_cast():
         ),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT 100.0 * SUM(sales_amount) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="sales_amount_sum_0",
@@ -77,9 +80,10 @@ def test_sum_with_coalesce():
     """
     Test decomposition for a metric definition that has a sum with coalesce.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT COALESCE(SUM(sales_amount), 0) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="sales_amount_sum_1",
@@ -98,9 +102,10 @@ def test_multiple_sums():
     """
     Test decomposition for a metric definition that has multiple sums.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT SUM(sales_amount) + SUM(fraud_sales) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="sales_amount_sum_0",
@@ -122,9 +127,10 @@ def test_multiple_sums():
         ),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT SUM(sales_amount) - SUM(fraud_sales) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
@@ -137,9 +143,10 @@ def test_nested_functions():
     """
     Test behavior with deeply nested functions inside aggregations.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT SUM(ROUND(COALESCE(sales_amount, 0) * 1.1)) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="sales_amount_sum_0",
@@ -153,9 +160,10 @@ def test_nested_functions():
         parse("SELECT SUM(sales_amount_sum_0) FROM parent_node"),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT LN(SUM(COALESCE(sales_amount, 0)) + 1) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="sales_amount_sum_1",
@@ -174,9 +182,10 @@ def test_average():
     """
     Test decomposition for a metric definition that uses AVG.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT AVG(sales_amount) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
 
     expected_measures = [
         Measure(
@@ -194,7 +203,7 @@ def test_average():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT SUM(sales_amount_sum_0) / COUNT(count) FROM parent_node"),
+        parse("SELECT SUM(sales_amount_sum_0) / SUM(count) FROM parent_node"),
     )
 
 
@@ -202,9 +211,10 @@ def test_rate():
     """
     Test decomposition for a rate metric definition.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT SUM(clicks) / SUM(impressions) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures0 = [
         Measure(
             name="clicks_sum_0",
@@ -224,9 +234,10 @@ def test_rate():
         parse("SELECT SUM(clicks_sum_0) / SUM(impressions_sum_1) FROM parent_node"),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT 1.0 * SUM(clicks) / NULLIF(SUM(impressions), 0) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="clicks_sum_0",
@@ -248,10 +259,11 @@ def test_rate():
         ),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT CAST(CAST(SUM(clicks) AS INT) AS DOUBLE) / "
         "CAST(SUM(impressions) AS DOUBLE) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     assert measures == expected_measures0
     assert str(derived_sql) == str(
         parse(
@@ -260,9 +272,10 @@ def test_rate():
         ),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT COALESCE(SUM(clicks) / SUM(impressions), 0) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="clicks_sum_1",
@@ -284,10 +297,11 @@ def test_rate():
         ),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT IF(SUM(clicks) > 0, CAST(SUM(impressions) AS DOUBLE) "
         "/ CAST(SUM(clicks) AS DOUBLE), NULL) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="clicks_sum_1",
@@ -316,9 +330,10 @@ def test_rate():
         ),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT ln(sum(clicks) + 1) / sum(views) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="clicks_sum_1",
@@ -343,9 +358,10 @@ def test_has_ever():
     """
     Test decomposition for a metric definition that uses MAX.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT MAX(IF(condition, 1, 0)) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="condition_max_0",
@@ -364,11 +380,12 @@ def test_fraction_with_if():
     """
     Test decomposition for a rate metric with complex numerator and denominators.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT IF(SUM(COALESCE(action, 0)) > 0, "
         "CAST(SUM(COALESCE(action_two, 0)) AS DOUBLE) / "
         "CAST(SUM(COALESCE(action, 0)) AS DOUBLE), NULL) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
 
     expected_measures = [
         Measure(
@@ -404,9 +421,10 @@ def test_count():
     """
     Test decomposition for a count metric.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT COUNT(IF(action = 1, action_event_ts, 0)) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="action_action_event_ts_count_0",
@@ -425,9 +443,10 @@ def test_count_distinct_rate():
     """
     Test decomposition for a metric that uses count distinct.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT COUNT(DISTINCT user_id) / COUNT(action) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="user_id_count_0",
@@ -454,9 +473,10 @@ def test_no_aggregation():
     """
     Test behavior when there is no aggregation function in the metric query.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT sales_amount FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = []
     assert measures == expected_measures
     assert str(derived_sql) == str(parse("SELECT sales_amount FROM parent_node"))
@@ -466,10 +486,11 @@ def test_multiple_aggregations_with_conditions():
     """
     Test behavior with conditional aggregations in the metric query.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT SUM(IF(region = 'US', sales_amount, 0)) + "
         "COUNT(DISTINCT IF(region = 'US', account_id, NULL)) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="region_sales_amount_sum_0",
@@ -492,10 +513,11 @@ def test_multiple_aggregations_with_conditions():
         ),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT cast(coalesce(max(a), max(b), 0) as double) + "
         "cast(coalesce(max(a), max(b)) as double) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = [
         Measure(
             name="a_max_1",
@@ -536,7 +558,8 @@ def test_empty_query():
     Test behavior when the metric query is empty.
     """
     with pytest.raises(DJParseException, match="Empty query provided!"):
-        extractor.extract_measures("")
+        extractor = MeasureExtractor.from_query_string("")
+        extractor.extract()
 
 
 def test_unsupported_aggregation_function():
@@ -544,22 +567,56 @@ def test_unsupported_aggregation_function():
     Test behavior when the query contains unsupported aggregation functions. We just return an
     empty list of measures in this case, because there are no pre-aggregatable measures.
     """
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT MEDIAN(sales_amount) FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = []
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse("SELECT MEDIAN(sales_amount) FROM parent_node"),
     )
 
-    measures, derived_sql = extractor.extract_measures(
+    extractor = MeasureExtractor.from_query_string(
         "SELECT approx_percentile(duration_ms, 1.0, 0.9) / 1000 FROM parent_node",
     )
+    measures, derived_sql = extractor.extract()
     expected_measures = []
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
             "SELECT approx_percentile(duration_ms, 1.0, 0.9) / 1000 FROM parent_node",
+        ),
+    )
+
+
+def test_metric_query_with_aliases():
+    """
+    Test behavior when the query contains unsupported aggregation functions. We just return an
+    empty list of measures in this case, because there are no pre-aggregatable measures.
+    """
+    extractor = MeasureExtractor.from_query_string(
+        "SELECT avg(cast(repair_orders_fact.time_to_dispatch as int)) "
+        "FROM default.repair_orders_fact repair_orders_fact",
+    )
+    measures, derived_sql = extractor.extract()
+    expected_measures = [
+        Measure(
+            name="time_to_dispatch_sum_0",
+            expression="CAST(time_to_dispatch AS INT)",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+        Measure(
+            name="count",
+            expression="1",
+            aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse(
+            "SELECT SUM(time_to_dispatch_sum_0) / SUM(count) FROM default.repair_orders_fact",
         ),
     )


### PR DESCRIPTION
### Summary

This PR adds the option to generate `preaggregated` measures SQL for a set of metrics + dimensions. This means that DJ will generate SQL for the requested metrics, aggregated as much as possible to the requested dimensions, using the extracted measures from the requested metrics.

Exactly how aggregated the measures SQL is depends on the measures in question. For example, a measure with `SUM` as the aggregation can always be further aggregated upon, but a measure with `COUNT DISTINCT` as the aggregation cannot be. For the latter, we'll continue to fallback to the previously generated measures SQL, which was at the level of the metric's parent node.

The final metric aggregation(s) can then be performed on the output of this "intermediate" stage. This also sets us up nicely for derived metrics support in the future.

#### Example

Suppose that we have the following nodes (one transform, two metrics):
```
- name: default.repair_orders_fact
  type: transform
  query: | 
    SELECT
      repair_orders.repair_order_id,
      repair_orders.dispatcher_id,
      repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
      repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch
    FROM default.repair_orders repair_orders
    JOIN default.repair_order_details repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id

- name: default.total_repair_cost
  type: metric
  query: SELECT sum(total_repair_cost) FROM default.repair_orders_fact

- name: default.avg_time_to_dispatch
  type: metric
  query: SELECT avg(cast(time_to_dispatch as int)) FROM default.repair_orders_fact
```

A user can request measures SQL for both metrics, pre-aggregated to the `repair_orders.dispatcher_id` dimension with:
```
GET /sql/measures/v2?metrics=default.total_repair_cost&metrics=default.avg_time_to_dispatch&dimensions=repair_orders.dispatcher_id
```

DJ will return SQL that selects all of the necessary measures for each of the metrics (for `total_repair_cost`, it will select the `SUM(total_repair_cost)` measure, for `avg_time_to_dispatch`, it will select these two measures: `SUM(cast(time_to_dispatch as int))`, `COUNT(1)`), grouped by the requested dimension `repair_orders.dispatcher_id`. 

### Test Plan

Locally

- [x] PR has an associated issue: #848   
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
