### PR TITLE
Make sure that cache key is static

### DIFF
--- a/datajunction-server/datajunction_server/internal/caching/cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/cache_manager.py
@@ -91,8 +91,8 @@ class RefreshAheadCacheManager(CacheManager):
         no_store = "no-store" in cache_control
         no_cache = "no-cache" in cache_control
 
+        key: str = await self.build_cache_key(request, params)
         if not no_cache:
-            key: str = await self.build_cache_key(request, params)
             if cached := self.cache.get(key):
                 if not no_store:
                     background_tasks.add_task(self._refresh_cache, key, request, params)
@@ -111,7 +111,6 @@ class RefreshAheadCacheManager(CacheManager):
         result = await self.fallback(request, params)
 
         if not no_store:
-            key = await self.build_cache_key(request, params)
             background_tasks.add_task(
                 self.cache.set,
                 key,

--- a/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dataclasses import asdict, dataclass
 import json
 from typing import Any, OrderedDict
@@ -75,6 +76,7 @@ class QueryCacheManager(RefreshAheadCacheManager):
         The fallback function to call if the cache is not hit. This should be overridden
         in subclasses.
         """
+        params = deepcopy(params)
         async with session_context(request) as session:
             nodes = list(OrderedDict.fromkeys(params.nodes))
             measures_query = await get_measures_query(


### PR DESCRIPTION
### Summary

It turns out that the measures SQL generation process actually changes the values of the parameters passed in. This adds some protection at the caching layer to make sure that this does not affect the cache keys generated.

### Test Plan

Locally

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan
