### PR TITLE
Disable query AST population for now

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -4,7 +4,7 @@ Node resolvers
 from typing import Any, List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload, selectinload, defer
 from strawberry.types import Info
 
 from datajunction_server.api.graphql.scalars.node import NodeName
@@ -109,7 +109,7 @@ def load_node_revision_options(node_revision_fields):
     Based on the GraphQL query input fields, builds a list of node revision
     load options.
     """
-    options = []
+    options = [defer(DBNodeRevision.query_ast)]
     is_cube_request = (
         "cube_metrics" in node_revision_fields
         or "cube_dimensions" in node_revision_fields

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -4,7 +4,7 @@ Node resolvers
 from typing import Any, List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload, defer
+from sqlalchemy.orm import defer, joinedload, selectinload
 from strawberry.types import Info
 
 from datajunction_server.api.graphql.scalars.node import NodeName

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -537,7 +537,7 @@ class QueryBuilder:  # pylint: disable=too-many-instance-attributes,too-many-pub
             ["availability", "columns", "query_ast"],
         )
         if self.node_revision.query_ast:
-            node_ast = self.node_revision.query_ast
+            node_ast = self.node_revision.query_ast  # pragma: no cover
         else:
             node_ast = (
                 await compile_node_ast(self.session, self.node_revision)
@@ -1554,8 +1554,8 @@ async def build_ast(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     context = CompileContext(session=session, exception=DJException())
     cached_query_ast = node.query_ast
     if use_pickled and cached_query_ast:
-        try:
-            query = cached_query_ast
+        try:  # pragma: no cover
+            query = cached_query_ast  # pragma: no cover
         except TypeError as exc:  # pragma: no cover
             logger.error(
                 "Error loading query AST pickle for %s@%s: %s",

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -511,7 +511,9 @@ class CompressedPickleType(TypeDecorator):  # pylint: disable=too-many-ancestors
         """
         if value is None:
             return None
-        return zlib.compress(pickle.dumps(value, protocol=self.protocol))
+        return zlib.compress(  # pragma: no cover
+            pickle.dumps(value, protocol=self.protocol),
+        )
 
     def process_result_value(self, value, dialect):
         """
@@ -519,8 +521,8 @@ class CompressedPickleType(TypeDecorator):  # pylint: disable=too-many-ancestors
         """
         if value is None:
             return None
-        try:
-            return pickle.loads(zlib.decompress(value))
+        try:  # pragma: no cover
+            return pickle.loads(zlib.decompress(value))  # pragma: no cover
         except TypeError:  # pragma: no cover
             return None
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -699,7 +699,7 @@ async def update_node_with_query(
             session=session,
             node_revision=new_revision,
         )
-        # TODO: Do not save this until:
+        # TODO: Do not save this until:  # pylint: disable=fixme
         #   1. We get to the bottom of why there are query building discrepancies
         #   2. We audit our database calls to defer pulling the query_ast in most cases
         # background_tasks.add_task(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -699,11 +699,14 @@ async def update_node_with_query(
             session=session,
             node_revision=new_revision,
         )
-        background_tasks.add_task(
-            save_query_ast,
-            session=session,
-            node_name=new_revision.name,
-        )
+        # TODO: Do not save this until:
+        #   1. We get to the bottom of why there are query building discrepancies
+        #   2. We audit our database calls to defer pulling the query_ast in most cases
+        # background_tasks.add_task(
+        #     save_query_ast,
+        #     session=session,
+        #     node_name=new_revision.name,
+        # )
 
     history_events = {}
     old_columns_map = {col.name: col.type for col in old_revision.columns}
@@ -1937,7 +1940,7 @@ async def revalidate_node(  # pylint: disable=too-many-locals,too-many-statement
     name: str,
     session: AsyncSession,
     current_user: User,
-    update_query_ast: bool = True,
+    update_query_ast: bool = False,
     background_tasks: BackgroundTasks = None,
 ) -> NodeValidator:
     """

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1338,7 +1338,7 @@ async def save_column_level_lineage(
     await session.commit()
 
 
-async def save_query_ast(
+async def save_query_ast(  # pragma: no cover
     session: AsyncSession,
     node_name: str,
 ):
@@ -2013,7 +2013,7 @@ async def revalidate_node(  # pylint: disable=too-many-locals,too-many-statement
 
     # Compile and save query AST
     if update_query_ast and background_tasks:
-        background_tasks.add_task(
+        background_tasks.add_task(  # pragma: no cover
             save_query_ast,
             session=session,
             node_name=node.name,  # type: ignore


### PR DESCRIPTION
### Summary

This change disables the query AST population for now, from #1280. I didn't fully undo that PR because some changes from there are still valuable. The primary reasons for this are:
* There are sometimes query building discrepancies
* We need to audit our database calls to defer pulling the `query_ast` in most cases, because it is a large object

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
