### PR TITLE
Fix bug when editing cube node with materialization

### DIFF
--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -173,12 +173,18 @@ async def build_cube_materialization_config(
                     if col.semantic_type == SemanticType.DIMENSION
                 ],
                 measures=metrics_expressions,
-                spark=upsert_input.config.spark,
+                spark=upsert_input.config.spark.__root__
+                if hasattr(upsert_input, "config") and upsert_input.config.spark
+                else {},
                 upstream_tables=measures_query.upstream_tables,
                 columns=measures_query.columns,
+                lookback_window=upsert_input.lookback_window
+                if hasattr(upsert_input, "lookback_window")
+                else "",
             )
         return generic_config
     except (KeyError, ValidationError, AttributeError) as exc:  # pragma: no cover
+        print("exc!!!!", exc)
         raise DJInvalidInputException(  # pragma: no cover
             message=(
                 "No change has been made to the materialization config for "

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -184,7 +184,6 @@ async def build_cube_materialization_config(
             )
         return generic_config
     except (KeyError, ValidationError, AttributeError) as exc:  # pragma: no cover
-        print("exc!!!!", exc)
         raise DJInvalidInputException(  # pragma: no cover
             message=(
                 "No change has been made to the materialization config for "

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -878,7 +878,7 @@ async def update_cube_node(
                 await create_new_materialization(
                     session,
                     new_cube_revision,
-                    UpsertMaterialization(
+                    UpsertCubeMaterialization(
                         **MaterializationConfigOutput.from_orm(old).dict(
                             exclude={"job"},
                         ),


### PR DESCRIPTION
### Summary

When editing a cube node with materialization configured, it will try to update the materialization based on the new cube state. However, this errors out due to using the wrong pydantic model (`UpsertMaterialization` rather than `UpsertCubeMaterialization`) to hydrate the old parameters.

### Test Plan

Ran this locally

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A