### PR TITLE
Display pre-agg hash in UI

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/NodePreAggregationsTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodePreAggregationsTab.jsx
@@ -202,6 +202,15 @@ export default function NodePreAggregationsTab({ node }) {
             {isExpanded ? '\u25BC' : '\u25B6'}
           </span>
 
+          {preagg.preagg_hash && (
+            <code
+              className="preagg-row-hash"
+              title="Pre-aggregation hash - used in table and workflow names"
+            >
+              {preagg.preagg_hash}
+            </code>
+          )}
+
           <div className="preagg-row-grain-chips">
             {(() => {
               const grainCols = preagg.grain_columns || [];
@@ -309,6 +318,19 @@ export default function NodePreAggregationsTab({ node }) {
                               : 'Not set'}
                           </td>
                         </tr>
+                        {preagg.preagg_hash && (
+                          <tr>
+                            <td className="preagg-config-key">Hash</td>
+                            <td className="preagg-config-value">
+                              <code
+                                className="preagg-hash-badge"
+                                title="Unique identifier for this pre-aggregation. Used in table and workflow names."
+                              >
+                                {preagg.preagg_hash}
+                              </code>
+                            </td>
+                          </tr>
+                        )}
                         <tr>
                           <td className="preagg-config-key">Schedule</td>
                           <td className="preagg-config-value">

--- a/datajunction-ui/src/styles/preaggregations.css
+++ b/datajunction-ui/src/styles/preaggregations.css
@@ -95,6 +95,17 @@
   color: #666;
 }
 
+.preagg-row-hash {
+  background-color: #f3e8ff;
+  padding: 2px 8px;
+  border-radius: 4px;
+  color: #7c3aed;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: monospace;
+  letter-spacing: 0.05em;
+}
+
 .preagg-row-grain-chips {
   display: flex;
   align-items: center;
@@ -383,6 +394,20 @@
   border-radius: 4px;
   font-size: 11px;
   font-weight: 500;
+}
+
+/* Hash badge (purple/violet) */
+.preagg-hash-badge {
+  background-color: #f3e8ff;
+  padding: 4px 10px;
+  border-radius: 4px;
+  color: #7c3aed;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: monospace;
+  letter-spacing: 0.05em;
+  user-select: all;
+  cursor: text;
 }
 
 /* Metric badge (red/rose) */


### PR DESCRIPTION
### Summary

Adds the pre-agg hash to the DJ UI for easier tracking:

<img width="843" height="371" alt="Screenshot 2026-01-26 at 9 00 14 PM" src="https://github.com/user-attachments/assets/7cc3ed65-d653-4dae-8bf2-060cbd1d261e" />

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
