### PR TITLE
Add decomposition logic for metrics with dimension refs

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -373,7 +373,10 @@ def build_preaggregate_query(
     added_components = set()
     for metric in children:
         for component in metric_to_components[metric.name][0]:
-            if component.name in added_components:
+            if (
+                component.name in final_query.select.column_mapping
+                or component.name in added_components
+            ):
                 continue
             added_components.add(component.name)
             component_ast = resolve_metric_component_against_parent(

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -1607,11 +1607,13 @@ def build_dimension_attribute(
     """
     dimension_attr = FullColumnName(full_column_name)
     dim_node = dimension_attr.node_name
+    print("dimension_node_joins", dim_node)
     node_query = (
         dimension_node_joins[dim_node].node_query
         if dim_node in dimension_node_joins
         else None
     )
+    print("node_query", node_query)
 
     if node_query:
         foreign_key_column_name = (
@@ -1621,10 +1623,14 @@ def build_dimension_attribute(
             if dimension_attr.name in link.foreign_keys_reversed
             else None
         )
+        print("foreign_key_column_name", foreign_key_column_name)
         for col in node_query.select.projection:
+            print("col.alias_or_name.name", col.alias_or_name.name)
             if col.alias_or_name.name == dimension_attr.column_name or (  # type: ignore
                 foreign_key_column_name
-                and col.alias_or_name.identifier() == foreign_key_column_name  # type: ignore
+                and foreign_key_column_name in (
+                    col.alias_or_name.identifier(), col.alias_or_name.name
+                )
             ):
                 return ast.Column(
                     name=ast.Name(col.alias_or_name.name),  # type: ignore

--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -1607,13 +1607,11 @@ def build_dimension_attribute(
     """
     dimension_attr = FullColumnName(full_column_name)
     dim_node = dimension_attr.node_name
-    print("dimension_node_joins", dim_node)
     node_query = (
         dimension_node_joins[dim_node].node_query
         if dim_node in dimension_node_joins
         else None
     )
-    print("node_query", node_query)
 
     if node_query:
         foreign_key_column_name = (
@@ -1623,14 +1621,11 @@ def build_dimension_attribute(
             if dimension_attr.name in link.foreign_keys_reversed
             else None
         )
-        print("foreign_key_column_name", foreign_key_column_name)
         for col in node_query.select.projection:
-            print("col.alias_or_name.name", col.alias_or_name.name)
             if col.alias_or_name.name == dimension_attr.column_name or (  # type: ignore
                 foreign_key_column_name
-                and foreign_key_column_name in (
-                    col.alias_or_name.identifier(), col.alias_or_name.name
-                )
+                and foreign_key_column_name
+                in (col.alias_or_name.identifier(), col.alias_or_name.name)  # type: ignore
             ):
                 return ast.Column(
                     name=ast.Name(col.alias_or_name.name),  # type: ignore

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -114,7 +114,7 @@ class MetricComponentExtractor:
                     ),
                 )
                 # Replace the column in the AST with a reference to the new metric component
-                if col.parent:
+                if col.parent:  # pragma: no cover
                     col.parent.replace(
                         from_=col,
                         to=ast.Column(ast.Name(component_name)),

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -520,7 +520,14 @@ def test_no_aggregation():
         "SELECT sales_amount FROM parent_node",
     )
     measures, derived_sql = extractor.extract()
-    expected_measures = []
+    expected_measures = [
+        MetricComponent(
+            name="sales_amount",
+            expression="sales_amount",
+            aggregation=None,
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+    ]
     assert measures == expected_measures
     assert str(derived_sql) == str(parse("SELECT sales_amount FROM parent_node"))
 
@@ -605,7 +612,14 @@ def test_unsupported_aggregation_function():
         "SELECT MEDIAN(sales_amount) FROM parent_node",
     )
     measures, derived_sql = extractor.extract()
-    expected_measures = []
+    expected_measures = [
+        MetricComponent(
+            name="sales_amount",
+            expression="sales_amount",
+            aggregation=None,
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+    ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse("SELECT MEDIAN(sales_amount) FROM parent_node"),
@@ -615,7 +629,14 @@ def test_unsupported_aggregation_function():
         "SELECT approx_percentile(duration_ms, 1.0, 0.9) / 1000 FROM parent_node",
     )
     measures, derived_sql = extractor.extract()
-    expected_measures = []
+    expected_measures = [
+        MetricComponent(
+            name="duration_ms",
+            expression="duration_ms",
+            aggregation=None,
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
+        ),
+    ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(


### PR DESCRIPTION
### Summary

This PR adds decomposition logic for metrics with dimension references in their expression. At the moment we don't extract them out into a valid metric component, which makes it hard to do the mapping on the metric query once a materialized dataset exists with the dimension ref.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
