### PR TITLE
Fix regression that slowed down common dimensions for metrics search

### DIFF
--- a/datajunction-server/tests/api/graphql/engine_test.py
+++ b/datajunction-server/tests/api/graphql/engine_test.py
@@ -90,9 +90,7 @@ async def test_list_dialects(
     expected_dialects = [
         {"name": "spark", "pluginClass": "SQLTranspilationPlugin"},
         {"name": "trino", "pluginClass": "SQLTranspilationPlugin"},
-        {"name": "postgres", "pluginClass": "SQLGlotTranspilationPlugin"},
         {"name": "druid", "pluginClass": "SQLTranspilationPlugin"},
-        {"name": "clickhouse", "pluginClass": "SQLGlotTranspilationPlugin"},
     ]
     actual_dialects = data["data"]["listDialects"]
     for expected in expected_dialects:

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -202,9 +202,9 @@ export const DataJunctionAPI = {
       const cubeMetrics = (current.cubeMetrics || []).map(m => m.name);
       const cubeDimensions = (current.cubeDimensions || []).map(d => d.name);
 
-      // Extract druid_cube materialization if present
+      // Extract druid_cube materialization if present (v3 or legacy)
       const druidMat = (current.materializations || []).find(
-        m => m.name === 'druid_cube',
+        m => m.name === 'druid_cube' || m.name === 'druid_cube_v3',
       );
       const cubeMaterialization = druidMat
         ? {


### PR DESCRIPTION
### Summary

This fixes a regression that was introduced where searching for common dimensions for a set of metrics was slowed down by us repeatedly traversing the dimensions graph for each metric, rather than grouping by parents first before traversing.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
