### PR TITLE
Add deactivated filter for downstreamNodes GraphQL query

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/queries/dag.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/dag.py
@@ -54,6 +54,12 @@ async def downstream_nodes(
             description="The node type to filter the downstream nodes on.",
         ),
     ] = None,
+    include_deactivated: Annotated[
+        bool,
+        strawberry.argument(
+            description="Whether to include deactivated nodes in the result.",
+        ),
+    ] = False,
     *,
     info: Info,
 ) -> list[Node]:
@@ -61,4 +67,9 @@ async def downstream_nodes(
     Return a list of downstream nodes for a given node.
     """
     session = info.context["session"]
-    return await get_downstream_nodes(session, node_name=node_name, node_type=node_type)  # type: ignore
+    return await get_downstream_nodes(  # type: ignore
+        session,
+        node_name=node_name,
+        node_type=node_type,
+        include_deactivated=include_deactivated,
+    )

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -409,6 +409,9 @@ type Query {
 
     """The node type to filter the downstream nodes on."""
     nodeType: NodeType = null
+
+    """Whether to include deactivated nodes in the result."""
+    includeDeactivated: Boolean! = false
   ): [Node!]!
 
   """Get measures SQL for a list of metrics, dimensions, and filters."""


### PR DESCRIPTION
### Summary

Adds an `include_deactivated` filter for the `downstreamNodes` GraphQL query. Most use cases will not want to query deleted nodes, but only the active ones.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
