### PR TITLE
Preagg Hash Uniqueness

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_01_26_0000-b2c3d4e5f6a7_add_preagg_hash_column.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_01_26_0000-b2c3d4e5f6a7_add_preagg_hash_column.py
@@ -1,0 +1,96 @@
+"""
+Add preagg_hash column to pre_aggregation table
+
+Adds a unique preagg_hash column that incorporates node_revision_id, grain_columns,
+AND measure_expr_hashes. This ensures unique table/workflow names for pre-aggregations
+with the same grain but different measures.
+
+Revision ID: b2c3d4e5f6a7
+Revises: b2c3d4e5f6g7
+Create Date: 2026-01-26 00:00:00.000000+00:00
+"""
+
+import hashlib
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.orm import Session
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6a7"
+down_revision = "b2c3d4e5f6g7"
+branch_labels = None
+depends_on = None
+
+
+def compute_preagg_hash(
+    node_revision_id: int,
+    grain_columns: list,
+    measures: list,
+) -> str:
+    """Compute unique hash for a pre-aggregation."""
+    # Extract expr_hash from each measure
+    measure_hashes = sorted(
+        [m.get("expr_hash", "") for m in measures if m.get("expr_hash")],
+    )
+    content = (
+        f"{node_revision_id}:"
+        f"{json.dumps(sorted(grain_columns))}:"
+        f"{json.dumps(measure_hashes)}"
+    )
+    return hashlib.md5(content.encode()).hexdigest()[:8]
+
+
+def upgrade():
+    # Add preagg_hash column (nullable initially for migration)
+    op.add_column(
+        "pre_aggregation",
+        sa.Column("preagg_hash", sa.String(8), nullable=True),
+    )
+
+    # Populate preagg_hash for existing rows
+    connection = op.get_bind()
+    session = Session(bind=connection)
+
+    # Get all existing pre-aggregations
+    result = connection.execute(
+        sa.text(
+            "SELECT id, node_revision_id, grain_columns, measures FROM pre_aggregation",
+        ),
+    )
+    rows = result.fetchall()
+
+    for row in rows:
+        preagg_id = row[0]
+        node_revision_id = row[1]
+        grain_columns = (
+            row[2] if isinstance(row[2], list) else json.loads(row[2] or "[]")
+        )
+        measures = row[3] if isinstance(row[3], list) else json.loads(row[3] or "[]")
+
+        preagg_hash = compute_preagg_hash(node_revision_id, grain_columns, measures)
+
+        connection.execute(
+            sa.text("UPDATE pre_aggregation SET preagg_hash = :hash WHERE id = :id"),
+            {"hash": preagg_hash, "id": preagg_id},
+        )
+
+    session.commit()
+
+    # Make column non-nullable and add unique constraint
+    op.alter_column("pre_aggregation", "preagg_hash", nullable=False)
+    op.create_unique_constraint(
+        "uq_pre_aggregation_preagg_hash",
+        "pre_aggregation",
+        ["preagg_hash"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "uq_pre_aggregation_preagg_hash",
+        "pre_aggregation",
+        type_="unique",
+    )
+    op.drop_column("pre_aggregation", "preagg_hash")

--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -149,6 +149,7 @@ class PreAggregationInfo(BaseModel):
     columns: Optional[List[V3ColumnMetadata]] = None  # Output columns with types
     sql: str  # The generated SQL for materializing this pre-agg
     grain_group_hash: str
+    preagg_hash: str  # Unique hash including measures (used for table/workflow naming)
 
     # Materialization config
     strategy: Optional[MaterializationStrategy] = None

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -3843,7 +3843,7 @@ class TestCubeMaterializeV2SuccessPaths:
                   SUM(line_total_sum_e1f61696) line_total_sum_e1f61696,
                   hll_union_agg(customer_id_hll_23002251) customer_id_hll_23002251,
                   week_order
-                FROM default.dj_preaggs.v3_order_details_preagg_3983c442
+                FROM default.dj_preaggs.v3_order_details_preagg_399a3bfd
                 GROUP BY  category, order_id, week_order
                 """,
             )

--- a/datajunction-server/tests/construction/build_v3/loaders_test.py
+++ b/datajunction-server/tests/construction/build_v3/loaders_test.py
@@ -11,7 +11,9 @@ from datajunction_server.construction.build_v3.types import BuildContext
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.column import Column
 from datajunction_server.database.node import Node, NodeRevision
-from datajunction_server.database.preaggregation import PreAggregation
+from datajunction_server.database.preaggregation import (
+    PreAggregation,
+)
 from datajunction_server.database.user import User
 from datajunction_server.models.decompose import (
     MetricComponent,
@@ -141,6 +143,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT x FROM t",
             grain_group_hash="hash123",
+            preagg_hash="load_t01",
             availability_id=availability.id,
         )
         clean_session.add(preagg)
@@ -174,6 +177,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT x FROM t",
             grain_group_hash="hash_no_avail",
+            preagg_hash="load_t02",
             # No availability_id
         )
         clean_session.add(preagg)
@@ -215,6 +219,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT x FROM t",
             grain_group_hash="hash_unavail",
+            preagg_hash="load_t03",
             availability_id=availability.id,
         )
         clean_session.add(preagg)
@@ -263,6 +268,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT a",
             grain_group_hash="hash_multi_1",
+            preagg_hash="load_t04",
             availability_id=availability1.id,
         )
         preagg2 = PreAggregation(
@@ -272,6 +278,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT b",
             grain_group_hash="hash_multi_2",
+            preagg_hash="load_t05",
             availability_id=availability2.id,
         )
         clean_session.add_all([preagg1, preagg2])
@@ -342,6 +349,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT a",
             grain_group_hash="hash_rev1",
+            preagg_hash="load_t06",
             availability_id=avail1.id,
         )
         preagg2 = PreAggregation(
@@ -351,6 +359,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT b",
             grain_group_hash="hash_rev2",
+            preagg_hash="load_t07",
             availability_id=avail2.id,
         )
         clean_session.add_all([preagg1, preagg2])
@@ -444,6 +453,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT a",
             grain_group_hash="hash_wanted",
+            preagg_hash="load_t08",
             availability_id=avail1.id,
         )
         unwanted_preagg = PreAggregation(
@@ -453,6 +463,7 @@ class TestLoadAvailablePreaggs:
             columns=[],
             sql="SELECT b",
             grain_group_hash="hash_unwanted",
+            preagg_hash="load_t09",
             availability_id=avail2.id,
         )
         clean_session.add_all([wanted_preagg, unwanted_preagg])

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -2779,7 +2779,7 @@ class TestCombinedMeasuresSQLEndpoint:
         # Source tables should be pre-agg table references
         assert len(data["source_tables"]) >= 1
         assert data["source_tables"] == [
-            "default.dj_preaggs.v3_order_details_preagg_b18e32ec",
+            "default.dj_preaggs.v3_order_details_preagg_d344b4e3",
         ]
 
         # Extract the preagg table name for SQL comparison
@@ -2788,7 +2788,7 @@ class TestCombinedMeasuresSQLEndpoint:
             data["sql"],
             """
             SELECT status, SUM(line_total_sum_e1f61696) line_total_sum_e1f61696
-            FROM default.dj_preaggs.v3_order_details_preagg_b18e32ec
+            FROM default.dj_preaggs.v3_order_details_preagg_d344b4e3
             GROUP BY status
             """,
         )
@@ -2820,7 +2820,7 @@ class TestCombinedMeasuresSQLEndpoint:
         # Source tables should include the default catalog.schema prefix
         assert len(data["source_tables"]) >= 1
         assert data["source_tables"] == [
-            "default.dj_preaggs.v3_order_details_preagg_b18e32ec",
+            "default.dj_preaggs.v3_order_details_preagg_d344b4e3",
         ]
 
         # Verify the SQL also references this table
@@ -2828,7 +2828,7 @@ class TestCombinedMeasuresSQLEndpoint:
             data["sql"],
             """
             SELECT status, SUM(line_total_sum_e1f61696) line_total_sum_e1f61696
-            FROM default.dj_preaggs.v3_order_details_preagg_b18e32ec
+            FROM default.dj_preaggs.v3_order_details_preagg_d344b4e3
             GROUP BY status
             """,
         )

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -302,6 +302,7 @@ class TestFindMatchingPreagg:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_01",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -345,6 +346,7 @@ class TestFindMatchingPreagg:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_02",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -394,6 +396,7 @@ class TestFindMatchingPreagg:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_03",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -440,6 +443,7 @@ class TestFindMatchingPreagg:
             ],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_04",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -491,6 +495,7 @@ class TestFindMatchingPreagg:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash_coarse",
+            preagg_hash="match_05",
             availability_id=avail1.id,
         )
         # Fine grain (2 columns) - should be preferred
@@ -500,6 +505,7 @@ class TestFindMatchingPreagg:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash_fine",
+            preagg_hash="match_06",
             availability_id=avail2.id,
         )
         session.add_all([preagg_coarse, preagg_fine])
@@ -544,6 +550,7 @@ class TestFindMatchingPreagg:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_07",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -589,6 +596,7 @@ class TestFindMatchingPreagg:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_08",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -640,6 +648,7 @@ class TestGetPreaggMeasureColumn:
             ],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_09",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -673,6 +682,7 @@ class TestGetPreaggMeasureColumn:
             measures=[make_preagg_measure("sum_x", "x")],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_10",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -706,6 +716,7 @@ class TestGetPreaggMeasureColumn:
             measures=[make_preagg_measure("preagg_col_name", "x * y")],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_11",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -740,6 +751,7 @@ class TestGetPreaggMeasureColumn:
             measures=[],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_12",
             availability_id=avail.id,
         )
         session.add(preagg)
@@ -782,6 +794,7 @@ class TestGetPreaggMeasureColumn:
             measures=[measure_no_hash],
             sql="SELECT ...",
             grain_group_hash="hash1",
+            preagg_hash="match_13",
             availability_id=avail.id,
         )
         session.add(preagg)


### PR DESCRIPTION
### Summary

Previously, pre-aggregation table and workflow names were derived from grain_group_hash, which only includes the node revision id + grain columns. This meant two pre-aggs with the same grain but different measures would collide on the same table/workflow name.

This PR adds a `preagg_hash` column to the `PreAggregation` db model that includes the node revision, grain, and measure expression hashes. We also add a unique constraint on `preagg_hash` at the database level, and updated all table/workflow name generation and combiner SQL gen to use the unique hash. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
