### PR TITLE
Enable cascading of deletes to the tag-node and column-attribute relationships

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2025_09_16_1513-b55add7e1ebc_add_cascade_delete_on_tag_node_and_.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_09_16_1513-b55add7e1ebc_add_cascade_delete_on_tag_node_and_.py
@@ -1,0 +1,111 @@
+"""
+Add cascade delete on tag-node and column-attr foreign keys
+Revision ID: b55add7e1ebc
+Revises: 759c4d50cb8d
+Create Date: 2025-09-16 15:13:39.963297+00:00
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b55add7e1ebc"
+down_revision = "759c4d50cb8d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("columnattribute", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_columnattribute_attribute_type_id_attributetype",
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            "fk_columnattribute_column_id_column",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_columnattribute_attribute_type_id_attributetype",
+            "attributetype",
+            ["attribute_type_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "fk_columnattribute_column_id_column",
+            "column",
+            ["column_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    with op.batch_alter_table("tagnoderelationship", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_tagnoderelationship_node_id_node",
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            "fk_tagnoderelationship_tag_id_tag",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_tagnoderelationship_tag_id_tag",
+            "tag",
+            ["tag_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "fk_tagnoderelationship_node_id_node",
+            "node",
+            ["node_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("tagnoderelationship", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_tagnoderelationship_node_id_node",
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            "fk_tagnoderelationship_tag_id_tag",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_tagnoderelationship_tag_id_tag",
+            "tag",
+            ["tag_id"],
+            ["id"],
+        )
+        batch_op.create_foreign_key(
+            "fk_tagnoderelationship_node_id_node",
+            "node",
+            ["node_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table("columnattribute", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_columnattribute_column_id_column",
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            "fk_columnattribute_attribute_type_id_attributetype",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_columnattribute_column_id_column",
+            "column",
+            ["column_id"],
+            ["id"],
+        )
+        batch_op.create_foreign_key(
+            "fk_columnattribute_attribute_type_id_attributetype",
+            "attributetype",
+            ["attribute_type_id"],
+            ["id"],
+        )

--- a/datajunction-server/datajunction_server/database/attributetype.py
+++ b/datajunction-server/datajunction_server/database/attributetype.py
@@ -98,6 +98,7 @@ class ColumnAttribute(Base):
         sa.ForeignKey(
             "attributetype.id",
             name="fk_columnattribute_attribute_type_id_attributetype",
+            ondelete="CASCADE",
         ),
     )
     attribute_type: Mapped[AttributeType] = relationship(
@@ -106,7 +107,11 @@ class ColumnAttribute(Base):
     )
 
     column_id: Mapped[Optional[int]] = mapped_column(
-        sa.ForeignKey("column.id", name="fk_columnattribute_column_id_column"),
+        sa.ForeignKey(
+            "column.id",
+            name="fk_columnattribute_column_id_column",
+            ondelete="CASCADE",
+        ),
     )
     column: Mapped[Optional["Column"]] = relationship(
         back_populates="attributes",

--- a/datajunction-server/datajunction_server/database/tag.py
+++ b/datajunction-server/datajunction_server/database/tag.py
@@ -110,10 +110,18 @@ class TagNodeRelationship(Base):
     __tablename__ = "tagnoderelationship"
 
     tag_id: Mapped[int] = mapped_column(
-        ForeignKey("tag.id", name="fk_tagnoderelationship_tag_id_tag"),
+        ForeignKey(
+            "tag.id",
+            name="fk_tagnoderelationship_tag_id_tag",
+            ondelete="CASCADE",
+        ),
         primary_key=True,
     )
     node_id: Mapped[int] = mapped_column(
-        ForeignKey("node.id", name="fk_tagnoderelationship_node_id_node"),
+        ForeignKey(
+            "node.id",
+            name="fk_tagnoderelationship_node_id_node",
+            ondelete="CASCADE",
+        ),
         primary_key=True,
     )

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -293,15 +293,20 @@ async def test_deactivate_namespaces(client_with_namespaced_roads: AsyncClient) 
     response = await client_with_namespaced_roads.get(
         "/history?node=foo.bar.avg_length_of_employment",
     )
-    assert [
-        (activity["activity_type"], activity["details"]) for activity in response.json()
-    ] == [
-        ("restore", {"message": "Cascaded from restoring namespace `foo.bar`"}),
-        ("status_change", {"upstream_node": "foo.bar.hard_hats"}),
-        ("status_change", {"upstream_node": "foo.bar.hard_hats"}),
-        ("delete", {"message": "Cascaded from deactivating namespace `foo.bar`"}),
-        ("create", {}),
-    ]
+    assert sorted(
+        [
+            (activity["activity_type"], activity["details"])
+            for activity in response.json()
+        ],
+    ) == sorted(
+        [
+            ("restore", {"message": "Cascaded from restoring namespace `foo.bar`"}),
+            ("status_change", {"upstream_node": "foo.bar.hard_hats"}),
+            ("status_change", {"upstream_node": "foo.bar.hard_hats"}),
+            ("delete", {"message": "Cascaded from deactivating namespace `foo.bar`"}),
+            ("create", {}),
+        ],
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This PR enables cascading deletes for tag-node and column-attr foreign keys.
* If a node is deleted, any entries in the `tagnoderelationship` table should be removed
* If a node deletion causes a set of columns to be deleted, any entries in the `columnattribute` table (this table connects columns with attributes) should be removed. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
