### PR TITLE
Normalize all column names to be lowercase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: pdm-project/setup-pdm@v3
+      - uses: pdm-project/setup-pdm@v4
         name: Setup PDM
         with:
           python-version: ${{ matrix.python-version }}

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1473,7 +1473,7 @@ async def column_lineage(
         col
         for col in query_ast.select.projection
         if (  # pragma: no cover
-            col != ast.Null() and col.alias_or_name.name == column_name  # type: ignore
+            col != ast.Null() and col.alias_or_name.name.lower() == column_name.lower()  # type: ignore
         )
     ][0]
     column_or_child = column.child if isinstance(column, ast.Alias) else column  # type: ignore

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1224,7 +1224,7 @@ async def create_new_revision_from_existing(
         type=old_revision.type,
         columns=[
             Column(
-                name=column_data.name,
+                name=column_data.name.lower(),
                 type=column_data.type,
                 dimension_column=column_data.dimension,
                 attributes=column_data.attributes or [],

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1224,7 +1224,9 @@ async def create_new_revision_from_existing(
         type=old_revision.type,
         columns=[
             Column(
-                name=column_data.name.lower(),
+                name=column_data.name.lower()
+                if node.type != NodeType.METRIC
+                else column_data.name,
                 type=column_data.type,
                 dimension_column=column_data.dimension,
                 attributes=column_data.attributes or [],

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -127,7 +127,9 @@ async def validate_node_data(
         try:
             column_type = str(col.type)  # type: ignore
             column = Column(
-                name=column_name.lower(),
+                name=column_name.lower()
+                if validated_node.type != NodeType.METRIC
+                else column_name,
                 display_name=labelize(column_name),
                 type=column_type,
                 attributes=existing_column.attributes if existing_column else [],

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -127,7 +127,7 @@ async def validate_node_data(
         try:
             column_type = str(col.type)  # type: ignore
             column = Column(
-                name=column_name,
+                name=column_name.lower(),
                 display_name=labelize(column_name),
                 type=column_type,
                 attributes=existing_column.attributes if existing_column else [],

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -412,7 +412,7 @@ class TestNodeCRUD:
             json={
                 "description": "Title",
                 "query": (
-                    "SELECT 0 AS title_code, 'Agha' AS title "
+                    "SELECT 0 AS title_code, 'Agha' AS Title "
                     "UNION ALL SELECT 1, 'Abbot' "
                     "UNION ALL SELECT 2, 'Akhoond' "
                     "UNION ALL SELECT 3, 'Apostle'"


### PR DESCRIPTION
### Summary

All column names should be case insensitive. In many (most?) SQL varieties, column names are not case sensitive. This means that we should always normalize the stored column names in the metadata db to be lower case. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
