### PR TITLE
Add GraphQL support for generating measures SQL directly on a cube

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/queries/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/sql.py
@@ -1,68 +1,19 @@
 """Generate SQL-related GraphQL queries."""
 
-from typing import Annotated, Optional, OrderedDict
+from typing import Annotated, Optional
 
 import strawberry
 from strawberry.types import Info
 
-from datajunction_server.models.node import NodeType
-from datajunction_server.errors import DJNodeNotFound
-from datajunction_server.database.node import Node as DBNode
-from datajunction_server.api.graphql.resolvers.nodes import find_nodes_by
-from datajunction_server.api.graphql.scalars.sql import GeneratedSQL
+from datajunction_server.api.graphql.resolvers.nodes import (
+    resolve_metrics_and_dimensions,
+)
+from datajunction_server.api.graphql.scalars.sql import (
+    GeneratedSQL,
+    CubeDefinition,
+    EngineSettings,
+)
 from datajunction_server.construction.build_v2 import get_measures_query
-from datajunction_server.utils import dedupe_append
-
-
-@strawberry.input
-class CubeDefinition:
-    """
-    The cube definition for the query
-    """
-    cube: Annotated[
-        str | None,
-        strawberry.argument(
-            description="The name of the cube to query",
-        ),
-    ] = None  # type: ignore
-    metrics: Annotated[
-        list[str] | None,
-        strawberry.argument(
-            description="A list of metric node names",
-        ),
-    ] = None  # type: ignore
-    dimensions: Annotated[
-        list[str] | None,
-        strawberry.argument(
-            description="A list of dimension attribute names",
-        ),
-    ] = None
-    filters: Annotated[
-        list[str] | None,
-        strawberry.argument(
-            description="A list of filter SQL clauses",
-        ),
-    ] = None
-    orderby: Annotated[
-        list[str] | None,
-        strawberry.argument(
-            description="A list of order by clauses",
-        ),
-    ] = None
-
-
-@strawberry.input
-class EngineSettings:
-    """
-    The engine settings for the query
-    """
-
-    name: str = strawberry.field(
-        description="The name of the engine used by the generated SQL",
-    )
-    version: str | None = strawberry.field(
-        description="The version of the engine used by the generated SQL",
-    )
 
 
 async def measures_sql(
@@ -95,19 +46,10 @@ async def measures_sql(
     Get measures SQL for a set of metrics with dimensions and filters
     """
     session = info.context["session"]
-    metrics = cube.metrics or []
-    dimensions = cube.dimensions or []
-
-    if cube.cube:
-        cube_node = await DBNode.get_cube_by_name(session, cube.cube)
-        if not cube_node:
-            raise DJNodeNotFound(f"Cube '{cube.cube}' not found.")
-        metrics = dedupe_append(cube_node.current.cube_node_metrics, metrics)
-        dimensions = dedupe_append(cube_node.current.cube_node_dimensions, dimensions)
-
+    metrics, dimensions = await resolve_metrics_and_dimensions(session, cube)
     queries = await get_measures_query(
         session=session,
-        metrics=list(OrderedDict.fromkeys(metrics)),  # type: ignore
+        metrics=metrics,  # type: ignore
         dimensions=dimensions,  # type: ignore
         filters=cube.filters,  # type: ignore
         orderby=cube.orderby,

--- a/datajunction-server/datajunction_server/api/graphql/queries/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/sql.py
@@ -11,6 +11,7 @@ from datajunction_server.database.node import Node as DBNode
 from datajunction_server.api.graphql.resolvers.nodes import find_nodes_by
 from datajunction_server.api.graphql.scalars.sql import GeneratedSQL
 from datajunction_server.construction.build_v2 import get_measures_query
+from datajunction_server.utils import dedupe_append
 
 
 @strawberry.input
@@ -96,15 +97,13 @@ async def measures_sql(
     session = info.context["session"]
     metrics = cube.metrics or []
     dimensions = cube.dimensions or []
+
     if cube.cube:
         cube_node = await DBNode.get_cube_by_name(session, cube.cube)
         if not cube_node:
             raise DJNodeNotFound(f"Cube '{cube.cube}' not found.")
-        current_revision = cube_node.current
-        cube_node_metrics = set(current_revision.cube_node_metrics)
-        cube_node_dimensions = set(current_revision.cube_node_dimensions)
-        metrics = current_revision.cube_node_metrics + [m for m in metrics if m not in cube_node_metrics]
-        dimensions = current_revision.cube_node_dimensions + [dim for dim in dimensions if dim not in cube_node_dimensions]
+        metrics = dedupe_append(cube_node.current.cube_node_metrics, metrics)
+        dimensions = dedupe_append(cube_node.current.cube_node_dimensions, dimensions)
 
     queries = await get_measures_query(
         session=session,

--- a/datajunction-server/datajunction_server/api/graphql/scalars/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/sql.py
@@ -1,11 +1,11 @@
 """SQL-related scalars."""
 
 from functools import cached_property
+from typing import Annotated
 
 import strawberry
 from strawberry.types import Info
 
-from datajunction_server.api.graphql.resolvers.nodes import get_node_by_name
 from datajunction_server.api.graphql.scalars.errors import DJError
 from datajunction_server.api.graphql.scalars.node import Node
 from datajunction_server.api.graphql.utils import extract_fields
@@ -82,6 +82,8 @@ class GeneratedSQL:
         """
         Loads a strawberry GeneratedSQL from the original pydantic model.
         """
+        from datajunction_server.api.graphql.resolvers.nodes import get_node_by_name
+
         fields = extract_fields(info)
         return GeneratedSQL(  # type: ignore
             node=await get_node_by_name(
@@ -103,3 +105,55 @@ class GeneratedSQL:
             upstream_tables=obj.upstream_tables,
             errors=obj.errors,
         )
+
+
+@strawberry.input
+class CubeDefinition:
+    """
+    The cube definition for the query
+    """
+
+    cube: Annotated[
+        str | None,
+        strawberry.argument(
+            description="The name of the cube to query",
+        ),
+    ] = None  # type: ignore
+    metrics: Annotated[
+        list[str] | None,
+        strawberry.argument(
+            description="A list of metric node names",
+        ),
+    ] = None  # type: ignore
+    dimensions: Annotated[
+        list[str] | None,
+        strawberry.argument(
+            description="A list of dimension attribute names",
+        ),
+    ] = None
+    filters: Annotated[
+        list[str] | None,
+        strawberry.argument(
+            description="A list of filter SQL clauses",
+        ),
+    ] = None
+    orderby: Annotated[
+        list[str] | None,
+        strawberry.argument(
+            description="A list of order by clauses",
+        ),
+    ] = None
+
+
+@strawberry.input
+class EngineSettings:
+    """
+    The engine settings for the query
+    """
+
+    name: str = strawberry.field(
+        description="The name of the engine used by the generated SQL",
+    )
+    version: str | None = strawberry.field(
+        description="The version of the engine used by the generated SQL",
+    )

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -58,7 +58,8 @@ type ColumnMetadata {
 }
 
 input CubeDefinition {
-  metrics: [String!]!
+  cube: String = null
+  metrics: [String!] = null
   dimensions: [String!] = null
   filters: [String!] = null
   orderby: [String!] = null

--- a/datajunction-server/datajunction_server/api/graphql/utils.py
+++ b/datajunction-server/datajunction_server/api/graphql/utils.py
@@ -1,9 +1,11 @@
 """Utils for handling GraphQL queries."""
 
 import re
-from typing import Any, Dict
+from typing import Any, Dict, TypeVar
 
 CURSOR_SEPARATOR = "-"
+
+T = TypeVar("T")
 
 
 def convert_camel_case(name):
@@ -44,3 +46,11 @@ def extract_fields(query_fields) -> Dict[str, Any]:
                 fields[field_name] = None
 
     return fields
+
+
+def dedupe_append(base: list[T], extras: list[T]) -> list[T]:
+    """
+    Append items from extras to base, ensuring no duplicates.
+    """
+    base_set = set(base)
+    return base + [x for x in extras if x not in base_set]

--- a/datajunction-server/tests/api/graphql/resolvers/test_node_resolvers.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_node_resolvers.py
@@ -11,7 +11,9 @@ from datajunction_server.errors import DJNodeNotFound
 async def test_no_cube_metrics_dimensions_passed():
     session = AsyncMock()
     cube_def = CubeDefinition(
-        cube=None, metrics=["metric1", "metric2"], dimensions=["dim1", "dim2"],
+        cube=None,
+        metrics=["metric1", "metric2"],
+        dimensions=["dim1", "dim2"],
     )
 
     metrics, dimensions = await resolve_metrics_and_dimensions(session, cube_def)
@@ -23,10 +25,13 @@ async def test_no_cube_metrics_dimensions_passed():
 @pytest.mark.asyncio
 @patch("datajunction_server.api.graphql.resolvers.nodes.DBNode.get_cube_by_name")
 async def test_cube_found_merges_metrics_and_dimensions(
-    mock_get_cube, session=AsyncMock(),
+    mock_get_cube,
+    session=AsyncMock(),
 ):
     cube_def = CubeDefinition(
-        cube="my_cube", metrics=["metric2", "metric3"], dimensions=["dim2", "dim3"],
+        cube="my_cube",
+        metrics=["metric2", "metric3"],
+        dimensions=["dim2", "dim3"],
     )
 
     # Mock the cube_node with current having cube_node_metrics and cube_node_dimensions
@@ -48,7 +53,9 @@ async def test_cube_found_merges_metrics_and_dimensions(
 @patch("datajunction_server.api.graphql.resolvers.nodes.DBNode.get_cube_by_name")
 async def test_cube_not_found_raises(mock_get_cube, session=AsyncMock()):
     cube_def = CubeDefinition(
-        cube="missing_cube", metrics=["metric1"], dimensions=["dim1"],
+        cube="missing_cube",
+        metrics=["metric1"],
+        dimensions=["dim1"],
     )
 
     mock_get_cube.return_value = None

--- a/datajunction-server/tests/api/graphql/resolvers/test_node_resolvers.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_node_resolvers.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datajunction_server.api.graphql.resolvers.nodes import (
+    resolve_metrics_and_dimensions,
+)
+from datajunction_server.api.graphql.scalars.sql import CubeDefinition
+from datajunction_server.errors import DJNodeNotFound
+
+
+@pytest.mark.asyncio
+async def test_no_cube_metrics_dimensions_passed():
+    session = AsyncMock()
+    cube_def = CubeDefinition(
+        cube=None, metrics=["metric1", "metric2"], dimensions=["dim1", "dim2"],
+    )
+
+    metrics, dimensions = await resolve_metrics_and_dimensions(session, cube_def)
+
+    assert metrics == ["metric1", "metric2"]
+    assert dimensions == ["dim1", "dim2"]
+
+
+@pytest.mark.asyncio
+@patch("datajunction_server.api.graphql.resolvers.nodes.DBNode.get_cube_by_name")
+async def test_cube_found_merges_metrics_and_dimensions(
+    mock_get_cube, session=AsyncMock(),
+):
+    cube_def = CubeDefinition(
+        cube="my_cube", metrics=["metric2", "metric3"], dimensions=["dim2", "dim3"],
+    )
+
+    # Mock the cube_node with current having cube_node_metrics and cube_node_dimensions
+    mock_cube_node = MagicMock()
+    mock_cube_node.current.cube_node_metrics = ["metric1", "metric2"]
+    mock_cube_node.current.cube_node_dimensions = ["dim1", "dim2"]
+
+    mock_get_cube.return_value = mock_cube_node
+
+    metrics, dimensions = await resolve_metrics_and_dimensions(session, cube_def)
+
+    # Metrics should be cube_node's metrics plus any not duplicated from cube_def.metrics
+    assert metrics == ["metric1", "metric2", "metric3"]
+    # Dimensions similarly
+    assert dimensions == ["dim1", "dim2", "dim3"]
+
+
+@pytest.mark.asyncio
+@patch("datajunction_server.api.graphql.resolvers.nodes.DBNode.get_cube_by_name")
+async def test_cube_not_found_raises(mock_get_cube, session=AsyncMock()):
+    cube_def = CubeDefinition(
+        cube="missing_cube", metrics=["metric1"], dimensions=["dim1"],
+    )
+
+    mock_get_cube.return_value = None
+
+    with pytest.raises(DJNodeNotFound) as e:
+        await resolve_metrics_and_dimensions(session, cube_def)
+    assert "missing_cube" in str(e.value)
+
+
+@pytest.mark.asyncio
+@patch("datajunction_server.api.graphql.resolvers.nodes.DBNode.get_cube_by_name")
+async def test_metrics_deduplication(mock_get_cube, session=AsyncMock()):
+    cube_def = CubeDefinition(
+        cube="cube1",
+        metrics=["metric1", "metric2", "metric1", "metric3"],
+        dimensions=None,
+    )
+
+    mock_cube_node = MagicMock()
+    mock_cube_node.current.cube_node_metrics = ["metric2", "metric4"]
+    mock_cube_node.current.cube_node_dimensions = []
+
+    mock_get_cube.return_value = mock_cube_node
+
+    metrics, dimensions = await resolve_metrics_and_dimensions(session, cube_def)
+
+    # Deduplication preserves order with cube node metrics first
+    assert metrics == ["metric2", "metric4", "metric1", "metric3"]
+    assert dimensions == []
+
+
+@pytest.mark.asyncio
+async def test_empty_metrics_and_dimensions_defaults():
+    session = AsyncMock()
+    cube_def = CubeDefinition(cube=None, metrics=None, dimensions=None)
+    metrics, dimensions = await resolve_metrics_and_dimensions(session, cube_def)
+    assert metrics == []
+    assert dimensions == []

--- a/datajunction-server/tests/api/graphql/utils_test.py
+++ b/datajunction-server/tests/api/graphql/utils_test.py
@@ -1,0 +1,33 @@
+import pytest
+from datajunction_server.api.graphql.utils import convert_camel_case, dedupe_append
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("camelCase", "camel_case"),
+        ("CamelCase", "camel_case"),
+        ("HttpRequest", "http_request"),
+        ("getUrlFromHtml", "get_url_from_html"),
+        ("already_snake_case", "already_snake_case"),
+        ("single", "single"),
+        ("", ""),
+    ],
+)
+def test_convert_camel_case(input_str, expected):
+    assert convert_camel_case(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "base, extras, expected",
+    [
+        (["a", "b"], ["c", "d"], ["a", "b", "c", "d"]),  # no duplicates
+        (["a", "b"], ["b", "c"], ["a", "b", "c"]),  # some duplicates
+        (["a", "b"], ["a", "b"], ["a", "b"]),  # all duplicates
+        ([], ["x", "y"], ["x", "y"]),  # empty base
+        (["x", "y"], [], ["x", "y"]),  # empty extras
+        ([], [], []),  # both empty
+    ],
+)
+def test_dedupe_append(base, extras, expected):
+    assert dedupe_append(base, extras) == expected


### PR DESCRIPTION
### Summary

This PR adds logic to resolve metrics and dimensions from a cube node if one is specified in the `measuresSql` GraphQL query's `CubeDefinition` input. If no cube is provided, it falls back to using the explicitly passed metrics and dimensions. Otherwise it tries to merge the cube's defined metrics and dimensions with any explicitly provided ones, deduplicating in order-preserving fashion.

This makes things more flexible so that downstream consumers can specify either a cube name, relying on its configured metrics/dimensions, or a custom list of metrics/dimensions (with or without a cube).

An example GQL query:
```graphql
query MeasuresSql($cube: String) {
  measuresSql(
    cube: {cube: $cube}
    preaggregate: true
  ) {
    sql
  }
}
```

### Test Plan

Added unit tests for:

* Handling missing or present cube references
* Deduplication of metrics and dimensions
* Error handling when cube is not found
* Fallback to direct input when no cube is specified

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
