### PR TITLE
run tests on main branch after merging PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ on:
       - datajunction-clients/javascript/package.json
       - datajunction-ui/package.json
       # java: TODO
+  push:
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
### Summary

This makes a small change to the test workflow so that tests run after a PR is merged to the main branch. In general I think this is good practice since multiple PRs can be merged very close to each other without a rebase and pass on their own but fail when combined in the main branch. I noticed this because the badge in the README shows as "no status" because it only shows tests run on the main branch.

![badge](https://github.com/DataJunction/dj/actions/workflows/test.yml/badge.svg?branch=main)

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
