### PR TITLE
Add plugin support for SQL transpilation

### DIFF
--- a/datajunction-clients/python/pyproject.toml
+++ b/datajunction-clients/python/pyproject.toml
@@ -61,6 +61,7 @@ test = [
     "greenlet>=3.0.3",
     "jinja2>=3.1.4",
     "nbformat>=5.10.4",
+    "sqlglot>=18.0.1",
 ]
 
 [project.urls]

--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -111,7 +111,14 @@ def module__settings(module_mocker: MockerFixture) -> Iterator[Settings]:
         redis_cache=None,
         query_service=None,
         secret="a-fake-secretkey",
+        transpilation_plugins=["default"],
     )
+    from datajunction_server.models.dialect import register_dialect_plugin
+    from datajunction_server.transpilation import SQLTranspilationPlugin
+
+    register_dialect_plugin("spark", SQLTranspilationPlugin)
+    register_dialect_plugin("trino", SQLTranspilationPlugin)
+    register_dialect_plugin("druid", SQLTranspilationPlugin)
 
     module_mocker.patch(
         "datajunction_server.utils.get_settings",

--- a/datajunction-server/datajunction_server/alembic/versions/2025_05_08_0601-ee0eb65f743b_convert_dialect.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_05_08_0601-ee0eb65f743b_convert_dialect.py
@@ -1,0 +1,38 @@
+"""Convert dialect
+
+Revision ID: ee0eb65f743b
+Revises: 51547dcccb10
+Create Date: 2025-05-08 06:01:38.039079+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "ee0eb65f743b"
+down_revision = "51547dcccb10"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("engine", schema=None) as batch_op:
+        batch_op.alter_column(
+            "dialect",
+            existing_type=postgresql.ENUM("SPARK", "TRINO", "DRUID", name="dialect"),
+            type_=sa.String(),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("engine", schema=None) as batch_op:
+        batch_op.alter_column(
+            "dialect",
+            existing_type=sa.String(),
+            type_=postgresql.ENUM("SPARK", "TRINO", "DRUID", name="dialect"),
+            existing_nullable=True,
+        )

--- a/datajunction-server/datajunction_server/alembic/versions/2025_05_08_0601-ee0eb65f743b_convert_dialect.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_05_08_0601-ee0eb65f743b_convert_dialect.py
@@ -1,9 +1,9 @@
-"""Convert dialect
+"""
+Convert dialect
 
 Revision ID: ee0eb65f743b
 Revises: 51547dcccb10
 Create Date: 2025-05-08 06:01:38.039079+00:00
-
 """
 # pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
 

--- a/datajunction-server/datajunction_server/api/graphql/queries/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/sql.py
@@ -84,7 +84,7 @@ async def measures_sql(
     """
     Get measures SQL for a set of metrics with dimensions and filters
     """
-    session, settings = info.context["session"], info.context["settings"]
+    session = info.context["session"]
     queries = await get_measures_query(
         session=session,
         metrics=list(OrderedDict.fromkeys(cube.metrics)),  # type: ignore
@@ -94,7 +94,6 @@ async def measures_sql(
         engine_name=engine.name if engine else None,
         engine_version=engine.version if engine else None,
         include_all_columns=include_all_columns,
-        sql_transpilation_library=settings.sql_transpilation_library,
         use_materialized=use_materialized,
         preagg_requested=preaggregate,
     )

--- a/datajunction-server/datajunction_server/api/graphql/scalars/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/sql.py
@@ -72,7 +72,6 @@ class GeneratedSQL:
 
     node: Node
     sql: str
-    sql_transpilation_library: str | None = None
     columns: list[ColumnMetadata]
     dialect: Dialect  # type: ignore
     upstream_tables: list[str]
@@ -91,7 +90,6 @@ class GeneratedSQL:
                 name=obj.node.name,
             ),
             sql=obj.sql,
-            sql_transpilation_library=obj.sql_transpilation_library,
             columns=[
                 ColumnMetadata(  # type: ignore
                     name=col.name,

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -717,7 +717,7 @@ async def build_sql_for_multiple_metrics(
         ]
         engine = materialized_cube_catalog.engines[0]
         return (
-            TranslatedSQL(
+            TranslatedSQL.create(
                 sql=str(query_ast),
                 columns=query_metric_columns + query_dimension_columns,
                 dialect=materialized_cube_catalog.engines[0].dialect,
@@ -745,7 +745,7 @@ async def build_sql_for_multiple_metrics(
     for tbl in upstream_tables:
         await refresh_if_needed(session, tbl.dj_node, ["availability"])
     return (
-        TranslatedSQL(
+        TranslatedSQL.create(
             sql=str(query_ast),
             columns=columns,
             dialect=engine.dialect if engine else None,
@@ -875,7 +875,7 @@ async def build_sql_for_dj_query(  # pragma: no cover
     ]
 
     return (  # pragma: no cover
-        TranslatedSQL(
+        TranslatedSQL.create(
             sql=str(query_ast),
             columns=columns,
             dialect=engine.dialect if engine else None,

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -2,14 +2,10 @@
 Main DJ server app.
 """
 
-# All the models need to be imported here so that SQLModel can define their
-# relationships at runtime without causing circular imports.
-# See https://sqlmodel.tiangolo.com/tutorial/code-structure/#make-circular-imports-work.
-
 import logging
+from datajunction_server.api import setup_logging  # noqa
+
 from http import HTTPStatus
-from logging import config
-from os import path
 from typing import TYPE_CHECKING
 
 from fastapi import Depends, FastAPI, Request
@@ -41,6 +37,7 @@ from datajunction_server.api import (
     tags,
     users,
 )
+
 from datajunction_server.api.access.authentication import basic, whoami
 from datajunction_server.api.attributes import default_attribute_types
 from datajunction_server.api.catalogs import default_catalog
@@ -54,11 +51,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _logger = logging.getLogger(__name__)
 settings = get_settings()
-
-config.fileConfig(
-    path.join(path.dirname(path.abspath(__file__)), "logging.conf"),
-    disable_existing_loggers=False,
-)
 
 dependencies = [Depends(default_attribute_types), Depends(default_catalog)]
 

--- a/datajunction-server/datajunction_server/api/setup_logging.py
+++ b/datajunction-server/datajunction_server/api/setup_logging.py
@@ -1,0 +1,7 @@
+from logging import config
+from os import path
+
+config.fileConfig(
+    path.join(path.dirname(path.abspath(__file__)), "logging.conf"),
+    disable_existing_loggers=False,
+)

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -450,7 +450,7 @@ async def get_sql_for_metrics(
             if engine_name
             else None
         )
-        return TranslatedSQL.create(
+        return TranslatedSQL.create(  # pragma: no cover
             sql=query_request.query,
             columns=query_request.columns,
             dialect=engine.dialect if engine else None,

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -94,7 +94,7 @@ async def get_measures_sql_for_cube_v2(
     )
 
     metrics = list(OrderedDict.fromkeys(metrics))
-    measures_query = await get_measures_query(
+    return await get_measures_query(
         session=session,
         metrics=metrics,
         dimensions=dimensions,
@@ -105,12 +105,10 @@ async def get_measures_sql_for_cube_v2(
         current_user=current_user,
         validate_access=validate_access,
         include_all_columns=include_all_columns,
-        sql_transpilation_library=settings.sql_transpilation_library,
         use_materialized=use_materialized,
         preagg_requested=preaggregate,
         query_parameters=json.loads(query_params),
     )
-    return measures_query
 
 
 async def build_and_save_node_sql(
@@ -297,7 +295,7 @@ async def get_node_sql(
             query_parameters=query_parameters,
         )
         return (
-            TranslatedSQL(
+            TranslatedSQL.create(
                 sql=query_request.query,
                 columns=query_request.columns,
                 dialect=engine.dialect if engine else None,
@@ -319,7 +317,7 @@ async def get_node_sql(
         query_parameters=query_parameters,
     )
     return (
-        TranslatedSQL(
+        TranslatedSQL.create(
             sql=query_request.query,
             columns=query_request.columns,
             dialect=engine.dialect if engine else None,
@@ -452,7 +450,7 @@ async def get_sql_for_metrics(
             if engine_name
             else None
         )
-        return TranslatedSQL(  # pragma: no cover
+        return TranslatedSQL.create(
             sql=query_request.query,
             columns=query_request.columns,
             dialect=engine.dialect if engine else None,

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -66,8 +66,8 @@ class Settings(BaseSettings):  # pragma: no cover
     # DJ UI host, used for OAuth redirection
     frontend_host: Optional[str] = "http://localhost:3000"
 
-    # Library to use when transpiling SQL to other dialects
-    sql_transpilation_library: Optional[str] = None
+    # Enabled transpilation plugin names
+    transpilation_plugins: List[str] = ["default", "sqlglot"]
 
     # 128 bit DJ secret, used to encrypt passwords and JSON web tokens
     secret: str = "a-fake-secretkey"

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -101,7 +101,6 @@ async def get_measures_query(
     current_user: Optional[User] = None,
     validate_access: access.ValidateAccessFn = None,
     include_all_columns: bool = False,
-    sql_transpilation_library: Optional[str] = None,
     use_materialized: bool = True,
     preagg_requested: bool = False,
     query_parameters: dict[str, Any] = None,
@@ -126,9 +125,7 @@ async def get_measures_query(
     )
 
     engine = (
-        await get_engine(session, engine_name, engine_version)
-        if engine_name and engine_version
-        else None
+        await get_engine(session, engine_name, engine_version) if engine_name else None  # type: ignore
     )
     build_criteria = BuildCriteria(
         dialect=engine.dialect if engine and engine.dialect else Dialect.SPARK,
@@ -245,9 +242,8 @@ async def get_measures_query(
             for col in final_query.select.projection
         ]
         measures_queries.append(
-            GeneratedSQL(
+            GeneratedSQL.create(
                 node=parent_node.current,
-                sql_transpilation_library=sql_transpilation_library,
                 sql=str(final_query),
                 columns=columns_metadata,
                 dialect=build_criteria.dialect,

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -114,7 +114,7 @@ async def build_dimensions_from_cube_query(
         amenable_name(elem.node_revision().name + SEPARATOR + elem.name): elem.type  # type: ignore
         for elem in cube.cube_elements
     }
-    return TranslatedSQL(
+    return TranslatedSQL.create(
         sql=str(query_ast),
         columns=[
             ColumnMetadata(

--- a/datajunction-server/datajunction_server/database/engine.py
+++ b/datajunction-server/datajunction_server/database/engine.py
@@ -3,11 +3,9 @@
 from typing import Optional
 
 import sqlalchemy as sa
-from sqlalchemy import Enum
 from sqlalchemy.orm import Mapped, mapped_column
 
 from datajunction_server.database.base import Base
-from datajunction_server.models.engine import Dialect
 
 
 class Engine(Base):
@@ -24,6 +22,4 @@ class Engine(Base):
     name: Mapped[str]
     version: Mapped[str]
     uri: Mapped[Optional[str]]
-    dialect: Mapped[Optional[Dialect]] = mapped_column(
-        Enum(Dialect),
-    )
+    dialect: Mapped[Optional[str]] = mapped_column(sa.String)

--- a/datajunction-server/datajunction_server/database/engine.py
+++ b/datajunction-server/datajunction_server/database/engine.py
@@ -6,6 +6,19 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from datajunction_server.database.base import Base
+from datajunction_server.models.dialect import Dialect
+
+
+class DialectType(sa.TypeDecorator):
+    impl = sa.String
+
+    def process_bind_param(self, value, dialect):
+        if isinstance(value, Dialect):
+            return value.name
+        return value
+
+    def process_result_value(self, value, dialect):
+        return Dialect(value) if value else None
 
 
 class Engine(Base):
@@ -22,4 +35,4 @@ class Engine(Base):
     name: Mapped[str]
     version: Mapped[str]
     uri: Mapped[Optional[str]]
-    dialect: Mapped[Optional[str]] = mapped_column(sa.String)
+    dialect: Mapped[Optional[Dialect]] = mapped_column(DialectType())

--- a/datajunction-server/datajunction_server/models/dialect.py
+++ b/datajunction-server/datajunction_server/models/dialect.py
@@ -1,0 +1,114 @@
+import logging
+from datajunction_server.enum import StrEnum
+from datajunction_server.utils import get_settings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datajunction_server.transpilation import SQLTranspilationPlugin
+
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+class Dialect(StrEnum):
+    """
+    SQL dialect
+    """
+
+    SPARK = "spark"
+    TRINO = "trino"
+    DRUID = "druid"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "Dialect":
+        """
+        Create a Dialect enum member from a string, but only if it corresponds to a
+        registered transpilation plugin in the plugin registry. If it has a corresponding
+        plugin, a dynamic enum member is created for the dialect. If not, a ValueError is
+        raised to prevent the use of unsupported dialects.
+        """
+        if isinstance(value, str):
+            key = value.lower()
+            if key in DialectRegistry._registry:
+                new_member = str.__new__(cls, key)
+                new_member._name_ = key.upper()
+                new_member._value_ = key
+                return new_member
+            raise ValueError(
+                f"Dialect '{value}' does not have a registered SQL transpilation plugin that "
+                "supports it. Please configure a plugin on the server to use this dialect.",
+            )
+        raise TypeError(f"{value!r} is not a valid string for {cls.__name__}")
+
+
+class DialectRegistry:
+    """
+    Registry for SQL dialect plugins.
+    """
+
+    _registry: dict[str, type["SQLTranspilationPlugin"]] = {}
+
+    @classmethod
+    def register(cls, dialect_name: str, plugin: type["SQLTranspilationPlugin"]):
+        """
+        Registers a new dialect plugin.
+        """
+        logger.info(
+            "Registering plugin %s for dialect %s",
+            plugin.__name__,
+            dialect_name,
+        )
+        cls._registry[dialect_name.lower()] = plugin
+
+    @classmethod
+    def get_plugin(cls, dialect_name: str) -> type["SQLTranspilationPlugin"] | None:
+        """
+        Retrieves the plugin class for a given dialect name.
+        """
+        return cls._registry.get(dialect_name.lower())
+
+    @classmethod
+    def list(cls) -> list[str]:
+        """
+        A list of supported dialects.
+        """
+        return list(cls._registry.keys())
+
+
+def register_dialect_plugin(name: str, plugin_cls: type["SQLTranspilationPlugin"]):
+    """
+    Registers a plugin for the given dialect. Skips registration if the plugin is not
+    configured in the settings.
+    """
+    if plugin_cls.package_name not in settings.transpilation_plugins:
+        logger.warning(
+            "Skipping plugin registration for '%s' (%s) (not in configured transpilation plugins: %s)",
+            name,
+            plugin_cls.package_name,
+            settings.transpilation_plugins,
+        )
+        return
+
+    DialectRegistry.register(name, plugin_cls)
+
+
+def dialect_plugin(name: str):
+    """
+    Decorator to register a dialect plugin. This decorator should be used on a class that
+    inherits from SQLTranspilationPlugin.
+
+    Example usage:
+
+    @dialect_plugin("my_dialect")
+    class MyDialectPlugin(SQLTranspilationPlugin):
+        def transpile_sql(self, query: str, input_dialect: str = None, output_dialect: str = None):
+            # Custom transpilation logic here
+            return query
+    """
+
+    def wrapper(cls):
+        register_dialect_plugin(name, cls)
+        return cls
+
+    return wrapper

--- a/datajunction-server/datajunction_server/models/engine.py
+++ b/datajunction-server/datajunction_server/models/engine.py
@@ -5,18 +5,7 @@ Models for columns.
 from typing import Optional
 
 from pydantic.main import BaseModel
-
-from datajunction_server.enum import StrEnum
-
-
-class Dialect(StrEnum):
-    """
-    SQL dialect
-    """
-
-    SPARK = "spark"
-    TRINO = "trino"
-    DRUID = "druid"
+from datajunction_server.models.dialect import Dialect
 
 
 class EngineInfo(BaseModel):

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -4,7 +4,6 @@ Models for metrics.
 
 from typing import List, Optional
 
-from pydantic import validator
 from pydantic.main import BaseModel
 
 from datajunction_server.database.node import Node
@@ -98,16 +97,10 @@ class TranslatedSQL(TranspiledSQL):
     upstream_tables: Optional[List[str]] = None
 
     @classmethod
-    def create(cls, *, dialect: Dialect, **kwargs):
+    def create(cls, *, dialect: Dialect | None = None, **kwargs):
         sql = transpile_sql(kwargs["sql"], dialect)
         return cls(
             sql=sql,
             dialect=dialect,
             **{k: v for k, v in kwargs.items() if k not in {"sql", "dialect"}},
         )
-
-    @validator("dialect", pre=True)
-    def validate_dialect(cls, v):
-        if v is None:
-            return None
-        return Dialect(v)

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -4,7 +4,7 @@ Models for metrics.
 
 from typing import List, Optional
 
-from pydantic.class_validators import root_validator
+from pydantic import validator
 from pydantic.main import BaseModel
 
 from datajunction_server.database.node import Node
@@ -15,11 +15,11 @@ from datajunction_server.models.node import (
     MetricMetadataOutput,
 )
 from datajunction_server.models.query import ColumnMetadata
+from datajunction_server.models.sql import TranspiledSQL
 from datajunction_server.sql.decompose import MeasureExtractor
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
-from datajunction_server.transpilation import get_transpilation_plugin
+from datajunction_server.transpilation import transpile_sql
 from datajunction_server.typing import UTCDatetime
-from datajunction_server.utils import get_settings
 
 
 class Metric(BaseModel):
@@ -85,7 +85,7 @@ class Metric(BaseModel):
         )
 
 
-class TranslatedSQL(BaseModel):
+class TranslatedSQL(TranspiledSQL):
     """
     Class for SQL generated from a given metric.
     """
@@ -97,21 +97,17 @@ class TranslatedSQL(BaseModel):
     dialect: Optional[Dialect] = None
     upstream_tables: Optional[List[str]] = None
 
-    @root_validator(pre=False)
-    def transpile_sql(
-        cls,
-        values,
-    ) -> "TranslatedSQL":
-        """
-        Transpiles SQL to the specified dialect with the configured transpilation plugin.
-        If no plugin is configured, it will just return the original generated query.
-        """
-        settings = get_settings()
-        if settings.sql_transpilation_library:  # pragma: no cover
-            plugin = get_transpilation_plugin(settings.sql_transpilation_library)
-            values["sql"] = plugin.transpile_sql(
-                values["sql"],
-                input_dialect=Dialect.SPARK,
-                output_dialect=values["dialect"],
-            )
-        return values
+    @classmethod
+    def create(cls, *, dialect: Dialect, **kwargs):
+        sql = transpile_sql(kwargs["sql"], dialect)
+        return cls(
+            sql=sql,
+            dialect=dialect,
+            **{k: v for k, v in kwargs.items() if k not in {"sql", "dialect"}},
+        )
+
+    @validator("dialect", pre=True)
+    def validate_dialect(cls, v):
+        if v is None:
+            return None
+        return Dialect(v)

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -4,7 +4,8 @@ Models for generated SQL
 
 from typing import List, Optional
 
-from pydantic.class_validators import root_validator
+from datajunction_server.transpilation import transpile_sql
+from pydantic import validator
 from pydantic.main import BaseModel
 
 from datajunction_server.errors import DJQueryBuildError
@@ -12,17 +13,39 @@ from datajunction_server.models.cube_materialization import Measure
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.node_type import NodeNameVersion
 from datajunction_server.models.query import ColumnMetadata
-from datajunction_server.transpilation import get_transpilation_plugin
 
 
-class GeneratedSQL(BaseModel):
+class TranspiledSQL(BaseModel):
+    """
+    Generated SQL for a given node, the output of a QueryBuilder(...).build() call.
+    """
+
+    sql: str
+    dialect: Optional[Dialect] = None
+
+    @classmethod
+    def create(cls, *, dialect, **kwargs):
+        sql = transpile_sql(kwargs["sql"], dialect)
+        return cls(
+            sql=sql,
+            dialect=dialect,
+            **{k: v for k, v in kwargs.items() if k not in {"sql", "dialect"}},
+        )
+
+    @validator("dialect", pre=True)
+    def validate_dialect(cls, v):
+        if v is None:
+            return None  # pragma: no-cover
+        return Dialect(v)
+
+
+class GeneratedSQL(TranspiledSQL):
     """
     Generated SQL for a given node, the output of a QueryBuilder(...).build() call.
     """
 
     node: NodeNameVersion
     sql: str
-    sql_transpilation_library: Optional[str] = None
     columns: Optional[List[ColumnMetadata]] = None  # pragma: no-cover
     grain: list[str] | None = None
     dialect: Optional[Dialect] = None
@@ -30,23 +53,3 @@ class GeneratedSQL(BaseModel):
     metrics: dict[str, tuple[list[Measure], str]] | None = None
     spark_conf: dict[str, str] | None = None
     errors: Optional[List[DJQueryBuildError]] = None
-
-    @root_validator(pre=False)
-    def transpile_sql(
-        cls,
-        values,
-    ):
-        """
-        Transpiles SQL to the specified dialect with the configured transpilation plugin.
-        If no plugin is configured, it will just return the original generated query.
-        """
-        if values.get("sql_transpilation_library"):
-            plugin = get_transpilation_plugin(  # pragma: no cover
-                values.get("sql_transpilation_library"),
-            )
-            values["sql"] = plugin.transpile_sql(  # pragma: no cover
-                values["sql"],
-                input_dialect=Dialect.SPARK,
-                output_dialect=values["dialect"],
-            )
-        return values

--- a/datajunction-server/datajunction_server/models/sql.py
+++ b/datajunction-server/datajunction_server/models/sql.py
@@ -35,7 +35,7 @@ class TranspiledSQL(BaseModel):
     @validator("dialect", pre=True)
     def validate_dialect(cls, v):
         if v is None:
-            return None  # pragma: no-cover
+            return None
         return Dialect(v)
 
 

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -1,14 +1,19 @@
 """SQL transpilation plugins manager."""
 
 import importlib
-from abc import ABC, abstractmethod
 from typing import Optional
+import logging
 
-from datajunction_server.errors import DJPluginNotFoundException
 from datajunction_server.models.engine import Dialect
+from datajunction_server.models.dialect import DialectRegistry, dialect_plugin
+from datajunction_server.utils import get_settings
+
+settings = get_settings()
+logger = logging.getLogger(__name__)
 
 
-class SQLTranspilationPlugin(ABC):
+@dialect_plugin(Dialect.SPARK.value)
+class SQLTranspilationPlugin:
     """
     SQL transpilation plugin base class. To add support for a new SQL transpilation library,
     implement this class with a custom `transpile_sql` method that works for the library. The
@@ -16,7 +21,7 @@ class SQLTranspilationPlugin(ABC):
     using it, or skipping transpilation if the package cannot be loaded.
     """
 
-    package_name: Optional[str] = None
+    package_name: Optional[str] = "default"
 
     def __init__(self):
         """
@@ -31,12 +36,12 @@ class SQLTranspilationPlugin(ABC):
         if self.package_name:  # pragma: no cover
             try:
                 importlib.import_module(self.package_name)
-            except ImportError as import_err:
-                raise DJPluginNotFoundException(
-                    message=f"The SQL transpilation package is not installed: {self.package_name}",
-                ) from import_err
+            except ImportError:
+                logger.warning(
+                    "The SQL transpilation package is not installed: %s",
+                    self.package_name,
+                )
 
-    @abstractmethod
     def transpile_sql(
         self,
         query: str,
@@ -45,8 +50,12 @@ class SQLTranspilationPlugin(ABC):
         output_dialect: Optional[Dialect] = None,
     ) -> str:
         """Transpile a given SQL query using the specific library."""
+        return query
 
 
+@dialect_plugin(Dialect.SPARK.value)
+@dialect_plugin(Dialect.TRINO.value)
+@dialect_plugin(Dialect.DRUID.value)
 class SQLGlotTranspilationPlugin(SQLTranspilationPlugin):
     """
     Implement sqlglot as a transpilation option
@@ -82,17 +91,18 @@ class SQLGlotTranspilationPlugin(SQLTranspilationPlugin):
         return query
 
 
-def get_transpilation_plugin(package_name: str) -> SQLTranspilationPlugin:
-    """
-    Retrieves the configured SQL transpilation plugin
-    """
-    transpilation_plugins = [
-        clazz
-        for clazz in SQLTranspilationPlugin.__subclasses__()
-        if clazz.package_name == package_name
-    ]
-    if not transpilation_plugins:
-        raise DJPluginNotFoundException(
-            message=f"No SQL transpilation plugin found for package `{package_name}`!",
-        )
-    return transpilation_plugins[0]()  # type: ignore
+def transpile_sql(
+    sql: str,
+    dialect: Dialect | None = None,
+) -> str:
+    if dialect:
+        if plugin_class := DialectRegistry.get_plugin(  # pragma: no cover
+            dialect.name.lower(),
+        ):
+            plugin = plugin_class()
+            return plugin.transpile_sql(
+                sql,
+                input_dialect=Dialect.SPARK,
+                output_dialect=dialect,
+            )
+    return sql

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -95,10 +95,19 @@ def transpile_sql(
     sql: str,
     dialect: Dialect | None = None,
 ) -> str:
+    print(
+        "dialect",
+        dialect,
+        "settings",
+        settings.transpilation_plugins,
+        "DialectRegistry",
+        DialectRegistry._registry,
+    )
     if dialect:
         if plugin_class := DialectRegistry.get_plugin(  # pragma: no cover
             dialect.name.lower(),
         ):
+            print("plugin_class", plugin_class)
             plugin = plugin_class()
             return plugin.transpile_sql(
                 sql,

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -127,7 +127,7 @@ async def test_find_existing_cube():
 @patch("datajunction_server.api.helpers.find_existing_cube")
 @patch("datajunction_server.api.helpers.get_catalog_by_name")
 @patch("datajunction_server.api.helpers.build_materialized_cube_node")
-@patch("datajunction_server.api.helpers.TranslatedSQL", MagicMock)
+@patch("datajunction_server.api.helpers.TranslatedSQL.create", MagicMock)
 async def test_build_sql_for_multiple_metrics(
     mock_build_materialized_cube_node,
     mock_get_catalog_by_name,

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -132,6 +132,8 @@ def settings_no_qs(
     from datajunction_server.transpilation import SQLTranspilationPlugin
 
     register_dialect_plugin("spark", SQLTranspilationPlugin)
+    register_dialect_plugin("trino", SQLTranspilationPlugin)
+    register_dialect_plugin("druid", SQLTranspilationPlugin)
 
     mocker.patch(
         "datajunction_server.utils.get_settings",
@@ -828,6 +830,41 @@ def module__settings(
     from datajunction_server.transpilation import SQLTranspilationPlugin
 
     register_dialect_plugin("spark", SQLTranspilationPlugin)
+    register_dialect_plugin("trino", SQLTranspilationPlugin)
+    register_dialect_plugin("druid", SQLTranspilationPlugin)
+
+    module_mocker.patch(
+        "datajunction_server.utils.get_settings",
+        return_value=settings,
+    )
+
+    yield settings
+
+
+@pytest_asyncio.fixture(scope="module")
+def regular_settings(
+    module_mocker: MockerFixture,
+    module__postgres_container: PostgresContainer,
+) -> Iterator[Settings]:
+    """
+    Custom settings for unit tests.
+    """
+    settings = Settings(
+        index=module__postgres_container.get_connection_url(),
+        repository="/path/to/repository",
+        results_backend=SimpleCache(default_timeout=0),
+        celery_broker=None,
+        redis_cache=None,
+        query_service=None,
+        secret="a-fake-secretkey",
+    )
+
+    from datajunction_server.models.dialect import register_dialect_plugin
+    from datajunction_server.transpilation import SQLGlotTranspilationPlugin
+
+    register_dialect_plugin("spark", SQLGlotTranspilationPlugin)
+    register_dialect_plugin("trino", SQLGlotTranspilationPlugin)
+    register_dialect_plugin("druid", SQLGlotTranspilationPlugin)
 
     module_mocker.patch(
         "datajunction_server.utils.get_settings",

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -93,7 +93,13 @@ def settings(
         redis_cache=None,
         query_service="query_service:8001",
         secret="a-fake-secretkey",
+        transpilation_plugins=["default"],
     )
+
+    from datajunction_server.models.dialect import register_dialect_plugin
+    from datajunction_server.transpilation import SQLTranspilationPlugin
+
+    register_dialect_plugin("spark", SQLTranspilationPlugin)
 
     mocker.patch(
         "datajunction_server.utils.get_settings",
@@ -119,7 +125,13 @@ def settings_no_qs(
         redis_cache=None,
         query_service=None,
         secret="a-fake-secretkey",
+        transpilation_plugins=["default"],
     )
+
+    from datajunction_server.models.dialect import register_dialect_plugin
+    from datajunction_server.transpilation import SQLTranspilationPlugin
+
+    register_dialect_plugin("spark", SQLTranspilationPlugin)
 
     mocker.patch(
         "datajunction_server.utils.get_settings",
@@ -809,7 +821,13 @@ def module__settings(
         redis_cache=None,
         query_service=None,
         secret="a-fake-secretkey",
+        transpilation_plugins=["default"],
     )
+
+    from datajunction_server.models.dialect import register_dialect_plugin
+    from datajunction_server.transpilation import SQLTranspilationPlugin
+
+    register_dialect_plugin("spark", SQLTranspilationPlugin)
 
     module_mocker.patch(
         "datajunction_server.utils.get_settings",

--- a/datajunction-server/tests/models/dialect_test.py
+++ b/datajunction-server/tests/models/dialect_test.py
@@ -1,0 +1,128 @@
+import pytest
+from datajunction_server.models.dialect import (
+    Dialect,
+    DialectRegistry,
+    register_dialect_plugin,
+)
+from datajunction_server.models.dialect import dialect_plugin
+from datajunction_server.transpilation import (
+    SQLTranspilationPlugin,
+)
+from datajunction_server.models.dialect import Dialect, DialectRegistry, dialect_plugin
+from datajunction_server.models.metric import TranslatedSQL
+
+
+@dialect_plugin("custom123")
+class TestPlugin(SQLTranspilationPlugin):
+    """
+    Custom transpilation plugin for testing.
+    """
+
+    package_name = "custom_transpilation_plugin"
+
+    def transpile_sql(
+        self,
+        query: str,
+        *,
+        input_dialect: Dialect | None = None,
+        output_dialect: Dialect | None = None,
+    ) -> str:
+        return query + "\n\n-- transpiled"
+
+
+def test_dialect_register_and_get_plugin():
+    """
+    Test the DialectRegistry register method.
+    """
+    DialectRegistry._registry.clear()
+    DialectRegistry.register("dialect_a", TestPlugin)
+    DialectRegistry.register("dialect_b", TestPlugin)
+    plugin_a = DialectRegistry.get_plugin("dialect_a")
+    plugin_b = DialectRegistry.get_plugin("dialect_b")
+    assert plugin_a is TestPlugin
+    assert plugin_b is TestPlugin
+    listed = DialectRegistry.list()
+    assert set(listed) == {"dialect_a", "dialect_b"}
+
+
+def test_custom_sql() -> None:
+    """
+    Verify that the custom dialect plugin can be used to transpile SQL.
+    """
+    DialectRegistry.register("dialect_a", TestPlugin)
+
+    translated_sql = TranslatedSQL.create(
+        sql="SELECT 1",
+        columns=[],
+        dialect=Dialect("dialect_a"),
+    )
+    assert translated_sql.sql == "SELECT 1\n\n-- transpiled"
+
+
+def test_dialect_enum():
+    """
+    Test the Dialect enum for valid and invalid values.
+    """
+    assert Dialect.SPARK == "spark"
+    assert Dialect.TRINO == "trino"
+    assert Dialect.DRUID == "druid"
+
+    with pytest.raises(ValueError):
+        Dialect("unknown_dialect")
+
+    with pytest.raises(TypeError):
+        Dialect(123)
+
+    # Test dynamic creation of a dialect if registered
+    DialectRegistry.register("custom", TestPlugin)
+    assert Dialect("custom") == "custom"
+
+    with pytest.raises(ValueError):
+        Dialect("unregistered_dialect")
+
+    # Registering again should raise an error
+    with pytest.raises(ValueError):
+        register_dialect_plugin("custom", TestPlugin)
+
+
+def test_dialect_registry_register_and_get_plugin():
+    """
+    Test registering and retrieving plugins in the DialectRegistry.
+    """
+
+    class MockPlugin:
+        pass
+
+    DialectRegistry.register("mock_dialect", MockPlugin)
+    assert DialectRegistry.get_plugin("mock_dialect") == MockPlugin
+    assert DialectRegistry.get_plugin("nonexistent_dialect") is None
+
+
+def test_dialect_registry_list():
+    """
+    Test listing all registered dialects in the DialectRegistry.
+    """
+
+    class MockPlugin:
+        pass
+
+    DialectRegistry._registry.clear()  # Clear the registry for a clean test
+    DialectRegistry.register("dialect1", MockPlugin)
+    DialectRegistry.register("dialect2", MockPlugin)
+
+    assert sorted(DialectRegistry.list()) == ["dialect1", "dialect2"]
+
+
+def test_register_dialect_plugin():
+    """
+    Test the register_dialect_plugin function.
+    """
+
+    class MockPlugin:
+        pass
+
+    register_dialect_plugin("test_dialect", MockPlugin)
+    assert DialectRegistry.get_plugin("test_dialect") == MockPlugin
+
+    with pytest.raises(ValueError):
+        register_dialect_plugin("test_dialect", MockPlugin)  # Duplicate registration

--- a/datajunction-server/tests/transpilation_test.py
+++ b/datajunction-server/tests/transpilation_test.py
@@ -1,63 +1,52 @@
 """Tests the transpilation plugins."""
 
-import pytest
-from pytest_mock import MockerFixture
+from unittest import mock
 
-from datajunction_server.errors import DJPluginNotFoundException
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.sql import GeneratedSQL, NodeNameVersion
-from datajunction_server.transpilation import get_transpilation_plugin
-
-
-class MockSettings:
-    """
-    Mock settings object
-    """
-
-    sql_transpilation_library = "sqlglot"
+from datajunction_server.transpilation import (
+    SQLGlotTranspilationPlugin,
+    SQLTranspilationPlugin,
+    transpile_sql,
+)
+from datajunction_server.models.dialect import Dialect, DialectRegistry
 
 
 def test_get_transpilation_plugin() -> None:
     """
     Test ``get_transpilation_plugin``
     """
-    # Will raise an error with for an unknown transpilation library
-    with pytest.raises(DJPluginNotFoundException) as excinfo:
-        get_transpilation_plugin("somepackage")
-    assert "No SQL transpilation plugin found for package `somepackage`!" in str(
-        excinfo,
-    )
+    plugin = DialectRegistry.get_plugin(Dialect.SPARK.value)
+    assert plugin == SQLGlotTranspilationPlugin
+    assert plugin.package_name == "sqlglot"
 
-    package_name = "sqlglot"
-    known = get_transpilation_plugin(package_name)
-    assert known.package_name == package_name
-    assert known.transpile_sql("1") == "1"
-    assert (
-        known.transpile_sql(
-            "1",
-            input_dialect=Dialect.SPARK,
-            output_dialect=Dialect.TRINO,
-        )
-        == "1"
-    )
-    assert known.transpile_sql("1", output_dialect=Dialect.TRINO) == "1"
+    plugin = DialectRegistry.get_plugin(Dialect.TRINO.value)
+    assert plugin == SQLGlotTranspilationPlugin
+
+    plugin = DialectRegistry.get_plugin(Dialect.DRUID.value)
+    assert plugin == SQLGlotTranspilationPlugin
 
 
-def test_translated_sql(mocker: MockerFixture) -> None:
+def test_get_transpilation_plugin_unknown() -> None:
+    """
+    Test ``get_transpilation_plugin`` with an unknown plugin
+    """
+    plugin = DialectRegistry.get_plugin("random")
+    assert not plugin
+
+
+def test_translated_sql() -> None:
     """
     Verify that the TranslatedSQL object will call the configured transpilation plugin
     """
-    mock_settings = mocker.MagicMock()
-    mock_settings.return_value = MockSettings()
-    mocker.patch("datajunction_server.models.metric.get_settings", mock_settings)
-    translated_sql = TranslatedSQL(
+    translated_sql = TranslatedSQL.create(
         sql="1",
         columns=[],
         dialect=Dialect.SPARK,
     )
     assert translated_sql.sql == "1"
-    generated_sql = GeneratedSQL(
+    generated_sql = GeneratedSQL.create(
         node=NodeNameVersion(name="a", version="v1.0"),
         sql="1",
         columns=[],
@@ -66,23 +55,73 @@ def test_translated_sql(mocker: MockerFixture) -> None:
     assert generated_sql.sql == "1"
 
 
-def test_druid_sql(mocker: MockerFixture) -> None:
+def test_druid_sql() -> None:
     """
     Verify that the TranslatedSQL object will call the configured transpilation plugin
     """
-    mock_settings = mocker.MagicMock()
-    mock_settings.return_value = MockSettings()
-    mocker.patch("datajunction_server.models.metric.get_settings", mock_settings)
-    translated_sql = TranslatedSQL(
+    translated_sql = TranslatedSQL.create(
         sql="SELECT 1",
         columns=[],
         dialect=Dialect.DRUID,
     )
     assert translated_sql.sql == "SELECT\n  1"
-    generated_sql = GeneratedSQL(
+    generated_sql = GeneratedSQL.create(
         node=NodeNameVersion(name="a", version="v1.0"),
         sql="SELECT 1",
         columns=[],
         dialect=Dialect.DRUID,
     )
-    assert generated_sql.sql == "SELECT 1"
+    assert generated_sql.sql == "SELECT\n  1"
+
+
+def test_sqlglot_transpile_success():
+    with mock.patch(
+        "datajunction_server.transpilation.settings.transpilation_plugins",
+        return_value=["sqlglot"],
+    ):
+        plugin = SQLGlotTranspilationPlugin()
+        DialectRegistry.register("custom123", SQLGlotTranspilationPlugin)
+        result = plugin.transpile_sql(
+            "SELECT * FROM bar",
+            input_dialect=Dialect.TRINO,
+            output_dialect=Dialect.SPARK,
+        )
+        assert result == "SELECT\n  *\nFROM bar"
+
+        result = plugin.transpile_sql(
+            "SELECT * FROM bar",
+            input_dialect=Dialect.TRINO,
+            output_dialect=Dialect("custom123"),
+        )
+        assert result == "SELECT * FROM bar"
+
+
+def test_default_transpile_success():
+    with mock.patch(
+        "datajunction_server.transpilation.settings.transpilation_plugins",
+        return_value=["default"],
+    ):
+        plugin = SQLTranspilationPlugin()
+        DialectRegistry.register("custom123", SQLTranspilationPlugin)
+        result = plugin.transpile_sql(
+            "SELECT * FROM bar",
+            input_dialect=Dialect.TRINO,
+            output_dialect=Dialect.SPARK,
+        )
+        assert result == "SELECT * FROM bar"
+
+        result = plugin.transpile_sql(
+            "SELECT * FROM bar",
+            input_dialect=Dialect.TRINO,
+            output_dialect=Dialect("custom123"),
+        )
+        assert result == "SELECT * FROM bar"
+
+
+def test_transpile_sql():
+    with mock.patch(
+        "datajunction_server.transpilation.settings.transpilation_plugins",
+        return_value=["default"],
+    ):
+        assert transpile_sql("1", dialect=Dialect.SPARK) == "1"
+        assert transpile_sql("SELECT 1", dialect=None) == "SELECT 1"

--- a/datajunction-server/tests/transpilation_test.py
+++ b/datajunction-server/tests/transpilation_test.py
@@ -13,7 +13,7 @@ from datajunction_server.transpilation import (
 from datajunction_server.models.dialect import Dialect, DialectRegistry
 
 
-def test_get_transpilation_plugin() -> None:
+def test_get_transpilation_plugin(regular_settings) -> None:
     """
     Test ``get_transpilation_plugin``
     """
@@ -55,7 +55,7 @@ def test_translated_sql() -> None:
     assert generated_sql.sql == "1"
 
 
-def test_druid_sql() -> None:
+def test_druid_sql(regular_settings) -> None:
     """
     Verify that the TranslatedSQL object will call the configured transpilation plugin
     """
@@ -125,3 +125,16 @@ def test_transpile_sql():
     ):
         assert transpile_sql("1", dialect=Dialect.SPARK) == "1"
         assert transpile_sql("SELECT 1", dialect=None) == "SELECT 1"
+
+
+def test_translated_sql_no_dialect() -> None:
+    """
+    Verify that the TranslatedSQL object will call the configured transpilation plugin
+    """
+    translated_sql = TranslatedSQL.create(
+        sql="1",
+        columns=[],
+        dialect=None,
+    )
+    assert translated_sql.sql == "1"
+    assert TranslatedSQL.validate_dialect(translated_sql.dialect) is None

--- a/docs/content/0.1.0/docs/deploying-dj/overview.md
+++ b/docs/content/0.1.0/docs/deploying-dj/overview.md
@@ -68,4 +68,3 @@ flowchart LR
     PythonClient --> Streamlit["Streamlit"]
     JSClient --> ReactApps["React Apps"]
 {{< /mermaid >}}
-

--- a/docs/content/0.1.0/docs/deploying-dj/sql-plugins.md
+++ b/docs/content/0.1.0/docs/deploying-dj/sql-plugins.md
@@ -1,0 +1,39 @@
+---
+weight: 50
+title: SQL Plugins
+---
+
+DataJunction has a flexible SQL transpilation plugin system that enables you to add support for transpiling SQL queries across any SQL dialects. By default, support is enabled for Spark SQL, Trino, and Druid. You can also add custom transpilation plugins by following the instructions below.
+
+**1. Create the Plugin Class**
+
+Subclass `SQLTranspilationPlugin`, and register it with the dialect(s) it supports using the @dialect_plugin decorator:
+
+```python
+@dialect_plugin("customdb")
+class CustomDBTranspilationPlugin(SQLTranspilationPlugin):
+    package_name: str = "customdb-sql"
+
+    def transpile_sql(
+        self,
+        query: str,
+        *,
+        input_dialect: Optional[Dialect] = None,
+        output_dialect: Optional[Dialect] = None,
+    ) -> str:
+        import customdb_sql  # Ensure the library is installed
+
+        # Ex: use the custom library’s transpilation interface
+        return customdb_sql.transpile(query, source=input_dialect.name, target=output_dialect.name)
+```
+
+**2. Update Configuration**
+
+Modify your settings to activate the new plugin:
+```toml
+sql_transpilation_plugins = ["default", "sqlglot", "customdb-sql"]
+```
+
+**3. Include Any Required Dependencies**
+
+Make sure the transpilation library for your dialect (e.g., customdb-sql) is listed in your requirements file and installed in the deployment setup.

--- a/docs/content/0.1.0/docs/deploying-dj/sql-plugins.md
+++ b/docs/content/0.1.0/docs/deploying-dj/sql-plugins.md
@@ -37,3 +37,18 @@ sql_transpilation_plugins = ["default", "sqlglot", "customdb-sql"]
 **3. Include Any Required Dependencies**
 
 Make sure the transpilation library for your dialect (e.g., customdb-sql) is listed in your requirements file and installed in the deployment setup.
+
+**4. Setup Engine + Catalogs**
+
+Once the plugin for your `customdb` dialect is registered, you can create an engine with the dialect `customdb`:
+```
+curl -X POST http://localhost:8000/engines -d '{"name": "customdb", "version": "", "uri": "", "dialect": "customdb"}'
+```
+Add this new engine to your existing catalog(s):
+```
+curl -X POST http://localhost:8000/catalogs/default/engines -d '{"name": "customdb", "version": "", "uri": "", "dialect": "customdb"}'
+```
+
+**5. Usage**
+
+Now it is ready to use -- you can request SQL in your new `customdb` dialect!


### PR DESCRIPTION
### Summary

This PR introduces a flexible plugin registration setup for SQL transpilation, enabling users to configure custom transpilation plugins for use in their DJ deployment.

In the new plugin architecture, instead of asking for a single `sql_transpilation_library` in the server settings, we're now taking a list of `transpilation_plugins`, e.g.,:
```env
SQL_TRANSPILATION_PLUGINS=default,my_custom_plugin
```

We also provide a `dialect_plugin` decorator for registering any new plugins that are built, e.g.:
```python
@dialect_plugin("my_dialect")
class MyCustomPlugin(SQLTranspilationPlugin):
    package_name = "my_custom_plugin"
    def transpile_sql(self, query: str, input_dialect: str = None, output_dialect: str = None):
        # Custom logic here
        return query
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Added documentation on how to enable a custom transpilation plugin. [See preview](https://681f8a6477d56b00087f5200--thriving-cassata-78ae72.netlify.app/docs/0.1.0/deploying-dj/sql-plugins/)