### PR TITLE
Support Viewing+Editing Multiple Dimension Links

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
@@ -37,12 +37,12 @@ export default function LinkDimensionPopover({
     const oldSet = new Set(dimensionNodes);
     const newSet = new Set(updatedDimensionNodes);
     try {
-      const linkPromises = Array.from(newSet.difference(oldSet)).map(
+      const linkPromises = Array.from(newSet).filter(item => !oldSet.has(item)).map(
         dimension => {
           return linkDimension(node, column, dimension, setStatus);
         },
       );
-      const unlinkPromises = Array.from(oldSet.difference(newSet)).map(
+      const unlinkPromises = Array.from(oldSet).filter(item => !newSet.has(item)).map(
         dimension => {
           return unlinkDimension(node, column, dimension, setStatus);
         },

--- a/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
@@ -128,7 +128,7 @@ export default function LinkDimensionPopover({
                               label: dimNode,
                             };
                           })
-                        : ''
+                        : []
                     }
                     isMulti={true}
                   />

--- a/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
@@ -37,16 +37,16 @@ export default function LinkDimensionPopover({
     const oldSet = new Set(dimensionNodes);
     const newSet = new Set(updatedDimensionNodes);
     try {
-      const linkPromises = Array.from(newSet).filter(item => !oldSet.has(item)).map(
-        dimension => {
+      const linkPromises = Array.from(newSet)
+        .filter(item => !oldSet.has(item))
+        .map(dimension => {
           return linkDimension(node, column, dimension, setStatus);
-        },
-      );
-      const unlinkPromises = Array.from(oldSet).filter(item => !newSet.has(item)).map(
-        dimension => {
+        });
+      const unlinkPromises = Array.from(oldSet)
+        .filter(item => !newSet.has(item))
+        .map(dimension => {
           return unlinkDimension(node, column, dimension, setStatus);
-        },
-      );
+        });
       await Promise.all([...linkPromises, ...unlinkPromises]);
     } catch (error) {
       console.error('Error in editing linked dimensions:', error);

--- a/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/LinkDimensionPopover.jsx
@@ -30,31 +30,23 @@ export default function LinkDimensionPopover({
     };
   }, [setPopoverAnchor]);
 
-  const configureMaterialization = async (
-    values,
-    { setSubmitting, setStatus },
-  ) => {
-    await materialize(values, setStatus).then(_ => {
-      window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-      setSubmitting(false);
-    });
-  };
-
   const handleSubmit = async (
     { node, column, updatedDimensionNodes },
     { setSubmitting, setStatus },
   ) => {
     const oldSet = new Set(dimensionNodes);
     const newSet = new Set(updatedDimensionNodes);
-    const toLink = Array.from(newSet.difference(oldSet));
-    const toUnlink = Array.from(oldSet.difference(newSet));
     try {
-      const linkPromises = toLink.map(dimension => {
-        return linkDimension(node, column, dimension, setStatus);
-      });
-      const unlinkPromises = toUnlink.map(dimension => {
-        return unlinkDimension(node, column, dimension, setStatus);
-      });
+      const linkPromises = Array.from(newSet.difference(oldSet)).map(
+        dimension => {
+          return linkDimension(node, column, dimension, setStatus);
+        },
+      );
+      const unlinkPromises = Array.from(oldSet.difference(newSet)).map(
+        dimension => {
+          return unlinkDimension(node, column, dimension, setStatus);
+        },
+      );
       await Promise.all([...linkPromises, ...unlinkPromises]);
     } catch (error) {
       console.error('Error in editing linked dimensions:', error);

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -147,15 +147,17 @@ export default function NodeColumnTab({ node, djClient }) {
           </td>
           {node.type !== 'cube' ? (
             <td>
-              {dimensionLinks.length > 0 ? (
-                dimensionLinks.map(link => (
-                  <span className='rounded-pill badge bg-secondary-soft' style={{fontSize: '14px'}} key={link[0]}>
-                    <a href={`/nodes/${link[0]}`}>{link[0]}</a>
-                  </span>
-                )
-              )) : (
-                ''
-              )}
+              {dimensionLinks.length > 0
+                ? dimensionLinks.map(link => (
+                    <span
+                      className="rounded-pill badge bg-secondary-soft"
+                      style={{ fontSize: '14px' }}
+                      key={link[0]}
+                    >
+                      <a href={`/nodes/${link[0]}`}>{link[0]}</a>
+                    </span>
+                  ))
+                : ''}
               <LinkDimensionPopover
                 column={col}
                 referencedDimensionNode={referencedDimensionNode}

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -92,6 +92,7 @@ export default function NodeColumnTab({ node, djClient }) {
           ),
         ])
         .filter(keys => keys[1].length >= 1);
+      console.log('dimensionLinks, dimensionLinks', dimensionLinks);
       const referencedDimensionNode =
         dimensionLinks.length > 0 ? dimensionLinks[0][0] : null;
       return (
@@ -146,11 +147,13 @@ export default function NodeColumnTab({ node, djClient }) {
           </td>
           {node.type !== 'cube' ? (
             <td>
-              {referencedDimensionNode !== null ? (
-                <a href={`/nodes/${referencedDimensionNode}`}>
-                  {referencedDimensionNode}
-                </a>
-              ) : (
+              {dimensionLinks.length > 0 ? (
+                dimensionLinks.map(link => (
+                  <span className='rounded-pill badge bg-secondary-soft' style={{fontSize: '14px'}} key={link[0]}>
+                    <a href={`/nodes/${link[0]}`}>{link[0]}</a>
+                  </span>
+                )
+              )) : (
                 ''
               )}
               <LinkDimensionPopover

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -7,6 +7,7 @@ import { labelize } from '../../../utils/form';
 import PartitionColumnPopover from './PartitionColumnPopover';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import { link } from 'fs';
 
 export default function NodeColumnTab({ node, djClient }) {
   const [attributes, setAttributes] = useState([]);
@@ -159,7 +160,7 @@ export default function NodeColumnTab({ node, djClient }) {
                 : ''}
               <LinkDimensionPopover
                 column={col}
-                referencedDimensionNode={referencedDimensionNode}
+                dimensionNodes={dimensionLinks.map(link => link[0])}
                 node={node}
                 options={dimensions}
                 onSubmit={async () => {

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -92,7 +92,6 @@ export default function NodeColumnTab({ node, djClient }) {
           ),
         ])
         .filter(keys => keys[1].length >= 1);
-      console.log('dimensionLinks, dimensionLinks', dimensionLinks);
       const referencedDimensionNode =
         dimensionLinks.length > 0 ? dimensionLinks[0][0] : null;
       return (

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/LinkDimensionPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/LinkDimensionPopover.test.jsx
@@ -19,7 +19,6 @@ describe('<LinkDimensionPopover />', () => {
     };
     const node = { name: 'default.node1' };
     const options = [
-      { value: 'Remove', label: '[Remove dimension link]' },
       { value: 'default.dimension1', label: 'Dimension 1' },
       { value: 'default.dimension2', label: 'Dimension 2' },
     ];
@@ -42,7 +41,7 @@ describe('<LinkDimensionPopover />', () => {
       <DJClientContext.Provider value={mockDjClient}>
         <LinkDimensionPopover
           column={column}
-          referencedDimensionNode={'default.dimension1'}
+          dimensionNodes={['default.dimension1']}
           node={node}
           options={options}
           onSubmit={onSubmitMock}
@@ -56,7 +55,7 @@ describe('<LinkDimensionPopover />', () => {
     // Click on a dimension and save
     const linkDimension = getByTestId('link-dimension');
     fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
-    fireEvent.click(screen.getByText('Dimension 1'));
+    fireEvent.click(screen.getByText('Dimension 2'));
     fireEvent.click(getByText('Save'));
 
     // Expect linkDimension to be called
@@ -64,14 +63,14 @@ describe('<LinkDimensionPopover />', () => {
       expect(mockDjClient.DataJunctionAPI.linkDimension).toHaveBeenCalledWith(
         'default.node1',
         'column1',
-        'default.dimension1',
+        'default.dimension2',
       );
       expect(getByText('Saved!')).toBeInTheDocument();
     });
 
     // Click on the 'Remove' option and save
-    fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
-    fireEvent.click(screen.getByText('[Remove dimension link]'));
+    const removeButton = screen.getByLabelText('Remove default.dimension1');
+    fireEvent.click(removeButton);
     fireEvent.click(getByText('Save'));
 
     // Expect unlinkDimension to be called
@@ -115,7 +114,7 @@ describe('<LinkDimensionPopover />', () => {
       <DJClientContext.Provider value={mockDjClient}>
         <LinkDimensionPopover
           column={column}
-          referencedDimensionNode={'default.dimension1'}
+          dimensionNodes={['default.dimension1']}
           node={node}
           options={options}
           onSubmit={onSubmitMock}
@@ -129,7 +128,7 @@ describe('<LinkDimensionPopover />', () => {
     // Click on a dimension and save
     const linkDimension = getByTestId('link-dimension');
     fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
-    fireEvent.click(screen.getByText('Dimension 1'));
+    fireEvent.click(screen.getByText('Dimension 2'));
     fireEvent.click(getByText('Save'));
 
     // Expect linkDimension to be called
@@ -137,7 +136,7 @@ describe('<LinkDimensionPopover />', () => {
       expect(mockDjClient.DataJunctionAPI.linkDimension).toHaveBeenCalledWith(
         'default.node1',
         'column1',
-        'default.dimension1',
+        'default.dimension2',
       );
       expect(
         getByText('Failed due to nonexistent dimension'),
@@ -145,8 +144,8 @@ describe('<LinkDimensionPopover />', () => {
     });
 
     // Click on the 'Remove' option and save
-    fireEvent.keyDown(linkDimension.firstChild, { key: 'ArrowDown' });
-    fireEvent.click(screen.getByText('[Remove Dimension]'));
+    const removeButton = screen.getByLabelText('Remove default.dimension1');
+    fireEvent.click(removeButton);
     fireEvent.click(getByText('Save'));
 
     // Expect unlinkDimension to be called


### PR DESCRIPTION
### Summary

This change supports the viewing or editing of multiple dimension links per column in the node columns tab.

**View**

In the node columns tab, if a column has a dimension link configured to more than one dimension node, these are all displayed, which reduces confusion:
<img width="872" alt="Screenshot 2025-04-27 at 12 03 47 PM" src="https://github.com/user-attachments/assets/f8b67c98-8575-409b-9eee-e9ae6734219d" />

**Edit**

It is now possible to add or remove more than one dimension link on a column. Note that all of these links will remain simple dimension links, e.g., they can only be done if the node has a single primary key that maps to that column. 

<img width="990" alt="Screenshot 2025-04-27 at 12 06 23 PM" src="https://github.com/user-attachments/assets/cd02c205-3d43-4d68-a19c-0162d1fedc39" />

**Loading**

This change also fixes a small bug (but point of confusion in the UX) where there should be a processing indicator when the dimension linking / unlinking is being processed by the backend. 

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1036
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
