### PR TITLE
Continue publishing on error and remove registry-url from setup-node …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
 
       #
       # Build Python packages
@@ -66,6 +65,7 @@ jobs:
       # Publish Python packages to PyPI (using OIDC trusted publishing)
       #
       - name: Publish DJ Server to PyPI
+        continue-on-error: true
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: datajunction-server/dist/
@@ -77,11 +77,13 @@ jobs:
       #     packages-dir: datajunction-query/dist/
 
       - name: Publish DJ Reflection service to PyPI
+        continue-on-error: true
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: datajunction-reflection/dist/
 
       - name: Publish DJ Python client to PyPI
+        continue-on-error: true
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: datajunction-clients/python/dist/
@@ -90,12 +92,14 @@ jobs:
       # Publish JavaScript packages to npm
       #
       - name: Publish DJ Javascript client to npm
+        continue-on-error: true
         working-directory: ./datajunction-clients/javascript
         run: |
           yarn install --frozen-lockfile
           npm publish --access public --provenance
 
       - name: Publish DJ UI to npm
+        continue-on-error: true
         working-directory: ./datajunction-ui
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION
…so that npm won't expect a token

### Summary

<!-- What's this change about? -->

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
