### PR TITLE
Switch order and try OIDC publishing for DJ UI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,16 +91,16 @@ jobs:
       #
       # Publish JavaScript packages to npm
       #
-      - name: Publish DJ Javascript client to npm
+      - name: Publish DJ UI to npm
         continue-on-error: true
-        working-directory: ./datajunction-clients/javascript
+        working-directory: ./datajunction-ui
         run: |
           yarn install --frozen-lockfile
           npm publish --access public --provenance
 
-      - name: Publish DJ UI to npm
+      - name: Publish DJ Javascript client to npm
         continue-on-error: true
-        working-directory: ./datajunction-ui
+        working-directory: ./datajunction-clients/javascript
         run: |
           yarn install --frozen-lockfile
           npm publish --access public --provenance


### PR DESCRIPTION
### Summary

Switch the order of javascript client vs datajunction-ui publishing and try OIDC trusted publishing.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
