### PR TITLE
Process every history event through notifier depnedency after saving

### DIFF
--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -4,13 +4,13 @@ Node namespace related APIs.
 
 import logging
 from http import HTTPStatus
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from fastapi import Depends, Query
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from datajunction_server.api.helpers import get_node_namespace
+from datajunction_server.api.helpers import get_node_namespace, get_save_history
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJAlreadyExistsException
@@ -50,6 +50,8 @@ async def create_node_namespace(
     include_parents: Optional[bool] = False,
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_and_update_current_user),
+    *,
+    save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
     Create a node namespace
@@ -84,6 +86,7 @@ async def create_node_namespace(
         namespace=namespace,
         include_parents=include_parents,  # type: ignore
         current_user=current_user,
+        save_history=save_history,
     )
     return JSONResponse(
         status_code=HTTPStatus.CREATED,
@@ -171,6 +174,7 @@ async def deactivate_a_namespace(
     ),
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_and_update_current_user),
+    save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
     Deactivates a node namespace
@@ -196,6 +200,7 @@ async def deactivate_a_namespace(
             namespace=node_namespace,  # type: ignore
             message=message,
             current_user=current_user,
+            save_history=save_history,
         )
         return JSONResponse(
             status_code=HTTPStatus.OK,
@@ -211,6 +216,7 @@ async def deactivate_a_namespace(
                 name=node_name,
                 message=f"Cascaded from deactivating namespace `{namespace}`",
                 current_user=current_user,
+                save_history=save_history,
             )
         message = (
             f"Namespace `{namespace}` has been deactivated. The following nodes"
@@ -221,6 +227,7 @@ async def deactivate_a_namespace(
             namespace=node_namespace,  # type: ignore
             message=message,
             current_user=current_user,
+            save_history=save_history,
         )
 
         return JSONResponse(
@@ -248,6 +255,7 @@ async def restore_a_namespace(
     ),
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_and_update_current_user),
+    save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
     Restores a node namespace
@@ -277,6 +285,7 @@ async def restore_a_namespace(
                 session=session,
                 message=f"Cascaded from restoring namespace `{namespace}`",
                 current_user=current_user,
+                save_history=save_history,
             )
 
         message = (
@@ -288,6 +297,7 @@ async def restore_a_namespace(
             namespace=node_namespace,
             message=message,
             current_user=current_user,
+            save_history=save_history,
         )
 
         return JSONResponse(
@@ -304,6 +314,7 @@ async def restore_a_namespace(
         namespace=node_namespace,
         message=message,
         current_user=current_user,
+        save_history=save_history,
     )
     return JSONResponse(
         status_code=HTTPStatus.CREATED,
@@ -318,6 +329,7 @@ async def hard_delete_node_namespace(
     cascade: bool = False,
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_and_update_current_user),
+    save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
     Hard delete a namespace, which will completely remove the namespace. Additionally,
@@ -330,6 +342,7 @@ async def hard_delete_node_namespace(
         namespace=namespace,
         cascade=cascade,
         current_user=current_user,
+        save_history=save_history,
     )
     return JSONResponse(
         status_code=HTTPStatus.OK,

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -61,6 +61,7 @@ async def test_propagate_valid_status(module__session: AsyncSession):
             valid_nodes=[invalid_node],
             catalog_id=1,
             current_user=example_user,
+            save_history=MagicMock(),
         )
 
     assert "Cannot propagate valid status: Node `foo` is not valid" in str(

--- a/docs/content/0.1.0/docs/deploying-dj/notifications.md
+++ b/docs/content/0.1.0/docs/deploying-dj/notifications.md
@@ -70,7 +70,7 @@ app.dependency_overrides[get_notifier] = get_custom_notifier
 Here's how the `get_notifier` dependency is used within the application to send a notification:
 
 ```python
-notify = Depends(get_notifier())
+notify = Depends(get_notifier)
 event = History(
     id=1,
     entity_name="bar",


### PR DESCRIPTION
### Summary

Currently saving history events and notifying are two separate calls, but in all cases they should be one right after the other (even if the notification dependency chooses not to send out any notifications for that history event type). Instead of adding calls to the notifier everywhere we save history, this PR couples the two together within a dependency function called `save_history` that also passes the event through the notifier dependency to handle it after it's saved.

### Test Plan

`make test`

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
