### PR TITLE
MAX function should be able to work on boolean arguments

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3241,6 +3241,13 @@ def infer_type(
     return arg.type  # pragma: no cover
 
 
+@Max.register  # type: ignore
+def infer_type(
+    arg: ct.BooleanType,
+) -> ct.BooleanType:
+    return arg.type  # pragma: no cover
+
+
 class MaxBy(Function):
     """
     max_by(val, key) - Returns the value of val corresponding to the maximum value of key.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -25,6 +25,7 @@ from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.sql.parsing.types import (
     BigIntType,
+    BooleanType,
     DateType,
     DecimalType,
     DoubleType,
@@ -2705,6 +2706,9 @@ async def test_max() -> None:
     assert Max.infer_type(ast.Column(ast.Name("x"), _type=BigIntType())) == BigIntType()
     assert Max.infer_type(ast.Column(ast.Name("x"), _type=FloatType())) == FloatType()
     assert Max.infer_type(ast.Column(ast.Name("x"), _type=StringType())) == StringType()
+    assert (
+        Max.infer_type(ast.Column(ast.Name("x"), _type=BooleanType())) == BooleanType()
+    )
     assert Max.infer_type(
         ast.Column(ast.Name("x"), _type=DecimalType(8, 6)),
     ) == DecimalType(8, 6)


### PR DESCRIPTION
### Summary

The `MAX` function implemented in DJ should be able to operate on boolean arguments.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
