### PR TITLE
Fix npm release by upgrading node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'  # Node 24+ includes npm 11.5.1+ required for OIDC trusted publishing
+          registry-url: 'https://registry.npmjs.org'
 
       #
       # Build Python packages
@@ -89,7 +90,10 @@ jobs:
           packages-dir: datajunction-clients/python/dist/
 
       #
-      # Publish JavaScript packages to npm
+      # Publish JavaScript packages to npm (using OIDC trusted publishing)
+      # NOTE: Each package must be configured on npmjs.com:
+      #   Package Settings → Trusted Publisher → GitHub Actions
+      #   Organization: DataJunction, Repository: dj, Workflow: publish.yml
       #
       - name: Publish DJ Javascript client to npm
         continue-on-error: true


### PR DESCRIPTION
### Summary

This updates `publish.yml` with node.js 24, which includes npm 11.5.1+, which is required for OIDC.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
