### PR TITLE
Fix python 3.11 unit test hanging

### DIFF
--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -608,18 +608,6 @@ async def clean_client(
     cleanup_database_for_module(postgres_container, dbname)
 
 
-@pytest.fixture(scope="module")
-def event_loop():
-    """
-    Module-scoped event loop for async fixtures.
-    This ensures all async fixtures within a module share the same event loop.
-    """
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    yield loop
-    loop.close()
-
-
 @pytest.fixture
 def query_service_client(
     mocker: MockerFixture,


### PR DESCRIPTION
### Summary

Remove event_loop fixture as it is deprecated with pytest-asyncio 0.21+ and can conflict with automatic event loop management

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
