### PR TITLE
Fix recursion error from deepcopy

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -1379,7 +1379,7 @@ async def compile_node_ast(session, node_revision: NodeRevision) -> ast.Query:
     """
     Parses the node's query into an AST and compiles it.
     """
-    node_ast = cached_parse(node_revision.query)
+    node_ast = parse(node_revision.query)
     ctx = CompileContext(session, DJException())
     await node_ast.compile(ctx)
     return node_ast


### PR DESCRIPTION
### Summary

Using `cached_parse` for the node query would sometimes cause `RecursionError: maximum recursion depth exceeded` errors. This error comes from the deepcopy, which fails with a recursion error on compiled node queries. 

### Test Plan

Reproduced the error locally 

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
