### PR TITLE
Add foreign key reference mapping to dimension link metadata output

### DIFF
--- a/datajunction-clients/python/datajunction/nodes.py
+++ b/datajunction-clients/python/datajunction/nodes.py
@@ -82,7 +82,7 @@ class DimensionLink(SerializableMixin):
     join_sql: str
     join_cardinality: str
     role: str | None
-    foreign_keys: dict[str, str]
+    foreign_keys: dict[str, str | None]
 
 
 @dataclass

--- a/datajunction-server/datajunction_server/database/dimensionlink.py
+++ b/datajunction-server/datajunction_server/database/dimensionlink.py
@@ -146,14 +146,19 @@ class DimensionLink(Base):
         the primary key column(s) on the dimension node. The dict values are column names.
         """
         from datajunction_server.sql.parsing.backends.antlr4 import ast
+
+        # Build equality operator-based mappings
         join_asts = self.joins()
-        columns = [col.identifier() for col in join_asts[0].find_all(ast.Column)]
-        foreign_key_refs = [col for col in columns if col.startswith(self.node_revision.name)]
-        mapping = {
+        mapping: dict[str, str | None] = {
             right.identifier(): left.identifier()
             for left, right in self.foreign_key_mapping().items()
         }
+
         # Add remaining foreign key references without an equality comparison
+        columns = [col.identifier() for col in join_asts[0].find_all(ast.Column)]
+        foreign_key_refs = [
+            col for col in columns if col.startswith(self.node_revision.name)
+        ]
         for foreign_key in foreign_key_refs:
             if foreign_key not in mapping:
                 mapping[foreign_key] = None

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1150,8 +1150,8 @@ async def create_new_revision_from_existing(
     )
     pk_changes = (
         data
-        and data.primary_key
-        and {col.name for col in old_revision.primary_key()} != set(data.primary_key)
+        and (data.primary_key == [] and len(old_revision.primary_key())
+        or {col.name for col in old_revision.primary_key()} != set(data.primary_key))
     )
     required_dim_changes = (
         data
@@ -1282,7 +1282,7 @@ async def create_new_revision_from_existing(
             new_revision.columns[0].display_name = new_revision.display_name
 
         # Update the primary key if one was set in the input
-        if data is not None and data.primary_key:
+        if data is not None and (data.primary_key or data.primary_key == []):
             pk_attribute = (
                 await session.execute(
                     select(AttributeType).where(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1148,10 +1148,11 @@ async def create_new_revision_from_existing(
         and data.columns
         and ({col.identifier() for col in old_revision.columns} != data.columns)
     )
-    pk_changes = (
-        data
-        and (data.primary_key == [] and len(old_revision.primary_key())
-        or {col.name for col in old_revision.primary_key()} != set(data.primary_key))
+    pk_changes = data and (
+        data.primary_key == []
+        and len(old_revision.primary_key())
+        or {col.name for col in old_revision.primary_key()}
+        != set(data.primary_key or [])
     )
     required_dim_changes = (
         data

--- a/datajunction-server/datajunction_server/models/dimensionlink.py
+++ b/datajunction-server/datajunction_server/models/dimensionlink.py
@@ -62,7 +62,7 @@ class LinkDimensionOutput(BaseModel):
     join_sql: str
     join_cardinality: Optional[JoinCardinality]
     role: Optional[str]
-    foreign_keys: Dict[str, str]
+    foreign_keys: Dict[str, str | None]
 
     class Config:
         orm_mode = True

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -405,7 +405,10 @@ async def test_link_complex_dimension_with_role(
             "INT)",
             "join_type": "left",
             "role": "user_windowed",
-            "foreign_keys": {"default.events.user_id": "default.users.user_id"},
+            "foreign_keys": {
+                "default.events.event_start_date": None,
+                "default.events.user_id": "default.users.user_id",
+            },
         },
     ]
 


### PR DESCRIPTION
### Summary

This change adds a full foreign key reference mapping when outputting dimension link metadata. This makes it easier to extract metadata from complex dimension links with `JOIN ... ON ...` clauses that go beyond equality comparisons.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
