### PR TITLE
Better categorize the various exceptions into user vs system errors

### DIFF
--- a/datajunction-server/datajunction_server/api/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/basic.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.constants import AUTH_COOKIE, LOGGED_IN_FLAG_COOKIE
 from datajunction_server.database.user import OAuthProvider, User
-from datajunction_server.errors import DJError, DJException, ErrorCode
+from datajunction_server.errors import DJAlreadyExistsException, DJError, ErrorCode
 from datajunction_server.internal.access.authentication.basic import (
     get_password_hash,
     validate_user_password,
@@ -35,8 +35,7 @@ async def create_a_user(
     """
     user_result = await session.execute(select(User).where(User.username == username))
     if user_result.unique().scalar_one_or_none():
-        raise DJException(
-            http_status_code=HTTPStatus.CONFLICT,
+        raise DJAlreadyExistsException(
             errors=[
                 DJError(
                     code=ErrorCode.ALREADY_EXISTS,

--- a/datajunction-server/datajunction_server/api/access/authentication/google.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/google.py
@@ -59,7 +59,9 @@ async def get_access_token(
     cookie. If the user does not already exist, a new user is created.
     """
     if error:
-        raise DJAuthenticationException(f"Ran into an error during Google auth: {error}")
+        raise DJAuthenticationException(
+            f"Ran into an error during Google auth: {error}",
+        )
     hostname = urlparse(settings.url).hostname
     url = str(request.url)
     flow.fetch_token(authorization_response=url)

--- a/datajunction-server/datajunction_server/api/access/authentication/google.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/google.py
@@ -59,7 +59,7 @@ async def get_access_token(
     cookie. If the user does not already exist, a new user is created.
     """
     if error:
-        raise DJAuthenticationException("Ran into an error during Google auth: {error}")
+        raise DJAuthenticationException(f"Ran into an error during Google auth: {error}")
     hostname = urlparse(settings.url).hostname
     url = str(request.url)
     flow.fetch_token(authorization_response=url)

--- a/datajunction-server/datajunction_server/api/access/authentication/google.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/google.py
@@ -19,7 +19,7 @@ from starlette.responses import RedirectResponse
 
 from datajunction_server.constants import AUTH_COOKIE, LOGGED_IN_FLAG_COOKIE
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJException
+from datajunction_server.errors import DJAuthenticationException
 from datajunction_server.internal.access.authentication.basic import get_password_hash
 from datajunction_server.internal.access.authentication.google import (
     flow,
@@ -59,10 +59,7 @@ async def get_access_token(
     cookie. If the user does not already exist, a new user is created.
     """
     if error:
-        raise DJException(
-            http_status_code=HTTPStatus.UNAUTHORIZED,
-            message="Ran into an error during Google auth: {error}",
-        )
+        raise DJAuthenticationException("Ran into an error during Google auth: {error}")
     hostname = urlparse(settings.url).hostname
     url = str(request.url)
     flow.fetch_token(authorization_response=url)

--- a/datajunction-server/datajunction_server/api/attributes.py
+++ b/datajunction-server/datajunction_server/api/attributes.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.attributetype import AttributeType
-from datajunction_server.errors import DJAlreadyExistsException, DJException
+from datajunction_server.errors import DJAlreadyExistsException, DJInvalidInputException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.models.attribute import (
     RESERVED_ATTRIBUTE_NAMESPACE,
@@ -50,7 +50,7 @@ async def add_attribute_type(
     Add a new attribute type
     """
     if data.namespace == RESERVED_ATTRIBUTE_NAMESPACE:
-        raise DJException(
+        raise DJInvalidInputException(
             message="Cannot use `system` as the attribute type namespace as it is reserved.",
         )
     attribute_type = await AttributeType.get_by_name(session, data.name)

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -2,7 +2,6 @@
 """
 Data related APIs.
 """
-from http import HTTPStatus
 from typing import Callable, Dict, List, Optional
 
 from fastapi import BackgroundTasks, Depends, Query, Request
@@ -22,7 +21,6 @@ from datajunction_server.database.history import ActivityType, EntityType, Histo
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
-    DJException,
     DJInvalidInputException,
     DJQueryServiceClientException,
 )
@@ -96,7 +94,7 @@ async def add_availability_state(
             or data.schema_ != node_revision.schema_
             or data.table != node_revision.table
         ):
-            raise DJException(
+            raise DJInvalidInputException(
                 message=(
                     "Cannot set availability state, "
                     "source nodes require availability "
@@ -356,9 +354,8 @@ def get_data_for_query(
             request_headers=request_headers,
         )
     except DJQueryServiceClientException as exc:
-        raise DJException(
-            message=str(exc.message),
-            http_status_code=HTTPStatus.NOT_FOUND,
+        raise DJQueryServiceClientException(
+            f"DJ Query Service Error: {exc.message}",
         ) from exc
 
 

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -354,7 +354,7 @@ def get_data_for_query(
             request_headers=request_headers,
         )
     except DJQueryServiceClientException as exc:
-        raise DJQueryServiceClientException(
+        raise DJQueryServiceClientException(  # pragma: no cover
             f"DJ Query Service Error: {exc.message}",
         ) from exc
 

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -42,7 +42,6 @@ from datajunction_server.errors import (
     DJAlreadyExistsException,
     DJDoesNotExistException,
     DJError,
-    DJException,
     DJInvalidInputException,
     DJNodeNotFound,
     ErrorCode,
@@ -410,7 +409,7 @@ async def validate_cube(  # pylint: disable=too-many-locals
 
     # Verify that the provided metrics are metric nodes
     if not metrics:
-        raise DJException(
+        raise DJInvalidInputException(
             message=("At least one metric is required"),
             http_status_code=http.client.UNPROCESSABLE_ENTITY,
         )
@@ -423,7 +422,7 @@ async def validate_cube(  # pylint: disable=too-many-locals
             if non_metrics[0].type == NodeType.DIMENSION  # type: ignore
             else ""
         )
-        raise DJException(
+        raise DJInvalidInputException(
             message=message,
             errors=[DJError(code=ErrorCode.NODE_TYPE_ERROR, message=message)],
             http_status_code=http.client.UNPROCESSABLE_ENTITY,
@@ -461,7 +460,7 @@ async def validate_cube(  # pylint: disable=too-many-locals
             f"Please make sure that `{missing_dimension_attributes}` "
             "is a dimensional attribute."
         )
-        raise DJException(  # pragma: no cover
+        raise DJInvalidInputException(  # pragma: no cover
             message,
             errors=[DJError(code=ErrorCode.INVALID_DIMENSION, message=message)],
         )
@@ -545,7 +544,7 @@ def validate_orderby(
         if orderby_element.split(" ")[0] not in metrics + dimension_attributes:
             invalid_orderbys.append(orderby_element)
     if invalid_orderbys:
-        raise DJException(
+        raise DJInvalidInputException(
             message=(
                 f"Columns {invalid_orderbys} in order by clause must also be "
                 "specified in the metrics or dimensions"

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -17,7 +17,7 @@ from datajunction_server.database.backfill import Backfill
 from datajunction_server.database.column import Column, ColumnAttribute
 from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJDoesNotExistException, DJException
+from datajunction_server.errors import DJDoesNotExistException, DJInvalidInputException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.internal.materializations import (
@@ -97,7 +97,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     request_headers = dict(request.headers)
     node = await Node.get_by_name(session, node_name)
     if node.type == NodeType.SOURCE:  # type: ignore
-        raise DJException(
+        raise DJInvalidInputException(
             http_status_code=HTTPStatus.BAD_REQUEST,
             message=f"Cannot set materialization config for source node `{node_name}`!",
         )
@@ -109,7 +109,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
 
     if data.strategy == MaterializationStrategy.INCREMENTAL_TIME:
         if not node.current.temporal_partition_columns():  # type: ignore
-            raise DJException(
+            raise DJInvalidInputException(
                 http_status_code=HTTPStatus.BAD_REQUEST,
                 message="Cannot create materialization with strategy "
                 f"`{data.strategy}` without specifying a time partition column!",

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql.operators import is_
 from datajunction_server.api.nodes import list_nodes
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJError, DJException, ErrorCode
+from datajunction_server.errors import DJError, DJInvalidInputException, ErrorCode
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.models import access
@@ -121,7 +121,7 @@ async def get_common_dimensions(
     """
     Return common dimensions for a set of metrics.
     """
-    errors = []
+    user_input_errors = []
     statement = (
         select(Node)
         .where(Node.name.in_(metric))  # type: ignore  # pylint: disable=no-member
@@ -130,20 +130,20 @@ async def get_common_dimensions(
     metric_nodes = (await session.execute(statement)).scalars().all()
     for node in metric_nodes:
         if node.type != NodeType.METRIC:
-            errors.append(
+            user_input_errors.append(
                 DJError(
                     message=f"Not a metric node: {node.name}",
                     code=ErrorCode.NODE_TYPE_ERROR,
                 ),
             )
     if not metric_nodes:
-        errors.append(
+        user_input_errors.append(
             DJError(
                 message=f"Metric nodes not found: {','.join(metric)}",
                 code=ErrorCode.UNKNOWN_NODE,
             ),
         )
 
-    if errors:
-        raise DJException(errors=errors)
+    if user_input_errors:
+        raise DJInvalidInputException(errors=user_input_errors)
     return await get_shared_dimensions(session, metric_nodes)

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -121,7 +121,7 @@ async def get_common_dimensions(
     """
     Return common dimensions for a set of metrics.
     """
-    user_input_errors = []
+    input_errors = []
     statement = (
         select(Node)
         .where(Node.name.in_(metric))  # type: ignore  # pylint: disable=no-member
@@ -130,20 +130,20 @@ async def get_common_dimensions(
     metric_nodes = (await session.execute(statement)).scalars().all()
     for node in metric_nodes:
         if node.type != NodeType.METRIC:
-            user_input_errors.append(
+            input_errors.append(
                 DJError(
                     message=f"Not a metric node: {node.name}",
                     code=ErrorCode.NODE_TYPE_ERROR,
                 ),
             )
     if not metric_nodes:
-        user_input_errors.append(
+        input_errors.append(
             DJError(
                 message=f"Metric nodes not found: {','.join(metric)}",
                 code=ErrorCode.UNKNOWN_NODE,
             ),
         )
 
-    if user_input_errors:
-        raise DJInvalidInputException(errors=user_input_errors)
+    if input_errors:
+        raise DJInvalidInputException(errors=input_errors)
     return await get_shared_dimensions(session, metric_nodes)

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -35,8 +35,8 @@ from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJActionNotAllowedException,
     DJAlreadyExistsException,
+    DJConfigurationException,
     DJDoesNotExistException,
-    DJException,
     DJInvalidInputException,
     ErrorCode,
 )
@@ -134,7 +134,7 @@ async def validate_node(
     """
 
     if data.type == NodeType.SOURCE:
-        raise DJException(message="Source nodes cannot be validated")
+        raise DJInvalidInputException(message="Source nodes cannot be validated")
 
     node_validator = await validate_node_data(data, session)
     if node_validator.errors:
@@ -704,7 +704,7 @@ async def register_table(
     """
     request_headers = dict(request.headers)
     if not query_service_client:
-        raise DJException(
+        raise DJConfigurationException(
             message="Registering tables or views requires that a query "
             "service is configured for columns inference",
         )
@@ -772,7 +772,7 @@ async def register_view(  # pylint: disable=too-many-locals
     """
     request_headers = dict(request.headers)
     if not query_service_client:
-        raise DJException(
+        raise DJConfigurationException(
             message="Registering tables or views requires that a query "
             "service is configured for columns inference",
         )
@@ -857,7 +857,7 @@ async def link_dimension(
     )
     if dimension_node.type != NodeType.DIMENSION:  # type: ignore  # pragma: no cover
         # pragma: no cover
-        raise DJException(message=f"Node {node.name} is not of type dimension!")  # type: ignore
+        raise DJInvalidInputException(f"Node {node.name} is not of type dimension!")  # type: ignore
     primary_key_columns = dimension_node.current.primary_key()  # type: ignore
     if len(primary_key_columns) > 1:
         raise DJActionNotAllowedException(  # pragma: no cover
@@ -1377,7 +1377,7 @@ async def calculate_node_similarity(
         raise_if_not_exists=True,
     )
     if NodeType.SOURCE in (node1.type, node2.type):  # type: ignore
-        raise DJException(
+        raise DJInvalidInputException(
             message="Cannot determine similarity of source nodes",
             http_status_code=HTTPStatus.CONFLICT,
         )

--- a/datajunction-server/datajunction_server/construction/exceptions.py
+++ b/datajunction-server/datajunction_server/construction/exceptions.py
@@ -4,7 +4,7 @@ Exceptions used in construction
 
 from typing import List, Optional
 
-from datajunction_server.errors import DJError, DJException
+from datajunction_server.errors import DJError, DJQueryBuildException
 
 
 class CompoundBuildException:
@@ -42,7 +42,7 @@ class CompoundBuildException:
         Accumulate DJ exceptions
         """
         if self._raise:
-            raise DJException(
+            raise DJQueryBuildException(
                 message=message or error.message,
                 errors=[error],
             )

--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -282,6 +282,14 @@ class DJQueryServiceClientException(DJException):
     http_status_code: int = 500
 
 
+class DJQueryServiceClientEntityNotFound(DJException):
+    """
+    Exception raised when an entity is not found on the query service
+    """
+
+    http_status_code: int = 404
+
+
 class DJActionNotAllowedException(DJException):
     """
     Exception raised when an action is not allowed.

--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -304,3 +304,40 @@ class DJQueryBuildError(DJError):
     """
     Query build error
     """
+
+
+class DJAuthorizationException(DJException):
+    """
+    Exception raised when the user is not authorized to perform a particular request
+    """
+
+    http_status_code: int = HTTPStatus.FORBIDDEN
+    message: str = "You do not have permission to perform this action."
+
+
+class DJAuthenticationException(DJException):
+    """
+    Exception raised when the user fails to authenticate.
+    """
+
+    http_status_code: int = HTTPStatus.UNAUTHORIZED
+    message: str = "Authentication failed. Please log in and try again."
+
+
+class DJUninitializedResourceException(DJInternalErrorException):
+    """
+    Raised when a required system resource (e.g., DatabaseSessionManager) is not initialized.
+    """
+
+
+class DJConfigurationException(DJException):
+    """
+    Exception raised when there is a missing or incorrect system configuration
+    that prevents the operation from proceeding.
+    """
+
+
+class DJGraphCycleException(DJException):
+    """
+    Exception raised when a cycle is detected in a graph during topological sorting.
+    """

--- a/datajunction-server/datajunction_server/internal/access/authentication/basic.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/basic.py
@@ -2,7 +2,6 @@
 Basic OAuth and JWT helper functions
 """
 import logging
-from http import HTTPStatus
 
 from passlib.context import CryptContext
 from sqlalchemy import select
@@ -10,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.base import ExecutableOption
 
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJError, DJException, ErrorCode
+from datajunction_server.errors import DJAuthenticationException, DJError, ErrorCode
 
 _logger = logging.getLogger(__name__)
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -48,8 +47,7 @@ async def get_user(
         .scalar_one_or_none()
     )
     if not user:
-        raise DJException(
-            http_status_code=HTTPStatus.UNAUTHORIZED,
+        raise DJAuthenticationException(
             errors=[
                 DJError(
                     message=f"User {username} not found",
@@ -70,8 +68,7 @@ async def validate_user_password(
     """
     user = await get_user(username=username, session=session)
     if not validate_password_hash(password, user.password):
-        raise DJException(
-            http_status_code=HTTPStatus.UNAUTHORIZED,
+        raise DJAuthenticationException(
             errors=[
                 DJError(
                     message=f"Invalid password for user {username}",

--- a/datajunction-server/datajunction_server/internal/access/authentication/github.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/github.py
@@ -3,7 +3,6 @@ GitHub OAuth helper functions
 """
 import logging
 import secrets
-from http import HTTPStatus
 from urllib.parse import urljoin
 
 import requests
@@ -11,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJException
+from datajunction_server.errors import DJAuthenticationException
 from datajunction_server.internal.access.authentication.basic import get_password_hash
 from datajunction_server.models.user import OAuthProvider
 from datajunction_server.utils import get_session, get_settings
@@ -42,9 +41,8 @@ def get_github_user(access_token: str) -> User:  # pragma: no cover
         timeout=10,
     ).json()
     if "message" in user_data and user_data["message"] == "Bad credentials":
-        raise DJException(
-            message="Cannot authorize user via GitHub, bad credentials",
-            http_status_code=HTTPStatus.UNAUTHORIZED,
+        raise DJAuthenticationException(
+            "Cannot authorize user via GitHub, bad credentials",
         )
     session = next(get_session())  # type: ignore  # pylint: disable=no-value-for-parameter
     existing_user = None

--- a/datajunction-server/datajunction_server/internal/access/authentication/google.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/google.py
@@ -13,7 +13,7 @@ from google.auth.external_account_authorized_user import Credentials
 from sqlalchemy import select
 
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJException
+from datajunction_server.errors import DJAuthenticationException
 from datajunction_server.internal.access.authentication.basic import get_password_hash
 from datajunction_server.models.user import OAuthProvider
 from datajunction_server.utils import get_session, get_settings
@@ -72,13 +72,13 @@ def get_google_user(token: str) -> User:
         timeout=10,
     )
     if response.status_code in (200, 201):
-        raise DJException(
+        raise DJAuthenticationException(
             http_status_code=HTTPStatus.FORBIDDEN,
             message=f"Error retrieving Google user: {response.text}",
         )
     user_data = response.json()
     if "message" in user_data and user_data["message"] == "Bad credentials":
-        raise DJException(
+        raise DJAuthenticationException(
             http_status_code=HTTPStatus.FORBIDDEN,
             message=f"Error retrieving Google user: {response.text}",
         )

--- a/datajunction-server/datajunction_server/internal/access/authentication/http.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/http.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from datajunction_server.constants import AUTH_COOKIE
-from datajunction_server.errors import DJError, DJException, ErrorCode
+from datajunction_server.errors import DJAuthenticationException, DJError, ErrorCode
 from datajunction_server.internal.access.authentication.basic import get_user
 from datajunction_server.internal.access.authentication.tokens import decode_token
 from datajunction_server.utils import get_session, get_settings
@@ -35,7 +35,7 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
             try:
                 jwt_data = decode_token(jwt)
             except (JWEError, JWTError) as exc:
-                raise DJException(
+                raise DJAuthenticationException(
                     http_status_code=HTTPStatus.UNAUTHORIZED,
                     errors=[
                         DJError(
@@ -54,7 +54,7 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
         scheme, credentials = get_authorization_scheme_param(authorization)
         if not (authorization and scheme and credentials):
             if self.auto_error:
-                raise DJException(
+                raise DJAuthenticationException(
                     http_status_code=HTTPStatus.FORBIDDEN,
                     errors=[
                         DJError(
@@ -66,7 +66,7 @@ class DJHTTPBearer(HTTPBearer):  # pylint: disable=too-few-public-methods
             return  # pragma: no cover
         if scheme.lower() != "bearer":
             if self.auto_error:
-                raise DJException(
+                raise DJAuthenticationException(
                     http_status_code=HTTPStatus.FORBIDDEN,
                     errors=[
                         DJError(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -129,7 +129,7 @@ async def validate_and_build_attribute(
 
     # Verify that the attribute type is allowed for this node
     if node.type not in attribute_type.allowed_node_types:
-        raise DJException(
+        raise DJInvalidInputException(
             message=f"Attribute type `{attribute.namespace}.{attribute_type.name}` "
             f"not allowed on node type `{node.type}`!",
         )
@@ -191,7 +191,7 @@ async def set_node_column_attributes(
     for (attribute, _), columns in attributes_columns_map.items():
         if len(columns) > 1 and attribute.uniqueness_scope:
             column.attributes = existing_attributes
-            raise DJException(
+            raise DJInvalidInputException(
                 message=f"The column attribute `{attribute.name}` is scoped to be "
                 f"unique to the `{attribute.uniqueness_scope}` level, but there "
                 "is more than one column tagged with it: "
@@ -1020,7 +1020,7 @@ async def create_node_from_inactive(  # pylint: disable=too-many-arguments
     )
     if previous_inactive_node and previous_inactive_node.deactivated_at:
         if previous_inactive_node.type != new_node_type:
-            raise DJException(  # pragma: no cover
+            raise DJInvalidInputException(  # pragma: no cover
                 message=f"A node with name `{data.name}` of a `{previous_inactive_node.type.value}` "  # pylint: disable=line-too-long
                 "type existed before. If you want to re-create it with a different type, "
                 "you need to remove all traces of the previous node with a hard delete call: "
@@ -1255,7 +1255,7 @@ async def create_new_revision_from_existing(  # pylint: disable=too-many-locals,
                 )
             ).scalar_one()
             if set(data.primary_key) - set(col.name for col in new_revision.columns):
-                raise DJException(  # pragma: no cover
+                raise DJInvalidInputException(  # pragma: no cover
                     f"Primary key {data.primary_key} does not exist on {new_revision.name}",
                 )
             for col in new_revision.columns:
@@ -1566,7 +1566,7 @@ async def upsert_complex_dimension_link(
 
     # Verify that the columns in the ON clause exist on both nodes
     if ctx.exception.errors:
-        raise DJException(
+        raise DJInvalidInputException(
             message=f"Join query {link_input.join_on} is not valid",
             errors=ctx.exception.errors,
         )
@@ -1833,7 +1833,7 @@ async def activate_node(
         include_inactive=True,
     )
     if not node.deactivated_at:
-        raise DJException(
+        raise DJInvalidInputException(
             http_status_code=HTTPStatus.BAD_REQUEST,
             message=f"Cannot restore `{name}`, node already active.",
         )

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -3,7 +3,6 @@ Models for authorization
 """
 from copy import deepcopy
 from enum import Enum
-from http import HTTPStatus
 from typing import TYPE_CHECKING, Callable, Iterable, Optional, Set, Union
 
 from pydantic import BaseModel, Field
@@ -11,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.utils import try_get_dj_node
 from datajunction_server.database.node import Node, NodeRevision
-from datajunction_server.errors import DJError, DJException, ErrorCode
+from datajunction_server.errors import DJAuthorizationException, DJError, ErrorCode
 from datajunction_server.models.user import UserOutput
 
 if TYPE_CHECKING:
@@ -241,8 +240,7 @@ class AccessControlStore(BaseModel):
                 if show_denials
                 else ""
             )
-            raise DJException(
-                http_status_code=HTTPStatus.FORBIDDEN,
+            raise DJAuthorizationException(
                 errors=[
                     DJError(
                         code=ErrorCode.UNAUTHORIZED_ACCESS,
@@ -270,8 +268,7 @@ class AccessControlStore(BaseModel):
         self.validation_results = access_control.requests
 
         if any((result.approved is None for result in self.validation_results)):
-            raise DJException(
-                http_status_code=HTTPStatus.FORBIDDEN,
+            raise DJAuthorizationException(
                 errors=[
                     DJError(
                         code=ErrorCode.INCOMPLETE_AUTHORIZATION,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -11,6 +11,7 @@ from datajunction_server.database.column import Column
 from datajunction_server.errors import (
     DJDoesNotExistException,
     DJError,
+    DJQueryServiceClientEntityNotFound,
     DJQueryServiceClientException,
     ErrorCode,
 )
@@ -131,7 +132,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             )
         table_columns = response.json()["columns"]
         if not table_columns:
-            raise DJQueryServiceClientException(
+            raise DJDoesNotExistException(
                 message=f"No columns found: {response.text}",
             )
         return [
@@ -215,6 +216,10 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             if request_headers
             else self.requests_session.headers,
         )
+        if response.status_code == 404:
+            raise DJQueryServiceClientEntityNotFound(
+                message=f"Error response from query service: {response.text}",
+            )
         if response.status_code not in (200, 201):
             raise DJQueryServiceClientException(
                 message=f"Error response from query service: {response.text}",

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -217,7 +217,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             else self.requests_session.headers,
         )
         if response.status_code == 404:
-            raise DJQueryServiceClientEntityNotFound(
+            raise DJQueryServiceClientEntityNotFound(  # pragma: no cover
                 message=f"Error response from query service: {response.text}",
             )
         if response.status_code not in (200, 201):

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -18,7 +18,7 @@ from datajunction_server.database.node import (
     NodeRelationship,
     NodeRevision,
 )
-from datajunction_server.errors import DJDoesNotExistException, DJException
+from datajunction_server.errors import DJDoesNotExistException, DJGraphCycleException
 from datajunction_server.models.attribute import ColumnAttributes
 from datajunction_server.models.node import DimensionAttributeOutput
 from datajunction_server.models.node_type import NodeType
@@ -832,7 +832,7 @@ def topological_sort(nodes: List[Node]) -> List[Node]:
 
     # Check for cycles
     if len(sorted_nodes) != len(in_degrees):
-        raise DJException("Graph has at least one cycle")
+        raise DJGraphCycleException("Graph has at least one cycle")
 
     return sorted_nodes[::-1]
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -35,7 +35,13 @@ from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.node import Node as DJNodeRef
 from datajunction_server.database.node import NodeRevision
 from datajunction_server.database.node import NodeRevision as DJNode
-from datajunction_server.errors import DJError, DJErrorException, DJException, ErrorCode
+from datajunction_server.errors import (
+    DJError,
+    DJErrorException,
+    DJException,
+    DJQueryBuildException,
+    ErrorCode,
+)
 from datajunction_server.models.column import SemanticType
 from datajunction_server.models.node import BuildCriteria
 from datajunction_server.models.node_type import NodeType as DJNodeType
@@ -1844,7 +1850,7 @@ class Number(Value):
                 except (ValueError, OverflowError) as exception:
                     cast_exceptions.append(exception)
             if len(cast_exceptions) >= len(numeric_types):
-                raise DJException(message="Not a valid number!")
+                raise DJParseException(message="Not a valid number!")
 
     def __str__(self) -> str:
         return str(self.value)
@@ -2834,7 +2840,9 @@ class Query(TableExpression, UnNamed):
 
         if not self.is_compiled():
             if not context:
-                raise DJException("Context not provided for query compilation!")
+                raise DJQueryBuildException(
+                    "Context not provided for query compilation!",
+                )
             await self.compile(context)
 
         deps: Dict[NodeRevision, List[Table]] = {}

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -198,7 +198,7 @@ def parse(sql: Optional[str]) -> ast.Query:
     try:
         return cast(ast.Query, parse_rule(sql, "singleStatement"))
     except SqlParsingError as exc:
-        raise DJParseException(message=f"Error parsing SQL {sql}") from exc
+        raise DJParseException(message=f"Error parsing SQL `{sql}`: {exc}") from exc
 
 
 def cached_parse(sql: Optional[str]) -> ast.Query:

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -195,7 +195,10 @@ def parse(sql: Optional[str]) -> ast.Query:
     """
     if not sql:
         raise DJParseException("Empty query provided!")
-    return cast(ast.Query, parse_rule(sql, "singleStatement"))
+    try:
+        return cast(ast.Query, parse_rule(sql, "singleStatement"))
+    except SqlParsingError as exc:
+        raise DJParseException(message=f"Error parsing SQL {sql}") from exc
 
 
 def cached_parse(sql: Optional[str]) -> ast.Query:

--- a/datajunction-server/datajunction_server/sql/parsing/backends/exceptions.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/exceptions.py
@@ -1,8 +1,12 @@
 """
 defines exceptions used for backend parsing
 """
+from http import HTTPStatus
+
 from datajunction_server.errors import DJException
 
 
 class DJParseException(DJException):
     """Exception type raised upon problem creating a DJ sql ast"""
+
+    http_status_code: int = HTTPStatus.UNPROCESSABLE_ENTITY

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -3,7 +3,7 @@ import importlib
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from datajunction_server.errors import DJException, DJPluginNotFoundException
+from datajunction_server.errors import DJPluginNotFoundException
 from datajunction_server.models.engine import Dialect
 
 
@@ -31,8 +31,8 @@ class SQLTranspilationPlugin(ABC):
             try:
                 importlib.import_module(self.package_name)
             except ImportError as import_err:
-                raise DJException(
-                    message=f"Not installed: {self.package_name}",
+                raise DJPluginNotFoundException(
+                    message=f"The SQL transpilation package is not installed: {self.package_name}",
                 ) from import_err
 
     @abstractmethod

--- a/datajunction-server/tests/api/attributes_test.py
+++ b/datajunction-server/tests/api/attributes_test.py
@@ -61,7 +61,7 @@ async def test_adding_new_attribute(
             "allowed_node_types": ["source"],
         },
     )
-    assert response.status_code == 500
+    assert response.status_code == 422
     data = response.json()
     assert data == {
         "message": "Cannot use `system` as the attribute type namespace as it is reserved.",

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -1694,7 +1694,7 @@ class TestAvailabilityState:  # pylint: disable=too-many-public-methods
         )
         data = response.json()
 
-        assert response.status_code == 500
+        assert response.status_code == 422
         assert data == {
             "message": (
                 "Cannot set availability state, source nodes require availability states "

--- a/datajunction-server/tests/api/djql_test.py
+++ b/datajunction-server/tests/api/djql_test.py
@@ -428,5 +428,5 @@ async def test_djsql_stream(
         "/djsql/stream/",
         params={"query": query},
     )
-    assert response.status_code == 500
+    assert response.status_code == 422
     assert response.json()["message"].startswith("Found no dj nodes in query")

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -700,7 +700,7 @@ async def test_raise_common_dimensions_not_a_metric_node(
         "metric=default.total_repair_order_discounts"
         "&metric=default.payment_type",
     )
-    assert response.status_code == 500
+    assert response.status_code == 422
     assert response.json()["message"] == "Not a metric node: default.payment_type"
 
 
@@ -714,7 +714,7 @@ async def test_raise_common_dimensions_metric_not_found(
     response = await module__client_with_roads.get(
         "/metrics/common/dimensions?metric=default.foo&metric=default.bar",
     )
-    assert response.status_code == 500
+    assert response.status_code == 422
     assert response.json() == {
         "errors": [
             {

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -3667,7 +3667,7 @@ class TestNodeColumnsAttributes:
             ],
         )
         data = response.json()
-        assert response.status_code == 500
+        assert response.status_code == 422
         assert (
             data["message"]
             == "Attribute type `system.dimension` not allowed on node type `dimension`!"

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -3939,6 +3939,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
             {
                 "code": 201,
                 "message": (
+                    "Error parsing SQL `SUPER invalid SQL query`: "
                     "('Parse error 1:0:', \"mismatched input 'SUPER' expecting "
                     "{'(', 'ADD', 'ALTER', 'ANALYZE', 'CACHE', 'CLEAR', 'COMMENT', "
                     "'COMMIT', 'CREATE', 'DELETE', 'DESC', 'DESCRIBE', 'DFS', 'DROP', "
@@ -4075,7 +4076,7 @@ class TestValidateNodes:  # pylint: disable=too-many-public-methods
         )
         data = response.json()
 
-        assert response.status_code == 500
+        assert response.status_code == 422
         assert data == {
             "message": "Source nodes cannot be validated",
             "errors": [],

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -40,7 +40,7 @@ from datajunction_server.database.base import Base
 from datajunction_server.database.column import Column
 from datajunction_server.database.engine import Engine
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJQueryServiceClientException
+from datajunction_server.errors import DJQueryServiceClientEntityNotFound
 from datajunction_server.internal.access.authorization import validate_access
 from datajunction_server.models.access import AccessControl, ValidateAccessFn
 from datajunction_server.models.materialization import MaterializationInfo
@@ -267,7 +267,7 @@ def query_service_client(
         ] = None,
     ) -> Collection[Collection[str]]:
         if query_id == "foo-bar-baz":
-            raise DJQueryServiceClientException("Query foo-bar-baz not found.")
+            raise DJQueryServiceClientEntityNotFound("Query foo-bar-baz not found.")
         for _, response in QUERY_DATA_MAPPINGS.items():
             if response.id == query_id:
                 return response
@@ -960,7 +960,7 @@ def module__query_service_client(
         ] = None,
     ) -> Collection[Collection[str]]:
         if query_id == "foo-bar-baz":
-            raise DJQueryServiceClientException("Query foo-bar-baz not found.")
+            raise DJQueryServiceClientEntityNotFound("Query foo-bar-baz not found.")
         for _, response in QUERY_DATA_MAPPINGS.items():
             if response.id == query_id:
                 return response

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -144,7 +144,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             status_code=200,
             json=MagicMock(return_value={"columns": []}),
         )
-        with pytest.raises(DJQueryServiceClientException) as exc_info:
+        with pytest.raises(DJDoesNotExistException) as exc_info:
             query_service_client.get_columns_for_table("hive", "test", "pies")
         assert "No columns found" in str(exc_info.value)
 

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -11,6 +11,7 @@ from datajunction_server.database.engine import Engine
 from datajunction_server.errors import (
     DJDoesNotExistException,
     DJError,
+    DJQueryServiceClientEntityNotFound,
     DJQueryServiceClientException,
     ErrorCode,
 )
@@ -459,25 +460,40 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         """
         Test handling an error response from the query service client
         """
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.json.return_value = {"message": "Errors", "errors": ["a", "b"]}
+        mock_400_response = MagicMock()
+        mock_400_response.status_code = 400
+        mock_400_response.json.return_value = {
+            "message": "Errors",
+            "errors": ["a", "b"],
+        }
 
-        mocker.patch(
-            "datajunction_server.service_clients.RequestsSessionWithEndpoint.get",
-            return_value=mock_response,
-        )
-        mocker.patch(
-            "datajunction_server.service_clients.RequestsSessionWithEndpoint.post",
-            return_value=mock_response,
-        )
+        mock_404_response = MagicMock()
+        mock_404_response.status_code = 404
+        mock_404_response.json.return_value = {
+            "message": "Query not found",
+            "errors": ["a"],
+        }
 
         query_service_client = QueryServiceClient(uri=self.endpoint)
 
-        with pytest.raises(DJQueryServiceClientException) as exc_info:
-            query_service_client.get_query(
-                "ef209eef-c31a-4089-aae6-833259a08e22",
-            )
+        with mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.get",
+            return_value=mock_400_response,
+        ):
+            with pytest.raises(DJQueryServiceClientException) as exc_info:
+                query_service_client.get_query(
+                    "ef209eef-c31a-4089-aae6-833259a08e22",
+                )
+
+        with mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.get",
+            return_value=mock_404_response,
+        ):
+            with pytest.raises(DJQueryServiceClientEntityNotFound) as exc_info:
+                query_service_client.get_query(
+                    "ef209eef-c31a-4089-aae6-833259a08e22",
+                )
+
         assert "Error response from query service" in str(exc_info.value)
         query_create = QueryCreate(
             catalog_name="hive",
@@ -487,10 +503,14 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             async_=False,
         )
 
-        with pytest.raises(DJQueryServiceClientException) as exc_info:
-            query_service_client.submit_query(
-                query_create,
-            )
+        with mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.post",
+            return_value=mock_400_response,
+        ):
+            with pytest.raises(DJQueryServiceClientException) as exc_info:
+                query_service_client.submit_query(
+                    query_create,
+                )
         assert "Error response from query service" in str(exc_info.value)
         assert exc_info.value.errors == [
             DJError(

--- a/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
+++ b/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
@@ -6,6 +6,7 @@ Tests for custom antlr4 parser
 import pytest
 
 from datajunction_server.sql.parsing.backends.antlr4 import parse
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 
 
 @pytest.mark.parametrize(
@@ -119,3 +120,11 @@ def test_antlr4_lambda_function():
     assert "FOO('a', 'b', c -> d) AS e" in str(query)
     query = parse("SELECT FOO('a', 'b', (c, c2, c3) -> d) AS e;")
     assert "FOO('a', 'b', (c, c2, c3) -> d) AS e" in str(query)
+
+
+def test_antlr4_parse_error():
+    """
+    Test LATERAL VIEW EXPLODE queries
+    """
+    with pytest.raises(DJParseException):
+        parse("SELECT ** FROM 1_#**")


### PR DESCRIPTION
### Summary

This PR goes through most of the instances where we raise `DJException` and tries to categorize them into more useful exception categories. This makes it easier to distinguish between user errors and system errors for debugging or alerting purposes.

### Test Plan

- [x] PR has an associated issue: #1261 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A