### PR TITLE
Fix parsing expressions with decimal numbers at end of input

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/backends/grammar/generated/SqlBaseLexer.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/grammar/generated/SqlBaseLexer.py
@@ -1834,7 +1834,10 @@ class SqlBaseLexer(Lexer):
         * by a space. 34.E2 is a valid decimal token because it is followed by symbol '+'
         * which is not a digit or letter or underscore.
         """
-        nextChar = chr(self._input.LA(1))
+        nextCharCode = self._input.LA(1)
+        if nextCharCode == -1:  # EOF - end of input is a valid delimiter
+            return True
+        nextChar = chr(nextCharCode)
         if (
             nextChar >= 'A'
             and nextChar <= 'Z' 
@@ -1853,7 +1856,10 @@ class SqlBaseLexer(Lexer):
         it as a bracketed comment.
         Returns true if the next character is '+'.
         """
-        nextChar = chr(self._input.LA(1))
+        nextCharCode = self._input.LA(1)
+        if nextCharCode == -1:  # EOF
+            return False
+        nextChar = chr(nextCharCode)
         if nextChar == '+':
             return True
         else:

--- a/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
+++ b/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
@@ -201,3 +201,30 @@ def test_antlr4_arithmetic_unary_op():
         expr=ast.Column(name=ast.Name(name="a")),
     )
     assert "~a" in str(query_ast)
+
+
+def test_antlr4_decimal_at_eof():
+    """
+    Test parsing expressions with decimal numbers at end of input.
+
+    This tests a fix for a bug where the lexer's isValidDecimal() method
+    would crash with `chr(-1)` ValueError when a decimal like `3600.0`
+    appeared at the end of the input string (EOF).
+    """
+    # Simple decimal at EOF
+    query_ast = parse("SELECT 3600.0")
+    assert "3600.0" in str(query_ast)
+
+    # Expression with decimal at EOF
+    query_ast = parse("SELECT x / 3600.0")
+    assert "3600.0" in str(query_ast)
+    assert "/" in str(query_ast)
+
+    # Multiple decimals, last one at EOF
+    query_ast = parse("SELECT 1.5 + 2.5")
+    assert "1.5" in str(query_ast)
+    assert "2.5" in str(query_ast)
+
+    # Decimal with scientific notation at EOF (normalized to 150.0)
+    query_ast = parse("SELECT 1.5E2")
+    assert "150.0" in str(query_ast)


### PR DESCRIPTION
### Summary

This fixes an issue with parsing expressions that have decimal numbers at the end of the input:
```
SELECT abcd / 1000.0
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
