### PR TITLE
Fix unit test failures due to expired JWT token.

### DIFF
--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -3,7 +3,7 @@ Node materialization related APIs.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Callable, List
 
@@ -385,7 +385,7 @@ async def deactivate_node_materializations(
         node_version=node_revision.version,  # type: ignore
         request_headers=request_headers,
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     materialization_to_deactivate.deactivated_at = UTCDatetime(
         year=now.year,
         month=now.month,

--- a/datajunction-server/datajunction_server/internal/access/authentication/tokens.py
+++ b/datajunction-server/datajunction_server/internal/access/authentication/tokens.py
@@ -3,7 +3,7 @@ Helper functions for authentication tokens
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from jose import jwe, jwt
@@ -53,9 +53,9 @@ def create_token(
     """
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:  # pragma: no cover
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     to_encode.update({"iss": iss})
     encoded_jwt = jwt.encode(

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -4,7 +4,7 @@ Helper methods for namespaces endpoints.
 
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Dict, List, Tuple
 
 from sqlalchemy import or_, select
@@ -121,7 +121,7 @@ async def mark_namespace_deactivated(
     """
     Deactivates the node namespace and updates history indicating so
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     namespace.deactivated_at = UTCDatetime(
         year=now.year,
         month=now.month,


### PR DESCRIPTION
### Summary

Some unit tests were using a static `EXAMPLE_TOKEN` hard-coded in the test setup. This token has since expired, causing tests that validate tokens to fail with:
```
jose.exceptions.ExpiredSignatureError: Signature has expired
```

This change replaces the static token with a fresh token generated at test setup using `create_token()`.

### Test Plan

Ran tests locally

- [x] PR has an associated issue: #1471
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
