### PR TITLE
When running client tests, print the missing coverage lines

### DIFF
--- a/datajunction-clients/python/Makefile
+++ b/datajunction-clients/python/Makefile
@@ -5,7 +5,7 @@ lint:
 	make check
 
 test:
-	pdm run pytest -n auto --cov=datajunction --cov-report=term -vv tests/ --doctest-modules datajunction --without-integration --without-slow-integration ${PYTEST_ARGS}
+	pdm run pytest -n auto --cov=datajunction --cov-report term-missing -vv tests/ --doctest-modules datajunction --without-integration --without-slow-integration ${PYTEST_ARGS}
 
 dev-release:
 	hatch version dev


### PR DESCRIPTION
### Summary

When running `make test` on the python client, it's useful to see the actual lines that are missing coverage.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
