### PR TITLE
Ensure that tags always point to commits on main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -101,11 +101,7 @@ jobs:
           git checkout -b releases/version-$NEW_VERSION
           git push --set-upstream origin releases/version-$NEW_VERSION -f
 
-          echo "Make a tag ..."
-          git tag -a version-$NEW_VERSION -m version-$NEW_VERSION
-          git push origin version-$NEW_VERSION
-
           echo "Create a PR ..."
-          gh pr create -B main -H "releases/version-$NEW_VERSION" --title "Bump DataJunction version to $NEW_VERSION" --body "This is an automated PR triggered by the github action. Merging this PR will publish all the component for version $NEW_VERSION ."
+          gh pr create -B main -H "releases/version-$NEW_VERSION" --title "Bump DataJunction version to $NEW_VERSION" --body "This is an automated PR triggered by the github action. Merging this PR will publish all the component for version $NEW_VERSION and create the git tag."
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}          
+          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}

--- a/.github/workflows/version-publish.yml
+++ b/.github/workflows/version-publish.yml
@@ -41,6 +41,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install hatch
 
+      - name: Get version and create tag
+        run: |
+          cd datajunction-server
+          NEW_VERSION=$(hatch version)
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          cd ..
+          
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          
+          # Create and push the tag on main (after merge)
+          git tag -a version-$NEW_VERSION -m "version-$NEW_VERSION"
+          git push origin version-$NEW_VERSION
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
+
       #
       # Publish Python / hatch
       #


### PR DESCRIPTION
### Summary

This ensures that tags always point to commits that on the main branch, which is the correct release tagging behavior.

The new flow is:
* `version-bump.yml`: bumps versions, creates PR (no tag)
* PR gets merged to main
* `version-publish.yml`: creates tag on main, publishes to PyPI

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
