### PR TITLE
SQL Generation Speed: Store pickled query AST

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2025_01_19_1808-9650f9b728a2_add_query_ast_for_noderevision.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_01_19_1808-9650f9b728a2_add_query_ast_for_noderevision.py
@@ -1,0 +1,29 @@
+"""Add query ast for noderevision
+
+Revision ID: 9650f9b728a2
+Revises: 70904373eab3
+Create Date: 2025-01-19 18:08:25.588956+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9650f9b728a2"
+down_revision = "70904373eab3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("query_ast", sa.PickleType(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.drop_column("query_ast")

--- a/datajunction-server/datajunction_server/alembic/versions/2025_01_19_1808-9650f9b728a2_add_query_ast_for_noderevision.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_01_19_1808-9650f9b728a2_add_query_ast_for_noderevision.py
@@ -9,9 +9,8 @@ Create Date: 2025-01-19 18:08:25.588956+00:00
 # pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "9650f9b728a2"

--- a/datajunction-server/datajunction_server/alembic/versions/2025_01_19_1808-9650f9b728a2_add_query_ast_for_noderevision.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_01_19_1808-9650f9b728a2_add_query_ast_for_noderevision.py
@@ -1,4 +1,5 @@
-"""Add query ast for noderevision
+"""
+Add query ast for noderevision
 
 Revision ID: 9650f9b728a2
 Revises: 70904373eab3

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional, Set, Tuple, cast
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import defer, joinedload, selectinload
 from sqlalchemy.sql.operators import and_, is_
 
 from datajunction_server.construction.build import (
@@ -441,9 +441,7 @@ async def check_metrics_exist(session: AsyncSession, metrics: list[str]) -> list
             metrics,
             options=[
                 joinedload(Node.current).options(
-                    selectinload(NodeRevision.columns).options(
-                        selectinload(Column.node_revisions),
-                    ),
+                    selectinload(NodeRevision.columns),
                     joinedload(NodeRevision.catalog),
                     selectinload(NodeRevision.parents),
                 ),
@@ -480,9 +478,8 @@ async def check_dimension_attributes_exist(
             dimension_node_names,
             options=[
                 joinedload(Node.current).options(
-                    selectinload(NodeRevision.columns).options(
-                        joinedload(Column.node_revisions),
-                    ),
+                    selectinload(NodeRevision.columns),
+                    defer(NodeRevision.query_ast),
                 ),
             ],
         )

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -157,6 +157,8 @@ async def revalidate(
     name: str,
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_and_update_current_user),
+    *,
+    background_tasks: BackgroundTasks,
 ) -> NodeStatusDetails:
     """
     Revalidate a single existing node and update its status appropriately
@@ -165,6 +167,7 @@ async def revalidate(
         name=name,
         session=session,
         current_user=current_user,
+        background_tasks=background_tasks,
     )
 
     return NodeStatusDetails(

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -1556,7 +1556,7 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     if use_pickled and node.query_ast:
         try:
             query = pickle.loads(node.query_ast)
-        except TypeError as exc:
+        except TypeError as exc:  # pragma: no cover
             logger.error(
                 "Error loading query AST pickle for %s@%s: %s\n%s",
                 node.name,

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -524,16 +524,16 @@ class CompressedPickleType(TypeDecorator):  # pylint: disable=too-many-ancestors
             return None
         try:
             return pickle.loads(zlib.decompress(value))
-        except TypeError:
+        except TypeError:  # pragma: no cover
             return None
 
     def process_literal_param(self, value, dialect):
         """Convert the value to a literal for SQL statements."""
-        if value is not None:
+        if value is not None:  # pragma: no cover
             # Convert the value to a compressed and pickled representation
             compressed_value = zlib.compress(pickle.dumps(value))
             return compressed_value.hex()  # Convert binary to a safe literal format
-        return None
+        return None  # pragma: no cover
 
 
 class NodeRevision(

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    PickleType,
     String,
     UniqueConstraint,
     select,
@@ -645,6 +646,8 @@ class NodeRevision(
         default=[],
     )
 
+    query_ast: Mapped[PickleType | None] = mapped_column(PickleType)
+
     def __hash__(self) -> int:
         return hash(self.id)
 
@@ -683,8 +686,10 @@ class NodeRevision(
                 joinedload(DimensionLink.dimension).options(
                     selectinload(Node.current),
                 ),
+                joinedload(DimensionLink.node_revision),
             ),
             selectinload(NodeRevision.required_dimensions),
+            selectinload(NodeRevision.availability),
         )
 
     @staticmethod

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1730,7 +1730,8 @@ class Function(Named, Operation):
     ):
         # Check if function is a table-valued function
         if (
-            not quantifier
+            hasattr(name, "name")
+            and not quantifier
             and over is None
             and name.name.upper() in table_function_registry
         ):

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2862,29 +2862,3 @@ class Query(TableExpression, UnNamed):
     @property
     def type(self) -> ColumnType:
         return self.select.type
-
-    async def build(  # pylint: disable=R0913,C0415
-        self,
-        session: AsyncSession,
-        memoized_queries: Dict[int, "Query"],
-        build_criteria: Optional[BuildCriteria] = None,
-        filters: Optional[List[str]] = None,
-        dimensions: Optional[List[str]] = None,
-        access_control=None,
-    ):
-        """
-        Transforms a query ast by replacing dj node references with their asts
-        """
-        from datajunction_server.construction.build import _build_select_ast
-
-        self.bake_ctes()  # pylint: disable=W0212
-        await _build_select_ast(
-            session,
-            self.select,
-            memoized_queries,
-            build_criteria,
-            filters,
-            dimensions,
-            access_control,
-        )
-        self.select.add_aliases_to_unnamed_columns()

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -853,7 +853,7 @@ class Column(Aliasable, Named, Expression):
         return column_namespace, column_name, subscript_name
 
     @classmethod
-    def from_existing(cls, col: Aliasable | Expression):
+    def from_existing(cls, col: Aliasable | Expression, table: "TableExpression"):
         """
         Build a selectable column from an existing one
         """
@@ -862,6 +862,7 @@ class Column(Aliasable, Named, Expression):
             _type=col.type,
             semantic_entity=col.semantic_entity,
             semantic_type=col.semantic_type,
+            _table=table,
         )
 
     async def find_table_sources(

--- a/datajunction-server/datajunction_server/sql/parsing/types.py
+++ b/datajunction-server/datajunction_server/sql/parsing/types.py
@@ -340,6 +340,13 @@ class NestedField(ColumnType):
         """
         return self._type
 
+    def __reduce__(self):
+        """
+        Custom method for pickling.
+        Returns a tuple of (callable, args) to recreate the object.
+        """
+        return (self.__class__, (self._name, self._type, self.is_optional, self.doc))
+
 
 class StructType(ColumnType):
     """A struct type
@@ -396,11 +403,18 @@ class ListType(ColumnType):
 
     def __new__(
         cls,
-        element_type: ColumnType,
+        element_type: ColumnType = None,
     ):
         key = (element_type,)
-        cls._instances[key] = cls._instances.get(key) or object.__new__(cls)  # type: ignore
+        cls._instances[key] = cls._instances.get(key) or super().__new__(cls)  # type: ignore
         return cls._instances[key]  # type: ignore
+
+    def __reduce__(self):
+        """
+        Custom method for pickling.
+        Returns a tuple of (callable, args) to recreate the object.
+        """
+        return (self.__class__, (self._element_field._type,))
 
     def __init__(
         self,
@@ -472,6 +486,13 @@ class MapType(ColumnType):
         The map's value
         """
         return self._value_field
+
+    def __reduce__(self):
+        """
+        Custom method for pickling.
+        Returns a tuple of (callable, args) to recreate the object.
+        """
+        return (self.__class__, (self._key_field, self._value_field))
 
 
 class BooleanType(PrimitiveType, Singleton):

--- a/datajunction-server/datajunction_server/sql/parsing/types.py
+++ b/datajunction-server/datajunction_server/sql/parsing/types.py
@@ -414,7 +414,7 @@ class ListType(ColumnType):
         Custom method for pickling.
         Returns a tuple of (callable, args) to recreate the object.
         """
-        return (self.__class__, (self._element_field._type,))
+        return (self.__class__, (self._element_field._type,))  # pragma: no cover
 
     def __init__(
         self,

--- a/datajunction-server/datajunction_server/sql/parsing/types.py
+++ b/datajunction-server/datajunction_server/sql/parsing/types.py
@@ -340,7 +340,7 @@ class NestedField(ColumnType):
         """
         return self._type
 
-    def __reduce__(self):
+    def __reduce__(self):  # pragma: no cover
         """
         Custom method for pickling.
         Returns a tuple of (callable, args) to recreate the object.
@@ -487,7 +487,7 @@ class MapType(ColumnType):
         """
         return self._value_field
 
-    def __reduce__(self):
+    def __reduce__(self):  # pragma: no cover
         """
         Custom method for pickling.
         Returns a tuple of (callable, args) to recreate the object.

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1203,6 +1203,7 @@ async def test_spark_with_availablity(
         },
     )
     assert response.status_code in (200, 201)
+
     # check the materialization query again (query should be the same)
     response = await module__client_with_roads.get(
         "/nodes/default.test_transform/materializations/",

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1203,7 +1203,6 @@ async def test_spark_with_availablity(
         },
     )
     assert response.status_code in (200, 201)
-
     # check the materialization query again (query should be the same)
     response = await module__client_with_roads.get(
         "/nodes/default.test_transform/materializations/",
@@ -1213,6 +1212,11 @@ async def test_spark_with_availablity(
 
     # refresh the materialization on 2nd node now with availability
     # (query should now include availability of the 1st node)
+    response = await module__client_with_roads.post(
+        "/nodes/default.test_transform_two/validate/",
+    )
+    assert response.status_code in (200, 201)
+
     response = await module__client_with_roads.post(
         "/nodes/default.test_transform_two/materialization/",
         json={

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -1758,7 +1758,18 @@ async def test_metric_with_nth_order_dimensions_filters(
             repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
             repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
             repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
-          FROM roads.repair_orders AS repair_orders
+          FROM (
+            SELECT
+              repair_order_id,
+              municipality_id,
+              hard_hat_id,
+              order_date,
+              required_date,
+              dispatched_date,
+              dispatcher_id
+            FROM roads.repair_orders
+            WHERE dispatcher_id = 1
+          ) repair_orders
           JOIN roads.repair_order_details AS repair_order_details
             ON repair_orders.repair_order_id = repair_order_details.repair_order_id
           WHERE

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -1758,18 +1758,7 @@ async def test_metric_with_nth_order_dimensions_filters(
             repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
             repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
             repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
-          FROM (
-            SELECT
-              repair_order_id,
-              municipality_id,
-              hard_hat_id,
-              order_date,
-              required_date,
-              dispatched_date,
-              dispatcher_id
-            FROM roads.repair_orders
-            WHERE dispatcher_id = 1
-          ) repair_orders
+          FROM roads.repair_orders AS repair_orders
           JOIN roads.repair_order_details AS repair_order_details
             ON repair_orders.repair_order_id = repair_order_details.repair_order_id
           WHERE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health/"]
       interval: 30s
       retries: 3
       start_period: 10s


### PR DESCRIPTION
### Summary

This PR speeds up SQL generation quite significantly by storing and loading pickled query ASTs rather than recompiling a node query every time we need it. The primary changes include:

* A new `query_ast` column on the `noderevision` table to store compressed pickled ASTs.
* Every time a transform or dimension node is created, updated, or revalidated, we refresh the stored query AST.
* When we need to load a compiled query AST, instead of parsing and compiling, which can be expensive for large/complex queries, we unpickle the object from the database and use that instead.

Our queries are structured in a way where we can easily reuse these compiled query ASTs across many query builds. 

### Test Plan

Local testing + unit tests.

- [x] PR has an associated issue: #1286 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

We should do some additional testing prior to release.
