### PR TITLE
Add caching for node and metrics SQL + reorganize 

### DIFF
--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -13,11 +13,13 @@ from sse_starlette.sse import EventSourceResponse
 
 from datajunction_server.models.user import UserOutput
 from datajunction_server.api.helpers import (
-    build_sql_for_multiple_metrics,
     resolve_engine,
     query_event_stream,
 )
-from datajunction_server.api.sql import build_node_sql
+from datajunction_server.internal.sql import (
+    build_node_sql,
+    build_sql_for_multiple_metrics,
+)
 from datajunction_server.api.helpers import get_save_history
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.history import History

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -491,7 +491,9 @@ async def check_dimension_attributes_exist(
             dimension_node_names,
             options=[
                 joinedload(Node.current).options(
-                    selectinload(NodeRevision.columns),
+                    selectinload(NodeRevision.columns).options(
+                        selectinload(Column.node_revisions),
+                    ),
                     defer(NodeRevision.query_ast),
                 ),
             ],

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -2,11 +2,9 @@
 SQL related APIs.
 """
 
-import json
 import logging
-from collections import OrderedDict
 from http import HTTPStatus
-from typing import Any, List, Optional, Tuple, cast
+from typing import List, Optional
 
 from fastapi import BackgroundTasks, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,27 +15,18 @@ from datajunction_server.internal.caching.query_cache_manager import (
     QueryCacheManager,
     QueryRequestParams,
 )
-from datajunction_server.api.helpers import (
-    assemble_column_metadata,
-    build_sql_for_multiple_metrics,
-    get_query,
-    validate_orderby,
-)
 from datajunction_server.internal.caching.cachelib_cache import get_cache
 from datajunction_server.internal.caching.interface import Cache
-from datajunction_server.database import Engine, Node
-from datajunction_server.database.queryrequest import QueryBuildType, QueryRequest
+from datajunction_server.database import Node
+from datajunction_server.database.queryrequest import QueryBuildType
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import validate_access
-from datajunction_server.internal.engines import get_engine
 from datajunction_server.models import access
-from datajunction_server.models.access import AccessControlStore
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.sql import GeneratedSQL
-from datajunction_server.models.user import UserOutput
 from datajunction_server.utils import (
     get_current_user,
     get_session,
@@ -122,161 +111,6 @@ async def get_measures_sql_for_cube_v2(
     )
 
 
-async def build_node_sql(
-    node_name: str,
-    dimensions: List[str] = Query([]),
-    filters: List[str] = Query([]),
-    orderby: List[str] = Query([]),
-    limit: Optional[int] = None,
-    *,
-    session: AsyncSession = Depends(get_session),
-    engine: Engine | None = None,
-    access_control: AccessControlStore | None = None,
-    ignore_errors: bool = True,
-    use_materialized: bool = True,
-    query_parameters: dict[str, Any] | None = None,
-) -> TranslatedSQL:
-    """
-    Build node SQL and save it to query requests
-    """
-    validate_orderby(orderby, [node_name], dimensions)
-
-    node = cast(
-        Node,
-        await Node.get_by_name(session, node_name, raise_if_not_exists=True),
-    )
-    if not engine:
-        engine = node.current.catalog.engines[0]
-
-    # If it's a cube, we'll build SQL for the metrics in the cube, along with any additional
-    # dimensions or filters provided in the arguments
-    if node.type == NodeType.CUBE:
-        node = cast(
-            Node,
-            await Node.get_cube_by_name(session, node_name),
-        )
-        dimensions = list(
-            OrderedDict.fromkeys(node.current.cube_node_dimensions + dimensions),
-        )
-        translated_sql, engine, _ = await build_sql_for_multiple_metrics(
-            session=session,
-            metrics=node.current.cube_node_metrics,
-            dimensions=dimensions,
-            filters=filters,
-            orderby=orderby,
-            limit=limit,
-            engine_name=engine.name if engine else None,
-            engine_version=engine.version if engine else None,
-            access_control=access_control,
-            use_materialized=use_materialized,
-            query_parameters=query_parameters,
-        )
-        return translated_sql
-
-    # For all other nodes, build the node query
-    node = await Node.get_by_name(session, node_name, raise_if_not_exists=True)  # type: ignore
-    if node.type == NodeType.METRIC:
-        translated_sql, engine, _ = await build_sql_for_multiple_metrics(
-            session,
-            [node_name],
-            dimensions,
-            filters,
-            orderby,
-            limit,
-            engine.name if engine else None,
-            engine.version if engine else None,
-            access_control=access_control,
-            ignore_errors=ignore_errors,
-            use_materialized=use_materialized,
-            query_parameters=query_parameters,
-        )
-        query = translated_sql.sql
-        columns = translated_sql.columns
-    else:
-        query_ast = await get_query(
-            session=session,
-            node_name=node_name,
-            dimensions=dimensions,
-            filters=filters,
-            orderby=orderby,
-            limit=limit,
-            engine=engine,
-            access_control=access_control,
-            use_materialized=use_materialized,
-            query_parameters=query_parameters,
-            ignore_errors=ignore_errors,
-        )
-        columns = [
-            assemble_column_metadata(col, use_semantic_metadata=True)  # type: ignore
-            for col in query_ast.select.projection
-        ]
-        query = str(query_ast)
-
-    return TranslatedSQL.create(
-        sql=query,
-        columns=columns,
-        dialect=engine.dialect if engine else None,
-    )
-
-
-async def get_node_sql(
-    node_name: str,
-    dimensions: List[str] = [],
-    filters: List[str] = [],
-    orderby: List[str] = [],
-    limit: Optional[int] = None,
-    *,
-    session: AsyncSession = Depends(get_session),
-    engine_name: Optional[str] = None,
-    engine_version: Optional[str] = None,
-    current_user: User,
-    validate_access: access.ValidateAccessFn,
-    background_tasks: BackgroundTasks,
-    ignore_errors: bool = True,
-    use_materialized: bool = True,
-    query_parameters: dict[str, Any] | None = None,
-    cache: Cache = None,
-) -> Tuple[TranslatedSQL, QueryRequest]:
-    """
-    Return SQL for a node.
-    """
-    dimensions = [dim for dim in dimensions if dim and dim != ""]
-    access_control = access.AccessControlStore(
-        validate_access=validate_access,
-        user=UserOutput.from_orm(current_user),
-        base_verb=access.ResourceRequestVerb.READ,
-    )
-
-    engine = (
-        await get_engine(session, engine_name, engine_version)  # type: ignore
-        if engine_name
-        else None
-    )
-    validate_orderby(orderby, [node_name], dimensions)
-
-    query_request = await build_node_sql(
-        node_name=node_name,
-        dimensions=dimensions,
-        filters=filters,
-        orderby=orderby,
-        limit=limit,
-        session=session,
-        engine=engine,  # type: ignore
-        access_control=access_control,
-        ignore_errors=ignore_errors,
-        use_materialized=use_materialized,
-        query_parameters=query_parameters,
-    )
-    return (
-        TranslatedSQL.create(
-            sql=query_request.sql,
-            columns=query_request.columns,
-            dialect=engine.dialect if engine else None,
-        ),
-        query_request,
-    )
-
-
 @router.get(
     "/sql/{node_name}/",
     response_model=TranslatedSQL,
@@ -349,17 +183,12 @@ async def get_sql_for_metrics(
     ignore_errors: Optional[bool] = True,
     use_materialized: Optional[bool] = True,
     background_tasks: BackgroundTasks,
+    cache: Cache = Depends(get_cache),
+    request: Request,
 ) -> TranslatedSQL:
     """
     Return SQL for a set of metrics with dimensions and filters
     """
-
-    access_control = access.AccessControlStore(
-        validate_access=validate_access,
-        user=current_user,
-        base_verb=access.ResourceRequestVerb.READ,
-    )
-
     # make sure all metrics exist and have correct node type
     nodes = [
         await Node.get_by_name(session, node, raise_if_not_exists=True)
@@ -374,108 +203,25 @@ async def get_sql_for_metrics(
             http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         )
 
-    if (
-        query_request := await QueryRequest.get_query_request(
-            session,
+    query_cache_manager = QueryCacheManager(
+        cache=cache,
+        query_type=QueryBuildType.METRICS,
+    )
+    return await query_cache_manager.get_or_load(
+        background_tasks,
+        request,
+        QueryRequestParams(
             nodes=metrics,
             dimensions=dimensions,
             filters=filters,
-            orderby=orderby,
             limit=limit,
+            orderby=orderby,
+            query_params=query_params,
             engine_name=engine_name,
             engine_version=engine_version,
-            query_type=QueryBuildType.METRICS,
-        )
-    ) and not query_params:
-        # Update the node SQL in a background task to keep it up-to-date
-        background_tasks.add_task(  # pragma: no cover
-            build_and_save_sql_for_metrics,
-            session=session,
-            metrics=metrics,
-            dimensions=dimensions,
-            filters=filters,
-            orderby=orderby,
-            limit=limit,
-            engine_name=engine_name,
-            engine_version=engine_version,
-            access_control=access_control,
-            ignore_errors=ignore_errors,
             use_materialized=use_materialized,
-            query_parameters=json.loads(query_params),
-            save=False,
-        )
-        engine = (  # pragma: no cover
-            await get_engine(session, engine_name, engine_version)  # type: ignore
-            if engine_name
-            else None
-        )
-        return TranslatedSQL.create(  # pragma: no cover
-            sql=query_request.query,
-            columns=query_request.columns,
-            dialect=engine.dialect if engine else None,
-        )
-
-    return await build_and_save_sql_for_metrics(
-        session,
-        metrics,
-        dimensions,
-        filters,
-        orderby,
-        limit,
-        engine_name,
-        engine_version,
-        access_control,
-        ignore_errors=ignore_errors,  # type: ignore
-        use_materialized=use_materialized,  # type: ignore
-        query_parameters=json.loads(query_params),
-        save=False,
+            ignore_errors=ignore_errors,
+            current_user=current_user,
+            validate_access=validate_access,
+        ),
     )
-
-
-async def build_and_save_sql_for_metrics(
-    session: AsyncSession,
-    metrics: List[str],
-    dimensions: List[str],
-    filters: List[str] = None,
-    orderby: List[str] = None,
-    limit: Optional[int] = None,
-    engine_name: Optional[str] = None,
-    engine_version: Optional[str] = None,
-    access_control: Optional[access.AccessControlStore] = None,
-    ignore_errors: bool = True,
-    use_materialized: bool = True,
-    query_parameters: dict[str, Any] | None = None,
-    save: bool = True,
-):
-    """
-    Builds and saves SQL for metrics.
-    """
-    translated_sql, _, _ = await build_sql_for_multiple_metrics(
-        session,
-        metrics,
-        dimensions,
-        filters,
-        orderby,
-        limit,
-        engine_name,
-        engine_version,
-        access_control,
-        ignore_errors=ignore_errors,  # type: ignore
-        use_materialized=use_materialized,  # type: ignore
-        query_parameters=query_parameters,
-    )
-    if save:
-        await QueryRequest.save_query_request(  # pragma: no cover
-            session=session,
-            nodes=metrics,
-            dimensions=dimensions,
-            filters=filters,  # type: ignore
-            orderby=orderby,  # type: ignore
-            limit=limit,
-            engine_name=engine_name,
-            engine_version=engine_version,
-            query_type=QueryBuildType.METRICS,
-            query=translated_sql.sql,
-            columns=[col.dict() for col in translated_sql.columns],  # type: ignore
-        )
-    return translated_sql

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_catalog_by_name
-from datajunction_server.construction.build_v2 import get_measures_query
+from datajunction_server.internal.sql import get_measures_query
 from datajunction_server.database.node import NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJInvalidInputException

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -534,12 +534,16 @@ class VersionedQueryKey:
         """
         Versions the dimensions by creating a versioned node key for each dimension.
         """
-        node_names = [".".join(dim.split(".")[:-1]) for dim in dimensions]
+        node_names = [
+            name
+            for name in [".".join(dim.split(".")[:-1]) for dim in dimensions]
+            if name
+        ]
         dimension_nodes = {
             node.name: node
             for node in await Node.get_by_names(
                 session,
-                [".".join(dim.split(".")[:-1]) for dim in dimensions],
+                node_names,
             )
         }
         return [

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -456,7 +456,9 @@ class VersionedQueryKey:
             },
         )
         versioned_nodes = [
-            VersionedNodeKey.from_node(nodes_objs[node_name]) for node_name in nodes
+            VersionedNodeKey.from_node(nodes_objs[node_name])
+            for node_name in nodes
+            if node_name in nodes_objs
         ]
         return versioned_nodes, versioned_parents
 
@@ -485,7 +487,7 @@ class VersionedQueryKey:
             VersionedNodeKey(
                 dim,
                 dimension_nodes[name].current_version
-                if dimension_nodes[name]
+                if name in dimension_nodes and dimension_nodes[name]
                 else current_node.version
                 if current_node
                 else None,

--- a/datajunction-server/datajunction_server/database/queryrequest.py
+++ b/datajunction-server/datajunction_server/database/queryrequest.py
@@ -3,8 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import partial
-from http import HTTPStatus
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from sqlalchemy import (
     JSON,
@@ -12,8 +11,6 @@ from sqlalchemy import (
     DateTime,
     Enum,
     UniqueConstraint,
-    and_,
-    select,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -24,12 +21,6 @@ from datajunction_server.construction.utils import to_namespaced_name
 from datajunction_server.database.base import Base
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.enum import StrEnum
-from datajunction_server.errors import DJInvalidInputException
-from datajunction_server.sql.dag import (
-    get_dimensions,
-    get_shared_dimensions,
-    get_upstream_nodes,
-)
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.typing import UTCDatetime
@@ -163,185 +154,6 @@ class QueryRequest(Base):  # type: ignore
     )
     # External identifier for the query
     query_id: Mapped[Optional[str]]
-
-    @classmethod
-    async def get_query_request(
-        cls,
-        session: AsyncSession,
-        query_type: QueryBuildType,
-        nodes: List[str],
-        dimensions: List[str],
-        filters: List[str],
-        engine_name: Optional[str],
-        engine_version: Optional[str],
-        limit: Optional[int],
-        orderby: List[str],
-        other_args: Optional[Dict[str, Any]] = None,
-    ) -> Optional["QueryRequest"]:
-        """
-        Retrieves saved query for a node SQL request
-        """
-        versioned_request = await cls.to_versioned_query_request(
-            session,
-            nodes,
-            dimensions,
-            filters,
-            orderby,
-            query_type,
-        )
-        statement = select(cls).where(
-            and_(
-                cls.query_type == query_type,
-                cls.nodes == (versioned_request["nodes"] or text("'[]'::jsonb")),
-                cls.parents == (versioned_request["parents"] or text("'[]'::jsonb")),
-                cls.dimensions
-                == (versioned_request["dimensions"] or text("'[]'::jsonb")),
-                cls.filters == (versioned_request["filters"] or text("'[]'::jsonb")),
-                cls.engine_name == engine_name,
-                cls.engine_version == engine_version,
-                cls.limit == limit,
-                cls.orderby == (versioned_request["orderby"] or text("'[]'::jsonb")),
-                cls.other_args == (other_args or text("'{}'::jsonb")),
-            ),
-        )
-        query_request = (await session.execute(statement)).scalar_one_or_none()
-        if query_request:
-            return query_request  # pragma: no cover
-        return None
-
-    @classmethod
-    async def to_versioned_query_request(
-        cls,
-        session: AsyncSession,
-        nodes: List[str],
-        dimensions: List[str],
-        filters: List[str],
-        orderby: List[str],
-        query_type: QueryBuildType,
-    ) -> Dict[str, List[str]]:
-        """
-        Prepare for searching in saved query requests by appending version numbers to all nodes
-        being worked with.
-        """
-        nodes_objs = [
-            await Node.get_by_name(
-                session,
-                node,
-                options=[
-                    joinedload(Node.current).options(
-                        selectinload(NodeRevision.columns),
-                        selectinload(NodeRevision.parents).options(
-                            joinedload(Node.current),
-                        ),
-                    ),
-                ],
-                raise_if_not_exists=True,
-            )
-            for node in nodes
-        ]
-
-        if not nodes_objs and query_type in (
-            QueryBuildType.MEASURES,
-            QueryBuildType.METRICS,
-        ):
-            raise DJInvalidInputException(
-                message="At least one metric is required",
-                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            )
-        node_columns = []
-        if len(nodes_objs) == 1:
-            node_columns = [col.name for col in nodes_objs[0].current.columns]  # type: ignore
-        available_dimensions = {
-            dim.name
-            for dim in (
-                await get_dimensions(session, nodes_objs[0])  # type: ignore
-                if len(nodes_objs) == 1
-                else await get_shared_dimensions(session, nodes_objs)  # type: ignore
-            )
-        }.union(set(node_columns))
-        invalid_dimensions = sorted(
-            list(set(dimensions).difference(available_dimensions)),
-        )
-        if dimensions and invalid_dimensions:
-            raise DJInvalidInputException(
-                f"{', '.join(invalid_dimensions)} are not available "
-                f"dimensions on {', '.join(nodes)}",
-            )
-
-        dimension_nodes = [
-            await Node.get_by_name(session, ".".join(dim.split(".")[:-1]), options=[])
-            for dim in dimensions
-        ]
-        filter_asts = {
-            filter_: parse(f"SELECT 1 WHERE {filter_}")
-            for filter_ in filters
-            if filter_
-        }
-        for filter_ in filter_asts:
-            for col in filter_asts[filter_].select.where.find_all(ast.Column):  # type: ignore
-                if isinstance(col.parent, ast.Subscript):
-                    if isinstance(col.parent.index, ast.Lambda):
-                        col.role = str(col.parent.index)
-                    else:
-                        col.role = col.parent.index.identifier()  # type: ignore
-                    col.parent.swap(col)
-                dimension_node = await Node.get_by_name(
-                    session,
-                    ".".join(col.identifier().split(".")[:-1]),  # type: ignore
-                    options=[],
-                )
-                if dimension_node:
-                    col.alias_or_name.name = to_namespaced_name(
-                        f"{col.alias_or_name.name}{'[' + col.role + ']' if col.role else ''}"
-                        f"@{dimension_node.current_version}",  # type: ignore
-                    )
-
-        orders = []
-        for order in orderby:
-            order_rule = order.split(" ")
-            metric = await Node.get_by_name(session, order_rule[0], options=[])
-            if metric:
-                order_rule[0] = f"{metric.name}@{metric.current_version}"
-            else:
-                node = await Node.get_by_name(
-                    session,
-                    ".".join(order_rule[0].split(".")[:-1]),
-                    options=[],
-                )
-                order_rule[0] = f"{order_rule[0]}@{node.current_version}"  # type: ignore
-            orders.append(" ".join(order_rule))
-
-        parents = [
-            upstream
-            for node in nodes
-            for upstream in await get_upstream_nodes(session, node)
-        ]
-        return {
-            "nodes": [
-                f"{node.name}@{node.current_version}"  # type: ignore
-                for node in nodes_objs
-            ],
-            "parents": sorted(
-                list(
-                    {
-                        f"{parent.name}@{parent.current_version}"  # type: ignore
-                        for parent in parents
-                    },
-                ),
-            ),
-            "dimensions": [
-                (
-                    f"{dim}@{node.current_version}"
-                    if node
-                    else f"{dim}@{nodes_objs[0].current_version}"  # type: ignore
-                )
-                for node, dim in zip(dimension_nodes, dimensions)
-            ],
-            "filters": [
-                str(filter_ast.select.where) for filter_ast in filter_asts.values()
-            ],
-            "orderby": orders,
-        }
 
 
 @dataclass(order=True)

--- a/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
@@ -112,7 +112,7 @@ class QueryCacheManager(RefreshAheadCacheManager):
                         query_parameters,
                         access_control_store,
                     )
-                case QueryBuildType.METRICS:
+                case QueryBuildType.METRICS:  # pragma: no cover
                     return await self._build_metrics_query(
                         session,
                         params,

--- a/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
@@ -89,10 +89,14 @@ class QueryCacheManager(RefreshAheadCacheManager):
             query_parameters = (
                 json.loads(params.query_params) if params.query_params else {}
             )
-            access_control_store = access.AccessControlStore(
-                validate_access=params.validate_access,
-                user=params.current_user,
-                base_verb=access.ResourceRequestVerb.READ,
+            access_control_store = (
+                access.AccessControlStore(
+                    validate_access=params.validate_access,
+                    user=params.current_user,
+                    base_verb=access.ResourceRequestVerb.READ,
+                )
+                if params.validate_access
+                else None
             )
             match self.query_type:
                 case QueryBuildType.MEASURES:
@@ -173,7 +177,7 @@ class QueryCacheManager(RefreshAheadCacheManager):
         session: AsyncSession,
         params: QueryRequestParams,
         query_parameters: dict[str, Any],
-        access_control_store: access.AccessControlStore,
+        access_control_store: access.AccessControlStore | None = None,
     ) -> TranslatedSQL:
         engine = (
             await get_engine(session, params.engine_name, params.engine_version)  # type: ignore
@@ -204,7 +208,7 @@ class QueryCacheManager(RefreshAheadCacheManager):
         session: AsyncSession,
         params: QueryRequestParams,
         query_parameters: dict[str, Any],
-        access_control_store: access.AccessControlStore,
+        access_control_store: access.AccessControlStore | None = None,
     ) -> TranslatedSQL:
         built_sql, _, _ = await build_sql_for_multiple_metrics(
             session=session,

--- a/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
@@ -126,6 +126,11 @@ class QueryCacheManager(RefreshAheadCacheManager):
                     query_parameters=json.loads(params.query_params)
                     if params.query_params
                     else {},
+                    access_control=access.AccessControlStore(
+                        validate_access=params.validate_access,
+                        user=params.current_user,
+                        base_verb=access.ResourceRequestVerb.READ,
+                    ),
                 )
                 return TranslatedSQL.create(
                     sql=built_sql.sql,

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -5,7 +5,7 @@ import itertools
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.sql.parsing.backends.antlr4 import parse
-from datajunction_server.construction.build_v2 import get_measures_query
+from datajunction_server.internal.sql import get_measures_query
 from datajunction_server.database.node import Column, NodeRevision
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.column import SemanticType

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -8,9 +8,10 @@ from pydantic import ValidationError
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from datajunction_server.api.helpers import build_sql_for_multiple_metrics
+from datajunction_server.internal.sql import build_sql_for_multiple_metrics
 from datajunction_server.construction.build import get_default_criteria
-from datajunction_server.construction.build_v2 import QueryBuilder, get_measures_query
+from datajunction_server.construction.build_v2 import QueryBuilder
+from datajunction_server.internal.sql import get_measures_query
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import NodeRevision
 from datajunction_server.database.user import User

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -73,7 +73,7 @@ async def build_node_sql(
         Node,
         await Node.get_by_name(session, node_name, raise_if_not_exists=True),
     )
-    if not engine:
+    if not engine:  # pragma: no cover
         engine = node.current.catalog.engines[0]
 
     # If it's a cube, we'll build SQL for the metrics in the cube, along with any additional

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -1,0 +1,503 @@
+import logging
+from typing import Any, Tuple, OrderedDict, cast
+import re
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from datajunction_server.api.helpers import (
+    assemble_column_metadata,
+    find_existing_cube,
+    get_catalog_by_name,
+    get_query,
+    validate_orderby,
+    validate_cube,
+    check_dimension_attributes_exist,
+    check_metrics_exist,
+)
+from datajunction_server.construction.build import (
+    build_materialized_cube_node,
+    build_metric_nodes,
+    group_metrics_by_parent,
+    extract_components_and_parent_columns,
+    rename_columns,
+)
+from datajunction_server.construction.build_v2 import (
+    QueryBuilder,
+    build_preaggregate_query,
+    get_dimensions_referenced_in_metrics,
+)
+from datajunction_server.database import Engine
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import User
+from datajunction_server.database.catalog import Catalog
+from datajunction_server.errors import DJInvalidInputException, DJException
+from datajunction_server.internal.engines import get_engine
+from datajunction_server.models import access
+from datajunction_server.models.column import SemanticType
+from datajunction_server.models.cube_materialization import Aggregability
+from datajunction_server.models.engine import Dialect
+from datajunction_server.models.metric import TranslatedSQL
+from datajunction_server.models.node import BuildCriteria
+from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.query import ColumnMetadata
+from datajunction_server.models.sql import GeneratedSQL
+from datajunction_server.naming import LOOKUP_CHARS, from_amenable_name
+from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.ast import CompileContext
+from datajunction_server.utils import SEPARATOR, refresh_if_needed
+
+logger = logging.getLogger(__name__)
+
+
+async def build_node_sql(
+    session: AsyncSession,
+    node_name: str,
+    dimensions: list[str] | None = None,
+    filters: list[str] | None = None,
+    orderby: list[str] | None = None,
+    limit: int | None = None,
+    engine: Engine | None = None,
+    access_control: access.AccessControlStore | None = None,
+    ignore_errors: bool = True,
+    use_materialized: bool = True,
+    query_parameters: dict[str, Any] | None = None,
+) -> TranslatedSQL:
+    """
+    Build node SQL and save it to query requests
+    """
+    if orderby:
+        validate_orderby(orderby, [node_name], dimensions or [])
+
+    node = cast(
+        Node,
+        await Node.get_by_name(session, node_name, raise_if_not_exists=True),
+    )
+    if not engine:
+        engine = node.current.catalog.engines[0]
+
+    # If it's a cube, we'll build SQL for the metrics in the cube, along with any additional
+    # dimensions or filters provided in the arguments
+    if node.type == NodeType.CUBE:
+        node = cast(
+            Node,
+            await Node.get_cube_by_name(session, node_name),
+        )
+        dimensions = list(
+            OrderedDict.fromkeys(node.current.cube_node_dimensions + dimensions),
+        )
+        translated_sql, engine, _ = await build_sql_for_multiple_metrics(
+            session=session,
+            metrics=node.current.cube_node_metrics,
+            dimensions=dimensions,
+            filters=filters,
+            orderby=orderby,
+            limit=limit,
+            engine_name=engine.name if engine else None,
+            engine_version=engine.version if engine else None,
+            access_control=access_control,
+            use_materialized=use_materialized,
+            query_parameters=query_parameters,
+        )
+        return translated_sql
+
+    # For all other nodes, build the node query
+    node = await Node.get_by_name(session, node_name, raise_if_not_exists=True)  # type: ignore
+    if node.type == NodeType.METRIC:
+        translated_sql, engine, _ = await build_sql_for_multiple_metrics(
+            session,
+            [node_name],
+            dimensions or [],
+            filters or [],
+            orderby or [],
+            limit,
+            engine.name if engine else None,
+            engine.version if engine else None,
+            access_control=access_control,
+            ignore_errors=ignore_errors,
+            use_materialized=use_materialized,
+            query_parameters=query_parameters,
+        )
+        query = translated_sql.sql
+        columns = translated_sql.columns
+    else:
+        query_ast = await get_query(
+            session=session,
+            node_name=node_name,
+            dimensions=dimensions or [],
+            filters=filters or [],
+            orderby=orderby or [],
+            limit=limit,
+            engine=engine,
+            access_control=access_control,
+            use_materialized=use_materialized,
+            query_parameters=query_parameters,
+            ignore_errors=ignore_errors,
+        )
+        columns = [
+            assemble_column_metadata(col, use_semantic_metadata=True)  # type: ignore
+            for col in query_ast.select.projection
+        ]
+        query = str(query_ast)
+
+    return TranslatedSQL.create(
+        sql=query,
+        columns=columns,
+        dialect=engine.dialect if engine else None,
+    )
+
+
+async def build_sql_for_multiple_metrics(
+    session: AsyncSession,
+    metrics: list[str],
+    dimensions: list[str],
+    filters: list[str] = None,
+    orderby: list[str] = None,
+    limit: int | None = None,
+    engine_name: str | None = None,
+    engine_version: str | None = None,
+    access_control: access.AccessControlStore | None = None,
+    ignore_errors: bool = True,
+    use_materialized: bool = True,
+    query_parameters: dict[str, str] | None = None,
+) -> Tuple[TranslatedSQL, Engine, Catalog]:
+    """
+    Build SQL for multiple metrics. Used by both /sql and /data endpoints
+    """
+    if not filters:
+        filters = []
+    if not orderby:
+        orderby = []
+
+    metric_columns, metric_nodes, _, dimension_columns, _ = await validate_cube(
+        session,
+        metrics,
+        dimensions,
+        require_dimensions=False,
+    )
+    leading_metric_node = await Node.get_by_name(
+        session,
+        metrics[0],
+        options=[
+            joinedload(Node.current).options(
+                joinedload(NodeRevision.catalog).options(joinedload(Catalog.engines)),
+            ),
+        ],
+    )
+    if access_control:
+        access_control.add_request_by_node(leading_metric_node.current)  # type: ignore
+    available_engines = (
+        leading_metric_node.current.catalog.engines  # type: ignore
+        if leading_metric_node.current.catalog  # type: ignore
+        else []
+    )
+
+    # Try to find a built cube that already has the given metrics and dimensions
+    # The cube needs to have a materialization configured and an availability state
+    # posted in order for us to use the materialized datasource
+    cube = await find_existing_cube(
+        session,
+        metric_columns,
+        dimension_columns,
+        materialized=True,
+    )
+    materialized_cube_catalog = None
+    if cube:
+        materialized_cube_catalog = await get_catalog_by_name(
+            session,
+            cube.availability.catalog,  # type: ignore
+        )
+
+    # Check if selected engine is available
+    engine = (
+        await get_engine(session, engine_name, engine_version)  # type: ignore
+        if engine_name
+        else available_engines[0]
+    )
+    if engine not in available_engines:
+        raise DJInvalidInputException(  # pragma: no cover
+            f"The selected engine is not available for the node {metrics[0]}. "
+            f"Available engines include: {', '.join(engine.name for engine in available_engines)}",
+        )
+
+    # Do not use the materialized cube if the chosen engine is not available for
+    # the materialized cube's catalog
+    if (
+        cube
+        and materialized_cube_catalog
+        and engine.name not in [eng.name for eng in materialized_cube_catalog.engines]
+    ):
+        cube = None
+
+    if orderby:
+        validate_orderby(orderby, metrics, dimensions)
+
+    if cube and cube.availability and use_materialized and materialized_cube_catalog:
+        if access_control:  # pragma: no cover
+            access_control.add_request_by_node(cube)
+            access_control.state = access.AccessControlState.INDIRECT
+            access_control.raise_if_invalid_requests()
+        query_ast = build_materialized_cube_node(
+            metric_columns,
+            dimension_columns,
+            cube,
+            filters,
+            orderby,
+            limit,
+        )
+        query_metric_columns = [
+            ColumnMetadata(
+                name=col.name,
+                type=str(col.type),
+                column=col.name,
+                node=col.node_revision().name,  # type: ignore
+            )
+            for col in metric_columns
+        ]
+        query_dimension_columns = [
+            ColumnMetadata(
+                name=(col.node_revision().name + SEPARATOR + col.name).replace(  # type: ignore
+                    SEPARATOR,
+                    f"_{LOOKUP_CHARS.get(SEPARATOR)}_",
+                ),
+                type=str(col.type),
+                node=col.node_revision().name,  # type: ignore
+                column=col.name,  # type: ignore
+            )
+            for col in dimension_columns
+        ]
+        engine = materialized_cube_catalog.engines[0]
+        return (
+            TranslatedSQL.create(
+                sql=str(query_ast),
+                columns=query_metric_columns + query_dimension_columns,
+                dialect=materialized_cube_catalog.engines[0].dialect,
+            ),
+            engine,
+            cube.catalog,
+        )
+
+    query_ast = await build_metric_nodes(
+        session,
+        metric_nodes,
+        filters=filters or [],
+        dimensions=dimensions or [],
+        orderby=orderby or [],
+        limit=limit,
+        access_control=access_control,
+        ignore_errors=ignore_errors,
+        query_parameters=query_parameters,
+    )
+    columns = [
+        assemble_column_metadata(col, use_semantic_metadata=True)  # type: ignore
+        for col in query_ast.select.projection
+    ]
+    upstream_tables = [tbl for tbl in query_ast.find_all(ast.Table) if tbl.dj_node]
+    for tbl in upstream_tables:
+        await refresh_if_needed(session, tbl.dj_node, ["availability"])
+    return (
+        TranslatedSQL.create(
+            sql=str(query_ast),
+            columns=columns,
+            dialect=engine.dialect if engine else None,
+            upstream_tables=[
+                f"{leading_metric_node.current.catalog.name}.{tbl.identifier()}"  # type: ignore
+                for tbl in upstream_tables
+                # If a table has a corresponding node with an associated physical table (either
+                # a source node or a node with a materialized table).
+                if cast(NodeRevision, tbl.dj_node).type == NodeType.SOURCE
+                or cast(NodeRevision, tbl.dj_node).availability is not None
+            ],
+        ),
+        engine,
+        leading_metric_node.current.catalog,  # type: ignore
+    )
+
+
+async def get_measures_query(
+    session: AsyncSession,
+    metrics: list[str],
+    dimensions: list[str],
+    filters: list[str],
+    orderby: list[str] = None,
+    engine_name: str | None = None,
+    engine_version: str | None = None,
+    current_user: User | None = None,
+    validate_access: access.ValidateAccessFn = None,
+    include_all_columns: bool = False,
+    use_materialized: bool = True,
+    preagg_requested: bool = False,
+    query_parameters: dict[str, Any] = None,
+) -> list[GeneratedSQL]:
+    """
+    Builds the measures SQL for a set of metrics with dimensions and filters.
+
+    Measures queries are generated at the grain of each of the metrics' upstream nodes.
+    For example, if some of your metrics are aggregations on measures in parent node A
+    and others are aggregations on measures in parent node B, this function will return a
+    dictionary that maps A to the measures query for A, and B to the measures query for B.
+    """
+    engine = (
+        await get_engine(session, engine_name, engine_version) if engine_name else None  # type: ignore
+    )
+    build_criteria = BuildCriteria(
+        dialect=engine.dialect if engine and engine.dialect else Dialect.SPARK,
+    )
+    access_control = (
+        access.AccessControlStore(
+            validate_access=validate_access,
+            user=current_user,
+            base_verb=access.ResourceRequestVerb.READ,
+        )
+        if validate_access
+        else None
+    )
+
+    if not filters:
+        filters = []
+
+    metrics_sorting_order = {val: idx for idx, val in enumerate(metrics)}
+    metric_nodes = await check_metrics_exist(session, metrics)
+    await check_dimension_attributes_exist(session, dimensions)
+
+    common_parents = group_metrics_by_parent(metric_nodes)
+    parent_columns, metric_components = extract_components_and_parent_columns(
+        metric_nodes,
+    )
+
+    column_name_regex = r"([A-Za-z0-9_\.]+)(\[[A-Za-z0-9_]+\])?"
+    matcher = re.compile(column_name_regex)
+
+    # Find any dimensions referenced in the metric definitions and add to requested dimensions
+    dimensions.extend(
+        [
+            dim
+            for dim in get_dimensions_referenced_in_metrics(metric_nodes)
+            if dim not in dimensions
+        ],
+    )
+
+    dimensions_without_roles = [matcher.findall(dim)[0][0] for dim in dimensions]
+
+    measures_queries = []
+    context = CompileContext(session=session, exception=DJException())
+    for parent_node, children in common_parents.items():  # type: ignore
+        children = sorted(children, key=lambda x: metrics_sorting_order.get(x.name, 0))
+
+        # Determine whether to pre-aggregate to the requested dimensions so that subsequent
+        # queries are more efficient by checking the measures on the requested metrics
+        preaggregate = preagg_requested and all(
+            len(metric_components[metric.name][0]) > 0
+            and all(
+                measure.rule.type in (Aggregability.FULL, Aggregability.LIMITED)
+                for measure in metric_components[metric.name][0]
+            )
+            for metric in children
+        )
+
+        measure_columns, dimensional_columns = [], []
+        await refresh_if_needed(session, parent_node, ["current"])
+        query_builder = await QueryBuilder.create(
+            session,
+            parent_node.current,
+            use_materialized=use_materialized,
+        )
+        parent_ast = await (
+            query_builder.ignore_errors()
+            .with_access_control(access_control)
+            .with_build_criteria(build_criteria)
+            .add_dimensions(dimensions)
+            .add_filters(filters)
+            .add_query_parameters(query_parameters)
+            .order_by(orderby)
+            .build()
+        )
+
+        # Select only columns that were one of the necessary measures
+        if not include_all_columns:
+            parent_ast.select.projection = [
+                expr
+                for expr in parent_ast.select.projection
+                if (
+                    (identifier := expr.alias_or_name.identifier(False))
+                    and (
+                        from_amenable_name(identifier).split(SEPARATOR)[-1]
+                        in parent_columns[parent_node.name]
+                        or identifier in parent_columns[parent_node.name]
+                        or expr.semantic_entity in dimensions_without_roles
+                        or from_amenable_name(identifier) in dimensions_without_roles
+                    )
+                )
+            ]
+
+        await refresh_if_needed(session, parent_node.current, ["columns"])
+        parent_ast = rename_columns(parent_ast, parent_node.current, preaggregate)
+
+        # Sort the selected columns into dimension vs measure columns and
+        # generate identifiers for them
+        for expr in parent_ast.select.projection:
+            column_identifier = expr.alias_or_name.identifier(False)  # type: ignore
+            if from_amenable_name(column_identifier) in dimensions_without_roles:
+                dimensional_columns.append(expr)
+                expr.set_semantic_type(SemanticType.DIMENSION)  # type: ignore
+            else:
+                measure_columns.append(expr)
+                expr.set_semantic_type(SemanticType.MEASURE)  # type: ignore
+        await parent_ast.compile(context)
+        dependencies, _ = await parent_ast.extract_dependencies(
+            CompileContext(session, DJException()),
+        )
+
+        final_query = (
+            build_preaggregate_query(
+                parent_ast,
+                parent_node,
+                dimensional_columns,
+                children,
+                metric_components,
+            )
+            if preaggregate
+            else parent_ast
+        )
+
+        # Build translated SQL object
+        columns_metadata = [
+            assemble_column_metadata(  # pragma: no cover
+                cast(ast.Column, col),
+                preaggregate,
+            )
+            for col in final_query.select.projection
+        ]
+        measures_queries.append(
+            GeneratedSQL.create(
+                node=parent_node.current,
+                sql=str(final_query),
+                columns=columns_metadata,
+                dialect=build_criteria.dialect,
+                upstream_tables=[
+                    f"{dep.catalog.name}.{dep.schema_}.{dep.table}"
+                    for dep in dependencies
+                    if dep.type == NodeType.SOURCE
+                ],
+                grain=(
+                    [
+                        col.name
+                        for col in columns_metadata
+                        if col.semantic_type == SemanticType.DIMENSION
+                    ]
+                    if preaggregate
+                    else [pk_col.name for pk_col in parent_node.current.primary_key()]
+                ),
+                errors=query_builder.errors,
+                metrics={
+                    metric.name: (
+                        metric_components[metric.name][0],
+                        str(metric_components[metric.name][1]).replace("\n", "")
+                        if preaggregate
+                        else metric.query,
+                    )
+                    for metric in children
+                },
+            ),
+        )
+    return measures_queries

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -36,10 +36,9 @@ class TestDataForNode:
             },
         )
         data = response.json()
-        assert response.status_code == 422
+        assert response.status_code == 500
         assert (
-            "something are not available dimensions on default.payment_type"
-            in data["message"]
+            "This dimension attribute cannot be joined in: something" in data["message"]
         )
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api import helpers
+from datajunction_server.internal import sql
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import DJDoesNotExistException, DJException
@@ -121,13 +122,13 @@ async def test_find_existing_cube():
 
 
 @pytest.mark.asyncio
-@patch("datajunction_server.api.helpers.ColumnMetadata", MagicMock)
-@patch("datajunction_server.api.helpers.validate_cube")
-@patch("datajunction_server.api.helpers.Node.get_by_name")
-@patch("datajunction_server.api.helpers.find_existing_cube")
-@patch("datajunction_server.api.helpers.get_catalog_by_name")
-@patch("datajunction_server.api.helpers.build_materialized_cube_node")
-@patch("datajunction_server.api.helpers.TranslatedSQL.create", MagicMock)
+@patch("datajunction_server.internal.sql.ColumnMetadata", MagicMock)
+@patch("datajunction_server.internal.sql.validate_cube")
+@patch("datajunction_server.internal.sql.Node.get_by_name")
+@patch("datajunction_server.internal.sql.find_existing_cube")
+@patch("datajunction_server.internal.sql.get_catalog_by_name")
+@patch("datajunction_server.internal.sql.build_materialized_cube_node")
+@patch("datajunction_server.internal.sql.TranslatedSQL.create", MagicMock)
 async def test_build_sql_for_multiple_metrics(
     mock_build_materialized_cube_node,
     mock_get_catalog_by_name,
@@ -160,9 +161,9 @@ async def test_build_sql_for_multiple_metrics(
     )
     mock_session = AsyncMock()
 
-    sql = await helpers.build_sql_for_multiple_metrics(
+    built_sql = await sql.build_sql_for_multiple_metrics(
         session=mock_session,
         metrics=["m1", "m2"],
         dimensions=[],
     )
-    assert sql is not None
+    assert built_sql is not None

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -3249,9 +3249,10 @@ GROUP BY
         compare_query_strings(query, expected_query)
 
     @pytest.mark.asyncio
+    @pytest.mark.xdist_group(name="serial")
     async def test_node_with_dj_logical_timestamp(
         self,
-        client_with_query_service_example_loader,
+        module__client,
     ) -> None:
         """
         1. Create a transform node that uses dj_logical_timestamp (i.e., it is
@@ -3260,8 +3261,7 @@ GROUP BY
         3. When SQL for the metric is requested without the transform having been materialized,
            the request will fail.
         """
-        custom_client = await client_with_query_service_example_loader(["ROADS"])
-        await custom_client.post(
+        await module__client.post(
             "/nodes/transform/",
             json={
                 "description": "Repair orders transform (partitioned)",
@@ -3283,12 +3283,12 @@ GROUP BY
                 "primary_key": ["repair_order_id"],
             },
         )
-        await custom_client.post(
+        await module__client.post(
             "/nodes/default.repair_orders_partitioned/columns/hard_hat_id/"
             "?dimension=default.hard_hat&dimension_column=hard_hat_id",
         )
 
-        await custom_client.post(
+        await module__client.post(
             "/nodes/metric/",
             json={
                 "description": "Number of repair orders",
@@ -3297,14 +3297,13 @@ GROUP BY
                 "name": "default.num_repair_orders_partitioned",
             },
         )
-        response = await custom_client.get(
+        response = await module__client.get(
             "/sql?metrics=default.num_repair_orders_partitioned"
             "&dimensions=default.hard_hat.last_name",
         )
         format_regex = r"\${(?P<capture>[^}]+)}"
 
         result_sql = response.json()["sql"]
-
         match = re.search(format_regex, result_sql)
         assert match and match.group("capture") == "dj_logical_timestamp"
         query = re.sub(format_regex, "FORMATTED", result_sql)
@@ -3339,7 +3338,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
  FROM m0_default_DOT_num_repair_orders_partitioned""",
         )
 
-        await custom_client.post(
+        await module__client.post(
             "/engines/",
             json={
                 "name": "spark",
@@ -3349,7 +3348,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
         )
 
         # Setting the materialization config should succeed
-        response = await custom_client.post(
+        response = await module__client.post(
             "/nodes/default.repair_orders_partitioned/materialization/",
             json={
                 "job": "spark_sql",
@@ -3366,7 +3365,7 @@ SELECT  m0_default_DOT_num_repair_orders_partitioned.default_DOT_num_repair_orde
             "`spark_sql__full` for node `default.repair_orders_partitioned`"
         )
 
-        response = await custom_client.get(
+        response = await module__client.get(
             "/nodes/default.repair_orders_partitioned",
         )
         result_sql = response.json()["materializations"][0]["config"]["query"]

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -684,13 +684,17 @@ async def client_qs(
             transport=httpx.ASGITransport(app=app),
             base_url="http://test",
         ) as test_client:
-            test_client.headers.update(
-                {
-                    "Authorization": f"Bearer {jwt_token}",
-                },
-            )
-            test_client.app = app
-            yield test_client
+            with patch(
+                "datajunction_server.internal.caching.query_cache_manager.session_context",
+                return_value=session,
+            ):
+                test_client.headers.update(
+                    {
+                        "Authorization": f"Bearer {jwt_token}",
+                    },
+                )
+                test_client.app = app
+                yield test_client
 
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
### Summary

This adds additional caching for SQL generation, specifically for node SQL and metrics SQL. It also does some clean up to remove much of the original `QueryRequest` caching and reorganizes the SQL generation functions into a single `internal.sql` module. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
