### PR TITLE
Fix background tasks to not have database sessions or ORM objects passed in

### DIFF
--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -302,6 +302,7 @@ async def create_new_materialization(
 
 
 async def schedule_materialization_jobs(
+    session: AsyncSession,
     node_revision_id: int,
     materialization_names: List[str],
     query_service_client: QueryServiceClient,
@@ -310,25 +311,43 @@ async def schedule_materialization_jobs(
     """
     Schedule recurring materialization jobs
     """
+    materializations = await Materialization.get_by_names(
+        session,
+        node_revision_id,
+        materialization_names,
+    )
+    materialization_jobs = {
+        cls.__name__: cls for cls in MaterializationJob.__subclasses__()
+    }
+    materialization_to_output = {}
+    for materialization in materializations:
+        clazz = materialization_jobs.get(materialization.job)
+        if clazz and materialization.name:  # pragma: no cover
+            materialization_to_output[materialization.name] = clazz().schedule(  # type: ignore
+                materialization,
+                query_service_client,
+                request_headers=request_headers,
+            )
+    return materialization_to_output
+
+
+async def schedule_materialization_jobs_bg(
+    node_revision_id: int,
+    materialization_names: List[str],
+    query_service_client: QueryServiceClient,
+    request_headers: Optional[Dict[str, str]] = None,
+) -> None:
+    """
+    Schedule a materialization job in the background.
+    """
     async with session_context() as session:
-        materializations = await Materialization.get_by_names(
-            session,
-            node_revision_id,
-            materialization_names,
+        await schedule_materialization_jobs(
+            session=session,
+            node_revision_id=node_revision_id,
+            materialization_names=materialization_names,
+            query_service_client=query_service_client,
+            request_headers=request_headers,
         )
-        materialization_jobs = {
-            cls.__name__: cls for cls in MaterializationJob.__subclasses__()
-        }
-        materialization_to_output = {}
-        for materialization in materializations:
-            clazz = materialization_jobs.get(materialization.job)
-            if clazz and materialization.name:  # pragma: no cover
-                materialization_to_output[materialization.name] = clazz().schedule(  # type: ignore
-                    materialization,
-                    query_service_client,
-                    request_headers=request_headers,
-                )
-        return materialization_to_output
 
 
 def _get_readable_name(expr):

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -246,9 +246,6 @@ async def session_context(request: Request = None) -> AsyncIterator[AsyncSession
     session = await gen.__anext__()
     try:
         yield session
-    except Exception as exc:
-        await session.rollback()
-        raise exc
     finally:
         await gen.aclose()  # type: ignore
 


### PR DESCRIPTION
### Summary

In general, background tasks should not have request-bound database sessions or objects passed into them. This is because there is a session lifetime issue with reusing request-bound sessions in bg tasks. A session created during a request is tied to that request’s lifecycle, and once the request ends, the session is closed. Any background task that tries to use that session may hit issues.

This fix makes it so that we pass along identifiers rather than ORM objects and use a session factory to create a new session in the background task.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
