### PR TITLE
Add additional details to cube history

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -860,12 +860,12 @@ async def update_cube_node(
                 "version": new_cube_revision.version,  # type: ignore
             },
             pre={
-                "metrics": node_revision.cube_metrics(),
-                "dimensions": node_revision.cube_dimensions(),
+                "metrics": old_metrics,
+                "dimensions": old_dimensions,
             },
             post={
-                "metrics": new_cube_revision.cube_metrics(),
-                "dimensions": new_cube_revision.cube_dimensions(),
+                "metrics": new_cube_revision.cube_node_metrics,
+                "dimensions": new_cube_revision.cube_node_dimensions,
             },
             user=current_user.username,
         ),

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -851,7 +851,24 @@ async def update_cube_node(
     new_cube_revision.node.current_version = new_cube_revision.version  # type: ignore
 
     await save_history(
-        event=node_update_history_event(new_cube_revision, current_user),
+        event=History(
+            entity_type=EntityType.NODE,
+            entity_name=new_cube_revision.name,
+            node=new_cube_revision.name,
+            activity_type=ActivityType.UPDATE,
+            details={
+                "version": new_cube_revision.version,  # type: ignore
+            },
+            pre={
+                "metrics": node_revision.cube_metrics(),
+                "dimensions": node_revision.cube_dimensions(),
+            },
+            post={
+                "metrics": new_cube_revision.cube_metrics(),
+                "dimensions": new_cube_revision.cube_dimensions(),
+            },
+            user=current_user.username,
+        ),
         session=session,
     )
 
@@ -1322,7 +1339,7 @@ async def create_new_revision_from_existing(
         if catalogs:
             new_revision.catalog_id = catalogs[0]
         new_revision.columns = node_validator.columns or []
-        if new_revision.type == NodeType.METRIC:
+        if new_revision.type == NodeType.METRIC and new_revision.columns:
             new_revision.columns[0].display_name = new_revision.display_name
 
         # Update the primary key if one was set in the input

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1590,8 +1590,34 @@ async def test_updating_cube(
             "entity_type": "node",
             "id": mock.ANY,
             "node": "default.repairs_cube_6",
-            "post": {},
-            "pre": {},
+            "post": {
+                "dimensions": [
+                    "default.hard_hat.city",
+                    "default.hard_hat.hire_date",
+                ],
+                "metrics": [
+                    "default.discounted_orders_rate",
+                ],
+            },
+            "pre": {
+                "dimensions": [
+                    "default.hard_hat.country",
+                    "default.hard_hat.postal_code",
+                    "default.hard_hat.city",
+                    "default.hard_hat.hire_date",
+                    "default.hard_hat.state",
+                    "default.dispatcher.company_name",
+                    "default.municipality_dim.local_region",
+                ],
+                "metrics": [
+                    "default.discounted_orders_rate",
+                    "default.num_repair_orders",
+                    "default.avg_repair_price",
+                    "default.total_repair_cost",
+                    "default.total_repair_order_discounts",
+                    "default.double_total_repair_cost",
+                ],
+            },
             "user": mock.ANY,
         },
         {
@@ -1602,8 +1628,44 @@ async def test_updating_cube(
             "entity_type": "node",
             "id": mock.ANY,
             "node": "default.repairs_cube_6",
-            "post": {},
-            "pre": {},
+            "post": {
+                "dimensions": [
+                    "default.hard_hat.country",
+                    "default.hard_hat.postal_code",
+                    "default.hard_hat.city",
+                    "default.hard_hat.hire_date",
+                    "default.hard_hat.state",
+                    "default.dispatcher.company_name",
+                    "default.municipality_dim.local_region",
+                ],
+                "metrics": [
+                    "default.discounted_orders_rate",
+                    "default.num_repair_orders",
+                    "default.avg_repair_price",
+                    "default.total_repair_cost",
+                    "default.total_repair_order_discounts",
+                    "default.double_total_repair_cost",
+                ],
+            },
+            "pre": {
+                "dimensions": [
+                    "default.hard_hat.country",
+                    "default.hard_hat.postal_code",
+                    "default.hard_hat.city",
+                    "default.hard_hat.hire_date",
+                    "default.hard_hat.state",
+                    "default.dispatcher.company_name",
+                    "default.municipality_dim.local_region",
+                ],
+                "metrics": [
+                    "default.discounted_orders_rate",
+                    "default.num_repair_orders",
+                    "default.avg_repair_price",
+                    "default.total_repair_cost",
+                    "default.total_repair_order_discounts",
+                    "default.double_total_repair_cost",
+                ],
+            },
             "user": mock.ANY,
         },
     ]
@@ -1850,8 +1912,34 @@ async def test_updating_cube_with_existing_materialization(
             "entity_type": "node",
             "id": mock.ANY,
             "node": "default.repairs_cube_2",
-            "post": {},
-            "pre": {},
+            "post": {
+                "dimensions": [
+                    "default.hard_hat.city",
+                    "default.hard_hat.hire_date",
+                ],
+                "metrics": [
+                    "default.discounted_orders_rate",
+                ],
+            },
+            "pre": {
+                "dimensions": [
+                    "default.hard_hat.country",
+                    "default.hard_hat.postal_code",
+                    "default.hard_hat.city",
+                    "default.hard_hat.hire_date",
+                    "default.hard_hat.state",
+                    "default.dispatcher.company_name",
+                    "default.municipality_dim.local_region",
+                ],
+                "metrics": [
+                    "default.discounted_orders_rate",
+                    "default.num_repair_orders",
+                    "default.avg_repair_price",
+                    "default.total_repair_cost",
+                    "default.total_repair_order_discounts",
+                    "default.double_total_repair_cost",
+                ],
+            },
             "user": "dj",
         },
         {


### PR DESCRIPTION
### Summary

This can be useful as a debugging log -- i.e., if there are issues with maintaining the right node revisions, we can store some basic information on cubes into the `pre` and `post` objects.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
