### PR TITLE
Shortcircuit the source node refresh if no table is found.

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1240,7 +1240,10 @@ async def refresh_source_node(  # pylint: disable=too-many-locals
             source_node.missing_table = False  # type: ignore
             refresh_details["missing_table"] = "False"
     else:
-        # since we don't see any columns, we'll assume the table is gone
+        # since we don't see any columns, we assume the table is gone
+        if source_node.missing_table:  # type: ignore
+            # but if the node already has a missing table, we can skip the update
+            return source_node  # type: ignore
         source_node.missing_table = True  # type: ignore
         new_columns = current_revision.columns
         refresh_details["missing_table"] = "True"

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1869,14 +1869,15 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         response = await module__client_with_roads.post(
             "/nodes/default.repair_orders/refresh/",
         )
-        data_second = response.json()
-        assert data_second["version"] == "v3.0"
-        assert data_second["node_revision_id"] != data["node_revision_id"]
-        assert len(data_second["columns"]) == 8
-        assert data_second["status"] == "valid"
-        assert data_second["missing_table"] is True
+        data_new = response.json()
+        assert data_new["version"] == "v3.0"
+        assert data_new["node_revision_id"] != data["node_revision_id"]
+        assert len(data_new["columns"]) == 8
+        assert data_new["status"] == "valid"
+        assert data_new["missing_table"] is True
 
         # Refresh it again, but this time the table is missing
+        data = data_new
         mocker.patch.object(
             module__query_service_client,
             "get_columns_for_table",
@@ -1887,14 +1888,27 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         response = await module__client_with_roads.post(
             "/nodes/default.repair_orders/refresh/",
         )
-        data_third = response.json()
-        assert data_third["version"] == "v4.0"
-        assert data_third["node_revision_id"] != data_second["node_revision_id"]
-        assert len(data_third["columns"]) == 8
-        assert data_third["status"] == "valid"
-        assert data_third["missing_table"] is True
+        data_new = response.json()
+        assert data_new["version"] == "v3.0"
+        assert data_new["node_revision_id"] == data["node_revision_id"]
+        assert len(data_new["columns"]) == 8
+        assert data_new["status"] == "valid"
+        assert data_new["missing_table"] is True
+
+        # Refresh it again, table is still missing
+        data = data_new
+        response = await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        data_new = response.json()
+        assert data_new["version"] == "v3.0"
+        assert data_new["node_revision_id"] == data["node_revision_id"]
+        assert len(data_new["columns"]) == 8
+        assert data_new["status"] == "valid"
+        assert data_new["missing_table"] is True
 
         # Refresh it again, back to normal state
+        data = data_new
         mocker.patch.object(
             module__query_service_client,
             "get_columns_for_table",
@@ -1903,12 +1917,12 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         response = await module__client_with_roads.post(
             "/nodes/default.repair_orders/refresh/",
         )
-        data_fourth = response.json()
-        assert data_fourth["version"] == "v5.0"
-        assert data_fourth["node_revision_id"] != data_second["node_revision_id"]
-        assert len(data_fourth["columns"]) == 8
-        assert data_fourth["status"] == "valid"
-        assert data_fourth["missing_table"] is False
+        data_new = response.json()
+        assert data_new["version"] == "v4.0"
+        assert data_new["node_revision_id"] != data["node_revision_id"]
+        assert len(data_new["columns"]) == 8
+        assert data_new["status"] == "valid"
+        assert data_new["missing_table"] is False
 
     @pytest.mark.asyncio
     async def test_refresh_source_node_with_query(


### PR DESCRIPTION
### Summary

Also, update the node version only if this is the first refresh after the table went missing.

### Test Plan

Unit tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

auto