### PR TITLE
Prevent unnecessary owner updates 

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -645,7 +645,7 @@ async def update_any_node(
     access_control.add_request_by_node(node)
     access_control.validate_and_raise()
 
-    if data.owners:
+    if data.owners and data.owners != [owner.username for owner in node.owners]:
         await update_owners(session, node, data.owners, current_user, save_history)
 
     if node.type == NodeType.CUBE:  # type: ignore


### PR DESCRIPTION
### Summary

If the owner is the same as it was before during a node update API call, there is no need to "update" it and also save a history event about having updated it when nothing changed.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
