### PR TITLE
Add endpoint to list available dialects

### DIFF
--- a/datajunction-server/datajunction_server/api/engines.py
+++ b/datajunction-server/datajunction_server/api/engines.py
@@ -13,10 +13,25 @@ from datajunction_server.database.engine import Engine
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.engines import get_engine
 from datajunction_server.models.engine import EngineInfo
+from datajunction_server.models.dialect import DialectRegistry, DialectInfo
 from datajunction_server.utils import get_session, get_settings
 
 settings = get_settings()
 router = SecureAPIRouter(tags=["engines"])
+
+
+@router.get("/dialects", response_model=list[DialectInfo])
+async def list_dialects():
+    """
+    Returns a list of registered SQL dialects and their associated transpilation plugin class names.
+    """
+    return [
+        DialectInfo(
+            name=dialect,
+            plugin_class=plugin.__name__,
+        )
+        for dialect, plugin in DialectRegistry._registry.items()
+    ]
 
 
 @router.get("/engines/", response_model=List[EngineInfo])

--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -7,10 +7,9 @@ import strawberry
 from fastapi import Depends
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import Info
-
 from datajunction_server.api.graphql.queries.catalogs import list_catalogs
 from datajunction_server.api.graphql.queries.dag import common_dimensions
-from datajunction_server.api.graphql.queries.engines import list_engines
+from datajunction_server.api.graphql.queries.engines import list_engines, list_dialects
 from datajunction_server.api.graphql.queries.nodes import (
     find_nodes,
     find_nodes_paginated,
@@ -18,7 +17,11 @@ from datajunction_server.api.graphql.queries.nodes import (
 from datajunction_server.api.graphql.queries.sql import measures_sql
 from datajunction_server.api.graphql.queries.tags import list_tag_types, list_tags
 from datajunction_server.api.graphql.scalars import Connection
-from datajunction_server.api.graphql.scalars.catalog_engine import Catalog, Engine
+from datajunction_server.api.graphql.scalars.catalog_engine import (
+    Catalog,
+    Engine,
+    DialectInfo,
+)
 from datajunction_server.api.graphql.scalars.node import DimensionAttribute, Node
 from datajunction_server.api.graphql.scalars.sql import GeneratedSQL
 from datajunction_server.api.graphql.scalars.tag import Tag
@@ -81,9 +84,15 @@ class Query:
     # Catalog and engine queries
     list_catalogs: list[Catalog] = strawberry.field(
         resolver=log_resolver(list_catalogs),
+        description="List available catalogs",
     )
     list_engines: list[Engine] = strawberry.field(
         resolver=log_resolver(list_engines),
+        description="List all available engines",
+    )
+    list_dialects: list[DialectInfo] = strawberry.field(
+        resolver=log_resolver(list_dialects),
+        description="List all supported SQL dialects",
     )
 
     # Node search queries
@@ -105,6 +114,7 @@ class Query:
     # Generate SQL queries
     measures_sql: list[GeneratedSQL] = strawberry.field(
         resolver=log_resolver(measures_sql),
+        description="Get measures SQL for a list of metrics, dimensions, and filters.",
     )
 
     # Tags queries

--- a/datajunction-server/datajunction_server/api/graphql/queries/engines.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/engines.py
@@ -7,7 +7,8 @@ from typing import List
 from sqlalchemy import select
 from strawberry.types import Info
 
-from datajunction_server.api.graphql.scalars.catalog_engine import Engine
+from datajunction_server.models.dialect import DialectRegistry
+from datajunction_server.api.graphql.scalars.catalog_engine import Engine, DialectInfo
 from datajunction_server.database.engine import Engine as DBEngine
 
 
@@ -22,4 +23,20 @@ async def list_engines(
     return [
         Engine.from_pydantic(engine)  # type: ignore #pylint: disable=E1101
         for engine in (await session.execute(select(DBEngine))).scalars().all()
+    ]
+
+
+async def list_dialects(
+    *,
+    info: Info = None,
+) -> List[DialectInfo]:
+    """
+    List all supported dialects
+    """
+    return [
+        DialectInfo(  # type: ignore
+            name=dialect,
+            plugin_class=plugin.__name__,
+        )
+        for dialect, plugin in DialectRegistry._registry.items()
     ]

--- a/datajunction-server/datajunction_server/api/graphql/scalars/catalog_engine.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/catalog_engine.py
@@ -4,7 +4,8 @@ import strawberry
 
 from datajunction_server.models.catalog import CatalogInfo
 from datajunction_server.models.engine import EngineInfo
-from datajunction_server.models.node import Dialect as Dialect_
+from datajunction_server.models.dialect import Dialect as Dialect_
+from datajunction_server.models.dialect import DialectInfo as DialectInfo_
 
 Dialect = strawberry.enum(Dialect_)
 
@@ -20,4 +21,11 @@ class Engine:
 class Catalog:
     """
     Class for a Catalog
+    """
+
+
+@strawberry.experimental.pydantic.type(model=DialectInfo_, all_fields=True)
+class DialectInfo:
+    """
+    Class for DialectInfo
     """

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -85,6 +85,11 @@ enum Dialect {
   DRUID
 }
 
+type DialectInfo {
+  name: String!
+  pluginClass: String!
+}
+
 type DimensionAttribute {
   name: String!
   attribute: String
@@ -331,8 +336,14 @@ enum PartitionType {
 }
 
 type Query {
+  """List available catalogs"""
   listCatalogs: [Catalog!]!
+
+  """List all available engines"""
   listEngines: [Engine!]!
+
+  """List all supported SQL dialects"""
+  listDialects: [DialectInfo!]!
 
   """Find nodes based on the search parameters."""
   findNodes(
@@ -383,6 +394,8 @@ type Query {
     """A list of nodes to find common dimensions for"""
     nodes: [String!] = null
   ): [DimensionAttribute!]!
+
+  """Get measures SQL for a list of metrics, dimensions, and filters."""
   measuresSql(
     cube: CubeDefinition!
     engine: EngineSettings = null

--- a/datajunction-server/datajunction_server/models/dialect.py
+++ b/datajunction-server/datajunction_server/models/dialect.py
@@ -1,4 +1,6 @@
 import logging
+
+from pydantic import BaseModel
 from datajunction_server.enum import StrEnum
 from datajunction_server.utils import get_settings
 from typing import TYPE_CHECKING
@@ -40,6 +42,15 @@ class Dialect(StrEnum):
                 "supports it. Please configure a plugin on the server to use this dialect.",
             )
         raise TypeError(f"{value!r} is not a valid string for {cls.__name__}")
+
+
+class DialectInfo(BaseModel):
+    """
+    Information about a SQL dialect and its associated plugin class.
+    """
+
+    name: str
+    plugin_class: str
 
 
 class DialectRegistry:

--- a/datajunction-server/tests/api/engine_test.py
+++ b/datajunction-server/tests/api/engine_test.py
@@ -151,3 +151,28 @@ async def test_engine_raise_on_engine_already_exists(
     assert response.status_code == 409
     data = response.json()
     assert data == {"detail": "Engine already exists: `spark-three` version `3.3.1`"}
+
+
+@pytest.mark.asyncio
+async def test_dialects_list(
+    module__client: AsyncClient,
+) -> None:
+    """
+    Test listing dialects
+    """
+    response = await module__client.get("/dialects/")
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "name": "spark",
+            "plugin_class": "SQLTranspilationPlugin",
+        },
+        {
+            "name": "druid",
+            "plugin_class": "SQLTranspilationPlugin",
+        },
+        {
+            "name": "trino",
+            "plugin_class": "SQLTranspilationPlugin",
+        },
+    ]

--- a/datajunction-server/tests/api/graphql/engine_test.py
+++ b/datajunction-server/tests/api/graphql/engine_test.py
@@ -62,3 +62,41 @@ async def test_engine_list(
             ],
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_list_dialects(
+    client: AsyncClient,
+) -> None:
+    """
+    Test listing dialects
+    """
+    query = """
+    {
+        listDialects{
+            name
+            pluginClass
+        }
+    }
+    """
+    response = await client.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "data": {
+            "listDialects": [
+                {
+                    "name": "spark",
+                    "pluginClass": "SQLTranspilationPlugin",
+                },
+                {
+                    "name": "druid",
+                    "pluginClass": "SQLTranspilationPlugin",
+                },
+                {
+                    "name": "trino",
+                    "pluginClass": "SQLTranspilationPlugin",
+                },
+            ],
+        },
+    }


### PR DESCRIPTION
### Summary

This can be useful for determining what dialects a given DJ server deployment can support. Now that we have the ability to register SQL dialect plugins, this will be helpful for debugging available custom dialects.

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
