### PR TITLE
Only generate preaggregated measures SQL where possible

### DIFF
--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -51,6 +51,13 @@ async def get_measures_sql_for_cube_v2(
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
     orderby: List[str] = Query([]),
+    preaggregate: bool = Query(
+        False,
+        description=(
+            "Whether to pre-aggregate to the requested dimensions so that "
+            "subsequent queries are more efficient."
+        ),
+    ),
     *,
     include_all_columns: bool = Query(
         False,
@@ -98,6 +105,7 @@ async def get_measures_sql_for_cube_v2(
         include_all_columns=include_all_columns,
         sql_transpilation_library=settings.sql_transpilation_library,
         use_materialized=use_materialized,
+        preagg_requested=preaggregate,
     )
     return measures_query
 

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -51,13 +51,6 @@ async def get_measures_sql_for_cube_v2(
     dimensions: List[str] = Query([]),
     filters: List[str] = Query([]),
     orderby: List[str] = Query([]),
-    preaggregate: bool = Query(
-        False,
-        description=(
-            "Whether to pre-aggregate to the requested dimensions so that "
-            "subsequent queries are more efficient."
-        ),
-    ),
     *,
     include_all_columns: bool = Query(
         False,
@@ -105,7 +98,6 @@ async def get_measures_sql_for_cube_v2(
         include_all_columns=include_all_columns,
         sql_transpilation_library=settings.sql_transpilation_library,
         use_materialized=use_materialized,
-        preaggregate=preaggregate,
     )
     return measures_query
 

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -103,7 +103,7 @@ async def get_measures_query(  # pylint: disable=too-many-locals
     include_all_columns: bool = False,
     sql_transpilation_library: Optional[str] = None,
     use_materialized: bool = True,
-    preagg_requested: bool = True,
+    preagg_requested: bool = False,
 ) -> List[GeneratedSQL]:
     """
     Builds the measures SQL for a set of metrics with dimensions and filters.

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -33,6 +33,7 @@ class GeneratedSQL(BaseModel):
     sql: str
     sql_transpilation_library: Optional[str] = None
     columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover
+    grain: list[str] | None = None
     dialect: Optional[Dialect] = None
     upstream_tables: Optional[List[str]] = None
     errors: Optional[List[DJQueryBuildError]] = None

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -1177,6 +1177,171 @@ async def test_measures_sql_errors(
 
 
 @pytest.mark.asyncio
+async def test_measures_sql_preagg_incompatible(  # pylint: disable=too-many-arguments
+    module__client_with_roads: AsyncClient,
+    duckdb_conn: duckdb.DuckDBPyConnection,  # pylint: disable=c-extension-no-member
+):
+    """
+    Test ``GET /sql/measures`` with incompatible metrics vs compatible metrics.
+    """
+    await fix_dimension_links(module__client_with_roads)
+    await module__client_with_roads.post(
+        "/nodes/metric",
+        json={
+            "description": "A preagg incompatible metric",
+            "query": "SELECT COUNT(DISTINCT hard_hat_id) FROM default.repair_orders_fact",
+            "mode": "published",
+            "name": "default.number_of_hard_hats",
+        },
+    )
+
+    response = await module__client_with_roads.get(
+        "/sql/measures/v2",
+        params={
+            "metrics": ["default.avg_repair_price", "default.number_of_hard_hats"],
+            "dimensions": [
+                "default.dispatcher.company_name",
+            ],
+            "filters": [],
+            "preaggregate": True,
+        },
+    )
+    data = response.json()
+    translated_sql = data[0]
+    assert translated_sql["grain"] == []
+    expected_sql = """
+    WITH default_DOT_repair_orders_fact AS (
+      SELECT
+        repair_orders.repair_order_id,
+        repair_orders.municipality_id,
+        repair_orders.hard_hat_id,
+        repair_orders.dispatcher_id,
+        repair_orders.order_date,
+        repair_orders.dispatched_date,
+        repair_orders.required_date,
+        repair_order_details.discount,
+        repair_order_details.price,
+        repair_order_details.quantity,
+        repair_order_details.repair_type_id,
+        repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+        repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+        repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
+      FROM roads.repair_orders AS repair_orders
+      JOIN roads.repair_order_details AS repair_order_details
+        ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+    ),
+    default_DOT_dispatcher AS (
+      SELECT
+        default_DOT_dispatchers.dispatcher_id,
+        default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.phone
+      FROM roads.dispatchers AS default_DOT_dispatchers
+    )
+    SELECT
+      default_DOT_repair_orders_fact.hard_hat_id default_DOT_repair_orders_fact_DOT_hard_hat_id,
+      default_DOT_repair_orders_fact.price default_DOT_repair_orders_fact_DOT_price,
+      default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name
+    FROM default_DOT_repair_orders_fact
+    LEFT JOIN default_DOT_dispatcher
+      ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    """
+    assert str(parse(str(expected_sql))) == str(parse(str(translated_sql["sql"])))
+    result = duckdb_conn.sql(translated_sql["sql"])
+    assert set(result.fetchall()) == {
+        (3, 67253.0, "Pothole Pete"),
+        (6, 65114.0, "Asphalts R Us"),
+        (3, 87858.0, "Asphalts R Us"),
+        (1, 92366.0, "Pothole Pete"),
+        (1, 63708.0, "Federal Roads Group"),
+        (4, 73600.0, "Pothole Pete"),
+        (2, 48919.0, "Federal Roads Group"),
+        (5, 21083.0, "Federal Roads Group"),
+        (5, 47857.0, "Asphalts R Us"),
+        (4, 63918.0, "Asphalts R Us"),
+        (3, 74555.0, "Asphalts R Us"),
+        (2, 29684.0, "Federal Roads Group"),
+        (4, 51594.0, "Pothole Pete"),
+        (5, 87289.0, "Pothole Pete"),
+        (7, 53374.0, "Federal Roads Group"),
+        (8, 76463.0, "Asphalts R Us"),
+        (8, 54901.0, "Federal Roads Group"),
+        (6, 68745.0, "Asphalts R Us"),
+        (5, 66808.0, "Asphalts R Us"),
+        (4, 27222.0, "Federal Roads Group"),
+        (6, 62928.0, "Pothole Pete"),
+        (1, 18497.0, "Pothole Pete"),
+        (1, 44120.0, "Pothole Pete"),
+        (5, 97916.0, "Federal Roads Group"),
+        (9, 70418.0, "Federal Roads Group"),
+    }
+
+    response = await module__client_with_roads.get(
+        "/sql/measures/v2",
+        params={
+            "metrics": ["default.avg_repair_price", "default.num_repair_orders"],
+            "dimensions": [
+                "default.dispatcher.company_name",
+            ],
+            "filters": [],
+            "preaggregate": True,
+        },
+    )
+    data = response.json()
+    translated_sql = data[0]
+    assert translated_sql["grain"] == ["default_DOT_dispatcher_DOT_company_name"]
+    expected_sql = """
+    WITH default_DOT_repair_orders_fact AS (
+      SELECT
+        repair_orders.repair_order_id,
+        repair_orders.municipality_id,
+        repair_orders.hard_hat_id,
+        repair_orders.dispatcher_id,
+        repair_orders.order_date,
+        repair_orders.dispatched_date,
+        repair_orders.required_date,
+        repair_order_details.discount,
+        repair_order_details.price,
+        repair_order_details.quantity,
+        repair_order_details.repair_type_id,
+        repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
+        repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
+        repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay 
+      FROM roads.repair_orders AS repair_orders
+      JOIN roads.repair_order_details AS repair_order_details
+        ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+    ),
+    default_DOT_dispatcher AS (
+      SELECT
+        default_DOT_dispatchers.dispatcher_id,
+        default_DOT_dispatchers.company_name,
+        default_DOT_dispatchers.phone 
+      FROM roads.dispatchers AS default_DOT_dispatchers
+    ),
+    default_DOT_repair_orders_fact_built AS (
+      SELECT
+        default_DOT_repair_orders_fact.repair_order_id,
+        default_DOT_repair_orders_fact.price,
+        default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name 
+      FROM default_DOT_repair_orders_fact LEFT JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id
+    )
+    SELECT
+      default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
+      COUNT(1) AS count,
+      SUM(price) AS price_sum_78a5eb43,
+      COUNT(repair_order_id) AS repair_order_id_count_0b7dfba0 
+    FROM default_DOT_repair_orders_fact_built 
+    GROUP BY  default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name
+    """
+    assert str(parse(str(expected_sql))) == str(parse(str(translated_sql["sql"])))
+    result = duckdb_conn.sql(translated_sql["sql"])
+    assert set(result.fetchall()) == {
+        ("Pothole Pete", 8, 497647.0, 8),
+        ("Asphalts R Us", 8, 551318.0, 8),
+        ("Federal Roads Group", 9, 467225.0, 9),
+    }
+
+
+@pytest.mark.asyncio
 async def test_metrics_sql_different_parents(
     module__client_with_roads: AsyncClient,
     duckdb_conn: duckdb.DuckDBPyConnection,  # pylint: disable=c-extension-no-member

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -1305,7 +1305,7 @@ async def test_measures_sql_preagg_incompatible(  # pylint: disable=too-many-arg
         repair_order_details.repair_type_id,
         repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
         repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
-        repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay 
+        repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
       FROM roads.repair_orders AS repair_orders
       JOIN roads.repair_order_details AS repair_order_details
         ON repair_orders.repair_order_id = repair_order_details.repair_order_id
@@ -1314,22 +1314,22 @@ async def test_measures_sql_preagg_incompatible(  # pylint: disable=too-many-arg
       SELECT
         default_DOT_dispatchers.dispatcher_id,
         default_DOT_dispatchers.company_name,
-        default_DOT_dispatchers.phone 
+        default_DOT_dispatchers.phone
       FROM roads.dispatchers AS default_DOT_dispatchers
     ),
     default_DOT_repair_orders_fact_built AS (
       SELECT
         default_DOT_repair_orders_fact.repair_order_id,
         default_DOT_repair_orders_fact.price,
-        default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name 
+        default_DOT_dispatcher.company_name default_DOT_dispatcher_DOT_company_name
       FROM default_DOT_repair_orders_fact LEFT JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id
     )
     SELECT
       default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
       COUNT(1) AS count,
       SUM(price) AS price_sum_78a5eb43,
-      COUNT(repair_order_id) AS repair_order_id_count_0b7dfba0 
-    FROM default_DOT_repair_orders_fact_built 
+      COUNT(repair_order_id) AS repair_order_id_count_0b7dfba0
+    FROM default_DOT_repair_orders_fact_built
     GROUP BY  default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name
     """
     assert str(parse(str(expected_sql))) == str(parse(str(translated_sql["sql"])))


### PR DESCRIPTION
### Summary

We should only generate preaggregated measures SQL if the metrics requested are compatible. For example, if the requested metric has measures with `Aggregability.LIMITED` or `Aggregability.NONE`, we should not generate preaggregated measures SQL.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
