### PR TITLE
Add bulk loading of parents before node compilation

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.construction.utils import to_namespaced_name
 from datajunction_server.database import Engine
@@ -40,6 +41,46 @@ from datajunction_server.sql.parsing.backends.antlr4 import ast, cached_parse, p
 from datajunction_server.utils import SEPARATOR, refresh_if_needed
 
 logger = logging.getLogger(__name__)
+
+
+async def create_compile_context_with_bulk_deps(
+    session: AsyncSession,
+    node_names: set[str] | None = None,
+    exception: DJException | None = None,
+) -> ast.CompileContext:
+    """
+    Create a CompileContext with bulk-loaded dependencies.
+
+    Args:
+        session: Database session
+        node_names: Node names to bulk load (if None, creates empty cache)
+        exception: DJException instance (creates new one if None)
+        max_depth: Maximum depth for transitive dependency loading
+
+    Returns:
+        CompileContext with preloaded dependencies cache
+    """
+    if exception is None:
+        exception = DJException()
+
+    dependencies_cache = {}
+    if node_names:
+        nodes = await Node.get_by_names(
+            session,
+            list(node_names),
+            options=[
+                joinedload(Node.current).options(
+                    selectinload(NodeRevision.columns),
+                ),
+            ],
+        )
+        dependencies_cache = {node.name: node for node in nodes}
+
+    return ast.CompileContext(
+        session=session,
+        exception=exception,
+        dependencies_cache=dependencies_cache,
+    )
 
 
 @dataclass
@@ -1401,7 +1442,11 @@ async def compile_node_ast(session, node_revision: NodeRevision) -> ast.Query:
     Parses the node's query into an AST and compiles it.
     """
     node_ast = parse(node_revision.query)
-    ctx = CompileContext(session, DJException())
+    await refresh_if_needed(session, node_revision, ["parents"])
+    ctx = await create_compile_context_with_bulk_deps(
+        session,
+        {parent.name for parent in node_revision.parents},
+    )
     await node_ast.compile(ctx)
     return node_ast
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2070,7 +2070,14 @@ async def upsert_complex_dimension_link(
         + (f"ON {link_input.join_on}" if link_input.join_on else ""),
     )
     exc = DJException()
-    ctx = ast.CompileContext(session=session, exception=exc)
+    ctx = ast.CompileContext(
+        session=session,
+        exception=exc,
+        dependencies_cache={
+            node_name: node,  # type: ignore
+            link_input.dimension_node: dimension_node,  # type: ignore
+        },
+    )
     await join_query.compile(ctx)
     join_relation = join_query.select.from_.relations[0].extensions[0]  # type: ignore
 

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Set, Union
 
 from sqlalchemy.exc import MissingGreenlet
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.api.helpers import find_bound_dimensions
 from datajunction_server.database import Node, NodeRevision
@@ -17,46 +16,6 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import SqlSyntaxError, parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
-
-
-async def create_compile_context_with_bulk_deps(
-    session: AsyncSession,
-    node_names: set[str] | None = None,
-    exception: DJException | None = None,
-) -> ast.CompileContext:
-    """
-    Create a CompileContext with bulk-loaded dependencies.
-
-    Args:
-        session: Database session
-        node_names: Node names to bulk load (if None, creates empty cache)
-        exception: DJException instance (creates new one if None)
-        max_depth: Maximum depth for transitive dependency loading
-
-    Returns:
-        CompileContext with preloaded dependencies cache
-    """
-    if exception is None:
-        exception = DJException()
-
-    dependencies_cache = {}
-    if node_names:
-        nodes = await Node.get_by_names(
-            session,
-            list(node_names),
-            options=[
-                joinedload(Node.current).options(
-                    selectinload(NodeRevision.columns),
-                ),
-            ],
-        )
-        dependencies_cache = {node.name: node for node in nodes}
-
-    return ast.CompileContext(
-        session=session,
-        exception=exception,
-        dependencies_cache=dependencies_cache,
-    )
 
 
 @dataclass
@@ -104,18 +63,12 @@ async def validate_node_data(
 
     if isinstance(data, NodeRevision):
         validated_node = data
-        await session.refresh(data, ["parents"])
-        ctx = await create_compile_context_with_bulk_deps(
-            session=session,
-            node_names={parent.name for parent in data.parents},
-        )
     else:
         node = Node(name=data.name, type=data.type)
         validated_node = NodeRevision(**data.model_dump())
         validated_node.node = node
 
-        # Create context without bulk loading for new nodes
-        ctx = ast.CompileContext(session=session, exception=DJException())
+    ctx = ast.CompileContext(session=session, exception=DJException())
 
     # Try to parse the node's query, extract dependencies and missing parents
     try:

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1397,6 +1397,9 @@ class Table(TableExpression, Named):
     async def compile(self, ctx: CompileContext):
         # things we can validate here:
         # - if the node is a dimension in a groupby, is it joinable?
+        if self.is_compiled():
+            return
+
         self._is_compiled = True
         try:
             if not self.dj_node:


### PR DESCRIPTION
### Summary

In many cases, we can bulk load nodes before compilation, which will lead to significantly faster compile times. This also tags on a refactor of the metric query validation into a separate function.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
