### PR TITLE
Add missing create read-only user script

### DIFF
--- a/init/create-readonly-user.sh
+++ b/init/create-readonly-user.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+psql -U dj -d dj <<EOF
+DO \$\$
+BEGIN
+   IF NOT EXISTS (
+      SELECT FROM pg_catalog.pg_roles WHERE rolname = 'readonly_user'
+   ) THEN
+      CREATE ROLE readonly_user LOGIN PASSWORD 'readonly_pass';
+   END IF;
+END
+\$\$;
+
+GRANT CONNECT ON DATABASE dj TO readonly_user;
+GRANT USAGE ON SCHEMA public TO readonly_user;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO readonly_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO readonly_user;
+EOF


### PR DESCRIPTION
### Summary

This adds the missing script to create a read-only user in Postgres.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1425 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
