### PR TITLE
Decompose ANY_VALUE in metric definitions into measures

### DIFF
--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -25,6 +25,7 @@ class MeasureExtractor:
             dj_functions.Max: self._simple_associative_agg,
             dj_functions.Min: self._simple_associative_agg,
             dj_functions.Avg: self._avg,
+            dj_functions.AnyValue: self._simple_associative_agg,
         }
 
         # Outputs from decomposition

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -487,6 +487,28 @@ def test_count_distinct_rate():
     )
 
 
+def test_any_value():
+    """
+    Test decomposition for a metric definition that has ANY_VALUE as the agg function
+    """
+    extractor = MeasureExtractor.from_query_string(
+        "SELECT ANY_VALUE(sales_amount) FROM parent_node",
+    )
+    measures, derived_sql = extractor.extract()
+    expected_measures = [
+        Measure(
+            name="sales_amount_any_value_a1b27bc7",
+            expression="sales_amount",
+            aggregation="ANY_VALUE",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
+    assert measures == expected_measures
+    assert str(derived_sql) == str(
+        parse("SELECT ANY_VALUE(sales_amount_any_value_a1b27bc7) FROM parent_node"),
+    )
+
+
 def test_no_aggregation():
     """
     Test behavior when there is no aggregation function in the metric query.


### PR DESCRIPTION
### Summary

This handles decomposition of metric definitions with `ANY_VALUE` as the aggregation function.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
