### PR TITLE
Allow filtering history to events subscribed to for notifications

### DIFF
--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -18,7 +18,7 @@ from datajunction_server.api.helpers import (
 from datajunction_server.api.sql import get_node_sql
 from datajunction_server.api.helpers import get_save_history
 from datajunction_server.database.availabilitystate import AvailabilityState
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
@@ -31,6 +31,7 @@ from datajunction_server.internal.access.authorization import (
     validate_access_requests,
 )
 from datajunction_server.internal.engines import get_engine
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.models import access
 from datajunction_server.models.node import AvailabilityStateBase
 from datajunction_server.models.node_type import NodeType

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -31,7 +31,7 @@ from datajunction_server.database.attributetype import AttributeType
 from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.column import Column
 from datajunction_server.database.engine import Engine
-from datajunction_server.database.history import EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import (
     MissingParent,
@@ -49,6 +49,7 @@ from datajunction_server.errors import (
     ErrorCode,
 )
 from datajunction_server.internal.engines import get_engine
+from datajunction_server.internal.history import EntityType
 from datajunction_server.models import access
 from datajunction_server.models.attribute import RESERVED_ATTRIBUTE_NAMESPACE
 from datajunction_server.models.history import status_change_history

--- a/datajunction-server/datajunction_server/api/history.py
+++ b/datajunction-server/datajunction_server/api/history.py
@@ -3,17 +3,26 @@ History related APIs.
 """
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import Depends, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+from sqlalchemy import and_, cast, func, String
 
 from datajunction_server.api.helpers import get_history
-from datajunction_server.database.history import EntityType, History
+from datajunction_server.database.history import History
+from datajunction_server.database.notification_preference import NotificationPreference
+from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.history import EntityType
 from datajunction_server.models.history import HistoryOutput
-from datajunction_server.utils import get_session, get_settings
+from datajunction_server.utils import (
+    get_and_update_current_user,
+    get_session,
+    get_settings,
+)
 
 _logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -44,26 +53,37 @@ async def list_history(
 
 @router.get("/history/", response_model=List[HistoryOutput])
 async def list_history_by_node_context(
-    node: str,
+    node: Optional[str] = None,
+    only_subscribed: bool = False,
     offset: int = 0,
     limit: int = Query(default=100, lte=100),
     *,
     session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_and_update_current_user),
 ) -> List[HistoryOutput]:
     """
     List all activity history for a node context
     """
-    hist = (
-        (
-            await session.execute(
-                select(History)
-                .where(History.node == node)
-                .order_by(History.created_at.desc())
-                .offset(offset)
-                .limit(limit),
-            )
+    statement = select(History)
+    if node:
+        statement = statement.where(History.node == node)
+    if only_subscribed:
+        np_alias = aliased(NotificationPreference)
+        statement = statement.join(
+            np_alias,
+            and_(
+                cast(History.entity_type, String) == cast(np_alias.entity_type, String),
+                History.entity_name == np_alias.entity_name,
+                cast(History.activity_type, String).in_(
+                    func.array_to_string(np_alias.activity_types, ","),
+                ),
+                np_alias.user_id == current_user.id,
+            ),
         )
-        .scalars()
-        .all()
+
+    statement = (
+        statement.order_by(History.created_at.desc()).offset(offset).limit(limit)
     )
+    result = await session.execute(statement)
+    hist = result.scalars().all()
     return [HistoryOutput.from_orm(entry) for entry in hist]

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -16,11 +16,12 @@ from datajunction_server.api.helpers import get_save_history
 from datajunction_server.database import Node, NodeRevision
 from datajunction_server.database.backfill import Backfill
 from datajunction_server.database.column import Column, ColumnAttribute
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJDoesNotExistException, DJInvalidInputException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import validate_access
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.materializations import (
     create_new_materialization,
     schedule_materialization_jobs,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -29,7 +29,7 @@ from datajunction_server.api.tags import get_tags_by_name
 from datajunction_server.database import DimensionLink
 from datajunction_server.database.attributetype import ColumnAttribute
 from datajunction_server.database.column import Column
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.partition import Partition
 from datajunction_server.database.user import User
@@ -46,6 +46,7 @@ from datajunction_server.internal.access.authorization import (
     validate_access,
     validate_access_requests,
 )
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.nodes import (
     activate_node,
     copy_to_new_node,

--- a/datajunction-server/datajunction_server/api/notifications.py
+++ b/datajunction-server/datajunction_server/api/notifications.py
@@ -10,11 +10,12 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from datajunction_server.database.history import ActivityType, EntityType, History
 from datajunction_server.database.notification_preference import NotificationPreference
 from datajunction_server.database.user import User
+from datajunction_server.database.history import History
 from datajunction_server.errors import DJDoesNotExistException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.notifications import (
     get_entity_notification_preferences,
     get_user_notification_preferences,

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -11,11 +11,12 @@ from sqlalchemy.orm import joinedload
 
 from datajunction_server.api.helpers import get_save_history
 from datajunction_server.database import Node
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJAlreadyExistsException, DJDoesNotExistException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.tag import CreateTag, TagOutput, UpdateTag

--- a/datajunction-server/datajunction_server/api/users.py
+++ b/datajunction-server/datajunction_server/api/users.py
@@ -10,10 +10,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.database.column import Column
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.user import UserActivity
 from datajunction_server.utils import get_session, get_settings

--- a/datajunction-server/datajunction_server/database/history.py
+++ b/datajunction-server/datajunction_server/database/history.py
@@ -4,48 +4,20 @@ from datetime import datetime, timezone
 from functools import partial
 from typing import Any, Dict, Optional
 
-from sqlalchemy import JSON, BigInteger, DateTime, Enum, Index, Integer, String
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    DateTime,
+    Enum,
+    Index,
+    Integer,
+    String,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from datajunction_server.database.base import Base
-from datajunction_server.enum import StrEnum
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.typing import UTCDatetime
-
-
-class ActivityType(StrEnum):
-    """
-    An activity type
-    """
-
-    CREATE = "create"
-    DELETE = "delete"
-    RESTORE = "restore"
-    UPDATE = "update"
-    REFRESH = "refresh"
-    TAG = "tag"
-    SET_ATTRIBUTE = "set_attribute"
-    STATUS_CHANGE = "status_change"
-
-
-class EntityType(StrEnum):
-    """
-    An entity type for which activity can occur
-    """
-
-    ATTRIBUTE = "attribute"
-    AVAILABILITY = "availability"
-    BACKFILL = "backfill"
-    CATALOG = "catalog"
-    COLUMN_ATTRIBUTE = "column_attribute"
-    DEPENDENCY = "dependency"
-    ENGINE = "engine"
-    LINK = "link"
-    MATERIALIZATION = "materialization"
-    NAMESPACE = "namespace"
-    NODE = "node"
-    PARTITION = "partition"
-    QUERY = "query"
-    TAG = "tag"
 
 
 class History(Base):

--- a/datajunction-server/datajunction_server/database/notification_preference.py
+++ b/datajunction-server/datajunction_server/database/notification_preference.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
-from datajunction_server.database.history import ActivityType, EntityType
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.database.user import User
 from datajunction_server.typing import UTCDatetime
 

--- a/datajunction-server/datajunction_server/internal/history.py
+++ b/datajunction-server/datajunction_server/internal/history.py
@@ -1,0 +1,39 @@
+"""Enums for history events"""
+
+from datajunction_server.enum import StrEnum
+
+
+class ActivityType(StrEnum):
+    """
+    An activity type
+    """
+
+    CREATE = "create"
+    DELETE = "delete"
+    RESTORE = "restore"
+    UPDATE = "update"
+    REFRESH = "refresh"
+    TAG = "tag"
+    SET_ATTRIBUTE = "set_attribute"
+    STATUS_CHANGE = "status_change"
+
+
+class EntityType(StrEnum):
+    """
+    An entity type for which activity can occur
+    """
+
+    ATTRIBUTE = "attribute"
+    AVAILABILITY = "availability"
+    BACKFILL = "backfill"
+    CATALOG = "catalog"
+    COLUMN_ATTRIBUTE = "column_attribute"
+    DEPENDENCY = "dependency"
+    ENGINE = "engine"
+    LINK = "link"
+    MATERIALIZATION = "materialization"
+    NAMESPACE = "namespace"
+    NODE = "node"
+    PARTITION = "partition"
+    QUERY = "query"
+    TAG = "tag"

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from datajunction_server.api.helpers import get_node_namespace
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import Column, Node, NodeRevision
 from datajunction_server.database.user import User
@@ -21,6 +21,7 @@ from datajunction_server.errors import (
     DJDoesNotExistException,
     DJInvalidInputException,
 )
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.nodes import (
     get_cube_revision_metadata,
     hard_delete_node,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -24,7 +24,7 @@ from datajunction_server.construction.build_v2 import compile_node_ast
 from datajunction_server.database.attributetype import AttributeType, ColumnAttribute
 from datajunction_server.database.column import Column
 from datajunction_server.database.dimensionlink import DimensionLink
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.metricmetadata import MetricMetadata
 from datajunction_server.database.node import MissingParent, Node, NodeRevision
@@ -42,6 +42,7 @@ from datajunction_server.internal.materializations import (
     create_new_materialization,
     schedule_materialization_jobs,
 )
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.validation import NodeValidator, validate_node_data
 from datajunction_server.models import access
 from datajunction_server.models.attribute import (

--- a/datajunction-server/datajunction_server/internal/notifications.py
+++ b/datajunction-server/datajunction_server/internal/notifications.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from datajunction_server.database.notification_preference import NotificationPreference
-from datajunction_server.database.history import EntityType
+from datajunction_server.internal.history import EntityType
 
 
 async def get_user_notification_preferences(

--- a/datajunction-server/datajunction_server/models/history.py
+++ b/datajunction-server/datajunction_server/models/history.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from pydantic.main import BaseModel
 
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
+from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.typing import UTCDatetime
 
 if TYPE_CHECKING:

--- a/datajunction-server/datajunction_server/models/notifications.py
+++ b/datajunction-server/datajunction_server/models/notifications.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from pydantic.main import BaseModel
 
-from datajunction_server.database.history import ActivityType, EntityType
+from datajunction_server.internal.history import ActivityType, EntityType
 
 
 class NotificationPreferenceModel(BaseModel):

--- a/datajunction-server/tests/api/notifications_test.py
+++ b/datajunction-server/tests/api/notifications_test.py
@@ -7,7 +7,8 @@ import pytest
 from httpx import AsyncClient
 
 from datajunction_server.api.notifications import get_notifier
-from datajunction_server.database.history import ActivityType, EntityType, History
+from datajunction_server.database.history import History
+from datajunction_server.internal.history import ActivityType, EntityType
 
 
 class TestNotification(unittest.TestCase):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     networks:
       - core
     environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=datajunction.server
       - DOTENV_FILE=${DOTENV_FILE:-/code/.env}
       - OAUTHLIB_INSECURE_TRANSPORT=1
     build:
@@ -204,19 +202,6 @@ services:
       fi && \
       start-notebook.sh --NotebookApp.token='' --NotebookApp.password=''
       "
-
-  jaeger:
-    container_name: jaeger
-    profiles: ["demo"]
-    image: jaegertracing/all-in-one:latest
-    ports:
-      - "16686:16686"
-      - "14268:14268"
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-      - LOG_LEVEL=debug
-    networks:
-      - core
 
   dj-trino:
     container_name: dj-trino


### PR DESCRIPTION
### Summary

This adds some logic to the `/history/` endpoint to allow filtering the history to only the events the user has subscribed to notifications on. Credit to @CircArgs for giving me this idea. The plan is this will be able to support a "Watch List" sort of history view where users can control which events show up in this filtered view in addition to which events they want to be notified about.

### Test Plan

Added a test using this flag.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
