### PR TITLE
Support usage of relative urls for notifications backend call from UI

### DIFF
--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1363,13 +1363,9 @@ export const DataJunctionAPI = {
   },
   // GET /notifications/
   getNotificationPreferences: async function (params = {}) {
-    const url = new URL(`${DJ_URL}/notifications/`);
-    Object.entries(params).forEach(([key, value]) =>
-      url.searchParams.append(key, value),
-    );
-
+    const query = new URLSearchParams(params).toString();
     return await (
-      await fetch(url, {
+      await fetch(`${DJ_URL}/notifications/${query ? `?${query}` : ''}`, {
         credentials: 'include',
       })
     ).json();


### PR DESCRIPTION
### Summary

If the react env DJ url is set to a relative uri, it will fail because `URL` doesn't support relative uris. This change enables that support (which is in line with all other calls to the backend from the UI).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
