### PR TITLE
Add GraphQL Upstream Endpoint + Optimize Dependencies Page

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -13,6 +13,7 @@ from datajunction_server.api.graphql.queries.catalogs import list_catalogs
 from datajunction_server.api.graphql.queries.dag import (
     common_dimensions,
     downstream_nodes,
+    upstream_nodes,
 )
 from datajunction_server.api.graphql.queries.engines import list_engines, list_dialects
 from datajunction_server.api.graphql.queries.nodes import (
@@ -132,6 +133,10 @@ class Query:
     downstream_nodes: list[Node] = strawberry.field(
         resolver=log_resolver(downstream_nodes),
         description="Find downstream nodes (optionally, of a given type) from a given node.",
+    )
+    upstream_nodes: list[Node] = strawberry.field(
+        resolver=log_resolver(upstream_nodes),
+        description="Find upstream nodes (optionally, of a given type) from a given node.",
     )
 
     # Generate SQL queries

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -445,10 +445,22 @@ type Query {
 
   """Find downstream nodes (optionally, of a given type) from a given node."""
   downstreamNodes(
-    """The node name to find downstream nodes for."""
-    nodeName: String!
+    """The node names to find downstream nodes for."""
+    nodeNames: [String!]!
 
     """The node type to filter the downstream nodes on."""
+    nodeType: NodeType = null
+
+    """Whether to include deactivated nodes in the result."""
+    includeDeactivated: Boolean! = false
+  ): [Node!]!
+
+  """Find upstream nodes (optionally, of a given type) from a given node."""
+  upstreamNodes(
+    """The node names to find upstream nodes for."""
+    nodeNames: [String!]!
+
+    """The node type to filter the upstream nodes on."""
     nodeType: NodeType = null
 
     """Whether to include deactivated nodes in the result."""

--- a/datajunction-server/tests/api/graphql/upstream_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/upstream_nodes_test.py
@@ -1,0 +1,239 @@
+"""
+Tests for the upstream nodes GraphQL query.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_upstream_nodes_overlapping_parents(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test upstreams for multiple metrics where one metric's parent transform
+    is also an upstream of another metric's parent transform.
+
+    This creates a diamond pattern:
+        source_data (SOURCE)
+             to
+        base_transform (TRANSFORM)
+             to
+        derived_transform (TRANSFORM)
+
+        metric_on_base (METRIC) → base_transform
+        metric_on_derived (METRIC) → derived_transform → base_transform
+    """
+    client = module__client_with_roads
+
+    # Create source
+    response = await client.post(
+        "/nodes/source/",
+        json={
+            "name": "default.diamond_source",
+            "description": "Source for diamond pattern test",
+            "columns": [
+                {"name": "id", "type": "int"},
+                {"name": "value", "type": "int"},
+            ],
+            "catalog": "default",
+            "schema_": "roads",
+            "table": "diamond_source",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 200
+
+    # Create base transform (T1)
+    response = await client.post(
+        "/nodes/transform/",
+        json={
+            "name": "default.diamond_base_transform",
+            "description": "Base transform",
+            "query": "SELECT id, value FROM default.diamond_source",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201
+
+    # Create derived transform (T2) that depends on T1
+    response = await client.post(
+        "/nodes/transform/",
+        json={
+            "name": "default.diamond_derived_transform",
+            "description": "Derived transform that depends on base",
+            "query": "SELECT id, value * 2 as doubled FROM default.diamond_base_transform",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201
+
+    # Create metric M1 on base transform
+    response = await client.post(
+        "/nodes/metric/",
+        json={
+            "name": "default.diamond_metric_base",
+            "description": "Metric on base transform",
+            "query": "SELECT sum(value) FROM default.diamond_base_transform",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201
+
+    # Create metric M2 on derived transform
+    response = await client.post(
+        "/nodes/metric/",
+        json={
+            "name": "default.diamond_metric_derived",
+            "description": "Metric on derived transform",
+            "query": "SELECT sum(doubled) FROM default.diamond_derived_transform",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201
+
+    # Query upstreams for both metrics - this should hit the deduplication branch
+    query = """
+    {
+        upstreamNodes(nodeNames: ["default.diamond_metric_base", "default.diamond_metric_derived"]) {
+            name
+            type
+        }
+    }
+    """
+    response = await client.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+
+    upstream_names = {node["name"] for node in data["data"]["upstreamNodes"]}
+
+    # Should include all upstreams, deduplicated
+    assert "default.diamond_source" in upstream_names
+    assert "default.diamond_base_transform" in upstream_names
+    assert "default.diamond_derived_transform" in upstream_names
+
+    # base_transform should appear exactly once (not duplicated)
+    base_transform_count = sum(
+        1
+        for node in data["data"]["upstreamNodes"]
+        if node["name"] == "default.diamond_base_transform"
+    )
+    assert base_transform_count == 1
+
+
+@pytest.mark.asyncio
+async def test_upstream_nodes(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test finding upstream nodes by node type
+    """
+
+    # of SOURCE type
+    query = """
+    {
+        upstreamNodes(nodeNames: ["default.repair_orders_fact"], nodeType: SOURCE) {
+            name
+            type
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    upstream_names = {node["name"] for node in data["data"]["upstreamNodes"]}
+    assert "default.repair_orders" in upstream_names
+    assert "default.repair_order_details" in upstream_names
+    for node in data["data"]["upstreamNodes"]:
+        assert node["type"] == "SOURCE"
+
+    # of any type
+    query = """
+    {
+        upstreamNodes(nodeNames: ["default.num_repair_orders"], nodeType: null) {
+            name
+            type
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    upstream_names = {node["name"] for node in data["data"]["upstreamNodes"]}
+    # The metric should have the transform as an upstream
+    assert "default.repair_orders_fact" in upstream_names
+
+
+@pytest.mark.asyncio
+async def test_upstream_nodes_multiple_inputs(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test finding upstream nodes from multiple input nodes.
+    """
+    query = """
+    {
+        upstreamNodes(nodeNames: ["default.num_repair_orders", "default.avg_repair_price"], nodeType: SOURCE) {
+            name
+            type
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    upstream_names = {node["name"] for node in data["data"]["upstreamNodes"]}
+    # Should include sources upstream of both metrics (deduplicated)
+    assert "default.repair_orders" in upstream_names
+    assert "default.repair_order_details" in upstream_names
+    for node in data["data"]["upstreamNodes"]:
+        assert node["type"] == "SOURCE"
+
+
+@pytest.mark.asyncio
+async def test_upstream_nodes_deactivated(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test finding upstream nodes with and without deactivated nodes.
+    """
+    # First deactivate a node that is upstream of the metric
+    response = await module__client_with_roads.delete(
+        "/nodes/default.repair_orders_fact",
+    )
+    assert response.status_code == 200
+
+    # Without deactivated nodes
+    query = """
+    {
+        upstreamNodes(nodeNames: ["default.num_repair_orders"], nodeType: null, includeDeactivated: false) {
+            name
+            type
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    upstream_names = {node["name"] for node in data["data"]["upstreamNodes"]}
+    assert "default.repair_orders_fact" not in upstream_names
+
+    # With deactivated nodes
+    query = """
+    {
+        upstreamNodes(nodeNames: ["default.num_repair_orders"], nodeType: null, includeDeactivated: true) {
+            name
+            type
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    upstream_names = {node["name"] for node in data["data"]["upstreamNodes"]}
+    assert "default.repair_orders_fact" in upstream_names

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodeDependenciesTab.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodeDependenciesTab.test.jsx
@@ -6,8 +6,8 @@ describe('<NodeDependenciesTab />', () => {
   const mockDjClient = {
     node: jest.fn(),
     nodeDimensions: jest.fn(),
-    upstreams: jest.fn(),
-    downstreams: jest.fn(),
+    upstreamsGQL: jest.fn(),
+    downstreamsGQL: jest.fn(),
   };
 
   const mockNode = {
@@ -131,14 +131,20 @@ describe('<NodeDependenciesTab />', () => {
   beforeEach(() => {
     // Reset the mocks before each test
     mockDjClient.nodeDimensions.mockReset();
-    mockDjClient.upstreams.mockReset();
-    mockDjClient.downstreams.mockReset();
+    mockDjClient.upstreamsGQL.mockReset();
+    mockDjClient.downstreamsGQL.mockReset();
   });
 
   it('renders nodes with dimensions', async () => {
-    mockDjClient.nodeDimensions.mockReturnValue(mockDimensions);
-    mockDjClient.upstreams.mockReturnValue([mockNode]);
-    mockDjClient.downstreams.mockReturnValue([mockNode]);
+    // Use mockResolvedValue since the component now uses .then()
+    mockDjClient.nodeDimensions.mockResolvedValue(mockDimensions);
+    // GraphQL responses return uppercase types (e.g., "SOURCE")
+    mockDjClient.upstreamsGQL.mockResolvedValue([
+      { name: mockNode.name, type: 'SOURCE' },
+    ]);
+    mockDjClient.downstreamsGQL.mockResolvedValue([
+      { name: mockNode.name, type: 'SOURCE' },
+    ]);
     render(<NodeDependenciesTab node={mockNode} djClient={mockDjClient} />);
     await waitFor(() => {
       for (const dimension of mockDimensions) {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -690,6 +690,49 @@ export const DataJunctionAPI = {
     ).json();
   },
 
+  // GraphQL-based upstream/downstream queries - more efficient as they only fetch needed fields
+  upstreamsGQL: async function (nodeNames) {
+    const names = Array.isArray(nodeNames) ? nodeNames : [nodeNames];
+    const query = `
+      query GetUpstreamNodes($nodeNames: [String!]!) {
+        upstreamNodes(nodeNames: $nodeNames) {
+          name
+          type
+        }
+      }
+    `;
+    const results = await (
+      await fetch(DJ_GQL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ query, variables: { nodeNames: names } }),
+      })
+    ).json();
+    return results.data?.upstreamNodes || [];
+  },
+
+  downstreamsGQL: async function (nodeNames) {
+    const names = Array.isArray(nodeNames) ? nodeNames : [nodeNames];
+    const query = `
+      query GetDownstreamNodes($nodeNames: [String!]!) {
+        downstreamNodes(nodeNames: $nodeNames) {
+          name
+          type
+        }
+      }
+    `;
+    const results = await (
+      await fetch(DJ_GQL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ query, variables: { nodeNames: names } }),
+      })
+    ).json();
+    return results.data?.downstreamNodes || [];
+  },
+
   node_dag: async function (name) {
     return await (
       await fetch(`${DJ_URL}/nodes/${name}/dag/`, {

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -324,6 +324,82 @@ describe('DataJunctionAPI', () => {
     );
   });
 
+  it('calls upstreamsGQL correctly with single node', async () => {
+    const nodeName = 'sampleNode';
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: { upstreamNodes: [{ name: 'upstream1', type: 'SOURCE' }] },
+      }),
+    );
+    const result = await DataJunctionAPI.upstreamsGQL(nodeName);
+    expect(fetch).toHaveBeenCalledWith(
+      `${DJ_URL}/graphql`,
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(result).toEqual([{ name: 'upstream1', type: 'SOURCE' }]);
+  });
+
+  it('calls upstreamsGQL correctly with multiple nodes', async () => {
+    const nodeNames = ['node1', 'node2'];
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: {
+          upstreamNodes: [
+            { name: 'upstream1', type: 'SOURCE' },
+            { name: 'upstream2', type: 'TRANSFORM' },
+          ],
+        },
+      }),
+    );
+    const result = await DataJunctionAPI.upstreamsGQL(nodeNames);
+    expect(result).toEqual([
+      { name: 'upstream1', type: 'SOURCE' },
+      { name: 'upstream2', type: 'TRANSFORM' },
+    ]);
+  });
+
+  it('calls downstreamsGQL correctly with single node', async () => {
+    const nodeName = 'sampleNode';
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: { downstreamNodes: [{ name: 'downstream1', type: 'METRIC' }] },
+      }),
+    );
+    const result = await DataJunctionAPI.downstreamsGQL(nodeName);
+    expect(fetch).toHaveBeenCalledWith(
+      `${DJ_URL}/graphql`,
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(result).toEqual([{ name: 'downstream1', type: 'METRIC' }]);
+  });
+
+  it('calls downstreamsGQL correctly with multiple nodes', async () => {
+    const nodeNames = ['node1', 'node2'];
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: {
+          downstreamNodes: [
+            { name: 'downstream1', type: 'METRIC' },
+            { name: 'downstream2', type: 'CUBE' },
+          ],
+        },
+      }),
+    );
+    const result = await DataJunctionAPI.downstreamsGQL(nodeNames);
+    expect(result).toEqual([
+      { name: 'downstream1', type: 'METRIC' },
+      { name: 'downstream2', type: 'CUBE' },
+    ]);
+  });
+
   it('calls node_dag correctly', async () => {
     const nodeName = 'sampleNode';
     fetch.mockResponseOnce(JSON.stringify({}));


### PR DESCRIPTION
### Summary

This PR adds an `upstreamNodes` GraphQL query and modifies the existing `downstreamNodes` query to accept multiple nodes. For the `upstreamNodes` query, it also layers in an optimization where we fetch the immediate parents of each metric with a lightweight query, then starts the CTE from the deduplicated set of immediate parents. 

This change also updates the UI dependencies page to use GraphQL for faster responses, since there is no need to retrieve the entire set of node metadata when we're only displaying the node's name and type.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
