### PR TITLE
Add filtering on columns for node revisions in GQL

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/column.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/column.py
@@ -58,6 +58,6 @@ class Column:
     name: str
     display_name: Optional[str]
     type: str
-    attributes: Optional[List[Attribute]]
+    attributes: List[Attribute] = strawberry.field(default_factory=list)
     dimension: Optional[NodeName]
     partition: Optional[Partition]

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -124,7 +124,43 @@ class NodeRevision:
         return Catalog.from_pydantic(root.catalog)  # type: ignore
 
     query: Optional[str] = None
-    columns: List[Column]
+
+    @strawberry.field
+    def columns(
+        self,
+        root: "DBNodeRevision",
+        attributes: list[str] | None = None,
+    ) -> list[Column]:
+        """
+        The columns of the node
+        """
+        return [
+            Column(  # type: ignore
+                name=col.name,
+                display_name=col.display_name,
+                type=col.type,
+                attributes=col.attributes,
+                dimension=(
+                    NodeName(name=col.dimension.name)  # type: ignore
+                    if col.dimension
+                    else None
+                ),
+                partition=Partition(
+                    type_=col.partition.type_,  # type: ignore
+                    format=col.partition.format,
+                    granularity=col.partition.granularity,
+                    expression=col.partition.expression,
+                )
+                if col.partition
+                else None,
+            )
+            for col in root.columns
+            if (
+                any(col.has_attribute(attr) for attr in attributes)
+                if attributes
+                else True
+            )
+        ]
 
     # Dimensions and data graph-related outputs
     dimension_links: List[DimensionLink]

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -45,7 +45,7 @@ type Column {
   name: String!
   displayName: String
   type: String!
-  attributes: [Attribute!]
+  attributes: [Attribute!]!
   dimension: NodeName
   partition: Partition
 }
@@ -263,7 +263,6 @@ type NodeRevision {
   updatedAt: DateTime!
   customMetadata: JSON
   query: String
-  columns: [Column!]!
   dimensionLinks: [DimensionLink!]!
   parents: [NodeName!]!
   availability: AvailabilityState
@@ -272,6 +271,7 @@ type NodeRevision {
   table: String
   requiredDimensions: [Column!]
   catalog: Catalog
+  columns(attributes: [String!] = null): [Column!]!
   primaryKey: [String!]!
   metricMetadata: MetricMetadata
   extractedMeasures: DecomposedMetric

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -1101,3 +1101,133 @@ async def test_find_nodes_paginated_empty_list(
             "hasPrevPage": False,
         },
     }
+
+
+def test_columns_resolver_filters_by_attribute():
+    """
+    Test that the columns resolver filters columns by attribute
+    """
+    mock_column = mock.MagicMock()
+    from datajunction_server.api.graphql.scalars.node import NodeRevision
+    from datajunction_server.database import (
+        NodeRevision as DBNodeRevision,
+        ColumnAttribute,
+        AttributeType,
+    )
+    from datajunction_server.database.column import Column
+
+    import datajunction_server.sql.parsing.types as ct
+    from datajunction_server.models.node_type import NodeType
+
+    primary_key_attribute = AttributeType(namespace="system", name="primary_key")
+    dimension_attribute = AttributeType(namespace="system", name="dimension")
+    db_node_revision = DBNodeRevision(
+        name="source_rev",
+        type=NodeType.SOURCE,
+        version="1",
+        columns=[
+            Column(
+                name="random_primary_key",
+                type=ct.StringType(),
+                attributes=[ColumnAttribute(attribute_type=primary_key_attribute)],
+                order=0,
+            ),
+            Column(
+                name="user_id",
+                type=ct.IntegerType(),
+                attributes=[ColumnAttribute(attribute_type=dimension_attribute)],
+                order=2,
+            ),
+            Column(
+                name="foo",
+                type=ct.FloatType(),
+                order=3,
+            ),
+        ],
+    )
+
+    mock_node = mock.MagicMock()
+    mock_node.columns = [mock_column]
+
+    result = NodeRevision.columns(
+        NodeRevision,
+        root=db_node_revision,
+        attributes=["primary_key"],
+    )
+    assert len(result) == 1
+    assert result[0].name == "random_primary_key"
+
+    result = NodeRevision.columns(
+        NodeRevision,
+        root=db_node_revision,
+        attributes=["dimension"],
+    )
+    assert len(result) == 1
+    assert result[0].name == "user_id"
+
+
+@pytest.mark.asyncio
+async def test_find_by_with_filtering_on_columns(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test that filter on columns works correctly
+    """
+    query = """
+    {
+        findNodes(names: ["default.regional_level_agg", "default.repair_orders"]) {
+            name
+            type
+            current {
+                columns(attributes: ["primary_key"]) {
+                    name
+                    type
+                }
+            }
+            currentVersion
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["findNodes"] == [
+        {
+            "current": {
+                "columns": [
+                    {
+                        "name": "us_region_id",
+                        "type": "int",
+                    },
+                    {
+                        "name": "state_name",
+                        "type": "string",
+                    },
+                    {
+                        "name": "order_year",
+                        "type": "int",
+                    },
+                    {
+                        "name": "order_month",
+                        "type": "int",
+                    },
+                    {
+                        "name": "order_day",
+                        "type": "int",
+                    },
+                ],
+            },
+            "currentVersion": "v1.0",
+            "name": "default.regional_level_agg",
+            "type": "TRANSFORM",
+        },
+        {
+            "current": {
+                "columns": [],
+            },
+            "currentVersion": "v1.0",
+            "name": "default.repair_orders",
+            "type": "SOURCE",
+        },
+    ]

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -1103,69 +1103,6 @@ async def test_find_nodes_paginated_empty_list(
     }
 
 
-def test_columns_resolver_filters_by_attribute():
-    """
-    Test that the columns resolver filters columns by attribute
-    """
-    mock_column = mock.MagicMock()
-    from datajunction_server.api.graphql.scalars.node import NodeRevision
-    from datajunction_server.database import (
-        NodeRevision as DBNodeRevision,
-        ColumnAttribute,
-        AttributeType,
-    )
-    from datajunction_server.database.column import Column
-
-    import datajunction_server.sql.parsing.types as ct
-    from datajunction_server.models.node_type import NodeType
-
-    primary_key_attribute = AttributeType(namespace="system", name="primary_key")
-    dimension_attribute = AttributeType(namespace="system", name="dimension")
-    db_node_revision = DBNodeRevision(
-        name="source_rev",
-        type=NodeType.SOURCE,
-        version="1",
-        columns=[
-            Column(
-                name="random_primary_key",
-                type=ct.StringType(),
-                attributes=[ColumnAttribute(attribute_type=primary_key_attribute)],
-                order=0,
-            ),
-            Column(
-                name="user_id",
-                type=ct.IntegerType(),
-                attributes=[ColumnAttribute(attribute_type=dimension_attribute)],
-                order=2,
-            ),
-            Column(
-                name="foo",
-                type=ct.FloatType(),
-                order=3,
-            ),
-        ],
-    )
-
-    mock_node = mock.MagicMock()
-    mock_node.columns = [mock_column]
-
-    result = NodeRevision.columns(
-        NodeRevision,
-        root=db_node_revision,
-        attributes=["primary_key"],
-    )
-    assert len(result) == 1
-    assert result[0].name == "random_primary_key"
-
-    result = NodeRevision.columns(
-        NodeRevision,
-        root=db_node_revision,
-        attributes=["dimension"],
-    )
-    assert len(result) == 1
-    assert result[0].name == "user_id"
-
-
 @pytest.mark.asyncio
 async def test_find_by_with_filtering_on_columns(
     module__client_with_roads: AsyncClient,

--- a/datajunction-server/tests/api/graphql/resolvers/test_node_resolver.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_node_resolver.py
@@ -1,0 +1,66 @@
+"""Tests for the Node and NodeRevision resolvers."""
+
+from unittest import mock
+
+
+def test_columns_resolver_filters_by_attribute():
+    """
+    Test that the columns resolver filters columns by attribute
+    """
+    mock_column = mock.MagicMock()
+    from datajunction_server.api.graphql.scalars.node import NodeRevision
+    from datajunction_server.database import (
+        NodeRevision as DBNodeRevision,
+        ColumnAttribute,
+        AttributeType,
+    )
+    from datajunction_server.database.column import Column
+
+    import datajunction_server.sql.parsing.types as ct
+    from datajunction_server.models.node_type import NodeType
+
+    primary_key_attribute = AttributeType(namespace="system", name="primary_key")
+    dimension_attribute = AttributeType(namespace="system", name="dimension")
+    db_node_revision = DBNodeRevision(
+        name="source_rev",
+        type=NodeType.SOURCE,
+        version="1",
+        columns=[
+            Column(
+                name="random_primary_key",
+                type=ct.StringType(),
+                attributes=[ColumnAttribute(attribute_type=primary_key_attribute)],
+                order=0,
+            ),
+            Column(
+                name="user_id",
+                type=ct.IntegerType(),
+                attributes=[ColumnAttribute(attribute_type=dimension_attribute)],
+                order=2,
+            ),
+            Column(
+                name="foo",
+                type=ct.FloatType(),
+                order=3,
+            ),
+        ],
+    )
+
+    mock_node = mock.MagicMock()
+    mock_node.columns = [mock_column]
+
+    result = NodeRevision.columns(
+        NodeRevision,
+        root=db_node_revision,
+        attributes=["primary_key"],
+    )
+    assert len(result) == 1
+    assert result[0].name == "random_primary_key"
+
+    result = NodeRevision.columns(
+        NodeRevision,
+        root=db_node_revision,
+        attributes=["dimension"],
+    )
+    assert len(result) == 1
+    assert result[0].name == "user_id"


### PR DESCRIPTION
### Summary

NodeRevision objects in GraphQL should include filtering capability on columns:
```graphql
query Find {
  findNodes(names: ["default.repair_order_detail"]) {
    name
    type
    current {
      columns (attributes: ["primary_key"]) {
        name
        type
      }
    }
  }
}
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
