### PR TITLE
Prevent cycles when building queries with dimension graph cycles

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v2.py
+++ b/datajunction-server/datajunction_server/construction/build_v2.py
@@ -1280,8 +1280,12 @@ async def dimension_join_path(
     processing_queue = collections.deque(
         [(link, [link]) for link in node.dimension_links],
     )
+    visited = set()
     while processing_queue:
         current_link, join_path = processing_queue.popleft()
+        if current_link.id in visited:
+            continue
+        visited.add(current_link.id)
         await refresh_if_needed(session, current_link, ["dimension"])
         if current_link.dimension.name == dimension_attr.node_name:
             return join_path


### PR DESCRIPTION
### Summary

If there are cycles in the dimensions graph, we should not continue to trace the graph when building queries.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
