### PR TITLE
Add better metric metadata to materializations

### DIFF
--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -262,6 +262,7 @@ async def build_cube_materialization(
         cube=NodeNameVersion(
             name=current_revision.name,
             version=current_revision.version,
+            display_name=current_revision.display_name,
         ),
         metrics=[
             CubeMetric(

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -4,6 +4,7 @@ import itertools
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.construction.build_v2 import get_measures_query
 from datajunction_server.database.node import Column, NodeRevision
 from datajunction_server.errors import DJInvalidInputException
@@ -253,6 +254,7 @@ async def build_cube_materialization(
                 metric=NodeNameVersion(
                     name=metric.name,
                     version=metric.current_version,
+                    display_name=metric.current.display_name,
                 ),
                 required_measures=[
                     MeasureKey(
@@ -262,6 +264,9 @@ async def build_cube_materialization(
                     for measure in metrics_mapping.get(metric.name)[1][0]  # type: ignore
                 ],
                 derived_expression=metrics_mapping.get(metric.name)[1][1],  # type: ignore
+                metric_expression=str(
+                    parse(metrics_mapping.get(metric.name)[1][1]).select.projection[0],  # type: ignore
+                ),
             )
             for metric in current_revision.cube_metrics()
         ],

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -207,7 +207,13 @@ class CubeMetric(BaseModel):
     )
     derived_expression: str = Field(
         description=(
-            "The expression for rewriting the original metric query "
+            "The query for rewriting the original metric query "
+            "using the materialized measures."
+        ),
+    )
+    metric_expression: str = Field(
+        description=(
+            "SQL expression for rewriting the original metric query "
             "using the materialized measures."
         ),
     )

--- a/datajunction-server/datajunction_server/models/node_type.py
+++ b/datajunction-server/datajunction_server/models/node_type.py
@@ -43,6 +43,7 @@ class NodeNameVersion(BaseModel):
 
     name: str
     version: str
+    display_name: str | None
 
     class Config:
         orm_mode = True

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2213,6 +2213,7 @@ async def test_cube_materialization_metadata(
     assert results["cube"] == {
         "name": "default.example_repairs_cube",
         "version": "v1.0",
+        "display_name": None,
     }
     assert results["job"] == "DRUID_CUBE"
     assert results["lookback_window"] == "1 DAY"
@@ -2232,9 +2233,12 @@ async def test_cube_materialization_metadata(
             "derived_expression": "SELECT  CAST(sum(discount_sum_62846f49) AS DOUBLE) / "
             "SUM(count_3389dae3) AS default_DOT_discounted_orders_rate  FROM "
             "default.repair_orders_fact",
+            "metric_expression": "CAST(sum(discount_sum_62846f49) AS DOUBLE) / "
+            "SUM(count_3389dae3)",
             "metric": {
                 "name": "default.discounted_orders_rate",
                 "version": "v1.0",
+                "display_name": "Discounted Orders Rate",
             },
             "required_measures": [
                 {
@@ -2242,6 +2246,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
+                        "display_name": "Repair Orders Fact",
                     },
                 },
                 {
@@ -2249,6 +2254,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
+                        "display_name": "Repair Orders Fact",
                     },
                 },
             ],
@@ -2256,9 +2262,11 @@ async def test_cube_materialization_metadata(
         {
             "derived_expression": "SELECT  SUM(repair_order_id_count_0b7dfba0)  FROM "
             "default.repair_orders_fact",
+            "metric_expression": "SUM(repair_order_id_count_0b7dfba0)",
             "metric": {
                 "name": "default.num_repair_orders",
                 "version": "v1.0",
+                "display_name": "Num Repair Orders",
             },
             "required_measures": [
                 {
@@ -2266,6 +2274,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
+                        "display_name": "Repair Orders Fact",
                     },
                 },
             ],
@@ -2273,9 +2282,11 @@ async def test_cube_materialization_metadata(
         {
             "derived_expression": "SELECT  SUM(price_sum_78a5eb43) / SUM(price_count_78a5eb43)  FROM "
             "default.repair_orders_fact",
+            "metric_expression": "SUM(price_sum_78a5eb43) / SUM(price_count_78a5eb43)",
             "metric": {
                 "name": "default.avg_repair_price",
                 "version": "v1.0",
+                "display_name": "Avg Repair Price",
             },
             "required_measures": [
                 {
@@ -2283,6 +2294,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
+                        "display_name": "Repair Orders Fact",
                     },
                 },
                 {
@@ -2290,6 +2302,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
+                        "display_name": "Repair Orders Fact",
                     },
                 },
             ],
@@ -2297,9 +2310,11 @@ async def test_cube_materialization_metadata(
         {
             "derived_expression": "SELECT  sum(total_repair_cost_sum_9bdaf803)  FROM "
             "default.repair_orders_fact",
+            "metric_expression": "sum(total_repair_cost_sum_9bdaf803)",
             "metric": {
                 "name": "default.total_repair_cost",
                 "version": "v1.0",
+                "display_name": "Total Repair Cost",
             },
             "required_measures": [
                 {
@@ -2307,6 +2322,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
+                        "display_name": "Repair Orders Fact",
                     },
                 },
             ],
@@ -2314,9 +2330,11 @@ async def test_cube_materialization_metadata(
         {
             "derived_expression": "SELECT  sum(price_discount_sum_017d55a8)  FROM "
             "default.repair_orders_fact",
+            "metric_expression": "sum(price_discount_sum_017d55a8)",
             "metric": {
                 "name": "default.total_repair_order_discounts",
                 "version": "v1.0",
+                "display_name": "Total Repair Order Discounts",
             },
             "required_measures": [
                 {
@@ -2324,6 +2342,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
+                        "display_name": "Repair Orders Fact",
                     },
                 },
             ],
@@ -2332,9 +2351,11 @@ async def test_cube_materialization_metadata(
             "derived_expression": "SELECT  sum(price_sum_78a5eb43) + sum(price_sum_78a5eb43) AS "
             "default_DOT_double_total_repair_cost  FROM "
             "default.repair_order_details",
+            "metric_expression": "sum(price_sum_78a5eb43) + sum(price_sum_78a5eb43)",
             "metric": {
                 "name": "default.double_total_repair_cost",
                 "version": "v1.0",
+                "display_name": "Double Total Repair Cost",
             },
             "required_measures": [
                 {
@@ -2342,6 +2363,7 @@ async def test_cube_materialization_metadata(
                     "node": {
                         "name": "default.repair_order_details",
                         "version": "v1.0",
+                        "display_name": "default.roads.repair_order_details",
                     },
                 },
             ],
@@ -2550,6 +2572,7 @@ async def test_cube_materialization_metadata(
             "node": {
                 "name": "default.repair_orders_fact",
                 "version": "v1.0",
+                "display_name": "Repair Orders Fact",
             },
             "output_table_name": "default_repair_orders_fact_v1_0_c9390406463b348e",
             "query": mock.ANY,
@@ -2666,6 +2689,7 @@ async def test_cube_materialization_metadata(
             "node": {
                 "name": "default.repair_order_details",
                 "version": "v1.0",
+                "display_name": "default.roads.repair_order_details",
             },
             "output_table_name": "default_repair_order_details_v1_0_5bf367d2fc7c255d",
             "query": mock.ANY,
@@ -3081,6 +3105,7 @@ async def test_cube_materialization_metadata(
                 },
             ],
             "node": {
+                "display_name": "Example Repairs Cube",
                 "name": "default.example_repairs_cube",
                 "version": "v1.0",
             },

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2213,7 +2213,7 @@ async def test_cube_materialization_metadata(
     assert results["cube"] == {
         "name": "default.example_repairs_cube",
         "version": "v1.0",
-        "display_name": None,
+        "display_name": "Example Repairs Cube",
     }
     assert results["job"] == "DRUID_CUBE"
     assert results["lookback_window"] == "1 DAY"

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -803,6 +803,7 @@ async def test_druid_cube_incremental(
     assert mat.cube == NodeNameVersion(
         name="default.repairs_cube__default_incremental",
         version="v1.0",
+        display_name="Repairs Cube  Default Incremental",
     )
     assert mat.dimensions == [
         "default.repair_orders_fact.order_date",

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -812,37 +812,50 @@ async def test_druid_cube_incremental(
     ]
     assert mat.metrics == [
         CubeMetric(
-            metric=NodeNameVersion(name="default.num_repair_orders", version="v1.0"),
+            metric=NodeNameVersion(
+                name="default.num_repair_orders",
+                version="v1.0",
+                display_name="Num Repair Orders",
+            ),
             required_measures=[
                 MeasureKey(
                     node=NodeNameVersion(
                         name="default.repair_orders_fact",
                         version=ANY_STRING,
+                        display_name="Repair Orders Fact",
                     ),
                     measure_name="repair_order_id_count_0b7dfba0",
                 ),
             ],
             derived_expression="SELECT  SUM(repair_order_id_count_0b7dfba0)"
             "  FROM default.repair_orders_fact",
+            metric_expression="SUM(repair_order_id_count_0b7dfba0)",
         ),
         CubeMetric(
-            metric=NodeNameVersion(name="default.total_repair_cost", version="v1.0"),
+            metric=NodeNameVersion(
+                name="default.total_repair_cost",
+                version="v1.0",
+                display_name="Total Repair Cost",
+            ),
             required_measures=[
                 MeasureKey(
                     node=NodeNameVersion(
                         name="default.repair_orders_fact",
                         version=ANY_STRING,
+                        display_name="Repair Orders Fact",
                     ),
                     measure_name="total_repair_cost_sum_9bdaf803",
                 ),
             ],
             derived_expression="SELECT  sum(total_repair_cost_sum_9bdaf803)"
             "  FROM default.repair_orders_fact",
+            metric_expression="sum(total_repair_cost_sum_9bdaf803)",
         ),
     ]
     assert mat.measures_materializations[0].node == NodeNameVersion(
         name="default.repair_orders_fact",
         version=ANY_STRING,
+        display_name="Repair Orders Fact",
     )
     assert mat.measures_materializations[0].grain == [
         "default_DOT_repair_orders_fact_DOT_order_date",
@@ -942,6 +955,7 @@ async def test_druid_cube_incremental(
     assert mat.combiners[0].node == NodeNameVersion(
         name="default.repair_orders_fact",
         version=ANY_STRING,
+        display_name="Repair Orders Fact",
     )
     assert mat.combiners[0].query is None
     assert mat.combiners[0].columns == [

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -790,6 +790,7 @@ class TestQueryServiceClient:
                     metric=NodeNameVersion(
                         name="default.num_repair_orders",
                         version="v1.0",
+                        display_name=None,
                     ),
                     required_measures=[
                         MeasureKey(
@@ -800,12 +801,14 @@ class TestQueryServiceClient:
                             measure_name="count",
                         ),
                     ],
-                    derived_expression="SUM(count)",
+                    derived_expression="SELECT SUM(count) FROM default.repair_orders",
+                    metric_expression="SUM(count)",
                 ),
                 CubeMetric(
                     metric=NodeNameVersion(
                         name="default.avg_repair_price",
                         version="v1.0",
+                        display_name=None,
                     ),
                     required_measures=[
                         MeasureKey(
@@ -816,7 +819,8 @@ class TestQueryServiceClient:
                             measure_name="sum_price_123abc",
                         ),
                     ],
-                    derived_expression="SUM(sum_price_123abc)",
+                    derived_expression="SELECT SUM(sum_price_123abc) FROM default.repair_orders",
+                    metric_expression="SUM(sum_price_123abc)",
                 ),
             ],
             measures_materializations=[],


### PR DESCRIPTION
### Summary

This adds better metric metadata to the saved materialization config:
* Exposes the metric expression rather than the full query (saves downstream consumers from having to parse out the expression)
* Includes each metric's display name for each materialization

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1321 #1320
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
