### PR TITLE
Enable correct sorting of nodes within namespace 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ Untitled*
 # postgres
 postgres_metadata
 postgres_superset
+node_modules

--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -49,6 +49,7 @@ async def find_nodes(
         strawberry.argument(description="Limit nodes"),
     ] = DEFAULT_LIMIT,
     order_by: NodeSortField = NodeSortField.CREATED_AT,
+    ascending: bool = False,
     *,
     info: Info,
 ) -> list[Node]:
@@ -75,6 +76,7 @@ async def find_nodes(
         tags,
         limit=limit,
         order_by=order_by,
+        ascending=ascending,
     )
 
 
@@ -122,6 +124,7 @@ async def find_nodes_paginated(
         strawberry.argument(description="Limit nodes"),
     ] = 100,
     order_by: NodeSortField = NodeSortField.CREATED_AT,
+    ascending: bool = False,
     *,
     info: Info,
 ) -> Connection[Node]:
@@ -142,6 +145,7 @@ async def find_nodes_paginated(
         before,
         after,
         order_by,
+        ascending,
     )
     return Connection.from_list(
         items=nodes_list,

--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -10,7 +10,7 @@ from strawberry.types import Info
 
 from datajunction_server.api.graphql.resolvers.nodes import find_nodes_by
 from datajunction_server.api.graphql.scalars import Connection
-from datajunction_server.api.graphql.scalars.node import Node
+from datajunction_server.api.graphql.scalars.node import Node, NodeSortField
 from datajunction_server.models.node import NodeCursor, NodeType
 
 DEFAULT_LIMIT = 1000
@@ -48,6 +48,7 @@ async def find_nodes(
         int | None,
         strawberry.argument(description="Limit nodes"),
     ] = DEFAULT_LIMIT,
+    order_by: NodeSortField = NodeSortField.CREATED_AT,
     *,
     info: Info,
 ) -> list[Node]:
@@ -66,7 +67,15 @@ async def find_nodes(
         )
         limit = UPPER_LIMIT
 
-    return await find_nodes_by(info, names, fragment, node_types, tags, limit=limit)  # type: ignore
+    return await find_nodes_by(  # type: ignore
+        info,
+        names,
+        fragment,
+        node_types,
+        tags,
+        limit=limit,
+        order_by=order_by,
+    )
 
 
 async def find_nodes_paginated(
@@ -112,6 +121,7 @@ async def find_nodes_paginated(
         int | None,
         strawberry.argument(description="Limit nodes"),
     ] = 100,
+    order_by: NodeSortField = NodeSortField.CREATED_AT,
     *,
     info: Info,
 ) -> Connection[Node]:
@@ -131,6 +141,7 @@ async def find_nodes_paginated(
         limit + 1,
         before,
         after,
+        order_by,
     )
     return Connection.from_list(
         items=nodes_list,

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -32,6 +32,7 @@ async def find_nodes_by(
     before: Optional[str] = None,
     after: Optional[str] = None,
     order_by: NodeSortField = NodeSortField.CREATED_AT,
+    ascending: bool = False,
 ) -> List[DBNode]:
     """
     Finds nodes based on the search parameters. This function also tries to optimize
@@ -57,7 +58,8 @@ async def find_nodes_by(
         limit,
         before,
         after,
-        order_by=order_by.field(),
+        order_by=order_by.column,
+        ascending=ascending,
         options=options,
     )
 

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import defer, joinedload, selectinload
 from strawberry.types import Info
 
 from datajunction_server.errors import DJNodeNotFound
-from datajunction_server.api.graphql.scalars.node import NodeName
+from datajunction_server.api.graphql.scalars.node import NodeName, NodeSortField
 from datajunction_server.api.graphql.scalars.sql import CubeDefinition
 from datajunction_server.api.graphql.utils import dedupe_append, extract_fields
 from datajunction_server.database.dimensionlink import DimensionLink
@@ -31,6 +31,7 @@ async def find_nodes_by(
     limit: Optional[int] = 100,
     before: Optional[str] = None,
     after: Optional[str] = None,
+    order_by: NodeSortField = NodeSortField.CREATED_AT,
 ) -> List[DBNode]:
     """
     Finds nodes based on the search parameters. This function also tries to optimize
@@ -56,6 +57,7 @@ async def find_nodes_by(
         limit,
         before,
         after,
+        order_by=order_by.field(),
         options=options,
     )
 

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -54,7 +54,7 @@ class NodeSortField(Enum):
     """
 
     NAME = ("name", DBNode.name)
-    DISPLAY_NAME = ("display_name", DBNode.display_name)
+    DISPLAY_NAME = ("display_name", DBNodeRevision.display_name)
     TYPE = ("type", DBNode.type)
     STATUS = ("status", DBNodeRevision.status)
     MODE = ("mode", DBNodeRevision.mode)

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -1,6 +1,7 @@
 """Node-related scalars."""
 
 import datetime
+from enum import Enum
 from typing import List, Optional
 
 import strawberry
@@ -43,6 +44,37 @@ NodeStatus = strawberry.enum(NodeStatus_)
 NodeMode = strawberry.enum(NodeMode_)
 JoinType = strawberry.enum(JoinType_)
 JoinCardinality = strawberry.enum(JoinCardinality_)
+
+
+@strawberry.enum
+class NodeSortField(Enum):
+    """
+    Available node sort fields
+    """
+
+    NAME = "name"
+    DISPLAY_NAME = "display_name"
+    TYPE = "type"
+    STATUS = "status"
+    MODE = "mode"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+    def field(self):
+        if self == NodeSortField.NAME:
+            return DBNode.name
+        if self == NodeSortField.DISPLAY_NAME:
+            return DBNode.display_name
+        if self == NodeSortField.TYPE:
+            return DBNode.type
+        if self == NodeSortField.STATUS:
+            return DBNodeRevision.status
+        if self == NodeSortField.MODE:
+            return DBNodeRevision.mode
+        if self == NodeSortField.CREATED_AT:
+            return DBNode.created_at
+        if self == NodeSortField.UPDATED_AT:
+            return DBNodeRevision.updated_at
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 import strawberry
 from strawberry.scalars import JSON
 from strawberry.types import Info
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from datajunction_server.api.graphql.scalars import BigInt
 from datajunction_server.api.graphql.scalars.availabilitystate import AvailabilityState
@@ -52,29 +53,22 @@ class NodeSortField(Enum):
     Available node sort fields
     """
 
-    NAME = "name"
-    DISPLAY_NAME = "display_name"
-    TYPE = "type"
-    STATUS = "status"
-    MODE = "mode"
-    CREATED_AT = "created_at"
-    UPDATED_AT = "updated_at"
+    NAME = ("name", DBNode.name)
+    DISPLAY_NAME = ("display_name", DBNode.display_name)
+    TYPE = ("type", DBNode.type)
+    STATUS = ("status", DBNodeRevision.status)
+    MODE = ("mode", DBNodeRevision.mode)
+    CREATED_AT = ("created_at", DBNode.created_at)
+    UPDATED_AT = ("updated_at", DBNodeRevision.updated_at)
 
-    def field(self):
-        if self == NodeSortField.NAME:
-            return DBNode.name
-        if self == NodeSortField.DISPLAY_NAME:
-            return DBNode.display_name
-        if self == NodeSortField.TYPE:
-            return DBNode.type
-        if self == NodeSortField.STATUS:
-            return DBNodeRevision.status
-        if self == NodeSortField.MODE:
-            return DBNodeRevision.mode
-        if self == NodeSortField.CREATED_AT:
-            return DBNode.created_at
-        if self == NodeSortField.UPDATED_AT:
-            return DBNodeRevision.updated_at
+    # The database column that this sort field maps to
+    column: InstrumentedAttribute
+
+    def __new__(cls, value, column):
+        obj = object.__new__(cls)
+        obj._value_ = value  # GraphQL will serialize this
+        obj.column = column
+        return obj
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -393,6 +393,7 @@ type Query {
     """Limit nodes"""
     limit: Int = 1000
     orderBy: NodeSortField! = CREATED_AT
+    ascending: Boolean! = false
   ): [Node!]!
 
   """Find nodes based on the search parameters with pagination"""
@@ -420,6 +421,7 @@ type Query {
     """Limit nodes"""
     limit: Int = 100
     orderBy: NodeSortField! = CREATED_AT
+    ascending: Boolean! = false
   ): NodeConnection!
 
   """Get common dimensions for one or more nodes"""

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -298,6 +298,16 @@ type NodeRevision {
   cubeDimensions: [DimensionAttribute!]!
 }
 
+enum NodeSortField {
+  NAME
+  DISPLAY_NAME
+  TYPE
+  STATUS
+  MODE
+  CREATED_AT
+  UPDATED_AT
+}
+
 enum NodeStatus {
   VALID
   INVALID
@@ -382,6 +392,7 @@ type Query {
 
     """Limit nodes"""
     limit: Int = 1000
+    orderBy: NodeSortField! = CREATED_AT
   ): [Node!]!
 
   """Find nodes based on the search parameters with pagination"""
@@ -408,6 +419,7 @@ type Query {
 
     """Limit nodes"""
     limit: Int = 100
+    orderBy: NodeSortField! = CREATED_AT
   ): NodeConnection!
 
   """Get common dimensions for one or more nodes"""

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -476,15 +476,14 @@ class Node(Base):
         statement = select(Node).where(is_(Node.deactivated_at, None))
 
         # Join NodeRevision if needed for order_by or fragment filtering
-        join_revision = (
-            True
-            if fragment
-            or (order_by and getattr(order_by, "class_", None) is NodeRevision)
-            else False
+        order_by_node_revision = (
+            order_by and getattr(order_by, "class_", None) is NodeRevision
         )
+        join_revision = True if fragment or order_by_node_revision else False
         if join_revision:
             statement = statement.join(NodeRevisionAlias, Node.current)
-            order_by = getattr(NodeRevisionAlias, order_by.key)
+            if order_by_node_revision:
+                order_by = getattr(NodeRevisionAlias, order_by.key)
 
         if namespace:
             statement = statement.where(

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -266,8 +266,8 @@ async def test_find_by_node_type_paginated(
         "edges": [
             {
                 "node": {
-                    "currentVersion": "v1.4",
-                    "name": "default.repair_orders_fact",
+                    "currentVersion": "v1.0",
+                    "name": "default.regional_level_agg",
                     "tags": [],
                     "type": "TRANSFORM",
                 },

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -1201,3 +1201,51 @@ async def test_find_by_with_filtering_on_columns(
             "type": "SOURCE",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_find_by_with_ordering(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test finding nodes with ordering
+    """
+    query = """
+    {
+        findNodes(fragment: "default.", orderBy: NAME, ascending: true) {
+            name
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert [node["name"] for node in data["data"]["findNodes"]][:6] == [
+        "default.avg_length_of_employment",
+        "default.avg_repair_order_discounts",
+        "default.avg_repair_price",
+        "default.avg_time_to_dispatch",
+        "default.contractor",
+        "default.contractors",
+    ]
+
+    query = """
+    {
+        findNodes(fragment: "default.", orderBy: UPDATED_AT, ascending: true) {
+            name
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert [node["name"] for node in data["data"]["findNodes"]][:6] == [
+        "default.repair_orders_view",
+        "default.municipality_municipality_type",
+        "default.municipality_type",
+        "default.municipality",
+        "default.dispatchers",
+        "default.hard_hats",
+    ]

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
@@ -146,59 +146,60 @@ describe('NamespacePage', () => {
       </MemoryRouter>,
     );
 
-    await waitFor(
-      () => {
-        expect(mockDjClient.listNodesForLanding).toHaveBeenCalled();
-        expect(screen.getByText('Namespaces')).toBeInTheDocument();
+    // Wait for initial nodes to load
+    await waitFor(() => {
+      expect(mockDjClient.listNodesForLanding).toHaveBeenCalled();
+      expect(screen.getByText('Namespaces')).toBeInTheDocument();
+    });
 
-        // check that it displays namespaces
-        expect(screen.getByText('common')).toBeInTheDocument();
-        expect(screen.getByText('one')).toBeInTheDocument();
-        expect(screen.getByText('fruits')).toBeInTheDocument();
-        expect(screen.getByText('vegetables')).toBeInTheDocument();
+    // Check that it displays namespaces
+    expect(screen.getByText('common')).toBeInTheDocument();
+    expect(screen.getByText('one')).toBeInTheDocument();
+    expect(screen.getByText('fruits')).toBeInTheDocument();
+    expect(screen.getByText('vegetables')).toBeInTheDocument();
 
-        // check that it renders nodes
-        expect(screen.getByText('Test Node')).toBeInTheDocument();
+    // Check that it renders nodes
+    expect(screen.getByText('Test Node')).toBeInTheDocument();
 
-        // check that it sorts nodes
-        fireEvent.click(screen.getByText('name'));
-        fireEvent.click(screen.getByText('name'));
-        fireEvent.click(screen.getByText('display Name'));
+    // --- Sorting ---
 
-        // paginate
-        const previousButton = screen.getByText('← Previous');
-        expect(previousButton).toBeDefined();
-        fireEvent.click(previousButton);
-        const nextButton = screen.getByText('Next →');
-        expect(nextButton).toBeDefined();
-        fireEvent.click(nextButton);
+    // sort by 'name'
+    fireEvent.click(screen.getByText('name'));
+    await waitFor(() => {
+      expect(mockDjClient.listNodesForLanding).toHaveBeenCalledTimes(2);
+    });
 
-        // check that we can filter by node type
-        const selectNodeType = screen.getAllByTestId('select-node-type')[0];
-        expect(selectNodeType).toBeDefined();
-        expect(selectNodeType).not.toBeNull();
-        fireEvent.keyDown(selectNodeType.firstChild, { key: 'ArrowDown' });
-        fireEvent.click(screen.getByText('Source'));
+    // flip direction
+    fireEvent.click(screen.getByText('name'));
+    await waitFor(() => {
+      expect(mockDjClient.listNodesForLanding).toHaveBeenCalledTimes(3);
+    });
 
-        // check that we can filter by tag
-        const selectTag = screen.getAllByTestId('select-tag')[0];
-        expect(selectTag).toBeDefined();
-        expect(selectTag).not.toBeNull();
-        fireEvent.keyDown(selectTag.firstChild, { key: 'ArrowDown' });
+    // sort by 'displayName'
+    fireEvent.click(screen.getByText('display Name'));
+    await waitFor(() => {
+      expect(mockDjClient.listNodesForLanding).toHaveBeenCalledTimes(4);
+    });
 
-        // check that we can filter by user
-        const selectUser = screen.getAllByTestId('select-user')[0];
-        expect(selectUser).toBeDefined();
-        expect(selectUser).not.toBeNull();
-        fireEvent.keyDown(selectUser.firstChild, { key: 'ArrowDown' });
+    // --- Filters ---
 
-        // click to open and close tab
-        fireEvent.click(screen.getByText('common'));
-        fireEvent.click(screen.getByText('common'));
-      },
-      { timeout: 3000 },
-    );
-  }, 60000);
+    // Node type
+    const selectNodeType = screen.getAllByTestId('select-node-type')[0];
+    fireEvent.keyDown(selectNodeType.firstChild, { key: 'ArrowDown' });
+    fireEvent.click(screen.getByText('Source'));
+
+    // Tag filter
+    const selectTag = screen.getAllByTestId('select-tag')[0];
+    fireEvent.keyDown(selectTag.firstChild, { key: 'ArrowDown' });
+
+    // User filter
+    const selectUser = screen.getAllByTestId('select-user')[0];
+    fireEvent.keyDown(selectUser.firstChild, { key: 'ArrowDown' });
+
+    // --- Expand/Collapse Namespace ---
+    fireEvent.click(screen.getByText('common'));
+    fireEvent.click(screen.getByText('common'));
+  });
 
   it('can add new namespace via add namespace popover', async () => {
     mockDjClient.addNamespace.mockReturnValue({

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -124,8 +124,8 @@ export function NamespacePage() {
       const hierarchy = createNamespaceHierarchy(namespaces);
       setNamespaceHierarchy(hierarchy);
       const currentUser = await djClient.whoami();
+      // setFilters({...filters, edited_by: currentUser?.username});
       setCurrentUser(currentUser);
-      setFilters({...filters, edited_by: currentUser?.username});
     };
     fetchData().catch(console.error);
   }, [djClient, djClient.namespaces]);
@@ -299,12 +299,12 @@ export function NamespacePage() {
                 })
               }
             />
-            {currentUser ? <UserSelect
+            <UserSelect
               onChange={entry =>
                 setFilters({ ...filters, edited_by: entry ? entry.value : '' })
               }
               currentUser={currentUser?.username}
-            /> : ''}
+            />
             <AddNodeDropdown namespace={namespace} />
           </div>
           <div className="table-responsive">

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -53,34 +53,14 @@ export function NamespacePage() {
   const [hasNextPage, setHasNextPage] = useState(true);
   const [hasPrevPage, setHasPrevPage] = useState(true);
 
-  const sortedNodes = React.useMemo(() => {
-    let sortableData = [...Object.values(state.nodes)];
-    if (sortConfig !== null) {
-      sortableData.sort((a, b) => {
-        if (
-          a[sortConfig.key] < b[sortConfig.key] ||
-          a.current[sortConfig.key] < b.current[sortConfig.key]
-        ) {
-          return sortConfig.direction === ASC ? -1 : 1;
-        }
-        if (
-          a[sortConfig.key] > b[sortConfig.key] ||
-          a.current[sortConfig.key] > b.current[sortConfig.key]
-        ) {
-          return sortConfig.direction === ASC ? 1 : -1;
-        }
-        return 0;
-      });
-    }
-    return sortableData;
-  }, [state.nodes, filters, sortConfig]);
-
   const requestSort = key => {
     let direction = ASC;
     if (sortConfig.key === key && sortConfig.direction === ASC) {
       direction = DESC;
     }
-    setSortConfig({ key, direction });
+    if (sortConfig.key !== key || sortConfig.direction !== direction) {
+      setSortConfig({ key, direction });
+    }
   };
 
   const getClassNamesFor = name => {
@@ -171,7 +151,8 @@ export function NamespacePage() {
       setRetrieved(true);
     };
     fetchData().catch(console.error);
-  }, [djClient, filters, before, after, sortConfig]);
+  }, [djClient, filters, before, after, sortConfig.key, sortConfig.direction]);
+
   const loadNext = () => {
     if (nextCursor) {
       setAfter(nextCursor);
@@ -186,8 +167,8 @@ export function NamespacePage() {
   };
 
   const nodesList = retrieved ? (
-    sortedNodes.length > 0 ? (
-      sortedNodes.map(node => (
+    state.nodes.length > 0 ? (
+      state.nodes.map(node => (
         <tr key={node.name}>
           <td>
             <a href={'/nodes/' + node.name} className="link-table">

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -124,8 +124,8 @@ export function NamespacePage() {
       const hierarchy = createNamespaceHierarchy(namespaces);
       setNamespaceHierarchy(hierarchy);
       const currentUser = await djClient.whoami();
-      // setFilters({...filters, edited_by: currentUser?.username});
       setCurrentUser(currentUser);
+      setFilters({...filters, edited_by: currentUser?.username});
     };
     fetchData().catch(console.error);
   }, [djClient, djClient.namespaces]);
@@ -141,6 +141,7 @@ export function NamespacePage() {
         before,
         after,
         50,
+        sortConfig,
       );
 
       setState({
@@ -170,7 +171,7 @@ export function NamespacePage() {
       setRetrieved(true);
     };
     fetchData().catch(console.error);
-  }, [djClient, filters, before, after]);
+  }, [djClient, filters, before, after, sortConfig]);
   const loadNext = () => {
     if (nextCursor) {
       setAfter(nextCursor);
@@ -298,12 +299,12 @@ export function NamespacePage() {
                 })
               }
             />
-            <UserSelect
+            {currentUser ? <UserSelect
               onChange={entry =>
                 setFilters({ ...filters, edited_by: entry ? entry.value : '' })
               }
               currentUser={currentUser?.username}
-            />
+            /> : ''}
             <AddNodeDropdown namespace={namespace} />
           </div>
           <div className="table-responsive">

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -20,7 +20,7 @@ export const DataJunctionAPI = {
     sortConfig,
   ) {
     const query = `
-      query ListNodes($namespace: String, $nodeTypes: [NodeType!], $tags: [String!], $editedBy: String, $before: String, $after: String, $limit: Int, $orderBy: NodeSortField) {
+      query ListNodes($namespace: String, $nodeTypes: [NodeType!], $tags: [String!], $editedBy: String, $before: String, $after: String, $limit: Int, $orderBy: NodeSortField, $ascending: Boolean) {
         findNodesPaginated(
           namespace: $namespace
           nodeTypes: $nodeTypes
@@ -29,7 +29,8 @@ export const DataJunctionAPI = {
           limit: $limit
           before: $before
           after: $after
-          orderBy: $orderBy
+          orderBy: $orderBy,
+          ascending: $ascending
         ) {
           pageInfo {
             hasNextPage
@@ -86,6 +87,7 @@ export const DataJunctionAPI = {
             after: after,
             limit: limit,
             orderBy: sortOrderMapping[sortConfig.key],
+            ascending: sortConfig.direction === "ascending",
           },
         }),
       })

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -17,9 +17,10 @@ export const DataJunctionAPI = {
     before,
     after,
     limit,
+    sortConfig,
   ) {
     const query = `
-      query ListNodes($namespace: String, $nodeTypes: [NodeType!], $tags: [String!], $editedBy: String, $before: String, $after: String, $limit: Int) {
+      query ListNodes($namespace: String, $nodeTypes: [NodeType!], $tags: [String!], $editedBy: String, $before: String, $after: String, $limit: Int, $orderBy: NodeSortField) {
         findNodesPaginated(
           namespace: $namespace
           nodeTypes: $nodeTypes
@@ -28,6 +29,7 @@ export const DataJunctionAPI = {
           limit: $limit
           before: $before
           after: $after
+          orderBy: $orderBy
         ) {
           pageInfo {
             hasNextPage
@@ -58,6 +60,13 @@ export const DataJunctionAPI = {
         }
       }
     `;
+    const sortOrderMapping = {
+      name: 'NAME',
+      displayName: 'DISPLAY_NAME',
+      type: 'TYPE',
+      status: 'STATUS',
+      updatedAt: 'UPDATED_AT',
+    };
 
     return await (
       await fetch(DJ_GQL, {
@@ -76,6 +85,7 @@ export const DataJunctionAPI = {
             before: before,
             after: after,
             limit: limit,
+            orderBy: sortOrderMapping[sortConfig.key],
           },
         }),
       })

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -87,7 +87,7 @@ export const DataJunctionAPI = {
             after: after,
             limit: limit,
             orderBy: sortOrderMapping[sortConfig.key],
-            ascending: sortConfig.direction === "ascending",
+            ascending: sortConfig.direction === 'ascending',
           },
         }),
       })

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -1085,6 +1085,10 @@ describe('DataJunctionAPI', () => {
       null,
       null,
       100,
+      {
+        key: 'updatedAt',
+        direction: 'descending',
+      },
     );
     expect(fetch).toHaveBeenCalledWith(
       `${DJ_URL}/graphql`,


### PR DESCRIPTION
### Summary

This adds backend support for sorting by specific fields using the `findNodes` and `findNodesPaginated` GraphQL calls, and modifies the UI to pass in those fields when a user toggles the sort order.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1462
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
