### PR TITLE
Add support for auto-registering source tables as nodes

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -259,11 +259,15 @@ class NodeSpecBulkValidator:
         existing_spec: Optional[ColumnSpec],
     ) -> ColumnSpec:
         """Create a ColumnSpec from AST column and existing spec"""
-        try:
-            column_type = str(ast_column.type)
-        except Exception as e:  # pragma: no cover
-            logger.error("Error inferring column %s: %s", column_name, e)
-            column_type = "unknown"
+        # If existing spec has a type, use it. Otherwise infer from AST.
+        if existing_spec and existing_spec.type:
+            column_type = existing_spec.type
+        else:
+            try:
+                column_type = str(ast_column.type)
+            except Exception as e:  # pragma: no cover
+                logger.exception("Error inferring column %s: %s", column_name, e)
+                column_type = "unknown"
 
         if existing_spec:
             return ColumnSpec(

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -630,6 +630,14 @@ class DeploymentSpec(BaseModel):
     tags: list[TagSpec] = Field(default_factory=list)
     source: DeploymentSource | None = None  # CI/CD provenance tracking
     git_config: NamespaceGitConfig | None = None  # Git branch management config
+    auto_register_sources: bool = Field(
+        default=True,
+        description=(
+            "If True, automatically register missing source nodes by introspecting "
+            "catalog tables. Missing nodes that match the pattern catalog.schema.table "
+            "will be looked up in the specified catalog and auto-created as source nodes."
+        ),
+    )
 
     @model_validator(mode="after")
     def set_namespaces(self):

--- a/datajunction-server/datajunction_server/query_clients/http.py
+++ b/datajunction-server/datajunction_server/query_clients/http.py
@@ -63,6 +63,19 @@ class HttpQueryServiceClient(BaseQueryServiceClient):
             engine=engine,
         )
 
+    def get_columns_for_tables_batch(
+        self,
+        tables: List[tuple[str, str, str]],
+        request_headers: Optional[Dict[str, str]] = None,
+        engine: Optional["Engine"] = None,
+    ) -> Dict[tuple[str, str, str], List[Column]]:
+        """Retrieves columns for multiple tables in a single batch request via HTTP query service."""
+        return self._client.get_columns_for_tables_batch(
+            tables=tables,
+            request_headers=request_headers,
+            engine=engine,
+        )
+
     def create_view(
         self,
         view_name: str,

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -149,6 +149,7 @@ def test_deployment_spec():
         ],
         "tags": [],
         "source": None,
+        "auto_register_sources": True,
     }
 
 

--- a/datajunction-server/tests/query_clients/http_query_client_test.py
+++ b/datajunction-server/tests/query_clients/http_query_client_test.py
@@ -126,3 +126,32 @@ class TestHttpQueryServiceClientCubeV2Methods:
             materializations=materializations,
             request_headers={"X-Test": "1"},
         )
+
+    def test_get_columns_for_tables_batch(self, mock_client):
+        """Test get_columns_for_tables_batch delegates to underlying client."""
+        from unittest.mock import Mock
+
+        client, mock_inner = mock_client
+
+        # Use mock columns to avoid SQLAlchemy issues
+        mock_col = Mock()
+        mock_col.name = "col1"
+
+        mock_inner.get_columns_for_tables_batch.return_value = {
+            ("cat1", "sch1", "table1"): [mock_col],
+        }
+
+        tables = [("cat1", "sch1", "table1")]
+        result = client.get_columns_for_tables_batch(
+            tables=tables,
+            request_headers={"X-Test": "1"},
+            engine=None,
+        )
+
+        mock_inner.get_columns_for_tables_batch.assert_called_once_with(
+            tables=tables,
+            request_headers={"X-Test": "1"},
+            engine=None,
+        )
+        assert len(result) == 1
+        assert result[("cat1", "sch1", "table1")][0].name == "col1"


### PR DESCRIPTION
### Summary

During YAML deployments, auto-register table-like references as source nodes if a matching catalog is found.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
