### PR TITLE
Speed up the recursive dimensions graph CTE query

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -106,7 +106,7 @@ from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
     _node_output_options,
     get_dimensions,
-    get_dimensions_graph,
+    get_dimension_attributes,
     get_downstream_nodes,
     get_upstream_nodes,
 )
@@ -1565,20 +1565,7 @@ async def list_all_dimension_attributes(
     """
     List all available dimension attributes for the given node.
     """
-    dims = await get_dimensions_graph(session, name)
-    dimensions_map = {dim.id: dim for dim, _ in dims}
-    return [
-        DimensionAttributeOutput(
-            name=f"{dim.name}.{col.name}",
-            node_name=dim.name,
-            node_display_name=dim.current.display_name,
-            properties=[],  # attribute_types.split(",") if attribute_types else [],
-            type=str(col.type),
-            path=[dimensions_map[int(node_id)].name for node_id in path],
-        )
-        for dim, path in dims
-        for col in dim.current.columns
-    ]
+    return await get_dimension_attributes(session, name)
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -108,7 +108,6 @@ from datajunction_server.sql.dag import (
     get_dimensions,
     get_dimensions_graph,
     get_downstream_nodes,
-    get_filter_only_dimensions,
     get_upstream_nodes,
 )
 from datajunction_server.sql.parsing.backends.antlr4 import parse, parse_rule
@@ -1567,7 +1566,7 @@ async def list_all_dimension_attributes(
     List all available dimension attributes for the given node.
     """
     dims = await get_dimensions_graph(session, name)
-    # DimensionAttributeOutput()
+    dimensions_map = {dim.id: dim for dim, _ in dims}
     return [
         DimensionAttributeOutput(
             name=f"{dim.name}.{col.name}",
@@ -1575,9 +1574,9 @@ async def list_all_dimension_attributes(
             node_display_name=dim.current.display_name,
             properties=[],  # attribute_types.split(",") if attribute_types else [],
             type=str(col.type),
-            path=[],
+            path=[dimensions_map[int(node_id)].name for node_id in path],
         )
-        for dim in dims
+        for dim, path in dims
         for col in dim.current.columns
     ]
     # dimensions = await get_dimensions(
@@ -1587,7 +1586,7 @@ async def list_all_dimension_attributes(
     #     depth=depth,
     # )
     # filter_only_dimensions = await get_filter_only_dimensions(session, name)
-    return [dim.name for dim in dims] # dimensions + filter_only_dimensions
+    return [dim.name for dim in dims]  # dimensions + filter_only_dimensions
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -108,6 +108,7 @@ from datajunction_server.sql.dag import (
     get_dimensions,
     get_dimension_attributes,
     get_downstream_nodes,
+    get_filter_only_dimensions,
     get_upstream_nodes,
 )
 from datajunction_server.sql.parsing.backends.antlr4 import parse, parse_rule
@@ -1565,7 +1566,9 @@ async def list_all_dimension_attributes(
     """
     List all available dimension attributes for the given node.
     """
-    return await get_dimension_attributes(session, name)
+    dimensions = await get_dimension_attributes(session, name)
+    filter_only_dimensions = await get_filter_only_dimensions(session, name)
+    return dimensions + filter_only_dimensions
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1579,14 +1579,6 @@ async def list_all_dimension_attributes(
         for dim, path in dims
         for col in dim.current.columns
     ]
-    # dimensions = await get_dimensions(
-    #     session,
-    #     node,  # type: ignore
-    #     with_attributes=True,
-    #     depth=depth,
-    # )
-    # filter_only_dimensions = await get_filter_only_dimensions(session, name)
-    return [dim.name for dim in dims]  # dimensions + filter_only_dimensions
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -106,6 +106,7 @@ from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
     _node_output_options,
     get_dimensions,
+    get_dimensions_graph,
     get_downstream_nodes,
     get_filter_only_dimensions,
     get_upstream_nodes,
@@ -1553,7 +1554,7 @@ async def list_node_dag(
 
 @router.get(
     "/nodes/{name}/dimensions/",
-    response_model=List[DimensionAttributeOutput],
+    response_model=List[str],
     name="List All Dimension Attributes",
 )
 async def list_all_dimension_attributes(
@@ -1561,7 +1562,7 @@ async def list_all_dimension_attributes(
     *,
     depth: int = 30,
     session: AsyncSession = Depends(get_session),
-) -> List[DimensionAttributeOutput]:
+) -> list[str]:
     """
     List all available dimension attributes for the given node.
     """
@@ -1574,14 +1575,15 @@ async def list_all_dimension_attributes(
             ),
         ],
     )
-    dimensions = await get_dimensions(
-        session,
-        node,  # type: ignore
-        with_attributes=True,
-        depth=depth,
-    )
-    filter_only_dimensions = await get_filter_only_dimensions(session, name)
-    return dimensions + filter_only_dimensions
+    dims = await get_dimensions_graph(session, name)
+    # dimensions = await get_dimensions(
+    #     session,
+    #     node,  # type: ignore
+    #     with_attributes=True,
+    #     depth=depth,
+    # )
+    # filter_only_dimensions = await get_filter_only_dimensions(session, name)
+    return [dim.name for dim in dims] # dimensions + filter_only_dimensions
 
 
 @router.get(

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -583,7 +583,7 @@ class DimensionAttributeOutput(BaseModel):
     node_name: Optional[str]
     node_display_name: Optional[str]
     properties: list[str] | None
-    type: str
+    type: str | None
     path: List[str]
     filter_only: bool = False
 

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -580,11 +580,11 @@ class DimensionAttributeOutput(BaseModel):
     """
 
     name: str
-    node_name: Optional[str]
-    node_display_name: Optional[str]
+    node_name: str | None
+    node_display_name: str | None
     properties: list[str] | None
     type: str | None
-    path: List[str]
+    path: list[str]
     filter_only: bool = False
 
 

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -248,9 +248,8 @@ async def build_reference_link(
         None,
     ):
         return DimensionAttributeOutput(
-            name=f"{col.dimension.name}.{col.dimension_column}" + f"[{'->'.join(role)}]"
-            if role
-            else "",
+            name=f"{col.dimension.name}.{col.dimension_column}"
+            + (f"[{'->'.join(role)}]" if role else ""),
             node_name=col.dimension.name,
             node_display_name=col.dimension.current.display_name,
             properties=dim_col.attribute_names(),

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -306,7 +306,7 @@ async def get_dimension_attributes(
                 join_path = (
                     [node.name] if dimension_node.name != node.name else []
                 ) + [dimensions_map[int(node_id)].name for node_id in path]
-                if ref_link := await build_reference_link(
+                if ref_link := await build_reference_link(  # pragma: no cover
                     session,
                     col,
                     join_path,
@@ -403,9 +403,9 @@ async def get_dimension_nodes(
 
     node_selector = select(Node, paths.c.join_path, paths.c.role)
     if not include_deactivated:
-        node_selector = node_selector.where(
+        node_selector = node_selector.where(  # pragma: no cover
             is_(Node.deactivated_at, None),
-        )  # pragma: no cover
+        )
     statement = (
         node_selector.join(paths, paths.c.node_id == Node.id)
         .join(

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -876,14 +876,16 @@ async def test_measures_sql_with_reference_dimension_links(
         "/nodes/default.elapsed_secs/dimensions",
     )
     dimensions_data = response.json()
-    assert [dim["name"] for dim in dimensions_data] == [
-        "default.users.account_type",
-        "default.users.registration_country",
-        "default.users.registration_country",
-        "default.users.residence_country",
-        "default.users.snapshot_date",
-        "default.users.user_id",
-    ]
+    assert set([dim["name"] for dim in dimensions_data]) == set(
+        [
+            "default.users.account_type",
+            "default.users.registration_country",
+            "default.users.registration_country",
+            "default.users.residence_country",
+            "default.users.snapshot_date",
+            "default.users.user_id",
+        ],
+    )
 
     sql_params = {
         "metrics": ["default.elapsed_secs"],

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5513,12 +5513,8 @@ async def test_cycle_detection_dimensions_graph(client_with_roads: AsyncClient) 
         "default.user -> default.country -> default.country.country_id",
         "default.user.birth_country",
     }
-    response = await client_with_roads.get("/nodes/default.events/dimensions")
 
-    print(
-        "!!!!!",
-        {" -> ".join(dim["path"] + [""]) + dim["name"] for dim in response.json()},
-    )
+    response = await client_with_roads.get("/nodes/default.events/dimensions")
     assert {
         " -> ".join(dim["path"] + [""]) + dim["name"] for dim in response.json()
     } == {

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -4295,7 +4295,7 @@ class TestValidateNodes:
         )
         response = await client_with_roads.get("/nodes/default.hard_hat/dimensions")
         dimensions = response.json()
-        assert [dim["name"] for dim in dimensions] == [
+        assert {dim["name"] for dim in dimensions} == {
             "default.hard_hat.hard_hat_id",
             "default.hard_hat.state",
             "default.hard_hat.title",
@@ -4303,7 +4303,7 @@ class TestValidateNodes:
             "default.us_state.state_name",
             "default.us_state.state_region",
             "default.us_state.state_short",
-        ]
+        }
 
         response = await client_with_roads.get("/history?node=default.hard_hat")
         history = response.json()
@@ -4376,10 +4376,10 @@ class TestValidateNodes:
         )
         response = await client_with_roads.get("/nodes/default.hard_hat/dimensions")
         dimensions = response.json()
-        assert [dim["name"] for dim in dimensions] == [
+        assert {dim["name"] for dim in dimensions} == {
             "default.hard_hat.hard_hat_id",
             "default.hard_hat.title",
-        ]
+        }
 
     @pytest.mark.asyncio
     async def test_propagate_update_downstream(
@@ -5320,100 +5320,103 @@ async def test_list_dimension_attributes(client_with_roads: AsyncClient) -> None
         "/nodes/default.regional_level_agg/dimensions/",
     )
     assert response.status_code in (200, 201)
-    assert response.json() == [
-        {
-            "filter_only": False,
-            "name": "default.regional_level_agg.order_day",
-            "node_display_name": "Regional Level Agg",
-            "node_name": "default.regional_level_agg",
-            "path": [],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": False,
-            "name": "default.regional_level_agg.order_month",
-            "node_display_name": "Regional Level Agg",
-            "node_name": "default.regional_level_agg",
-            "path": [],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": False,
-            "name": "default.regional_level_agg.order_year",
-            "node_display_name": "Regional Level Agg",
-            "node_name": "default.regional_level_agg",
-            "path": [],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": False,
-            "name": "default.regional_level_agg.state_name",
-            "node_display_name": "Regional Level Agg",
-            "node_name": "default.regional_level_agg",
-            "path": [],
-            "type": "string",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": False,
-            "name": "default.regional_level_agg.us_region_id",
-            "node_display_name": "Regional Level Agg",
-            "node_name": "default.regional_level_agg",
-            "path": [],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": True,
-            "name": "default.repair_order.repair_order_id",
-            "node_display_name": "Repair Order",
-            "node_name": "default.repair_order",
-            "path": ["default.repair_orders"],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": True,
-            "name": "default.dispatcher.dispatcher_id",
-            "node_display_name": "Dispatcher",
-            "node_name": "default.dispatcher",
-            "path": ["default.repair_orders"],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": True,
-            "name": "default.repair_order.repair_order_id",
-            "node_display_name": "Repair Order",
-            "node_name": "default.repair_order",
-            "path": ["default.repair_order_details"],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": True,
-            "name": "default.contractor.contractor_id",
-            "node_display_name": "Contractor",
-            "node_name": "default.contractor",
-            "path": ["default.repair_type"],
-            "type": "int",
-            "properties": ["primary_key"],
-        },
-        {
-            "filter_only": True,
-            "name": "default.us_state.state_short",
-            "node_display_name": "Us State",
-            "node_name": "default.us_state",
-            "path": [
-                "default.contractors",
-            ],
-            "type": "string",
-            "properties": ["primary_key"],
-        },
-    ]
+    assert sorted(response.json(), key=lambda x: x["name"]) == sorted(
+        [
+            {
+                "filter_only": False,
+                "name": "default.regional_level_agg.order_day",
+                "node_display_name": "Regional Level Agg",
+                "node_name": "default.regional_level_agg",
+                "path": [],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": False,
+                "name": "default.regional_level_agg.order_month",
+                "node_display_name": "Regional Level Agg",
+                "node_name": "default.regional_level_agg",
+                "path": [],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": False,
+                "name": "default.regional_level_agg.order_year",
+                "node_display_name": "Regional Level Agg",
+                "node_name": "default.regional_level_agg",
+                "path": [],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": False,
+                "name": "default.regional_level_agg.state_name",
+                "node_display_name": "Regional Level Agg",
+                "node_name": "default.regional_level_agg",
+                "path": [],
+                "type": "string",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": False,
+                "name": "default.regional_level_agg.us_region_id",
+                "node_display_name": "Regional Level Agg",
+                "node_name": "default.regional_level_agg",
+                "path": [],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": True,
+                "name": "default.repair_order.repair_order_id",
+                "node_display_name": "Repair Order",
+                "node_name": "default.repair_order",
+                "path": ["default.repair_orders"],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": True,
+                "name": "default.dispatcher.dispatcher_id",
+                "node_display_name": "Dispatcher",
+                "node_name": "default.dispatcher",
+                "path": ["default.repair_orders"],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": True,
+                "name": "default.repair_order.repair_order_id",
+                "node_display_name": "Repair Order",
+                "node_name": "default.repair_order",
+                "path": ["default.repair_order_details"],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": True,
+                "name": "default.contractor.contractor_id",
+                "node_display_name": "Contractor",
+                "node_name": "default.contractor",
+                "path": ["default.repair_type"],
+                "type": "int",
+                "properties": ["primary_key"],
+            },
+            {
+                "filter_only": True,
+                "name": "default.us_state.state_short",
+                "node_display_name": "Us State",
+                "node_name": "default.us_state",
+                "path": [
+                    "default.contractors",
+                ],
+                "type": "string",
+                "properties": ["primary_key"],
+            },
+        ],
+        key=lambda x: x["name"],  # type: ignore
+    )
 
 
 @pytest.mark.asyncio
@@ -5498,30 +5501,35 @@ async def test_cycle_detection_dimensions_graph(client_with_roads: AsyncClient) 
 
     # Requesting dimensions for any of the above nodes should have a finite end
     response = await client_with_roads.get("/nodes/default.user/dimensions")
-    assert [
+    assert {
         " -> ".join(dim["path"] + [""]) + dim["name"] for dim in response.json()
-    ] == [
-        "default.user -> default.country.country_id",
-        "default.user -> default.country -> default.user -> default.country.country_id",
-        "default.user -> default.country.user_id",
-        "default.user -> default.country -> default.user -> default.country.user_id",
-        "default.user.birth_country",
-        "default.user -> default.country -> default.user.birth_country",
+    } == {
+        "default.user -> default.country -> default.user -> default.user.birth_country",
+        "default.user -> default.country -> default.user -> default.user.user_id",
+        "default.user -> default.country -> default.user -> default.country -> default.country.user_id",
         "default.user.user_id",
-        "default.user -> default.country -> default.user.user_id",
-    ]
+        "default.user -> default.country -> default.user -> default.country -> default.country.country_id",
+        "default.user -> default.country -> default.country.user_id",
+        "default.user -> default.country -> default.country.country_id",
+        "default.user.birth_country",
+    }
     response = await client_with_roads.get("/nodes/default.events/dimensions")
-    assert [
+
+    print(
+        "!!!!!",
+        {" -> ".join(dim["path"] + [""]) + dim["name"] for dim in response.json()},
+    )
+    assert {
         " -> ".join(dim["path"] + [""]) + dim["name"] for dim in response.json()
-    ] == [
-        "default.events -> default.user -> default.country.country_id",
-        "default.events -> default.user -> default.country.user_id",
+    } == {
+        "default.events -> default.user -> default.country -> default.country.user_id",
         "default.events.event_id",
-        "default.events -> default.user.birth_country",
-        "default.events -> default.user -> default.country -> default.user.birth_country",
-        "default.events -> default.user.user_id",
-        "default.events -> default.user -> default.country -> default.user.user_id",
-    ]
+        "default.events -> default.user -> default.country -> default.user -> default.user.birth_country",
+        "default.events -> default.user -> default.user.birth_country",
+        "default.events -> default.user -> default.user.user_id",
+        "default.events -> default.user -> default.country -> default.country.country_id",
+        "default.events -> default.user -> default.country -> default.user -> default.user.user_id",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

The existing dimensions graph query is a recursive CTE that is increasingly slow on even fairly small graphs. I had a closer look at the recursive CTE query we're using, and it looks like it's exhaustively tracing the graph in a way that finds every possible path to a dimension node, rather than just picking up the shortest paths.

This PR changes things so that the dimensions graph function does the following:
1. Discovers all dimension nodes in the graph via a recursive CTE (this is the same structure as the node upstreams or downstreams query and is reasonably fast).
2. Uses each dimension node's columns to augment with reference links.
3. Augments with any local dimensions from the original node.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
