### PR TITLE
Pin bcrpyt to be <=4.3.0 due to bcrypt error

### DIFF
--- a/datajunction-server/pdm.lock
+++ b/datajunction-server/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "transpilation", "uvicorn"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:1baf871e25f3d791478f4a847c7353b4fef15aa620144893c9d43b51069af187"
+content_hash = "sha256:6d120b9c7fcf6efbe0165a6d8d073df531dd599af1160ae3f4fd3281ea2b290d"
 
 [[metadata.targets]]
 requires_python = "~=3.10"

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "passlib>=1.7.4",
     "python-jose>=3.3.0",
     "cryptography<=45.0.0",
-    "bcrypt>=4.0.1",
+    "bcrypt<=4.3.0,>=4.0.1",
 
     # Google APIs
     "google-api-python-client>=2.95.0",


### PR DESCRIPTION
### Summary

This pins bcrypt to be <= 4.3.0 to avoid this error from 5.0.0:
```
ValueError: password cannot be longer than 72 bytes
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
