### PR TITLE
Add several timestamp related UDFs.

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3233,16 +3233,30 @@ class Max(Function):
 
 @Max.register  # type: ignore
 def infer_type(
-    arg: ct.NumberType,
-) -> ct.NumberType:
-    return arg.type
+    arg: ct.StringType,
+) -> ct.StringType:
+    return arg.type  # pragma: no cover
 
 
 @Max.register  # type: ignore
 def infer_type(
-    arg: ct.StringType,
-) -> ct.StringType:
-    return arg.type
+    arg: ct.NumberType,
+) -> ct.NumberType:
+    return arg.type  # pragma: no cover
+
+
+@Max.register  # type: ignore
+def infer_type(
+    arg: ct.DateType,
+) -> ct.DateType:
+    return arg.type  # pragma: no cover
+
+
+@Max.register  # type: ignore
+def infer_type(
+    arg: ct.TimestampType,
+) -> ct.TimestampType:
+    return arg.type  # pragma: no cover
 
 
 class MaxBy(Function):
@@ -3309,9 +3323,16 @@ class Min(Function):
 
 @Min.register  # type: ignore
 def infer_type(
+    arg: ct.StringType,
+) -> ct.StringType:
+    return arg.type  # pragma: no cover
+
+
+@Min.register  # type: ignore
+def infer_type(
     arg: ct.NumberType,
 ) -> ct.NumberType:
-    return arg.type
+    return arg.type  # pragma: no cover
 
 
 @Min.register  # type: ignore
@@ -4315,6 +4336,62 @@ def infer_type(arg: ct.StringType) -> ct.StringType:
     return ct.StringType()
 
 
+class Timestamp(Function):
+    """
+    timestamp(expr) - Casts the value expr to the target data type timestamp.
+    """
+
+    # Druid has this function but it means something else: unix_millis()
+    dialects = [Dialect.SPARK]
+
+
+@Timestamp.register
+def infer_type(expr: ct.StringType) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
+class TimestampMicros(Function):
+    """
+    timestamp_micros(microseconds) - Creates timestamp from the number of microseconds
+    since UTC epoch.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@TimestampMicros.register
+def infer_type(microseconds: ct.BigIntType) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
+class TimestampMillis(Function):
+    """
+    timestamp_millis(milliseconds) - Creates timestamp from the number of milliseconds
+    since UTC epoch.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@TimestampMillis.register
+def infer_type(milliseconds: ct.BigIntType) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
+class TimestampSeconds(Function):
+    """
+    timestamp_seconds(seconds) - Creates timestamp from the number of seconds
+    (can be fractional) since UTC epoch.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@TimestampSeconds.register
+def infer_type(seconds: ct.NumberType) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
 class Unhex(Function):
     """
     unhex(str) - Interprets each pair of characters in the input string as a
@@ -4326,6 +4403,82 @@ class Unhex(Function):
 @Unhex.register  # type: ignore
 def infer_type(arg: ct.StringType) -> ct.ColumnType:
     return ct.BinaryType()
+
+
+class UnixDate(Function):
+    """
+    unix_date(date) - Returns the number of days since 1970-01-01.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@UnixDate.register  # type: ignore
+def infer_type(arg: ct.DateType) -> ct.IntegerType:
+    return ct.IntegerType()
+
+
+class UnixMicros(Function):
+    """
+    unix_micros(timestamp) - Returns the number of microseconds since 1970-01-01 00:00:00 UTC.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@UnixMicros.register  # type: ignore
+def infer_type(arg: ct.TimestampType) -> ct.BigIntType:
+    return ct.BigIntType()
+
+
+class UnixMillis(Function):
+    """
+    unix_millis(timestamp) - Returns the number of milliseconds since 1970-01-01 00:00:00 UTC.
+    Truncates higher levels of precision.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@UnixMillis.register  # type: ignore
+def infer_type(arg: ct.TimestampType) -> ct.BigIntType:
+    return ct.BigIntType()
+
+
+class UnixSeconds(Function):
+    """
+    unix_seconds(timestamp) - Returns the number of seconds since 1970-01-01 00:00:00 UTC.
+    Truncates higher levels of precision.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@UnixSeconds.register  # type: ignore
+def infer_type(arg: ct.TimestampType) -> ct.BigIntType:
+    return ct.BigIntType()
+
+
+class UnixTimestamp(Function):
+    """
+    unix_timestamp([time_exp[, fmt]]) - Returns the UNIX timestamp of current or specified time.
+
+    Arguments:
+        time_exp - A date/timestamp or string. If not provided, this defaults to current time.
+        fmt - Date/time format pattern to follow. Ignored if time_exp is not a string.
+            Default value is "yyyy-MM-dd HH:mm:ss". See Datetime Patterns for valid date and time
+            format patterns.
+    """
+
+    dialects = [Dialect.SPARK, Dialect.DRUID]
+
+
+@UnixTimestamp.register  # type: ignore
+def infer_type(
+    time_exp: Optional[ct.StringType] = None,
+    fmt: Optional[ct.StringType] = None,
+) -> ct.BigIntType:
+    return ct.BigIntType()
 
 
 class Upper(Function):

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2698,15 +2698,10 @@ async def test_max() -> None:
     )
     assert Max.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
     assert Max.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
+    assert Max.infer_type(ast.Column(ast.Name("x"), _type=StringType())) == StringType()
     assert Max.infer_type(
         ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
     ) == DecimalType(8, 6)
-    assert (
-        Max.infer_type(
-            ast.Column(ast.Name("x"), _type=StringType()),
-        )
-        == StringType()
-    )
 
 
 @pytest.mark.asyncio
@@ -2817,13 +2812,10 @@ async def test_min() -> None:
     )
     assert Min.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
     assert Min.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
+    assert Min.infer_type(ast.Column(ast.Name("x"), _type=StringType())) == StringType()
     assert Min.infer_type(
         ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
     ) == DecimalType(8, 6)
-    with pytest.raises(Exception):
-        Min.infer_type(  # pylint: disable=expression-not-assigned
-            ast.Column(ast.Name("x"), _type=StringType()),
-        ) == StringType()
 
 
 @pytest.mark.asyncio
@@ -3601,3 +3593,121 @@ async def test_var_samp(session: AsyncSession):
     await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.DoubleType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_unix_date(session: AsyncSession):
+    """
+    Test the `unix_date` function
+    """
+    query = parse("SELECT unix_date(DATE('1970-01-02'))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.IntegerType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_unix_micros(session: AsyncSession):
+    """
+    Test the `unix_micros` function
+    """
+    query = parse("SELECT unix_micros(cast('1970-01-01 00:00:01Z' as timestamp))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_unix_millis(session: AsyncSession):
+    """
+    Test the `unix_millis` function
+    """
+    query = parse("SELECT unix_millis(cast('1970-01-01 00:00:01Z' as timestamp))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_unix_seconds(session: AsyncSession):
+    """
+    Test the `unix_seconds` function
+    """
+    query = parse("SELECT unix_seconds(cast('1970-01-01 00:00:01Z' as timestamp))")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_unix_timestamp(session: AsyncSession):
+    """
+    Test the `unix_timestamp` function
+    """
+    query = parse("SELECT unix_timestamp(), unix_timestamp('2016-04-08', 'yyyy-MM-dd')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+    assert query.select.projection[1].type == ct.BigIntType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_timestamp(session: AsyncSession):
+    """
+    Test the `timestamp` function
+    """
+    query = parse("SELECT timestamp('2016-04-08')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_timestamp_micros(session: AsyncSession):
+    """
+    Test the `timestamp_micros` function
+    """
+    query = parse("SELECT timestamp_micros(1230219000123123)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_timestamp_millis(session: AsyncSession):
+    """
+    Test the `timestamp_millis` function
+    """
+    query = parse("SELECT timestamp_millis(1230219000123)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_timestamp_seconds(session: AsyncSession):
+    """
+    Test the `timestamp_seconds` function
+    """
+    query = parse("SELECT timestamp_seconds(1230219000.123)")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore


### PR DESCRIPTION
### Summary

Add `timestamp_*` and `unix_*` Spark UDFs.

### Test Plan

Unit tests only.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

auto