### PR TITLE
Support query params and caching in GQL measures SQL generation

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -4,9 +4,11 @@ import logging
 from functools import wraps
 
 import strawberry
-from fastapi import Depends
+from fastapi import Depends, Request, BackgroundTasks
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import Info
+
+from datajunction_server.internal.caching.cachelib_cache import get_cache
 from datajunction_server.api.graphql.queries.catalogs import list_catalogs
 from datajunction_server.api.graphql.queries.dag import (
     common_dimensions,
@@ -74,13 +76,21 @@ def log_resolver(func):
     return wrapper
 
 
-async def get_context(db_session=Depends(get_session)):
+async def get_context(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db_session=Depends(get_session),
+    cache=Depends(get_cache),
+):
     """
     Provides the context for graphql requests
     """
     return {
         "session": db_session,
         "settings": get_settings(),
+        "request": request,
+        "background_tasks": background_tasks,
+        "cache": cache,
     }
 
 

--- a/datajunction-server/datajunction_server/api/graphql/queries/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/sql.py
@@ -4,6 +4,7 @@ from typing import Annotated, Optional
 
 import strawberry
 from strawberry.types import Info
+from strawberry.scalars import JSON
 
 from datajunction_server.api.graphql.resolvers.nodes import (
     get_metrics,
@@ -49,6 +50,12 @@ async def measures_sql(
             "subsequent queries are more efficient.",
         ),
     ] = False,
+    query_parameters: Annotated[
+        JSON | None,
+        strawberry.argument(
+            description="Query parameters to include in the SQL",
+        ),
+    ] = None,
     *,
     info: Info,
 ) -> list[GeneratedSQL]:
@@ -68,6 +75,7 @@ async def measures_sql(
         include_all_columns=include_all_columns,
         use_materialized=use_materialized,
         preagg_requested=preaggregate,
+        query_parameters=query_parameters,
     )
     return [
         await GeneratedSQL.from_pydantic(info, measures_query)

--- a/datajunction-server/datajunction_server/api/graphql/queries/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/sql.py
@@ -28,7 +28,6 @@ from datajunction_server.api.graphql.scalars.sql import (
     VersionedRef,
     MetricComponent,
 )
-from datajunction_server.construction.build_v2 import get_measures_query
 from datajunction_server.construction.build import group_metrics_by_parent
 
 
@@ -73,7 +72,7 @@ async def measures_sql(
         cache=info.context["cache"],
         query_type=QueryBuildType.MEASURES,
     )
-    return await query_cache_manager.get_or_load(
+    queries = await query_cache_manager.get_or_load(
         info.context["background_tasks"],
         info.context["request"],
         QueryRequestParams(
@@ -87,22 +86,7 @@ async def measures_sql(
             include_all_columns=include_all_columns,
             preaggregate=preaggregate,
             use_materialized=use_materialized,
-            # current_user=current_user,
-            # validate_access=validate_access,
         ),
-    )
-    queries = await get_measures_query(
-        session=session,
-        metrics=metrics,  # type: ignore
-        dimensions=dimensions,  # type: ignore
-        filters=cube.filters,  # type: ignore
-        orderby=cube.orderby,
-        engine_name=engine.name if engine else None,
-        engine_version=engine.version if engine else None,
-        include_all_columns=include_all_columns,
-        use_materialized=use_materialized,
-        preagg_requested=preaggregate,
-        query_parameters=query_parameters,
     )
     return [
         await GeneratedSQL.from_pydantic(info, measures_query)

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -464,6 +464,9 @@ type Query {
     Whether to pre-aggregate to the requested dimensions so that subsequent queries are more efficient.
     """
     preaggregate: Boolean! = false
+
+    """Query parameters to include in the SQL"""
+    queryParameters: JSON = null
   ): [GeneratedSQL!]!
 
   """


### PR DESCRIPTION
### Summary

Two changes to the GraphQL measures SQL generation:
* Support passing in query parameters to GraphQL measures SQL requests.
* Leverage the caching layer for GraphQL measures SQL generation. This is already being used in the REST interface, but we can do the same for GraphQL.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
