### PR TITLE
Metrics editor requires the parent node types

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/column.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/column.py
@@ -45,6 +45,7 @@ class NodeNameVersion:
 
     name: str
     current_version: str
+    type: str
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -280,6 +280,7 @@ type NodeName {
 type NodeNameVersion {
   name: String!
   currentVersion: String!
+  type: String!
 }
 
 type NodeRevision {

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -537,6 +537,7 @@ async def test_find_transform(
                 parents {
                     name
                     currentVersion
+                    type
                 }
                 materializations {
                     name
@@ -582,10 +583,12 @@ async def test_find_transform(
                     {
                         "name": "default.repair_orders",
                         "currentVersion": "v1.2",
+                        "type": "source",
                     },
                     {
                         "name": "default.repair_order_details",
                         "currentVersion": "v1.2",
+                        "type": "source",
                     },
                 ],
                 "extractedMeasures": None,


### PR DESCRIPTION
### Summary

The metrics editor UI now supports derived metrics, which requires that its parent nodes' types are available via GraphQL.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
