### PR TITLE
Speed up SQL generation

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -32,6 +32,8 @@ from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.utils import refresh_if_needed
 from datajunction_server.construction.utils import get_dj_node, to_namespaced_name
+from datajunction_server.database.attributetype import ColumnAttribute
+from datajunction_server.database.column import Column as DBColumn
 from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.node import Node as DJNodeRef
 from datajunction_server.database.node import NodeRevision
@@ -353,13 +355,20 @@ class Node(ABC):
 
     def contains(self, other: "Node") -> bool:
         """
-        Checks if the subtree of `self` contains the node
+        Checks if the subtree of `self` contains the node.
+        Optimized to walk up parent pointers instead of traversing the entire subtree.
         """
-        return any(self.filter(lambda node: node is other))
+        # Walk up from `other` to see if we reach `self`
+        current: Optional["Node"] = other
+        while current is not None:
+            if current is self:
+                return True
+            current = current.parent
+        return False
 
-    def is_ancestor_of(self, other: Optional["Node"]) -> bool:
+    def has_ancestor(self, other: Optional["Node"]) -> bool:
         """
-        Checks if `self` is an ancestor of the node
+        Checks if `other` is an ancestor of `self` (i.e., `self` is in `other`'s subtree).
         """
         return bool(other) and other.contains(self)
 
@@ -878,15 +887,19 @@ class Column(Aliasable, Named, Expression):
             Query,
             self.get_nearest_parent_of_type(Query),
         )
-        direct_tables = list(
-            filter(
-                lambda tbl: tbl.in_from_or_lateral()
-                and tbl.get_nearest_parent_of_type(Query) is query,
-                query.find_all(TableExpression),
-            ),
-        )
+
+        # Use cached table expressions to avoid repeated AST traversals
+        all_table_expressions = query.get_table_expressions()
+        direct_tables = [
+            tbl
+            for tbl in all_table_expressions
+            if tbl.in_from_or_lateral()
+            and tbl.get_nearest_parent_of_type(Query) is query
+        ]
+
         if hasattr(self, "child"):
             self.add_type(self.child.type)
+
         for table in direct_tables:
             if not table.is_compiled():
                 await table.compile(ctx)
@@ -936,13 +949,12 @@ class Column(Aliasable, Named, Expression):
             return found
 
         if not query.in_from_or_lateral():
-            correlation_tables = list(
-                filter(
-                    lambda tbl: tbl.in_from_or_lateral()
-                    and query.is_ancestor_of(tbl.get_nearest_parent_of_type(Query)),
-                    query.find_all(TableExpression),
-                ),
-            )
+            correlation_tables = [
+                tbl
+                for tbl in all_table_expressions
+                if tbl.in_from_or_lateral()
+                and query.has_ancestor(tbl.get_nearest_parent_of_type(Query))
+            ]
             for table in correlation_tables:
                 if not namespace or table.alias_or_name.identifier(False) == namespace:
                     if await table.add_ref_column(self, ctx):
@@ -957,13 +969,38 @@ class Column(Aliasable, Named, Expression):
             direct_table.alias_or_name.identifier() for direct_table in direct_tables
         }
         if isinstance(alpha_query, Query) and alpha_query.ctes:
+            # Get the column name we're looking for
+            column_name = self.name.name
             for cte in alpha_query.ctes:
                 cte_name = cte.alias_or_name.identifier(False)
                 if cte_name == namespace or (
                     not namespace and cte_name in direct_table_names
                 ):
-                    if await cte.add_ref_column(self, ctx):
-                        found.append(cte)
+                    # Quick check: see if CTE projection has a column with this name
+                    # before triggering expensive compilation
+                    if cte._columns:
+                        # CTE already compiled, use fast path
+                        if await cte.add_ref_column(self, ctx):
+                            found.append(cte)
+                    else:
+                        # Check if the CTE's projection might have this column
+                        # by looking at alias names in the projection
+                        might_have_column = False
+                        for proj_expr in cte.select.projection:
+                            if hasattr(proj_expr, "alias_or_name"):
+                                if proj_expr.alias_or_name.name == column_name:
+                                    might_have_column = True
+                                    break
+                            elif hasattr(proj_expr, "name") and hasattr(
+                                proj_expr.name,
+                                "name",
+                            ):
+                                if proj_expr.name.name == column_name:
+                                    might_have_column = True
+                                    break
+                        if might_have_column:
+                            if await cte.add_ref_column(self, ctx):
+                                found.append(cte)
 
         # If nothing was found in the initial AST, traverse through dimensions graph
         # to find another table in DJ that could be its origin
@@ -1054,7 +1091,6 @@ class Column(Aliasable, Named, Expression):
         Compile a column.
         Determines the table from which a column is from.
         """
-
         if self.is_compiled():
             return
 
@@ -1269,7 +1305,14 @@ class TableExpression(Aliasable, Expression):
                 column.add_table(self)
                 column.add_expression(matching_column)
                 column.add_type(matching_column.type)
-                # return True
+                # Fast path: if we found it in column_mapping, we're done
+                # (unless it's a struct type that needs special handling)
+                if not (
+                    hasattr(matching_column, "_type")
+                    and matching_column._type
+                    and isinstance(matching_column.type, StructType)
+                ):
+                    return True
 
         # For table-valued functions, add the list of columns that gets
         # returned as reference columns and compile them
@@ -1402,9 +1445,16 @@ class Table(TableExpression, Named):
             return
 
         self._is_compiled = True
+
+        table_name = self.identifier(quotes=False)
+
+        # Skip DB lookup for names that don't look like DJ nodes
+        if SEPARATOR not in table_name:
+            return
+
         try:
             if not self.dj_node:
-                db_node = ctx.dependencies_cache.get(self.identifier(quotes=False))
+                db_node = ctx.dependencies_cache.get(table_name)
                 if db_node:
                     await refresh_if_needed(ctx.session, db_node, ["current"])
                     await refresh_if_needed(ctx.session, db_node.current, ["columns"])
@@ -1412,15 +1462,19 @@ class Table(TableExpression, Named):
                 else:
                     dj_node = await get_dj_node(
                         ctx.session,
-                        self.identifier(quotes=False),
+                        table_name,
                         {DJNodeType.SOURCE, DJNodeType.TRANSFORM, DJNodeType.DIMENSION},
                     )
+                    # Cache successful lookups in context
+                    ctx.dependencies_cache[table_name] = dj_node
                 self.set_dj_node(dj_node)
             self._columns = [
                 Column(Name(col.name), _type=col.type, _table=self)
                 for col in self.dj_node.columns
             ]
         except DJErrorException as exc:
+            # Don't cache failed lookups - the node might be created later
+            # Only the pattern-based checks above should add to the cache
             ctx.exception.errors.append(exc.dj_error)
 
 
@@ -2762,6 +2816,24 @@ class Query(TableExpression, UnNamed):
 
     select: SelectExpression = field(default_factory=SelectExpression)
     ctes: List["Query"] = field(default_factory=list)
+    # Cache for find_all(TableExpression) to avoid repeated traversals
+    _table_expr_cache: Optional[List["TableExpression"]] = field(
+        default=None,
+        repr=False,
+    )
+
+    def get_table_expressions(self) -> List["TableExpression"]:
+        """
+        Get all TableExpression nodes in this query's subtree.
+        Results are cached for performance.
+        """
+        if self._table_expr_cache is None:
+            self._table_expr_cache = list(self.find_all(TableExpression))
+        return self._table_expr_cache
+
+    def invalidate_table_expr_cache(self):
+        """Clear the table expression cache (call after AST modifications)."""
+        self._table_expr_cache = None
 
     def is_compiled(self) -> bool:
         return not any(
@@ -2812,12 +2884,8 @@ class Query(TableExpression, UnNamed):
             cte.alias_or_name.name: cte
             for cte in (nearest_query.ctes if nearest_query else [])
         }
-        referenced_dimension_options = [
-            Table(Name(col.identifier().rsplit(SEPARATOR, 1)[0]))
-            for col in self.select.find_all(Column)
-            if SEPARATOR in col.identifier().rsplit(SEPARATOR, 1)[0]
-        ]
-        table_options = (
+        # Get tables from FROM clause first
+        from_tables = (
             [
                 tbl
                 for tbl in self.select.from_.find_all(TableExpression)
@@ -2825,19 +2893,66 @@ class Query(TableExpression, UnNamed):
             ]
             if self.select.from_
             else []
-        ) + referenced_dimension_options
+        )
+        # Get the identifiers of tables already in FROM clause to avoid duplicates
+        from_table_identifiers = {
+            tbl.identifier() for tbl in from_tables if isinstance(tbl, Table)
+        }
+        # Only add referenced_dimension_options for tables NOT already in FROM clause
+        referenced_dimension_options = [
+            Table(Name(col.identifier().rsplit(SEPARATOR, 1)[0]))
+            for col in self.select.find_all(Column)
+            if SEPARATOR in col.identifier().rsplit(SEPARATOR, 1)[0]
+            and col.identifier().rsplit(SEPARATOR, 1)[0] not in from_table_identifiers
+        ]
+        table_options = from_tables + referenced_dimension_options
+
         if table_options:
-            referenced_nodes = await DJNodeRef.get_by_names(
-                ctx.session,
-                {
-                    option.identifier()
-                    for option in table_options
-                    if isinstance(option, Table)
-                },
-            )
-            ctx.dependencies_cache.update(
-                {node.name: node for node in referenced_nodes},
-            )
+            # Only look up tables not already in the cache
+            table_names_to_lookup = {
+                option.identifier()
+                for option in table_options
+                if isinstance(option, Table)
+                and option.identifier() not in ctx.dependencies_cache
+            }
+            if table_names_to_lookup:
+                # Load options for AST compilation
+                # Includes parents/materializations for Pydantic serialization in validation
+                eager_options = [
+                    joinedload(DJNodeRef.current).options(
+                        # Columns with attributes for proper type resolution
+                        selectinload(NodeRevision.columns).options(
+                            joinedload(DBColumn.attributes).joinedload(
+                                ColumnAttribute.attribute_type,
+                            ),
+                            joinedload(DBColumn.dimension),
+                        ),
+                        # Catalog needed for get_table_for_node (SOURCE nodes)
+                        joinedload(NodeRevision.catalog),
+                        # Availability needed for get_table_for_node (materialized nodes)
+                        selectinload(NodeRevision.availability),
+                        # Dimension links for dimension graph traversal
+                        selectinload(NodeRevision.dimension_links).options(
+                            joinedload(DimensionLink.dimension).options(
+                                joinedload(DJNodeRef.current).options(
+                                    selectinload(NodeRevision.columns),
+                                ),
+                            ),
+                        ),
+                        # Parents and materializations needed for Pydantic serialization
+                        selectinload(NodeRevision.parents),
+                        selectinload(NodeRevision.materializations),
+                    ),
+                ]
+                referenced_nodes = await DJNodeRef.get_by_names(
+                    ctx.session,
+                    table_names_to_lookup,
+                    options=eager_options,
+                )
+                ctx.dependencies_cache.update(
+                    {node.name: node for node in referenced_nodes},
+                )
+
             for idx, option in enumerate(table_options):
                 if isinstance(option, Table) and option.name.name in cte_mapping:
                     option = cte_mapping[option.name.name]
@@ -2846,6 +2961,7 @@ class Query(TableExpression, UnNamed):
 
             expressions_to_compile = [
                 self.select.projection,
+                self.select.from_,
                 self.select.group_by,
                 self.select.having,
                 self.select.where,

--- a/datajunction-server/tests/construction/compile_test.py
+++ b/datajunction-server/tests/construction/compile_test.py
@@ -15,17 +15,17 @@ from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 @pytest.mark.asyncio
 async def test_get_table_node_is_none(construction_session: AsyncSession):
     """
-    Test a nonexistent table node with compound exception ignore
+    Test a nonexistent table node with compound exception ignore.
     """
 
-    query = parse("select x from purchases")
+    query = parse("select x from default.purchases")
     ctx = CompileContext(
         session=construction_session,
         exception=DJException(),
     )
     await query.compile(ctx)
 
-    assert "No node `purchases`" in str(ctx.exception.errors)
+    assert "No node `default.purchases`" in str(ctx.exception.errors)
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -40,43 +40,43 @@ async def test_ast_compile_table(
 @pytest.mark.asyncio
 async def test_ast_compile_table_missing_node(session: AsyncSession):
     """
-    Test compiling a table when the node is missing
+    Test compiling a table when the node is missing.
     """
-    query = parse("SELECT a FROM foo")
+    query = parse("SELECT a FROM default.foo")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.select.from_.relations[0].primary.compile(ctx)  # type: ignore
-    assert "No node `foo` exists of kind" in exc.errors[0].message
+    assert "No node `default.foo` exists of kind" in exc.errors[0].message
 
-    query = parse("SELECT a FROM foo, bar, baz")
+    query = parse("SELECT a FROM default.foo, default.bar, default.baz")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.select.from_.relations[0].primary.compile(ctx)  # type: ignore
-    assert "No node `foo` exists of kind" in exc.errors[0].message
+    assert "No node `default.foo` exists of kind" in exc.errors[0].message
     await query.select.from_.relations[1].primary.compile(ctx)  # type: ignore
-    assert "No node `bar` exists of kind" in exc.errors[1].message
+    assert "No node `default.bar` exists of kind" in exc.errors[1].message
     await query.select.from_.relations[2].primary.compile(ctx)  # type: ignore
-    assert "No node `baz` exists of kind" in exc.errors[2].message
+    assert "No node `default.baz` exists of kind" in exc.errors[2].message
 
-    query = parse("SELECT a FROM foo LEFT JOIN bar")
+    query = parse("SELECT a FROM default.foo LEFT JOIN default.bar")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.select.from_.relations[0].primary.compile(ctx)  # type: ignore
-    assert "No node `foo` exists of kind" in exc.errors[0].message
+    assert "No node `default.foo` exists of kind" in exc.errors[0].message
     await query.select.from_.relations[0].extensions[0].right.compile(ctx)  # type: ignore
-    assert "No node `bar` exists of kind" in exc.errors[1].message
+    assert "No node `default.bar` exists of kind" in exc.errors[1].message
 
-    query = parse("SELECT a FROM foo LEFT JOIN (SELECT b FROM bar) b")
+    query = parse("SELECT a FROM default.foo LEFT JOIN (SELECT b FROM default.bar) b")
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.select.from_.relations[0].primary.compile(ctx)  # type: ignore
-    assert "No node `foo` exists of kind" in exc.errors[0].message
+    assert "No node `default.foo` exists of kind" in exc.errors[0].message
     await (
         query.select.from_.relations[0].extensions[0].right.select.from_.relations  # type: ignore
     )[0].primary.compile(
         ctx,
     )
-    assert "No node `bar` exists of kind" in exc.errors[1].message
+    assert "No node `default.bar` exists of kind" in exc.errors[1].message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

**Dimension Path Loading**: When building dimension joins, the code used BFS traversal with individual database queries at each step. For a query with 19 dimensions and 3-hop depth, this meant ~57 separate DB queries. After this change, we're now running a single recursive CTE query to find all dimension join paths at once.

**Batch Loading of ORM Objects**

This change batch loads all required `DimensionLink` and their associated `Node` objects in a single query with eager loading, eliminating expensive query patterns where each object was loaded individually, for each link in the path.

We also reduce the number of times `get_dj_node` gets called for each table reference by introducing a `dependencies_cache`. This is populated early in the build process with a batch load of required nodes.

**Other Changes**
* Renamed `is_ancestor_of` to `has_ancestor`. The old name was confusing, since it actually checked if other was an ancestor of self, not the other way around.
* Added an inline check (`SEPARATOR in name`) to determine if a name could be a DJ node before going to the db.
* Uses dependencies cache instead of always defaulting to a database lookup for access control.

### Benchmarking

Complexity | Before (avg) | After (avg) | Speedup
-- | -- | -- | --
Complex (deep deps, multi-dim) | 5763 ms | 1502 ms | 3.8x faster
Complex (long queries) | 5644 ms | 1300 ms | 4.3x faster
Medium (moderate deps) | 1108 ms | 603 ms | 1.8x faster
Simple (few deps, 3 dims) | 357 ms | 371 ms | ~same
Simple (no dims) | 134 ms | 148 ms | ~same

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
