### PR TITLE
Display fewer items in search list

### DIFF
--- a/datajunction-ui/src/app/components/Search.jsx
+++ b/datajunction-ui/src/app/components/Search.jsx
@@ -72,7 +72,7 @@ export default function Search() {
         />
       </form>
       <div className="search-results">
-        {searchResults.map(item => {
+        {searchResults.slice(0, 20).map(item => {
           const itemUrl =
             item.type !== 'tag' ? `/nodes/${item.name}` : `/tags/${item.name}`;
           return (


### PR DESCRIPTION
### Summary

The search list stretches to the end of the browser window when searching, which is a too long to actually use. This change limits it to 20 items, which is more manageable.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
