### PR TITLE
Hide deleted dimension nodes from dimension links

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -168,7 +168,19 @@ class NodeRevision:
         ]
 
     # Dimensions and data graph-related outputs
-    dimension_links: List[DimensionLink]
+    @strawberry.field
+    def dimension_links(self) -> list[DimensionLink]:
+        """
+        Returns the dimension links for this node revision.
+        """
+        return [
+            link
+            for link in self.dimension_links
+            if link.dimension is not None  # handles hard-deleted dimension nodes
+            and link.dimension.deactivated_at
+            is None  # handles deactivated dimension nodes
+        ]
+
     parents: List[NodeNameVersion]
 
     # Materialization-related outputs

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -268,7 +268,6 @@ type NodeRevision {
   updatedAt: DateTime!
   customMetadata: JSON
   query: String
-  dimensionLinks: [DimensionLink!]!
   parents: [NodeNameVersion!]!
   availability: AvailabilityState
   materializations: [MaterializationConfig!]
@@ -277,6 +276,7 @@ type NodeRevision {
   requiredDimensions: [Column!]
   catalog: Catalog
   columns(attributes: [String!] = null): [Column!]!
+  dimensionLinks: [DimensionLink!]!
   primaryKey: [String!]!
   metricMetadata: MetricMetadata
   extractedMeasures: DecomposedMetric

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -769,6 +769,12 @@ class GenericNodeOutputModel(BaseModel):
         }
         for k, v in current_dict.items():
             final_dict[k] = v
+
+        final_dict["dimension_links"] = [
+            link
+            for link in final_dict["dimension_links"]
+            if link.dimension.deactivated_at is None
+        ]
         final_dict["node_revision_id"] = final_dict["id"]
         return final_dict
 


### PR DESCRIPTION
### Summary

When a dimension node is deactivated, it should be hidden from the dimension links for all nodes. If this dimension node is ever restored, the dimension links are still recoverable (they're only hidden, not cleared out).

If a dimension node is hard-deleted, it should be removed from the dimension links for all nodes. The node cannot be restored, and if it is recreated, the links will also need to be recreated.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
