### PR TITLE
Execute database statements with retry logic

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -56,7 +56,7 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionType
 from datajunction_server.naming import amenable_name
 from datajunction_server.typing import UTCDatetime
-from datajunction_server.utils import SEPARATOR
+from datajunction_server.utils import SEPARATOR, execute_with_retry
 
 if TYPE_CHECKING:
     from datajunction_server.database.dimensionlink import DimensionLink
@@ -487,7 +487,7 @@ class Node(Base):
 
         limit = limit if limit and limit > 0 else 100
         statement = statement.limit(limit)
-        result = await session.execute(statement.options(*(options or [])))
+        result = await execute_with_retry(session, statement.options(*(options or [])))
         nodes = result.unique().scalars().all()
 
         # Reverse for backward pagination

--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -255,6 +255,15 @@ class DJNotImplementedException(DJException):
     http_status_code: int = 500
 
 
+class DJDatabaseException(DJException):
+    """
+    Exception raised when the database returns an error.
+    """
+
+    dbapi_exception: DBAPIExceptions = "DatabaseError"
+    http_status_code: int = 500
+
+
 class DJInternalErrorException(DJException):
     """
     Exception raised when we do something wrong in the code.

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -200,8 +200,7 @@ async def execute_with_retry(
     attempt = 0
     while True:
         try:
-            result = await session.execute(statement)
-            return result.unique().scalars().all()
+            return await session.execute(statement)
         except OperationalError as exc:
             attempt += 1
             if attempt > retries:

--- a/datajunction-server/tests/utils_test.py
+++ b/datajunction-server/tests/utils_test.py
@@ -195,7 +195,8 @@ async def test_execute_with_retry_success_after_flaky_connection():
     ]
 
     result = await execute_with_retry(session, statement, retries=5, base_delay=0.01)
-    assert result == ["node1", "node2"]
+    values = result.unique().scalars().all()
+    assert values == ["node1", "node2"]
     assert session.execute.call_count == 3
 
 

--- a/datajunction-server/tests/utils_test.py
+++ b/datajunction-server/tests/utils_test.py
@@ -3,11 +3,12 @@ Tests for ``datajunction_server.utils``.
 """
 
 import logging
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.background import BackgroundTasks
 from testcontainers.postgres import PostgresContainer
@@ -15,9 +16,10 @@ from yarl import URL
 
 from datajunction_server.config import Settings
 from datajunction_server.database.user import OAuthProvider, User
-from datajunction_server.errors import DJException
+from datajunction_server.errors import DJDatabaseException, DJException
 from datajunction_server.utils import (
     Version,
+    execute_with_retry,
     get_and_update_current_user,
     get_engine,
     get_issue_url,
@@ -170,3 +172,45 @@ async def test_get_and_update_current_user(session: AsyncSession):
     assert found_user.name == "djuser"
     assert found_user.email == "userfoo@datajunction.io"
     assert found_user.oauth_provider == "basic"
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_success_after_flaky_connection():
+    """
+    Test that execute_with_retry succeeds after a flaky connection.
+    """
+    session = AsyncMock(spec=AsyncSession)
+    statement = MagicMock()
+
+    # Simulate flaky DB: first 2 calls raise OperationalError, 3rd returns success
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalars.return_value.all.return_value = [
+        "node1",
+        "node2",
+    ]
+    session.execute.side_effect = [
+        OperationalError("flaky", None, None),
+        OperationalError("still flaky", None, None),
+        mock_result,
+    ]
+
+    result = await execute_with_retry(session, statement, retries=5, base_delay=0.01)
+    assert result == ["node1", "node2"]
+    assert session.execute.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_exhausts_retries():
+    """
+    Test that execute_with_retry exhausts retries and fails.
+    """
+    session = AsyncMock(spec=AsyncSession)
+    statement = MagicMock()
+
+    # Always fail
+    session.execute.side_effect = OperationalError("permanent fail", None, None)
+
+    with pytest.raises(DJDatabaseException):
+        await execute_with_retry(session, statement, retries=3, base_delay=0.01)
+
+    assert session.execute.call_count == 4  # initial try + 3 retries


### PR DESCRIPTION
### Summary

Add support to execute SQLAlchemy statements with retry logic for transient errors. In some cases, the database returns `OperationalError`, which can range from network issues to issues with the database itself. We can retry (with exponential backoff) in these cases, in case the error was transient.

### Test Plan

Locally + added unit tests

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
