### PR TITLE
Fix error with getting cube materialization

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -1560,6 +1560,7 @@ async def build_ast(
     (filters are only applied if they don't require dimension node joins).
     """
     context = CompileContext(session=session, exception=DJException())
+    await refresh_if_needed(session, node, ["query_ast"])
     cached_query_ast = node.query_ast
     if use_pickled and cached_query_ast:
         try:  # pragma: no cover


### PR DESCRIPTION
### Summary

Fixes this error when calling `GET /cubes/{cube}/materialization`:
```
greenlet_spawn has not been called; can't call await_only() here.
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
