### PR TITLE
Remove orphaned columns as a part of the database migration

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2025_09_25_1615-2282ef218abf_switch_to_many_to_one_relationship_.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2025_09_25_1615-2282ef218abf_switch_to_many_to_one_relationship_.py
@@ -49,6 +49,11 @@ def upgrade():
         WHERE c.id = sub.column_id;
     """)
 
+    # Remove any orphaned columns that do not have a node_revision_id
+    op.execute("""
+        DELETE FROM "column" WHERE node_revision_id IS NULL;
+    """)
+
     # Make it non-nullable
     with op.batch_alter_table("column") as batch_op:
         batch_op.alter_column("node_revision_id", nullable=False)


### PR DESCRIPTION
### Summary

This removes orphaned columns from the db migration

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
