### PR TITLE
Fix hashing on measure decomposition.

### DIFF
--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -59,7 +59,7 @@ class MetricComponentExtractor:
             # Normalize metric queries with aliases
             parent_node_alias = self._query_ast.select.from_.relations[  # type: ignore
                 0
-            ].primary.alias
+            ].primary.alias  # type: ignore
             if parent_node_alias:
                 for col in self._query_ast.find_all(ast.Column):
                     if (
@@ -84,6 +84,13 @@ class MetricComponentExtractor:
             self._extracted = True
         return self._components, self._query_ast
 
+    def _short_hash(self, expression: str) -> str:
+        """
+        Generates a short hash for the given expression.
+        """
+        signature = expression + str(self._query_ast.select.from_)
+        return hashlib.md5(signature.encode("utf-8")).hexdigest()[:8]
+
     def _simple_associative_agg(self, func) -> list[MetricComponent]:
         """
         Handles decomposition for a single-argument associative aggregation function.
@@ -104,7 +111,7 @@ class MetricComponentExtractor:
             )
 
         expression = str(arg)
-        short_hash = hashlib.md5(expression.encode("utf-8")).hexdigest()[:8]
+        short_hash = self._short_hash(expression)
 
         return [
             MetricComponent(
@@ -134,7 +141,7 @@ class MetricComponentExtractor:
         arg = func.args[0]
         component_name = "_".join([str(col) for col in arg.find_all(ast.Column)])
         expression = str(arg)
-        short_hash = hashlib.md5(expression.encode("utf-8")).hexdigest()[:8]
+        short_hash = self._short_hash(expression)
         return [
             MetricComponent(
                 name=f"{component_name}_{dj_functions.Sum.__name__.lower()}_{short_hash}",

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2302,13 +2302,13 @@ async def test_derive_sql_column():
             display_name="Revenue",
             node_name="foo.bar.baz",
             type="metric",
-        ),
+        ),  # type: ignore
     )
     expected_sql_column = ColumnOutput(
         name="foo_DOT_bar_DOT_baz_DOT_revenue",
         display_name="Revenue",
         type="metric",
-    )
+    )  # type: ignore
     assert sql_column.name == expected_sql_column.name
     assert sql_column.display_name == expected_sql_column.display_name
     assert sql_column.type == expected_sql_column.type
@@ -2318,13 +2318,13 @@ async def test_derive_sql_column():
             display_name="Owner",
             node_name="foo.bar.baz",
             type="dimension",
-        ),
+        ),  # type: ignore
     )
     expected_sql_column = ColumnOutput(
         name="foo_DOT_bar_DOT_baz_DOT_owner",
         display_name="Owner",
         type="dimension",
-    )
+    )  # type: ignore
     assert sql_column.name == expected_sql_column.name
     assert sql_column.display_name == expected_sql_column.display_name
     assert sql_column.type == expected_sql_column.type
@@ -2383,11 +2383,11 @@ async def test_cube_materialization_metadata(
     ]
     assert results["metrics"] == [
         {
-            "derived_expression": "SELECT  CAST(sum(discount_sum_62846f49) AS DOUBLE) / "
-            "SUM(count_3389dae3) AS default_DOT_discounted_orders_rate  FROM "
+            "derived_expression": "SELECT  CAST(sum(discount_sum_30b84e6c) AS DOUBLE) / "
+            "SUM(count_c8e42e74) AS default_DOT_discounted_orders_rate  FROM "
             "default.repair_orders_fact",
-            "metric_expression": "CAST(sum(discount_sum_62846f49) AS DOUBLE) / "
-            "SUM(count_3389dae3)",
+            "metric_expression": "CAST(sum(discount_sum_30b84e6c) AS DOUBLE) / "
+            "SUM(count_c8e42e74)",
             "metric": {
                 "name": "default.discounted_orders_rate",
                 "version": "v1.0",
@@ -2395,7 +2395,7 @@ async def test_cube_materialization_metadata(
             },
             "required_measures": [
                 {
-                    "measure_name": "discount_sum_62846f49",
+                    "measure_name": "discount_sum_30b84e6c",
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
@@ -2403,7 +2403,7 @@ async def test_cube_materialization_metadata(
                     },
                 },
                 {
-                    "measure_name": "count_3389dae3",
+                    "measure_name": "count_c8e42e74",
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
@@ -2413,9 +2413,9 @@ async def test_cube_materialization_metadata(
             ],
         },
         {
-            "derived_expression": "SELECT  SUM(repair_order_id_count_0b7dfba0)  FROM "
+            "derived_expression": "SELECT  SUM(repair_order_id_count_bd241964)  FROM "
             "default.repair_orders_fact",
-            "metric_expression": "SUM(repair_order_id_count_0b7dfba0)",
+            "metric_expression": "SUM(repair_order_id_count_bd241964)",
             "metric": {
                 "name": "default.num_repair_orders",
                 "version": "v1.0",
@@ -2423,7 +2423,7 @@ async def test_cube_materialization_metadata(
             },
             "required_measures": [
                 {
-                    "measure_name": "repair_order_id_count_0b7dfba0",
+                    "measure_name": "repair_order_id_count_bd241964",
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
@@ -2433,9 +2433,9 @@ async def test_cube_materialization_metadata(
             ],
         },
         {
-            "derived_expression": "SELECT  SUM(price_sum_78a5eb43) / SUM(price_count_78a5eb43)  FROM "
+            "derived_expression": "SELECT  SUM(price_sum_935e7117) / SUM(price_count_935e7117)  FROM "
             "default.repair_orders_fact",
-            "metric_expression": "SUM(price_sum_78a5eb43) / SUM(price_count_78a5eb43)",
+            "metric_expression": "SUM(price_sum_935e7117) / SUM(price_count_935e7117)",
             "metric": {
                 "name": "default.avg_repair_price",
                 "version": "v1.0",
@@ -2443,7 +2443,7 @@ async def test_cube_materialization_metadata(
             },
             "required_measures": [
                 {
-                    "measure_name": "price_count_78a5eb43",
+                    "measure_name": "price_count_935e7117",
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
@@ -2451,7 +2451,7 @@ async def test_cube_materialization_metadata(
                     },
                 },
                 {
-                    "measure_name": "price_sum_78a5eb43",
+                    "measure_name": "price_sum_935e7117",
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
@@ -2461,9 +2461,9 @@ async def test_cube_materialization_metadata(
             ],
         },
         {
-            "derived_expression": "SELECT  sum(total_repair_cost_sum_9bdaf803)  FROM "
+            "derived_expression": "SELECT  sum(total_repair_cost_sum_67874507)  FROM "
             "default.repair_orders_fact",
-            "metric_expression": "sum(total_repair_cost_sum_9bdaf803)",
+            "metric_expression": "sum(total_repair_cost_sum_67874507)",
             "metric": {
                 "name": "default.total_repair_cost",
                 "version": "v1.0",
@@ -2471,7 +2471,7 @@ async def test_cube_materialization_metadata(
             },
             "required_measures": [
                 {
-                    "measure_name": "total_repair_cost_sum_9bdaf803",
+                    "measure_name": "total_repair_cost_sum_67874507",
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
@@ -2481,9 +2481,9 @@ async def test_cube_materialization_metadata(
             ],
         },
         {
-            "derived_expression": "SELECT  sum(price_discount_sum_017d55a8)  FROM "
+            "derived_expression": "SELECT  sum(price_discount_sum_e4ba5456)  FROM "
             "default.repair_orders_fact",
-            "metric_expression": "sum(price_discount_sum_017d55a8)",
+            "metric_expression": "sum(price_discount_sum_e4ba5456)",
             "metric": {
                 "name": "default.total_repair_order_discounts",
                 "version": "v1.0",
@@ -2491,7 +2491,7 @@ async def test_cube_materialization_metadata(
             },
             "required_measures": [
                 {
-                    "measure_name": "price_discount_sum_017d55a8",
+                    "measure_name": "price_discount_sum_e4ba5456",
                     "node": {
                         "name": "default.repair_orders_fact",
                         "version": "v1.0",
@@ -2501,10 +2501,10 @@ async def test_cube_materialization_metadata(
             ],
         },
         {
-            "derived_expression": "SELECT  sum(price_sum_78a5eb43) + sum(price_sum_78a5eb43) AS "
+            "derived_expression": "SELECT  sum(price_sum_252381cf) + sum(price_sum_252381cf) AS "
             "default_DOT_double_total_repair_cost  FROM "
             "default.repair_order_details",
-            "metric_expression": "sum(price_sum_78a5eb43) + sum(price_sum_78a5eb43)",
+            "metric_expression": "sum(price_sum_252381cf) + sum(price_sum_252381cf)",
             "metric": {
                 "name": "default.double_total_repair_cost",
                 "version": "v1.0",
@@ -2512,7 +2512,7 @@ async def test_cube_materialization_metadata(
             },
             "required_measures": [
                 {
-                    "measure_name": "price_sum_78a5eb43",
+                    "measure_name": "price_sum_252381cf",
                     "node": {
                         "name": "default.repair_order_details",
                         "version": "v1.0",
@@ -2582,58 +2582,58 @@ async def test_cube_materialization_metadata(
                     "type": "string",
                 },
                 {
-                    "column": "discount_sum_62846f49",
-                    "name": "discount_sum_62846f49",
+                    "column": "discount_sum_30b84e6c",
+                    "name": "discount_sum_30b84e6c",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.discount_sum_62846f49",
+                    "semantic_entity": "default.repair_orders_fact.discount_sum_30b84e6c",
                     "semantic_type": "measure",
                     "type": "bigint",
                 },
                 {
-                    "column": "count_3389dae3",
-                    "name": "count_3389dae3",
+                    "column": "count_c8e42e74",
+                    "name": "count_c8e42e74",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.count_3389dae3",
+                    "semantic_entity": "default.repair_orders_fact.count_c8e42e74",
                     "semantic_type": "measure",
                     "type": "bigint",
                 },
                 {
-                    "column": "repair_order_id_count_0b7dfba0",
-                    "name": "repair_order_id_count_0b7dfba0",
+                    "column": "repair_order_id_count_bd241964",
+                    "name": "repair_order_id_count_bd241964",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+                    "semantic_entity": "default.repair_orders_fact.repair_order_id_count_bd241964",
                     "semantic_type": "measure",
                     "type": "bigint",
                 },
                 {
-                    "column": "price_count_78a5eb43",
-                    "name": "price_count_78a5eb43",
+                    "column": "price_count_935e7117",
+                    "name": "price_count_935e7117",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.price_count_78a5eb43",
+                    "semantic_entity": "default.repair_orders_fact.price_count_935e7117",
                     "semantic_type": "measure",
                     "type": "bigint",
                 },
                 {
-                    "column": "price_sum_78a5eb43",
-                    "name": "price_sum_78a5eb43",
+                    "column": "price_sum_935e7117",
+                    "name": "price_sum_935e7117",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.price_sum_78a5eb43",
+                    "semantic_entity": "default.repair_orders_fact.price_sum_935e7117",
                     "semantic_type": "measure",
                     "type": "double",
                 },
                 {
-                    "column": "total_repair_cost_sum_9bdaf803",
-                    "name": "total_repair_cost_sum_9bdaf803",
+                    "column": "total_repair_cost_sum_67874507",
+                    "name": "total_repair_cost_sum_67874507",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
+                    "semantic_entity": "default.repair_orders_fact.total_repair_cost_sum_67874507",
                     "semantic_type": "measure",
                     "type": "double",
                 },
                 {
-                    "column": "price_discount_sum_017d55a8",
-                    "name": "price_discount_sum_017d55a8",
+                    "column": "price_discount_sum_e4ba5456",
+                    "name": "price_discount_sum_e4ba5456",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.price_discount_sum_017d55a8",
+                    "semantic_entity": "default.repair_orders_fact.price_discount_sum_e4ba5456",
                     "semantic_type": "measure",
                     "type": "double",
                 },
@@ -2661,7 +2661,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "SUM",
                     "expression": "if(discount > 0.0, 1, 0)",
-                    "name": "discount_sum_62846f49",
+                    "name": "discount_sum_30b84e6c",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2670,7 +2670,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "COUNT",
                     "expression": "*",
-                    "name": "count_3389dae3",
+                    "name": "count_c8e42e74",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2679,7 +2679,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "COUNT",
                     "expression": "repair_order_id",
-                    "name": "repair_order_id_count_0b7dfba0",
+                    "name": "repair_order_id_count_bd241964",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2688,7 +2688,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "COUNT",
                     "expression": "price",
-                    "name": "price_count_78a5eb43",
+                    "name": "price_count_935e7117",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2697,7 +2697,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "SUM",
                     "expression": "price",
-                    "name": "price_sum_78a5eb43",
+                    "name": "price_sum_935e7117",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2706,7 +2706,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "SUM",
                     "expression": "total_repair_cost",
-                    "name": "total_repair_cost_sum_9bdaf803",
+                    "name": "total_repair_cost_sum_67874507",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2715,7 +2715,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "SUM",
                     "expression": "price * discount",
-                    "name": "price_discount_sum_017d55a8",
+                    "name": "price_discount_sum_e4ba5456",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2727,7 +2727,7 @@ async def test_cube_materialization_metadata(
                 "version": "v1.0",
                 "display_name": "Repair Orders Fact",
             },
-            "output_table_name": "default_repair_orders_fact_v1_0_c9390406463b348e",
+            "output_table_name": "default_repair_orders_fact_v1_0_15b7da54aa19ecd7",
             "query": mock.ANY,
             "spark_conf": None,
             "timestamp_column": "default_DOT_hard_hat_DOT_hire_date",
@@ -2801,10 +2801,10 @@ async def test_cube_materialization_metadata(
                     "type": "string",
                 },
                 {
-                    "column": "price_sum_78a5eb43",
-                    "name": "price_sum_78a5eb43",
+                    "column": "price_sum_252381cf",
+                    "name": "price_sum_252381cf",
                     "node": "default.repair_order_details",
-                    "semantic_entity": "default.repair_order_details.price_sum_78a5eb43",
+                    "semantic_entity": "default.repair_order_details.price_sum_252381cf",
                     "semantic_type": "measure",
                     "type": "double",
                 },
@@ -2832,7 +2832,7 @@ async def test_cube_materialization_metadata(
                 {
                     "aggregation": "SUM",
                     "expression": "price",
-                    "name": "price_sum_78a5eb43",
+                    "name": "price_sum_252381cf",
                     "rule": {
                         "level": None,
                         "type": "full",
@@ -2844,7 +2844,7 @@ async def test_cube_materialization_metadata(
                 "version": "v1.0",
                 "display_name": "default.roads.repair_order_details",
             },
-            "output_table_name": "default_repair_order_details_v1_0_5bf367d2fc7c255d",
+            "output_table_name": "default_repair_order_details_v1_0_f15982420cc5c632",
             "query": mock.ANY,
             "spark_conf": None,
             "timestamp_column": "default_DOT_hard_hat_DOT_hire_date",
@@ -2941,13 +2941,13 @@ async def test_cube_materialization_metadata(
       default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_state,
       default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
       default_DOT_repair_orders_fact_built.default_DOT_municipality_dim_DOT_local_region,
-      SUM(if(discount > 0.0, 1, 0)) AS discount_sum_62846f49,
-      COUNT(*) AS count_3389dae3,
-      COUNT(repair_order_id) AS repair_order_id_count_0b7dfba0,
-      COUNT(price) AS price_count_78a5eb43,
-      SUM(price) AS price_sum_78a5eb43,
-      SUM(total_repair_cost) AS total_repair_cost_sum_9bdaf803,
-      SUM(price * discount) AS price_discount_sum_017d55a8
+      SUM(if(discount > 0.0, 1, 0)) AS discount_sum_30b84e6c,
+      COUNT(*) AS count_c8e42e74,
+      COUNT(repair_order_id) AS repair_order_id_count_bd241964,
+      COUNT(price) AS price_count_935e7117,
+      SUM(price) AS price_sum_935e7117,
+      SUM(total_repair_cost) AS total_repair_cost_sum_67874507,
+      SUM(price * discount) AS price_discount_sum_e4ba5456
     FROM default_DOT_repair_orders_fact_built
     GROUP BY  default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_country, default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_postal_code, default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_city, default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_hire_date, default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_state, default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name, default_DOT_repair_orders_fact_built.default_DOT_municipality_dim_DOT_local_region
     """
@@ -2962,127 +2962,142 @@ async def test_cube_materialization_metadata(
 
     assert results["combiners"] == [
         {
+            "node": {
+                "name": "default.example_repairs_cube",
+                "version": "v1.0",
+                "display_name": "Example Repairs Cube",
+            },
+            "query": "SELECT  COALESCE(default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_country, default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_country) default_DOT_hard_hat_DOT_country,\n\tCOALESCE(default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_postal_code, default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_postal_code) default_DOT_hard_hat_DOT_postal_code,\n\tCOALESCE(default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_city, default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_city) default_DOT_hard_hat_DOT_city,\n\tCOALESCE(default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_hire_date, default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_hire_date) default_DOT_hard_hat_DOT_hire_date,\n\tCOALESCE(default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_state, default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_state) default_DOT_hard_hat_DOT_state,\n\tCOALESCE(default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_dispatcher_DOT_company_name, default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_dispatcher_DOT_company_name) default_DOT_dispatcher_DOT_company_name,\n\tCOALESCE(default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_municipality_dim_DOT_local_region, default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_municipality_dim_DOT_local_region) default_DOT_municipality_dim_DOT_local_region,\n\tdefault_repair_orders_fact_v1_0_15b7da54aa19ecd7.discount_sum_30b84e6c,\n\tdefault_repair_orders_fact_v1_0_15b7da54aa19ecd7.count_c8e42e74,\n\tdefault_repair_orders_fact_v1_0_15b7da54aa19ecd7.repair_order_id_count_bd241964,\n\tdefault_repair_orders_fact_v1_0_15b7da54aa19ecd7.price_count_935e7117,\n\tdefault_repair_orders_fact_v1_0_15b7da54aa19ecd7.price_sum_935e7117,\n\tdefault_repair_orders_fact_v1_0_15b7da54aa19ecd7.total_repair_cost_sum_67874507,\n\tdefault_repair_orders_fact_v1_0_15b7da54aa19ecd7.price_discount_sum_e4ba5456,\n\tdefault_repair_order_details_v1_0_f15982420cc5c632.price_sum_252381cf \n FROM default_repair_orders_fact_v1_0_15b7da54aa19ecd7 FULL OUTER JOIN default_repair_order_details_v1_0_f15982420cc5c632 ON default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_country = default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_country AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_postal_code = default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_postal_code AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_city = default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_city AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_hire_date = default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_hire_date AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_state = default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_state AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_dispatcher_DOT_company_name = default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_dispatcher_DOT_company_name AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_municipality_dim_DOT_local_region = default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_municipality_dim_DOT_local_region\n",
             "columns": [
                 {
-                    "column": "country",
                     "name": "default_DOT_hard_hat_DOT_country",
+                    "type": "string",
+                    "column": "country",
                     "node": "default.hard_hat",
                     "semantic_entity": "default.hard_hat.country",
                     "semantic_type": "dimension",
-                    "type": "string",
                 },
                 {
-                    "column": "postal_code",
                     "name": "default_DOT_hard_hat_DOT_postal_code",
+                    "type": "string",
+                    "column": "postal_code",
                     "node": "default.hard_hat",
                     "semantic_entity": "default.hard_hat.postal_code",
                     "semantic_type": "dimension",
-                    "type": "string",
                 },
                 {
-                    "column": "city",
                     "name": "default_DOT_hard_hat_DOT_city",
+                    "type": "string",
+                    "column": "city",
                     "node": "default.hard_hat",
                     "semantic_entity": "default.hard_hat.city",
                     "semantic_type": "dimension",
-                    "type": "string",
                 },
                 {
-                    "column": "hire_date",
                     "name": "default_DOT_hard_hat_DOT_hire_date",
+                    "type": "timestamp",
+                    "column": "hire_date",
                     "node": "default.hard_hat",
                     "semantic_entity": "default.hard_hat.hire_date",
                     "semantic_type": "dimension",
-                    "type": "timestamp",
                 },
                 {
-                    "column": "state",
                     "name": "default_DOT_hard_hat_DOT_state",
+                    "type": "string",
+                    "column": "state",
                     "node": "default.hard_hat",
                     "semantic_entity": "default.hard_hat.state",
                     "semantic_type": "dimension",
-                    "type": "string",
                 },
                 {
-                    "column": "company_name",
                     "name": "default_DOT_dispatcher_DOT_company_name",
+                    "type": "string",
+                    "column": "company_name",
                     "node": "default.dispatcher",
                     "semantic_entity": "default.dispatcher.company_name",
                     "semantic_type": "dimension",
-                    "type": "string",
                 },
                 {
-                    "column": "local_region",
                     "name": "default_DOT_municipality_dim_DOT_local_region",
+                    "type": "string",
+                    "column": "local_region",
                     "node": "default.municipality_dim",
                     "semantic_entity": "default.municipality_dim.local_region",
                     "semantic_type": "dimension",
-                    "type": "string",
                 },
                 {
-                    "column": "discount_sum_62846f49",
-                    "name": "discount_sum_62846f49",
-                    "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.discount_sum_62846f49",
-                    "semantic_type": "measure",
+                    "name": "discount_sum_30b84e6c",
                     "type": "bigint",
-                },
-                {
-                    "column": "count_3389dae3",
-                    "name": "count_3389dae3",
+                    "column": "discount_sum_30b84e6c",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.count_3389dae3",
+                    "semantic_entity": "default.repair_orders_fact.discount_sum_30b84e6c",
                     "semantic_type": "measure",
-                    "type": "bigint",
                 },
                 {
-                    "column": "repair_order_id_count_0b7dfba0",
-                    "name": "repair_order_id_count_0b7dfba0",
+                    "name": "count_c8e42e74",
+                    "type": "bigint",
+                    "column": "count_c8e42e74",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+                    "semantic_entity": "default.repair_orders_fact.count_c8e42e74",
                     "semantic_type": "measure",
-                    "type": "bigint",
                 },
                 {
-                    "column": "price_count_78a5eb43",
-                    "name": "price_count_78a5eb43",
+                    "name": "repair_order_id_count_bd241964",
+                    "type": "bigint",
+                    "column": "repair_order_id_count_bd241964",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.price_count_78a5eb43",
+                    "semantic_entity": "default.repair_orders_fact.repair_order_id_count_bd241964",
                     "semantic_type": "measure",
-                    "type": "bigint",
                 },
                 {
-                    "column": "price_sum_78a5eb43",
-                    "name": "price_sum_78a5eb43",
+                    "name": "price_count_935e7117",
+                    "type": "bigint",
+                    "column": "price_count_935e7117",
+                    "node": "default.repair_orders_fact",
+                    "semantic_entity": "default.repair_orders_fact.price_count_935e7117",
+                    "semantic_type": "measure",
+                },
+                {
+                    "name": "price_sum_935e7117",
+                    "type": "double",
+                    "column": "price_sum_935e7117",
+                    "node": "default.repair_orders_fact",
+                    "semantic_entity": "default.repair_orders_fact.price_sum_935e7117",
+                    "semantic_type": "measure",
+                },
+                {
+                    "name": "total_repair_cost_sum_67874507",
+                    "type": "double",
+                    "column": "total_repair_cost_sum_67874507",
+                    "node": "default.repair_orders_fact",
+                    "semantic_entity": "default.repair_orders_fact.total_repair_cost_sum_67874507",
+                    "semantic_type": "measure",
+                },
+                {
+                    "name": "price_discount_sum_e4ba5456",
+                    "type": "double",
+                    "column": "price_discount_sum_e4ba5456",
+                    "node": "default.repair_orders_fact",
+                    "semantic_entity": "default.repair_orders_fact.price_discount_sum_e4ba5456",
+                    "semantic_type": "measure",
+                },
+                {
+                    "name": "price_sum_252381cf",
+                    "type": "double",
+                    "column": "price_sum_252381cf",
                     "node": "default.repair_order_details",
-                    "semantic_entity": "default.repair_order_details.price_sum_78a5eb43",
+                    "semantic_entity": "default.repair_order_details.price_sum_252381cf",
                     "semantic_type": "measure",
-                    "type": "double",
                 },
-                {
-                    "column": "total_repair_cost_sum_9bdaf803",
-                    "name": "total_repair_cost_sum_9bdaf803",
-                    "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
-                    "semantic_type": "measure",
-                    "type": "double",
-                },
-                {
-                    "column": "price_discount_sum_017d55a8",
-                    "name": "price_discount_sum_017d55a8",
-                    "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.price_discount_sum_017d55a8",
-                    "semantic_type": "measure",
-                    "type": "double",
-                },
-                {
-                    "column": "price_sum_78a5eb43",
-                    "name": "price_sum_78a5eb43",
-                    "node": "default.repair_order_details",
-                    "semantic_entity": "default.repair_order_details.price_sum_78a5eb43",
-                    "semantic_type": "measure",
-                    "type": "double",
-                },
+            ],
+            "grain": [
+                "default_DOT_hard_hat_DOT_country",
+                "default_DOT_hard_hat_DOT_postal_code",
+                "default_DOT_hard_hat_DOT_city",
+                "default_DOT_hard_hat_DOT_hire_date",
+                "default_DOT_hard_hat_DOT_state",
+                "default_DOT_dispatcher_DOT_company_name",
+                "default_DOT_municipality_dim_DOT_local_region",
             ],
             "dimensions": [
                 "default_DOT_hard_hat_DOT_country",
@@ -3093,58 +3108,66 @@ async def test_cube_materialization_metadata(
                 "default_DOT_dispatcher_DOT_company_name",
                 "default_DOT_municipality_dim_DOT_local_region",
             ],
+            "measures": [
+                {
+                    "name": "discount_sum_30b84e6c",
+                    "expression": "if(discount > 0.0, 1, 0)",
+                    "aggregation": "SUM",
+                    "rule": {"type": "full", "level": None},
+                },
+                {
+                    "name": "count_c8e42e74",
+                    "expression": "*",
+                    "aggregation": "COUNT",
+                    "rule": {"type": "full", "level": None},
+                },
+                {
+                    "name": "repair_order_id_count_bd241964",
+                    "expression": "repair_order_id",
+                    "aggregation": "COUNT",
+                    "rule": {"type": "full", "level": None},
+                },
+                {
+                    "name": "price_count_935e7117",
+                    "expression": "price",
+                    "aggregation": "COUNT",
+                    "rule": {"type": "full", "level": None},
+                },
+                {
+                    "name": "price_sum_935e7117",
+                    "expression": "price",
+                    "aggregation": "SUM",
+                    "rule": {"type": "full", "level": None},
+                },
+                {
+                    "name": "total_repair_cost_sum_67874507",
+                    "expression": "total_repair_cost",
+                    "aggregation": "SUM",
+                    "rule": {"type": "full", "level": None},
+                },
+                {
+                    "name": "price_discount_sum_e4ba5456",
+                    "expression": "price * discount",
+                    "aggregation": "SUM",
+                    "rule": {"type": "full", "level": None},
+                },
+                {
+                    "name": "price_sum_252381cf",
+                    "expression": "price",
+                    "aggregation": "SUM",
+                    "rule": {"type": "full", "level": None},
+                },
+            ],
+            "timestamp_column": "default_DOT_hard_hat_DOT_hire_date",
+            "timestamp_format": "yyyyMMdd",
+            "granularity": "day",
+            "upstream_tables": [],
             "druid_spec": {
                 "dataSchema": {
-                    "dataSource": "dj__default_example_repairs_cube_v1_0_41f1198b6e6032dd",
-                    "granularitySpec": {
-                        "intervals": [],
-                        "segmentGranularity": "DAY",
-                        "type": "uniform",
-                    },
-                    "metricsSpec": [
-                        {
-                            "fieldName": "discount_sum_62846f49",
-                            "name": "discount_sum_62846f49",
-                            "type": "longSum",
-                        },
-                        {
-                            "fieldName": "count_3389dae3",
-                            "name": "count_3389dae3",
-                            "type": "longSum",
-                        },
-                        {
-                            "fieldName": "repair_order_id_count_0b7dfba0",
-                            "name": "repair_order_id_count_0b7dfba0",
-                            "type": "longSum",
-                        },
-                        {
-                            "fieldName": "price_count_78a5eb43",
-                            "name": "price_count_78a5eb43",
-                            "type": "longSum",
-                        },
-                        {
-                            "fieldName": "price_sum_78a5eb43",
-                            "name": "price_sum_78a5eb43",
-                            "type": "doubleSum",
-                        },
-                        {
-                            "fieldName": "total_repair_cost_sum_9bdaf803",
-                            "name": "total_repair_cost_sum_9bdaf803",
-                            "type": "doubleSum",
-                        },
-                        {
-                            "fieldName": "price_discount_sum_017d55a8",
-                            "name": "price_discount_sum_017d55a8",
-                            "type": "doubleSum",
-                        },
-                        {
-                            "fieldName": "price_sum_78a5eb43",
-                            "name": "price_sum_78a5eb43",
-                            "type": "doubleSum",
-                        },
-                    ],
+                    "dataSource": "dj__default_example_repairs_cube_v1_0_fdc5182835060cb1",
                     "parser": {
                         "parseSpec": {
+                            "format": "parquet",
                             "dimensionsSpec": {
                                 "dimensions": [
                                     "default_DOT_dispatcher_DOT_company_name",
@@ -3156,12 +3179,58 @@ async def test_cube_materialization_metadata(
                                     "default_DOT_municipality_dim_DOT_local_region",
                                 ],
                             },
-                            "format": "parquet",
                             "timestampSpec": {
                                 "column": "default_DOT_hard_hat_DOT_hire_date",
                                 "format": "yyyyMMdd",
                             },
                         },
+                    },
+                    "metricsSpec": [
+                        {
+                            "fieldName": "discount_sum_30b84e6c",
+                            "name": "discount_sum_30b84e6c",
+                            "type": "longSum",
+                        },
+                        {
+                            "fieldName": "count_c8e42e74",
+                            "name": "count_c8e42e74",
+                            "type": "longSum",
+                        },
+                        {
+                            "fieldName": "repair_order_id_count_bd241964",
+                            "name": "repair_order_id_count_bd241964",
+                            "type": "longSum",
+                        },
+                        {
+                            "fieldName": "price_count_935e7117",
+                            "name": "price_count_935e7117",
+                            "type": "longSum",
+                        },
+                        {
+                            "fieldName": "price_sum_935e7117",
+                            "name": "price_sum_935e7117",
+                            "type": "doubleSum",
+                        },
+                        {
+                            "fieldName": "total_repair_cost_sum_67874507",
+                            "name": "total_repair_cost_sum_67874507",
+                            "type": "doubleSum",
+                        },
+                        {
+                            "fieldName": "price_discount_sum_e4ba5456",
+                            "name": "price_discount_sum_e4ba5456",
+                            "type": "doubleSum",
+                        },
+                        {
+                            "fieldName": "price_sum_252381cf",
+                            "name": "price_sum_252381cf",
+                            "type": "doubleSum",
+                        },
+                    ],
+                    "granularitySpec": {
+                        "type": "uniform",
+                        "segmentGranularity": "DAY",
+                        "intervals": [],
                     },
                 },
                 "tuningConfig": {
@@ -3169,161 +3238,68 @@ async def test_cube_materialization_metadata(
                         "targetPartitionSize": 5000000,
                         "type": "hashed",
                     },
-                    "type": "hadoop",
                     "useCombiner": True,
+                    "type": "hadoop",
                 },
             },
-            "grain": [
-                "default_DOT_hard_hat_DOT_country",
-                "default_DOT_hard_hat_DOT_postal_code",
-                "default_DOT_hard_hat_DOT_city",
-                "default_DOT_hard_hat_DOT_hire_date",
-                "default_DOT_hard_hat_DOT_state",
-                "default_DOT_dispatcher_DOT_company_name",
-                "default_DOT_municipality_dim_DOT_local_region",
-            ],
-            "granularity": "day",
-            "measures": [
-                {
-                    "aggregation": "SUM",
-                    "expression": "if(discount > 0.0, 1, 0)",
-                    "name": "discount_sum_62846f49",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-                {
-                    "aggregation": "COUNT",
-                    "expression": "*",
-                    "name": "count_3389dae3",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-                {
-                    "aggregation": "COUNT",
-                    "expression": "repair_order_id",
-                    "name": "repair_order_id_count_0b7dfba0",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-                {
-                    "aggregation": "COUNT",
-                    "expression": "price",
-                    "name": "price_count_78a5eb43",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-                {
-                    "aggregation": "SUM",
-                    "expression": "price",
-                    "name": "price_sum_78a5eb43",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-                {
-                    "aggregation": "SUM",
-                    "expression": "total_repair_cost",
-                    "name": "total_repair_cost_sum_9bdaf803",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-                {
-                    "aggregation": "SUM",
-                    "expression": "price * discount",
-                    "name": "price_discount_sum_017d55a8",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-                {
-                    "aggregation": "SUM",
-                    "expression": "price",
-                    "name": "price_sum_78a5eb43",
-                    "rule": {
-                        "level": None,
-                        "type": "full",
-                    },
-                },
-            ],
-            "node": {
-                "display_name": "Example Repairs Cube",
-                "name": "default.example_repairs_cube",
-                "version": "v1.0",
-            },
-            "output_table_name": "default_example_repairs_cube_v1_0_41f1198b6e6032dd",
-            "query": mock.ANY,
-            "timestamp_column": "default_DOT_hard_hat_DOT_hire_date",
-            "timestamp_format": "yyyyMMdd",
-            "upstream_tables": [],
+            "output_table_name": "default_example_repairs_cube_v1_0_fdc5182835060cb1",
         },
     ]
 
     expected_combiner = """
     SELECT
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_country,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_country
+        default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_country,
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_country
       ) default_DOT_hard_hat_DOT_country,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_postal_code,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_postal_code
+        default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_postal_code,
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_postal_code
       ) default_DOT_hard_hat_DOT_postal_code,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_city,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_city
+        default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_city,
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_city
       ) default_DOT_hard_hat_DOT_city,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_hire_date,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_hire_date
+        default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_hire_date,
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_hire_date
       ) default_DOT_hard_hat_DOT_hire_date,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_state,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_state
+        default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_state,
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_state
       ) default_DOT_hard_hat_DOT_state,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_dispatcher_DOT_company_name,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_dispatcher_DOT_company_name
+        default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_dispatcher_DOT_company_name,
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_dispatcher_DOT_company_name
       ) default_DOT_dispatcher_DOT_company_name,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_municipality_dim_DOT_local_region,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_municipality_dim_DOT_local_region
+        default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_municipality_dim_DOT_local_region,
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_municipality_dim_DOT_local_region
       ) default_DOT_municipality_dim_DOT_local_region,
-      default_repair_orders_fact_v1_0_c9390406463b348e.discount_sum_62846f49,
-      default_repair_orders_fact_v1_0_c9390406463b348e.count_3389dae3,
-      default_repair_orders_fact_v1_0_c9390406463b348e.repair_order_id_count_0b7dfba0,
-      default_repair_orders_fact_v1_0_c9390406463b348e.price_count_78a5eb43,
-      default_repair_orders_fact_v1_0_c9390406463b348e.price_sum_78a5eb43,
-      default_repair_orders_fact_v1_0_c9390406463b348e.total_repair_cost_sum_9bdaf803,
-      default_repair_orders_fact_v1_0_c9390406463b348e.price_discount_sum_017d55a8,
-      default_repair_order_details_v1_0_5bf367d2fc7c255d.price_sum_78a5eb43
-    FROM default_repair_orders_fact_v1_0_c9390406463b348e
-    FULL OUTER JOIN default_repair_order_details_v1_0_5bf367d2fc7c255d
-      ON default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_country =
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_country
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_postal_code =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_postal_code
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_city =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_city
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_hire_date =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_hire_date
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_state =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_state
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_dispatcher_DOT_company_name =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_dispatcher_DOT_company_name
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_municipality_dim_DOT_local_region =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_municipality_dim_DOT_local_region
+      default_repair_orders_fact_v1_0_15b7da54aa19ecd7.discount_sum_30b84e6c,
+      default_repair_orders_fact_v1_0_15b7da54aa19ecd7.count_c8e42e74,
+      default_repair_orders_fact_v1_0_15b7da54aa19ecd7.repair_order_id_count_bd241964,
+      default_repair_orders_fact_v1_0_15b7da54aa19ecd7.price_count_935e7117,
+      default_repair_orders_fact_v1_0_15b7da54aa19ecd7.price_sum_935e7117,
+      default_repair_orders_fact_v1_0_15b7da54aa19ecd7.total_repair_cost_sum_67874507,
+      default_repair_orders_fact_v1_0_15b7da54aa19ecd7.price_discount_sum_e4ba5456,
+      default_repair_order_details_v1_0_f15982420cc5c632.price_sum_252381cf
+    FROM default_repair_orders_fact_v1_0_15b7da54aa19ecd7
+    FULL OUTER JOIN default_repair_order_details_v1_0_f15982420cc5c632
+      ON default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_country =
+        default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_country
+        AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_postal_code =
+          default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_postal_code
+        AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_city =
+          default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_city
+        AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_hire_date =
+          default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_hire_date
+        AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_hard_hat_DOT_state =
+          default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_hard_hat_DOT_state
+        AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_dispatcher_DOT_company_name =
+          default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_dispatcher_DOT_company_name
+        AND default_repair_orders_fact_v1_0_15b7da54aa19ecd7.default_DOT_municipality_dim_DOT_local_region =
+          default_repair_order_details_v1_0_f15982420cc5c632.default_DOT_municipality_dim_DOT_local_region
     """
     assert str(parse(results["combiners"][0]["query"])) == str(parse(expected_combiner))
 

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -745,7 +745,7 @@ async def test_find_metric(
                         {
                             "aggregation": "SUM",
                             "expression": "completed_repairs",
-                            "name": "completed_repairs_sum_81105666",
+                            "name": "completed_repairs_sum_8b112bf1",
                             "rule": {
                                 "type": "FULL",
                             },
@@ -753,7 +753,7 @@ async def test_find_metric(
                         {
                             "aggregation": "SUM",
                             "expression": "total_repairs_dispatched",
-                            "name": "total_repairs_dispatched_sum_01dc2341",
+                            "name": "total_repairs_dispatched_sum_601dc4f1",
                             "rule": {
                                 "type": "FULL",
                             },
@@ -761,7 +761,7 @@ async def test_find_metric(
                         {
                             "aggregation": "SUM",
                             "expression": "total_amount_in_region",
-                            "name": "total_amount_in_region_sum_1c94ab45",
+                            "name": "total_amount_in_region_sum_3426ede4",
                             "rule": {
                                 "type": "FULL",
                             },
@@ -769,23 +769,23 @@ async def test_find_metric(
                         {
                             "aggregation": "SUM",
                             "expression": "na.total_amount_nationwide",
-                            "name": "na_DOT_total_amount_nationwide_sum_fed946fe",
+                            "name": "na_DOT_total_amount_nationwide_sum_4ecb2318",
                             "rule": {
                                 "type": "FULL",
                             },
                         },
                     ],
-                    "derivedQuery": "SELECT  (SUM(completed_repairs_sum_81105666) * 1.0 / "
-                    "SUM(total_repairs_dispatched_sum_01dc2341)) * "
-                    "(SUM(total_amount_in_region_sum_1c94ab45) * 1.0 / "
-                    "SUM(na_DOT_total_amount_nationwide_sum_fed946fe)) * 100 \n"
+                    "derivedQuery": "SELECT  (SUM(completed_repairs_sum_8b112bf1) * 1.0 / "
+                    "SUM(total_repairs_dispatched_sum_601dc4f1)) * "
+                    "(SUM(total_amount_in_region_sum_3426ede4) * 1.0 / "
+                    "SUM(na_DOT_total_amount_nationwide_sum_4ecb2318)) * 100 \n"
                     " FROM default.regional_level_agg CROSS JOIN "
                     "default.national_level_agg na\n"
                     "\n",
-                    "derivedExpression": "(SUM(completed_repairs_sum_81105666) * 1.0 / "
-                    "SUM(total_repairs_dispatched_sum_01dc2341)) * "
-                    "(SUM(total_amount_in_region_sum_1c94ab45) * 1.0 / "
-                    "SUM(na_DOT_total_amount_nationwide_sum_fed946fe)) * 100",
+                    "derivedExpression": "(SUM(completed_repairs_sum_8b112bf1) * 1.0 / "
+                    "SUM(total_repairs_dispatched_sum_601dc4f1)) * "
+                    "(SUM(total_amount_in_region_sum_3426ede4) * 1.0 / "
+                    "SUM(na_DOT_total_amount_nationwide_sum_4ecb2318)) * 100",
                 },
             },
             "name": "default.regional_repair_efficiency",

--- a/datajunction-server/tests/api/graphql/measures_sql_test.py
+++ b/datajunction-server/tests/api/graphql/measures_sql_test.py
@@ -71,28 +71,28 @@ async def test_measures_sql(
                 "semanticType": "DIMENSION",
             },
             {
-                "name": "repair_order_id_count_0b7dfba0",
+                "name": "repair_order_id_count_bd241964",
                 "semanticEntity": {
-                    "column": "repair_order_id_count_0b7dfba0",
-                    "name": "default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+                    "column": "repair_order_id_count_bd241964",
+                    "name": "default.repair_orders_fact.repair_order_id_count_bd241964",
                     "node": "default.repair_orders_fact",
                 },
                 "semanticType": "MEASURE",
             },
             {
-                "name": "price_count_78a5eb43",
+                "name": "price_count_935e7117",
                 "semanticEntity": {
-                    "column": "price_count_78a5eb43",
-                    "name": "default.repair_orders_fact.price_count_78a5eb43",
+                    "column": "price_count_935e7117",
+                    "name": "default.repair_orders_fact.price_count_935e7117",
                     "node": "default.repair_orders_fact",
                 },
                 "semanticType": "MEASURE",
             },
             {
-                "name": "price_sum_78a5eb43",
+                "name": "price_sum_935e7117",
                 "semanticEntity": {
-                    "column": "price_sum_78a5eb43",
-                    "name": "default.repair_orders_fact.price_sum_78a5eb43",
+                    "column": "price_sum_935e7117",
+                    "name": "default.repair_orders_fact.price_sum_935e7117",
                     "node": "default.repair_orders_fact",
                 },
                 "semanticType": "MEASURE",

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -314,7 +314,7 @@ async def test_druid_measures_cube_full(
     - [failure] When there are no columns on the cube with type `timestamp` and no partition labels
     - [failure] If nothing has changed, will not update the existing materialization
     """
-    client_with_repairs_cube = await client_with_repairs_cube()
+    client_with_repairs_cube = await client_with_repairs_cube()  # type: ignore
     # [success] When there is a column on the cube with a temporal partition label:
     await set_temporal_column(
         client_with_repairs_cube,
@@ -437,7 +437,7 @@ async def test_druid_measures_cube_incremental(
     - [success] When the underlying measures node contains DJ_LOGICAL_TIMESTAMP
     """
     cube_name = "default.repairs_cube__incremental"
-    client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)
+    client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)  # type: ignore
     # [failure] If there is no time partition column configured
     response = await client_with_repairs_cube.post(
         f"/nodes/{cube_name}/materialization/",
@@ -625,7 +625,7 @@ async def test_druid_metrics_cube_incremental(
     - [success] When the underlying measures node contains DJ_LOGICAL_TIMESTAMP
     """
     cube_name = "default.repairs_cube__metrics_incremental"
-    client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)
+    client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)  # type: ignore
 
     # [failure] If there is no time partition column configured
     response = await client_with_repairs_cube.post(
@@ -757,7 +757,7 @@ async def test_druid_cube_incremental(
     - Strategy: incremental_time
     """
     cube_name = "default.repairs_cube__default_incremental"
-    client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)
+    client_with_repairs_cube = await client_with_repairs_cube(cube_name=cube_name)  # type: ignore
     # [failure] If there is no time partition column configured
     response = await client_with_repairs_cube.post(
         f"/nodes/{cube_name}/materialization/",
@@ -825,12 +825,12 @@ async def test_druid_cube_incremental(
                         version=ANY_STRING,
                         display_name="Repair Orders Fact",
                     ),
-                    measure_name="repair_order_id_count_0b7dfba0",
+                    measure_name="repair_order_id_count_bd241964",
                 ),
             ],
-            derived_expression="SELECT  SUM(repair_order_id_count_0b7dfba0)"
+            derived_expression="SELECT  SUM(repair_order_id_count_bd241964)"
             "  FROM default.repair_orders_fact",
-            metric_expression="SUM(repair_order_id_count_0b7dfba0)",
+            metric_expression="SUM(repair_order_id_count_bd241964)",
         ),
         CubeMetric(
             metric=NodeNameVersion(
@@ -845,12 +845,12 @@ async def test_druid_cube_incremental(
                         version=ANY_STRING,
                         display_name="Repair Orders Fact",
                     ),
-                    measure_name="total_repair_cost_sum_9bdaf803",
+                    measure_name="total_repair_cost_sum_67874507",
                 ),
             ],
-            derived_expression="SELECT  sum(total_repair_cost_sum_9bdaf803)"
+            derived_expression="SELECT  sum(total_repair_cost_sum_67874507)"
             "  FROM default.repair_orders_fact",
-            metric_expression="sum(total_repair_cost_sum_9bdaf803)",
+            metric_expression="sum(total_repair_cost_sum_67874507)",
         ),
     ]
     assert mat.measures_materializations[0].node == NodeNameVersion(
@@ -872,13 +872,13 @@ async def test_druid_cube_incremental(
     ]
     assert mat.measures_materializations[0].measures == [
         MetricComponent(
-            name="repair_order_id_count_0b7dfba0",
+            name="repair_order_id_count_bd241964",
             expression="repair_order_id",
             aggregation="COUNT",
             rule=AggregationRule(type=Aggregability.FULL, level=None),
         ),
         MetricComponent(
-            name="total_repair_cost_sum_9bdaf803",
+            name="total_repair_cost_sum_67874507",
             expression="total_repair_cost",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL, level=None),
@@ -918,19 +918,19 @@ async def test_druid_cube_incremental(
             semantic_type="dimension",
         ),
         ColumnMetadata(
-            name="repair_order_id_count_0b7dfba0",
+            name="repair_order_id_count_bd241964",
             type="bigint",
-            column="repair_order_id_count_0b7dfba0",
+            column="repair_order_id_count_bd241964",
             node="default.repair_orders_fact",
-            semantic_entity="default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+            semantic_entity="default.repair_orders_fact.repair_order_id_count_bd241964",
             semantic_type="measure",
         ),
         ColumnMetadata(
-            name="total_repair_cost_sum_9bdaf803",
+            name="total_repair_cost_sum_67874507",
             type="double",
-            column="total_repair_cost_sum_9bdaf803",
+            column="total_repair_cost_sum_67874507",
             node="default.repair_orders_fact",
-            semantic_entity="default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
+            semantic_entity="default.repair_orders_fact.total_repair_cost_sum_67874507",
             semantic_type="measure",
         ),
     ]
@@ -993,19 +993,19 @@ async def test_druid_cube_incremental(
             semantic_type="dimension",
         ),
         ColumnMetadata(
-            name="repair_order_id_count_0b7dfba0",
+            name="repair_order_id_count_bd241964",
             type="bigint",
-            column="repair_order_id_count_0b7dfba0",
+            column="repair_order_id_count_bd241964",
             node="default.repair_orders_fact",
-            semantic_entity="default.repair_orders_fact.repair_order_id_count_0b7dfba0",
+            semantic_entity="default.repair_orders_fact.repair_order_id_count_bd241964",
             semantic_type="measure",
         ),
         ColumnMetadata(
-            name="total_repair_cost_sum_9bdaf803",
+            name="total_repair_cost_sum_67874507",
             type="double",
-            column="total_repair_cost_sum_9bdaf803",
+            column="total_repair_cost_sum_67874507",
             node="default.repair_orders_fact",
-            semantic_entity="default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
+            semantic_entity="default.repair_orders_fact.total_repair_cost_sum_67874507",
             semantic_type="measure",
         ),
     ]
@@ -1023,13 +1023,13 @@ async def test_druid_cube_incremental(
     ]
     assert mat.combiners[0].measures == [
         MetricComponent(
-            name="repair_order_id_count_0b7dfba0",
+            name="repair_order_id_count_bd241964",
             expression="repair_order_id",
             aggregation="COUNT",
             rule=AggregationRule(type=Aggregability.FULL, level=None),
         ),
         MetricComponent(
-            name="total_repair_cost_sum_9bdaf803",
+            name="total_repair_cost_sum_67874507",
             expression="total_repair_cost",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL, level=None),

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -418,7 +418,7 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
         {
             "aggregation": "SUM",
             "expression": "if(discount > 0.0, 1, 0)",
-            "name": "discount_sum_62846f49",
+            "name": "discount_sum_30b84e6c",
             "rule": {
                 "level": None,
                 "type": "full",
@@ -427,7 +427,7 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
         {
             "aggregation": "COUNT",
             "expression": "*",
-            "name": "count_3389dae3",
+            "name": "count_c8e42e74",
             "rule": {
                 "level": None,
                 "type": "full",
@@ -435,11 +435,11 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
         },
     ]
     assert data["derived_query"] == (
-        "SELECT  CAST(sum(discount_sum_62846f49) AS DOUBLE) / SUM(count_3389dae3) AS "
+        "SELECT  CAST(sum(discount_sum_30b84e6c) AS DOUBLE) / SUM(count_c8e42e74) AS "
         "default_DOT_discounted_orders_rate \n FROM default.repair_orders_fact"
     )
     assert data["derived_expression"] == (
-        "CAST(sum(discount_sum_62846f49) AS DOUBLE) / SUM(count_3389dae3) "
+        "CAST(sum(discount_sum_30b84e6c) AS DOUBLE) / SUM(count_c8e42e74) "
         "AS default_DOT_discounted_orders_rate"
     )
 

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -572,7 +572,7 @@ async def test_measures_sql_with_filters__v2(
             )
             SELECT
               default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id,
-              SUM(price * discount) AS price_discount_sum_017d55a8
+              SUM(price * discount) AS price_discount_sum_e4ba5456
             FROM default_DOT_repair_orders_fact_built
             GROUP BY default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id
             """,
@@ -586,10 +586,10 @@ async def test_measures_sql_with_filters__v2(
                     "type": "int",
                 },
                 {
-                    "column": "price_discount_sum_017d55a8",
-                    "name": "price_discount_sum_017d55a8",
+                    "column": "price_discount_sum_e4ba5456",
+                    "name": "price_discount_sum_e4ba5456",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.price_discount_sum_017d55a8",
+                    "semantic_entity": "default.repair_orders_fact.price_discount_sum_e4ba5456",
                     "semantic_type": "measure",
                     "type": "double",
                 },
@@ -637,8 +637,8 @@ async def test_measures_sql_with_filters__v2(
             )
             SELECT
               default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id,
-              SUM(price * discount) AS price_discount_sum_017d55a8,
-              COUNT(price * discount) AS price_discount_count_017d55a8
+              SUM(price * discount) AS price_discount_sum_e4ba5456,
+              COUNT(price * discount) AS price_discount_count_e4ba5456
             FROM default_DOT_repair_orders_fact_built
             GROUP BY  default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_dispatcher_id
             """,
@@ -652,18 +652,18 @@ async def test_measures_sql_with_filters__v2(
                     "type": "int",
                 },
                 {
-                    "column": "price_discount_sum_017d55a8",
-                    "name": "price_discount_sum_017d55a8",
+                    "column": "price_discount_sum_e4ba5456",
+                    "name": "price_discount_sum_e4ba5456",
                     "node": mock.ANY,
                     "semantic_entity": mock.ANY,
                     "semantic_type": "measure",
                     "type": "double",
                 },
                 {
-                    "column": "price_discount_count_017d55a8",
-                    "name": "price_discount_count_017d55a8",
+                    "column": "price_discount_count_e4ba5456",
+                    "name": "price_discount_count_e4ba5456",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.price_discount_count_017d55a8",
+                    "semantic_entity": "default.repair_orders_fact.price_discount_count_e4ba5456",
                     "semantic_type": "measure",
                     "type": "bigint",
                 },
@@ -762,9 +762,9 @@ async def test_measures_sql_with_filters__v2(
               default_DOT_repair_orders_fact_built.default_DOT_us_state_DOT_state_name,
               default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
               default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name,
-              COUNT(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_count_bf99afd6,
-              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_bf99afd6,
-              SUM(total_repair_cost) AS total_repair_cost_sum_9bdaf803
+              COUNT(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_count_3bc9baed,
+              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_3bc9baed,
+              SUM(total_repair_cost) AS total_repair_cost_sum_67874507
             FROM default_DOT_repair_orders_fact_built
             GROUP BY
               default_DOT_repair_orders_fact_built.default_DOT_us_state_DOT_state_name,
@@ -797,26 +797,26 @@ async def test_measures_sql_with_filters__v2(
                     "type": "string",
                 },
                 {
-                    "column": "time_to_dispatch_count_bf99afd6",
-                    "name": "time_to_dispatch_count_bf99afd6",
+                    "column": "time_to_dispatch_count_3bc9baed",
+                    "name": "time_to_dispatch_count_3bc9baed",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.time_to_dispatch_count_bf99afd6",
+                    "semantic_entity": "default.repair_orders_fact.time_to_dispatch_count_3bc9baed",
                     "semantic_type": "measure",
                     "type": "bigint",
                 },
                 {
-                    "column": "time_to_dispatch_sum_bf99afd6",
-                    "name": "time_to_dispatch_sum_bf99afd6",
+                    "column": "time_to_dispatch_sum_3bc9baed",
+                    "name": "time_to_dispatch_sum_3bc9baed",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.time_to_dispatch_sum_bf99afd6",
+                    "semantic_entity": "default.repair_orders_fact.time_to_dispatch_sum_3bc9baed",
                     "semantic_type": "measure",
                     "type": "bigint",
                 },
                 {
-                    "column": "total_repair_cost_sum_9bdaf803",
-                    "name": "total_repair_cost_sum_9bdaf803",
+                    "column": "total_repair_cost_sum_67874507",
+                    "name": "total_repair_cost_sum_67874507",
                     "node": "default.repair_orders_fact",
-                    "semantic_entity": "default.repair_orders_fact.total_repair_cost_sum_9bdaf803",
+                    "semantic_entity": "default.repair_orders_fact.total_repair_cost_sum_67874507",
                     "semantic_type": "measure",
                     "type": "double",
                 },
@@ -891,8 +891,8 @@ async def test_measures_sql_with_filters__v2(
             SELECT
               default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
               default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name,
-              COUNT(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_count_bf99afd6,
-              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_bf99afd6
+              COUNT(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_count_3bc9baed,
+              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_3bc9baed
             FROM default_DOT_repair_orders_fact_built
             GROUP BY
               default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
@@ -971,8 +971,8 @@ async def test_measures_sql_with_filters__v2(
             SELECT
               default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
               default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_last_name,
-              COUNT(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_count_bf99afd6,
-              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_bf99afd6
+              COUNT(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_count_3bc9baed,
+              SUM(CAST(time_to_dispatch AS INT)) AS time_to_dispatch_sum_3bc9baed
             FROM default_DOT_repair_orders_fact_built
             GROUP BY
               default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
@@ -1193,13 +1193,13 @@ async def create_metric_distinct_single_column(client: AsyncClient):
         {
             "aggregation": None,
             "expression": "hard_hat_id",
-            "name": "hard_hat_id_distinct_c311610d",
+            "name": "hard_hat_id_distinct_ac37a223",
             "rule": {"level": ["hard_hat_id"], "type": "limited"},
         },
     ]
     assert (
         metric_data["derived_expression"]
-        == "COUNT( DISTINCT hard_hat_id_distinct_c311610d)"
+        == "COUNT( DISTINCT hard_hat_id_distinct_ac37a223)"
     )
     return metric_name
 
@@ -1221,13 +1221,13 @@ async def create_metric_distinct_expression(client: AsyncClient):
         {
             "aggregation": None,
             "expression": "IF(hard_hat_id = 1, 1, 0)",
-            "name": "hard_hat_id_distinct_276dd924",
+            "name": "hard_hat_id_distinct_0291ee39",
             "rule": {"level": ["IF(hard_hat_id = 1, 1, 0)"], "type": "limited"},
         },
     ]
     assert (
         metric_data["derived_expression"]
-        == "COUNT( DISTINCT hard_hat_id_distinct_276dd924)"
+        == "COUNT( DISTINCT hard_hat_id_distinct_0291ee39)"
     )
     return metric_name
 
@@ -1298,10 +1298,10 @@ async def test_measures_sql_agg_distinct_metric(
     )
     SELECT
       default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
-      COUNT(price) AS price_count_78a5eb43,
-      SUM(price) AS price_sum_78a5eb43,
-      hard_hat_id AS hard_hat_id_distinct_c311610d,
-      IF(hard_hat_id = 1, 1, 0) AS hard_hat_id_distinct_276dd924
+      COUNT(price) AS price_count_935e7117,
+      SUM(price) AS price_sum_935e7117,
+      hard_hat_id AS hard_hat_id_distinct_ac37a223,
+      IF(hard_hat_id = 1, 1, 0) AS hard_hat_id_distinct_0291ee39
     FROM default_DOT_repair_orders_fact_built
     GROUP BY
       default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
@@ -1391,9 +1391,9 @@ async def test_measures_sql_simple_agg_metric(
     )
     SELECT
       default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
-      COUNT(price) AS price_count_78a5eb43,
-      SUM(price) AS price_sum_78a5eb43,
-      COUNT(repair_order_id) AS repair_order_id_count_0b7dfba0
+      COUNT(price) AS price_count_935e7117,
+      SUM(price) AS price_sum_935e7117,
+      COUNT(repair_order_id) AS repair_order_id_count_bd241964
     FROM default_DOT_repair_orders_fact_built
     GROUP BY  default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name
     """
@@ -1570,8 +1570,8 @@ async def test_measures_sql_local_dimensions(
     )
     SELECT
       default_DOT_hard_hat_built.default_DOT_hard_hat_DOT_hire_date,
-      COUNT(CAST(NOW() AS DATE) - default_DOT_hard_hat_DOT_hire_date) AS hire_date_count_9b06ca5d,
-      SUM(CAST(NOW() AS DATE) - default_DOT_hard_hat_DOT_hire_date) AS hire_date_sum_9b06ca5d
+      COUNT(CAST(NOW() AS DATE) - default_DOT_hard_hat_DOT_hire_date) AS hire_date_count_3ce5a421,
+      SUM(CAST(NOW() AS DATE) - default_DOT_hard_hat_DOT_hire_date) AS hire_date_sum_3ce5a421
     FROM default_DOT_hard_hat_built
     GROUP BY
       default_DOT_hard_hat_built.default_DOT_hard_hat_DOT_hire_date
@@ -1614,7 +1614,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
             {
                 "aggregation": "SUM",
                 "expression": "default.local_hard_hats_2.hard_hat_id",
-                "name": "default_DOT_local_hard_hats_2_DOT_hard_hat_id_sum_edfc4090",
+                "name": "default_DOT_local_hard_hats_2_DOT_hard_hat_id_sum_bf8a8419",
                 "rule": {
                     "level": None,
                     "type": "full",
@@ -1623,7 +1623,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
         ]
         assert (
             data["derived_expression"]
-            == "SUM(default_DOT_local_hard_hats_2_DOT_hard_hat_id_sum_edfc4090)"
+            == "SUM(default_DOT_local_hard_hats_2_DOT_hard_hat_id_sum_bf8a8419)"
         )
         response = await module__client_with_roads.get(
             "/sql/measures/v2",
@@ -1676,7 +1676,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
             {
                 "aggregation": None,
                 "expression": "default.municipality_dim.contact_name",
-                "name": "default_DOT_municipality_dim_DOT_contact_name_distinct_8a8441e2",
+                "name": "default_DOT_municipality_dim_DOT_contact_name_distinct_bc16351d",
                 "rule": {
                     "level": ["default.municipality_dim.contact_name"],
                     "type": "limited",
@@ -1685,7 +1685,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
         ]
         assert (
             data["derived_expression"]
-            == "COUNT( DISTINCT default_DOT_municipality_dim_DOT_contact_name_distinct_8a8441e2)"
+            == "COUNT( DISTINCT default_DOT_municipality_dim_DOT_contact_name_distinct_bc16351d)"
         )
         response = await module__client_with_roads.get(
             "/sql/measures/v2",
@@ -1737,7 +1737,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
         )
         SELECT
           default_DOT_repair_orders_fact_built.default_DOT_municipality_dim_DOT_contact_name,
-          default_DOT_municipality_dim_DOT_contact_name AS default_DOT_municipality_dim_DOT_contact_name_distinct_8a8441e2
+          default_DOT_municipality_dim_DOT_contact_name AS default_DOT_municipality_dim_DOT_contact_name_distinct_bc16351d
         FROM default_DOT_repair_orders_fact_built
         GROUP BY
           default_DOT_repair_orders_fact_built.default_DOT_municipality_dim_DOT_contact_name,
@@ -1780,7 +1780,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
                 "aggregation": None,
                 "expression": "IF(default.hard_hat.state = 'NY', default.hard_hat.first_name, "
                 "NULL)",
-                "name": "default_DOT_hard_hat_DOT_state_default_DOT_hard_hat_DOT_first_name_distinct_da41d3a0",
+                "name": "default_DOT_hard_hat_DOT_state_default_DOT_hard_hat_DOT_first_name_distinct_1a99d6a7",
                 "rule": {
                     "level": [
                         "IF(default.hard_hat.state = 'NY', "
@@ -1791,7 +1791,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
             },
         ]
         assert data["derived_expression"] == (
-            "COUNT( DISTINCT default_DOT_hard_hat_DOT_state_default_DOT_hard_hat_DOT_first_name_distinct_da41d3a0)"
+            "COUNT( DISTINCT default_DOT_hard_hat_DOT_state_default_DOT_hard_hat_DOT_first_name_distinct_1a99d6a7)"
         )
         response = await module__client_with_roads.get(
             "/sql/measures/v2",
@@ -1852,7 +1852,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
           default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_city,
           default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_first_name,
           default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_state,
-          IF(default_DOT_hard_hat_DOT_state = 'NY', default_DOT_hard_hat_DOT_first_name, NULL) AS default_DOT_hard_hat_DOT_state_default_DOT_hard_hat_DOT_first_name_distinct_da41d3a0
+          IF(default_DOT_hard_hat_DOT_state = 'NY', default_DOT_hard_hat_DOT_first_name, NULL) AS default_DOT_hard_hat_DOT_state_default_DOT_hard_hat_DOT_first_name_distinct_1a99d6a7
         FROM default_DOT_repair_orders_fact_built
         GROUP BY
           default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_city,

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -24,7 +24,7 @@ def test_simple_sum():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_a1b27bc7",
+            name="sales_amount_sum_b5a3cefe",
             expression="sales_amount",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -32,7 +32,7 @@ def test_simple_sum():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT SUM(sales_amount_sum_a1b27bc7) FROM parent_node"),
+        parse("SELECT SUM(sales_amount_sum_b5a3cefe) FROM parent_node"),
     )
 
 
@@ -46,7 +46,7 @@ def test_sum_with_cast():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_a1b27bc7",
+            name="sales_amount_sum_b5a3cefe",
             expression="sales_amount",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -55,7 +55,7 @@ def test_sum_with_cast():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT CAST(SUM(sales_amount_sum_a1b27bc7) AS DOUBLE) * 100.0 FROM parent_node",
+            "SELECT CAST(SUM(sales_amount_sum_b5a3cefe) AS DOUBLE) * 100.0 FROM parent_node",
         ),
     )
 
@@ -65,7 +65,7 @@ def test_sum_with_cast():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_a1b27bc7",
+            name="sales_amount_sum_b5a3cefe",
             expression="sales_amount",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -73,7 +73,7 @@ def test_sum_with_cast():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT 100.0 * SUM(sales_amount_sum_a1b27bc7) FROM parent_node"),
+        parse("SELECT 100.0 * SUM(sales_amount_sum_b5a3cefe) FROM parent_node"),
     )
 
 
@@ -87,7 +87,7 @@ def test_sum_with_coalesce():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_a1b27bc7",
+            name="sales_amount_sum_b5a3cefe",
             expression="sales_amount",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -95,7 +95,7 @@ def test_sum_with_coalesce():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT COALESCE(SUM(sales_amount_sum_a1b27bc7), 0) FROM parent_node"),
+        parse("SELECT COALESCE(SUM(sales_amount_sum_b5a3cefe), 0) FROM parent_node"),
     )
 
     extractor = MetricComponentExtractor.from_query_string(
@@ -104,7 +104,7 @@ def test_sum_with_coalesce():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_bc5c6414",
+            name="sales_amount_sum_65a3b528",
             expression="COALESCE(sales_amount, 0)",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -112,7 +112,7 @@ def test_sum_with_coalesce():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT SUM(sales_amount_sum_bc5c6414) FROM parent_node"),
+        parse("SELECT SUM(sales_amount_sum_65a3b528) FROM parent_node"),
     )
 
 
@@ -126,13 +126,13 @@ def test_multiple_sums():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_a1b27bc7",
+            name="sales_amount_sum_b5a3cefe",
             expression="sales_amount",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="fraud_sales_sum_0a5d6799",
+            name="fraud_sales_sum_0e1bc4a2",
             expression="fraud_sales",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -141,8 +141,8 @@ def test_multiple_sums():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT SUM(sales_amount_sum_a1b27bc7) + "
-            "SUM(fraud_sales_sum_0a5d6799) FROM parent_node",
+            "SELECT SUM(sales_amount_sum_b5a3cefe) + "
+            "SUM(fraud_sales_sum_0e1bc4a2) FROM parent_node",
         ),
     )
 
@@ -150,11 +150,25 @@ def test_multiple_sums():
         "SELECT SUM(sales_amount) - SUM(fraud_sales) FROM parent_node",
     )
     measures, derived_sql = extractor.extract()
+    expected_measures = [
+        MetricComponent(
+            name="sales_amount_sum_b5a3cefe",
+            expression="sales_amount",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+        MetricComponent(
+            name="fraud_sales_sum_0e1bc4a2",
+            expression="fraud_sales",
+            aggregation="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+        ),
+    ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT SUM(sales_amount_sum_a1b27bc7) - "
-            "SUM(fraud_sales_sum_0a5d6799) FROM parent_node",
+            "SELECT SUM(sales_amount_sum_b5a3cefe) - "
+            "SUM(fraud_sales_sum_0e1bc4a2) FROM parent_node",
         ),
     )
 
@@ -169,7 +183,7 @@ def test_nested_functions():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_d511860a",
+            name="sales_amount_sum_090066cf",
             expression="ROUND(COALESCE(sales_amount, 0) * 1.1)",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -177,7 +191,7 @@ def test_nested_functions():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT SUM(sales_amount_sum_d511860a) FROM parent_node"),
+        parse("SELECT SUM(sales_amount_sum_090066cf) FROM parent_node"),
     )
 
     extractor = MetricComponentExtractor.from_query_string(
@@ -186,7 +200,7 @@ def test_nested_functions():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_sum_bc5c6414",
+            name="sales_amount_sum_65a3b528",
             expression="COALESCE(sales_amount, 0)",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -194,7 +208,7 @@ def test_nested_functions():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT LN(SUM(sales_amount_sum_bc5c6414) + 1) FROM parent_node"),
+        parse("SELECT LN(SUM(sales_amount_sum_65a3b528) + 1) FROM parent_node"),
     )
 
 
@@ -209,13 +223,13 @@ def test_average():
 
     expected_measures = [
         MetricComponent(
-            name="sales_amount_count_a1b27bc7",
+            name="sales_amount_count_b5a3cefe",
             expression="sales_amount",
             aggregation="COUNT",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="sales_amount_sum_a1b27bc7",
+            name="sales_amount_sum_b5a3cefe",
             expression="sales_amount",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -224,8 +238,8 @@ def test_average():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT SUM(sales_amount_sum_a1b27bc7) / "
-            "SUM(sales_amount_count_a1b27bc7) FROM parent_node",
+            "SELECT SUM(sales_amount_sum_b5a3cefe) / "
+            "SUM(sales_amount_count_b5a3cefe) FROM parent_node",
         ),
     )
 
@@ -240,13 +254,13 @@ def test_rate():
     measures, derived_sql = extractor.extract()
     expected_measures0 = [
         MetricComponent(
-            name="clicks_sum_c9e9e0fc",
+            name="clicks_sum_c45fd8cf",
             expression="clicks",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="impressions_sum_87e980e6",
+            name="impressions_sum_3be0a0e7",
             expression="impressions",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -255,7 +269,7 @@ def test_rate():
     assert measures == expected_measures0
     assert str(derived_sql) == str(
         parse(
-            "SELECT SUM(clicks_sum_c9e9e0fc) / SUM(impressions_sum_87e980e6) FROM parent_node",
+            "SELECT SUM(clicks_sum_c45fd8cf) / SUM(impressions_sum_3be0a0e7) FROM parent_node",
         ),
     )
 
@@ -265,13 +279,13 @@ def test_rate():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="clicks_sum_c9e9e0fc",
+            name="clicks_sum_c45fd8cf",
             expression="clicks",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="impressions_sum_87e980e6",
+            name="impressions_sum_3be0a0e7",
             expression="impressions",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -280,8 +294,8 @@ def test_rate():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT 1.0 * SUM(clicks_sum_c9e9e0fc) / "
-            "NULLIF(SUM(impressions_sum_87e980e6), 0) FROM parent_node",
+            "SELECT 1.0 * SUM(clicks_sum_c45fd8cf) / "
+            "NULLIF(SUM(impressions_sum_3be0a0e7), 0) FROM parent_node",
         ),
     )
 
@@ -293,8 +307,8 @@ def test_rate():
     assert measures == expected_measures0
     assert str(derived_sql) == str(
         parse(
-            "SELECT CAST(CAST(SUM(clicks_sum_c9e9e0fc) AS INT) AS DOUBLE) / "
-            "CAST(SUM(impressions_sum_87e980e6) AS DOUBLE) FROM parent_node",
+            "SELECT CAST(CAST(SUM(clicks_sum_c45fd8cf) AS INT) AS DOUBLE) / "
+            "CAST(SUM(impressions_sum_3be0a0e7) AS DOUBLE) FROM parent_node",
         ),
     )
 
@@ -304,13 +318,13 @@ def test_rate():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="clicks_sum_c9e9e0fc",
+            name="clicks_sum_c45fd8cf",
             expression="clicks",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="impressions_sum_87e980e6",
+            name="impressions_sum_3be0a0e7",
             expression="impressions",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -319,8 +333,8 @@ def test_rate():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT COALESCE(SUM(clicks_sum_c9e9e0fc) / "
-            "SUM(impressions_sum_87e980e6), 0) FROM parent_node",
+            "SELECT COALESCE(SUM(clicks_sum_c45fd8cf) / "
+            "SUM(impressions_sum_3be0a0e7), 0) FROM parent_node",
         ),
     )
 
@@ -331,13 +345,13 @@ def test_rate():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="clicks_sum_c9e9e0fc",
+            name="clicks_sum_c45fd8cf",
             expression="clicks",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="impressions_sum_87e980e6",
+            name="impressions_sum_3be0a0e7",
             expression="impressions",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -346,8 +360,8 @@ def test_rate():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT IF(SUM(clicks_sum_c9e9e0fc) > 0, CAST(SUM(impressions_sum_87e980e6) AS DOUBLE)"
-            " / CAST(SUM(clicks_sum_c9e9e0fc) AS DOUBLE), NULL) FROM parent_node",
+            "SELECT IF(SUM(clicks_sum_c45fd8cf) > 0, CAST(SUM(impressions_sum_3be0a0e7) AS DOUBLE)"
+            " / CAST(SUM(clicks_sum_c45fd8cf) AS DOUBLE), NULL) FROM parent_node",
         ),
     )
 
@@ -357,13 +371,13 @@ def test_rate():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="clicks_sum_c9e9e0fc",
+            name="clicks_sum_c45fd8cf",
             expression="clicks",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="views_sum_59a14a57",
+            name="views_sum_d8e39817",
             expression="views",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -372,7 +386,7 @@ def test_rate():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT ln(sum(clicks_sum_c9e9e0fc) + 1) / sum(views_sum_59a14a57) FROM parent_node",
+            "SELECT ln(sum(clicks_sum_c45fd8cf) + 1) / sum(views_sum_d8e39817) FROM parent_node",
         ),
     )
 
@@ -387,7 +401,7 @@ def test_has_ever():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="condition_max_98f2d913",
+            name="condition_max_f04b0c57",
             expression="IF(condition, 1, 0)",
             aggregation="MAX",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -395,7 +409,7 @@ def test_has_ever():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT MAX(condition_max_98f2d913) FROM parent_node"),
+        parse("SELECT MAX(condition_max_f04b0c57) FROM parent_node"),
     )
 
 
@@ -412,13 +426,13 @@ def test_fraction_with_if():
 
     expected_measures = [
         MetricComponent(
-            name="action_sum_d0b4f8e5",
+            name="action_sum_c9802ccb",
             expression="COALESCE(action, 0)",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="action_two_sum_0c8945fc",
+            name="action_two_sum_05d921a8",
             expression="COALESCE(action_two, 0)",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -427,9 +441,9 @@ def test_fraction_with_if():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT IF(SUM(action_sum_d0b4f8e5) > 0, "
-            "CAST(SUM(action_two_sum_0c8945fc) AS DOUBLE) / "
-            "CAST(SUM(action_sum_d0b4f8e5) AS DOUBLE), NULL) FROM parent_node",
+            "SELECT IF(SUM(action_sum_c9802ccb) > 0, "
+            "CAST(SUM(action_two_sum_05d921a8) AS DOUBLE) / "
+            "CAST(SUM(action_sum_c9802ccb) AS DOUBLE), NULL) FROM parent_node",
         ),
     )
 
@@ -444,7 +458,7 @@ def test_count():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="action_action_event_ts_count_59b28b54",
+            name="action_action_event_ts_count_7d582e65",
             expression="IF(action = 1, action_event_ts, 0)",
             aggregation="COUNT",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -452,7 +466,7 @@ def test_count():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT SUM(action_action_event_ts_count_59b28b54) FROM parent_node"),
+        parse("SELECT SUM(action_action_event_ts_count_7d582e65) FROM parent_node"),
     )
 
 
@@ -466,7 +480,7 @@ def test_count_distinct_rate():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="user_id_distinct_e8701ad4",
+            name="user_id_distinct_7f092f23",
             expression="user_id",
             aggregation=None,
             rule=AggregationRule(
@@ -475,7 +489,7 @@ def test_count_distinct_rate():
             ),
         ),
         MetricComponent(
-            name="action_count_418c5509",
+            name="action_count_50d753fd",
             expression="action",
             aggregation="COUNT",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -484,8 +498,8 @@ def test_count_distinct_rate():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT COUNT( DISTINCT user_id_distinct_e8701ad4) / "
-            "SUM(action_count_418c5509) FROM parent_node",
+            "SELECT COUNT( DISTINCT user_id_distinct_7f092f23) / "
+            "SUM(action_count_50d753fd) FROM parent_node",
         ),
     )
 
@@ -500,7 +514,7 @@ def test_any_value():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="sales_amount_any_value_a1b27bc7",
+            name="sales_amount_any_value_b5a3cefe",
             expression="sales_amount",
             aggregation="ANY_VALUE",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -508,7 +522,7 @@ def test_any_value():
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
-        parse("SELECT ANY_VALUE(sales_amount_any_value_a1b27bc7) FROM parent_node"),
+        parse("SELECT ANY_VALUE(sales_amount_any_value_b5a3cefe) FROM parent_node"),
     )
 
 
@@ -536,13 +550,13 @@ def test_multiple_aggregations_with_conditions():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="region_sales_amount_sum_55eb544e",
+            name="region_sales_amount_sum_5467b14a",
             expression="IF(region = 'US', sales_amount, 0)",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="region_account_id_distinct_11ca6967",
+            name="region_account_id_distinct_ee608f27",
             expression="IF(region = 'US', account_id, NULL)",
             aggregation=None,
             rule=AggregationRule(
@@ -554,8 +568,8 @@ def test_multiple_aggregations_with_conditions():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT SUM(region_sales_amount_sum_55eb544e) + "
-            "COUNT(DISTINCT region_account_id_distinct_11ca6967) FROM parent_node",
+            "SELECT SUM(region_sales_amount_sum_5467b14a) + "
+            "COUNT(DISTINCT region_account_id_distinct_ee608f27) FROM parent_node",
         ),
     )
 
@@ -566,23 +580,23 @@ def test_multiple_aggregations_with_conditions():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="a_max_0cc175b9",
+            name="a_max_0f00346b",
             expression="a",
             aggregation="MAX",
-            rule=AggregationRule(type=Aggregability.FULL),
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
         ),
         MetricComponent(
-            name="b_max_92eb5ffe",
+            name="b_max_6d64a2e5",
             expression="b",
             aggregation="MAX",
-            rule=AggregationRule(type=Aggregability.FULL),
+            rule=AggregationRule(type=Aggregability.FULL, level=None),
         ),
     ]
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT CAST(coalesce(max(a_max_0cc175b9), max(b_max_92eb5ffe), 0) AS DOUBLE) + "
-            "CAST(coalesce(max(a_max_0cc175b9), max(b_max_92eb5ffe)) AS DOUBLE) FROM parent_node",
+            "SELECT CAST(coalesce(max(a_max_0f00346b), max(b_max_6d64a2e5), 0) AS DOUBLE) + "
+            "CAST(coalesce(max(a_max_0f00346b), max(b_max_6d64a2e5)) AS DOUBLE) FROM parent_node",
         ),
     )
 
@@ -635,13 +649,13 @@ def test_count_if():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="field_a_count_if_c1f2ed10",
+            name="field_a_count_if_3979ffbd",
             expression="ARRAY_CONTAINS(field_a, 'xyz')",
             aggregation="COUNT_IF",
             rule=AggregationRule(type=Aggregability.FULL),
         ),
         MetricComponent(
-            name="count_3389dae3",
+            name="count_58ac32c5",
             expression="*",
             aggregation="COUNT",
             rule=AggregationRule(type=Aggregability.FULL),
@@ -650,7 +664,7 @@ def test_count_if():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT  CAST(SUM(field_a_count_if_c1f2ed10) AS FLOAT) / SUM(count_3389dae3) "
+            "SELECT  CAST(SUM(field_a_count_if_3979ffbd) AS FLOAT) / SUM(count_58ac32c5) "
             "FROM parent_node",
         ),
     )
@@ -668,13 +682,13 @@ def test_metric_query_with_aliases():
     measures, derived_sql = extractor.extract()
     expected_measures = [
         MetricComponent(
-            name="time_to_dispatch_count_bf99afd6",
+            name="time_to_dispatch_count_3bc9baed",
             expression="CAST(time_to_dispatch AS INT)",
             aggregation="COUNT",
             rule=AggregationRule(type=Aggregability.FULL, level=None),
         ),
         MetricComponent(
-            name="time_to_dispatch_sum_bf99afd6",
+            name="time_to_dispatch_sum_3bc9baed",
             expression="CAST(time_to_dispatch AS INT)",
             aggregation="SUM",
             rule=AggregationRule(type=Aggregability.FULL, level=None),
@@ -683,7 +697,7 @@ def test_metric_query_with_aliases():
     assert measures == expected_measures
     assert str(derived_sql) == str(
         parse(
-            "SELECT SUM(time_to_dispatch_sum_bf99afd6) / "
-            "SUM(time_to_dispatch_count_bf99afd6) FROM default.repair_orders_fact",
+            "SELECT SUM(time_to_dispatch_sum_3bc9baed) / "
+            "SUM(time_to_dispatch_count_3bc9baed) FROM default.repair_orders_fact",
         ),
     )


### PR DESCRIPTION
### Summary

Because we only used the metric expression to create a measure hash we saw conflicts when the same looking metric (say `COUNT(*)`) was defined on different tables. This fix adds the FROM clause to the hashing so we still get to reuse the measure on the same parent nodes, but we get a different one if they come from a different node.

### Test Plan

Unit tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Auto.