### PR TITLE
Remove user upsert and group sync on every write request

### DIFF
--- a/datajunction-server/datajunction_server/api/access/authentication/service_account.py
+++ b/datajunction-server/datajunction_server/api/access/authentication/service_account.py
@@ -26,7 +26,6 @@ from datajunction_server.models.service_account import (
 )
 from datajunction_server.utils import (
     Settings,
-    get_and_update_current_user,
     get_current_user,
     get_session,
     get_settings,
@@ -41,7 +40,7 @@ logger = logging.getLogger(__name__)
 async def create_service_account(
     payload: ServiceAccountCreate,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
 ):
     """
     Create a new service account

--- a/datajunction-server/datajunction_server/api/collection.py
+++ b/datajunction-server/datajunction_server/api/collection.py
@@ -18,7 +18,7 @@ from datajunction_server.errors import DJException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.models.collection import CollectionDetails, CollectionInfo
 from datajunction_server.utils import (
-    get_and_update_current_user,
+    get_current_user,
     get_session,
     get_settings,
 )
@@ -37,7 +37,7 @@ async def create_a_collection(
     data: CollectionInfo,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> CollectionInfo:
     """
     Create a Collection

--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -39,7 +39,6 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate, QueryWithResults
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import (
-    get_and_update_current_user,
     get_current_user,
     get_query_service_client,
     get_session,
@@ -66,7 +65,7 @@ async def add_availability_state(
     data: AvailabilityStateBase,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     validate_access: access.ValidateAccessFn = Depends(
         validate_access,
     ),
@@ -190,7 +189,7 @@ async def remove_availability_state(
     node_name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     validate_access: access.ValidateAccessFn = Depends(
         validate_access,
     ),

--- a/datajunction-server/datajunction_server/api/deployments.py
+++ b/datajunction-server/datajunction_server/api/deployments.py
@@ -31,7 +31,7 @@ from datajunction_server.internal.access.authorization import (
 from datajunction_server.models import access
 from datajunction_server.models.deployment import DeploymentStatus
 from datajunction_server.utils import (
-    get_and_update_current_user,
+    get_current_user,
     get_query_service_client,
     get_session,
     get_settings,
@@ -157,7 +157,7 @@ async def create_deployment(
     request: Request,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     save_history: Callable = Depends(get_save_history),
     cache: Cache = Depends(get_cache),

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -46,7 +46,7 @@ from datajunction_server.naming import amenable_name
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import (
-    get_and_update_current_user,
+    get_current_user,
     get_query_service_client,
     get_session,
     get_settings,
@@ -95,7 +95,7 @@ async def upsert_materialization(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     validate_access: access.ValidateAccessFn = Depends(
         validate_access,
@@ -335,7 +335,7 @@ async def deactivate_node_materializations(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -438,7 +438,7 @@ async def run_materialization_backfill(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> MaterializationInfo:
     """

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -37,7 +37,6 @@ from datajunction_server.models.node import NamespaceOutput, NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.utils import (
     SEPARATOR,
-    get_and_update_current_user,
     get_current_user,
     get_query_service_client,
     get_session,
@@ -54,7 +53,7 @@ async def create_node_namespace(
     namespace: str,
     include_parents: Optional[bool] = False,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     *,
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
@@ -178,7 +177,7 @@ async def deactivate_a_namespace(
     ),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     background_tasks: BackgroundTasks,
@@ -265,7 +264,7 @@ async def restore_a_namespace(
         description="Cascade the restore down to the nodes in the namespace",
     ),
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -339,7 +338,7 @@ async def hard_delete_node_namespace(
     *,
     cascade: bool = False,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -111,7 +111,6 @@ from datajunction_server.sql.dag import (
 )
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.utils import (
-    get_and_update_current_user,
     get_current_user,
     get_query_service_client,
     get_session,
@@ -156,7 +155,7 @@ async def validate_node(
 async def revalidate(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     *,
     background_tasks: BackgroundTasks,
@@ -208,7 +207,7 @@ async def set_column_attributes(
     attributes: List[AttributeTypeIdentifier],
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> List[ColumnOutput]:
     """
@@ -346,7 +345,7 @@ async def delete_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     background_tasks: BackgroundTasks,
@@ -374,7 +373,7 @@ async def delete_node(
 async def hard_delete(
     name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -401,7 +400,7 @@ async def restore_node(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ):
     """
@@ -444,7 +443,7 @@ async def create_source(
     data: CreateSourceNode,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     validate_access: access.ValidateAccessFn = Depends(
@@ -492,7 +491,7 @@ async def create_node(
     request: Request,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(
@@ -531,7 +530,7 @@ async def create_cube(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(
         validate_access,
@@ -573,7 +572,7 @@ async def register_table(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     background_tasks: BackgroundTasks,
     save_history: Callable = Depends(get_save_history),
 ) -> NodeOutput:
@@ -647,7 +646,7 @@ async def register_view(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     background_tasks: BackgroundTasks,
     save_history: Callable = Depends(get_save_history),
 ) -> NodeOutput:
@@ -728,7 +727,7 @@ async def link_dimension(
     dimension: str,
     dimension_column: Optional[str] = None,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -770,7 +769,7 @@ async def add_reference_dimension_link(
     dimension_column: str,
     role: Optional[str] = None,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -802,7 +801,7 @@ async def remove_reference_dimension_link(
     node_name: str,
     node_column: str,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -852,7 +851,7 @@ async def add_complex_dimension_link(
     node_name: str,
     link_input: JoinLinkInput,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -887,7 +886,7 @@ async def remove_complex_dimension_link(
     node_name: str,
     link_identifier: LinkDimensionIdentifier,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -909,7 +908,7 @@ async def delete_dimension_link(
     dimension: str,
     dimension_column: Optional[str] = None,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -935,7 +934,7 @@ async def tags_node(
     tag_names: Optional[List[str]] = Query(default=None),
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
@@ -988,7 +987,7 @@ async def refresh_source_node(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> NodeOutput:
     """
@@ -1013,7 +1012,7 @@ async def update_node(
     session: AsyncSession = Depends(get_session),
     request: Request,
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     background_tasks: BackgroundTasks,
     validate_access: access.ValidateAccessFn = Depends(
         validate_access,
@@ -1235,7 +1234,7 @@ async def set_column_display_name(
     node_name: str,
     column_name: str,
     display_name: str,
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     *,
     session: AsyncSession = Depends(get_session),
@@ -1277,7 +1276,7 @@ async def set_column_description(
     node_name: str,
     column_name: str,
     description: str,
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     *,
     session: AsyncSession = Depends(get_session),
@@ -1322,7 +1321,7 @@ async def set_column_partition(
     input_partition: PartitionInput,
     *,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> ColumnOutput:
     """
@@ -1392,7 +1391,7 @@ async def copy_node(
     *,
     new_name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> DAGNodeOutput:
     """

--- a/datajunction-server/datajunction_server/api/notifications.py
+++ b/datajunction-server/datajunction_server/api/notifications.py
@@ -23,7 +23,6 @@ from datajunction_server.internal.notifications import (
 )
 from datajunction_server.models.notifications import NotificationPreferenceModel
 from datajunction_server.utils import (
-    get_and_update_current_user,
     get_current_user,
     get_session,
 )
@@ -49,7 +48,7 @@ async def subscribe(
     activity_types: list[ActivityType],
     alert_types: list[str],
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Subscribes to notifications by upserting a notification preference.
@@ -91,7 +90,7 @@ async def unsubscribe(
     entity_type: EntityType,
     entity_name: str,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> JSONResponse:
     """Unsubscribes from notifications by deleting a notification preference"""
     result = await session.execute(
@@ -167,7 +166,7 @@ async def get_users_for_notification(
 @router.post("/notifications/mark-read")
 async def mark_notifications_read(
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Mark all notifications as read by updating the user's

--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -21,7 +21,7 @@ from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.tag import CreateTag, TagOutput, UpdateTag
 from datajunction_server.utils import (
-    get_and_update_current_user,
+    get_current_user,
     get_session,
     get_settings,
 )
@@ -103,7 +103,7 @@ async def get_a_tag(
 async def create_a_tag(
     data: CreateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> TagOutput:
     """
@@ -143,7 +143,7 @@ async def update_a_tag(
     name: str,
     data: UpdateTag,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_and_update_current_user),
+    current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
 ) -> TagOutput:
     """


### PR DESCRIPTION
### Summary

This change replaces `get_and_update_current_user` with `get_current_user` across all API endpoints. The removed function was performing unnecessary work on every write request:
- Upserting the user (who already exists from authentication)
- Syncing user groups (should be done at login, not on every request)

In OSS, users are created via explicit signup or OAuth callbacks, so by the time any protected endpoint runs, the user already exists in the database. The auth middleware (DJHTTPBearer) already loads and validates the user, making the upsert redundant.

For internal deployments with external auth (e.g., SSO/SAML), user provisioning and group sync should be handled in the auth middleware, not in a per-request dependency.

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
