### PR TITLE
Allow unix_timestamp to also accept a timestamp or date, which spark supports

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -4462,7 +4462,7 @@ class UnixTimestamp(Function):
 
 @UnixTimestamp.register  # type: ignore
 def infer_type(
-    time_exp: Optional[ct.StringType] = None,
+    time_exp: Optional[Union[ct.TimestampType, ct.DateType, ct.StringType]] = None,
     fmt: Optional[ct.StringType] = None,
 ) -> ct.BigIntType:
     return ct.BigIntType()

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -3672,6 +3672,15 @@ async def test_unix_timestamp(session: AsyncSession):
     assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
     assert query.select.projection[1].type == ct.BigIntType()  # type: ignore
 
+    query = parse(
+        "SELECT unix_timestamp(to_timestamp('2025-01-01 10:10:10.123', 'yyyy-MM-dd HH:mm:ss.SSS'))",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.BigIntType()  # type: ignore
+
 
 @pytest.mark.asyncio
 async def test_timestamp(session: AsyncSession):


### PR DESCRIPTION
### Summary

This fixes a small issue with the type of the first arg to `unix_timestamp`. Currently it only accepts a string but spark has this arg's type as "timeExp" which allows for a string, timestamp _or_ date.

### Test Plan

Added a test

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
