### PR TITLE
Consolidate to Single Cube Materialization Option

### DIFF
--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -26,6 +26,7 @@ from datajunction_server.utils import (
     get_session,
     get_settings,
 )
+from fastapi import Request
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
 from sqlalchemy import create_engine

--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -274,6 +274,7 @@ def module__server(  # pylint: disable=too-many-statements
     module__session: AsyncSession,
     module__settings: Settings,
     module__query_service_client: QueryServiceClient,
+    module_mocker,
 ) -> Iterator[TestClient]:
     """
     Create a mock server for testing APIs that contains a mock query service.
@@ -289,6 +290,11 @@ def module__server(  # pylint: disable=too-many-statements
 
     def get_settings_override() -> Settings:
         return module__settings
+
+    module_mocker.patch(
+        "datajunction_server.api.materializations.get_query_service_client",
+        get_query_service_client_override,
+    )
 
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_settings] = get_settings_override

--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -278,7 +278,9 @@ def module__server(  # pylint: disable=too-many-statements
     Create a mock server for testing APIs that contains a mock query service.
     """
 
-    def get_query_service_client_override() -> QueryServiceClient:
+    def get_query_service_client_override(
+        request: Request = None,  # pylint: disable=unused-argument
+    ) -> QueryServiceClient:
         return module__query_service_client
 
     async def get_session_override() -> AsyncSession:

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -58,7 +58,7 @@ async def get_cube(
     return await get_cube_revision_metadata(session, name)
 
 
-@router.get("/cubes/{name}/materialization", name="Materialization Config Cube")
+@router.get("/cubes/{name}/materialization", name="Cube Materialization Config")
 async def cube_materialization_info(
     name: str,
     session: AsyncSession = Depends(get_session),
@@ -89,9 +89,9 @@ async def cube_materialization_info(
     """
     node = await Node.get_cube_by_name(session, name)
     temporal_partitions = node.current.temporal_partition_columns()  # type: ignore
-    if not temporal_partitions:
+    if len(temporal_partitions) != 1:
         raise DJInvalidInputException(
-            "The cube must have a temporal partition column set "
+            "The cube must have a single temporal partition column set "
             "in order for it to be materialized.",
         )
     temporal_partition = temporal_partitions[0] if temporal_partitions else None

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -2,6 +2,7 @@
 """
 Data related APIs.
 """
+import logging
 from typing import Callable, Dict, List, Optional
 
 from fastapi import BackgroundTasks, Depends, Query, Request
@@ -42,6 +43,8 @@ from datajunction_server.utils import (
     get_settings,
 )
 
+_logger = logging.getLogger(__name__)
+
 settings = get_settings()
 router = SecureAPIRouter(tags=["data"])
 
@@ -61,6 +64,7 @@ async def add_availability_state(
     """
     Add an availability state to a node.
     """
+    _logger.info("Storing availability for node=%s", node_name)
 
     node = await Node.get_by_name(
         session,

--- a/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/metricmetadata.py
@@ -4,10 +4,14 @@ from typing import Optional
 
 import strawberry
 
+from datajunction_server.models.cube_materialization import (
+    Aggregability as Aggregability_,
+)
+from datajunction_server.models.cube_materialization import (
+    AggregationRule as AggregationRule_,
+)
+from datajunction_server.models.cube_materialization import Measure as Measure_
 from datajunction_server.models.node import MetricDirection as MetricDirection_
-from datajunction_server.sql.decompose import Aggregability as Aggregability_
-from datajunction_server.sql.decompose import AggregationRule as AggregationRule_
-from datajunction_server.sql.decompose import Measure as Measure_
 
 MetricDirection = strawberry.enum(MetricDirection_)
 Aggregability = strawberry.enum(Aggregability_)

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -366,6 +366,8 @@ async def validate_cube(  # pylint: disable=too-many-locals
 
     # Verify that the provided metrics are metric nodes
     metrics: List[Column] = [metric.current.columns[0] for metric in metric_nodes]
+    for metric in metrics:
+        await session.refresh(metric, ["node_revisions"])
     if not metrics:
         raise DJInvalidInputException(
             message=("At least one metric is required"),

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -81,7 +81,7 @@ def materialization_jobs_info() -> JSONResponse:
 )
 async def upsert_materialization(  # pylint: disable=too-many-locals
     node_name: str,
-    data: UpsertCubeMaterialization | UpsertMaterialization,
+    data: UpsertMaterialization | UpsertCubeMaterialization,
     *,
     session: AsyncSession = Depends(get_session),
     request: Request,

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -175,7 +175,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
             session,
             node_revision_id=current_revision.id,
             materialization_names=[new_materialization.name],
-            query_service_client=get_query_service_client(),  # type: ignore
+            query_service_client=get_query_service_client(request),  # type: ignore
             request_headers=request_headers,
         )
         return JSONResponse(
@@ -250,7 +250,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
         session,
         node_revision_id=current_revision.id,
         materialization_names=[new_materialization.name],
-        query_service_client=get_query_service_client(),  # type: ignore
+        query_service_client=get_query_service_client(request),  # type: ignore
         request_headers=request_headers,
     )
     return JSONResponse(

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -105,7 +105,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     if node.type == NodeType.CUBE:  # type: ignore
         node = await Node.get_cube_by_name(session, node_name)
     _logger.info(
-        "Upserting materialization for node=%s@%s",
+        "Upserting materialization for node=%s version=%s",
         node.name,  # type: ignore
         node.current_version,  # type: ignore
     )
@@ -138,7 +138,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
         and existing_materialization.config == new_materialization.config
     ):
         _logger.info(
-            "Existing materialization found for node=%s@%s",
+            "Existing materialization found for node=%s version=%s",
             node.name,  # type: ignore
             node.current_version,  # type: ignore
         )
@@ -167,7 +167,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
             request_headers=request_headers,
         )
         _logger.info(
-            "Refresh materialization workflows for node=%s@%s",
+            "Refresh materialization workflows for node=%s version=%s",
             node.name,  # type: ignore
             node.current_version,  # type: ignore
         )
@@ -195,7 +195,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     # If changes are detected, update the existing or save the new materialization
     if existing_materialization:
         _logger.info(
-            "Updating existing materialization for node=%s@%s",
+            "Updating existing materialization for node=%s version=%s",
             node.name,  # type: ignore
             node.current_version,  # type: ignore
         )
@@ -206,7 +206,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
         new_materialization.deactivated_at = None
     else:
         _logger.info(
-            "Adding new materialization for node=%s@%s",
+            "Adding new materialization for node=%s version=%s",
             node.name,  # type: ignore
             node.current_version,  # type: ignore
         )
@@ -242,7 +242,7 @@ async def upsert_materialization(  # pylint: disable=too-many-locals
     )
     await session.commit()
     _logger.info(
-        "Scheduling materialization workflows for node=%s@%s",
+        "Scheduling materialization workflows for node=%s version=%s",
         node.name,  # type: ignore
         node.current_version,  # type: ignore
     )

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -14,12 +14,13 @@ from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.errors import DJError, DJInvalidInputException, ErrorCode
 from datajunction_server.internal.engines import get_engine
 from datajunction_server.models import access
+from datajunction_server.models.cube_materialization import Measure
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import GenericCubeConfig
 from datajunction_server.models.node import BuildCriteria
 from datajunction_server.naming import LOOKUP_CHARS, amenable_name, from_amenable_name
 from datajunction_server.sql.dag import get_shared_dimensions
-from datajunction_server.sql.decompose import Measure, MeasureExtractor
+from datajunction_server.sql.decompose import MeasureExtractor
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
 from datajunction_server.sql.parsing.types import ColumnType
 from datajunction_server.utils import SEPARATOR

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -23,12 +23,12 @@ from datajunction_server.errors import (
 from datajunction_server.internal.engines import get_engine
 from datajunction_server.models import access
 from datajunction_server.models.column import SemanticType
+from datajunction_server.models.cube_materialization import Aggregability, Measure
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.node import BuildCriteria
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.sql import GeneratedSQL
 from datajunction_server.naming import amenable_name, from_amenable_name
-from datajunction_server.sql.decompose import Aggregability, Measure
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import ast, cached_parse, parse
 from datajunction_server.utils import SEPARATOR, refresh_if_needed
@@ -262,6 +262,15 @@ async def get_measures_query(  # pylint: disable=too-many-locals
                     else [pk_col.name for pk_col in parent_node.current.primary_key()]
                 ),
                 errors=query_builder.errors,
+                metrics={
+                    metric.name: (
+                        metrics2measures[metric.name][0],
+                        str(metrics2measures[metric.name][1]).replace("\n", "")
+                        if preaggregate
+                        else metric.query,
+                    )
+                    for metric in children
+                },
             ),
         )
     return measures_queries

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -106,18 +106,6 @@ def combine_measures_on_shared_grain(
         select=ast.Select(
             projection=grain_fields + measures_fields,  # type: ignore
             from_=ast.From(relations=[from_relation]),
-            # where=ast.BinaryOp.And(
-            #     *[
-            #         ast.BinaryOp.Eq(
-            #             ast.Column(
-            #                 ast.Name(mat.timestamp_column),
-            #                 _table=measures_tables[mat.output_table_name],
-            #             ),
-            #             ast.Function(ast.Name("DJ_LOGICAL_TIMESTAMP"), args=[]),
-            #         )
-            #         for mat in measures_materializations
-            #     ]
-            # )
         ),
     )
 

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -168,7 +168,7 @@ async def build_cube_materialization(  # pylint: disable=used-before-assignment,
         )
     }
     if len(query_grains) > 1:
-        raise DJInvalidInputException(
+        raise DJInvalidInputException(  # pragma: no cover
             "DJ cannot manage materializations for cubes that have underlying "
             "measures queries at different grains: "
             + " vs ".join(

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -37,9 +37,16 @@ def generate_partition_filter_sql(
         lookback_window == "1 DAY" or not lookback_window
     ):
         return f"{temporal_partition.name} = {partition_sql}"
-    lookback_timestamp = f"{logical_ts} - INTERVAL {lookback_window}"
-    partition_start = _partition_sql(lookback_timestamp, str(temporal_partition.type))
-    return f"{temporal_partition.name} BETWEEN {partition_start} AND {partition_sql}"
+    lookback_timestamp = (
+        f"{logical_ts} - INTERVAL {lookback_window}"  # pragma: no cover
+    )
+    partition_start = _partition_sql(  # pragma: no cover
+        lookback_timestamp,
+        str(temporal_partition.type),
+    )
+    return (  # pragma: no cover
+        f"{temporal_partition.name} BETWEEN {partition_start} AND {partition_sql}"
+    )
 
 
 def combine_measures_on_shared_grain(

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -1,0 +1,269 @@
+"""Helper functions related to cube materializations."""
+import itertools
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.construction.build_v2 import get_measures_query
+from datajunction_server.database.node import Column, NodeRevision
+from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.models.column import SemanticType
+from datajunction_server.models.cube_materialization import (
+    CombineMaterialization,
+    CubeMetric,
+    DruidCubeConfig,
+    MeasureKey,
+    MeasuresMaterialization,
+    UpsertCubeMaterialization,
+)
+from datajunction_server.models.node_type import NodeNameVersion
+from datajunction_server.models.partition import Granularity
+from datajunction_server.sql.parsing import ast
+
+
+def generate_partition_filter_sql(
+    temporal_partition: Column,
+    lookback_window: str,
+) -> str:
+    """
+    Generate filter SQL on partitions
+    """
+    logical_ts = "CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP)"
+
+    def _partition_sql(timestamp_expression, column_type):
+        return f"CAST(DATE_FORMAT({timestamp_expression}, 'yyyyMMdd') AS {column_type})"
+
+    partition_sql = _partition_sql(logical_ts, str(temporal_partition.type))
+    if temporal_partition.partition.granularity == Granularity.DAY and (
+        lookback_window == "1 DAY" or not lookback_window
+    ):
+        return f"{temporal_partition.name} = {partition_sql}"
+    lookback_timestamp = f"{logical_ts} - INTERVAL {lookback_window}"
+    partition_start = _partition_sql(lookback_timestamp, str(temporal_partition.type))
+    return f"{temporal_partition.name} BETWEEN {partition_start} AND {partition_sql}"
+
+
+def combine_measures_on_shared_grain(
+    measures_materializations: list[MeasuresMaterialization],
+    query_grain: list[str],
+) -> ast.Query:
+    """
+    Generate a query that combines measures datasets on their shared grain.
+    An example:
+      SELECT
+        COALESCE(measureA.grain1, measureB.grain1) grain1,
+        COALESCE(measureA.grain2, measureB.grain2) grain2,
+        measureA.one,
+        measureA.two,
+        measureB.three,
+        measureB.four
+      FROM measureA
+      JOIN measureB ON 
+        measureA.grain1 = measureB.grain1 AND
+        measureA.grain2 = measureB.grain2
+    """
+    measures_tables = {mat.output_table_name: mat.table_ast() for mat in measures_materializations}
+    initial_mat = measures_materializations[0]
+
+    # Coalesce grain fields
+    grain_fields = [
+        ast.Function(
+            name=ast.Name("COALESCE"),
+            args=[
+                ast.Column(
+                    name=ast.Name(grain),
+                    _table=measures_tables.get(mat.output_table_name),
+                )
+                for mat in measures_materializations
+            ],
+        ).set_alias(alias=ast.Name(grain))
+        for grain in query_grain
+    ]
+    measures_fields = [
+        ast.Column(
+            name=ast.Name(measure.name),
+            _table=measures_tables.get(mat.output_table_name),
+            semantic_type=SemanticType.MEASURE,
+        )
+        for mat in measures_materializations
+        for measure in mat.measures
+    ]
+    from_relation = ast.Relation(
+        primary=measures_tables.get(initial_mat.output_table_name),  # type: ignore
+        extensions=[
+            ast.Join(
+                join_type="FULL OUTER",
+                right=ast.Table(name=ast.Name(measures_tables[mat.output_table_name])),
+                criteria=ast.JoinCriteria(
+                    on=_combine_measures_join_criteria(
+                        measures_tables[initial_mat.output_table_name],
+                        measures_tables[mat.output_table_name],
+                        query_grain
+                    ),
+                ),
+            ) for mat in measures_materializations[1:]
+        ],
+    )
+    return ast.Query(
+        select=ast.Select(
+            projection=grain_fields + measures_fields,  # type: ignore
+            from_=ast.From(relations=[from_relation]),
+            # where=ast.BinaryOp.And(
+            #     *[
+            #         ast.BinaryOp.Eq(
+            #             ast.Column(
+            #                 ast.Name(mat.timestamp_column),
+            #                 _table=measures_tables[mat.output_table_name],
+            #             ),
+            #             ast.Function(ast.Name("DJ_LOGICAL_TIMESTAMP"), args=[]),
+            #         )
+            #         for mat in measures_materializations
+            #     ]
+            # )
+        ),
+    )
+
+
+def _combine_measures_join_criteria(left_table, right_table, query_grain):
+    """
+    Generate the join condition across tables for shared grains.
+    """
+    return ast.BinaryOp.And(*[
+        ast.BinaryOp.Eq(
+            ast.Column(name=ast.Name(grain), _table=left_table),
+            ast.Column(name=ast.Name(grain), _table=right_table),
+        )
+        for grain in query_grain
+    ])
+
+
+async def build_cube_materialization(
+    session: AsyncSession,
+    current_revision: NodeRevision,
+    upsert_input: UpsertCubeMaterialization,
+) -> DruidCubeConfig:
+    """
+    Build the full config needed for a Druid cube materialization
+    """
+    temporal_partitions = current_revision.temporal_partition_columns()
+    temporal_partition = temporal_partitions[0]
+    measures_queries = await get_measures_query(
+        session=session,
+        metrics=current_revision.cube_node_metrics,
+        dimensions=current_revision.cube_node_dimensions,
+        filters=[
+            generate_partition_filter_sql(
+                temporal_partition,
+                upsert_input.lookback_window,  # type: ignore
+            ),
+        ],
+        include_all_columns=False,
+        use_materialized=True,
+        preagg_requested=True,
+    )
+    query_grains = {
+        k: [q.node.name for q in queries]
+        for k, queries in itertools.groupby(
+            measures_queries,
+            lambda query: tuple(query.grain),  # type: ignore
+        )
+    }
+    if len(query_grains) > 1:
+        raise DJInvalidInputException(
+            "DJ cannot manage materializations for cubes that have underlying "
+            "measures queries at different grains: "
+            + " vs ".join(
+                f"{', '.join(query_nodes)} at [{', '.join(grain)}]"
+                for grain, query_nodes in query_grains.items()
+            ),
+        )
+    measures_materializations = [
+        MeasuresMaterialization.from_measures_query(measures_query, temporal_partition)
+        for measures_query in measures_queries
+    ]
+
+    # Combine the queries on the shared query grain
+    query_grain = next(iter(query_grains))
+    if len(measures_materializations) == 1:
+        measures_materialization = measures_materializations[0]
+        combiners = [
+            CombineMaterialization(
+                output_table_name=measures_materialization.output_table_name,
+                columns=measures_materialization.columns,
+                grain=measures_materialization.grain,
+                measures=measures_materialization.measures,
+                dimensions=measures_materialization.dimensions,
+                timestamp_column=measures_materialization.timestamp_column,
+                timestamp_format=measures_materialization.timestamp_format,
+                granularity=measures_materialization.granularity,
+                upstream_tables=measures_materialization.output_table_name,
+            ),
+        ]
+    if len(measures_materializations) > 1:
+        measures_materialization = measures_materializations[0]
+        combiner_query = combine_measures_on_shared_grain(
+            measures_materializations,
+            query_grain,  # type: ignore
+        )
+        columns_metadata_lookup = {
+            col.name: col
+            for mat in measures_materializations
+            for col in mat.columns
+            if col.name in combiner_query.select.column_mapping
+        }
+        measures_lookup = {
+            measure.name: measure
+            for mat in measures_materializations
+            for measure in mat.measures
+        }
+        combiners = [
+            CombineMaterialization(
+                node=current_revision,
+                query=str(combiner_query),
+                columns=[
+                    columns_metadata_lookup.get(col.alias_or_name.name)  # type: ignore
+                    for col in combiner_query.select.projection
+                ],
+                grain=query_grain,
+                measures=[
+                    measures_lookup.get(col.alias_or_name.name)  # type: ignore
+                    for col in combiner_query.select.projection
+                    if col.semantic_type == SemanticType.MEASURE  # type: ignore
+                ],
+                dimensions=query_grain,
+                timestamp_column=measures_materialization.timestamp_column,
+                timestamp_format=measures_materialization.timestamp_format,
+                granularity=measures_materialization.granularity,
+            ),
+        ]
+
+    metrics_mapping = {
+        metric: (measures_query.node, measures)
+        for measures_query in measures_queries
+        for metric, measures in measures_query.metrics.items()  # type: ignore
+    }
+    config = DruidCubeConfig(
+        cube=NodeNameVersion(
+            name=current_revision.name,
+            version=current_revision.version,
+        ),
+        metrics=[
+            CubeMetric(
+                metric=NodeNameVersion(
+                    name=metric.name,
+                    version=metric.current_version,
+                ),
+                required_measures=[
+                    MeasureKey(
+                        node=metrics_mapping.get(metric.name)[0],  # type: ignore
+                        measure_name=measure.name,
+                    )
+                    for measure in metrics_mapping.get(metric.name)[1][0]  # type: ignore
+                ],
+                derived_expression=metrics_mapping.get(metric.name)[1][1],  # type: ignore
+            )
+            for metric in current_revision.cube_metrics()
+        ],
+        dimensions=current_revision.cube_node_dimensions,
+        measures_materializations=measures_materializations,
+        combiners=combiners,
+    )
+    return config

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -1,4 +1,5 @@
 """Node materialization helper functions"""
+import logging
 import zlib
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -40,6 +41,7 @@ from datajunction_server.sql.parsing.types import TimestampType
 from datajunction_server.utils import SEPARATOR
 
 MAX_COLUMN_NAME_LENGTH = 128
+_logger = logging.getLogger(__name__)
 
 
 async def rewrite_metrics_expressions(
@@ -193,6 +195,12 @@ async def build_non_cube_materialization_config(
     """
     Build materialization config for non-cube nodes (transforms and dimensions).
     """
+    _logger.info(
+        "Building materialization config for node=%s node_type=%s %s",
+        current_revision.name,
+        current_revision.type,
+        upsert,
+    )
     build_criteria = get_default_criteria(
         node=current_revision,
     )

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -262,7 +262,7 @@ async def create_new_materialization(
                 "least one cube element has a temporal partition defined",
             )
 
-        # Druid Cube (this job will take subsume all existing jobs)
+        # Druid Cube (this job will subsume all existing cube materialization types)
         if upsert.job == MaterializationJobTypeEnum.DRUID_CUBE:
             generic_config = await build_cube_materialization(
                 session=session,

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -141,7 +141,7 @@ class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
                 "The materialization job config class must be defined!",
             )
         cube_config = self.config_class.parse_obj(materialization.config)  # type: ignore
-        return query_service_client.materialize(
+        return query_service_client.materialize_cube(
             materialization_input=DruidCubeMaterializationInput(
                 name=materialization.name,
                 cube=cube_config.cube,

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -1,6 +1,7 @@
 """
 Cube materialization jobs
 """
+import logging
 from typing import Dict, Optional
 
 from datajunction_server.database.materialization import Materialization
@@ -25,6 +26,8 @@ from datajunction_server.naming import amenable_name
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
+
+_logger = logging.getLogger(__name__)
 
 
 class DefaultCubeMaterialization(
@@ -141,6 +144,10 @@ class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
                 "The materialization job config class must be defined!",
             )
         cube_config = self.config_class.parse_obj(materialization.config)  # type: ignore
+        _logger.info(
+            "Scheduling DruidCubeMaterializationJob for node=%s",
+            cube_config.cube,
+        )
         return query_service_client.materialize_cube(
             materialization_input=DruidCubeMaterializationInput(
                 name=materialization.name,

--- a/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
@@ -44,6 +44,8 @@ class MaterializationJob(abc.ABC):  # pylint: disable=too-few-public-methods
         """
         return query_service_client.run_backfill(
             materialization.node_revision.name,
+            materialization.node_revision.version,
+            materialization.node_revision.type,
             materialization.name,  # type: ignore
             partitions,
             request_headers=request_headers,

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -1,0 +1,410 @@
+"""Models related to cube materialization"""
+import hashlib
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, validator
+
+from datajunction_server.enum import StrEnum
+from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.models.materialization import MaterializationJobTypeEnum, MaterializationStrategy, DRUID_AGG_MAPPING
+from datajunction_server.models.node_type import NodeNameVersion
+from datajunction_server.models.partition import (
+    Granularity,
+)
+from datajunction_server.models.query import ColumnMetadata
+from datajunction_server.models.column import SemanticType
+
+class Aggregability(StrEnum):
+    """
+    Type of allowed aggregation for a given measure.
+    """
+
+    FULL = "full"
+    LIMITED = "limited"
+    NONE = "none"
+
+
+class AggregationRule(BaseModel):
+    """
+    The aggregation rule for the measure. If the Aggregability type is LIMITED, the `level` should
+    be specified to highlight the level at which the measure needs to be aggregated in order to
+    support the specified aggregation function.
+
+    For example, consider a metric like COUNT(DISTINCT user_id). It can be decomposed into a
+    single measure with LIMITED aggregability, i.e., it is only aggregatable if the measure is
+    calculated at the `user_id` level:
+    - name: num_users
+      expression: DISTINCT user_id
+      aggregation: COUNT
+      rule:
+        type: LIMITED
+        level: ["user_id"]
+    """
+
+    type: Aggregability = Aggregability.NONE
+    level: list[str] | None = None
+
+
+class Measure(BaseModel):
+    """
+    Measures are aggregated facts (e.g. SUM(view_secs)). They can be optionally combined
+    to build derived metrics, e.g. SUM(clicks) / SUM(view_secs). Combining is optional because
+    a stand-alone measure can itself be a metric.
+    """
+
+    name: str
+    expression: str  # A SQL expression for defining the measure
+    aggregation: str
+    rule: AggregationRule
+
+
+class MetricMeasures(BaseModel):
+    """
+    Represent a metric as a set of measures, along with the expression for
+    combining the measures to make the metric.
+    """
+
+    metric: str
+    measures: List[Measure]
+    combiner: str
+
+
+class DruidSpec(BaseModel):
+    """
+    Represents Druid-specific configuration for a MeasuresMaterialization.
+    """
+
+    datasource: str = Field(description="The Druid datasource name.")
+    ingestion_spec: Dict = Field(
+        description="Druid ingestion spec for the materialization.",
+    )
+
+
+class MeasuresMaterialization(BaseModel):
+    """
+    Represents a single pre-aggregation transform query for materializing a partition.
+    """
+
+    node: NodeNameVersion = Field(description="The node being materialized")
+    grain: list[str] = Field(
+        description="The grain at which the node is being materialized.",
+    )
+    dimensions: list[str] = Field(
+        description="List of dimensions included in this materialization.",
+    )
+    measures: list[Measure] = Field(
+        description="List of measures included in this materialization.",
+    )
+    query: str = Field(
+        description="The query used for each materialization run.",
+    )
+
+    columns: list[ColumnMetadata]
+
+    timestamp_column: str | None = Field(description="Timestamp column name")
+    timestamp_format: str | None = Field(
+        description="Timestamp format. Example: `yyyyMMdd`",
+    )
+
+    granularity: Granularity | None = Field(
+        description="The time granularity for each materialization run. Examples: DAY, HOUR",
+    )
+
+    spark_conf: dict[str, str] | None = Field(
+        description="Spark config for this materialization.",
+    )
+    # druid_spec: dict[str, Any] | None = Field(
+    #     description="Druid ingestion configuration for this materialization.",
+    # )
+    upstream_tables: list[str] = Field(
+        description="List of upstream tables used in this materialization.",
+    )
+
+    def table_ast(self):
+        """
+        Generate a unique output table name based on the parameters.
+        """
+        from datajunction_server.sql.parsing import ast
+
+        return ast.Table(name=ast.Name(self.output_table_name))
+
+    @property
+    def output_table_name(self) -> str:
+        """
+        Generate a unique output table name based on the parameters.
+        """
+        unique_string = "|".join(
+            [
+                self.node.name,
+                str(self.node.version),
+                self.timestamp_column or "",
+                ",".join(sorted(self.grain)),
+                ",".join(sorted(self.dimensions)),
+                ",".join(sorted([measure.name for measure in self.measures])),
+            ],
+        )
+        unique_hash = hashlib.sha256(unique_string.encode()).hexdigest()[:16]
+        return f"{self.node.name}_{self.node.version}_{unique_hash}".replace(".", "_")
+
+    def dict(self, **kwargs):
+        base = super().dict(**kwargs)
+        base["output_table_name"] = self.output_table_name
+        # base["druid_spec"] = self.build_druid_spec()
+        return base
+
+    @classmethod
+    def from_measures_query(cls, measures_query, temporal_partition):
+        return MeasuresMaterialization(
+            node=measures_query.node,
+            grain=measures_query.grain,
+            columns=measures_query.columns,
+            timestamp_column=[
+                col.name
+                for col in measures_query.columns
+                if col.semantic_entity == temporal_partition.name
+            ][0],
+            timestamp_format=temporal_partition.partition.format,
+            granularity=temporal_partition.partition.granularity,
+            query=measures_query.sql,
+            dimensions=[
+                col.name
+                for col in measures_query.columns  # type: ignore # pylint: disable=not-an-iterable
+                if col.semantic_type == SemanticType.DIMENSION
+            ],
+            measures=list(
+                {
+                    measure.name: measure
+                    for metric, (measures, combiner) in measures_query.metrics.items()
+                    for measure in measures
+                }.values(),
+            ),
+            spark_conf=measures_query.spark_conf,
+            upstream_tables=measures_query.upstream_tables,
+        )
+
+
+class MeasureKey(BaseModel):
+    """
+    Lookup key for a measure
+    """
+
+    node: NodeNameVersion
+    measure_name: str
+
+
+class CubeMetric(BaseModel):
+    """
+    Represents a metric belonging to a cube.
+    """
+
+    metric: NodeNameVersion = Field(description="The name and version of the metric.")
+    required_measures: list[MeasureKey] = Field(
+        description="List of measures required by this metric.",
+    )
+    derived_expression: str = Field(
+        description="The expression for rewriting the original metric query using the materialized measures.",
+    )
+
+
+class UpsertCubeMaterialization(BaseModel):
+    """
+    An upsert object for cube materializations
+    """
+
+    # For cubes this is the only materialization type we support
+    job: MaterializationJobTypeEnum = MaterializationJobTypeEnum.DRUID_CUBE
+
+    # Only FULL or INCREMENTAL_TIME is available for cubes
+    strategy: MaterializationStrategy = MaterializationStrategy.INCREMENTAL_TIME
+
+    # Cron schedule
+    schedule: str
+
+    # Lookback window, only relevant if materialization strategy is INCREMENTAL_TIME
+    lookback_window: str | None = "1 DAY"
+
+    @validator("job", pre=True)
+    def validate_job(  # pylint: disable=no-self-argument
+        cls,
+        job: Union[str, MaterializationJobTypeEnum],
+    ) -> MaterializationJobTypeEnum:
+        """
+        Validates the `job` field. Converts to an enum if `job` is a string.
+        """
+        if isinstance(job, str):
+            job_name = job.upper()
+            options = (
+                MaterializationJobTypeEnum._member_names_  # pylint: disable=protected-access,no-member
+            )
+            if job_name not in options:
+                raise DJInvalidInputException(
+                    http_status_code=404,
+                    message=f"Materialization job type `{job.upper()}` not found. "
+                    f"Available job types: {[job.name for job in MaterializationJobTypeEnum]}",
+                )
+            return MaterializationJobTypeEnum[job_name]
+        return job
+
+
+class CombineMaterialization(BaseModel):
+
+    # Optional query to combine measures. If there is only one measures output
+    # then this is unnecessary.
+    node: NodeNameVersion
+    query: str | None
+    columns: List[ColumnMetadata]
+    grain: list[str] = Field(
+        description="The grain at which the node is being materialized.",
+    )
+    dimensions: list[str] = Field(
+        description="List of dimensions included in this materialization.",
+    )
+    measures: list[Measure] = Field(
+        description="List of measures included in this materialization.",
+    )
+
+    timestamp_column: str | None = Field(description="Timestamp column name")
+    timestamp_format: str | None = Field(
+        description="Timestamp format. Example: `yyyyMMdd`",
+    )
+
+    granularity: Granularity | None = Field(
+        description="The time granularity for each materialization run. Examples: DAY, HOUR",
+    )
+    upstream_tables: list[str] = []
+
+    @property
+    def output_table_name(self) -> str:
+        unique_string = "|".join(
+            [
+                self.node.name,
+                str(self.node.version),
+                self.timestamp_column or "",
+                ",".join(sorted(self.grain)),
+                ",".join(sorted(self.dimensions)),
+                ",".join(sorted([measure.name for measure in self.measures])),
+            ],
+        )
+        unique_hash = hashlib.sha256(unique_string.encode()).hexdigest()[:16]
+        return f"{self.node.name}_{self.node.version}_{unique_hash}".replace(".", "_")
+
+    def metrics_spec(self) -> list[dict[str, Any]]:
+        """
+        Returns the Druid metrics spec for ingestion
+        """
+        column_mapping = {col.name: col.type for col in self.columns}  # type: ignore
+        return [
+            {
+                "fieldName": measure.name,
+                "name": measure.name,
+                "type": DRUID_AGG_MAPPING[
+                    (column_mapping[measure.name], measure.aggregation.lower())
+                ],
+            }
+            for measure in self.measures
+            if (column_mapping.get(measure.name), measure.aggregation.lower())
+            in DRUID_AGG_MAPPING
+        ]
+
+    def build_druid_spec(self):
+        """
+        Builds the Druid ingestion spec from a materialization config.
+        """
+        # A temporal partition should be configured on the cube, raise an error if not
+        if not self.timestamp_column:
+            raise DJInvalidInputException(  # pragma: no cover
+                "There must be at least one time-based partition configured"
+                " on this cube or it cannot be materialized to Druid.",
+            )
+
+        druid_datasource_name = f"dj__{self.output_table_name}"
+
+        # if there are categorical partitions, we can additionally include one of them
+        # in the partitionDimension field under partitionsSpec
+        druid_spec: Dict = {
+            "dataSchema": {
+                "dataSource": druid_datasource_name,
+                "parser": {
+                    "parseSpec": {
+                        "format": "parquet",
+                        "dimensionsSpec": {
+                            "dimensions": sorted(
+                                # pylint: disable=no-member
+                                list(set(self.dimensions)),  # type: ignore
+                            ),
+                        },
+                        "timestampSpec": {
+                            "column": self.timestamp_column,
+                            "format": self.timestamp_format,
+                        },
+                    },
+                },
+                "metricsSpec": self.metrics_spec(),
+                "granularitySpec": {
+                    "type": "uniform",
+                    "segmentGranularity": str(self.granularity).upper(),
+                    "intervals": [],  # this should be set at runtime
+                },
+            },
+            "tuningConfig": {
+                "partitionsSpec": {
+                    "targetPartitionSize": 5000000,
+                    "type": "hashed",
+                },
+                "useCombiner": True,
+                "type": "hadoop",
+            },
+        }
+        return druid_spec
+
+    def dict(self, **kwargs):
+        base = super().dict(**kwargs)
+        base["druid_spec"] = self.build_druid_spec()
+        base["output_table_name"] = self.output_table_name
+        return base
+
+
+class DruidCubeConfig(BaseModel):
+    """
+    Represents a DruidCube job that contains multiple MeasuresMaterialization configurations.
+    """
+
+    cube: NodeNameVersion
+
+    dimensions: list[str]
+    metrics: list[CubeMetric]
+
+    # List of MeasuresMaterialization configurations.
+    measures_materializations: List[MeasuresMaterialization]
+
+    # List of materializations used to combine measures outputs. For hyper efficient
+    # Druid queries, there should ideally only be a single one, but this may not be
+    # possible for metrics at different levels.
+    combiners: list[CombineMaterialization]
+
+
+class DruidCubeMaterializationInput(BaseModel):
+    """
+    Materialization info as passed to the query service.
+    """
+
+    name: str
+
+    # Frozen cube info at the time of materialization
+    cube: NodeNameVersion
+    dimensions: list[str]
+    metrics: list[CubeMetric]
+
+    # Materialization metadata
+    strategy: MaterializationStrategy
+    schedule: str
+    job: str
+    lookback_window: Optional[str] = "1 DAY"
+
+    # List of measures materializations
+    measures_materializations: List[MeasuresMaterialization]
+
+    # List of materializations used to combine measures outputs. For hyper efficient
+    # Druid queries, there should ideally only be a single one, but this may not be
+    # possible for metrics at different levels.
+    combiners: list[CombineMaterialization]

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -239,7 +239,7 @@ class UpsertCubeMaterialization(BaseModel):
         """
         Validates the `job` field. Converts to an enum if `job` is a string.
         """
-        if isinstance(job, str):
+        if isinstance(job, str):  # pragma: no cover
             job_name = job.upper()
             options = (
                 MaterializationJobTypeEnum._member_names_  # pylint: disable=protected-access,no-member

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -460,6 +460,17 @@ class MaterializationJobTypeEnum(enum.Enum):
         job_class="DruidMetricsCubeMaterializationJob",
     )
 
+    DRUID_CUBE = MaterializationJobType(
+        name="druid_cube",
+        label="Druid Cube",
+        description=(
+            "Used to materialize a cube of metrics and dimensions to Druid for low-latency access."
+            "Will replace the other cube materialization types."
+        ),
+        allowed_node_types=[NodeType.CUBE],
+        job_class="DruidCubeMaterializationJob",
+    )
+
     @classmethod
     def find_match(cls, job_name: str) -> "MaterializationJobTypeEnum":
         """Find a matching enum value for the given job name"""

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -7,13 +7,14 @@ from pydantic.class_validators import root_validator
 from pydantic.main import BaseModel
 
 from datajunction_server.database.node import Node
+from datajunction_server.models.cube_materialization import Measure
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.node import (
     DimensionAttributeOutput,
     MetricMetadataOutput,
 )
 from datajunction_server.models.query import ColumnMetadata
-from datajunction_server.sql.decompose import Measure, MeasureExtractor
+from datajunction_server.sql.decompose import MeasureExtractor
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
 from datajunction_server.transpilation import get_transpilation_plugin
 from datajunction_server.typing import UTCDatetime

--- a/datajunction-server/datajunction_server/models/node_type.py
+++ b/datajunction-server/datajunction_server/models/node_type.py
@@ -45,14 +45,3 @@ class NodeNameVersion(BaseModel):
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
         orm_mode = True
-
-    def __str__(self):
-        return f"{self.name}@{self.version}"
-
-    @classmethod
-    def from_string(cls, node_name_version: str):
-        """
-        Returns the object from a name + version string in the format node.name@v1
-        """
-        name, version = node_name_version.split("@")
-        return NodeNameVersion(name=name, version=version)

--- a/datajunction-server/datajunction_server/models/node_type.py
+++ b/datajunction-server/datajunction_server/models/node_type.py
@@ -33,3 +33,26 @@ class NodeNameOutput(BaseModel):
 
     class Config:  # pylint: disable=missing-class-docstring, too-few-public-methods
         orm_mode = True
+
+
+class NodeNameVersion(BaseModel):
+    """
+    Node name and version
+    """
+
+    name: str
+    version: str
+
+    class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        orm_mode = True
+
+    def __str__(self):
+        return f"{self.name}@{self.version}"
+
+    @classmethod
+    def from_string(cls, node_name_version: str):
+        """
+        Returns the object from a name + version string in the format node.name@v1
+        """
+        name, version = node_name_version.split("@")
+        return NodeNameVersion(name=name, version=version)

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -7,21 +7,11 @@ from pydantic.class_validators import root_validator
 from pydantic.main import BaseModel
 
 from datajunction_server.errors import DJQueryBuildError
+from datajunction_server.models.cube_materialization import Measure
 from datajunction_server.models.engine import Dialect
+from datajunction_server.models.node_type import NodeNameVersion
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.transpilation import get_transpilation_plugin
-
-
-class NodeNameVersion(BaseModel):
-    """
-    Node name and version
-    """
-
-    name: str
-    version: str
-
-    class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods
-        orm_mode = True
 
 
 class GeneratedSQL(BaseModel):
@@ -36,6 +26,8 @@ class GeneratedSQL(BaseModel):
     grain: list[str] | None = None
     dialect: Optional[Dialect] = None
     upstream_tables: Optional[List[str]] = None
+    metrics: dict[str, tuple[list[Measure], str]] | None = None
+    spark_conf: dict[str, str] | None = None
     errors: Optional[List[DJQueryBuildError]] = None
 
     @root_validator(pre=False)

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -295,7 +295,8 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
         Gets materialization info for the node and materialization config name.
         """
         response = self.requests_session.get(
-            f"/materialization/{node_name}/{node_version}/{materialization_name}/?node_type={node_type}",
+            f"/materialization/{node_name}/{node_version}/{materialization_name}/"
+            f"?node_type={node_type}",
             timeout=3,
             headers={
                 **self.requests_session.headers,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -278,11 +278,12 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             }
             if request_headers
             else self.requests_session.headers,
+            timeout=10,
         )
         if response.status_code not in (200, 201):  # pragma: no cover
-            return MaterializationInfo(urls=[], output_tables=[])
-        result = response.json()
-        return MaterializationInfo(**result)
+            return MaterializationInfo(urls=[], output_tables=[])  # pragma: no cover
+        result = response.json()  # pragma: no cover
+        return MaterializationInfo(**result)  # pragma: no cover
 
     def deactivate_materialization(
         self,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -422,7 +422,7 @@ class QueryServiceClient:  # pylint: disable=too-few-public-methods
             timeout=20,
         )
         if response.status_code not in (200, 201):
-            _logger.exception(
+            _logger.exception(  # pragma: no cover
                 "[DJQS] Failed to run backfill for node=%s with `POST %s`",
                 node_name,
                 backfill_endpoint,

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -2,55 +2,13 @@
 import hashlib
 from functools import lru_cache
 
-from pydantic import BaseModel
-
-from datajunction_server.enum import StrEnum
+from datajunction_server.models.cube_materialization import (
+    Aggregability,
+    AggregationRule,
+    Measure,
+)
 from datajunction_server.sql import functions as dj_functions
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
-
-
-class Aggregability(StrEnum):
-    """
-    Type of allowed aggregation for a given measure.
-    """
-
-    FULL = "full"
-    LIMITED = "limited"
-    NONE = "none"
-
-
-class AggregationRule(BaseModel):
-    """
-    The aggregation rule for the measure. If the Aggregability type is LIMITED, the `level` should
-    be specified to highlight the level at which the measure needs to be aggregated in order to
-    support the specified aggregation function.
-
-    For example, consider a metric like COUNT(DISTINCT user_id). It can be decomposed into a
-    single measure with LIMITED aggregability, i.e., it is only aggregatable if the measure is
-    calculated at the `user_id` level:
-    - name: num_users
-      expression: DISTINCT user_id
-      aggregation: COUNT
-      rule:
-        type: LIMITED
-        level: ["user_id"]
-    """
-
-    type: Aggregability = Aggregability.NONE
-    level: list[str] | None = None
-
-
-class Measure(BaseModel):
-    """
-    Measures are aggregated facts (e.g. SUM(view_secs)). They can be optionally combined
-    to build derived metrics, e.g. SUM(clicks) / SUM(view_secs). Combining is optional because
-    a stand-alone measure can itself be a metric.
-    """
-
-    name: str
-    expression: str  # A SQL expression for defining the measure
-    aggregation: str
-    rule: AggregationRule
 
 
 class MeasureExtractor:

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -185,7 +185,9 @@ async def refresh_if_needed(session: AsyncSession, obj, attributes: list[str]):
         await session.refresh(obj, attributes_to_refresh)
 
 
-def get_query_service_client() -> Optional[QueryServiceClient]:
+def get_query_service_client(  # pylint: disable=unused-argument
+    request: Request = None,
+) -> Optional[QueryServiceClient]:
     """
     Return query service client
     """

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2194,7 +2194,8 @@ async def test_cube_materialization_metadata(
     )
     results = response.json()
     assert results["message"] == (
-        "The cube must have a temporal partition column set in order for it to be materialized."
+        "The cube must have a single temporal partition column set"
+        " in order for it to be materialized."
     )
 
     await client_with_repairs_cube.post(

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -843,7 +843,7 @@ async def test_druid_cube_incremental(
     ]
     assert mat.measures_materializations[0].node == NodeNameVersion(
         name="default.repair_orders_fact",
-        version="v1.0",
+        version=ANY_STRING,
     )
     assert mat.measures_materializations[0].grain == [
         "default_DOT_repair_orders_fact_DOT_order_date",
@@ -939,7 +939,7 @@ async def test_druid_cube_incremental(
     ]
     assert mat.combiners == [
         CombineMaterialization(
-            node=NodeNameVersion(name="default.repair_orders_fact", version="v1.0"),
+            node=NodeNameVersion(name="default.repair_orders_fact", version=ANY_STRING),
             query=None,
             columns=[
                 ColumnMetadata(

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -741,7 +741,7 @@ async def test_druid_cube_incremental(
     - Job Type: druid_cube
     - Strategy: incremental_time
     """
-    cube_name = "default.repairs_cube__incremental"
+    cube_name = "default.repairs_cube__default_incremental"
     client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)
     # [failure] If there is no time partition column configured
     response = await client_with_repairs_cube.post(
@@ -776,7 +776,7 @@ async def test_druid_cube_incremental(
     assert response.status_code in (200, 201)
     assert response.json()["message"] == (
         "Successfully updated materialization config named `druid_cube__incremental_time__default"
-        ".repair_orders_fact.order_date` for node `default.repairs_cube__incremental`"
+        ".repair_orders_fact.order_date` for node `default.repairs_cube__default_incremental`"
     )
     _, kwargs = module__query_service_client.materialize_cube.call_args_list[0]  # type: ignore
     mat = kwargs["materialization_input"]
@@ -786,7 +786,7 @@ async def test_druid_cube_incremental(
     )
     assert mat.job == "DruidCubeMaterializationJob"
     assert mat.cube == NodeNameVersion(
-        name="default.repairs_cube__incremental",
+        name="default.repairs_cube__default_incremental",
         version="v1.0",
     )
     assert mat.dimensions == [

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -730,6 +730,22 @@ async def test_druid_metrics_cube_incremental(
     )
 
 
+class AnyString(str):
+    "A helper str obj that compares equal to everything."
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+    def __repr__(self):
+        return "<ANY_STRING>"
+
+
+ANY_STRING = AnyString()
+
+
 @pytest.mark.asyncio
 async def test_druid_cube_incremental(
     client_with_repairs_cube: AsyncClient,  # pylint: disable=redefined-outer-name
@@ -802,7 +818,7 @@ async def test_druid_cube_incremental(
                 MeasureKey(
                     node=NodeNameVersion(
                         name="default.repair_orders_fact",
-                        version="v1.0",
+                        version=ANY_STRING,
                     ),
                     measure_name="repair_order_id_count_0b7dfba0",
                 ),
@@ -816,7 +832,7 @@ async def test_druid_cube_incremental(
                 MeasureKey(
                     node=NodeNameVersion(
                         name="default.repair_orders_fact",
-                        version="v1.0",
+                        version=ANY_STRING,
                     ),
                     measure_name="total_repair_cost_sum_9bdaf803",
                 ),

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -156,6 +156,17 @@ async def test_materialization_info(module__client: AsyncClient) -> None:
                 "label": "Druid Metrics Cube (Post-Agg Cube)",
                 "name": "druid_metrics_cube",
             },
+            {
+                "allowed_node_types": [
+                    "cube",
+                ],
+                "description": "Used to materialize a cube of metrics and dimensions to Druid for "
+                "low-latency access.Will replace the other cube materialization "
+                "types.",
+                "job_class": "DruidCubeMaterializationJob",
+                "label": "Druid Cube",
+                "name": "druid_cube",
+            },
         ],
         "strategies": [
             {"label": "Full", "name": "full"},

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -12,7 +12,6 @@ from httpx import AsyncClient
 from datajunction_server.models.cube_materialization import (
     Aggregability,
     AggregationRule,
-    CombineMaterialization,
     CubeMetric,
     Measure,
     MeasureKey,
@@ -937,91 +936,98 @@ async def test_druid_cube_incremental(
         "default.roads.municipality_municipality_type",
         "default.roads.municipality_type",
     ]
-    assert mat.combiners == [
-        CombineMaterialization(
-            node=NodeNameVersion(name="default.repair_orders_fact", version=ANY_STRING),
-            query=None,
-            columns=[
-                ColumnMetadata(
-                    name="default_DOT_repair_orders_fact_DOT_order_date",
-                    type="timestamp",
-                    column="order_date",
-                    node="default.repair_orders_fact",
-                    semantic_entity="default.repair_orders_fact.order_date",
-                    semantic_type="dimension",
-                ),
-                ColumnMetadata(
-                    name="default_DOT_hard_hat_DOT_state",
-                    type="string",
-                    column="state",
-                    node="default.hard_hat",
-                    semantic_entity="default.hard_hat.state",
-                    semantic_type="dimension",
-                ),
-                ColumnMetadata(
-                    name="default_DOT_dispatcher_DOT_company_name",
-                    type="string",
-                    column="company_name",
-                    node="default.dispatcher",
-                    semantic_entity="default.dispatcher.company_name",
-                    semantic_type="dimension",
-                ),
-                ColumnMetadata(
-                    name="default_DOT_municipality_dim_DOT_local_region",
-                    type="string",
-                    column="local_region",
-                    node="default.municipality_dim",
-                    semantic_entity="default.municipality_dim.local_region",
-                    semantic_type="dimension",
-                ),
-                ColumnMetadata(
-                    name="repair_order_id_count_0b7dfba0",
-                    type="bigint",
-                    column="repair_order_id_count_0b7dfba0",
-                    node="default.repair_orders_fact",
-                    semantic_entity="default.repair_orders_fact.repair_order_id_count_0b7dfba0",
-                    semantic_type="measure",
-                ),
-                ColumnMetadata(
-                    name="total_repair_cost_sum_9bdaf803",
-                    type="double",
-                    column="total_repair_cost_sum_9bdaf803",
-                    node="default.repair_orders_fact",
-                    semantic_entity="default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
-                    semantic_type="measure",
-                ),
-            ],
-            grain=[
-                "default_DOT_repair_orders_fact_DOT_order_date",
-                "default_DOT_hard_hat_DOT_state",
-                "default_DOT_dispatcher_DOT_company_name",
-                "default_DOT_municipality_dim_DOT_local_region",
-            ],
-            dimensions=[
-                "default_DOT_repair_orders_fact_DOT_order_date",
-                "default_DOT_hard_hat_DOT_state",
-                "default_DOT_dispatcher_DOT_company_name",
-                "default_DOT_municipality_dim_DOT_local_region",
-            ],
-            measures=[
-                Measure(
-                    name="repair_order_id_count_0b7dfba0",
-                    expression="repair_order_id",
-                    aggregation="COUNT",
-                    rule=AggregationRule(type=Aggregability.FULL, level=None),
-                ),
-                Measure(
-                    name="total_repair_cost_sum_9bdaf803",
-                    expression="total_repair_cost",
-                    aggregation="SUM",
-                    rule=AggregationRule(type=Aggregability.FULL, level=None),
-                ),
-            ],
-            timestamp_column="default_DOT_repair_orders_fact_DOT_order_date",
-            timestamp_format="yyyyMMdd",
-            granularity=Granularity.DAY,
-            upstream_tables=["default_repair_orders_fact_v1_0_950074a749e6c113"],
+    assert mat.measures_materializations[0].output_table_name == (
+        "default_repair_orders_fact_v1_0_950074a749e6c113"
+    )
+    assert mat.combiners[0].node == NodeNameVersion(
+        name="default.repair_orders_fact",
+        version=ANY_STRING,
+    )
+    assert mat.combiners[0].query is None
+    assert mat.combiners[0].columns == [
+        ColumnMetadata(
+            name="default_DOT_repair_orders_fact_DOT_order_date",
+            type="timestamp",
+            column="order_date",
+            node="default.repair_orders_fact",
+            semantic_entity="default.repair_orders_fact.order_date",
+            semantic_type="dimension",
         ),
+        ColumnMetadata(
+            name="default_DOT_hard_hat_DOT_state",
+            type="string",
+            column="state",
+            node="default.hard_hat",
+            semantic_entity="default.hard_hat.state",
+            semantic_type="dimension",
+        ),
+        ColumnMetadata(
+            name="default_DOT_dispatcher_DOT_company_name",
+            type="string",
+            column="company_name",
+            node="default.dispatcher",
+            semantic_entity="default.dispatcher.company_name",
+            semantic_type="dimension",
+        ),
+        ColumnMetadata(
+            name="default_DOT_municipality_dim_DOT_local_region",
+            type="string",
+            column="local_region",
+            node="default.municipality_dim",
+            semantic_entity="default.municipality_dim.local_region",
+            semantic_type="dimension",
+        ),
+        ColumnMetadata(
+            name="repair_order_id_count_0b7dfba0",
+            type="bigint",
+            column="repair_order_id_count_0b7dfba0",
+            node="default.repair_orders_fact",
+            semantic_entity="default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+            semantic_type="measure",
+        ),
+        ColumnMetadata(
+            name="total_repair_cost_sum_9bdaf803",
+            type="double",
+            column="total_repair_cost_sum_9bdaf803",
+            node="default.repair_orders_fact",
+            semantic_entity="default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
+            semantic_type="measure",
+        ),
+    ]
+    assert mat.combiners[0].grain == [
+        "default_DOT_repair_orders_fact_DOT_order_date",
+        "default_DOT_hard_hat_DOT_state",
+        "default_DOT_dispatcher_DOT_company_name",
+        "default_DOT_municipality_dim_DOT_local_region",
+    ]
+    assert mat.combiners[0].dimensions == [
+        "default_DOT_repair_orders_fact_DOT_order_date",
+        "default_DOT_hard_hat_DOT_state",
+        "default_DOT_dispatcher_DOT_company_name",
+        "default_DOT_municipality_dim_DOT_local_region",
+    ]
+    assert mat.combiners[0].measures == [
+        Measure(
+            name="repair_order_id_count_0b7dfba0",
+            expression="repair_order_id",
+            aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+        Measure(
+            name="total_repair_cost_sum_9bdaf803",
+            expression="total_repair_cost",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+    ]
+    assert (
+        mat.combiners[0].timestamp_column
+        == "default_DOT_repair_orders_fact_DOT_order_date"
+    )
+    assert mat.combiners[0].timestamp_format == "yyyyMMdd"
+    assert mat.combiners[0].granularity == Granularity.DAY
+    assert mat.combiners[0].upstream_tables == [
+        "default_repair_orders_fact_v1_0_950074a749e6c113",
     ]
 
 

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -936,8 +936,8 @@ async def test_druid_cube_incremental(
         "default.roads.municipality_municipality_type",
         "default.roads.municipality_type",
     ]
-    assert mat.measures_materializations[0].output_table_name == (
-        "default_repair_orders_fact_v1_0_950074a749e6c113"
+    assert mat.measures_materializations[0].output_table_name.startswith(
+        "default_repair_orders_fact",
     )
     assert mat.combiners[0].node == NodeNameVersion(
         name="default.repair_orders_fact",
@@ -1026,9 +1026,7 @@ async def test_druid_cube_incremental(
     )
     assert mat.combiners[0].timestamp_format == "yyyyMMdd"
     assert mat.combiners[0].granularity == Granularity.DAY
-    assert mat.combiners[0].upstream_tables == [
-        "default_repair_orders_fact_v1_0_950074a749e6c113",
-    ]
+    assert mat.combiners[0].upstream_tables[0].startswith("default_repair_orders_fact")
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -9,7 +9,17 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
-from datajunction_server.models.partition import PartitionBackfill
+from datajunction_server.models.cube_materialization import (
+    Aggregability,
+    AggregationRule,
+    CombineMaterialization,
+    CubeMetric,
+    Measure,
+    MeasureKey,
+    NodeNameVersion,
+)
+from datajunction_server.models.partition import Granularity, PartitionBackfill
+from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 
@@ -718,6 +728,285 @@ async def test_druid_metrics_cube_incremental(
     assert args[0].druid_spec == load_expected_file(
         "druid_metrics_cube.incremental.druid_spec.json",
     )
+
+
+@pytest.mark.asyncio
+async def test_druid_cube_incremental(
+    client_with_repairs_cube: AsyncClient,  # pylint: disable=redefined-outer-name
+    module__query_service_client: QueryServiceClient,
+    set_temporal_column,  # pylint: disable=redefined-outer-name
+):
+    """
+    Verifying this materialization setup:
+    - Job Type: druid_cube
+    - Strategy: incremental_time
+    """
+    cube_name = "default.repairs_cube__incremental"
+    client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)
+    # [failure] If there is no time partition column configured
+    response = await client_with_repairs_cube.post(
+        f"/nodes/{cube_name}/materialization/",
+        json={
+            "job": "druid_cube",
+            "strategy": "incremental_time",
+            "schedule": "@daily",
+            "lookback_window": "1 DAY",
+        },
+    )
+    assert response.json()["message"] == (
+        "Cannot create materialization with strategy `incremental_time` "
+        "without specifying a time partition column!"
+    )
+
+    # [success] When there is a column on the cube with the partition label, should succeed.
+    await set_temporal_column(
+        client_with_repairs_cube,
+        cube_name,
+        "default.repair_orders_fact.order_date",
+    )
+    response = await client_with_repairs_cube.post(
+        f"/nodes/{cube_name}/materialization/",
+        json={
+            "job": "druid_cube",
+            "strategy": "incremental_time",
+            "schedule": "@daily",
+            "lookback_window": "1 DAY",
+        },
+    )
+    assert response.status_code in (200, 201)
+    assert response.json()["message"] == (
+        "Successfully updated materialization config named `druid_cube__incremental_time__default"
+        ".repair_orders_fact.order_date` for node `default.repairs_cube__incremental`"
+    )
+    _, kwargs = module__query_service_client.materialize_cube.call_args_list[0]  # type: ignore
+    mat = kwargs["materialization_input"]
+    assert (
+        mat.name
+        == "druid_cube__incremental_time__default.repair_orders_fact.order_date"
+    )
+    assert mat.job == "DruidCubeMaterializationJob"
+    assert mat.cube == NodeNameVersion(
+        name="default.repairs_cube__incremental",
+        version="v1.0",
+    )
+    assert mat.dimensions == [
+        "default.repair_orders_fact.order_date",
+        "default.hard_hat.state",
+        "default.dispatcher.company_name",
+        "default.municipality_dim.local_region",
+    ]
+    assert mat.metrics == [
+        CubeMetric(
+            metric=NodeNameVersion(name="default.num_repair_orders", version="v1.0"),
+            required_measures=[
+                MeasureKey(
+                    node=NodeNameVersion(
+                        name="default.repair_orders_fact",
+                        version="v1.0",
+                    ),
+                    measure_name="repair_order_id_count_0b7dfba0",
+                ),
+            ],
+            derived_expression="SELECT  SUM(repair_order_id_count_0b7dfba0)"
+            "  FROM default.repair_orders_fact",
+        ),
+        CubeMetric(
+            metric=NodeNameVersion(name="default.total_repair_cost", version="v1.0"),
+            required_measures=[
+                MeasureKey(
+                    node=NodeNameVersion(
+                        name="default.repair_orders_fact",
+                        version="v1.0",
+                    ),
+                    measure_name="total_repair_cost_sum_9bdaf803",
+                ),
+            ],
+            derived_expression="SELECT  sum(total_repair_cost_sum_9bdaf803)"
+            "  FROM default.repair_orders_fact",
+        ),
+    ]
+    assert mat.measures_materializations[0].node == NodeNameVersion(
+        name="default.repair_orders_fact",
+        version="v1.0",
+    )
+    assert mat.measures_materializations[0].grain == [
+        "default_DOT_repair_orders_fact_DOT_order_date",
+        "default_DOT_hard_hat_DOT_state",
+        "default_DOT_dispatcher_DOT_company_name",
+        "default_DOT_municipality_dim_DOT_local_region",
+    ]
+    assert mat.measures_materializations[0].dimensions == [
+        "default_DOT_repair_orders_fact_DOT_order_date",
+        "default_DOT_hard_hat_DOT_state",
+        "default_DOT_dispatcher_DOT_company_name",
+        "default_DOT_municipality_dim_DOT_local_region",
+    ]
+    assert mat.measures_materializations[0].measures == [
+        Measure(
+            name="repair_order_id_count_0b7dfba0",
+            expression="repair_order_id",
+            aggregation="COUNT",
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+        Measure(
+            name="total_repair_cost_sum_9bdaf803",
+            expression="total_repair_cost",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+    ]
+    assert mat.measures_materializations[0].columns == [
+        ColumnMetadata(
+            name="default_DOT_repair_orders_fact_DOT_order_date",
+            type="timestamp",
+            column="order_date",
+            node="default.repair_orders_fact",
+            semantic_entity="default.repair_orders_fact.order_date",
+            semantic_type="dimension",
+        ),
+        ColumnMetadata(
+            name="default_DOT_hard_hat_DOT_state",
+            type="string",
+            column="state",
+            node="default.hard_hat",
+            semantic_entity="default.hard_hat.state",
+            semantic_type="dimension",
+        ),
+        ColumnMetadata(
+            name="default_DOT_dispatcher_DOT_company_name",
+            type="string",
+            column="company_name",
+            node="default.dispatcher",
+            semantic_entity="default.dispatcher.company_name",
+            semantic_type="dimension",
+        ),
+        ColumnMetadata(
+            name="default_DOT_municipality_dim_DOT_local_region",
+            type="string",
+            column="local_region",
+            node="default.municipality_dim",
+            semantic_entity="default.municipality_dim.local_region",
+            semantic_type="dimension",
+        ),
+        ColumnMetadata(
+            name="repair_order_id_count_0b7dfba0",
+            type="bigint",
+            column="repair_order_id_count_0b7dfba0",
+            node="default.repair_orders_fact",
+            semantic_entity="default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+            semantic_type="measure",
+        ),
+        ColumnMetadata(
+            name="total_repair_cost_sum_9bdaf803",
+            type="double",
+            column="total_repair_cost_sum_9bdaf803",
+            node="default.repair_orders_fact",
+            semantic_entity="default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
+            semantic_type="measure",
+        ),
+    ]
+    assert (
+        mat.measures_materializations[0].timestamp_column
+        == "default_DOT_repair_orders_fact_DOT_order_date"
+    )
+    assert mat.measures_materializations[0].timestamp_format == "yyyyMMdd"
+    assert mat.measures_materializations[0].granularity == Granularity.DAY
+    assert mat.measures_materializations[0].spark_conf is None
+    assert mat.measures_materializations[0].upstream_tables == [
+        "default.roads.repair_orders",
+        "default.roads.repair_order_details",
+        "default.roads.hard_hats",
+        "default.roads.dispatchers",
+        "default.roads.municipality",
+        "default.roads.municipality_municipality_type",
+        "default.roads.municipality_type",
+    ]
+    assert mat.combiners == [
+        CombineMaterialization(
+            node=NodeNameVersion(name="default.repair_orders_fact", version="v1.0"),
+            query=None,
+            columns=[
+                ColumnMetadata(
+                    name="default_DOT_repair_orders_fact_DOT_order_date",
+                    type="timestamp",
+                    column="order_date",
+                    node="default.repair_orders_fact",
+                    semantic_entity="default.repair_orders_fact.order_date",
+                    semantic_type="dimension",
+                ),
+                ColumnMetadata(
+                    name="default_DOT_hard_hat_DOT_state",
+                    type="string",
+                    column="state",
+                    node="default.hard_hat",
+                    semantic_entity="default.hard_hat.state",
+                    semantic_type="dimension",
+                ),
+                ColumnMetadata(
+                    name="default_DOT_dispatcher_DOT_company_name",
+                    type="string",
+                    column="company_name",
+                    node="default.dispatcher",
+                    semantic_entity="default.dispatcher.company_name",
+                    semantic_type="dimension",
+                ),
+                ColumnMetadata(
+                    name="default_DOT_municipality_dim_DOT_local_region",
+                    type="string",
+                    column="local_region",
+                    node="default.municipality_dim",
+                    semantic_entity="default.municipality_dim.local_region",
+                    semantic_type="dimension",
+                ),
+                ColumnMetadata(
+                    name="repair_order_id_count_0b7dfba0",
+                    type="bigint",
+                    column="repair_order_id_count_0b7dfba0",
+                    node="default.repair_orders_fact",
+                    semantic_entity="default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+                    semantic_type="measure",
+                ),
+                ColumnMetadata(
+                    name="total_repair_cost_sum_9bdaf803",
+                    type="double",
+                    column="total_repair_cost_sum_9bdaf803",
+                    node="default.repair_orders_fact",
+                    semantic_entity="default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
+                    semantic_type="measure",
+                ),
+            ],
+            grain=[
+                "default_DOT_repair_orders_fact_DOT_order_date",
+                "default_DOT_hard_hat_DOT_state",
+                "default_DOT_dispatcher_DOT_company_name",
+                "default_DOT_municipality_dim_DOT_local_region",
+            ],
+            dimensions=[
+                "default_DOT_repair_orders_fact_DOT_order_date",
+                "default_DOT_hard_hat_DOT_state",
+                "default_DOT_dispatcher_DOT_company_name",
+                "default_DOT_municipality_dim_DOT_local_region",
+            ],
+            measures=[
+                Measure(
+                    name="repair_order_id_count_0b7dfba0",
+                    expression="repair_order_id",
+                    aggregation="COUNT",
+                    rule=AggregationRule(type=Aggregability.FULL, level=None),
+                ),
+                Measure(
+                    name="total_repair_cost_sum_9bdaf803",
+                    expression="total_repair_cost",
+                    aggregation="SUM",
+                    rule=AggregationRule(type=Aggregability.FULL, level=None),
+                ),
+            ],
+            timestamp_column="default_DOT_repair_orders_fact_DOT_order_date",
+            timestamp_format="yyyyMMdd",
+            granularity=Granularity.DAY,
+            upstream_tables=["default_repair_orders_fact_v1_0_950074a749e6c113"],
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -834,6 +834,8 @@ async def test_spark_sql_full(
     )
     assert module__query_service_client.run_backfill.call_args_list[0].args == (  # type: ignore
         "default.hard_hat",
+        "v1.0",
+        "dimension",
         "spark_sql__full__birth_date__country",
         [
             PartitionBackfill(
@@ -944,6 +946,8 @@ async def test_spark_sql_incremental(
     )
     assert module__query_service_client.run_backfill.call_args_list[-1].args == (  # type: ignore
         "default.hard_hat_2",
+        "v1.0",
+        "dimension",
         "spark_sql__incremental_time__birth_date",
         [
             PartitionBackfill(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2910,7 +2910,7 @@ class TestNodeCRUD:  # pylint: disable=too-many-public-methods
         data = response.json()
         assert data["message"] == (
             "Materialization job type `SOMETHING` not found. Available job "
-            "types: ['SPARK_SQL', 'DRUID_MEASURES_CUBE', 'DRUID_METRICS_CUBE']"
+            "types: ['SPARK_SQL', 'DRUID_MEASURES_CUBE', 'DRUID_METRICS_CUBE', 'DRUID_CUBE']"
         )
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -693,7 +693,7 @@ async def module__client(  # pylint: disable=too-many-statements
     module__session: AsyncSession,
     module__settings: Settings,
     module__query_service_client: QueryServiceClient,  # pylint: disable=unused-argument
-    mocker: MockerFixture,
+    module_mocker: MockerFixture,
 ) -> AsyncGenerator[AsyncClient, None]:
     """
     Create a client for testing APIs.
@@ -710,7 +710,7 @@ async def module__client(  # pylint: disable=too-many-statements
     def get_query_service_client_override(
         request: Request = None,  # pylint: disable=unused-argument
     ) -> QueryServiceClient:
-        return query_service_client
+        return module__query_service_client
 
     def get_session_override() -> AsyncSession:
         return module__session
@@ -724,7 +724,7 @@ async def module__client(  # pylint: disable=too-many-statements
 
         return _
 
-    mocker.patch(
+    module_mocker.patch(
         "datajunction_server.api.materializations.get_query_service_client",
         get_query_service_client_override,
     )

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -1038,6 +1038,17 @@ def module__query_service_client(
         mock_materialize,
     )
 
+    mock_materialize_cube = MagicMock()
+    mock_materialize_cube.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=["common.a", "common.b"],
+    )
+    module_mocker.patch.object(
+        qs_client,
+        "materialize_cube",
+        mock_materialize_cube,
+    )
+
     mock_deactivate_materialization = MagicMock()
     mock_deactivate_materialization.return_value = MaterializationInfo(
         urls=["http://fake.url/job"],

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -604,6 +604,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         response = query_service_client.get_materialization_info(
             node_name="default.hard_hat",
             node_version="v3.1",
+            node_type=NodeType.DIMENSION,
             materialization_name="default",
         )
         mock_request.assert_called_with(
@@ -633,6 +634,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         response = query_service_client.get_materialization_info(
             node_name="default.hard_hat",
             node_version="v3.1",
+            node_type=NodeType.DIMENSION,
             materialization_name="default",
         )
         assert response == {
@@ -659,6 +661,8 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         query_service_client = QueryServiceClient(uri=self.endpoint)
         response = query_service_client.run_backfill(
             node_name="default.hard_hat",
+            node_version="v1",
+            node_type=NodeType.DIMENSION,
             partitions=[
                 PartitionBackfill(
                     column_name="hire_date",
@@ -689,6 +693,8 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         query_service_client = QueryServiceClient(uri=self.endpoint)
         response = query_service_client.run_backfill(
             node_name="default.hard_hat",
+            node_version="v1",
+            node_type=NodeType.DIMENSION,
             partitions=[
                 PartitionBackfill(
                     column_name="hire_date",

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -608,7 +608,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             materialization_name="default",
         )
         mock_request.assert_called_with(
-            "/materialization/default.hard_hat/v3.1/default/",
+            "/materialization/default.hard_hat/v3.1/default/?node_type=dimension",
             timeout=3,
             headers=ANY,
         )
@@ -676,7 +676,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "output_tables": [],
         }
         mocked_call.assert_called_with(
-            "/materialization/run/default.hard_hat/default/",
+            "/materialization/run/default.hard_hat/default/?node_version=v1&node_type=dimension",
             json=[
                 {
                     "column_name": "hire_date",
@@ -712,7 +712,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
             "output_tables": [],
         }
         mocked_call.assert_called_with(
-            "/materialization/run/default.hard_hat/default/",
+            "/materialization/run/default.hard_hat/default/?node_version=v1&node_type=dimension",
             json=[
                 {
                     "column_name": "hire_date",

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -15,6 +15,12 @@ from datajunction_server.errors import (
     DJQueryServiceClientException,
     ErrorCode,
 )
+from datajunction_server.models.cube_materialization import (
+    CubeMetric,
+    DruidCubeMaterializationInput,
+    MeasureKey,
+    NodeNameVersion,
+)
 from datajunction_server.models.materialization import (
     GenericMaterializationInput,
     MaterializationStrategy,
@@ -752,4 +758,77 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         ) == {
             "User-Agent": "python-requests/2.29.0",
             "Accept": "*/*",
+        }
+
+    def test_materialize_cube(self, mocker: MockerFixture) -> None:
+        """
+        Test materialize cube via query service client
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "urls": ["http://fake.url/job"],
+            "output_tables": ["common.a", "common.b"],
+        }
+
+        mock_request = mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.post",
+            return_value=mock_response,
+        )
+
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        materialization_input = DruidCubeMaterializationInput(
+            name="default",
+            strategy=MaterializationStrategy.INCREMENTAL_TIME,
+            schedule="@daily",
+            job="DruidCubeMaterialization",
+            cube=NodeNameVersion(name="default.repairs_cube", version="v1.0"),
+            dimensions=["default.hard_hat.first_name", "default.hard_hat.last_name"],
+            metrics=[
+                CubeMetric(
+                    metric=NodeNameVersion(
+                        name="default.num_repair_orders",
+                        version="v1.0",
+                    ),
+                    required_measures=[
+                        MeasureKey(
+                            node=NodeNameVersion(
+                                name="default.repair_orders",
+                                version="v1.0",
+                            ),
+                            measure_name="count",
+                        ),
+                    ],
+                    derived_expression="SUM(count)",
+                ),
+                CubeMetric(
+                    metric=NodeNameVersion(
+                        name="default.avg_repair_price",
+                        version="v1.0",
+                    ),
+                    required_measures=[
+                        MeasureKey(
+                            node=NodeNameVersion(
+                                name="default.repair_orders",
+                                version="v1.0",
+                            ),
+                            measure_name="sum_price_123abc",
+                        ),
+                    ],
+                    derived_expression="SUM(sum_price_123abc)",
+                ),
+            ],
+            measures_materializations=[],
+            combiners=[],
+        )
+        response = query_service_client.materialize_cube(materialization_input)
+        mock_request.assert_called_with(
+            "/cubes/materialize",
+            json=materialization_input.dict(),
+            timeout=10,
+            headers=ANY,
+        )
+        assert response == {
+            "urls": ["http://fake.url/job"],
+            "output_tables": ["common.a", "common.b"],
         }

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -825,7 +825,7 @@ class TestQueryServiceClient:  # pylint: disable=too-few-public-methods
         mock_request.assert_called_with(
             "/cubes/materialize",
             json=materialization_input.dict(),
-            timeout=10,
+            timeout=20,
             headers=ANY,
         )
         assert response == {

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -3,12 +3,12 @@ Tests for ``datajunction_server.sql.decompose``.
 """
 import pytest
 
-from datajunction_server.sql.decompose import (
+from datajunction_server.models.cube_materialization import (
     Aggregability,
     AggregationRule,
     Measure,
-    MeasureExtractor,
 )
+from datajunction_server.sql.decompose import MeasureExtractor
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 

--- a/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
@@ -133,21 +133,12 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
 
                     <Field as="select" name="job_type">
                       <>
-                        {/* <option
-                          key={'druid_measures_cube'}
-                          value={'druid_measures_cube'}
-                        >
-                          Druid Measures Cube (Pre-Agg Cube)
-                        </option> */}
                         <option
-                          key={'druid_measures_cube'}
-                          value={'druid_measures_cube'}
+                          key={'druid_cube'}
+                          value={'druid_cube'}
                         >
                           Druid
                         </option>
-                        {/* <option key={'spark_sql'} value={'spark_sql'}>
-                          Iceberg Table
-                        </option> */}
                       </>
                     </Field>
                     <br />

--- a/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
@@ -12,6 +12,8 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
   const [options, setOptions] = useState([]);
   const [jobs, setJobs] = useState([]);
 
+  const timePartitionColumns = node.columns.filter(col => col.partition);
+
   const ref = useRef(null);
 
   useEffect(() => {
@@ -42,13 +44,23 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
     if (!values.job_type) {
       values.job_type = 'spark_sql';
     }
-    const { status, json } = await djClient.materialize(
-      values.node,
-      values.job_type,
-      values.strategy,
-      values.schedule,
-      config,
-    );
+    const { status, json } = (
+      values.job_type === 'druid_cube' ?
+      await djClient.materializeCube(
+        values.node,
+        values.job_type,
+        values.strategy,
+        values.schedule,
+        values.lookback_window,
+      ) :
+      await djClient.materialize(
+        values.node,
+        values.job_type,
+        values.strategy,
+        values.schedule,
+        config,
+      )
+  );
     if (status === 200 || status === 201) {
       setStatus({ success: json.message });
       window.location.reload();
@@ -99,8 +111,8 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
           initialValues={{
             node: node?.name,
             job_type:
-              node?.type === 'cube' ? 'druid_metrics_cube' : 'spark_sql',
-            strategy: 'full',
+              node?.type === 'cube' ? 'druid_cube' : 'spark_sql',
+            strategy: timePartitionColumns.length == 1 ? 'incremental_time' : 'full',
             schedule: '@daily',
             lookback_window: '1 DAY',
             spark_config: {
@@ -121,21 +133,21 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
 
                     <Field as="select" name="job_type">
                       <>
-                        <option
+                        {/* <option
                           key={'druid_measures_cube'}
                           value={'druid_measures_cube'}
                         >
                           Druid Measures Cube (Pre-Agg Cube)
-                        </option>
+                        </option> */}
                         <option
-                          key={'druid_metrics_cube'}
-                          value={'druid_metrics_cube'}
+                          key={'druid_measures_cube'}
+                          value={'druid_measures_cube'}
                         >
-                          Druid Metrics Cube (Post-Agg Cube)
+                          Druid
                         </option>
-                        <option key={'spark_sql'} value={'spark_sql'}>
+                        {/* <option key={'spark_sql'} value={'spark_sql'}>
                           Iceberg Table
-                        </option>
+                        </option> */}
                       </>
                     </Field>
                     <br />
@@ -150,6 +162,7 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
                   value={node?.name}
                   readOnly={true}
                 />
+                {console.log('timePartitionColumns.length', timePartitionColumns.length)}
                 <span data-testid="edit-partition">
                   <label htmlFor="strategy">Strategy</label>
                   <Field as="select" name="strategy">

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -70,7 +70,7 @@ export default function NodeInfoTab({ node }) {
     );
 
   const metricQueryDiv =
-    node.type === 'metric' ? (
+    node?.type === 'metric' ? (
       <div className="list-group-item d-flex">
         <div className="gap-2 w-100 justify-content-between py-3">
           <div style={{ marginBottom: '30px' }}>

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -980,6 +980,25 @@ export const DataJunctionAPI = {
     );
     return { status: response.status, json: await response.json() };
   },
+  materializeCube: async function (nodeName, jobType, strategy, schedule, lookbackWindow) {
+    const response = await fetch(
+      `${DJ_URL}/nodes/${nodeName}/materialization`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          job: jobType,
+          strategy: strategy,
+          schedule: schedule,
+          lookback_window: lookbackWindow,
+        }),
+        credentials: 'include',
+      },
+    );
+    return { status: response.status, json: await response.json() };
+  },
   runBackfill: async function (nodeName, materializationName, partitionValues) {
     const response = await fetch(
       `${DJ_URL}/nodes/${nodeName}/materializations/${materializationName}/backfill`,


### PR DESCRIPTION
### Summary

This PR adds a new cube materialization option that chooses the most efficient way to materialize the cube for downstream use. This should be our sole cube materialization option, replacing the "measures" and "metrics" materialization options.

The core DJ API builds a materialization job with the following pieces of job metadata:

**Cube Metadata**

We keep track of frozen cube metadata, like cube's metrics (versioned) and dimensions. We maintain additional info on each metric's required measures and their derived expression that uses those measures.

**Measures Queries**

We group the metrics by parent and build a list of measures queries based on the parent nodes, which computes the pre-aggregated measures for its child metrics and the cube's selected dimensions.

For each measures query, we will additionally keep track of:
  - The node it was generated for
  - The grain it was generated at
  - A list of measures and dimensions that it provides
  - Temporal partition info (e.g., timestamp column, granularity)
  - Spark configuration (it is unclear how we would configure this at the moment)
  - Generated output table name

**Combiner Queries**

This stage merges the results of the above measures queries into a single dataset, with the intention of ingesting into Druid. At the moment we raise an error if someone tries to materialize a cube that has measures datasets at different grains and therefore cannot be combined. The metadata for this stage provides:
  - A combiner query in Spark, if necessary
  - Druid ingestion spec for the combined dataset
  - The grain it was generated at
  - A list of measures and dimensions that it provides
  - Temporal partition info (e.g., timestamp column, granularity)
  - Generated output table name

### Test Plan

Locally

- [x] PR has an associated issue: #1294 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
