### PR TITLE
Switch `/data/` endpoint to use v3 SQL builder

### DIFF
--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -469,32 +469,22 @@ class TestDataForNode:
                 {
                     "columns": [
                         {
-                            "column": "company_name",
-                            "name": "default_DOT_dispatcher_DOT_company_name",
-                            "node": "default.dispatcher",
-                            "semantic_entity": "default.dispatcher.company_name",
-                            "semantic_type": "dimension",
+                            "name": "company_name",
+                            "semantic_name": "default.dispatcher.company_name",
                             "type": "string",
+                            "semantic_type": "dimension",
                         },
                         {
-                            "column": "default_DOT_num_repair_orders",
-                            "name": "default_DOT_num_repair_orders",
-                            "node": "default.num_repair_orders",
-                            "semantic_entity": (
-                                "default.num_repair_orders.default_DOT_num_repair_orders"
-                            ),
-                            "semantic_type": "metric",
+                            "name": "num_repair_orders",
+                            "semantic_name": "default.num_repair_orders",
                             "type": "bigint",
+                            "semantic_type": "metric",
                         },
                         {
-                            "column": "default_DOT_avg_repair_price",
-                            "name": "default_DOT_avg_repair_price",
-                            "node": "default.avg_repair_price",
-                            "semantic_entity": (
-                                "default.avg_repair_price.default_DOT_avg_repair_price"
-                            ),
-                            "semantic_type": "metric",
+                            "name": "avg_repair_price",
+                            "semantic_name": "default.avg_repair_price",
                             "type": "double",
+                            "semantic_type": "metric",
                         },
                     ],
                     "row_count": 0,


### PR DESCRIPTION
### Summary

  - Migrate `/data/` and `/stream/` endpoints from the old SQL builder to the v3 SQL builder (build_metrics_sql)
  - Update column metadata format to use v3's cleaner structure
  - Update test infrastructure to handle Spark-to-DuckDB transpilation

#### V3 Builder Benefits
  - Derived metrics (multi-level) support
  - Cube matching for materialized tables
  - Grain group joins for metrics from different facts

#### Column Metadata Format Change
  The v3 builder uses a cleaner column format
#####  Old format
```
  {
      "column": "company_name",
      "name": "default_DOT_dispatcher_DOT_company_name",
      "node": "default.dispatcher",
      "semantic_entity": "default.dispatcher.company_name",
      "semantic_type": "dimension",
      "type": "string",
  }
```

##### New v3 format
```
  {
      "name": "company_name",
      "semantic_name": "default.dispatcher.company_name",
      "type": "string",
      "semantic_type": "dimension",
  }
```

### Test Plan

  - Added `transpile_to_duckdb()` helper using sqlglot to convert Spark SQL to DuckDB
  - Create default catalog in DuckDB fixture so "default".schema.table references work

### Deployment Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage
