### PR TITLE
Fix aggregation function check for metric definition

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -778,7 +778,7 @@ class NodeRevision(
         # must have an aggregation
         if (
             not hasattr(projection_0, "is_aggregation")
-            or not projection_0.is_aggregation()  # type: ignore
+            and not projection_0.is_aggregation()  # type: ignore
         ):
             raise DJInvalidMetricQueryException(
                 f"Metric {self.name} has an invalid query, should have an aggregate expression",

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -776,10 +776,7 @@ class NodeRevision(
         projection_0 = tree.select.projection[0]
 
         # must have an aggregation
-        if (
-            not hasattr(projection_0, "is_aggregation")
-            and not projection_0.is_aggregation()  # type: ignore
-        ):
+        if not projection_0.is_aggregation():
             raise DJInvalidMetricQueryException(
                 f"Metric {self.name} has an invalid query, should have an aggregate expression",
             )

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -593,10 +593,10 @@ class Expression(Node):
         """
         Determines whether an Expression is an aggregation or not
         """
-        for child in self.children:
-            if hasattr(child, "is_aggregation") and child.is_aggregation():
-                return True
-        return False
+        return any(
+            hasattr(child, "is_aggregation") and child.is_aggregation()
+            for child in self.children
+        )
 
     def set_alias(self: TExpression, alias: "Name") -> Alias[TExpression]:
         return Alias(child=self).set_alias(alias)
@@ -2168,11 +2168,6 @@ class Case(Expression):
         if self.parenthesized:
             return f"({ret})"
         return ret
-
-    def is_aggregation(self) -> bool:
-        return all(result.is_aggregation() for result in self.results) and (
-            self.else_result.is_aggregation() if self.else_result else True
-        )
 
     @property
     def type(self) -> ColumnType:

--- a/datajunction-server/tests/models/node_test.py
+++ b/datajunction-server/tests/models/node_test.py
@@ -96,6 +96,16 @@ def test_extra_validation() -> None:
     )
     node_revision.extra_validation()
 
+    node = Node(name="ABC", type=NodeType.METRIC, current_version="1")
+    node_revision = NodeRevision(
+        name=node.name,
+        type=node.type,
+        node=node,
+        version="1",
+        query="SELECT CASE WHEN COUNT(repair_order_id) = 1 THEN 1 ELSE 0 END FROM repair_orders",
+    )
+    node_revision.extra_validation()
+
     node = Node(name="A", type=NodeType.TRANSFORM, current_version="1")
     node_revision = NodeRevision(
         name=node.name,


### PR DESCRIPTION
### Summary

We should check all children of the metric query for aggregation functions before raising an error.

### Test Plan

Locally

- [x] PR has an associated issue: #1330
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
