### PR TITLE
Fix bug for preagg measures sql

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -313,6 +313,13 @@ def build_preaggregate_query(
                 f"SELECT {measure.aggregation}({measure.expression}) AS {measure.name}",
             ).select
             for col in temp_select.find_all(ast.Column):
+                # Realias based on canonical dimension name if needed
+                if col.alias_or_name.name not in parent_ast.select.column_mapping:
+                    new_alias = amenable_name(
+                        parent_node.name + SEPARATOR + col.alias_or_name.name,
+                    )
+                    if new_alias in parent_ast.select.column_mapping:
+                        col.name.name = new_alias
                 if (  # pragma: no cover
                     col.alias_or_name.name in parent_ast.select.column_mapping
                 ):

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -4137,6 +4137,13 @@ def infer_type(
     return ct.DoubleType()
 
 
+@Sum.register  # type: ignore
+def infer_type(
+    arg: Union[ct.DateType, ct.TimestampType],
+) -> ct.DoubleType:
+    return ct.DoubleType()
+
+
 class ToDate(Function):  # pragma: no cover # pylint: disable=abstract-method
     """
     Converts a date string to a date value.


### PR DESCRIPTION
### Summary

This PR fixes a bug where requesting pre-aggregated measures SQL for metrics that reference local dimensions errors out. This is because it should use the fully qualified dimension name when finding the column.

### Test Plan

Locally + added unit test

- [x] PR has an associated issue: #1272
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
