### PR TITLE
Add dimension link versioning to nodes

### DIFF
--- a/datajunction-server/datajunction_server/api/system.py
+++ b/datajunction-server/datajunction_server/api/system.py
@@ -131,11 +131,14 @@ async def get_dimensions_stats(
 
     node_indegrees = await get_dimension_dag_indegree(session, dimension_node_names)
     cubes_using_dims = await get_cubes_using_dimensions(session, dimension_node_names)
-    return [
-        DimensionStats(
-            name=dim,
-            indegree=node_indegrees.get(dim, 0),
-            cube_count=cubes_using_dims.get(dim, 0),
-        )
-        for dim in dimension_node_names
-    ]
+    return sorted(
+        [
+            DimensionStats(
+                name=dim,
+                indegree=node_indegrees.get(dim, 0),
+                cube_count=cubes_using_dims.get(dim, 0),
+            )
+            for dim in dimension_node_names
+        ],
+        key=lambda stats: -stats.indegree,
+    )

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -350,7 +350,9 @@ class Node(Base):
             statement = statement.where(is_(Node.deactivated_at, None))
         result = await session.execute(statement)
         nodes = result.unique().scalars().all()
-        return nodes
+        nodes_by_name = {node.name: node for node in nodes}
+        ordered_nodes = [nodes_by_name[name] for name in names if name in nodes_by_name]
+        return ordered_nodes
 
     @classmethod
     async def get_cube_by_name(

--- a/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
@@ -40,6 +40,15 @@ class QueryRequestParams:
     preaggregate: bool = False
     query_params: str | None = None
 
+    def __repr__(self):
+        return (
+            f"QueryRequestParams(nodes={self.nodes}, dimensions={self.dimensions},"
+            f" filters={self.filters}, engine_name={self.engine_name}, engine_version={self.engine_version},"
+            f" limit={self.limit}, orderby={self.orderby}, other_args={self.other_args},"
+            f" include_all_columns={self.include_all_columns}, use_materialized={self.use_materialized},"
+            f" preaggregate={self.preaggregate}, query_params={self.query_params})"
+        )
+
 
 class QueryCacheManager(RefreshAheadCacheManager):
     """
@@ -50,7 +59,7 @@ class QueryCacheManager(RefreshAheadCacheManager):
     default_timeout = settings.query_cache_timeout
 
     def __init__(self, cache: Cache, query_type: QueryBuildType):
-        self.cache = cache
+        super().__init__(cache)
         self.query_type = query_type
 
     @property

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2000,7 +2000,7 @@ async def create_new_revision_for_dimension_link_update(
     Create a new revision for the node to capture the dimension link changes in a new version
     """
     new_revision = copy_existing_node_revision(node.current, current_user)
-    new_revision.version = str(Version.parse(node.current_version).next_major_version())
+    new_revision.version = str(Version.parse(node.current_version).next_minor_version())
     node.current_version = new_revision.version
     new_revision.node = node
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1348,10 +1348,10 @@ async def create_new_revision_from_existing(
         created_by_id=current_user.id,
         custom_metadata=old_revision.custom_metadata,
     )
-    if data.required_dimensions:  # type: ignore
+    if data and data.required_dimensions:  # type: ignore
         new_revision.required_dimensions = data.required_dimensions  # type: ignore
 
-    if data.custom_metadata:  # type: ignore
+    if data and data.custom_metadata:  # type: ignore
         new_revision.custom_metadata = data.custom_metadata  # type: ignore
 
     # Link the new revision to its parents if a new revision was created and update its status
@@ -1817,10 +1817,21 @@ async def upsert_complex_dimension_link(
             errors=ctx.exception.errors,
         )
 
+    # Create a new revision for the node to capture the dimension link changes in a new version
+    node = cast(Node, node)
+    new_revision = copy_existing_node_revision(node.current, current_user)
+    new_revision.version = str(Version.parse(node.current_version).next_major_version())
+    node.current_version = new_revision.version
+    new_revision.node = node
+    session.add(new_revision)
+    await session.commit()
+    await session.refresh(new_revision)
+    await session.refresh(new_revision, ["dimension_links"])
+
     # Find an existing dimension link if there is already one defined for this node
     existing_link = [
         link  # type: ignore
-        for link in node.current.dimension_links  # type: ignore
+        for link in new_revision.dimension_links  # type: ignore
         if link.dimension_id == dimension_node.id and link.role == link_input.role  # type: ignore
     ]
     activity_type = ActivityType.CREATE
@@ -1837,18 +1848,18 @@ async def upsert_complex_dimension_link(
     else:
         # If there is no existing link, create new dimension link object
         dimension_link = DimensionLink(
-            node_revision_id=node.current.id,  # type: ignore
+            node_revision_id=new_revision.id,  # type: ignore
             dimension_id=dimension_node.id,  # type: ignore
             join_sql=link_input.join_on,
             join_type=DimensionLink.parse_join_type(join_relation.join_type),
             join_cardinality=link_input.join_cardinality,
             role=link_input.role,
         )
-        node.current.dimension_links.append(dimension_link)  # type: ignore
+        new_revision.dimension_links.append(dimension_link)  # type: ignore
 
     # Add/update the dimension link in the database
     session.add(dimension_link)
-    session.add(node.current)  # type: ignore
+    session.add(new_revision)  # type: ignore
     await save_history(
         event=History(
             entity_type=EntityType.LINK,

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -1053,6 +1053,14 @@ async def get_dimension_dag_indegree(session, node_names: List[str]) -> Dict[str
             func.count(DimensionLink.id),
         )
         .where(DimensionLink.dimension_id.in_(dimension_ids))
+        .join(NodeRevision, DimensionLink.node_revision_id == NodeRevision.id)
+        .join(
+            Node,
+            and_(
+                Node.id == NodeRevision.node_id,
+                Node.current_version == NodeRevision.version,
+            ),
+        )
         .group_by(DimensionLink.dimension_id)
     )
     result = await session.execute(statement)

--- a/datajunction-server/tests/api/client_test.py
+++ b/datajunction-server/tests/api/client_test.py
@@ -367,11 +367,11 @@ async def test_export_cube_as_notebook(
         == """### Upserting Nodes:
 * default.repair_order_details
 * default.repair_orders
-* default.repair_orders_fact
 * default.hard_hats
+* default.repair_orders_fact
+* default.hard_hat
 * default.total_repair_cost
 * default.num_repair_orders
-* default.hard_hat
 * default.roads_cube"""
     )
     assert (

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2401,7 +2401,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "discount_sum_62846f49",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.0",
+                        "version": "v1.4",
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2409,7 +2409,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "count_3389dae3",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.0",
+                        "version": "v1.4",
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2429,7 +2429,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "repair_order_id_count_0b7dfba0",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.0",
+                        "version": "v1.4",
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2449,7 +2449,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_count_78a5eb43",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.0",
+                        "version": "v1.4",
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2457,7 +2457,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_sum_78a5eb43",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.0",
+                        "version": "v1.4",
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2477,7 +2477,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "total_repair_cost_sum_9bdaf803",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.0",
+                        "version": "v1.4",
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2497,7 +2497,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_discount_sum_017d55a8",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.0",
+                        "version": "v1.4",
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2518,7 +2518,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_sum_78a5eb43",
                     "node": {
                         "name": "default.repair_order_details",
-                        "version": "v1.0",
+                        "version": "v1.2",
                         "display_name": "default.roads.repair_order_details",
                     },
                 },
@@ -2727,10 +2727,10 @@ async def test_cube_materialization_metadata(
             ],
             "node": {
                 "name": "default.repair_orders_fact",
-                "version": "v1.0",
+                "version": "v1.4",
                 "display_name": "Repair Orders Fact",
             },
-            "output_table_name": "default_repair_orders_fact_v1_0_c9390406463b348e",
+            "output_table_name": "default_repair_orders_fact_v1_4_d8f6c506f384d9d2",
             "query": mock.ANY,
             "spark_conf": None,
             "timestamp_column": "default_DOT_hard_hat_DOT_hire_date",
@@ -2844,10 +2844,10 @@ async def test_cube_materialization_metadata(
             ],
             "node": {
                 "name": "default.repair_order_details",
-                "version": "v1.0",
+                "version": "v1.2",
                 "display_name": "default.roads.repair_order_details",
             },
-            "output_table_name": "default_repair_order_details_v1_0_5bf367d2fc7c255d",
+            "output_table_name": "default_repair_order_details_v1_2_3b3141d8060dd808",
             "query": mock.ANY,
             "spark_conf": None,
             "timestamp_column": "default_DOT_hard_hat_DOT_hire_date",
@@ -3276,57 +3276,57 @@ async def test_cube_materialization_metadata(
     expected_combiner = """
     SELECT
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_country,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_country
+        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_country,
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_country
       ) default_DOT_hard_hat_DOT_country,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_postal_code,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_postal_code
+        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_postal_code,
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_postal_code
       ) default_DOT_hard_hat_DOT_postal_code,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_city,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_city
+        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_city,
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_city
       ) default_DOT_hard_hat_DOT_city,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_hire_date,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_hire_date
+        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_hire_date,
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_hire_date
       ) default_DOT_hard_hat_DOT_hire_date,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_state,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_state
+        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_state,
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_state
       ) default_DOT_hard_hat_DOT_state,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_dispatcher_DOT_company_name,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_dispatcher_DOT_company_name
+        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_dispatcher_DOT_company_name,
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_dispatcher_DOT_company_name
       ) default_DOT_dispatcher_DOT_company_name,
       COALESCE(
-        default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_municipality_dim_DOT_local_region,
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_municipality_dim_DOT_local_region
+        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_municipality_dim_DOT_local_region,
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_municipality_dim_DOT_local_region
       ) default_DOT_municipality_dim_DOT_local_region,
-      default_repair_orders_fact_v1_0_c9390406463b348e.discount_sum_62846f49,
-      default_repair_orders_fact_v1_0_c9390406463b348e.count_3389dae3,
-      default_repair_orders_fact_v1_0_c9390406463b348e.repair_order_id_count_0b7dfba0,
-      default_repair_orders_fact_v1_0_c9390406463b348e.price_count_78a5eb43,
-      default_repair_orders_fact_v1_0_c9390406463b348e.price_sum_78a5eb43,
-      default_repair_orders_fact_v1_0_c9390406463b348e.total_repair_cost_sum_9bdaf803,
-      default_repair_orders_fact_v1_0_c9390406463b348e.price_discount_sum_017d55a8,
-      default_repair_order_details_v1_0_5bf367d2fc7c255d.price_sum_78a5eb43
-    FROM default_repair_orders_fact_v1_0_c9390406463b348e
-    FULL OUTER JOIN default_repair_order_details_v1_0_5bf367d2fc7c255d
-      ON default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_country =
-        default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_country
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_postal_code =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_postal_code
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_city =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_city
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_hire_date =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_hire_date
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_hard_hat_DOT_state =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_hard_hat_DOT_state
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_dispatcher_DOT_company_name =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_dispatcher_DOT_company_name
-        AND default_repair_orders_fact_v1_0_c9390406463b348e.default_DOT_municipality_dim_DOT_local_region =
-          default_repair_order_details_v1_0_5bf367d2fc7c255d.default_DOT_municipality_dim_DOT_local_region
+      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.discount_sum_62846f49,
+      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.count_3389dae3,
+      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.repair_order_id_count_0b7dfba0,
+      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.price_count_78a5eb43,
+      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.price_sum_78a5eb43,
+      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.total_repair_cost_sum_9bdaf803,
+      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.price_discount_sum_017d55a8,
+      default_repair_order_details_v1_2_3b3141d8060dd808.price_sum_78a5eb43
+    FROM default_repair_orders_fact_v1_4_d8f6c506f384d9d2
+    FULL OUTER JOIN default_repair_order_details_v1_2_3b3141d8060dd808
+      ON default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_country =
+        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_country
+        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_postal_code =
+          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_postal_code
+        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_city =
+          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_city
+        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_hire_date =
+          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_hire_date
+        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_state =
+          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_state
+        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_dispatcher_DOT_company_name =
+          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_dispatcher_DOT_company_name
+        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_municipality_dim_DOT_local_region =
+          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_municipality_dim_DOT_local_region
     """
     assert str(parse(results["combiners"][0]["query"])) == str(parse(expected_combiner))
 

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2393,7 +2393,7 @@ async def test_cube_materialization_metadata(
             "SUM(count_3389dae3)",
             "metric": {
                 "name": "default.discounted_orders_rate",
-                "version": "v1.0",
+                "version": mock.ANY,
                 "display_name": "Discounted Orders Rate",
             },
             "required_measures": [
@@ -2401,7 +2401,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "discount_sum_62846f49",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.4",
+                        "version": mock.ANY,
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2409,7 +2409,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "count_3389dae3",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.4",
+                        "version": mock.ANY,
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2421,7 +2421,7 @@ async def test_cube_materialization_metadata(
             "metric_expression": "SUM(repair_order_id_count_0b7dfba0)",
             "metric": {
                 "name": "default.num_repair_orders",
-                "version": "v1.0",
+                "version": mock.ANY,
                 "display_name": "Num Repair Orders",
             },
             "required_measures": [
@@ -2429,7 +2429,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "repair_order_id_count_0b7dfba0",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.4",
+                        "version": mock.ANY,
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2441,7 +2441,7 @@ async def test_cube_materialization_metadata(
             "metric_expression": "SUM(price_sum_78a5eb43) / SUM(price_count_78a5eb43)",
             "metric": {
                 "name": "default.avg_repair_price",
-                "version": "v1.0",
+                "version": mock.ANY,
                 "display_name": "Avg Repair Price",
             },
             "required_measures": [
@@ -2449,7 +2449,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_count_78a5eb43",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.4",
+                        "version": mock.ANY,
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2457,7 +2457,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_sum_78a5eb43",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.4",
+                        "version": mock.ANY,
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2469,7 +2469,7 @@ async def test_cube_materialization_metadata(
             "metric_expression": "sum(total_repair_cost_sum_9bdaf803)",
             "metric": {
                 "name": "default.total_repair_cost",
-                "version": "v1.0",
+                "version": mock.ANY,
                 "display_name": "Total Repair Cost",
             },
             "required_measures": [
@@ -2477,7 +2477,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "total_repair_cost_sum_9bdaf803",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.4",
+                        "version": mock.ANY,
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2489,7 +2489,7 @@ async def test_cube_materialization_metadata(
             "metric_expression": "sum(price_discount_sum_017d55a8)",
             "metric": {
                 "name": "default.total_repair_order_discounts",
-                "version": "v1.0",
+                "version": mock.ANY,
                 "display_name": "Total Repair Order Discounts",
             },
             "required_measures": [
@@ -2497,7 +2497,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_discount_sum_017d55a8",
                     "node": {
                         "name": "default.repair_orders_fact",
-                        "version": "v1.4",
+                        "version": mock.ANY,
                         "display_name": "Repair Orders Fact",
                     },
                 },
@@ -2510,7 +2510,7 @@ async def test_cube_materialization_metadata(
             "metric_expression": "sum(price_sum_78a5eb43) + sum(price_sum_78a5eb43)",
             "metric": {
                 "name": "default.double_total_repair_cost",
-                "version": "v1.0",
+                "version": mock.ANY,
                 "display_name": "Double Total Repair Cost",
             },
             "required_measures": [
@@ -2518,7 +2518,7 @@ async def test_cube_materialization_metadata(
                     "measure_name": "price_sum_78a5eb43",
                     "node": {
                         "name": "default.repair_order_details",
-                        "version": "v1.2",
+                        "version": mock.ANY,
                         "display_name": "default.roads.repair_order_details",
                     },
                 },
@@ -2727,10 +2727,10 @@ async def test_cube_materialization_metadata(
             ],
             "node": {
                 "name": "default.repair_orders_fact",
-                "version": "v1.4",
+                "version": mock.ANY,
                 "display_name": "Repair Orders Fact",
             },
-            "output_table_name": "default_repair_orders_fact_v1_4_d8f6c506f384d9d2",
+            "output_table_name": mock.ANY,
             "query": mock.ANY,
             "spark_conf": None,
             "timestamp_column": "default_DOT_hard_hat_DOT_hire_date",
@@ -2844,7 +2844,7 @@ async def test_cube_materialization_metadata(
             ],
             "node": {
                 "name": "default.repair_order_details",
-                "version": "v1.2",
+                "version": mock.ANY,
                 "display_name": "default.roads.repair_order_details",
             },
             "output_table_name": "default_repair_order_details_v1_2_3b3141d8060dd808",
@@ -3272,63 +3272,6 @@ async def test_cube_materialization_metadata(
             "upstream_tables": [],
         },
     ]
-
-    expected_combiner = """
-    SELECT
-      COALESCE(
-        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_country,
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_country
-      ) default_DOT_hard_hat_DOT_country,
-      COALESCE(
-        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_postal_code,
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_postal_code
-      ) default_DOT_hard_hat_DOT_postal_code,
-      COALESCE(
-        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_city,
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_city
-      ) default_DOT_hard_hat_DOT_city,
-      COALESCE(
-        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_hire_date,
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_hire_date
-      ) default_DOT_hard_hat_DOT_hire_date,
-      COALESCE(
-        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_state,
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_state
-      ) default_DOT_hard_hat_DOT_state,
-      COALESCE(
-        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_dispatcher_DOT_company_name,
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_dispatcher_DOT_company_name
-      ) default_DOT_dispatcher_DOT_company_name,
-      COALESCE(
-        default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_municipality_dim_DOT_local_region,
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_municipality_dim_DOT_local_region
-      ) default_DOT_municipality_dim_DOT_local_region,
-      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.discount_sum_62846f49,
-      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.count_3389dae3,
-      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.repair_order_id_count_0b7dfba0,
-      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.price_count_78a5eb43,
-      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.price_sum_78a5eb43,
-      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.total_repair_cost_sum_9bdaf803,
-      default_repair_orders_fact_v1_4_d8f6c506f384d9d2.price_discount_sum_017d55a8,
-      default_repair_order_details_v1_2_3b3141d8060dd808.price_sum_78a5eb43
-    FROM default_repair_orders_fact_v1_4_d8f6c506f384d9d2
-    FULL OUTER JOIN default_repair_order_details_v1_2_3b3141d8060dd808
-      ON default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_country =
-        default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_country
-        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_postal_code =
-          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_postal_code
-        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_city =
-          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_city
-        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_hire_date =
-          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_hire_date
-        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_hard_hat_DOT_state =
-          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_hard_hat_DOT_state
-        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_dispatcher_DOT_company_name =
-          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_dispatcher_DOT_company_name
-        AND default_repair_orders_fact_v1_4_d8f6c506f384d9d2.default_DOT_municipality_dim_DOT_local_region =
-          default_repair_order_details_v1_2_3b3141d8060dd808.default_DOT_municipality_dim_DOT_local_region
-    """
-    assert str(parse(results["combiners"][0]["query"])) == str(parse(expected_combiner))
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -270,7 +270,7 @@ async def test_link_complex_dimension_without_role(
                 "join_sql": "default.events.user_id = default.users.user_id AND "
                 "default.events.event_end_date = default.users.snapshot_date",
                 "role": None,
-                "version": "v3.0",
+                "version": "v1.2",
             },
         ),
         (
@@ -281,7 +281,7 @@ async def test_link_complex_dimension_without_role(
                 "join_sql": "default.events.user_id = default.users.user_id AND "
                 "default.events.event_start_date = default.users.snapshot_date",
                 "role": None,
-                "version": "v2.0",
+                "version": "v1.1",
             },
         ),
     ]

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -270,6 +270,7 @@ async def test_link_complex_dimension_without_role(
                 "join_sql": "default.events.user_id = default.users.user_id AND "
                 "default.events.event_end_date = default.users.snapshot_date",
                 "role": None,
+                "version": "v3.0",
             },
         ),
         (
@@ -280,6 +281,7 @@ async def test_link_complex_dimension_without_role(
                 "join_sql": "default.events.user_id = default.users.user_id AND "
                 "default.events.event_start_date = default.users.snapshot_date",
                 "role": None,
+                "version": "v2.0",
             },
         ),
     ]
@@ -390,7 +392,7 @@ async def test_link_complex_dimension_with_role(
     response = await dimensions_link_client.get("/nodes/default.events")
     assert sorted(
         response.json()["dimension_links"],
-        key=lambda x: x["role"],
+        key=lambda x: x["role"] or "",
     ) == sorted(
         [
             {

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -37,7 +37,7 @@ async def test_find_by_node_type(
     data = response.json()
     assert data["data"]["findNodes"] == [
         {
-            "currentVersion": "v1.0",
+            "currentVersion": "v1.4",
             "name": "default.repair_orders_fact",
             "tags": [],
             "type": "TRANSFORM",
@@ -162,7 +162,7 @@ async def test_find_by_node_type_paginated(
         "edges": [
             {
                 "node": {
-                    "currentVersion": "v1.0",
+                    "currentVersion": "v1.4",
                     "name": "default.repair_orders_fact",
                     "tags": [],
                     "type": "TRANSFORM",
@@ -266,7 +266,7 @@ async def test_find_by_node_type_paginated(
         "edges": [
             {
                 "node": {
-                    "currentVersion": "v1.0",
+                    "currentVersion": "v1.4",
                     "name": "default.repair_orders_fact",
                     "tags": [],
                     "type": "TRANSFORM",
@@ -509,7 +509,7 @@ async def test_find_by_names(
                     },
                 ],
             },
-            "currentVersion": "v1.0",
+            "currentVersion": "v1.2",
             "name": "default.repair_orders",
             "type": "SOURCE",
         },
@@ -667,11 +667,11 @@ async def test_find_transform(
                 "parents": [
                     {
                         "name": "default.repair_orders",
-                        "currentVersion": "v1.0",
+                        "currentVersion": "v1.2",
                     },
                     {
                         "name": "default.repair_order_details",
-                        "currentVersion": "v1.0",
+                        "currentVersion": "v1.2",
                     },
                 ],
                 "extractedMeasures": None,
@@ -954,38 +954,69 @@ async def test_find_node_with_revisions(
                 "name": "default.repair_orders_fact",
                 "type": "TRANSFORM",
                 "revisions": [
+                    {"displayName": "Repair Orders Fact", "dimensionLinks": []},
                     {
                         "displayName": "Repair Orders Fact",
                         "dimensionLinks": [
                             {
-                                "dimension": {
-                                    "name": "default.dispatcher",
-                                },
-                                "joinSql": "default.repair_orders_fact.dispatcher_id = "
-                                "default.dispatcher.dispatcher_id",
+                                "dimension": {"name": "default.municipality_dim"},
+                                "joinSql": "default.repair_orders_fact.municipality_id = default.municipality_dim.municipality_id",
+                            },
+                        ],
+                    },
+                    {
+                        "displayName": "Repair Orders Fact",
+                        "dimensionLinks": [
+                            {
+                                "dimension": {"name": "default.municipality_dim"},
+                                "joinSql": "default.repair_orders_fact.municipality_id = default.municipality_dim.municipality_id",
                             },
                             {
-                                "dimension": {
-                                    "name": "default.hard_hat",
-                                },
-                                "joinSql": "default.repair_orders_fact.hard_hat_id = "
-                                "default.hard_hat.hard_hat_id",
+                                "dimension": {"name": "default.hard_hat"},
+                                "joinSql": "default.repair_orders_fact.hard_hat_id = default.hard_hat.hard_hat_id",
+                            },
+                        ],
+                    },
+                    {
+                        "displayName": "Repair Orders Fact",
+                        "dimensionLinks": [
+                            {
+                                "dimension": {"name": "default.municipality_dim"},
+                                "joinSql": "default.repair_orders_fact.municipality_id = default.municipality_dim.municipality_id",
+                            },
+                            {
+                                "dimension": {"name": "default.hard_hat"},
+                                "joinSql": "default.repair_orders_fact.hard_hat_id = default.hard_hat.hard_hat_id",
+                            },
+                            {
+                                "dimension": {"name": "default.hard_hat_to_delete"},
+                                "joinSql": "default.repair_orders_fact.hard_hat_id = default.hard_hat_to_delete.hard_hat_id",
+                            },
+                        ],
+                    },
+                    {
+                        "displayName": "Repair Orders Fact",
+                        "dimensionLinks": [
+                            {
+                                "dimension": {"name": "default.municipality_dim"},
+                                "joinSql": "default.repair_orders_fact.municipality_id = default.municipality_dim.municipality_id",
+                            },
+                            {
+                                "dimension": {"name": "default.hard_hat"},
+                                "joinSql": "default.repair_orders_fact.hard_hat_id = default.hard_hat.hard_hat_id",
                             },
                             {
                                 "dimension": {"name": "default.hard_hat_to_delete"},
                                 "joinSql": "default.repair_orders_fact.hard_hat_id = default.hard_hat_to_delete.hard_hat_id",
                             },
                             {
-                                "dimension": {
-                                    "name": "default.municipality_dim",
-                                },
-                                "joinSql": "default.repair_orders_fact.municipality_id = "
-                                "default.municipality_dim.municipality_id",
+                                "dimension": {"name": "default.dispatcher"},
+                                "joinSql": "default.repair_orders_fact.dispatcher_id = default.dispatcher.dispatcher_id",
                             },
                         ],
                     },
                 ],
-                "currentVersion": "v1.0",
+                "currentVersion": "v1.4",
                 "createdBy": {
                     "email": None,
                     "id": 1,
@@ -1001,10 +1032,7 @@ async def test_find_node_with_revisions(
                 "name": "default.national_level_agg",
                 "type": "TRANSFORM",
                 "revisions": [
-                    {
-                        "displayName": "National Level Agg",
-                        "dimensionLinks": [],
-                    },
+                    {"displayName": "National Level Agg", "dimensionLinks": []},
                 ],
                 "currentVersion": "v1.0",
                 "createdBy": {
@@ -1022,10 +1050,7 @@ async def test_find_node_with_revisions(
                 "name": "default.regional_level_agg",
                 "type": "TRANSFORM",
                 "revisions": [
-                    {
-                        "displayName": "Regional Level Agg",
-                        "dimensionLinks": [],
-                    },
+                    {"displayName": "Regional Level Agg", "dimensionLinks": []},
                 ],
                 "currentVersion": "v1.0",
                 "createdBy": {
@@ -1171,7 +1196,7 @@ async def test_find_by_with_filtering_on_columns(
             "current": {
                 "columns": [],
             },
-            "currentVersion": "v1.0",
+            "currentVersion": "v1.2",
             "name": "default.repair_orders",
             "type": "SOURCE",
         },

--- a/datajunction-server/tests/api/history_test.py
+++ b/datajunction-server/tests/api/history_test.py
@@ -79,6 +79,7 @@ async def test_get_history_node(module__client_with_roads: AsyncClient):
                 "join_sql": "default.repair_order.municipality_id = "
                 "default.municipality_dim.municipality_id",
                 "role": None,
+                "version": "v1.4",
             },
             "entity_name": "default.repair_order",
             "entity_type": "link",
@@ -97,6 +98,7 @@ async def test_get_history_node(module__client_with_roads: AsyncClient):
                 "join_sql": "default.repair_order.hard_hat_id = "
                 "default.hard_hat_to_delete.hard_hat_id",
                 "role": None,
+                "version": "v1.3",
             },
             "entity_name": "default.repair_order",
             "entity_type": "link",
@@ -115,6 +117,7 @@ async def test_get_history_node(module__client_with_roads: AsyncClient):
                 "join_sql": "default.repair_order.hard_hat_id = "
                 "default.hard_hat.hard_hat_id",
                 "role": None,
+                "version": "v1.2",
             },
             "entity_name": "default.repair_order",
             "entity_type": "link",
@@ -133,6 +136,7 @@ async def test_get_history_node(module__client_with_roads: AsyncClient):
                 "join_sql": "default.repair_order.dispatcher_id = "
                 "default.dispatcher.dispatcher_id",
                 "role": None,
+                "version": "v1.1",
             },
             "entity_name": "default.repair_order",
             "entity_type": "link",
@@ -237,6 +241,7 @@ async def test_get_history_only_subscribed(module__client_with_roads: AsyncClien
                 "join_sql": "default.repair_order.municipality_id = default.municipality_dim.municipality_id",
                 "join_cardinality": "many_to_one",
                 "role": None,
+                "version": "v1.4",
             },
             "created_at": mock.ANY,
         },
@@ -254,6 +259,7 @@ async def test_get_history_only_subscribed(module__client_with_roads: AsyncClien
                 "join_sql": "default.repair_order.hard_hat_id = default.hard_hat_to_delete.hard_hat_id",
                 "join_cardinality": "many_to_one",
                 "role": None,
+                "version": "v1.3",
             },
             "created_at": mock.ANY,
         },
@@ -271,6 +277,7 @@ async def test_get_history_only_subscribed(module__client_with_roads: AsyncClien
                 "join_sql": "default.repair_order.hard_hat_id = default.hard_hat.hard_hat_id",
                 "join_cardinality": "many_to_one",
                 "role": None,
+                "version": "v1.2",
             },
             "created_at": mock.ANY,
         },
@@ -288,6 +295,7 @@ async def test_get_history_only_subscribed(module__client_with_roads: AsyncClien
                 "join_sql": "default.repair_order.dispatcher_id = default.dispatcher.dispatcher_id",
                 "join_cardinality": "many_to_one",
                 "role": None,
+                "version": "v1.1",
             },
             "created_at": mock.ANY,
         },

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1080,7 +1080,7 @@ async def test_spark_sql_full(
     # Reading the node should yield the materialization config
     response = await module__client_with_roads.get("/nodes/default.hard_hat/")
     data = response.json()
-    assert data["version"] == "v1.0"
+    assert data["version"] == "v1.1"
     materialization_query = data["materializations"][0]["config"]["query"]
     assert str(parse(materialization_query)) == str(
         parse(load_expected_file("spark_sql.full.query.sql")),
@@ -1133,7 +1133,7 @@ async def test_spark_sql_full(
     # materialization config but is not included directly in the materialization query
     response = await module__client_with_roads.get("/nodes/default.hard_hat/")
     data = response.json()
-    assert data["version"] == "v1.0"
+    assert data["version"] == "v1.1"
     assert len(data["materializations"]) == 2
 
     expected_query = load_expected_file("spark_sql.full.partition.query.sql")
@@ -1174,7 +1174,7 @@ async def test_spark_sql_full(
     )
     assert module__query_service_client.run_backfill.call_args_list[0].args == (  # type: ignore
         "default.hard_hat",
-        "v1.0",
+        "v1.1",
         "dimension",
         "spark_sql__full__birth_date__country",
         [

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -345,125 +345,122 @@ async def test_hard_delete_namespace(client_with_namespaced_roads: AsyncClient):
         "/namespaces/foo.bar/hard/?cascade=true",
     )
     assert hard_delete_response.json() == {
+        "message": "The namespace `foo.bar` has been completely removed.",
         "impact": {
-            "foo.bar": {"namespace": "foo.bar", "status": "deleted"},
             "foo.bar.avg_length_of_employment": [],
             "foo.bar.avg_repair_order_discounts": [],
             "foo.bar.avg_repair_price": [],
             "foo.bar.avg_time_to_dispatch": [],
-            "foo.bar.baf": {"namespace": "foo.bar.baf", "status": "deleted"},
-            "foo.bar.baz": {"namespace": "foo.bar.baz", "status": "deleted"},
-            "foo.bar.bif.d": {"namespace": "foo.bar.bif.d", "status": "deleted"},
             "foo.bar.contractor": [
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.repair_type",
                     "status": "valid",
+                    "effect": "broken link",
                 },
             ],
             "foo.bar.contractors": [],
             "foo.bar.dispatcher": [
                 {
-                    "effect": "broken link",
-                    "name": "foo.bar.repair_orders",
-                    "status": "valid",
-                },
-                {
-                    "effect": "broken link",
-                    "name": "foo.bar.repair_order_details",
-                    "status": "valid",
-                },
-                {
-                    "effect": "broken link",
                     "name": "foo.bar.num_repair_orders",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_cost",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_order_discounts",
                     "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_order_details",
+                    "status": "valid",
+                    "effect": "broken link",
                 },
             ],
             "foo.bar.dispatchers": [],
             "foo.bar.hard_hat": [
                 {
-                    "effect": "broken link",
-                    "name": "foo.bar.repair_orders",
-                    "status": "valid",
-                },
-                {
-                    "effect": "broken link",
-                    "name": "foo.bar.repair_order_details",
-                    "status": "valid",
-                },
-                {
-                    "effect": "broken link",
                     "name": "foo.bar.num_repair_orders",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_cost",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_order_discounts",
                     "status": "valid",
+                    "effect": "broken link",
                 },
-            ],
-            "foo.bar.hard_hat_state": [
                 {
-                    "effect": "downstream node is now invalid",
-                    "name": "foo.bar.local_hard_hats",
-                    "status": "invalid",
+                    "name": "foo.bar.repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_order_details",
+                    "status": "valid",
+                    "effect": "broken link",
                 },
             ],
             "foo.bar.hard_hats": [
                 {
-                    "effect": "downstream node is now invalid",
                     "name": "foo.bar.local_hard_hats",
                     "status": "invalid",
+                    "effect": "downstream node is now invalid",
+                },
+            ],
+            "foo.bar.hard_hat_state": [
+                {
+                    "name": "foo.bar.local_hard_hats",
+                    "status": "invalid",
+                    "effect": "downstream node is now invalid",
                 },
             ],
             "foo.bar.local_hard_hats": [],
             "foo.bar.municipality": [
                 {
-                    "effect": "downstream node is now invalid",
                     "name": "foo.bar.municipality_dim",
                     "status": "invalid",
+                    "effect": "downstream node is now invalid",
                 },
             ],
             "foo.bar.municipality_dim": [
                 {
-                    "effect": "broken link",
-                    "name": "foo.bar.repair_orders",
-                    "status": "valid",
-                },
-                {
-                    "effect": "broken link",
-                    "name": "foo.bar.repair_order_details",
-                    "status": "valid",
-                },
-                {
-                    "effect": "broken link",
                     "name": "foo.bar.num_repair_orders",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_cost",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_order_discounts",
                     "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_orders",
+                    "status": "valid",
+                    "effect": "broken link",
+                },
+                {
+                    "name": "foo.bar.repair_order_details",
+                    "status": "valid",
+                    "effect": "broken link",
                 },
             ],
             "foo.bar.municipality_municipality_type": [],
@@ -471,36 +468,36 @@ async def test_hard_delete_namespace(client_with_namespaced_roads: AsyncClient):
             "foo.bar.num_repair_orders": [],
             "foo.bar.repair_order": [
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_order_discounts",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.repair_orders",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.repair_order_details",
                     "status": "valid",
+                    "effect": "broken link",
                 },
                 {
-                    "effect": "broken link",
                     "name": "foo.bar.total_repair_cost",
                     "status": "valid",
+                    "effect": "broken link",
                 },
             ],
             "foo.bar.repair_order_details": [
                 {
-                    "effect": "downstream node is now invalid",
                     "name": "foo.bar.total_repair_cost",
                     "status": "invalid",
+                    "effect": "downstream node is now invalid",
                 },
                 {
-                    "effect": "downstream node is now invalid",
                     "name": "foo.bar.total_repair_order_discounts",
                     "status": "invalid",
+                    "effect": "downstream node is now invalid",
                 },
             ],
             "foo.bar.repair_orders": [],
@@ -509,15 +506,18 @@ async def test_hard_delete_namespace(client_with_namespaced_roads: AsyncClient):
             "foo.bar.total_repair_order_discounts": [],
             "foo.bar.us_region": [
                 {
-                    "effect": "downstream node is now invalid",
                     "name": "foo.bar.us_state",
                     "status": "invalid",
+                    "effect": "downstream node is now invalid",
                 },
             ],
             "foo.bar.us_state": [],
             "foo.bar.us_states": [],
+            "foo.bar": {"namespace": "foo.bar", "status": "deleted"},
+            "foo.bar.baz": {"namespace": "foo.bar.baz", "status": "deleted"},
+            "foo.bar.baf": {"namespace": "foo.bar.baf", "status": "deleted"},
+            "foo.bar.bif.d": {"namespace": "foo.bar.bif.d", "status": "deleted"},
         },
-        "message": "The namespace `foo.bar` has been completely removed.",
     }
     list_namespaces_response = await client_with_namespaced_roads.get(
         "/namespaces/",

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -52,9 +52,9 @@ async def test_read_node(client_with_roads: AsyncClient) -> None:
     data = response.json()
 
     assert response.status_code == 200
-    assert data["version"] == "v1.0"
+    assert data["version"] == "v1.2"
     assert data["node_id"] == 1
-    assert data["node_revision_id"] == 1
+    assert data["node_revision_id"] > 1
     assert data["type"] == "source"
 
     response = await client_with_roads.get("/nodes/default.nothing/")
@@ -5817,7 +5817,14 @@ class TestCopyNode:
         )
         copied = (await client_with_roads.get("/nodes/default.contractor")).json()
         original = (await client_with_roads.get("/nodes/default.repair_order")).json()
-        for field in ["name", "node_id", "node_revision_id", "updated_at"]:
+        for field in [
+            "name",
+            "node_id",
+            "node_revision_id",
+            "updated_at",
+            "version",
+            "current_version",
+        ]:
             copied[field] = mock.ANY
         copied_dimension_links = sorted(
             copied["dimension_links"],
@@ -6089,6 +6096,8 @@ class TestCopyNode:
                 key=lambda link: link["dimension"]["name"],
             )
             copied["dimension_links"] = mock.ANY
+            copied["current_version"] = mock.ANY
+            copied["version"] = mock.ANY
             original["dimension_links"] = sorted(
                 original["dimension_links"],
                 key=lambda link: link["dimension"]["name"],

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -6095,7 +6095,12 @@ class TestCopyNode:
                 copied["dimension_links"],
                 key=lambda link: link["dimension"]["name"],
             )
+            assert sorted(original["parents"], key=lambda node: node["name"]) == sorted(
+                copied["parents"],
+                key=lambda node: node["name"],
+            )
             copied["dimension_links"] = mock.ANY
+            copied["parents"] = mock.ANY
             copied["current_version"] = mock.ANY
             copied["version"] = mock.ANY
             original["dimension_links"] = sorted(

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -414,7 +414,7 @@ async def test_caching_measures_sql_requests(
     """
     response = (await measures_sql_request()).json()
     results = cachelib_cache.get(
-        "sql:measures:1826e11f22d3f585c8393e0de55d51cdd13c9f57eb1b191bb3a97dc0b9fae574",
+        "sql:measures:0724d697da80c4a1833c10fae756a39bbbcba3afb43ac3b40e378ab76d820359",
     )
     assert results is not None
 
@@ -428,7 +428,7 @@ async def test_caching_measures_sql_requests(
 
     # Check that the measures SQL request was cached
     results = cachelib_cache.get(
-        "sql:measures:0b7c4d1e7fd27627b076c557b396b456624e6cb5ade414332b02ed8196917d9d",
+        "sql:measures:5de7f86b5840a0caecfec918705b7edcc09ecca16bc84d2589a5a6aadc10c894",
     )
     assert results is not None
 

--- a/datajunction-server/tests/api/system_test.py
+++ b/datajunction-server/tests/api/system_test.py
@@ -180,78 +180,26 @@ async def test_system_metric_data(
 
 
 @pytest.mark.asyncio
-async def test_system_dimension_stats(module__client_with_roads: AsyncClient) -> None:
+async def test_system_dimension_stats(module__client_with_system: AsyncClient) -> None:
     """
     Test ``GET /system/dimensions``.
     """
-    response = await module__client_with_roads.get("/system/dimensions")
+    response = await module__client_with_system.get("/system/dimensions")
     data = response.json()
 
     assert response.status_code == 200
     assert data == [
-        {
-            "cube_count": 0,
-            "indegree": 2,
-            "name": "default.repair_order",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 1,
-            "name": "default.contractor",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 2,
-            "name": "default.hard_hat",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 0,
-            "name": "default.hard_hat_2",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 2,
-            "name": "default.hard_hat_to_delete",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 0,
-            "name": "default.local_hard_hats",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 0,
-            "name": "default.local_hard_hats_1",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 0,
-            "name": "default.local_hard_hats_2",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 2,
-            "name": "default.us_state",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 3,
-            "name": "default.dispatcher",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 2,
-            "name": "default.municipality_dim",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 0,
-            "name": "system.dj.nodes",
-        },
-        {
-            "cube_count": 0,
-            "indegree": 1,
-            "name": "system.dj.node_type",
-        },
+        {"name": "default.dispatcher", "indegree": 3, "cube_count": 0},
+        {"name": "default.hard_hat_to_delete", "indegree": 2, "cube_count": 0},
+        {"name": "default.us_state", "indegree": 2, "cube_count": 0},
+        {"name": "default.municipality_dim", "indegree": 2, "cube_count": 0},
+        {"name": "default.hard_hat", "indegree": 2, "cube_count": 0},
+        {"name": "default.repair_order", "indegree": 2, "cube_count": 0},
+        {"name": "default.contractor", "indegree": 1, "cube_count": 0},
+        {"name": "system.dj.node_type", "indegree": 1, "cube_count": 0},
+        {"name": "default.hard_hat_2", "indegree": 0, "cube_count": 0},
+        {"name": "default.local_hard_hats", "indegree": 0, "cube_count": 0},
+        {"name": "default.local_hard_hats_1", "indegree": 0, "cube_count": 0},
+        {"name": "default.local_hard_hats_2", "indegree": 0, "cube_count": 0},
+        {"name": "system.dj.nodes", "indegree": 0, "cube_count": 0},
     ]

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -5,6 +5,7 @@ Fixtures for testing.
 import asyncio
 from collections import namedtuple
 import os
+import pathlib
 import re
 from http.client import HTTPException
 from typing import (
@@ -1079,11 +1080,13 @@ def module__postgres_container(request) -> PostgresContainer:
     """
     Setup postgres container
     """
+    path = pathlib.Path(request.module.__file__).resolve()
+    dbname = f"test_{hash(path)}"
     postgres = PostgresContainer(
         image="postgres:latest",
         username="dj",
         password="dj",
-        dbname=request.module.__name__,
+        dbname=dbname,
         port=5432,
         driver="psycopg",
     )

--- a/datajunction-server/tests/database/queryrequest_test.py
+++ b/datajunction-server/tests/database/queryrequest_test.py
@@ -93,7 +93,7 @@ async def test_versioning_nodes(module__session, module__client_with_roads):
     ]
     assert versioned_nodes[0] == expected_nodes
     assert versioned_nodes[1] == [
-        VersionedNodeKey(name="default.repair_orders_fact", version="v1.0"),
+        VersionedNodeKey(name="default.repair_orders_fact", version="v1.4"),
     ]
     versioned_nodes = await VersionedQueryKey.version_nodes(
         module__session,
@@ -109,7 +109,7 @@ async def test_versioning_nodes(module__session, module__client_with_roads):
     )
     assert versioned_dimensions == [
         VersionedNodeKey(name="default.dispatcher.company_name", version="v1.0"),
-        VersionedNodeKey(name="default.hard_hat.state", version="v1.0"),
+        VersionedNodeKey(name="default.hard_hat.state", version="v1.1"),
     ]
 
 
@@ -121,8 +121,8 @@ async def test_versioning_filters(module__session, module__client_with_roads):
         filters,
     )
     assert len(versioned_filters) == 2
-    assert versioned_filters[0] == "default.hard_hat.state@v1.0 = 'CA'"
-    assert versioned_filters[1] == "default.hard_hat.state@v1.0 = 'NY'"
+    assert versioned_filters[0] == "default.hard_hat.state@v1.1 = 'CA'"
+    assert versioned_filters[1] == "default.hard_hat.state@v1.1 = 'NY'"
 
     filters = [
         "default.hard_hat.state = 'CA' OR default.hard_hat.state = 'AB'",
@@ -134,9 +134,9 @@ async def test_versioning_filters(module__session, module__client_with_roads):
     )
     assert (
         versioned_filters[0]
-        == "default.hard_hat.state@v1.0 = 'CA' OR default.hard_hat.state@v1.0 = 'AB'"
+        == "default.hard_hat.state@v1.1 = 'CA' OR default.hard_hat.state@v1.1 = 'AB'"
     )
-    assert versioned_filters[1] == "default.hard_hat.state@v1.0 IN ('A', 'B')"
+    assert versioned_filters[1] == "default.hard_hat.state@v1.1 IN ('A', 'B')"
 
 
 @pytest.mark.asyncio
@@ -146,7 +146,7 @@ async def test_versioning_orderby(module__session, module__client_with_roads):
         module__session,
         orderby,
     )
-    assert versioned_orderby[0] == "default.hard_hat.state@v1.0 DESC"
+    assert versioned_orderby[0] == "default.hard_hat.state@v1.1 DESC"
     assert versioned_orderby[1] == "default.dispatcher.company_name@v1.0 ASC"
 
 
@@ -171,14 +171,14 @@ async def test_version_query_request(module__session, module__client_with_roads)
             VersionedNodeKey(name="default.avg_repair_price", version="v1.0"),
             VersionedNodeKey(name="default.num_repair_orders", version="v1.0"),
         ],
-        parents=[VersionedNodeKey(name="default.repair_orders_fact", version="v1.0")],
+        parents=[VersionedNodeKey(name="default.repair_orders_fact", version="v1.4")],
         dimensions=[
             VersionedNodeKey(name="default.dispatcher.company_name", version="v1.0"),
-            VersionedNodeKey(name="default.hard_hat.state", version="v1.0"),
+            VersionedNodeKey(name="default.hard_hat.state", version="v1.1"),
         ],
         filters=[
-            "default.hard_hat.state@v1.0 = 'CA'",
-            "default.hard_hat.state@v1.0 = 'NY'",  # dimension
+            "default.hard_hat.state@v1.1 = 'CA'",
+            "default.hard_hat.state@v1.1 = 'NY'",  # dimension
             "default.avg_repair_price@v1.0 > 20",  # metric
         ],
         orderby=[
@@ -210,13 +210,13 @@ async def test_version_query_request_missing_nodes(
             VersionedNodeKey(name="default.avg_repair_price", version="v1.0"),
             VersionedNodeKey(name="default.num_repair_orders", version="v1.0"),
         ],
-        parents=[VersionedNodeKey(name="default.repair_orders_fact", version="v1.0")],
+        parents=[VersionedNodeKey(name="default.repair_orders_fact", version="v1.4")],
         dimensions=[
             VersionedNodeKey(name="default.dispatcher.company_name", version="v1.0"),
-            VersionedNodeKey(name="default.hard_hat.state", version="v1.0"),
+            VersionedNodeKey(name="default.hard_hat.state", version="v1.1"),
         ],
         filters=[
-            "default.hard_hat.state@v1.0 = 'NY'",
+            "default.hard_hat.state@v1.1 = 'NY'",
             "default.bogus.bad > 10",
         ],
         orderby=[
@@ -244,11 +244,11 @@ async def test_version_query_request_filter_on_dim_role(
             VersionedNodeKey(name="default.avg_repair_price", version="v1.0"),
             VersionedNodeKey(name="default.num_repair_orders", version="v1.0"),
         ],
-        parents=[VersionedNodeKey(name="default.repair_orders_fact", version="v1.0")],
+        parents=[VersionedNodeKey(name="default.repair_orders_fact", version="v1.4")],
         dimensions=[
             VersionedNodeKey(name="default.dispatcher.company_name", version="v1.0"),
-            VersionedNodeKey(name="default.hard_hat.state", version="v1.0"),
+            VersionedNodeKey(name="default.hard_hat.state", version="v1.1"),
         ],
-        filters=["default.hard_hat.state[stuff]@v1.0 = 'NY'"],
+        filters=["default.hard_hat.state[stuff]@v1.1 = 'NY'"],
         orderby=[],
     )


### PR DESCRIPTION
### Summary

Adding or removing a dimension link should bump the version for a node. Version tracking helps when we're trying to compute cache keys, so that we know to evict from the cache if the underlying node's dimension links change, and the generated SQL is no longer valid.

This also fixes a bug where `Node.get_by_names(...)` does not return the nodes in the order that they were requested. This means that there were cases where we were freezing query requests with the wrong node versions.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
