### PR TITLE
Add node owners

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2025_06_28_1606-1c27711f42cd_add_node_owner.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_06_28_1606-1c27711f42cd_add_node_owner.py
@@ -19,7 +19,7 @@ depends_on = None
 
 def upgrade():
     op.create_table(
-        "nodeowner",
+        "node_owners",
         sa.Column(
             "node_id",
             sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
@@ -30,18 +30,26 @@ def upgrade():
             sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
             nullable=False,
         ),
-        sa.Column("ownership_type", sa.String(length=50), nullable=True),
-        sa.ForeignKeyConstraint(["node_id"], ["node.id"], name="fk_nodeowner_node_id"),
-        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_nodeowner_user_id"),
+        sa.Column("ownership_type", sa.String(length=256), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["node_id"],
+            ["node.id"],
+            name="fk_node_owners_node_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_node_owners_user_id",
+        ),
         sa.PrimaryKeyConstraint("node_id", "user_id"),
     )
-    with op.batch_alter_table("nodeowner", schema=None) as batch_op:
-        batch_op.create_index("idx_nodeowner_node_id", ["node_id"], unique=False)
-        batch_op.create_index("idx_nodeowner_user_id", ["user_id"], unique=False)
+    with op.batch_alter_table("node_owners", schema=None) as batch_op:
+        batch_op.create_index("idx_node_owners_node_id", ["node_id"], unique=False)
+        batch_op.create_index("idx_node_owners_user_id", ["user_id"], unique=False)
 
-    # Autopopulate nodeowner from node.created_by_id
+    # Autopopulate node_owners from node.created_by_id
     op.execute("""
-        INSERT INTO nodeowner (node_id, user_id)
+        INSERT INTO node_owners (node_id, user_id)
         SELECT id, created_by_id
         FROM node
         WHERE created_by_id IS NOT NULL
@@ -49,8 +57,8 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table("nodeowner", schema=None) as batch_op:
-        batch_op.drop_index("idx_nodeowner_user_id")
-        batch_op.drop_index("idx_nodeowner_node_id")
+    with op.batch_alter_table("node_owners", schema=None) as batch_op:
+        batch_op.drop_index("idx_node_owners_user_id")
+        batch_op.drop_index("idx_node_owners_node_id")
 
-    op.drop_table("nodeowner")
+    op.drop_table("node_owners")

--- a/datajunction-server/datajunction_server/alembic/versions/2025_06_28_1606-1c27711f42cd_add_node_owner.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_06_28_1606-1c27711f42cd_add_node_owner.py
@@ -1,0 +1,55 @@
+"""
+Add node owner
+
+Revision ID: 1c27711f42cd
+Revises: 395952b010b0
+Create Date: 2025-06-28 16:06:33.834754+00:00
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1c27711f42cd"
+down_revision = "395952b010b0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "nodeowner",
+        sa.Column(
+            "node_id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["node_id"], ["node.id"], name="fk_nodeowner_node_id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_nodeowner_user_id"),
+        sa.PrimaryKeyConstraint("node_id", "user_id"),
+    )
+    with op.batch_alter_table("nodeowner", schema=None) as batch_op:
+        batch_op.create_index("idx_nodeowner_node_id", ["node_id"], unique=False)
+        batch_op.create_index("idx_nodeowner_user_id", ["user_id"], unique=False)
+
+    # Autopopulate nodeowner from node.created_by_id
+    op.execute("""
+        INSERT INTO nodeowner (node_id, user_id)
+        SELECT id, created_by_id
+        FROM node
+        WHERE created_by_id IS NOT NULL
+    """)
+
+
+def downgrade():
+    with op.batch_alter_table("nodeowner", schema=None) as batch_op:
+        batch_op.drop_index("idx_nodeowner_user_id")
+        batch_op.drop_index("idx_nodeowner_node_id")
+
+    op.drop_table("nodeowner")

--- a/datajunction-server/datajunction_server/alembic/versions/2025_06_28_1606-1c27711f42cd_add_node_owner.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_06_28_1606-1c27711f42cd_add_node_owner.py
@@ -30,6 +30,7 @@ def upgrade():
             sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
             nullable=False,
         ),
+        sa.Column("ownership_type", sa.String(length=50), nullable=True),
         sa.ForeignKeyConstraint(["node_id"], ["node.id"], name="fk_nodeowner_node_id"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_nodeowner_user_id"),
         sa.PrimaryKeyConstraint("node_id", "user_id"),

--- a/datajunction-server/datajunction_server/api/access/authentication/whoami.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/whoami.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 
 from fastapi import Depends, Request
 from fastapi.responses import JSONResponse
-
+from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authentication.tokens import create_token
@@ -15,6 +15,7 @@ from datajunction_server.models.user import UserOutput
 from datajunction_server.utils import (
     Settings,
     get_current_user,
+    get_session,
     get_settings,
 )
 
@@ -24,11 +25,13 @@ router = SecureAPIRouter(tags=["Who am I?"])
 @router.get("/whoami/")
 async def whoami(
     current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
 ):
     """
     Returns the current authenticated user
     """
-    return UserOutput.from_orm(current_user)
+    user = await User.get_by_username(session, current_user.username)
+    return UserOutput.from_orm(user)
 
 
 @router.get("/token/")

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -100,7 +100,9 @@ def load_node_options(fields):
         node_revision_options = load_node_revision_options(fields["current"])
         options.append(joinedload(DBNode.current).options(*node_revision_options))
     if "created_by" in fields:
-        options.append(joinedload(DBNode.created_by))
+        options.append(selectinload(DBNode.created_by))
+    if "owners" in fields:
+        options.append(selectinload(DBNode.owners))
     if "edited_by" in fields:
         options.append(selectinload(DBNode.history))
     if "tags" in fields:

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -322,13 +322,14 @@ class Node:
     deactivated_at: Optional[datetime.datetime]
 
     current: NodeRevision
-    revisions: List[NodeRevision]
+    revisions: list[NodeRevision]
 
-    tags: List[TagBase]
+    tags: list[TagBase]
     created_by: User
+    owners: list[User]
 
     @strawberry.field
-    def edited_by(self, root: "DBNode") -> List[str]:
+    def edited_by(self, root: "DBNode") -> list[str]:
         """
         The users who edited this node
         """

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -230,6 +230,7 @@ type Node {
   revisions: [NodeRevision!]!
   tags: [TagBase!]!
   createdBy: User!
+  owners: [User!]!
   editedBy: [String!]!
 }
 

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -536,15 +536,12 @@ async def create_source(
         current_user=current_user,
         save_history=save_history,
     )
-    node = await Node.get_by_name(  # type: ignore
+
+    return await Node.get_by_name(  # type: ignore
         session,
         node.name,
-        options=[
-            joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            joinedload(Node.tags),
-        ],
+        options=NodeOutput.load_options(),
     )
-    return node
 
 
 @router.post(
@@ -664,15 +661,11 @@ async def create_node(
                     current_user=current_user,
                     save_history=save_history,
                 )
-    node = await Node.get_by_name(  # type: ignore
+    return await Node.get_by_name(  # type: ignore
         session,
         node.name,
-        options=[
-            joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            joinedload(Node.tags),
-        ],
+        options=NodeOutput.load_options(),
     )
-    return node
 
 
 @router.post(
@@ -741,8 +734,11 @@ async def create_cube(
         current_user=current_user,
         save_history=save_history,
     )
-    node = await Node.get_by_name(session, data.name)  # type: ignore
-    return node
+    return await Node.get_by_name(  # type: ignore
+        session,
+        node.name,
+        options=NodeOutput.load_options(),
+    )
 
 
 @router.post(
@@ -1263,10 +1259,7 @@ async def refresh_source_node(
     source_node = await Node.get_by_name(
         session,
         name,
-        options=[
-            joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            joinedload(Node.tags),
-        ],
+        options=NodeOutput.load_options(),
     )
     current_revision = source_node.current  # type: ignore
 
@@ -1396,10 +1389,7 @@ async def refresh_source_node(
     source_node = await Node.get_by_name(
         session,
         name,
-        options=[
-            joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            joinedload(Node.tags),
-        ],
+        options=NodeOutput.load_options(),
     )
     await session.refresh(source_node, ["current"])
     return source_node  # type: ignore
@@ -1435,13 +1425,11 @@ async def update_node(
         request_headers=request_headers,
         save_history=save_history,
     )
+
     node = await Node.get_by_name(
         session,
         name,
-        options=[
-            joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            joinedload(Node.tags),
-        ],
+        options=NodeOutput.load_options(),
     )
     return node  # type: ignore
 

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -224,6 +224,17 @@ class Node(Base):
         default=None,
     )
 
+    owner_associations = relationship(
+        "NodeOwner",
+        back_populates="node",
+        cascade="all, delete-orphan",
+    )
+    owners: Mapped[list[User]] = relationship(
+        "User",
+        secondary="nodeowner",
+        back_populates="owned_nodes",
+    )
+
     revisions: Mapped[List["NodeRevision"]] = relationship(
         "NodeRevision",
         back_populates="node",
@@ -296,6 +307,7 @@ class Node(Base):
             ),
             selectinload(Node.tags),
             selectinload(Node.created_by),
+            selectinload(Node.owners),
         ]
         statement = statement.options(*options)
         if not include_inactive:

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -231,7 +231,7 @@ class Node(Base):
     )
     owners: Mapped[list[User]] = relationship(
         "User",
-        secondary="nodeowner",
+        secondary="node_owners",
         back_populates="owned_nodes",
     )
 

--- a/datajunction-server/datajunction_server/database/nodeowner.py
+++ b/datajunction-server/datajunction_server/database/nodeowner.py
@@ -14,7 +14,7 @@ class NodeOwner(Base):
     Join table for users and nodes that represents ownership
     """
 
-    __tablename__ = "nodeowner"
+    __tablename__ = "node_owners"
     __table_args__ = (
         Index("idx_nodeowner_node_id", "node_id"),
         Index("idx_nodeowner_user_id", "user_id"),
@@ -35,7 +35,7 @@ class NodeOwner(Base):
         primary_key=True,
     )
     ownership_type: Mapped[str] = mapped_column(
-        String(50),
+        String(256),
         nullable=True,
     )
 

--- a/datajunction-server/datajunction_server/database/nodeowner.py
+++ b/datajunction-server/datajunction_server/database/nodeowner.py
@@ -1,0 +1,43 @@
+"""Node - owners database schema."""
+
+from sqlalchemy import (
+    ForeignKey,
+    Index,
+    String,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from datajunction_server.database.base import Base
+
+
+class NodeOwner(Base):
+    """
+    Join table for users and nodes that represents ownership
+    """
+
+    __tablename__ = "nodeowner"
+    __table_args__ = (
+        Index("idx_nodeowner_node_id", "node_id"),
+        Index("idx_nodeowner_user_id", "user_id"),
+    )
+
+    node_id: Mapped[int] = mapped_column(
+        ForeignKey(
+            "node.id",
+            name="fk_nodeowner_node_id",
+        ),
+        primary_key=True,
+    )
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey(
+            "users.id",
+            name="fk_nodeowner_user_id",
+        ),
+        primary_key=True,
+    )
+    ownership_type: Mapped[str] = mapped_column(
+        String(50),
+        nullable=True,
+    )
+
+    node = relationship("Node", back_populates="owner_associations")
+    user = relationship("User", back_populates="owned_associations")

--- a/datajunction-server/datajunction_server/database/nodeowner.py
+++ b/datajunction-server/datajunction_server/database/nodeowner.py
@@ -16,21 +16,21 @@ class NodeOwner(Base):
 
     __tablename__ = "node_owners"
     __table_args__ = (
-        Index("idx_nodeowner_node_id", "node_id"),
-        Index("idx_nodeowner_user_id", "user_id"),
+        Index("idx_node_owners_node_id", "node_id"),
+        Index("idx_node_owners_user_id", "user_id"),
     )
 
     node_id: Mapped[int] = mapped_column(
         ForeignKey(
             "node.id",
-            name="fk_nodeowner_node_id",
+            name="fk_node_owners_node_id",
         ),
         primary_key=True,
     )
     user_id: Mapped[int] = mapped_column(
         ForeignKey(
             "users.id",
-            name="fk_nodeowner_user_id",
+            name="fk_node_owners_user_id",
         ),
         primary_key=True,
     )

--- a/datajunction-server/datajunction_server/database/user.py
+++ b/datajunction-server/datajunction_server/database/user.py
@@ -82,7 +82,7 @@ class User(Base):
     )
     owned_nodes = relationship(
         "Node",
-        secondary="nodeowner",
+        secondary="node_owners",
         back_populates="owners",
         overlaps="owned_associations,user",
         lazy="selectin",

--- a/datajunction-server/datajunction_server/database/user.py
+++ b/datajunction-server/datajunction_server/database/user.py
@@ -2,13 +2,15 @@
 
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import BigInteger, Enum, Integer, String, select
+from sqlalchemy import BigInteger, Enum, Integer, String, case, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-
+from sqlalchemy.sql.base import ExecutableOption
+from sqlalchemy.orm import selectinload
 from datajunction_server.database.base import Base
 from datajunction_server.database.nodeowner import NodeOwner
 from datajunction_server.enum import StrEnum
+from datajunction_server.errors import DJDoesNotExistException
 
 if TYPE_CHECKING:
     from datajunction_server.database.collection import Collection
@@ -50,7 +52,7 @@ class User(Base):
         "Collection",
         back_populates="created_by",
         foreign_keys="Collection.created_by_id",
-        lazy="joined",
+        lazy="selectin",
     )
     created_nodes: Mapped[list["Node"]] = relationship(
         "Node",
@@ -67,7 +69,7 @@ class User(Base):
         "Tag",
         back_populates="created_by",
         foreign_keys="Tag.created_by_id",
-        lazy="joined",
+        lazy="selectin",
     )
     notification_preferences: Mapped[list["NotificationPreference"]] = relationship(
         "NotificationPreference",
@@ -83,6 +85,7 @@ class User(Base):
         secondary="nodeowner",
         back_populates="owners",
         overlaps="owned_associations,user",
+        lazy="selectin",
     )
 
     @classmethod
@@ -90,11 +93,18 @@ class User(Base):
         cls,
         session: AsyncSession,
         username: str,
+        options: list[ExecutableOption] = None,
     ) -> Optional["User"]:
         """
         Find a user by username
         """
-        statement = select(User).where(User.username == username)
+        options = options or [
+            selectinload(User.created_nodes),
+            selectinload(User.created_collections),
+            selectinload(User.created_tags),
+            selectinload(User.owned_nodes),
+        ]
+        statement = select(User).where(User.username == username).options(*options)
         result = await session.execute(statement)
         return result.unique().scalar_one_or_none()
 
@@ -103,10 +113,26 @@ class User(Base):
         cls,
         session: AsyncSession,
         usernames: list[str],
-    ) -> Optional["User"]:
+    ) -> list["User"]:
         """
-        Find users by username
+        Find users by username, preserving the order of the input usernames list.
         """
-        statement = select(User).where(User.username.in_(usernames))
+        if not usernames:
+            return []
+
+        order_case = case(
+            {username: index for index, username in enumerate(usernames)},
+            value=User.username,
+        )
+
+        statement = (
+            select(User).where(User.username.in_(usernames)).order_by(order_case)
+        )
         result = await session.execute(statement)
-        return result.unique().scalars().all()
+        users = result.unique().scalars().all()
+        if len(users) != len(usernames):
+            missing_usernames = set(usernames) - {user.username for user in users}
+            raise DJDoesNotExistException(
+                f"Users not found: {', '.join(missing_usernames)}",
+            )
+        return users

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime, timezone
 from http import HTTPStatus
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union, cast
 
 from fastapi import BackgroundTasks
 from fastapi.responses import JSONResponse
@@ -633,10 +633,24 @@ async def update_node_with_query(
         name,
         options=[
             joinedload(Node.current).options(*NodeRevision.default_load_options()),
+            selectinload(Node.owners),
         ],
-        # for_update=True,
         include_inactive=True,
     )
+    node = cast(Node, node)
+
+    # Check that the user has access to modify this node
+    access_control = access.AccessControlStore(
+        validate_access=validate_access,
+        user=current_user,
+        base_verb=access.ResourceRequestVerb.WRITE,
+    )
+    access_control.add_request_by_node(node)
+    access_control.validate_and_raise()
+
+    if data.owners:
+        await update_node_owners(session, node, data.owners, current_user, save_history)
+
     old_revision = node.current  # type: ignore
     new_revision = await create_new_revision_from_existing(
         session=session,
@@ -764,7 +778,33 @@ async def update_node_with_query(
     )
     await session.refresh(node, ["current"])
     await session.refresh(node.current, ["materializations"])  # type: ignore
+    await session.refresh(node, ["owners"])  # type: ignore
     return node  # type: ignore
+
+
+async def update_node_owners(
+    session: AsyncSession,
+    node: Node,
+    new_owner_usernames: list[str],
+    current_user: User,
+    save_history: Callable,
+):
+    """
+    Update the owners of a node with the given usernames and commit the change
+    """
+    existing_owners = node.owners
+    users = await User.get_by_usernames(session, usernames=new_owner_usernames)
+    node.owners = users
+    session.add(node)
+    await save_history(
+        event=node_update_owners_history_event(
+            node,
+            existing_owners,
+            current_user,
+        ),
+        session=session,
+    )
+    await session.commit()
 
 
 def has_minor_changes(
@@ -796,6 +836,28 @@ def node_update_history_event(new_revision: NodeRevision, current_user: User):
         activity_type=ActivityType.UPDATE,
         details={
             "version": new_revision.version,  # type: ignore
+        },
+        user=current_user.username,
+    )
+
+
+def node_update_owners_history_event(
+    node: Node,
+    old_owners: list[User],
+    current_user: User,
+):
+    """
+    History event for node owner changes
+    """
+    return History(
+        entity_type=EntityType.NODE,
+        entity_name=node.name,
+        node=node.name,
+        activity_type=ActivityType.UPDATE,
+        details={
+            "version": node.current_version,
+            "old_owners": [owner.username for owner in old_owners],
+            "new_owners": [owner.username for owner in node.owners],  # type: ignore
         },
         user=current_user.username,
     )

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -497,11 +497,12 @@ class MutableNodeFields(BaseModel):
     Node fields that can be changed.
     """
 
-    display_name: Optional[str]
-    description: Optional[str]
+    display_name: str | None
+    description: str | None
     mode: NodeMode = NodeMode.PUBLISHED
-    primary_key: Optional[List[str]]
-    custom_metadata: Optional[Dict]
+    primary_key: list[str] | None
+    custom_metadata: dict | None
+    owners: list[str] | None
 
 
 class MutableNodeQueryField(BaseModel):
@@ -766,6 +767,7 @@ class GenericNodeOutputModel(BaseModel):
             "missing_table": values.get("missing_table"),
             "tags": values.get("tags"),
             "created_by": values.get("created_by").__dict__,
+            "owners": [owner.__dict__ for owner in values.get("owners")],
         }
         for k, v in current_dict.items():
             final_dict[k] = v
@@ -854,6 +856,7 @@ class NodeOutput(GenericNodeOutputModel):
     current_version: str
     missing_table: Optional[bool] = False
     custom_metadata: Optional[Dict] = None
+    owners: list[UserNameOnly]
 
     class Config:
         orm_mode = True
@@ -872,6 +875,7 @@ class NodeOutput(GenericNodeOutputModel):
             selectinload(Node.current).options(*NodeRevision.default_load_options()),
             joinedload(Node.tags),
             selectinload(Node.created_by),
+            selectinload(Node.owners),
         ]
 
 

--- a/datajunction-server/datajunction_server/models/user.py
+++ b/datajunction-server/datajunction_server/models/user.py
@@ -46,6 +46,7 @@ class UserOutput(BaseModel):
     is_admin: bool = False
     created_collections: Optional[List[CollectionInfo]] = []
     created_nodes: Optional[List[CreatedNode]] = []
+    owned_nodes: Optional[List[CreatedNode]] = []
     created_tags: Optional[List[TagOutput]] = []
 
     class Config:

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -51,6 +51,7 @@ def _node_output_options():
             ),
         ),
         selectinload(Node.tags),
+        selectinload(Node.owners),
     ]
 
 

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -137,9 +137,12 @@ async def test_find_by_node_type_paginated(
             name
             type
             tags {
-                name
+              name
             }
             currentVersion
+            owners {
+              username
+            }
           }
         }
         pageInfo {
@@ -163,6 +166,7 @@ async def test_find_by_node_type_paginated(
                     "name": "default.repair_orders_fact",
                     "tags": [],
                     "type": "TRANSFORM",
+                    "owners": [{"username": "dj"}],
                 },
             },
             {
@@ -171,6 +175,7 @@ async def test_find_by_node_type_paginated(
                     "name": "default.national_level_agg",
                     "tags": [],
                     "type": "TRANSFORM",
+                    "owners": [{"username": "dj"}],
                 },
             },
         ],

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1089,6 +1089,7 @@ async def test_metric_expression_auto_aliased(module__client_with_roads: AsyncCl
     )
     assert response.status_code == 201
     data = response.json()
+    assert data["owners"] == [{"username": "dj"}]
     assert data["query"] == "SELECT SUM(counts.b) + SUM(counts.b) FROM basic.dreams_4"
     assert data["columns"] == [
         {

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1651,6 +1651,7 @@ class TestNodeCRUD:
         assert data["catalog"]["name"] == "public"
         assert data["schema_"] == "basic"
         assert data["table"] == "comments"
+        assert data["owners"] == [{"username": "dj"}]
         assert data["columns"] == [
             {
                 "name": "id",
@@ -2377,6 +2378,7 @@ class TestNodeCRUD:
             == "SELECT country, COUNT(DISTINCT id) AS num_users FROM basic.source.users"
         )
         assert data["status"] == "valid"
+        assert data["owners"] == [{"username": "dj"}]
         assert data["columns"] == [
             {
                 "attributes": [],
@@ -5710,6 +5712,7 @@ ON s.state_region = r.us_region_id""",
     )
     node_data = response.json()
     assert node_data["version"] == "v2.0"
+    assert node_data["owners"] == [{"username": "dj"}]
     response = await client_with_roads.get("/history?node=default.us_state")
     assert [activity["activity_type"] for activity in response.json()] == [
         "restore",

--- a/datajunction-server/tests/api/nodes_update_test.py
+++ b/datajunction-server/tests/api/nodes_update_test.py
@@ -173,3 +173,38 @@ async def test_update_source_node(
             "type": "double",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_update_source_node_new_owner(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test updating a source node with a new owner
+    """
+    response = await module__client_with_roads.patch(
+        "/nodes/default.repair_order_details/",
+        json={
+            "columns": [
+                {"name": "repair_order_id", "type": "string"},
+            ],
+            "owners": ["dj"],
+        },
+    )
+    assert response.json()["owners"] == [{"username": "dj"}]
+
+
+@pytest.mark.asyncio
+async def test_update_node_non_existent_owners(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    response = await module__client_with_roads.patch(
+        "/nodes/default.repair_order_details/",
+        json={
+            "columns": [
+                {"name": "repair_order_id", "type": "string"},
+            ],
+            "owners": ["nonexistent_user", "dj"],
+        },
+    )
+    assert response.json()["message"] == "Users not found: nonexistent_user"

--- a/datajunction-server/tests/database/nodeowner_test.py
+++ b/datajunction-server/tests/database/nodeowner_test.py
@@ -1,0 +1,204 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from datajunction_server.database.node import Node, NodeType, NodeRevision, Column
+from datajunction_server.database.user import OAuthProvider, User
+from datajunction_server.database.nodeowner import NodeOwner
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import datajunction_server.sql.parsing.types as ct
+
+
+@pytest_asyncio.fixture
+async def user(session: AsyncSession) -> User:
+    """
+    A user fixture.
+    """
+    user = User(
+        username="testuser",
+        oauth_provider=OAuthProvider.BASIC,
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def another_user(session: AsyncSession) -> User:
+    """
+    Another user fixture.
+    """
+    user = User(
+        username="anotheruser",
+        oauth_provider=OAuthProvider.BASIC,
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def transform_node(session: AsyncSession, user: User) -> Node:
+    """
+    A transform node fixture.
+    """
+    node = Node(
+        name="basic.users",
+        type=NodeType.TRANSFORM,
+        current_version="v1",
+        display_name="Users Transform",
+        created_by_id=user.id,
+    )
+    node_revision = NodeRevision(
+        node=node,
+        name=node.name,
+        type=node.type,
+        version="v1",
+        query="SELECT user_id, username FROM users",
+        columns=[
+            Column(name="user_id", display_name="ID", type=ct.IntegerType()),
+            Column(name="username", type=ct.StringType()),
+        ],
+        created_by_id=user.id,
+    )
+    session.add_all([node, node_revision])
+    await session.commit()
+    return node
+
+
+@pytest.mark.asyncio
+async def test_create_node_owner(
+    session: AsyncSession,
+    user: User,
+    transform_node: Node,
+):
+    # This node initially has no owners
+    await session.refresh(transform_node, ["owners"])
+    assert transform_node.owners == []
+
+    # Assign ownership to the user
+    owner_association = NodeOwner(
+        user_id=user.id,
+        node_id=transform_node.id,
+        ownership_type="domain",
+    )
+    session.add(owner_association)
+    await session.commit()
+    await session.refresh(owner_association)
+    await session.refresh(user)
+    await session.refresh(transform_node)
+
+    # Check that the ownership relationship was created correctly
+    assert owner_association.user_id == user.id
+    assert owner_association.node_id == transform_node.id
+    assert owner_association.ownership_type == "domain"
+
+    # Test relationships
+    assert owner_association.user.username == user.username
+    assert owner_association.node.name == transform_node.name
+
+    await session.refresh(transform_node, ["owners", "owner_associations"])
+    assert transform_node.owners == [user]
+    assert transform_node.owner_associations == [owner_association]
+
+    await session.refresh(user, ["owned_nodes", "owned_associations"])
+    assert user.owned_nodes == [transform_node]
+    assert user.owned_associations == [owner_association]
+
+
+@pytest.mark.asyncio
+async def test_remove_node_owner(
+    session: AsyncSession,
+    user: User,
+    transform_node: Node,
+):
+    # Add the ownership association
+    owner_association = NodeOwner(
+        user_id=user.id,
+        node_id=transform_node.id,
+        ownership_type="domain",
+    )
+    session.add(owner_association)
+    await session.commit()
+
+    # Confirm ownership exists
+    await session.refresh(transform_node, ["owners", "owner_associations"])
+    assert transform_node.owners == [user]
+    assert transform_node.owner_associations == [owner_association]
+
+    await session.refresh(user, ["owned_nodes", "owned_associations"])
+    assert user.owned_nodes == [transform_node]
+    assert user.owned_associations == [owner_association]
+
+    # Delete the association
+    await session.delete(owner_association)
+    await session.commit()
+
+    # Refresh and confirm it's removed
+    await session.refresh(transform_node)
+    await session.refresh(user)
+
+    await session.refresh(transform_node, ["owners", "owner_associations"])
+    assert transform_node.owners == []
+    assert transform_node.owner_associations == []
+
+    await session.refresh(user, ["owned_nodes", "owned_associations"])
+    assert user.owned_nodes == []
+    assert user.owned_associations == []
+
+    # Optional: double-check DB-level deletion
+    result = await session.execute(
+        select(NodeOwner).where(
+            NodeOwner.user_id == user.id,
+            NodeOwner.node_id == transform_node.id,
+        ),
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_add_multiple_node_owners(
+    session: AsyncSession,
+    user: User,
+    another_user: User,
+    transform_node: Node,
+):
+    # Initially, no owners
+    await session.refresh(transform_node, ["owners", "owner_associations"])
+    assert transform_node.owners == []
+
+    # Create multiple associations
+    owner_1 = NodeOwner(
+        user_id=user.id,
+        node_id=transform_node.id,
+        ownership_type="domain",
+    )
+    owner_2 = NodeOwner(
+        user_id=another_user.id,
+        node_id=transform_node.id,
+        ownership_type="technical",
+    )
+
+    session.add_all([owner_1, owner_2])
+    await session.commit()
+
+    # Refresh node and users
+    await session.refresh(transform_node, ["owners", "owner_associations"])
+    await session.refresh(user, ["owned_nodes", "owned_associations"])
+    await session.refresh(another_user, ["owned_nodes", "owned_associations"])
+
+    # Confirm relationships on node
+    owner_usernames = {u.username for u in transform_node.owners}
+    assert owner_usernames == {user.username, another_user.username}
+    assert len(transform_node.owner_associations) == 2
+
+    # Confirm relationships on users
+    assert transform_node in user.owned_nodes
+    assert transform_node in another_user.owned_nodes
+    assert len(user.owned_associations) == 1
+    assert len(another_user.owned_associations) == 1
+
+    # Confirm ownership types
+    types = {assoc.ownership_type for assoc in transform_node.owner_associations}
+    assert types == {"domain", "technical"}

--- a/datajunction-server/tests/database/user_test.py
+++ b/datajunction-server/tests/database/user_test.py
@@ -1,0 +1,70 @@
+from typing import cast
+import pytest
+import pytest_asyncio
+import pytest_asyncio
+from datajunction_server.database.user import OAuthProvider, User
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest_asyncio.fixture
+async def user(session: AsyncSession) -> User:
+    """
+    A user fixture.
+    """
+    user = User(
+        username="testuser",
+        oauth_provider=OAuthProvider.BASIC,
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def another_user(session: AsyncSession) -> User:
+    """
+    Another user fixture.
+    """
+    user = User(
+        username="anotheruser",
+        oauth_provider=OAuthProvider.BASIC,
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_get_by_usernames(
+    session: AsyncSession,
+    user: User,
+    another_user: User,
+):
+    users = await User.get_by_usernames(session, usernames=["testuser", "anotheruser"])
+    assert len(users) == 2
+    assert users[0].id == user.id
+    assert users[0].username == user.username
+
+    assert users[1].id == another_user.id
+    assert users[1].username == another_user.username
+
+
+@pytest.mark.asyncio
+async def test_get_by_username(
+    session: AsyncSession,
+    user: User,
+    another_user: User,
+):
+    retrieved_user = cast(
+        User,
+        await User.get_by_username(session, username="testuser"),
+    )
+    assert retrieved_user.id == user.id
+    assert retrieved_user.username == user.username
+
+    retrieved_another_user = cast(
+        User,
+        await User.get_by_username(session, username="anotheruser"),
+    )
+    assert retrieved_another_user.id == another_user.id
+    assert retrieved_another_user.username == another_user.username

--- a/datajunction-server/tests/internal/authentication/basic_test.py
+++ b/datajunction-server/tests/internal/authentication/basic_test.py
@@ -153,16 +153,21 @@ async def test_whoami(client: AsyncClient):
     """
     Test the /whoami/ endpoint
     """
+    await client.post(
+        "/basic/user/",
+        data={"email": "dj@datajunction.io", "username": "dj", "password": "dj"},
+    )
     response = await client.get("/whoami/")
     assert response.status_code in (200, 201)
     assert response.json() == {
         "id": 1,
         "username": "dj",
-        "email": None,
+        "email": "dj@datajunction.io",
         "name": None,
         "oauth_provider": "basic",
         "is_admin": False,
         "created_collections": [],
         "created_nodes": [],
         "created_tags": [],
+        "owned_nodes": [],
     }

--- a/datajunction-server/tests/internal/authentication/http_test.py
+++ b/datajunction-server/tests/internal/authentication/http_test.py
@@ -90,6 +90,7 @@ def test_dj_http_bearer_w_cookie():
         "created_collections": [],
         "created_nodes": [],
         "created_tags": [],
+        "owned_nodes": [],
     }
 
 
@@ -112,6 +113,7 @@ def test_dj_http_bearer_w_auth_headers():
         "created_collections": [],
         "created_nodes": [],
         "created_tags": [],
+        "owned_nodes": [],
     }
 
 

--- a/datajunction-server/tests/internal/authentication/whoami_test.py
+++ b/datajunction-server/tests/internal/authentication/whoami_test.py
@@ -9,21 +9,21 @@ from datajunction_server.internal.access.authentication.tokens import decode_tok
 
 
 @pytest.mark.asyncio
-async def test_whoami(client: AsyncClient):
+async def test_whoami(module__client: AsyncClient):
     """
     Test /whoami endpoint
     """
-    response = await client.get("/whoami/")
+    response = await module__client.get("/whoami/")
     assert response.status_code in (200, 201)
     assert response.json()["username"] == "dj"
 
 
 @pytest.mark.asyncio
-async def test_short_lived_token(client: AsyncClient):
+async def test_short_lived_token(module__client: AsyncClient):
     """
     Test getting a short-lived token from the /token endpoint
     """
-    response = await client.get("/token/")
+    response = await module__client.get("/token/")
     assert response.status_code in (200, 201)
     data = response.json()
     user = decode_token(data["token"])

--- a/datajunction-server/tests/internal/nodes/update_nodes_test.py
+++ b/datajunction-server/tests/internal/nodes/update_nodes_test.py
@@ -1,0 +1,209 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from datajunction_server.database.node import Node, NodeType, NodeRevision, Column
+from datajunction_server.database.user import OAuthProvider, User
+from datajunction_server.database.history import History
+from datajunction_server.errors import DJDoesNotExistException
+from datajunction_server.api.helpers import get_save_history
+from datajunction_server.internal.nodes import update_owners
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import datajunction_server.sql.parsing.types as ct
+
+
+@pytest_asyncio.fixture
+async def user(session: AsyncSession) -> User:
+    """
+    A user fixture.
+    """
+    user = User(
+        username="testuser",
+        oauth_provider=OAuthProvider.BASIC,
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def another_user(session: AsyncSession) -> User:
+    """
+    Another user fixture.
+    """
+    user = User(
+        username="anotheruser",
+        oauth_provider=OAuthProvider.BASIC,
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def transform_node(session: AsyncSession, user: User) -> Node:
+    """
+    A transform node fixture.
+    """
+    node = Node(
+        name="basic.users",
+        type=NodeType.TRANSFORM,
+        current_version="v1",
+        display_name="Users Transform",
+        created_by_id=user.id,
+    )
+    node_revision = NodeRevision(
+        node=node,
+        name=node.name,
+        type=node.type,
+        version="v1",
+        query="SELECT user_id, username FROM users",
+        columns=[
+            Column(name="user_id", display_name="ID", type=ct.IntegerType()),
+            Column(name="username", type=ct.StringType()),
+        ],
+        created_by_id=user.id,
+    )
+    session.add_all([node, node_revision])
+    await session.commit()
+    return node
+
+
+@pytest.mark.asyncio
+async def test_update_node_owners(
+    session: AsyncSession,
+    user: User,
+    another_user: User,
+    transform_node: Node,
+):
+    await session.refresh(transform_node, ["owners"])
+    transform_node.owners = [user]
+    session.add(transform_node)
+    await session.commit()
+
+    # Change the owner to another_user
+    await update_owners(
+        session=session,
+        node=transform_node,
+        new_owner_usernames=[another_user.username],
+        current_user=user,
+        save_history=(await get_save_history(notify=lambda event: None)),
+    )
+
+    # Refresh node and check updated owners
+    await session.refresh(transform_node, ["owners"])
+    owner_usernames = {owner.username for owner in transform_node.owners}
+    assert owner_usernames == {another_user.username}
+
+    # Check history was recorded
+    history_entries = await session.execute(
+        select(History).where(History.node == transform_node.name),
+    )
+    history = history_entries.scalars().all()
+    assert any(
+        "old_owners" in h.details and h.details["old_owners"] == [user.username]
+        for h in history
+    )
+    assert any(
+        "new_owners" in h.details and another_user.username in h.details["new_owners"]
+        for h in history
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_node_owners_multiple_owners(
+    session: AsyncSession,
+    user: User,
+    another_user: User,
+    transform_node: Node,
+):
+    await session.refresh(transform_node, ["owners"])
+    transform_node.owners = [user]
+    await session.commit()
+
+    # Add multiple owners
+    await update_owners(
+        session=session,
+        node=transform_node,
+        new_owner_usernames=[user.username, another_user.username],
+        current_user=user,
+        save_history=(await get_save_history(notify=lambda event: None)),
+    )
+    await session.refresh(transform_node, ["owners"])
+    usernames = {owner.username for owner in transform_node.owners}
+    assert usernames == {user.username, another_user.username}
+
+
+@pytest.mark.asyncio
+async def test_update_node_owners_clear_owners(
+    session: AsyncSession,
+    user: User,
+    transform_node: Node,
+):
+    await session.refresh(transform_node, ["owners"])
+    transform_node.owners = [user]
+    await session.commit()
+
+    # Remove all owners
+    await update_owners(
+        session=session,
+        node=transform_node,
+        new_owner_usernames=[],
+        current_user=user,
+        save_history=(await get_save_history(notify=lambda event: None)),
+    )
+    await session.refresh(transform_node, ["owners"])
+    assert transform_node.owners == []
+
+
+@pytest.mark.asyncio
+async def test_update_node_owners_noop(
+    session: AsyncSession,
+    user: User,
+    transform_node: Node,
+):
+    await session.refresh(transform_node, ["owners"])
+    transform_node.owners = [user]
+    await session.commit()
+
+    # Set same owner
+    await update_owners(
+        session=session,
+        node=transform_node,
+        new_owner_usernames=[user.username],
+        current_user=user,
+        save_history=(await get_save_history(notify=lambda event: None)),
+    )
+    await session.refresh(transform_node, ["owners"])
+    assert transform_node.owners == [user]
+
+    # Confirm only one history record was created
+    history_entries = await session.execute(
+        select(History).where(History.node == transform_node.name),
+    )
+    history = history_entries.scalars().all()
+    assert len(history) == 1
+    assert history[0].details["old_owners"] == [user.username]
+    assert history[0].details["new_owners"] == [user.username]
+
+
+@pytest.mark.asyncio
+async def test_update_node_owners_invalid_user(
+    session: AsyncSession,
+    user: User,
+    transform_node: Node,
+):
+    await session.refresh(transform_node, ["owners"])
+    transform_node.owners = [user]
+    await session.commit()
+
+    # Try to assign a non-existent user
+    with pytest.raises(DJDoesNotExistException):
+        await update_owners(
+            session=session,
+            node=transform_node,
+            new_owner_usernames=["non_existent_user"],
+            current_user=user,
+            save_history=(await get_save_history(notify=lambda event: None)),
+        )

--- a/datajunction-ui/src/app/pages/AddEditNodePage/OwnersField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/OwnersField.jsx
@@ -1,0 +1,54 @@
+/**
+ * Owner select field
+ */
+import { ErrorMessage } from 'formik';
+import { useContext, useEffect, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+import { FormikSelect } from './FormikSelect';
+
+export const OwnersField = ({ defaultValue }) => {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+
+  const [availableUsers, setAvailableUsers] = useState([]);
+  const [currentUser, setCurrentUser] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      const users = await djClient.users();
+      setAvailableUsers(
+        users.map(user => {
+          return {
+            value: user.username,
+            label: user.username,
+          };
+        }),
+      );
+      const current = await djClient.whoami();
+      setCurrentUser(current);
+    }
+    fetchData();
+  }, [djClient]);
+
+  return defaultValue || currentUser ? (
+    <div className="NodeCreationInput">
+      <ErrorMessage name="owners" component="span" />
+      <label htmlFor="Owners">Owners</label>
+      <span data-testid="select-owner">
+        <FormikSelect
+          className="MultiSelectInput"
+          defaultValue={
+            defaultValue || [
+              { value: currentUser.username, label: currentUser.username },
+            ]
+          }
+          selectOptions={availableUsers}
+          formikFieldName="owners"
+          placeholder="Select Owners"
+          isMulti={true}
+        />
+      </span>
+    </div>
+  ) : (
+    ''
+  );
+};

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/AddEditNodePageFormSuccess.test.jsx
@@ -103,6 +103,11 @@ describe('AddEditNodePage submission succeeded', () => {
       mocks.metricMetadata,
     );
 
+    mockDjClient.DataJunctionAPI.whoami.mockReturnValue({
+      id: 123,
+      username: 'test_user',
+    });
+
     const element = testElement(mockDjClient);
     const { container } = renderCreateMetric(element);
 
@@ -128,7 +133,7 @@ describe('AddEditNodePage submission succeeded', () => {
           'default.some_test_metric',
           'Some Test Metric',
           '',
-          'SELECT SUM(a) FROM default.repair_orders',
+          'SELECT SUM(a) \n FROM default.repair_orders',
           'published',
           'default',
           null,
@@ -195,6 +200,7 @@ describe('AddEditNodePage submission succeeded', () => {
         '',
         '',
         undefined,
+        ['dj'],
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(
@@ -233,6 +239,11 @@ describe('AddEditNodePage submission succeeded', () => {
       { name: 'intent', display_name: 'Intent' },
     ]);
 
+    mockDjClient.DataJunctionAPI.whoami.mockReturnValue({
+      id: 123,
+      username: 'test_user',
+    });
+
     const element = testElement(mockDjClient);
     const { getByTestId } = renderEditNode(element);
 
@@ -250,13 +261,14 @@ describe('AddEditNodePage submission succeeded', () => {
         'default.num_repair_orders',
         'Default: Num Repair Orders!!!',
         'Number of repair orders!!!',
-        'SELECT count(repair_order_id) FROM default.repair_orders',
+        'SELECT count(repair_order_id) \n FROM default.repair_orders',
         'published',
         ['repair_order_id', 'country'],
         'neutral',
         'unitless',
         5,
         undefined,
+        ['dj'],
       );
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledTimes(1);
       expect(mockDjClient.DataJunctionAPI.tagsNode).toBeCalledWith(

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/index.test.jsx
@@ -66,6 +66,20 @@ export const initializeMockDJClient = () => {
           { name: 'second', label: 'Second' },
         ],
       }),
+      users: jest.fn().mockReturnValue([
+        {
+          id: 123,
+          username: 'test_user',
+        },
+        {
+          id: 1111,
+          username: 'dj',
+        },
+      ]),
+      whoami: jest.fn().mockReturnValue({
+        id: 123,
+        username: 'test_user',
+      }),
     },
   };
 };

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -15,6 +15,7 @@ import { displayMessageAfterSubmit } from '../../../utils/form';
 import { NodeQueryField } from './NodeQueryField';
 import { MetricMetadataFields } from './MetricMetadataFields';
 import { UpstreamNodeField } from './UpstreamNodeField';
+import { OwnersField } from './OwnersField';
 import { TagsField } from './TagsField';
 import { NamespaceField } from './NamespaceField';
 import { AlertMessage } from './AlertMessage';
@@ -50,6 +51,7 @@ export function AddEditNodePage({ extensions = {} }) {
     description: '',
     primary_key: '',
     mode: 'published',
+    owners: [],
   };
 
   const validator = values => {
@@ -112,7 +114,7 @@ export function AddEditNodePage({ extensions = {} }) {
       values.display_name,
       values.description,
       values.type === 'metric'
-        ? `SELECT ${values.aggregate_expression} FROM ${values.upstream_node}`
+        ? `SELECT ${values.aggregate_expression} \n FROM ${values.upstream_node}`
         : values.query,
       values.mode,
       values.namespace,
@@ -146,7 +148,7 @@ export function AddEditNodePage({ extensions = {} }) {
       values.display_name,
       values.description,
       values.type === 'metric'
-        ? `SELECT ${values.aggregate_expression} FROM ${values.upstream_node}`
+        ? `SELECT ${values.aggregate_expression} \n FROM ${values.upstream_node}`
         : values.query,
       values.mode,
       values.primary_key ? primaryKeyToList(values.primary_key) : null,
@@ -154,6 +156,7 @@ export function AddEditNodePage({ extensions = {} }) {
       values.metric_unit,
       values.significant_digits,
       values.required_dimensions,
+      values.owners,
     );
     const tagsResponse = await djClient.tagsNode(
       values.name,
@@ -201,6 +204,7 @@ export function AddEditNodePage({ extensions = {} }) {
       query: node.current.query,
       tags: node.tags,
       mode: node.current.mode.toLowerCase(),
+      owners: node.owners,
     };
 
     if (node.type === 'METRIC') {
@@ -244,6 +248,7 @@ export function AddEditNodePage({ extensions = {} }) {
     setSelectPrimaryKey,
     setSelectUpstreamNode,
     setSelectRequiredDims,
+    setSelectOwners,
   ) => {
     // Update fields with existing data to prepare for edit
     const fields = [
@@ -259,12 +264,18 @@ export function AddEditNodePage({ extensions = {} }) {
       'metric_unit',
       'metric_direction',
       'significant_digits',
+      'owners',
     ];
     fields.forEach(field => {
       if (field === 'tags') {
         setFieldValue(
           field,
           data[field].map(tag => tag.name),
+        );
+      } else if (field === 'owners') {
+        setFieldValue(
+          field,
+          data[field].map(owner => owner.username),
         );
       } else {
         setFieldValue(field, data[field] || '', false);
@@ -306,6 +317,15 @@ export function AddEditNodePage({ extensions = {} }) {
         }}
       />,
     );
+    if (data.owners) {
+      setSelectOwners(
+        <OwnersField
+          defaultValue={data.owners.map(owner => {
+            return { value: owner.username, label: owner.username };
+          })}
+        />,
+      );
+    }
   };
 
   return (
@@ -345,6 +365,7 @@ export function AddEditNodePage({ extensions = {} }) {
                   useState(null);
                 const [selectUpstreamNode, setSelectUpstreamNode] =
                   useState(null);
+                const [selectOwners, setSelectOwners] = useState(null);
                 const [selectTags, setSelectTags] = useState(null);
                 const [message, setMessage] = useState('');
 
@@ -361,6 +382,7 @@ export function AddEditNodePage({ extensions = {} }) {
                         setSelectPrimaryKey,
                         setSelectUpstreamNode,
                         setSelectRequiredDims,
+                        setSelectOwners,
                       );
                     }
                   };
@@ -390,6 +412,13 @@ export function AddEditNodePage({ extensions = {} }) {
                           )
                         ) : (
                           ''
+                        )}
+                        <br />
+                        <br />
+                        {action === Action.Edit ? (
+                          selectOwners
+                        ) : (
+                          <OwnersField />
                         )}
                         <br />
                         <br />

--- a/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
@@ -89,6 +89,27 @@ export default function NodeHistory({ node, djClient }) {
       );
     }
     if (event.activity_type === 'update' && event.entity_type === 'node') {
+      console.log('event!!', event);
+      if (event.details?.old_owners) {
+        return (
+          <div className="history-left">
+            <b style={{ textTransform: 'capitalize' }}>Ownership Change</b> for{' '}
+            {event.entity_type}{' '}
+            <b>
+              <a href={'/nodes/' + event.entity_name}>{event.entity_name}</a>
+            </b>
+            <small>
+              {' '}
+              to{' '}
+              {event.details?.new_owners.map(owner => (
+                <span className="badge version" style={{ margin: '2px' }}>
+                  {owner}
+                </span>
+              ))}
+            </small>
+          </div>
+        );
+      }
       return (
         <div className="history-left">
           <b style={{ textTransform: 'capitalize' }}>{event.activity_type}</b>{' '}

--- a/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeHistory.jsx
@@ -89,7 +89,6 @@ export default function NodeHistory({ node, djClient }) {
       );
     }
     if (event.activity_type === 'update' && event.entity_type === 'node') {
-      console.log('event!!', event);
       if (event.details?.old_owners) {
         return (
           <div className="history-left">

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -259,6 +259,23 @@ export default function NodeInfoTab({ node }) {
       <div className="list-group-item d-flex">
         <div className="d-flex gap-2 w-100 justify-content-between py-3">
           <div>
+            <h6 className="mb-0 w-100">Owners</h6>
+            <p className="mb-0 opacity-75">
+              {node?.owners.map(owner => (
+                <span
+                  className="badge node_type__transform"
+                  style={{ margin: '2px', fontSize: '16px', cursor: 'pointer' }}
+                >
+                  {owner.username}
+                </span>
+              ))}
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="list-group-item d-flex">
+        <div className="d-flex gap-2 w-100 justify-content-between py-3">
+          <div>
             <h6 className="mb-0 w-100">Version</h6>
 
             <p className="mb-0 opacity-75">

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -328,7 +328,6 @@ export const DataJunctionAPI = {
     required_dimensions,
     owners,
   ) {
-    console.log('owners', owners);
     try {
       const metricMetadata =
         metric_direction || metric_unit

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -156,6 +156,9 @@ export const DataJunctionAPI = {
             name
             displayName
           }
+          owners {
+            username
+          }
         }
       }
     `;
@@ -323,7 +326,9 @@ export const DataJunctionAPI = {
     metric_unit,
     significant_digits,
     required_dimensions,
+    owners,
   ) {
+    console.log('owners', owners);
     try {
       const metricMetadata =
         metric_direction || metric_unit
@@ -346,6 +351,7 @@ export const DataJunctionAPI = {
           primary_key: primary_key,
           metric_metadata: metricMetadata,
           required_dimensions: required_dimensions,
+          owners: owners,
         }),
         credentials: 'include',
       });

--- a/datajunction-ui/src/mocks/mockNodes.jsx
+++ b/datajunction-ui/src/mocks/mockNodes.jsx
@@ -57,6 +57,7 @@ export const mocks = {
     dimension_links: [],
     created_at: '2024-01-24T16:39:14.028077+00:00',
     tags: [],
+    owners: [{ username: 'dj' }],
     current_version: 'v1.0',
     missing_table: false,
   },
@@ -104,6 +105,7 @@ export const mocks = {
     ],
     created_at: '2023-08-21T16:48:56.841631+00:00',
     tags: [{ name: 'purpose', display_name: 'Purpose' }],
+    owners: [{ username: 'dj' }],
     dimension_links: [],
     incompatible_druid_functions: ['IF'],
     dimensions: [
@@ -302,6 +304,7 @@ export const mocks = {
       mode: 'PUBLISHED',
     },
     tags: [],
+    owners: [{ username: 'dj' }],
   },
 
   mockGetMetricNode: {
@@ -331,6 +334,7 @@ export const mocks = {
       mode: 'PUBLISHED',
     },
     tags: [{ name: 'purpose', displayName: 'Purpose' }],
+    owners: [{ username: 'dj' }],
   },
 
   mockGetTransformNode: {
@@ -352,6 +356,7 @@ export const mocks = {
       mode: 'PUBLISHED',
     },
     tags: [],
+    owners: [{ username: 'dj' }],
   },
 
   attributes: [
@@ -789,6 +794,7 @@ export const mocks = {
     ],
     created_at: '2023-08-21T16:49:01.671395+00:00',
     tags: [],
+    owners: [{ username: 'dj' }],
   },
   mockCubesCube: {
     node_revision_id: 33,

--- a/datajunction-ui/yarn.lock
+++ b/datajunction-ui/yarn.lock
@@ -4966,9 +4966,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688:
-  version "1.0.30001690"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz"
-  integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
+  version "1.0.30001726"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz"
+  integrity sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
### Summary

This PR introduces ownership metadata to DJ nodes. Each node can now be associated with one or more user-level owners, enabling better visibility into who is responsible for maintaining a given node.

#### Database Changes

To support this, we add a `nodeowner` association table between nodes and owners, which enables additional metadata like `ownership_type` on the relationship. While this PR does not support setting the `ownership_type` for the time being, it is something that can be easily enabled via an API call.

There is a database migration that also uses each node's `created_by` user to populate the list of owners.

#### API Changes

* `PATCH /nodes/{node}` will support passing in a list of owners, which will be used to update the owners for the node
* `POST /nodes/{nodetype}` will support passing in a list of owners at creation time. If no owners are specified, the user creating the node will automatically be assigned as the owner.
 
#### UI Changes

In the UI, the list of owners are displayed on the node info page and can be edited by selecting from a dropdown of available users.

| Info   | Edit |
| ----- | ---- |
| <img alt="Screenshot 2025-07-01 at 7 19 53 PM" src="https://github.com/user-attachments/assets/76bedd86-3f48-47da-9018-4e325f1c14eb" height="400"/> | <img alt="Screenshot 2025-07-01 at 7 22 07 PM" src="https://github.com/user-attachments/assets/d16e414f-3c93-4fac-95b7-236b6388de6e"  height="400" /> |

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #786
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
