### PR TITLE
Column metadata should include origin for columns

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -897,23 +897,24 @@ def assemble_column_metadata(
     """
     Extract column metadata from AST
     """
+    has_semantic_entity = hasattr(column, "semantic_entity") and column.semantic_entity
+
+    if use_semantic_metadata and has_semantic_entity:
+        column_name = column.semantic_entity.split(SEPARATOR)[-1]  # type: ignore
+        node_name = SEPARATOR.join(column.semantic_entity.split(SEPARATOR)[:-1])  # type: ignore
+    else:
+        column_name = getattr(column.name, "name", None)
+        node_name = (
+            from_amenable_name(column.table.alias_or_name.name)  # type: ignore
+            if hasattr(column, "table") and column.table
+            else None
+        )
+
     metadata = ColumnMetadata(
         name=column.alias_or_name.name,
         type=str(column.type),
-        column=(
-            column.name.name
-            if hasattr(column, "name") and column.name and not use_semantic_metadata
-            else column.semantic_entity.split(SEPARATOR)[-1]
-            if hasattr(column, "semantic_entity") and column.semantic_entity
-            else None
-        ),
-        node=(
-            from_amenable_name(column.table.alias_or_name.name)
-            if hasattr(column, "table") and column.table and not use_semantic_metadata
-            else SEPARATOR.join(column.semantic_entity.split(SEPARATOR)[:-1])
-            if hasattr(column, "semantic_entity") and column.semantic_entity
-            else None
-        ),
+        column=column_name,
+        node=node_name,
         semantic_entity=column.semantic_entity
         if hasattr(column, "semantic_entity")
         else None,

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -214,7 +214,7 @@ async def build_and_save_node_sql(
             ignore_errors=ignore_errors,
         )
         columns = [
-            assemble_column_metadata(col)  # type: ignore
+            assemble_column_metadata(col, use_semantic_metadata=True)  # type: ignore
             for col in query_ast.select.projection
         ]
         query = str(query_ast)

--- a/datajunction-server/datajunction_server/construction/build.py
+++ b/datajunction-server/datajunction_server/construction/build.py
@@ -63,6 +63,12 @@ def rename_columns(
     projection = []
     node_columns = {col.name for col in node.columns}
     for expression in built_ast.select.projection:
+        if hasattr(expression, "semantic_entity") and expression.semantic_entity:  # type: ignore
+            # If the expression already has a semantic entity, we assume it is already
+            # fully qualified and skip renaming.
+            projection.append(expression)
+            expression.set_alias(ast.Name(amenable_name(expression.semantic_entity)))  # type: ignore
+            continue
         if (
             not isinstance(expression, ast.Alias)
             and not isinstance(

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -862,7 +862,14 @@ class QueryBuilder:
             # Realias based on canonical dimension name
             new_alias = amenable_name(dim_name)
             if node_col and new_alias not in self.final_ast.select.column_mapping:
-                node_col.set_alias(ast.Name(amenable_name(dim_name)))
+                self.final_ast.select.projection.append(
+                    ast.Column(
+                        ast.Name(node_col.name.name),
+                        _table=node_col.table,  # type: ignore
+                        _type=node_col.type,  # type: ignore
+                        alias=ast.Name(new_alias),  # type: ignore
+                    ),
+                )
 
     async def add_request_by_node_name(self, node_name):
         """Add a node request to the access control validator."""

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -996,8 +996,8 @@ FROM default_DOT_events"""
         {
             "name": "default_DOT_users_DOT_registration_country",
             "type": "string",
-            "column": "registration_country",
-            "node": "default.users",
+            "column": "user_registration_country",
+            "node": "default.events",
             "semantic_entity": "default.users.registration_country",
             "semantic_type": "dimension",
         },

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -951,7 +951,7 @@ async def test_transform_sql_filter_dimension_pk_col(
                 "name": "default_DOT_hard_hat_DOT_hard_hat_id",
                 "node": "default.hard_hat",
                 "semantic_entity": "default.hard_hat.hard_hat_id",
-                "semantic_type": None,
+                "semantic_type": "dimension",
                 "type": "int",
             },
             {

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -89,7 +89,7 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
                 {
                     "column": "dispatcher_id",
                     "name": "default_DOT_dispatcher_DOT_dispatcher_id",
-                    "node": "default.dispatcher",
+                    "node": "default.repair_orders_fact",
                     "semantic_entity": "default.dispatcher.dispatcher_id",
                     "semantic_type": "dimension",
                     "type": "int",
@@ -182,7 +182,7 @@ async def fix_dimension_links(module__client_with_roads: AsyncClient):
                 {
                     "column": "dispatcher_id",
                     "name": "default_DOT_dispatcher_DOT_dispatcher_id",
-                    "node": "default.dispatcher",
+                    "node": "default.repair_orders_fact",
                     "semantic_entity": "default.dispatcher.dispatcher_id",
                     "semantic_type": "dimension",
                     "type": "int",


### PR DESCRIPTION
### Summary

At the moment, the `ColumnMetadata` provided by the measures SQL query includes several fields: `node`, `column`, and `semantic_entity`. At the moment,  `node` and `column` are just split-up versions of `semantic_entity`, which is not helpful for downstream consumers, since it's providing the exact same metadata that can be derived.

Instead, it would be more helpful if `node` and `column` actually represented the origin column of the parent node(s), where possible. This PR makes that switch.
 
### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
