### PR TITLE
Dimensions DAG Efficiency

### DIFF
--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -455,6 +455,7 @@ async def get_dimensions_dag(
             )
             .select_from(NodeColumns)
             .join(Column, NodeColumns.column_id == Column.id)
+            .where(Column.dimension_id.isnot(None))
         )
         .union_all(
             select(
@@ -659,6 +660,13 @@ async def get_dimensions_dag(
             .where(NodeRevision.id == node_revision.id),
         )
     )
+    from sqlalchemy.dialects import postgresql
+
+    compiled_query = final_query.compile(
+        dialect=postgresql.dialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    print("compiled_query", compiled_query)
 
     def _extract_roles_from_path(join_path) -> str:
         """Extracts dimension roles from the query results' join path"""

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -660,13 +660,6 @@ async def get_dimensions_dag(
             .where(NodeRevision.id == node_revision.id),
         )
     )
-    from sqlalchemy.dialects import postgresql
-
-    compiled_query = final_query.compile(
-        dialect=postgresql.dialect(),
-        compile_kwargs={"literal_binds": True},
-    )
-    print("compiled_query", compiled_query)
 
     def _extract_roles_from_path(join_path) -> str:
         """Extracts dimension roles from the query results' join path"""


### PR DESCRIPTION
### Summary

This makes the dimensions graph recursive CTE a lot more efficient by filtering out node columns that don't have a `dimension_id` attached, since those can never branch out further in the graph.

The query plan for `graph_branches` is much nicer with this filter -- instead of exploding to 200K rows, it reduces that to 15K:
```
CTE graph_branches
  ->  Append  (cost=4895.31..8352.96 rows=15020 width=80) (actual time=14.972..38.231 rows=14998 loops=1)
        ->  Gather  (cost=4895.31..7630.76 rows=1693 width=41) (actual time=14.972..33.045 rows=1671 loops=1)
```
vs
```
CTE graph_branches
  ->  Append  (cost=8962.73..18015.16 rows=213305 width=80) (actual time=89.277..193.841 rows=213305 loops=1)
        ->  Hash Join  (cost=8962.73..16318.46 rows=199978 width=41) (actual time=89.276..180.801 rows=199978 loops=1)
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
