### PR TITLE
Add check for node existence when upserting complex dimension link

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1737,6 +1737,7 @@ async def upsert_complex_dimension_link(
     node = await Node.get_by_name(
         session,
         node_name,
+        raise_if_not_exists=True,
     )
     if node.type not in (NodeType.SOURCE, NodeType.DIMENSION, NodeType.TRANSFORM):  # type: ignore
         raise DJInvalidInputException(
@@ -1748,6 +1749,7 @@ async def upsert_complex_dimension_link(
     dimension_node = await Node.get_by_name(
         session,
         link_input.dimension_node,
+        raise_if_not_exists=True,
     )
     if (
         dimension_node.current.catalog.name != settings.seed_setup.virtual_catalog_name  # type: ignore

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -36,6 +36,32 @@ async def test_link_dimension_with_errors(
     Test linking dimensions with errors
     """
     response = await dimensions_link_client.post(
+        "/nodes/default.does_not_exist/link",
+        json={
+            "dimension_node": "default.users",
+            "join_on": ("default.does_not_exist.x = default.users.y"),
+            "join_cardinality": "many_to_one",
+        },
+    )
+    assert (
+        response.json()["message"]
+        == "A node with name `default.does_not_exist` does not exist."
+    )
+
+    response = await dimensions_link_client.post(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.random_dimension",
+            "join_on": ("default.events.x = default.random_dimension.y"),
+            "join_cardinality": "many_to_one",
+        },
+    )
+    assert (
+        response.json()["message"]
+        == "A node with name `default.random_dimension` does not exist."
+    )
+
+    response = await dimensions_link_client.post(
         "/nodes/default.elapsed_secs/link",
         json={
             "dimension_node": "default.users",


### PR DESCRIPTION
### Summary

We should check for node existence when upserting a complex dimension link so that users have a useful error rather than allowing it to fail later with:
```
AttributeError-'NoneType' object has no attribute 'type'
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
