### PR TITLE
Fix limit and order by propagation from djsql

### DIFF
--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -177,11 +177,10 @@ async def get_sql_for_djsql(
         metrics=metrics,
         dimensions=dimensions,
         filters=filters,
+        orderby=orderby if orderby else None,
+        limit=limit,
         dialect=dialect_enum,
     )
-
-    # TODO: Apply ORDER BY and LIMIT to the generated SQL if needed
-    # The v3 builder doesn't currently support these directly
 
     return TranslatedDJSQL(
         sql=result.sql,


### PR DESCRIPTION
### Summary

Fixes an issue with `/djsql` where we weren't propagating `LIMIT` and `ORDER BY`

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
