### PR TITLE
Speed up metric edit UI load time

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -115,7 +115,7 @@ def load_node_revision_options(node_revision_fields):
         "cube_metrics" in node_revision_fields
         or "cube_dimensions" in node_revision_fields
     )
-    if "columns" in node_revision_fields or is_cube_request:
+    if "columns" in node_revision_fields or is_cube_request or "primary_key" in node_revision_fields:
         options.append(
             selectinload(DBNodeRevision.columns).options(
                 joinedload(Column.attributes).joinedload(

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -115,7 +115,11 @@ def load_node_revision_options(node_revision_fields):
         "cube_metrics" in node_revision_fields
         or "cube_dimensions" in node_revision_fields
     )
-    if "columns" in node_revision_fields or is_cube_request or "primary_key" in node_revision_fields:
+    if (
+        "columns" in node_revision_fields
+        or is_cube_request
+        or "primary_key" in node_revision_fields
+    ):
         options.append(
             selectinload(DBNodeRevision.columns).options(
                 joinedload(Column.attributes).joinedload(

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -138,7 +138,14 @@ class NodeRevision:
     table: Optional[str]
 
     # Only metrics will have these fields
-    required_dimensions: Optional[List[Column]] = None
+    required_dimensions: List[Column] | None = None
+
+    @strawberry.field
+    def primary_key(self, root: "DBNodeRevision") -> list[str]:
+        """
+        The primary key of the node
+        """
+        return [col.name for col in root.primary_key()]
 
     @strawberry.field
     def metric_metadata(self, root: "DBNodeRevision") -> MetricMetadata | None:

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -592,6 +592,7 @@ async def test_find_transform(
                         name
                     }
                 }
+                primaryKey
             }
         }
     }
@@ -617,6 +618,7 @@ async def test_find_transform(
                 ],
                 "extractedMeasures": None,
                 "metricMetadata": None,
+                "primaryKey": [],
             },
             "name": "default.repair_orders_fact",
             "type": "TRANSFORM",

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormFailed.test.jsx
@@ -67,7 +67,9 @@ describe('AddEditNodePage submission failed', () => {
 
   it('for editing a node', async () => {
     const mockDjClient = initializeMockDJClient();
-    mockDjClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    mockDjClient.DataJunctionAPI.getNodeForEditing.mockReturnValue(
+      mocks.mockGetMetricNode,
+    );
     mockDjClient.DataJunctionAPI.patchNode.mockReturnValue({
       status: 500,
       json: { message: 'Update failed' },

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -152,7 +152,9 @@ describe('AddEditNodePage submission succeeded', () => {
   it('for editing a transform or dimension node', async () => {
     const mockDjClient = initializeMockDJClient();
 
-    mockDjClient.DataJunctionAPI.node.mockReturnValue(mocks.mockTransformNode);
+    mockDjClient.DataJunctionAPI.getNodeForEditing.mockReturnValue(
+      mocks.mockGetTransformNode,
+    );
     mockDjClient.DataJunctionAPI.patchNode = jest.fn();
     mockDjClient.DataJunctionAPI.patchNode.mockReturnValue({
       status: 201,
@@ -189,9 +191,9 @@ describe('AddEditNodePage submission succeeded', () => {
         'SELECT repair_order_id, municipality_id, hard_hat_id, dispatcher_id FROM default.repair_orders',
         'published',
         [],
-        undefined,
-        undefined,
-        undefined,
+        '',
+        '',
+        '',
         undefined,
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
@@ -212,8 +214,9 @@ describe('AddEditNodePage submission succeeded', () => {
   it('for editing a metric node', async () => {
     const mockDjClient = initializeMockDJClient();
 
-    mockDjClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
-    mockDjClient.DataJunctionAPI.metric.mockReturnValue(mocks.mockMetricNode);
+    mockDjClient.DataJunctionAPI.getNodeForEditing.mockReturnValue(
+      mocks.mockGetMetricNode,
+    );
     mockDjClient.DataJunctionAPI.patchNode = jest.fn();
     mockDjClient.DataJunctionAPI.patchNode.mockReturnValue({
       status: 201,
@@ -249,10 +252,10 @@ describe('AddEditNodePage submission succeeded', () => {
         'Number of repair orders!!!',
         'SELECT count(repair_order_id) FROM default.repair_orders',
         'published',
-        [],
+        ['repair_order_id', 'country'],
         'neutral',
         'unitless',
-        4,
+        5,
         undefined,
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/index.test.jsx
@@ -35,6 +35,7 @@ export const initializeMockDJClient = () => {
         ];
       },
       metrics: {},
+      getNodeForEditing: jest.fn(),
       namespaces: () => {
         return [
           {
@@ -146,7 +147,9 @@ describe('AddEditNodePage', () => {
 
   it('Edit node page renders with the selected node', async () => {
     const mockDjClient = initializeMockDJClient();
-    mockDjClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    mockDjClient.DataJunctionAPI.getNodeForEditing.mockReturnValue(
+      mocks.mockGetMetricNode,
+    );
 
     const element = testElement(mockDjClient);
     renderEditNode(element);
@@ -175,17 +178,12 @@ describe('AddEditNodePage', () => {
 
   it('Verify edit page node not found', async () => {
     const mockDjClient = initializeMockDJClient();
-    mockDjClient.DataJunctionAPI.node = jest.fn();
-    mockDjClient.DataJunctionAPI.node.mockReturnValue({
-      message: 'A node with name `default.num_repair_orders` does not exist.',
-      errors: [],
-      warnings: [],
-    });
+    mockDjClient.DataJunctionAPI.getNodeForEditing.mockReturnValue(null);
     const element = testElement(mockDjClient);
     renderEditNode(element);
 
     await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.node).toBeCalledTimes(1);
+      expect(mockDjClient.DataJunctionAPI.getNodeForEditing).toBeCalledTimes(1);
       expect(
         screen.getByText('Node default.num_repair_orders does not exist!'),
       ).toBeInTheDocument();
@@ -194,18 +192,14 @@ describe('AddEditNodePage', () => {
 
   it('Verify only transforms, metrics, and dimensions can be edited', async () => {
     const mockDjClient = initializeMockDJClient();
-    mockDjClient.DataJunctionAPI.node = jest.fn();
-    mockDjClient.DataJunctionAPI.node.mockReturnValue({
-      namespace: 'default',
-      type: 'source',
-      name: 'default.repair_orders',
-      display_name: 'Default: Repair Orders',
-    });
+    mockDjClient.DataJunctionAPI.getNodeForEditing.mockReturnValue(
+      mocks.mockGetSourceNode,
+    );
     const element = testElement(mockDjClient);
     renderEditNode(element);
 
     await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.node).toBeCalledTimes(1);
+      expect(mockDjClient.DataJunctionAPI.getNodeForEditing).toBeCalledTimes(1);
       expect(
         screen.getByText(
           'Node default.num_repair_orders is of type source and cannot be edited',

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -189,6 +189,9 @@ export function AddEditNodePage({ extensions = {} }) {
 
   const getExistingNodeData = async name => {
     const node = await djClient.getNodeForEditing(name);
+    if (node === null) {
+      return { message: `Node ${name} does not exist` };
+    }
     const baseData = {
       name: node.name,
       type: node.type.toLowerCase(),
@@ -223,7 +226,7 @@ export function AddEditNodePage({ extensions = {} }) {
       setMessage(`Node ${name} does not exist!`);
       return;
     }
-
+    console.log('data!!', data);
     // Check if node type can be edited
     if (!nodeCanBeEdited(data.type)) {
       setNode(null);

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -226,7 +226,6 @@ export function AddEditNodePage({ extensions = {} }) {
       setMessage(`Node ${name} does not exist!`);
       return;
     }
-    console.log('data!!', data);
     // Check if node type can be edited
     if (!nodeCanBeEdited(data.type)) {
       setNode(null);

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -188,26 +188,32 @@ export function AddEditNodePage({ extensions = {} }) {
   };
 
   const getExistingNodeData = async name => {
-    const data = await djClient.node(name);
-    if (data.type === 'metric') {
-      const metric = await djClient.metric(name);
-      data.upstream_node = metric.upstream_node;
-      data.expression = metric.expression;
-      data.required_dimensions = metric.required_dimensions;
-    }
-    return data;
-  };
+    const node = await djClient.getNodeForEditing(name);
+    const baseData = {
+      name: node.name,
+      type: node.type.toLowerCase(),
+      display_name: node.current.displayName,
+      description: node.current.description,
+      primary_key: node.current.primaryKey,
+      query: node.current.query,
+      tags: node.tags,
+      mode: node.current.mode.toLowerCase(),
+    };
 
-  const primaryKeyFromNode = node => {
-    return node.columns
-      .filter(
-        col =>
-          col.attributes &&
-          col.attributes.filter(
-            attr => attr.attribute_type.name === 'primary_key',
-          ).length > 0,
-      )
-      .map(col => col.name);
+    if (node.type === 'METRIC') {
+      return {
+        ...baseData,
+        metric_direction: node.current.metricMetadata?.direction?.toLowerCase(),
+        metric_unit: node.current.metricMetadata?.unit?.name?.toLowerCase(),
+        significant_digits: node.current.metricMetadata?.significantDigits,
+        required_dimensions: node.current.requiredDimensions.map(
+          dim => dim.name,
+        ),
+        upstream_node: node.current.parents[0]?.name,
+        aggregate_expression: node.current.metricMetadata?.expression,
+      };
+    }
+    return baseData;
   };
 
   const runValidityChecks = (data, setNode, setMessage) => {
@@ -246,14 +252,14 @@ export function AddEditNodePage({ extensions = {} }) {
       'primary_key',
       'mode',
       'tags',
-      'expression',
+      'aggregate_expression',
       'upstream_node',
+      'metric_unit',
+      'metric_direction',
+      'significant_digits',
     ];
-    const primaryKey = primaryKeyFromNode(data);
     fields.forEach(field => {
-      if (field === 'primary_key') {
-        setFieldValue(field, primaryKey);
-      } else if (field === 'tags') {
+      if (field === 'tags') {
         setFieldValue(
           field,
           data[field].map(tag => tag.name),
@@ -262,27 +268,6 @@ export function AddEditNodePage({ extensions = {} }) {
         setFieldValue(field, data[field] || '', false);
       }
     });
-    if (data.metric_metadata?.direction) {
-      setFieldValue('metric_direction', data.metric_metadata.direction);
-    }
-    if (data.metric_metadata?.unit) {
-      setFieldValue(
-        'metric_unit',
-        data.metric_metadata.unit.name.toLowerCase(),
-      );
-    }
-    if (data.metric_metadata?.significant_digits) {
-      setFieldValue(
-        'significant_digits',
-        data.metric_metadata.significant_digits,
-      );
-    }
-    if (data.expression) {
-      setFieldValue('aggregate_expression', data.expression);
-    }
-    if (data.upstream_node) {
-      setFieldValue('upstream_node', data.upstream_node);
-    }
     setNode(data);
 
     // For react-select fields, we have to explicitly set the entire
@@ -290,13 +275,13 @@ export function AddEditNodePage({ extensions = {} }) {
     setSelectTags(
       <TagsField
         defaultValue={data.tags.map(t => {
-          return { value: t.name, label: t.display_name };
+          return { value: t.name, label: t.displayName };
         })}
       />,
     );
     setSelectPrimaryKey(
       <ColumnsSelect
-        defaultValue={primaryKey}
+        defaultValue={data.primary_key}
         fieldName="primary_key"
         label="Primary Key"
         isMulti={true}
@@ -409,7 +394,11 @@ export function AddEditNodePage({ extensions = {} }) {
                         {nodeType === 'metric' || node.type === 'metric' ? (
                           <MetricQueryField
                             djClient={djClient}
-                            value={node.expression ? node.expression : ''}
+                            value={
+                              node.aggregate_expression
+                                ? node.aggregate_expression
+                                : ''
+                            }
                           />
                         ) : (
                           <NodeQueryField

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -181,7 +181,6 @@ export default function NodeInfoTab({ node }) {
                 : 'None'}
             </p>
           </div>
-          {console.log('node?.metric_metadata', node?.metric_metadata)}
           <div style={{ marginRight: '2rem' }}>
             <h6 className="mb-0 w-100">Significant Digits</h6>
             <p

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -128,6 +128,56 @@ export const DataJunctionAPI = {
     return data;
   },
 
+  getNodeForEditing: async function (name) {
+    const query = `
+      query GetNodeForEditing($name: String!) {
+        findNodes (names: [$name]) {
+          name
+          type
+          current {
+            displayName
+            description
+            primaryKey
+            query
+            parents { name }
+            metricMetadata {
+              direction
+              unit { name }
+              expression
+              significantDigits
+              incompatibleDruidFunctions
+            }
+            requiredDimensions {
+              name
+            }
+            mode
+          }
+          tags { 
+            name
+            displayName
+          }
+        }
+      }
+    `;
+
+    const results = await (
+      await fetch(DJ_GQL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          query,
+          variables: {
+            name: name,
+          },
+        }),
+      })
+    ).json();
+    return results.data.findNodes[0];
+  },
+
   getMetric: async function (name) {
     const query = `
       query GetMetric($name: String!) {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -175,6 +175,9 @@ export const DataJunctionAPI = {
         }),
       })
     ).json();
+    if (results.data.findNodes.length === 0) {
+      return null;
+    }
     return results.data.findNodes[0];
   },
 

--- a/datajunction-ui/src/mocks/mockNodes.jsx
+++ b/datajunction-ui/src/mocks/mockNodes.jsx
@@ -287,6 +287,73 @@ export const mocks = {
     aggregate_expression: 'count(repair_order_id)',
     required_dimensions: [],
   },
+
+  mockGetSourceNode: {
+    name: 'default.num_repair_orders',
+    type: 'SOURCE',
+    current: {
+      displayName: 'source.prodhive.dse.playback_f',
+      description:
+        'This source node was automatically created as a registered table.',
+      primaryKey: [],
+      parents: [],
+      metricMetadata: null,
+      requiredDimensions: [],
+      mode: 'PUBLISHED',
+    },
+    tags: [],
+  },
+
+  mockGetMetricNode: {
+    name: 'default.num_repair_orders',
+    type: 'METRIC',
+    current: {
+      displayName: 'Default: Num Repair Orders',
+      description: 'Number of repair orders',
+      primaryKey: ['repair_order_id', 'country'],
+      query:
+        'SELECT count(repair_order_id) default_DOT_num_repair_orders FROM default.repair_orders',
+      parents: [
+        {
+          name: 'default.repair_orders',
+        },
+      ],
+      metricMetadata: {
+        direction: 'NEUTRAL',
+        unit: {
+          name: 'UNITLESS',
+        },
+        expression: 'count(repair_order_id)',
+        significantDigits: 5,
+        incompatibleDruidFunctions: ['IF'],
+      },
+      requiredDimensions: [],
+      mode: 'PUBLISHED',
+    },
+    tags: [{ name: 'purpose', displayName: 'Purpose' }],
+  },
+
+  mockGetTransformNode: {
+    name: 'default.repair_order_transform',
+    type: 'TRANSFORM',
+    current: {
+      displayName: 'Default: Repair Order Transform',
+      description: 'Repair order dimension',
+      primaryKey: [],
+      query:
+        'SELECT repair_order_id, municipality_id, hard_hat_id, dispatcher_id FROM default.repair_orders',
+      parents: [
+        {
+          name: 'default.repair_orders',
+        },
+      ],
+      metricMetadata: null,
+      requiredDimensions: [],
+      mode: 'PUBLISHED',
+    },
+    tags: [],
+  },
+
   attributes: [
     {
       uniqueness_scope: [],


### PR DESCRIPTION
### Summary

This speeds up loading the metric edit UI by making a single GraphQL call to retrieve all the relevant form fields, rather than making multiple API calls, some of which retrieve expensive fields (like `/metrics`, which unnecessarily retrieves the entire dimensions graph for a metric).

### Test Plan

The speedup is quite significant -- going from ~3s before there is a meaningful UI load (i.e., data in the metric UI fields) to under 1s.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
