### PR TITLE
Fix YAML tagging so that all nodes actually get tagged

### DIFF
--- a/datajunction-clients/python/datajunction/compile.py
+++ b/datajunction-clients/python/datajunction/compile.py
@@ -884,9 +884,8 @@ class CompiledProject(Project):
                 project_tags = [tag.name for tag in self.tags]
                 if node_config.definition.tags:
                     rendered_node_config.definition.tags = [
-                        f"{prefix}.{tag}"
+                        f"{prefix}.{tag}" if tag in project_tags else tag
                         for tag in node_config.definition.tags
-                        if tag in project_tags
                     ]
                 created_node = rendered_node_config.definition.deploy(
                     name=rendered_node_config.name,


### PR DESCRIPTION
### Summary

There was a bug where we only include the tag in the project if it's in the list of project tags, and we always prefix these tags. However, it makes more sense to include all tags, and only prefix them if they're new tags created as a part of this project.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1324 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
