### PR TITLE
Manage GraphQL DB session via middleware

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -66,6 +66,9 @@ def log_resolver(func):
 
 
 async def get_context(request: Request):
+    """
+    Provides the context for graphql requests
+    """
     return {
         "session": request.state.db,
         "settings": get_settings(),

--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -4,7 +4,7 @@ import logging
 from functools import wraps
 
 import strawberry
-from fastapi import Depends
+from fastapi import Request
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import Info
 from datajunction_server.api.graphql.queries.catalogs import list_catalogs
@@ -25,7 +25,7 @@ from datajunction_server.api.graphql.scalars.catalog_engine import (
 from datajunction_server.api.graphql.scalars.node import DimensionAttribute, Node
 from datajunction_server.api.graphql.scalars.sql import GeneratedSQL
 from datajunction_server.api.graphql.scalars.tag import Tag
-from datajunction_server.utils import get_session, get_settings
+from datajunction_server.utils import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -65,14 +65,11 @@ def log_resolver(func):
     return wrapper
 
 
-async def get_context(
-    session=Depends(get_session),
-    settings=Depends(get_settings),
-):
-    """
-    Provides the context for graphql requests
-    """
-    return {"session": session, "settings": settings}
+async def get_context(request: Request):
+    return {
+        "session": request.state.db,
+        "settings": get_settings(),
+    }
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/graphql/middleware.py
+++ b/datajunction-server/datajunction_server/api/graphql/middleware.py
@@ -1,0 +1,26 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from datajunction_server.utils import get_session_manager
+
+
+class GraphQLSessionMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        """
+        Middleware to manage database sessions for GraphQL requests. This ensures that
+        a database session is created for each GraphQL request, and that it's committed
+        or rolled back as appropriate.
+        """
+        if request.url.path.startswith("/graphql"):
+            session = get_session_manager().session()
+            request.state.db = session  # Attach to request so context can access it
+            try:
+                response = await call_next(request)
+                await session.commit()
+                return response
+            except Exception:
+                await session.rollback()
+                raise
+            finally:
+                await session.close()
+        else:
+            return await call_next(request)

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -42,6 +42,7 @@ from datajunction_server.api.access.authentication import basic, whoami
 from datajunction_server.api.attributes import default_attribute_types
 from datajunction_server.api.catalogs import default_catalog
 from datajunction_server.api.graphql.main import graphql_app, schema as graphql_schema  # noqa: F401
+from datajunction_server.api.graphql.middleware import GraphQLSessionMiddleware
 from datajunction_server.constants import AUTH_COOKIE, LOGGED_IN_FLAG_COOKIE
 from datajunction_server.errors import DJException
 from datajunction_server.utils import get_settings
@@ -72,7 +73,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
+app.add_middleware(GraphQLSessionMiddleware)
 app.include_router(catalogs.router)
 app.include_router(collection.router)
 app.include_router(engines.router)

--- a/datajunction-server/tests/api/graphql/middleware_test.py
+++ b/datajunction-server/tests/api/graphql/middleware_test.py
@@ -1,0 +1,58 @@
+from fastapi.routing import APIRoute
+import pytest
+from fastapi import Request
+from unittest.mock import AsyncMock, Mock, patch
+
+
+@pytest.mark.asyncio
+async def test_middleware_success(client):
+    """
+    Test that the middleware commits the session and closes it on success.
+    """
+    mock_session = AsyncMock()
+    mock_manager = Mock()
+    mock_manager.session = Mock(return_value=mock_session)
+
+    with patch(
+        "datajunction_server.api.graphql.middleware.get_session_manager",
+        return_value=mock_manager,
+    ):
+        response = await client.post("/graphql", json={"query": "{ __typename }"})
+
+    assert response.status_code == 200
+    mock_session.commit.assert_awaited_once()
+    mock_session.rollback.assert_not_called()
+    mock_session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_middleware_failure(client):
+    """
+    Test that the middleware rolls back the session and closes it on failure.
+    """
+
+    async def failing_endpoint(request: Request):
+        raise ValueError("Something went wrong")
+
+    app = client.app
+    app.router.routes = [
+        route
+        for route in app.router.routes
+        if not (hasattr(route, "path") and route.path == "/graphql")
+    ]
+    app.router.routes.append(APIRoute("/graphql", failing_endpoint, methods=["POST"]))
+
+    mock_session = AsyncMock()
+    mock_manager = Mock()
+    mock_manager.session = Mock(return_value=mock_session)
+
+    with patch(
+        "datajunction_server.api.graphql.middleware.get_session_manager",
+        return_value=mock_manager,
+    ):
+        with pytest.raises(ValueError):
+            await client.post("/graphql", json={"query": "{ __typename }"})
+
+    mock_session.commit.assert_not_called()
+    mock_session.rollback.assert_awaited_once()
+    mock_session.close.assert_awaited_once()


### PR DESCRIPTION
### Summary

There is an issue in the current GraphQL database session management, where we currently use `Depends(get_session)` in `get_context()` to provide a database session for each request. However, this does not work well because Strawberry's `get_context()` is meant to be a regular function that returns a dict, with no support for teardown/generator-based context. That means that we get errors like the following when servicing GraphQL requests:
```
Can't reconnect until invalid transaction is rolled back.  Please rollback() fully before proceeding
```

This change adds a `GraphQLSessionMiddleware` to handle database session creation, commit/rollback, and cleanup for each GraphQL request. This middleware only applies to /graphql endpoint, so REST dependency behavior is kept unchanged. It ensures consistent db session management without manual handling in each resolver.

### Test Plan

Added unit tests

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
