### PR TITLE
Fix issue when a query uses a CTE with a table alias and DJ fails to …

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -3176,6 +3176,8 @@ class Query(TableExpression, UnNamed):
                 lambda node: isinstance(node, Table)
                 and node.identifier(False) == cte.alias_or_name.identifier(False),
             ):
+                if tbl.alias:
+                    cte.set_alias(tbl.alias)
                 tbl.swap(cte)
         self.ctes = []
         return self


### PR DESCRIPTION
### Summary

This fixes an issue when a query uses a CTE with a table alias and DJ fails to resolve column types:

```sql
WITH monthly_totals AS (
    SELECT region, SUM(amount) AS total FROM orders GROUP BY region
)
SELECT m.region, m.total
FROM monthly_totals m  -- aliased as 'm'
```
results in
```
Error: Cannot resolve type of column m.region
```

This is because when inlining a CTE as a subquery, the table alias from the `FROM` clause is not preserved. The CTE is inlined with its original name (`monthly_totals`) instead of the alias (`m`), causing column references like `m.region` to fail resolution.

The fix is to modify `bake_ctes()` to preserve the table alias when swapping a CTE reference.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
