### PR TITLE
Break out logic for getting a user's notification preferences to a separate function

### DIFF
--- a/datajunction-server/datajunction_server/internal/notifications.py
+++ b/datajunction-server/datajunction_server/internal/notifications.py
@@ -1,0 +1,31 @@
+"""
+Module related to all things notifications
+"""
+
+from typing import List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.notification_preference import NotificationPreference
+from datajunction_server.database.history import EntityType
+
+
+async def get_notification_preferences(
+    session: AsyncSession,
+    user: str,
+    entity_name: Optional[str] = None,
+    entity_type: Optional[EntityType] = None,
+) -> List[NotificationPreference]:
+    """
+    Get all notification preferences for a user, optionally filtering to a specific entity name and/or entity type
+    """
+    statement = select(NotificationPreference).where(
+        NotificationPreference.user == user,
+    )
+    if entity_name:
+        statement = statement.where(NotificationPreference.entity_name == entity_name)
+    if entity_type:
+        statement = statement.where(NotificationPreference.entity_type == entity_type)
+    result = await session.execute(statement)
+    return result.scalar().all()

--- a/datajunction-server/datajunction_server/internal/notifications.py
+++ b/datajunction-server/datajunction_server/internal/notifications.py
@@ -28,4 +28,4 @@ async def get_notification_preferences(
     if entity_type:
         statement = statement.where(NotificationPreference.entity_type == entity_type)
     result = await session.execute(statement)
-    return result.scalar().all()
+    return result.scalars().all()

--- a/docs/content/0.1.0/docs/deploying-dj/notifications.md
+++ b/docs/content/0.1.0/docs/deploying-dj/notifications.md
@@ -67,10 +67,9 @@ app.dependency_overrides[get_notifier] = get_custom_notifier
 
 ## Example Usage
 
-Here's how the `get_notifier` dependency is used within the application to send a notification:
+Here's an illustrative example to help understand how the `get_notifier` dependency is used within the application to send a notification:
 
 ```python
-notify = Depends(get_notifier)
 event = History(
     id=1,
     entity_name="bar",
@@ -81,4 +80,33 @@ notify(event)
 ```
 
 By customizing the `get_notifier` dependency, you can tailor the notification system to suit your specific needs, such
-as integrating with third-party services or implementing advanced notification configuration or logic.
+as integrating with third-party services or implementing advanced notification configuration or logic. Below are the different
+types of entities and activities that DataJunction will pass through the notification dependency.
+
+### Entity types
+
+- ATTRIBUTE
+- AVAILABILITY
+- BACKFILL
+- CATALOG
+- COLUMN_ATTRIBUTE
+- DEPENDENCY
+- ENGINE
+- LINK
+- MATERIALIZATION
+- NAMESPACE
+- NODE
+- PARTITION
+- QUERY
+- TAG
+
+### Activity types
+
+- CREATE
+- DELETE
+- RESTORE
+- UPDATE
+- REFRESH
+- TAG
+- SET_ATTRIBUTE
+- STATUS_CHANGE


### PR DESCRIPTION
### Summary

This moves the logic in the endpoint for getting a user's notification preferences out to a separate function because it's useful to use it in other places. The main place top of mind is in injected notification dependencies that need to look up what the current user's preferences are.

### Test Plan

`make test`

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
