### PR TITLE
Enable cubes to be created with no dimensions

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -419,7 +419,9 @@ async def validate_cube(
             dimensions.append(columns[column_name_without_role])
 
     if require_dimensions and not dimensions:
-        raise DJInvalidInputException(message="At least one dimension is required")
+        raise DJInvalidInputException(  # pragma: no cover
+            message="At least one dimension is required",
+        )
 
     if len(set(catalogs)) > 1:
         raise DJInvalidInputException(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -327,7 +327,7 @@ async def create_cube_node_revision(
         session,
         data.metrics,
         data.dimensions,
-        require_dimensions=True,
+        require_dimensions=False,
     )
     status = (
         NodeStatus.VALID
@@ -2137,7 +2137,7 @@ async def revalidate_node(
                 session,
                 metric_names=cube_metrics,
                 dimension_names=cube_dimensions,
-                require_dimensions=True,
+                require_dimensions=False,
             )
             current_node_revision.status = NodeStatus.VALID
         except DJException as exc:  # pragma: no cover

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -226,7 +226,14 @@ async def test_create_invalid_cube(module__client_with_account_revenue: AsyncCli
         "warnings": [],
     }
 
-    # Check that creating a cube with no dimension nodes fails appropriately
+
+@pytest.mark.asyncio
+async def test_create_cube_no_dimensions(
+    module__client_with_account_revenue: AsyncClient,
+):
+    """
+    Check that creating a cube with no dimension attributes works
+    """
     response = await module__client_with_account_revenue.post(
         "/nodes/cube/",
         json={
@@ -234,16 +241,12 @@ async def test_create_invalid_cube(module__client_with_account_revenue: AsyncCli
             "dimensions": [],
             "description": "A cube of number of accounts grouped by account type",
             "mode": "published",
-            "name": "default.cubes_must_have_dimensions",
+            "name": "default.cubes_can_have_no_dimensions",
         },
     )
-    assert response.status_code == 422
+    assert response.status_code == 201
     data = response.json()
-    assert data == {
-        "message": "At least one dimension is required",
-        "errors": [],
-        "warnings": [],
-    }
+    assert data["parents"] == [{"name": "default.number_of_account_types"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This relaxes the restrictions on cubes so that cubes can be created with with no dimension attributes. There is no reason why dimensions have to be included.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
