### PR TITLE
Add temporal filter support to Python client's plan() method

### DIFF
--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -202,6 +202,8 @@ class DJClient(_internal.DJClient):
         filters: Optional[List[str]] = None,
         dialect: Optional[str] = None,
         use_materialized: bool = True,
+        include_temporal_filters: bool = False,
+        lookback_window: Optional[str] = None,
     ):
         """
         Returns a query execution plan for the given metrics and dimensions.
@@ -220,13 +222,21 @@ class DJClient(_internal.DJClient):
             filters: List of filter expressions
             dialect: SQL dialect (e.g., 'spark', 'trino'). Defaults to engine dialect.
             use_materialized: Whether to use materialized tables when available
+            include_temporal_filters: Whether to include temporal partition filters.
+                Only applies if the metrics and dimensions resolve to a cube with
+                temporal partitions.
+            lookback_window: Lookback window for temporal filters (e.g., '3 DAY',
+                '1 WEEK'). Only applicable when include_temporal_filters is True.
         """
         params: dict = {
             "metrics": metrics,
             "dimensions": dimensions or [],
             "filters": filters or [],
             "use_materialized": use_materialized,
+            "include_temporal_filters": include_temporal_filters,
         }
+        if lookback_window is not None:
+            params["lookback_window"] = lookback_window
         effective_dialect = dialect or self.engine_name
         if effective_dialect:
             params["dialect"] = effective_dialect  # pragma: no cover


### PR DESCRIPTION
### Summary

This PR adds support to expose the `include_temporal_filters` and `lookback_window` parameters in the Python client's `plan()` method, enabling users to generate execution plans with temporal partition filters when querying cubes with temporal partitions.

#### Usage Examples

Basic usage with temporal filters:
```python
from datajunction import DJClient

dj = DJClient("http://localhost:8000")

# Generate plan with temporal partition filters enabled
plan = dj.plan(
    metrics=["revenue.total_sales"],
    dimensions=["product.category", "date.month"],
    include_temporal_filters=True
)
```

With a lookback window:
```python
# Generate plan with 7-day lookback window
plan = dj.plan(
    metrics=["revenue.total_sales", "revenue.transaction_count"],
    dimensions=["product.category", "date.day"],
    filters=["product.status = 'active'"],
    include_temporal_filters=True,
    lookback_window="7 DAY"
)
```

#### When temporal filters apply 

Temporal filters only apply when:
  1. include_temporal_filters=True is set
  2. The metrics and dimensions resolve to a cube with temporal partitions
  3. The cube has temporal partition configuration

If these conditions aren't met, the parameters are safely ignored.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
