### PR TITLE
Support DISTINCT decomposition + pre-aggregation

### DIFF
--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -104,6 +104,11 @@ class MeasureExtractor:
                     type=Aggregability.FULL
                     if func.quantifier != ast.SetQuantifier.Distinct
                     else Aggregability.LIMITED,
+                    level=(
+                        [arg.identifier() for arg in func.args]
+                        if func.quantifier == ast.SetQuantifier.Distinct
+                        else None
+                    ),
                 ),
             ),
         ]
@@ -126,6 +131,11 @@ class MeasureExtractor:
                     type=Aggregability.FULL
                     if func.quantifier != ast.SetQuantifier.Distinct
                     else Aggregability.LIMITED,
+                    level=(
+                        [arg.identifier() for arg in func.args]
+                        if func.quantifier == ast.SetQuantifier.Distinct
+                        else None
+                    ),
                 ),
             ),
             Measure(
@@ -136,6 +146,11 @@ class MeasureExtractor:
                     type=Aggregability.FULL
                     if func.quantifier != ast.SetQuantifier.Distinct
                     else Aggregability.LIMITED,
+                    level=(
+                        [arg.identifier() for arg in func.args]
+                        if func.quantifier == ast.SetQuantifier.Distinct
+                        else None
+                    ),
                 ),
             ),
         ]

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -469,7 +469,10 @@ def test_count_distinct_rate():
             name="user_id_count_5deb6d4f",
             expression="DISTINCT user_id",
             aggregation="COUNT",
-            rule=AggregationRule(type=Aggregability.LIMITED),
+            rule=AggregationRule(
+                type=Aggregability.LIMITED,
+                level=["user_id"],
+            ),
         ),
         Measure(
             name="action_count_418c5509",
@@ -542,7 +545,10 @@ def test_multiple_aggregations_with_conditions():
             name="region_account_id_count_04a6925b",
             expression="DISTINCT IF(region = 'US', account_id, NULL)",
             aggregation="COUNT",
-            rule=AggregationRule(type=Aggregability.LIMITED),
+            rule=AggregationRule(
+                type=Aggregability.LIMITED,
+                level=["IF(region = 'US', account_id, NULL)"],
+            ),
         ),
     ]
     assert measures == expected_measures


### PR DESCRIPTION
### Summary

This supports decomposing metrics that have `DISTINCT` aggregations into measures, and makes sure that the required levels for these measures are added to the generated preaggregated SQL's `GROUP BY` clause.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
