### PR TITLE
Fix `show_deleted` query param for /materializations, rename it `include_all`

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -954,6 +954,7 @@ def get_materialization_info(
     materialization: Materialization,
     request_headers: Optional[Dict[str, str]] = None,
 ) -> MaterializationConfigInfoUnified:
+    """Merge in materialization info from the query service for a node revision"""
     info = query_service_client.get_materialization_info(
         node_revision.name,
         node_revision.version,

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -314,7 +314,7 @@ async def list_node_materializations(
                             request_headers=request_headers,
                         ),
                     )
-    else:  # Get just the active materializations on the current node revision
+    else:  # Get just the materializations on the current node revision
         for materialization in node.current.materializations:  # type: ignore
             if not materialization.deactivated_at or show_inactive:  # pragma: no cover
                 materializations.append(

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -305,7 +305,7 @@ async def list_node_materializations(
     if include_all_revisions:  # Get all materializations for all node revisions
         for node_revision in node.revisions:  # type: ignore
             for materialization in node_revision.materializations:
-                if materialization.deactivated_at or show_inactive:
+                if not materialization.deactivated_at or show_inactive:
                     materializations.append(
                         get_materialization_info(
                             query_service_client=query_service_client,

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -305,7 +305,9 @@ async def list_node_materializations(
     if include_all_revisions:  # Get all materializations for all node revisions
         for node_revision in node.revisions:  # type: ignore
             for materialization in node_revision.materializations:
-                if not materialization.deactivated_at or show_inactive:
+                if (
+                    not materialization.deactivated_at or show_inactive
+                ):  # pragma: no cover
                     materializations.append(
                         get_materialization_info(
                             query_service_client=query_service_client,

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -32,7 +32,6 @@ from datajunction_server.models.base import labelize
 from datajunction_server.models.cube_materialization import UpsertCubeMaterialization
 from datajunction_server.models.materialization import (
     MaterializationConfigInfoUnified,
-    MaterializationConfigOutput,
     MaterializationInfo,
     MaterializationJobTypeEnum,
     MaterializationStrategy,
@@ -277,7 +276,8 @@ async def upsert_materialization(
 )
 async def list_node_materializations(
     node_name: str,
-    include_all: bool = False,
+    show_inactive: bool = False,
+    include_all_revisions: bool = False,
     *,
     session: AsyncSession = Depends(get_session),
     request: Request,
@@ -286,6 +286,9 @@ async def list_node_materializations(
     """
     Show all materializations configured for the node, with any associated metadata
     like urls from the materialization service, if available.
+
+    show_inactive: bool - Show materializations that have a deactivated_at timestamp set
+    include_all_revisions: bool - Show  materializations for all revisions of the node
     """
     request_headers = dict(request.headers)
     node = await Node.get_by_name(
@@ -294,42 +297,34 @@ async def list_node_materializations(
         options=[
             joinedload(Node.revisions).options(*NodeRevision.default_load_options()),
         ]
-        if include_all
+        if include_all_revisions
         else [],
+        raise_if_not_exists=True,
     )
     materializations = []
-    if include_all:  # Get all materializations for all node revisions
+    if include_all_revisions:  # Get all materializations for all node revisions
         for node_revision in node.revisions:  # type: ignore
             for materialization in node_revision.materializations:
+                if materialization.deactivated_at or show_inactive:
+                    materializations.append(
+                        get_materialization_info(
+                            query_service_client=query_service_client,
+                            node_revision=node_revision,
+                            materialization=materialization,
+                            request_headers=request_headers,
+                        ),
+                    )
+    else:  # Get just the active materializations on the current node revision
+        for materialization in node.current.materializations:  # type: ignore
+            if not materialization.deactivated_at or show_inactive:  # pragma: no cover
                 materializations.append(
                     get_materialization_info(
                         query_service_client=query_service_client,
-                        node_revision=node_revision,
+                        node_revision=node.current,  # type: ignore
                         materialization=materialization,
                         request_headers=request_headers,
                     ),
                 )
-    else:  # Get just the active materializations on the current node revision
-        for materialization in node.current.materializations:  # type: ignore
-            if not materialization.deactivated_at:  # pragma: no cover
-                info = query_service_client.get_materialization_info(
-                    node_name,
-                    node.current.version,  # type: ignore
-                    node.type,  # type: ignore
-                    materialization.name,  # type: ignore
-                    request_headers=request_headers,
-                )
-                if materialization.strategy != MaterializationStrategy.INCREMENTAL_TIME:
-                    info.urls = [info.urls[0]]
-                materialization_config_output = MaterializationConfigOutput.from_orm(
-                    materialization,
-                )
-                materialization = MaterializationConfigInfoUnified(
-                    **materialization_config_output.dict(),
-                    **info.dict(),
-                )
-                materializations.append(materialization)
-
     return materializations
 
 

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1678,14 +1678,15 @@ async def test_getting_materializations_for_all_revisions(
         f"/nodes/{cube_name}/materialization/",
         json={
             "job": "druid_measures_cube",
-            "strategy": "full",
-            "schedule": "",
+            "strategy": "incremental_time",
+            "config": {},
+            "schedule": "@daily",
         },
     )
     assert (
         response.json()["message"]
         == "Successfully updated materialization config named "
-        "`druid_measures_cube__full__default.repair_orders_fact.order_date` "
+        "`druid_measures_cube__incremental_time__default.repair_orders_fact.order_date` "
         f"for node `{cube_name}`"
     )
 

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1707,8 +1707,9 @@ async def test_include_all_materialization_configs(
     )
     assert len(response.json()) == 1
 
-    # Make sure both materializations show up when include_all=true is used
+    # Make sure both materializations show up when all materializations are requested
     response = await client.get(
-        "/nodes/default.repair_analytics/materializations?include_all=true",
+        "/nodes/default.repair_analytics/materializations"
+        "?include_all_revisions=true&show_inactive=true",
     )
     assert len(response.json()) == 2


### PR DESCRIPTION
### Summary

When calling `/nodes/{node_name}/materializations?show_deleted=true`, it wasn't returning all of the materializations for a given node because it only looks at the current version (via `node.current`). This fixes that by pulling all materializations for all node revisions, only when that query param is enabled, otherwise the behavior remains the same.

I also renamed it to `include_all` since previous versions of the node could have materializations that aren't deleted, but still can only be accessed via this flag, so viewing deleted materializations is just a subset of why this would be used. I don't think this query param is used anywhere so changing this shouldn't break anything, but let me know if I missed somewhere it is being used.

### Test Plan

Added `test_include_all_materialization_configs`.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
