### PR TITLE
Prevent linking to non-dimension nodes

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2043,6 +2043,11 @@ async def validate_complex_dimension_link(
             message=f"Cannot link dimension to a node of type {node.type}. "  # type: ignore
             "Must be a source, dimension, or transform node.",
         )
+    if dimension_node.type != NodeType.DIMENSION:
+        raise DJInvalidInputException(
+            message=f"Cannot link dimension to a node of type {dimension_node.type}. "
+            "Must be a dimension node.",
+        )
 
     if (
         dimension_node.current.catalog.name != settings.seed_setup.virtual_catalog_name  # type: ignore

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -99,6 +99,19 @@ async def test_link_dimension_with_errors(
         == "Join query default.events.order_year = default.users.year is not valid"
     )
 
+    # Test linking a non-dimension node as the dimension_node (source node instead of dimension)
+    response = await dimensions_link_client.post(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.events_table",
+            "join_on": ("default.events.user_id = default.events_table.user_id"),
+            "join_cardinality": "many_to_one",
+        },
+    )
+    assert response.json()["message"] == (
+        "Cannot link dimension to a node of type source. Must be a dimension node."
+    )
+
 
 @pytest.fixture
 def link_events_to_users_without_role(


### PR DESCRIPTION
### Summary

We should not enable users to create a dimension link to non-dimension nodes.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
