### PR TITLE
Window function PARTITION BY injection of dimensions

### DIFF
--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -1559,6 +1559,22 @@ async def module__client_with_examples(
 
 
 @pytest_asyncio.fixture(scope="module")
+async def module__client_with_build_v3(
+    module__client_example_loader: Callable[[Optional[List[str]]], AsyncClient],
+) -> AsyncClient:
+    """
+    Provides a module-scoped DJ client fixture with BUILD_V3 examples.
+    This is the comprehensive test model for V3 SQL generation, including:
+    - Multi-hop dimension traversal with roles
+    - Dimension hierarchies (date, location)
+    - Cross-fact derived metrics (orders + page_views)
+    - Period-over-period metrics (window functions)
+    - Multiple aggregability levels
+    """
+    return await module__client_example_loader(["BUILD_V3"])
+
+
+@pytest_asyncio.fixture(scope="module")
 async def module__clean_client(
     request,
     postgres_container: PostgresContainer,

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -859,9 +859,18 @@ class TestMetricsSQLCrossFact:
             SELECT  COALESCE(order_details_0.category) AS category,
                 COALESCE(order_details_0.month) AS month,
                 COALESCE(order_details_0.week) AS week,
-                (SUM(order_details_0.total_revenue) - LAG(SUM(order_details_0.total_revenue), 1) OVER ( ORDER BY week) ) / NULLIF(LAG(SUM(order_details_0.total_revenue), 1) OVER ( ORDER BY week) , 0) * 100 AS wow_revenue_change,
-                (CAST(COUNT( DISTINCT order_details_0.order_id) AS DOUBLE) - LAG(CAST(COUNT( DISTINCT order_details_0.order_id) AS DOUBLE), 1) OVER ( ORDER BY week) ) / NULLIF(LAG(CAST(COUNT( DISTINCT order_details_0.order_id) AS DOUBLE), 1) OVER ( ORDER BY week) , 0) * 100 AS wow_order_growth,
-                (SUM(order_details_0.total_revenue) - LAG(SUM(order_details_0.total_revenue), 1) OVER ( ORDER BY month) ) / NULLIF(LAG(SUM(order_details_0.total_revenue), 1) OVER ( ORDER BY month) , 0) * 100 AS mom_revenue_change
+
+                (SUM(order_details_0.total_revenue) - LAG(SUM(order_details_0.total_revenue), 1) OVER ( PARTITION BY category, month
+ ORDER BY week) ) / NULLIF(LAG(SUM(order_details_0.total_revenue), 1) OVER ( PARTITION BY category, month
+ ORDER BY week) , 0) * 100 AS wow_revenue_change,
+
+                (CAST(COUNT( DISTINCT order_details_0.order_id) AS DOUBLE) - LAG(CAST(COUNT( DISTINCT order_details_0.order_id) AS DOUBLE), 1) OVER ( PARTITION BY category, month
+ ORDER BY week) ) / NULLIF(LAG(CAST(COUNT( DISTINCT order_details_0.order_id) AS DOUBLE), 1) OVER ( PARTITION BY category, month
+ ORDER BY week) , 0) * 100 AS wow_order_growth,
+
+                (SUM(order_details_0.total_revenue) - LAG(SUM(order_details_0.total_revenue), 1) OVER ( PARTITION BY category, week
+ ORDER BY month) ) / NULLIF(LAG(SUM(order_details_0.total_revenue), 1) OVER ( PARTITION BY category, week
+ ORDER BY month) , 0) * 100 AS mom_revenue_change
             FROM order_details_0
             GROUP BY  order_details_0.category, order_details_0.month, order_details_0.week
         """,


### PR DESCRIPTION
### Summary

This change is for automatically injecting `PARTITION BY` clauses into navigation/ranking window functions (LAG, LEAD, RANK, etc.) so that period-over-period comparisons happen within dimensional partitions.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
