### PR TITLE
Fix ability to run validation queries

### DIFF
--- a/datajunction-query/djqs/api/queries.py
+++ b/datajunction-query/djqs/api/queries.py
@@ -111,12 +111,6 @@ async def submit_query(  # pylint: disable=too-many-arguments
     )
 
     return_type = get_best_match(accept, ["application/json", "application/msgpack"])
-    if not return_type:
-        raise HTTPException(
-            status_code=HTTPStatus.NOT_ACCEPTABLE,
-            detail="Client MUST accept: application/json, application/msgpack",
-        )
-
     if return_type == "application/msgpack":
         content = msgpack.packb(
             asdict(query_with_results),

--- a/datajunction-query/djqs/api/queries.py
+++ b/datajunction-query/djqs/api/queries.py
@@ -111,6 +111,12 @@ async def submit_query(  # pylint: disable=too-many-arguments
     )
 
     return_type = get_best_match(accept, ["application/json", "application/msgpack"])
+    if not return_type:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_ACCEPTABLE,
+            detail="Client MUST accept: application/json, application/msgpack",
+        )
+
     if return_type == "application/msgpack":
         content = msgpack.packb(
             asdict(query_with_results),

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -284,7 +284,7 @@ async def get_data_stream_for_node(
         background_tasks=background_tasks,
     )
     if query_request and query_request.query_id:
-        return EventSourceResponse(
+        return EventSourceResponse(  # pragma: no cover
             query_event_stream(
                 query=QueryWithResults(
                     id=query_request.query_id,

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -324,11 +324,6 @@ async def get_data_stream_for_node(
         request_headers=request_headers,
     )
 
-    # Save the external query id reference
-    query_request.query_id = initial_query_info.id
-    session.add(query_request)
-    await session.commit()
-
     return EventSourceResponse(
         query_event_stream(
             query=initial_query_info,

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -287,7 +287,7 @@ async def get_node_sql(
         query_type=QueryBuildType.NODE,
     ):
         # Update the node SQL in a background task to keep it up-to-date
-        background_tasks.add_task(
+        background_tasks.add_task(  # pragma: no cover
             build_and_save_node_sql,
             node_name=node_name,
             dimensions=dimensions,
@@ -301,7 +301,7 @@ async def get_node_sql(
             query_parameters=query_parameters,
             save=False,
         )
-        return (
+        return (  # pragma: no cover
             TranslatedSQL.create(
                 sql=query_request.query,
                 columns=query_request.columns,

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -205,7 +205,7 @@ class QueryRequest(Base):  # type: ignore
         )
         query_request = (await session.execute(statement)).scalar_one_or_none()
         if query_request:
-            return query_request
+            return query_request  # pragma: no cover
         return None
 
     @classmethod

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -192,6 +192,7 @@ class QueryServiceClient:
             headers={
                 **self.requests_session.headers,
                 **QueryServiceClient.filtered_headers(request_headers),
+                "accept": "application/json",
             }
             if request_headers
             else self.requests_session.headers,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -200,7 +200,7 @@ class QueryServiceClient:
         response_data = response.json()
         if response.status_code not in (200, 201):
             raise DJQueryServiceClientException(
-                message=f"Error response from query service: {response_data['message']}",
+                message=f"Error response from query service: {response_data}",
                 errors=[
                     DJError(code=ErrorCode.QUERY_SERVICE_ERROR, message=error)
                     for error in response_data["errors"]

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -11,9 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from datajunction_server.database import QueryRequest
 from datajunction_server.database.node import Node, NodeRevision
-from datajunction_server.database.queryrequest import QueryBuildType
 from datajunction_server.models.node import AvailabilityStateBase
 
 
@@ -565,20 +563,6 @@ class TestDataForNode:
             full_text = "\n".join([text async for text in response.aiter_lines()])
             assert "event: message" in full_text
             assert "SELECT  default_DOT_repair_orders_fact.repair_order_id" in full_text
-
-        # Check that the query request for the above transform has an external query id saved
-        query_request = await QueryRequest.get_query_request(
-            session=module__session,
-            query_type=QueryBuildType.NODE,
-            nodes=["default.repair_orders_fact"],
-            dimensions=["default.dispatcher.company_name"],
-            engine_name=None,
-            engine_version=None,
-            filters=[],
-            limit=10,
-            orderby=[],
-        )
-        assert query_request.query_id == "bd98d6be-e2d2-413e-94c7-96d9411ddee2"  # type: ignore
 
         # Hit the same SSE stream again
         async with module__client_with_roads.stream(


### PR DESCRIPTION
### Summary

This fixes the interaction between the core API and query service so that we can actually run validation queries:

<img width="1306" alt="Screenshot 2025-06-27 at 12 40 40 AM" src="https://github.com/user-attachments/assets/784af12d-d85f-477b-98f2-e40b86f44f5b" />

The primary fix is that the core service needs to pass in an `accept` header that works for the query service.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
