### PR TITLE
Fix Cube() making in DJ client.

### DIFF
--- a/datajunction-clients/python/datajunction/_base.py
+++ b/datajunction-clients/python/datajunction/_base.py
@@ -65,7 +65,7 @@ class SerializableMixin:  # pylint: disable=too-few-public-methods
                         if isinstance(item, dict)
                         else item
                     )
-                except TypeError:  # Ignore and try the next candidate
+                except (TypeError, AttributeError):  # Ignore and try the next candidate
                     pass
             return item  # pragma: no cover
 


### PR DESCRIPTION
### Summary

In some Python env we can see the following error when creating a Cube() node using DJ client from dict.
```
datajunction/_base.py:107: in from_dict
    field_values[field.name] = serialization_func(
datajunction/_base.py:72: in _serialize_list
    return [serialize_item(item) for item in field_value]
datajunction/_base.py:72: in <listcomp>
    return [serialize_item(item) for item in field_value]
datajunction/_base.py:64: in serialize_item
    candidate.from_dict(dj_client, item)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = typing.Dict[str, typing.Any], attr = 'from_dict'

    def __getattr__(self, attr):
        if attr in {'__name__', '__qualname__'}:
            return self._name or self.__origin__.__name__

        # We are careful for copy and pickle.
        # Also for simplicity we don't relay any dunder names
        if '__origin__' in self.__dict__ and not _is_dunder(attr):
>           return getattr(self.__origin__, attr)
E           AttributeError: type object 'dict' has no attribute 'from_dict'

/apps/python3.10/lib/python3.10/typing.py:983: AttributeError
```
This PR fixes that.

### Test Plan

Checked unit tests. Checked a big cube dict manually. 

### Deployment Plan

auto