### PR TITLE
Enable metrics to reference available dimensions in definition

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -890,6 +890,13 @@ async def build_sql_for_dj_query(  # pragma: no cover
     )
 
 
+def try_column_type(col):
+    try:
+        return col.type
+    except:  # noqa: E722
+        return None
+
+
 def assemble_column_metadata(
     column: ast.Column,
     # node_name: Union[List[str], str],
@@ -899,7 +906,7 @@ def assemble_column_metadata(
     """
     metadata = ColumnMetadata(
         name=column.alias_or_name.name,
-        type=str(column.type),
+        type=str(try_column_type(column)),
         column=(
             column.semantic_entity.split(SEPARATOR)[-1]
             if hasattr(column, "semantic_entity") and column.semantic_entity

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -890,6 +890,13 @@ async def build_sql_for_dj_query(  # pragma: no cover
     )
 
 
+def try_column_type(col):
+    try:
+        return col.type
+    except:  # noqa: E722
+        return None
+
+
 def assemble_column_metadata(
     column: ast.Column,
     # node_name: Union[List[str], str],
@@ -899,7 +906,7 @@ def assemble_column_metadata(
     """
     metadata = ColumnMetadata(
         name=column.alias_or_name.name,
-        type=str(type(column)),
+        type=str(try_column_type(column)),
         column=(
             column.semantic_entity.split(SEPARATOR)[-1]
             if hasattr(column, "semantic_entity") and column.semantic_entity

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -890,13 +890,6 @@ async def build_sql_for_dj_query(  # pragma: no cover
     )
 
 
-def try_column_type(col):
-    try:
-        return col.type
-    except:  # noqa: E722
-        return None
-
-
 def assemble_column_metadata(
     column: ast.Column,
     # node_name: Union[List[str], str],
@@ -906,7 +899,7 @@ def assemble_column_metadata(
     """
     metadata = ColumnMetadata(
         name=column.alias_or_name.name,
-        type=str(try_column_type(column)),
+        type=str(type(column)),
         column=(
             column.semantic_entity.split(SEPARATOR)[-1]
             if hasattr(column, "semantic_entity") and column.semantic_entity

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -890,13 +890,6 @@ async def build_sql_for_dj_query(  # pragma: no cover
     )
 
 
-def try_column_type(col):
-    try:
-        return col.type
-    except:  # noqa: E722
-        return None
-
-
 def assemble_column_metadata(
     column: ast.Column,
     # node_name: Union[List[str], str],
@@ -906,7 +899,7 @@ def assemble_column_metadata(
     """
     metadata = ColumnMetadata(
         name=column.alias_or_name.name,
-        type=str(try_column_type(column)),
+        type=str(column.type),
         column=(
             column.semantic_entity.split(SEPARATOR)[-1]
             if hasattr(column, "semantic_entity") and column.semantic_entity

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -381,13 +381,6 @@ def build_preaggregate_query(
     return final_query
 
 
-def try_column_type(col):
-    try:
-        return col.type
-    except:  # noqa: E722
-        return None
-
-
 class QueryBuilder:
     """
     This class allows users to configure building node SQL by incrementally building out
@@ -749,7 +742,7 @@ class QueryBuilder:
                     ast.Column(
                         ast.Name(col.alias_or_name.name),  # type: ignore
                         _table=node_ast,
-                        _type=try_column_type(col),  # type: ignore
+                        _type=type(col),  # type: ignore
                     )
                     for col in node_ast.select.projection
                 ],
@@ -1130,7 +1123,7 @@ class CubeQueryBuilder:
                 projection=[
                     ast.Column(
                         name=ast.Name(proj.alias, namespace=initial_cte.alias),  # type: ignore
-                        _type=try_column_type(proj),  # type: ignore
+                        _type=type(proj),  # type: ignore
                         semantic_entity=proj.semantic_entity,  # type: ignore
                         semantic_type=proj.semantic_type,  # type: ignore
                     )

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -8,6 +8,7 @@ from datajunction_server.models.cube_materialization import (
     AggregationRule,
     MetricComponent,
 )
+from datajunction_server.naming import amenable_name
 from datajunction_server.sql import functions as dj_functions
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
 
@@ -93,11 +94,12 @@ class MetricComponentExtractor:
         arg = func.args[0]
         if func.quantifier == ast.SetQuantifier.Distinct:
             component_name = "_".join(
-                [str(col) for col in arg.find_all(ast.Column)] + ["distinct"],
+                [amenable_name(str(col)) for col in arg.find_all(ast.Column)]
+                + ["distinct"],
             )
         else:
             component_name = "_".join(
-                [str(col) for col in arg.find_all(ast.Column)]
+                [amenable_name(str(col)) for col in arg.find_all(ast.Column)]
                 + [func.name.name.lower()],
             )
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2603,6 +2603,13 @@ class SelectExpression(Aliasable, Expression):
         """
         return {col.alias_or_name.name: col for col in self.projection}
 
+    @property
+    def semantic_column_mapping(self) -> Dict[str, "Column"]:
+        """
+        Returns a dictionary with the output column names mapped to the columns
+        """
+        return {col.semantic_entity: col for col in self.projection}
+
 
 @dataclass(eq=False)
 class QueryParameter(Expression):

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -95,19 +95,10 @@ def transpile_sql(
     sql: str,
     dialect: Dialect | None = None,
 ) -> str:
-    print(
-        "dialect",
-        dialect,
-        "settings",
-        settings.transpilation_plugins,
-        "DialectRegistry",
-        DialectRegistry._registry,
-    )
     if dialect:
         if plugin_class := DialectRegistry.get_plugin(  # pragma: no cover
             dialect.name.lower(),
         ):
-            print("plugin_class", plugin_class)
             plugin = plugin_class()
             return plugin.transpile_sql(
                 sql,

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -769,7 +769,7 @@ async def test_find_metric(
                         {
                             "aggregation": "SUM",
                             "expression": "na.total_amount_nationwide",
-                            "name": "na.total_amount_nationwide_sum_fed946fe",
+                            "name": "na_DOT_total_amount_nationwide_sum_fed946fe",
                             "rule": {
                                 "type": "FULL",
                             },
@@ -778,14 +778,14 @@ async def test_find_metric(
                     "derivedQuery": "SELECT  (SUM(completed_repairs_sum_81105666) * 1.0 / "
                     "SUM(total_repairs_dispatched_sum_01dc2341)) * "
                     "(SUM(total_amount_in_region_sum_1c94ab45) * 1.0 / "
-                    "SUM(na.total_amount_nationwide_sum_fed946fe)) * 100 \n"
+                    "SUM(na_DOT_total_amount_nationwide_sum_fed946fe)) * 100 \n"
                     " FROM default.regional_level_agg CROSS JOIN "
                     "default.national_level_agg na\n"
                     "\n",
                     "derivedExpression": "(SUM(completed_repairs_sum_81105666) * 1.0 / "
                     "SUM(total_repairs_dispatched_sum_01dc2341)) * "
                     "(SUM(total_amount_in_region_sum_1c94ab45) * 1.0 / "
-                    "SUM(na.total_amount_nationwide_sum_fed946fe)) * 100",
+                    "SUM(na_DOT_total_amount_nationwide_sum_fed946fe)) * 100",
                 },
             },
             "name": "default.regional_repair_efficiency",


### PR DESCRIPTION
### Summary

This PR enables metrics to reference available dimensions in the metric's SQL definition. This enables flexibility to model the dimensions graph in the right way -- e.g., leveraging the dimension link structure to support optionally joining in dimensions as needed, rather than directly building it into a transform node. 

For example, it should be possible to write metric definitions like the following, assuming that `default.repair_orders_fact` is linked to `default.municipality_dim` in its dimensions graph:
```sql
SELECT
  COUNT(DISTINCT default.municipality_dim.contact_name)
FROM default.repair_orders_fact
```

The above setup means that you don't have to write the join between `default.repair_orders_fact` and `default.municipality_dim` directly into the query for `default.repair_orders_fact`. DJ will perform the join when the metric is requested, and will not do so when other metrics from this transform are requested.

### Test Plan

Tested locally and wrote a series of unit tests.

- [ ] PR has an associated issue:
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
