### PR TITLE
Fix build_preaggregate_query bug.

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -297,9 +297,13 @@ def build_preaggregate_query(
     # Find all required GROUP BY columns based on each of the measure's aggregation rules.
     # If the measure supports full aggregation, there are no required group-by columns, but if it
     # supports limited aggregation, we need to aggregate to the specified level.
+    colum_name_to_alias = {
+        col.name.identifier(): (col.alias or col.name).identifier()
+        for col in parent_ast.select.column_mapping.values()
+    }
     required_group_by_columns = [
         ast.Column.from_existing(
-            parent_ast.select.column_mapping[group_by_col],
+            parent_ast.select.column_mapping[colum_name_to_alias[group_by_col]],
             table=from_table,
         )
         for metric in metrics2measures

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -342,7 +342,7 @@ class ApproxCountDistinct(Function):
     """
 
     is_aggregation = True
-    dialects = [Dialect.DRUID]
+    dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
 @ApproxCountDistinct.register

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -243,7 +243,10 @@ async def test_approx_count_distinct(session: AsyncSession):
     await query.compile(ctx)
     assert not exc.errors
     assert query.select.projection[0].type == ct.LongType()  # type: ignore
-    assert query.select.projection[0].function().dialects == [Dialect.DRUID]  # type: ignore
+    assert query.select.projection[0].function().dialects == [  # type: ignore
+        Dialect.SPARK,
+        Dialect.DRUID,
+    ]
     assert query.select.projection[1].type == ct.LongType()  # type: ignore
     assert query.select.projection[1].function().dialects == [Dialect.DRUID]  # type: ignore
     assert query.select.projection[2].type == ct.LongType()  # type: ignore


### PR DESCRIPTION
### Summary

Main: fix a bug in query generation for metrics referencing columns that need to go to the group by clause, example `COUNT(DISTINCT col1)`.

Piggyback: add Spark dialect to APPROX_COUNT_DISTINCT.

### Test Plan

With some manual runs, but ideally we should add a unit test.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan
Auto