### PR TITLE
Arithmetic Unary Operator Support

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1466,7 +1466,7 @@ class ArithmeticUnaryOpKind(DJEnum):
 
     Minus = "-"
     Plus = "+"
-    Tilde = "~"
+    BitwiseNot = "~"
 
     def __str__(self):
         return self.value

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1459,6 +1459,36 @@ class UnaryOp(Operation):
         raise DJParseException(f"Unary operation {self.op} not supported!")
 
 
+class ArithmeticUnaryOpKind(DJEnum):
+    """
+    Arithmetic unary operations
+    """
+
+    Minus = "-"
+    Plus = "+"
+    Tilde = "~"
+
+    def __str__(self):
+        return self.value
+
+
+@dataclass(eq=False)
+class ArithmeticUnaryOp(Operation):
+    """
+    An operation that operates on a single expression
+    """
+
+    op: ArithmeticUnaryOpKind
+    expr: Expression
+
+    def __str__(self) -> str:
+        return f"{self.op}{self.expr}"
+
+    @property
+    def type(self) -> ColumnType:
+        return self.expr.type
+
+
 class BinaryOpKind(DJEnum):
     """
     The DJ AST accepted binary operations

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -384,6 +384,24 @@ def _(ctx: sbp.BooleanValueContext):
 
 
 @visit.register
+def _(ctx: sbp.ArithmeticUnaryContext):
+    value_expr = visit(ctx.valueExpression())
+    if ctx.MINUS():
+        return ast.ArithmeticUnaryOp(
+            op=ast.ArithmeticUnaryOpKind.Minus,
+            expr=value_expr,
+        )
+    if ctx.PLUS():
+        return ast.ArithmeticUnaryOp(op=ast.ArithmeticUnaryOpKind.Plus, expr=value_expr)
+    if ctx.TILDE():
+        return ast.ArithmeticUnaryOp(
+            op=ast.ArithmeticUnaryOpKind.Tilde,
+            expr=value_expr,
+        )
+    raise DJParseException("blah")
+
+
+@visit.register
 def _(ctx: sbp.PredicatedContext):
     if value_expr := ctx.valueExpression():
         if not ctx.predicate():

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -395,7 +395,7 @@ def _(ctx: sbp.ArithmeticUnaryContext):
         return ast.ArithmeticUnaryOp(op=ast.ArithmeticUnaryOpKind.Plus, expr=value_expr)
     if ctx.TILDE():
         return ast.ArithmeticUnaryOp(
-            op=ast.ArithmeticUnaryOpKind.Tilde,
+            op=ast.ArithmeticUnaryOpKind.BitwiseNot,
             expr=value_expr,
         )
     raise DJParseException("blah")

--- a/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
+++ b/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
@@ -197,7 +197,7 @@ def test_antlr4_arithmetic_unary_op():
 
     query_ast = parse("SELECT ~a")
     assert query_ast.select.projection[0] == ast.ArithmeticUnaryOp(
-        op=ast.ArithmeticUnaryOpKind.Tilde,
+        op=ast.ArithmeticUnaryOpKind.BitwiseNot,
         expr=ast.Column(name=ast.Name(name="a")),
     )
     assert "~a" in str(query_ast)

--- a/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
+++ b/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
@@ -175,3 +175,29 @@ def test_query_parameters():
             quote_style="",
         ),
     ]
+
+
+def test_antlr4_arithmetic_unary_op():
+    """
+    Test parsing arithmetic unary operations
+    """
+    query_ast = parse("SELECT -a")
+    assert query_ast.select.projection[0] == ast.ArithmeticUnaryOp(
+        op=ast.ArithmeticUnaryOpKind.Minus,
+        expr=ast.Column(name=ast.Name(name="a")),
+    )
+    assert "-a" in str(query_ast)
+
+    query_ast = parse("SELECT +a")
+    assert query_ast.select.projection[0] == ast.ArithmeticUnaryOp(
+        op=ast.ArithmeticUnaryOpKind.Plus,
+        expr=ast.Column(name=ast.Name(name="a")),
+    )
+    assert "+a" in str(query_ast)
+
+    query_ast = parse("SELECT ~a")
+    assert query_ast.select.projection[0] == ast.ArithmeticUnaryOp(
+        op=ast.ArithmeticUnaryOpKind.Tilde,
+        expr=ast.Column(name=ast.Name(name="a")),
+    )
+    assert "~a" in str(query_ast)


### PR DESCRIPTION
### Summary

Add AST support for parsing arithmetic unary operators like `-`, `+` and `~`.

### Test Plan

Locally + added tests

- [x] PR has an associated issue: #1454 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
