### PR TITLE
Enable modifying a cube's owners

### DIFF
--- a/datajunction-server/tests/api/nodes_update_test.py
+++ b/datajunction-server/tests/api/nodes_update_test.py
@@ -222,7 +222,10 @@ async def test_update_source_node_new_owner(
             "owners": ["dj", "userone"],
         },
     )
-    assert response.json()["owners"] == [{"username": "dj"}, {"username": "userone"}]
+    assert {owner["username"] for owner in response.json()["owners"]} == {
+        "dj",
+        "userone",
+    }
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/nodes_update_test.py
+++ b/datajunction-server/tests/api/nodes_update_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from httpx import AsyncClient
+import pytest_asyncio
 
 from datajunction_server.models.node import NodeStatus
 
@@ -175,10 +176,40 @@ async def test_update_source_node(
     ]
 
 
+@pytest_asyncio.fixture(scope="module")
+async def user_one(module__client_with_roads: AsyncClient):
+    await module__client_with_roads.post(
+        "/basic/user/",
+        data={
+            "email": "userone@datajunction.io",
+            "username": "userone",
+            "password": "userone",
+        },
+    )
+
+
+@pytest_asyncio.fixture(scope="module")
+async def cube(module__client_with_roads: AsyncClient):
+    await module__client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": ["default.num_repair_orders", "default.total_repair_cost"],
+            "dimensions": [
+                "default.hard_hat.country",
+                "default.dispatcher.company_name",
+            ],
+            "description": "Cube of various metrics related to repairs",
+            "mode": "published",
+            "name": "default.repair_orders_cube",
+        },
+    )
+
+
 @pytest.mark.asyncio
 async def test_update_source_node_new_owner(
     module__client_with_roads: AsyncClient,
-) -> None:
+    user_one,
+):
     """
     Test updating a source node with a new owner
     """
@@ -188,10 +219,30 @@ async def test_update_source_node_new_owner(
             "columns": [
                 {"name": "repair_order_id", "type": "string"},
             ],
-            "owners": ["dj"],
+            "owners": ["dj", "userone"],
         },
     )
+    assert response.json()["owners"] == [{"username": "dj"}, {"username": "userone"}]
+
+
+@pytest.mark.asyncio
+async def test_update_cube_node_new_owner(
+    module__client_with_roads: AsyncClient,
+    user_one,
+    cube,
+):
+    """
+    Test updating a cube with new owners
+    """
+    response = await module__client_with_roads.get("/nodes/default.repair_orders_cube/")
     assert response.json()["owners"] == [{"username": "dj"}]
+    response = await module__client_with_roads.patch(
+        "/nodes/default.repair_orders_cube/",
+        json={
+            "owners": ["userone"],
+        },
+    )
+    assert response.json()["owners"] == [{"username": "userone"}]
 
 
 @pytest.mark.asyncio

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/DimensionsSelect.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/DimensionsSelect.jsx
@@ -30,16 +30,14 @@ export const DimensionsSelect = ({ cube }) => {
     const fetchData = async () => {
       let cubeDimensions = undefined;
       if (cube) {
-        cubeDimensions = cube?.cube_elements
-          .filter(element => element.type === 'dimension')
-          .map(cubeDim => {
-            return {
-              value: cubeDim.node_name + '.' + cubeDim.name,
-              label:
-                labelize(cubeDim.name) +
-                (cubeDim.properties?.includes('primary_key') ? ' (PK)' : ''),
-            };
-          });
+        cubeDimensions = cube?.current.cubeDimensions.map(cubeDim => {
+          return {
+            value: cubeDim.name,
+            label:
+              labelize(cubeDim.attribute) +
+              (cubeDim.properties?.includes('primary_key') ? ' (PK)' : ''),
+          };
+        });
         setDefaultDimensions(cubeDimensions);
         setValue(cubeDimensions.map(m => m.value));
       }

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
@@ -24,14 +24,12 @@ export const MetricsSelect = ({ cube }) => {
   useEffect(() => {
     const fetchData = async () => {
       if (cube) {
-        const cubeMetrics = cube?.cube_elements
-          .filter(element => element.type === 'metric')
-          .map(metric => {
-            return {
-              value: metric.node_name,
-              label: metric.node_name,
-            };
-          });
+        const cubeMetrics = cube?.current.cubeMetrics.map(metric => {
+          return {
+            value: metric.name,
+            label: metric.name,
+          };
+        });
         setDefaultMetrics(cubeMetrics);
         await setValue(cubeMetrics.map(m => m.value));
       }

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/__tests__/index.test.jsx
@@ -10,10 +10,13 @@ const mockDjClient = {
   createCube: jest.fn(),
   namespaces: jest.fn(),
   cube: jest.fn(),
+  getCubeForEditing: jest.fn(),
   node: jest.fn(),
   listTags: jest.fn(),
   tagsNode: jest.fn(),
   patchCube: jest.fn(),
+  users: jest.fn(),
+  whoami: jest.fn(),
 };
 
 const mockMetrics = [
@@ -23,81 +26,44 @@ const mockMetrics = [
 ];
 
 const mockCube = {
-  node_revision_id: 102,
-  node_id: 33,
-  type: 'cube',
   name: 'default.repair_orders_cube',
-  display_name: 'Default: Repair Orders Cube',
-  version: 'v4.0',
-  description: 'Repairs cube',
-  availability: null,
-  cube_elements: [
+  type: 'CUBE',
+  owners: [
     {
-      name: 'default_DOT_total_repair_cost',
-      display_name: 'Total Repair Cost',
-      node_name: 'default.total_repair_cost',
-      type: 'metric',
-      partition: null,
-    },
-    {
-      name: 'default_DOT_num_repair_orders',
-      display_name: 'Num Repair Orders',
-      node_name: 'default.num_repair_orders',
-      type: 'metric',
-      partition: null,
-    },
-    {
-      name: 'country',
-      display_name: 'Country',
-      node_name: 'default.hard_hat',
-      type: 'dimension',
-      partition: null,
-    },
-    {
-      name: 'state',
-      display_name: 'State',
-      node_name: 'default.hard_hat',
-      type: 'dimension',
-      partition: null,
+      username: 'someone@example.com',
     },
   ],
-  query: '',
-  columns: [
+  current: {
+    displayName: 'Default: Repair Orders Cube',
+    description: 'Repairs cube',
+    mode: 'DRAFT',
+    cubeMetrics: [
+      {
+        name: 'default.total_repair_cost',
+      },
+      {
+        name: 'default.num_repair_orders',
+      },
+    ],
+    cubeDimensions: [
+      {
+        name: 'default.hard_hat.country',
+        attribute: 'country',
+        properties: ['dimension'],
+      },
+      {
+        name: 'default.hard_hat.state',
+        attribute: 'state',
+        properties: ['dimension'],
+      },
+    ],
+  },
+  tags: [
     {
-      name: 'default.total_repair_cost',
-      display_name: 'Total Repair Cost',
-      type: 'double',
-      attributes: [],
-      dimension: null,
-      partition: null,
-    },
-    {
-      name: 'default.num_repair_orders',
-      display_name: 'Num Repair Orders',
-      type: 'bigint',
-      attributes: [],
-      dimension: null,
-      partition: null,
-    },
-    {
-      name: 'default.hard_hat.country',
-      display_name: 'Country',
-      type: 'string',
-      attributes: [],
-      dimension: null,
-      partition: null,
-    },
-    {
-      name: 'default.hard_hat.state',
-      display_name: 'State',
-      type: 'string',
-      attributes: [],
-      dimension: null,
-      partition: null,
+      name: 'repairs',
+      displayName: 'Repairs Domain',
     },
   ],
-  updated_at: '2023-12-03T06:51:09.598532+00:00',
-  materializations: [],
 };
 
 const mockCommonDimensions = [
@@ -205,11 +171,13 @@ describe('CubeBuilderPage', () => {
     mockDjClient.commonDimensions.mockResolvedValue(mockCommonDimensions);
     mockDjClient.createCube.mockResolvedValue({ status: 201, json: {} });
     mockDjClient.namespaces.mockResolvedValue(['default']);
-    mockDjClient.cube.mockResolvedValue(mockCube);
-    mockDjClient.node.mockResolvedValue(mockCube);
+    mockDjClient.getCubeForEditing.mockResolvedValue(mockCube);
+    // mockDjClient.node.mockResolvedValue(mockCube);
     mockDjClient.listTags.mockResolvedValue([]);
     mockDjClient.tagsNode.mockResolvedValue([]);
     mockDjClient.patchCube.mockResolvedValue({ status: 201, json: {} });
+    mockDjClient.users.mockResolvedValue([{ username: 'dj' }]);
+    mockDjClient.whoami.mockResolvedValue({ username: 'dj' });
 
     window.scrollTo = jest.fn();
   });
@@ -342,7 +310,7 @@ describe('CubeBuilderPage', () => {
     );
     expect(screen.getAllByText('Edit')[0]).toBeInTheDocument();
     await waitFor(() => {
-      expect(mockDjClient.cube).toHaveBeenCalled();
+      expect(mockDjClient.getCubeForEditing).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(mockDjClient.metrics).toHaveBeenCalled();
@@ -398,6 +366,7 @@ describe('CubeBuilderPage', () => {
           'default.date_dim.year',
           'default.date_dim.dateint',
         ],
+        [],
         [],
       );
     });

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/__tests__/index.test.jsx
@@ -172,7 +172,6 @@ describe('CubeBuilderPage', () => {
     mockDjClient.createCube.mockResolvedValue({ status: 201, json: {} });
     mockDjClient.namespaces.mockResolvedValue(['default']);
     mockDjClient.getCubeForEditing.mockResolvedValue(mockCube);
-    // mockDjClient.node.mockResolvedValue(mockCube);
     mockDjClient.listTags.mockResolvedValue([]);
     mockDjClient.tagsNode.mockResolvedValue([]);
     mockDjClient.patchCube.mockResolvedValue({ status: 201, json: {} });

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/index.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/index.jsx
@@ -79,7 +79,6 @@ export function CubeBuilderPage() {
   };
 
   const patchNode = async (values, setStatus) => {
-    console.log('values!', values);
     const { status, json } = await djClient.patchCube(
       values.name,
       values.display_name,
@@ -132,7 +131,6 @@ export function CubeBuilderPage() {
         })}
       />,
     );
-    console.log('data.owners', data.owners);
     if (data.owners) {
       setSelectOwners(
         <OwnersField

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -224,6 +224,57 @@ export const DataJunctionAPI = {
     return results.data.findNodes[0];
   },
 
+  getCubeForEditing: async function (name) {
+    const query = `
+      query GetCubeForEditing($name: String!) {
+        findNodes(names: [$name]) {
+          name
+          type
+          owners {
+            username
+          }
+          current {
+            displayName
+            description
+            mode
+            cubeMetrics {
+              name
+            }
+            cubeDimensions {
+              name
+              attribute
+              properties
+            }
+          }
+          tags {
+            name
+            displayName
+          }
+        }
+      }
+    `;
+
+    const results = await (
+      await fetch(DJ_GQL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          query,
+          variables: {
+            name: name,
+          },
+        }),
+      })
+    ).json();
+    if (results.data.findNodes.length === 0) {
+      return null;
+    }
+    return results.data.findNodes[0];
+  },
+
   nodes: async function (prefix) {
     const queryParams = prefix ? `?prefix=${prefix}` : '';
     return await (
@@ -396,6 +447,7 @@ export const DataJunctionAPI = {
     metrics,
     dimensions,
     filters,
+    owners,
   ) {
     const response = await fetch(`${DJ_URL}/nodes/${name}`, {
       method: 'PATCH',
@@ -409,6 +461,7 @@ export const DataJunctionAPI = {
         dimensions: dimensions,
         filters: filters || [],
         mode: mode,
+        owners: owners,
       }),
       credentials: 'include',
     });


### PR DESCRIPTION
### Summary

The existing setup for `PATCH /nodes/{name}` only enabled editing a non-cube node's owners. This PR fixes it so that the logic also works for cube nodes, and that the equivalent owners field is displayed on the cube node edit UI.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
