### PR TITLE
Dynamic Field Loading for Upstream/Downstream GQL Endpoints

### DIFF
--- a/datajunction-server/tests/api/graphql/downstream_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/downstream_nodes_test.py
@@ -174,3 +174,75 @@ async def test_downstream_nodes_deactivated(
         {"name": "default.avg_repair_order_discounts", "type": "METRIC"},
         {"name": "default.avg_time_to_dispatch", "type": "METRIC"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_downstream_nodes_with_nested_fields(
+    module__client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test downstream nodes query with nested fields that require database joins.
+    This tests that load_node_options correctly builds options based on the
+    requested GraphQL fields (tags, owners, current.columns, etc.).
+    """
+    # Query with many nested fields that require joins
+    query = """
+    {
+        downstreamNodes(nodeNames: ["default.repair_order_details"], nodeType: TRANSFORM) {
+            name
+            type
+            tags {
+                name
+                tagType
+            }
+            owners {
+                username
+            }
+            current {
+                displayName
+                status
+                description
+                columns {
+                    name
+                    type
+                }
+                parents {
+                    name
+                }
+            }
+        }
+    }
+    """
+
+    response = await module__client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+
+    # Verify we got results
+    downstreams = data["data"]["downstreamNodes"]
+    assert len(downstreams) > 0
+
+    # Find the repair_orders_fact transform
+    repair_orders_fact = next(
+        (n for n in downstreams if n["name"] == "default.repair_orders_fact"),
+        None,
+    )
+    assert repair_orders_fact is not None
+
+    # Verify nested fields are populated
+    assert repair_orders_fact["type"] == "TRANSFORM"
+    assert repair_orders_fact["current"] is not None
+    assert repair_orders_fact["current"]["status"] == "VALID"
+    assert repair_orders_fact["current"]["displayName"] == "Repair Orders Fact"
+
+    # Verify columns are loaded (requires selectinload)
+    columns = repair_orders_fact["current"]["columns"]
+    assert columns is not None
+    assert len(columns) > 0
+    column_names = {c["name"] for c in columns}
+    assert "repair_order_id" in column_names
+
+    # Verify parents are loaded (requires selectinload)
+    parents = repair_orders_fact["current"]["parents"]
+    assert parents is not None
+    assert len(parents) > 0


### PR DESCRIPTION
### Summary

This PR introduces dynamic field loading to `upstreamNodes` and `downstreamNodes`. This significantly reduces database overhead when GraphQL callers are only requesting basic node information in the upstreams/downstreams output. The REST API will continue to output a broader set of fields (see `DAGNodeOutput`).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
