### PR TITLE
Add ability to filter by nodes with dimension

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -44,6 +44,13 @@ async def find_nodes(
             description="Filter to nodes tagged with these tags",
         ),
     ] = None,
+    dimensions: Annotated[
+        list[str] | None,
+        strawberry.argument(
+            description="Filter to nodes that have ALL of these dimensions. "
+            "Accepts dimension node names or dimension attributes",
+        ),
+    ] = None,
     limit: Annotated[
         int | None,
         strawberry.argument(description="Limit nodes"),
@@ -74,6 +81,7 @@ async def find_nodes(
         fragment,
         node_types,
         tags,
+        dimensions=dimensions,
         limit=limit,
         order_by=order_by,
         ascending=ascending,

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -34,6 +34,7 @@ async def find_nodes_by(
     order_by: NodeSortField = NodeSortField.CREATED_AT,
     ascending: bool = False,
     mode: Optional[NodeMode] = None,
+    dimensions: Optional[List[str]] = None,
 ) -> List[DBNode]:
     """
     Finds nodes based on the search parameters. This function also tries to optimize
@@ -63,6 +64,7 @@ async def find_nodes_by(
         ascending=ascending,
         options=options,
         mode=mode,
+        dimensions=dimensions,
     )
 
 

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -402,6 +402,11 @@ type Query {
     """Filter to nodes tagged with these tags"""
     tags: [String!] = null
 
+    """
+    Filter to nodes that have ALL of these dimensions. Accepts dimension node names or dimension attributes
+    """
+    dimensions: [String!] = null
+
     """Limit nodes"""
     limit: Int = 1000
     orderBy: NodeSortField! = CREATED_AT


### PR DESCRIPTION
### Summary

This PR adds a new `dimensions` filter to the GraphQL `findNodes` query, allowing users to filter nodes that have specific dimensions. The `dimensions` parameter supports both dimension attributes and dimension node names (e.g., `["default.hard_hat"]` or `["default.hard_hat.city"]`).

#### Example Usage
Here's an example GraphQL query:
```
{
    findNodes(dimensions: ["default.hard_hat.city"], nodeTypes: [METRIC]) {
        name
        type
    }
}
```

This would return all metrics that have the `default.hard_hat.city` dimension available.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1588
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
