### PR TITLE
Enable registering table under a custom namespace

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -568,6 +568,7 @@ async def register_table(
     catalog: str,
     schema_: str,
     table: str,
+    source_node_namespace: str | None = None,
     *,
     session: AsyncSession = Depends(get_session),
     request: Request,
@@ -586,7 +587,12 @@ async def register_table(
             message="Registering tables or views requires that a query "
             "service is configured for columns inference",
         )
-    namespace = f"{settings.source_node_namespace}.{catalog}.{schema_}"
+    prefix = (
+        source_node_namespace
+        if source_node_namespace is not None
+        else settings.source_node_namespace
+    )
+    namespace = f"{(prefix or '') + ('.' if prefix else '')}{catalog}.{schema_}"
     name = f"{namespace}.{table}"
     await raise_if_node_exists(session, name)
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1670,6 +1670,12 @@ class TestNodeCRUD:
         ]
         assert response.status_code == 201
 
+        response = await module__client_with_basic.post(
+            "/register/table/public/basic/comments/?source_node_namespace=default",
+        )
+        data = response.json()
+        assert data["name"] == "default.public.basic.comments"
+
     @pytest.mark.asyncio
     async def test_refresh_source_node(
         self,


### PR DESCRIPTION
### Summary

This enables registering a table as a source node under a custom namespace

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
