### PR TITLE
Fix SQL column metadata

### DIFF
--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -72,7 +72,7 @@ def rename_columns(
             and not (hasattr(expression, "alias") and expression.alias)  # type: ignore
         ):
             alias_name = expression.alias_or_name.identifier(False)  # type: ignore
-            if expression.alias_or_name.name in node_columns:  # type: ignore  # pragma: no cover
+            if expression.alias_or_name.name.lower() in node_columns:  # type: ignore  # pragma: no cover
                 alias_name = node.name + SEPARATOR + expression.alias_or_name.name  # type: ignore
             expression = expression.copy()
             expression.set_semantic_entity(alias_name)  # type: ignore


### PR DESCRIPTION
### Summary

When building SQL and then providing column metadata for the built SQL, there were cases where we weren't assigning the node name correctly to the semantic entity for a given column. 

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
