### PR TITLE
Add custom_metadata and downstream nodes to GraphQL api.

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -8,7 +8,10 @@ from fastapi import Request
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import Info
 from datajunction_server.api.graphql.queries.catalogs import list_catalogs
-from datajunction_server.api.graphql.queries.dag import common_dimensions
+from datajunction_server.api.graphql.queries.dag import (
+    common_dimensions,
+    downstream_nodes,
+)
 from datajunction_server.api.graphql.queries.engines import list_engines, list_dialects
 from datajunction_server.api.graphql.queries.nodes import (
     find_nodes,
@@ -109,6 +112,10 @@ class Query:
     common_dimensions: list[DimensionAttribute] = strawberry.field(
         resolver=log_resolver(common_dimensions),
         description="Get common dimensions for one or more nodes",
+    )
+    downstream_nodes: list[Node] = strawberry.field(
+        resolver=log_resolver(downstream_nodes),
+        description="Find downstream nodes (optionally, of a given type) from a given node.",
     )
 
     # Generate SQL queries

--- a/datajunction-server/datajunction_server/api/graphql/queries/dag.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/dag.py
@@ -7,9 +7,11 @@ from typing import Annotated
 import strawberry
 from strawberry.types import Info
 
+from datajunction_server.database.node import Node
 from datajunction_server.api.graphql.resolvers.nodes import find_nodes_by
 from datajunction_server.api.graphql.scalars.node import DimensionAttribute
-from datajunction_server.sql.dag import get_common_dimensions
+from datajunction_server.sql.dag import get_common_dimensions, get_downstream_nodes
+from datajunction_server.models.node_type import NodeType
 from datajunction_server.utils import SEPARATOR
 
 
@@ -32,8 +34,31 @@ async def common_dimensions(
         DimensionAttribute(  # type: ignore
             name=dim.name,
             attribute=dim.name.split(SEPARATOR)[-1],
-            properties=dim.properties,
-            type=dim.type,
+            properties=dim.properties,  # type: ignore
+            type=dim.type,  # type: ignore
         )
         for dim in dimensions
     ]
+
+
+async def downstream_nodes(
+    node_name: Annotated[
+        str,
+        strawberry.argument(
+            description="The node name to find downstream nodes for.",
+        ),
+    ],
+    node_type: Annotated[
+        NodeType | None,
+        strawberry.argument(
+            description="The node type to filter the downstream nodes on.",
+        ),
+    ] = None,
+    *,
+    info: Info,
+) -> list[Node]:
+    """
+    Return a list of downstream nodes for a given node.
+    """
+    session = info.context["session"]
+    return await get_downstream_nodes(session, node_name=node_name, node_type=node_type)  # type: ignore

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -114,6 +114,7 @@ class NodeRevision:
     mode: Optional[NodeMode]  # type: ignore
     description: str = ""
     updated_at: datetime.datetime
+    custom_metadata: Optional[JSON] = strawberry.field(default_factory=dict)
 
     @strawberry.field
     def catalog(self, root: "DBNodeRevision") -> Optional[Catalog]:

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -260,6 +260,7 @@ type NodeRevision {
   mode: NodeMode
   description: String!
   updatedAt: DateTime!
+  customMetadata: JSON
   query: String
   columns: [Column!]!
   dimensionLinks: [DimensionLink!]!
@@ -394,6 +395,15 @@ type Query {
     """A list of nodes to find common dimensions for"""
     nodes: [String!] = null
   ): [DimensionAttribute!]!
+
+  """Find downstream nodes (optionally, of a given type) from a given node."""
+  downstreamNodes(
+    """The node name to find downstream nodes for."""
+    nodeName: String!
+
+    """The node type to filter the downstream nodes on."""
+    nodeType: NodeType = null
+  ): [Node!]!
 
   """Get measures SQL for a list of metrics, dimensions, and filters."""
   measuresSql(

--- a/datajunction-server/tests/api/graphql/downstream_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/downstream_nodes_test.py
@@ -1,0 +1,96 @@
+"""
+Tests for the engine API.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_downstream_nodes(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test finding nodes by node type
+    """
+
+    # of METRIC type
+    query = """
+    {
+        downstreamNodes(nodeName: "default.repair_orders_fact", nodeType: METRIC) {
+            name
+            type
+            current {
+                customMetadata
+            }
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["downstreamNodes"] == [
+        {
+            "name": "default.num_repair_orders",
+            "type": "METRIC",
+            "current": {"customMetadata": {"foo": "bar"}},
+        },
+        {
+            "name": "default.avg_repair_price",
+            "type": "METRIC",
+            "current": {"customMetadata": None},
+        },
+        {
+            "name": "default.total_repair_cost",
+            "type": "METRIC",
+            "current": {"customMetadata": None},
+        },
+        {
+            "name": "default.discounted_orders_rate",
+            "type": "METRIC",
+            "current": {"customMetadata": None},
+        },
+        {
+            "name": "default.total_repair_order_discounts",
+            "type": "METRIC",
+            "current": {"customMetadata": None},
+        },
+        {
+            "name": "default.avg_repair_order_discounts",
+            "type": "METRIC",
+            "current": {"customMetadata": None},
+        },
+        {
+            "name": "default.avg_time_to_dispatch",
+            "type": "METRIC",
+            "current": {"customMetadata": None},
+        },
+    ]
+
+    # of any type
+    query = """
+    {
+        downstreamNodes(nodeName: "default.repair_order_details", nodeType: null) {
+            name
+            type
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["downstreamNodes"] == [
+        {"name": "default.regional_level_agg", "type": "TRANSFORM"},
+        {"name": "default.national_level_agg", "type": "TRANSFORM"},
+        {"name": "default.repair_orders_fact", "type": "TRANSFORM"},
+        {"name": "default.regional_repair_efficiency", "type": "METRIC"},
+        {"name": "default.num_repair_orders", "type": "METRIC"},
+        {"name": "default.avg_repair_price", "type": "METRIC"},
+        {"name": "default.total_repair_cost", "type": "METRIC"},
+        {"name": "default.discounted_orders_rate", "type": "METRIC"},
+        {"name": "default.total_repair_order_discounts", "type": "METRIC"},
+        {"name": "default.avg_repair_order_discounts", "type": "METRIC"},
+        {"name": "default.avg_time_to_dispatch", "type": "METRIC"},
+    ]

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -25,6 +25,9 @@ async def test_find_by_node_type(
                 name
             }
             currentVersion
+            current {
+                customMetadata
+            }
         }
     }
     """
@@ -38,18 +41,21 @@ async def test_find_by_node_type(
             "name": "default.repair_orders_fact",
             "tags": [],
             "type": "TRANSFORM",
+            "current": {"customMetadata": {"foo": "bar"}},
         },
         {
             "currentVersion": "v1.0",
             "name": "default.national_level_agg",
             "tags": [],
             "type": "TRANSFORM",
+            "current": {"customMetadata": None},
         },
         {
             "currentVersion": "v1.0",
             "name": "default.regional_level_agg",
             "tags": [],
             "type": "TRANSFORM",
+            "current": {"customMetadata": None},
         },
     ]
 

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -602,6 +602,7 @@ GROUP BY
             "name": "default.repair_orders_fact",
             "display_name": "Repair Orders Fact",
             "mode": "published",
+            "custom_metadata": {"foo": "bar"},
             "query": """SELECT
   repair_orders.repair_order_id,
   repair_orders.municipality_id,
@@ -655,6 +656,9 @@ CROSS JOIN
             "metric_metadata": {
                 "direction": "higher_is_better",
                 "unit": "dollar",
+            },
+            "custom_metadata": {
+                "foo": "bar",
             },
         },
     ),


### PR DESCRIPTION
### Summary

Two things in this PR:
- added `custom_metadata` field to GraphQL node output,
- added new query `downstream_nodes` to GraphQL api.

### Test Plan

Unit tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Auto.