### PR TITLE
Fix bug with displaying required dimensions for metrics

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -229,7 +229,7 @@ export default function NodeInfoTab({ node }) {
             ))
           : node?.required_dimensions?.map(dim => (
               <span className="rounded-pill badge bg-secondary-soft PrimaryKey">
-                <a href={`/nodes/${node?.upstream_node}`}>{dim}</a>
+                <a href={`/nodes/${node?.upstream_node}`}>{dim.name}</a>
               </span>
             ))}
       </p>


### PR DESCRIPTION
### Summary

When displaying metrics with required dimensions, the DJ UI errors out because it doesn't pick the dimension's name field.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
<!-- Any special instructions around deployment? -->
