### PR TITLE
Start using patch release numbers.

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -8,18 +8,18 @@ on:
         type: choice
         description: "Select version cycle"
         required: true
-        default: alpha
+        default: patch
         options:
           # Uncomment next item when ready to switch:
           - alpha
-          # - patch
+          - patch
           # - minor
           # - major
 
 jobs:
   bump:
     env:
-      bump-type: ${{ github.event.inputs.bump || 'alpha' }}  # Default to alpha
+      bump-type: ${{ github.event.inputs.bump || 'patch' }}  # Default to patch
     strategy:
       fail-fast: false
       matrix:
@@ -83,16 +83,7 @@ jobs:
         working-directory: ./datajunction-clients/javascript
         run: |
           yarn version --new-version $NEW_VERSION --no-git-tag-version
-  
-      #
-      # Docs (after alpha)
-      # 
-      - name: Update docs (for major, minor or patch release)
-        working-directory: ./docs
-        if: ${{ env.bump-type == 'major' || env.bump-type == 'minor' || env.bump-type == 'patch'}}
-        run: |
-          ./build-docs.sh $NEW_VERSION true
-  
+    
       #
       # Pull request
       # 


### PR DESCRIPTION
### Summary

This PR switches our release pattern from `alpha` to `patch`.

### Test Plan

Tested with manual run: https://github.com/DataJunction/dj/pull/1498

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Auto.
