### PR TITLE
Add metric SQL validation

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -697,6 +697,15 @@ class NodeRevision(
         )
 
         tree = parse(query)
+        if len(tree.select.projection) != 1:
+            raise DJInvalidInputException(
+                "Metric SQL cannot have more than one output column expression."
+            )
+        if tree.select.where:
+            raise DJInvalidInputException(
+                "Metric cannot have a WHERE clause. Please use IF(<clause>, ...) instead"
+                " to represent a WHERE clause."
+            )
         projection_0 = tree.select.projection[0]
         tree.select.projection[0] = projection_0.set_alias(
             ast.Name(amenable_name(name)),

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -699,12 +699,12 @@ class NodeRevision(
         tree = parse(query)
         if len(tree.select.projection) != 1:
             raise DJInvalidInputException(
-                "Metric SQL cannot have more than one output column expression."
+                "Metric SQL cannot have more than one output column expression.",
             )
         if tree.select.where:
             raise DJInvalidInputException(
                 "Metric cannot have a WHERE clause. Please use IF(<clause>, ...) instead"
-                " to represent a WHERE clause."
+                " to represent a WHERE clause.",
             )
         projection_0 = tree.select.projection[0]
         tree.select.projection[0] = projection_0.set_alias(

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -34,7 +34,11 @@ from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.metricmetadata import MetricMetadata
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJInvalidInputException, DJNodeNotFound
+from datajunction_server.errors import (
+    DJInvalidInputException,
+    DJInvalidMetricQueryException,
+    DJNodeNotFound,
+)
 from datajunction_server.models.base import labelize
 from datajunction_server.models.node import (
     DEFAULT_DRAFT_VERSION,
@@ -697,15 +701,6 @@ class NodeRevision(
         )
 
         tree = parse(query)
-        if len(tree.select.projection) != 1:
-            raise DJInvalidInputException(
-                "Metric SQL cannot have more than one output column expression.",
-            )
-        if tree.select.where:
-            raise DJInvalidInputException(
-                "Metric cannot have a WHERE clause. Please use IF(<clause>, ...) instead"
-                " to represent a WHERE clause.",
-            )
         projection_0 = tree.select.projection[0]
         tree.select.projection[0] = projection_0.set_alias(
             ast.Name(amenable_name(name)),
@@ -738,10 +733,29 @@ class NodeRevision(
             not hasattr(projection_0, "is_aggregation")
             or not projection_0.is_aggregation()  # type: ignore
         ):
-            raise DJInvalidInputException(
-                http_status_code=HTTPStatus.BAD_REQUEST,
-                message=f"Metric {self.name} has an invalid query, "
-                "should have an aggregate expression",
+            raise DJInvalidMetricQueryException(
+                f"Metric {self.name} has an invalid query, should have an aggregate expression",
+            )
+
+        if tree.select.where:
+            raise DJInvalidMetricQueryException(
+                "Metric cannot have a WHERE clause. Please use IF(<clause>, ...) instead",
+            )
+
+        clauses = [
+            "GROUP BY" if tree.select.group_by else None,
+            "HAVING" if tree.select.having else None,
+            "LATERAL VIEW" if tree.select.lateral_views else None,
+            "UNION or INTERSECT" if tree.select.set_op else None,
+            "LIMIT" if tree.select.limit else None,
+            "ORDER BY" if tree.select.organization.order else None,
+            "SORT BY" if tree.select.organization.sort else None,
+        ]
+        invalid_clauses = [clause for clause in clauses if clause is not None]
+        if invalid_clauses:
+            raise DJInvalidMetricQueryException(
+                "Metric has an invalid query. The following are not allowed: "
+                + ", ".join(invalid_clauses),
             )
 
     def extra_validation(self) -> None:

--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -237,6 +237,14 @@ class DJInvalidInputException(DJException):
     http_status_code: int = HTTPStatus.UNPROCESSABLE_ENTITY
 
 
+class DJInvalidMetricQueryException(DJInvalidInputException):
+    """
+    Exception raised when the metric query provided by the user is invalid.
+    """
+
+    http_status_code: int = HTTPStatus.BAD_REQUEST
+
+
 class DJNotImplementedException(DJException):
     """
     Exception raised when some functionality hasn't been implemented in DJ yet.

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1296,7 +1296,7 @@ async def test_create_invalid_metric(module__client_with_roads: AsyncClient):
         },
     )
     assert response.json()["message"] == (
-        "Metric SQL cannot have more than one output column expression."
+        "Metric queries can only have a single expression, found 2"
     )
 
     response = await module__client_with_roads.post(
@@ -1312,6 +1312,21 @@ async def test_create_invalid_metric(module__client_with_roads: AsyncClient):
         },
     )
     assert response.json()["message"] == (
-        "Metric cannot have a WHERE clause. Please use IF(<clause>, ...)"
-        " instead to represent a WHERE clause."
+        "Metric cannot have a WHERE clause. Please use IF(<clause>, ...) instead"
+    )
+
+    response = await module__client_with_roads.post(
+        "/nodes/metric/",
+        json={
+            "query": (
+                "SELECT sum(total_repair_cost) FROM default.repair_orders_fact "
+                "GROUP BY total_repair_cost HAVING count(*) > 0 ORDER BY 1"
+            ),
+            "description": "Something invalid",
+            "mode": "published",
+            "name": "default.invalid_metric_example",
+        },
+    )
+    assert response.json()["message"] == (
+        "Metric has an invalid query. The following are not allowed: GROUP BY, HAVING, ORDER BY"
     )


### PR DESCRIPTION
### Summary

This PR adds validation checks for metric SQL when creating a metric:
* Only a single output column
* No `WHERE` clause

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1275 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
