### PR TITLE
Add cascade delete for fks and fix derived metric upstream

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_01_20_0000-a1b2c3d4e5f7_add_cascade_delete_to_fks.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_01_20_0000-a1b2c3d4e5f7_add_cascade_delete_to_fks.py
@@ -1,0 +1,139 @@
+"""
+Add ON DELETE CASCADE to foreign keys referencing noderevision
+
+Fixes foreign key constraint violations when deleting nodes that have
+related records in pre_aggregation, nodeavailabilitystate, materialization,
+or nodemissingparents tables.
+
+Revision ID: a1b2c3d4e5f7
+Revises: f6562450c2c7
+Create Date: 2026-01-20 00:00:00.000000+00:00
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f7"
+down_revision = "f6562450c2c7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Fix pre_aggregation.node_revision_id FK
+    op.drop_constraint(
+        "fk_pre_aggregation_node_revision_id_noderevision",
+        "pre_aggregation",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_pre_aggregation_node_revision_id_noderevision",
+        "pre_aggregation",
+        "noderevision",
+        ["node_revision_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Fix nodeavailabilitystate.node_id FK
+    op.drop_constraint(
+        "fk_nodeavailabilitystate_node_id_noderevision",
+        "nodeavailabilitystate",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_nodeavailabilitystate_node_id_noderevision",
+        "nodeavailabilitystate",
+        "noderevision",
+        ["node_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Fix materialization.node_revision_id FK
+    op.drop_constraint(
+        "fk_materialization_node_revision_id_noderevision",
+        "materialization",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_materialization_node_revision_id_noderevision",
+        "materialization",
+        "noderevision",
+        ["node_revision_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Fix nodemissingparents.referencing_node_id FK
+    op.drop_constraint(
+        "fk_nodemissingparents_referencing_node_id_noderevision",
+        "nodemissingparents",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_nodemissingparents_referencing_node_id_noderevision",
+        "nodemissingparents",
+        "noderevision",
+        ["referencing_node_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    # Remove CASCADE from pre_aggregation.node_revision_id FK
+    op.drop_constraint(
+        "fk_pre_aggregation_node_revision_id_noderevision",
+        "pre_aggregation",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_pre_aggregation_node_revision_id_noderevision",
+        "pre_aggregation",
+        "noderevision",
+        ["node_revision_id"],
+        ["id"],
+    )
+
+    # Remove CASCADE from nodeavailabilitystate.node_id FK
+    op.drop_constraint(
+        "fk_nodeavailabilitystate_node_id_noderevision",
+        "nodeavailabilitystate",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_nodeavailabilitystate_node_id_noderevision",
+        "nodeavailabilitystate",
+        "noderevision",
+        ["node_id"],
+        ["id"],
+    )
+
+    # Remove CASCADE from materialization.node_revision_id FK
+    op.drop_constraint(
+        "fk_materialization_node_revision_id_noderevision",
+        "materialization",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_materialization_node_revision_id_noderevision",
+        "materialization",
+        "noderevision",
+        ["node_revision_id"],
+        ["id"],
+    )
+
+    # Remove CASCADE from nodemissingparents.referencing_node_id FK
+    op.drop_constraint(
+        "fk_nodemissingparents_referencing_node_id_noderevision",
+        "nodemissingparents",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_nodemissingparents_referencing_node_id_noderevision",
+        "nodemissingparents",
+        "noderevision",
+        ["referencing_node_id"],
+        ["id"],
+    )

--- a/datajunction-server/datajunction_server/api/metrics.py
+++ b/datajunction-server/datajunction_server/api/metrics.py
@@ -108,7 +108,8 @@ async def get_a_metric(
     Return a metric by name.
     """
     node = await get_metric(session, name)
-    dims = await get_dimensions(session, node.current.parents[0])
+    # get_dimensions handles derived metrics by finding ultimate non-metric parents
+    dims = await get_dimensions(session, node)
     metric = await Metric.parse_node(node, dims, session)
     return metric
 

--- a/datajunction-server/datajunction_server/database/availabilitystate.py
+++ b/datajunction-server/datajunction_server/database/availabilitystate.py
@@ -95,6 +95,7 @@ class NodeAvailabilityState(Base):
         ForeignKey(
             "noderevision.id",
             name="fk_nodeavailabilitystate_node_id_noderevision",
+            ondelete="CASCADE",
         ),
         primary_key=True,
     )

--- a/datajunction-server/datajunction_server/database/materialization.py
+++ b/datajunction-server/datajunction_server/database/materialization.py
@@ -55,11 +55,13 @@ class Materialization(Base):
         ForeignKey(
             "noderevision.id",
             name="fk_materialization_node_revision_id_noderevision",
+            ondelete="CASCADE",
         ),
     )
     node_revision: Mapped["NodeRevision"] = relationship(
         "NodeRevision",
         back_populates="materializations",
+        passive_deletes=True,
     )
 
     name: Mapped[str]

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -204,6 +204,7 @@ class NodeMissingParents(Base):
         ForeignKey(
             "noderevision.id",
             name="fk_nodemissingparents_referencing_node_id_noderevision",
+            ondelete="CASCADE",
         ),
         primary_key=True,
     )

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -168,6 +168,7 @@ class PreAggregation(Base):
         ForeignKey(
             "noderevision.id",
             name="fk_pre_aggregation_node_revision_id_noderevision",
+            ondelete="CASCADE",
         ),
         nullable=False,
         index=True,
@@ -250,7 +251,10 @@ class PreAggregation(Base):
     )
 
     # === Relationships ===
-    node_revision: Mapped["NodeRevision"] = relationship("NodeRevision")
+    node_revision: Mapped["NodeRevision"] = relationship(
+        "NodeRevision",
+        passive_deletes=True,
+    )
     availability: Mapped[Optional["AvailabilityState"]] = relationship(
         "AvailabilityState",
     )

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -37,7 +37,7 @@ class Metric(BaseModel):
     updated_at: UTCDatetime
 
     query: str
-    upstream_node: str
+    upstream_node: Optional[str] = None
     expression: str
 
     dimensions: List[DimensionAttributeOutput]
@@ -80,7 +80,11 @@ class Metric(BaseModel):
             created_at=node.created_at,
             updated_at=node.current.updated_at,
             query=node.current.query,  # type: ignore
-            upstream_node=node.current.parents[0].name,
+            upstream_node=(
+                node.current.non_metric_parents[0].name
+                if node.current.non_metric_parents
+                else None
+            ),
             expression=str(query_ast.select.projection[0]),
             dimensions=dims,
             metric_metadata=node.current.metric_metadata,


### PR DESCRIPTION
### Summary

This PR has two bugfixes:
* When deleting any nodes or node revisions, we'll hit an issue with the delete being blocked on foreign key references. This fixes that by setting the deletes to cascade on pre-aggregate, availability, and other FK refs.
* A derived metric should not display any upstreams, since there may be more than one. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
