### PR TITLE
Do not use breaking version of virtualenv

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,8 +34,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade virtualenv
-          pip install 'hatch<1.13' hatchling
+          pip install hatch 'virtualenv!=21.0.0'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade virtualenv
-          pip install 'hatch<1.13' hatchling
+          pip install hatch 'virtualenv!=21.0.0'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -17,8 +17,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          python -m pip install --upgrade pip
-          pip install 'hatch<1.13' hatchling
+          pip install hatch 'virtualenv!=21.0.0'
         
       #
       # Collect from Python / hatch


### PR DESCRIPTION
### Summary

This is related to https://github.com/pypa/hatch/issues/2193. This fix excludes the breaking version of virtualenv.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
