### PR TITLE
Add ability to search on display name using findNodes

### DIFF
--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -29,7 +29,7 @@ from datajunction_server.utils import (
 from fastapi import Request
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
@@ -149,6 +149,7 @@ async def module__session(
         poolclass=StaticPool,
     )
     async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
         await conn.run_sync(Base.metadata.create_all)
     async_session_factory = async_sessionmaker(
         bind=engine,

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -105,10 +105,10 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
             "foo.bar.avg_repair_order_discounts",
             "foo.bar.avg_time_to_dispatch",
         }
-        assert client.namespace("foo.bar").transforms() == [
+        assert set(client.namespace("foo.bar").transforms()) == {
             "foo.bar.with_custom_metadata",
             "foo.bar.repair_orders_thin",
-        ]
+        }
         assert client.namespace("foo.bar").cubes() == ["foo.bar.cube_one"]
 
     def test_all_nodes(self, client):

--- a/datajunction-server/datajunction_server/alembic/versions/2025_03_14_1513-ae9eba981a2d_add_index_on_display_name.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_03_14_1513-ae9eba981a2d_add_index_on_display_name.py
@@ -7,24 +7,32 @@ Create Date: 2025-03-14 15:13:06.383265+00:00
 """
 # pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
 
-import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = 'ae9eba981a2d'
-down_revision = 'c3d5f327296c'
+revision = "ae9eba981a2d"
+down_revision = "c3d5f327296c"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
-    with op.batch_alter_table('noderevision', schema=None) as batch_op:
-        batch_op.create_index('ix_noderevision_display_name', ['display_name'], unique=False, postgresql_using='gin', postgresql_ops={'display_name': 'gin_trgm_ops'})
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_noderevision_display_name",
+            ["display_name"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={"display_name": "gin_trgm_ops"},
+        )
 
 
 def downgrade():
-    with op.batch_alter_table('noderevision', schema=None) as batch_op:
-        batch_op.drop_index('ix_noderevision_display_name', postgresql_using='gin', postgresql_ops={'display_name': 'gin_trgm_ops'})
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.drop_index(
+            "ix_noderevision_display_name",
+            postgresql_using="gin",
+            postgresql_ops={"display_name": "gin_trgm_ops"},
+        )
     op.execute("DROP EXTENSION IF EXISTS pg_trgm;")

--- a/datajunction-server/datajunction_server/alembic/versions/2025_03_14_1513-ae9eba981a2d_add_index_on_display_name.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_03_14_1513-ae9eba981a2d_add_index_on_display_name.py
@@ -1,0 +1,30 @@
+"""
+Add index on display name
+
+Revision ID: ae9eba981a2d
+Revises: c3d5f327296c
+Create Date: 2025-03-14 15:13:06.383265+00:00
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'ae9eba981a2d'
+down_revision = 'c3d5f327296c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+    with op.batch_alter_table('noderevision', schema=None) as batch_op:
+        batch_op.create_index('ix_noderevision_display_name', ['display_name'], unique=False, postgresql_using='gin', postgresql_ops={'display_name': 'gin_trgm_ops'})
+
+
+def downgrade():
+    with op.batch_alter_table('noderevision', schema=None) as batch_op:
+        batch_op.drop_index('ix_noderevision_display_name', postgresql_using='gin', postgresql_ops={'display_name': 'gin_trgm_ops'})
+    op.execute("DROP EXTENSION IF EXISTS pg_trgm;")

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -290,6 +290,52 @@ async def test_find_by_fragment(
         },
     ]
 
+    query = """
+    {
+        findNodes(fragment: "Repair Ord") {
+            name
+            current {
+                displayName
+            }
+        }
+    }
+    """
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["findNodes"] == [
+        {
+            "current": {
+                "displayName": "Avg Repair Order Discounts",
+            },
+            "name": "default.avg_repair_order_discounts",
+        },
+        {
+            "current": {
+                "displayName": "Total Repair Order Discounts",
+            },
+            "name": "default.total_repair_order_discounts",
+        },
+        {
+            "current": {
+                "displayName": "Num Repair Orders",
+            },
+            "name": "default.num_repair_orders",
+        },
+        {
+            "current": {
+                "displayName": "Repair Orders Fact",
+            },
+            "name": "default.repair_orders_fact",
+        },
+        {
+            "current": {
+                "displayName": "Repair Order",
+            },
+            "name": "default.repair_order",
+        },
+    ]
+
 
 @pytest.mark.asyncio
 async def test_find_by_names(

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -775,6 +775,7 @@ async def module__session(
         poolclass=StaticPool,
     )
     async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
         await conn.run_sync(Base.metadata.create_all)
     async_session_factory = async_sessionmaker(
         bind=engine,

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -30,7 +30,7 @@ from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
-from sqlalchemy import StaticPool, insert
+from sqlalchemy import StaticPool, insert, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from testcontainers.core.waiting_utils import wait_for_logs
 from testcontainers.postgres import PostgresContainer
@@ -178,6 +178,7 @@ async def session(
         poolclass=StaticPool,
     )
     async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
         await conn.run_sync(Base.metadata.create_all)
     async_session_factory = async_sessionmaker(
         bind=engine,


### PR DESCRIPTION
### Summary

Add the ability to search nodes by display name using the GraphQL `findNodes` query.

This change includes a GIN index on the noderevision's `display_name` field to help with faster query times.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
