### PR TITLE
Hide deactivated nodes from DAG

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1409,7 +1409,13 @@ async def list_downstream_nodes(
     List all nodes that are downstream from the given node, filterable by type and max depth.
     Setting a max depth of -1 will include all downstream nodes.
     """
-    return await get_downstream_nodes(session, name, node_type, depth=depth)
+    return await get_downstream_nodes(
+        session=session,
+        node_name=name,
+        node_type=node_type,
+        include_deactivated=False,
+        depth=depth,
+    )
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -296,6 +296,7 @@ class QueryRequest(Base):  # type: ignore  # pylint: disable=too-few-public-meth
                         ),
                     ),
                 ],
+                raise_if_not_exists=True,
             )
             for node in nodes
         ]

--- a/datajunction-ui/src/app/icons/LoadingIcon.jsx
+++ b/datajunction-ui/src/app/icons/LoadingIcon.jsx
@@ -1,14 +1,14 @@
 import '../../styles/loading.css';
 
-export default function LoadingIcon() {
-  return (
-    <center>
-      <div className="lds-ring">
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-      </div>
-    </center>
+export default function LoadingIcon({ centered = true }) {
+  const content = (
+    <div className="lds-ring">
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
   );
+
+  return centered ? <center>{content}</center> : content;
 }

--- a/datajunction-ui/src/app/pages/NodePage/NodeDependenciesTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeDependenciesTab.jsx
@@ -34,24 +34,24 @@ export default function NodeDependenciesTab({ node, djClient }) {
       {retrieved ? (
         <NodeList nodes={nodeDAG.upstreams} />
       ) : (
-        <span style={{ display: 'inline-block' }}>
-          <LoadingIcon />
+        <span style={{ display: 'block' }}>
+          <LoadingIcon centered={false} />
         </span>
       )}
       <h2>Downstreams</h2>
       {retrieved ? (
         <NodeList nodes={nodeDAG.downstreams} />
       ) : (
-        <span style={{ display: 'inline-block' }}>
-          <LoadingIcon />
+        <span style={{ display: 'block' }}>
+          <LoadingIcon centered={false} />
         </span>
       )}
       <h2>Dimensions</h2>
       {retrieved ? (
         <NodeDimensionsList rawDimensions={nodeDAG.dimensions} />
       ) : (
-        <span style={{ display: 'inline-block' }}>
-          <LoadingIcon />
+        <span style={{ display: 'block' }}>
+          <LoadingIcon centered={false} />
         </span>
       )}
     </div>
@@ -142,6 +142,6 @@ export function NodeList({ nodes }) {
       ))}
     </ul>
   ) : (
-    <span style={{ display: 'inline-block' }}>None</span>
+    <span style={{ display: 'block' }}>None</span>
   );
 }


### PR DESCRIPTION
### Summary

At the moment we show deactivated nodes in the DAG, which is confusing for users and causes needless graph traversal.

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
