### PR TITLE
Fix catalog None check in dimension link validation

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2161,8 +2161,10 @@ async def validate_complex_dimension_link(
         )
 
     if (
-        dimension_node.current.catalog.name != settings.seed_setup.virtual_catalog_name  # type: ignore
-        and dimension_node.current.catalog is not None  # type: ignore
+        dimension_node.current.catalog is not None  # type: ignore
+        and node.current.catalog is not None  # type: ignore
+        and dimension_node.current.catalog.name
+        != settings.seed_setup.virtual_catalog_name  # type: ignore
         and node.current.catalog.name != dimension_node.current.catalog.name  # type: ignore
     ):
         raise DJInvalidInputException(  # pragma: no cover


### PR DESCRIPTION
### Summary

Make sure that the catalog check doesn't fail too late -- as in, if the catalog is None, we shouldn't be checking `catalog.name`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
