### PR TITLE
Make YAML export of queries multiline

### DIFF
--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -904,9 +904,12 @@ def _get_yaml_dumper():
     Get a YAML dumper configured for clean node export.
     Uses literal block style for multiline strings (like SQL queries).
     """
-    dumper = yaml.SafeDumper
-    dumper.add_representer(str, _multiline_str_representer)
-    return dumper
+
+    class MultilineStrDumper(yaml.SafeDumper):
+        pass
+
+    MultilineStrDumper.add_representer(str, _multiline_str_representer)
+    return MultilineStrDumper
 
 
 def _node_spec_to_yaml_dict(node_spec) -> dict:

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -1487,19 +1487,26 @@ class TestYamlHelpers:
         assert result.style is None  # Default style
 
     def test_get_yaml_dumper(self):
-        """Test that YAML dumper is properly configured"""
+        """Test that YAML dumper uses literal block style for multiline strings"""
         from datajunction_server.internal.namespaces import _get_yaml_dumper
+        from pathlib import Path
         import yaml
 
         dumper = _get_yaml_dumper()
 
-        # Verify it's a SafeDumper
-        assert dumper == yaml.SafeDumper or issubclass(dumper, yaml.SafeDumper)
+        # Verify it's a SafeDumper subclass
+        assert issubclass(dumper, yaml.SafeDumper)
 
         # Test dumping a multiline string uses literal block style
-        data = {"query": "SELECT *\nFROM table\nWHERE x = 1"}
-        output = yaml.dump(data, Dumper=dumper)
-        assert "|" in output  # Should use literal block style
+        data = {"query": "SELECT *\nFROM table\nWHERE x = 1", "name": "test_node"}
+        output = yaml.dump(data, Dumper=dumper, sort_keys=False)
+
+        # Compare against expected fixture
+        fixture_path = (
+            Path(__file__).parent.parent / "fixtures" / "expected_multiline_query.yaml"
+        )
+        expected = fixture_path.read_text()
+        assert output == expected
 
     def test_node_spec_to_yaml_dict_excludes_none(self):
         """Test that _node_spec_to_yaml_dict excludes None values"""

--- a/datajunction-server/tests/fixtures/expected_multiline_query.yaml
+++ b/datajunction-server/tests/fixtures/expected_multiline_query.yaml
@@ -1,0 +1,5 @@
+query: |-
+  SELECT *
+  FROM table
+  WHERE x = 1
+name: test_node


### PR DESCRIPTION
### Summary

This fixes the YAML export of nodes to have queries that are multiline rather than a single string separated by newlines.

The original code was modifying the `yaml.SafeDumper` class directly, which didn't reliably apply the multiline representer. The fix creates a new subclass each time. Now queries with newlines will be exported as:

```
  query: |
    select
    *
    FROM ...
```

Instead of:
```
  query: "select\n*\nFROM ..."
```

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1661 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
