### PR TITLE
Add support for count_if in decomposing to measures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,4 +159,4 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -x test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,16 +150,14 @@ jobs:
       run:
         working-directory: ./datajunction-clients/java
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Official Gradle Wrapper Validation Action
-        uses: gradle/actions/wrapper-validation@v3
       - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           arguments: build -x test
           build-root-directory: ./datajunction-clients/java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,8 +156,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Build with Gradle
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          arguments: build -x test
-          build-root-directory: ./datajunction-clients/java
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -161,7 +161,7 @@ class MeasureExtractor:
                 ),
             )
         elif (
-            func.function() == dj_functions.Count
+            func.function() in (dj_functions.Count, dj_functions.CountIf)
             and func.quantifier != ast.SetQuantifier.Distinct
         ):
             func.name.name = "SUM"

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -88,27 +88,25 @@ class MeasureExtractor:
         Handles measures decomposition for a single-argument associative aggregation function.
         Examples: SUM, MAX, MIN, COUNT
         """
-        measures = []
-        for arg in func.args:
-            measure_name = "_".join(
-                [str(col) for col in arg.find_all(ast.Column)]
-                + [func.name.name.lower()],
-            )
-            expression = f"{func.quantifier} {arg}" if func.quantifier else str(arg)
-            short_hash = hashlib.md5(expression.encode("utf-8")).hexdigest()[:8]
-            measures.append(
-                Measure(
-                    name=f"{measure_name}_{short_hash}",
-                    expression=expression,
-                    aggregation=func.name.name.upper(),
-                    rule=AggregationRule(
-                        type=Aggregability.FULL
-                        if func.quantifier != ast.SetQuantifier.Distinct
-                        else Aggregability.LIMITED,
-                    ),
+        arg = func.args[0]
+        measure_name = "_".join(
+            [str(col) for col in arg.find_all(ast.Column)] + [func.name.name.lower()],
+        )
+        expression = f"{func.quantifier} {arg}" if func.quantifier else str(arg)
+        short_hash = hashlib.md5(expression.encode("utf-8")).hexdigest()[:8]
+
+        return [
+            Measure(
+                name=f"{measure_name}_{short_hash}",
+                expression=expression,
+                aggregation=func.name.name.upper(),
+                rule=AggregationRule(
+                    type=Aggregability.FULL
+                    if func.quantifier != ast.SetQuantifier.Distinct
+                    else Aggregability.LIMITED,
                 ),
-            )
-        return measures
+            ),
+        ]
 
     def _avg(self, func) -> list[Measure]:
         """

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1222,6 +1222,8 @@ class CountIf(Function):
     count_if(expr) - Returns the number of true values in expr.
     """
 
+    is_aggregation = True
+
 
 @CountIf.register  # type: ignore
 def infer_type(arg: ct.BooleanType) -> ct.IntegerType:
@@ -3244,6 +3246,8 @@ class MaxBy(Function):
     max_by(val, key) - Returns the value of val corresponding to the maximum value of key.
     """
 
+    is_aggregation = True
+
 
 @MaxBy.register  # type: ignore
 def infer_type(val: ct.ColumnType, key: ct.ColumnType) -> ct.ColumnType:
@@ -3333,6 +3337,8 @@ class MinBy(Function):
     """
     min_by(val, key) - Returns the value of val corresponding to the minimum value of key.
     """
+
+    is_aggregation = True
 
 
 @MinBy.register  # type: ignore

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -644,7 +644,7 @@ def test_count_if():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT CAST(COUNT_IF(field_a_count_if_c1f2ed10) AS FLOAT) / SUM(count_3389dae3) "
+            "SELECT  CAST(SUM(field_a_count_if_c1f2ed10) AS FLOAT) / SUM(count_3389dae3) "
             "FROM parent_node",
         ),
     )


### PR DESCRIPTION
### Summary

This adds support for decomposing the `COUNT_IF` aggregation function into measures.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
