### PR TITLE
Add support for filtering on metrics

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -28,6 +28,7 @@ from datajunction_server.construction.build_v3.measures import (
 )
 from datajunction_server.construction.build_v3.metrics import (
     generate_metrics_sql,
+    classify_filters,
 )
 from datajunction_server.construction.build_v3.types import (
     BuildContext,
@@ -222,12 +223,18 @@ async def setup_build_context(
     add_dimensions_from_metric_expressions(ctx, ctx.decomposed_metrics)
 
     # Add dimensions referenced in filters (for WHERE clause resolution)
+    # This processes ALL filters initially - we'll classify them later
     add_dimensions_from_filters(ctx)
 
     # Load any missing dimension nodes (and their upstreams, including sources)
-    # This is needed for dimensions discovered from metric expressions
+    # This is needed for dimensions discovered from metric expressions and filters
     # load_nodes adds to ctx.nodes rather than replacing, so this is safe to call again
     await load_nodes(ctx)
+
+    # Classify filters into dimension filters (WHERE) and metric filters (HAVING)
+    # This MUST happen AFTER all nodes are loaded so we can correctly identify
+    # whether a filter references a dimension or a metric
+    ctx.dimension_filters, ctx.metric_filters = classify_filters(ctx.filters, ctx)
 
     return ctx
 

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -438,12 +438,12 @@ def build_synthetic_grain_group(
         cube_col_name = component_aliases[comp.name]
         projection.append(ast.Column(name=ast.Name(cube_col_name)))
 
-    # Apply filters as WHERE clause on the cube table
-    # This ensures filters are applied before aggregation in generate_metrics_sql
+    # Apply DIMENSION filters as WHERE clause on the cube table
+    # Metric filters are handled separately in HAVING clause (in generate_metrics_sql)
     where_clause = None
-    if ctx.filters:
+    if ctx.dimension_filters:
         where_clause = parse_and_resolve_filters(
-            ctx.filters,
+            ctx.dimension_filters,
             dimension_aliases,
             cte_alias=None,  # No CTE alias - selecting directly from cube table
         )

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -177,3 +177,32 @@ def parse_and_resolve_filters(
         parsed_filters.append(resolved)
 
     return combine_filters(parsed_filters)
+
+
+def get_filter_column_references(filter_str: str) -> list[str]:
+    """
+    Extract all column references from a filter string.
+
+    Args:
+        filter_str: A SQL predicate expression
+
+    Returns:
+        List of full column reference strings (e.g., ["v3.product.category", "v3.status"])
+
+    Example::
+
+        refs = get_filter_column_references("v3.product.category = 'Electronics'")
+        # Returns: ["v3.product.category"]
+
+        refs = get_filter_column_references("v3.total_revenue > 10000 AND v3.order_count > 100")
+        # Returns: ["v3.total_revenue", "v3.order_count"]
+    """
+    filter_ast = parse_filter(filter_str)
+    references = []
+
+    for col in filter_ast.find_all(ast.Column):
+        full_ref = _extract_full_column_ref(col)
+        if full_ref and full_ref not in references:  # pragma: no branch
+            references.append(full_ref)
+
+    return references

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1139,7 +1139,7 @@ def build_grain_group_sql(
             resolved_dimensions=resolved_dimensions,
             parent_node=parent_node,
             grain_columns=pass_through_columns,
-            filters=ctx.filters,
+            filters=ctx.dimension_filters,  # Use dimension_filters only (not metric_filters)
             skip_aggregation=True,  # Don't add GROUP BY
         )
     else:
@@ -1151,7 +1151,7 @@ def build_grain_group_sql(
             resolved_dimensions=resolved_dimensions,
             parent_node=parent_node,
             grain_columns=effective_grain_columns,
-            filters=ctx.filters,
+            filters=ctx.dimension_filters,  # Use dimension_filters only (not metric_filters)
         )
 
     # Build column metadata

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -24,6 +24,8 @@ from datajunction_server.construction.build_v3.cte import (
     replace_metric_refs_in_ast,
 )
 from datajunction_server.construction.build_v3.filters import (
+    combine_filters,
+    get_filter_column_references,
     parse_and_resolve_filters,
     parse_filter,
 )
@@ -51,6 +53,58 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.parsing import ast
 
 logger = logging.getLogger(__name__)
+
+
+def classify_filters(
+    filters: list[str],
+    ctx: BuildContext,
+) -> tuple[list[str], list[str]]:
+    """
+    Classify filters into dimension filters (WHERE) and metric filters (HAVING).
+
+    A filter is classified as a metric filter if it references any metric node.
+    Otherwise, it's a dimension filter.
+
+    Args:
+        filters: List of filter strings
+        ctx: Build context with nodes loaded
+
+    Returns:
+        Tuple of (dimension_filters, metric_filters)
+
+    Example::
+
+        dimension_filters, metric_filters = classify_filters(
+            [
+                "v3.product.category = 'Electronics'",  # dimension filter
+                "v3.total_revenue > 10000",              # metric filter
+            ],
+            ctx,
+        )
+        # dimension_filters = ["v3.product.category = 'Electronics'"]
+        # metric_filters = ["v3.total_revenue > 10000"]
+    """
+    dimension_filters = []
+    metric_filters = []
+
+    for filter_str in filters:
+        # Extract all column references from this filter
+        refs = get_filter_column_references(filter_str)
+
+        # Check if any reference is a metric
+        is_metric_filter = False
+        for ref in refs:
+            node = ctx.nodes.get(ref)
+            if node and node.type == NodeType.METRIC:
+                is_metric_filter = True
+                break
+
+        if is_metric_filter:
+            metric_filters.append(filter_str)
+        else:
+            dimension_filters.append(filter_str)
+
+    return dimension_filters, metric_filters
 
 
 def build_base_metric_expression(
@@ -1832,10 +1886,16 @@ def generate_metrics_sql(
         grain_levels,
     )
 
-    # Build WHERE clause from filters
+    # Use pre-classified filters from BuildContext
+    # Filters were classified early in setup_build_context() to ensure grain groups
+    # only use dimension filters (not metric filters)
+    dimension_filters_raw = ctx.dimension_filters
+    metric_filters_raw = ctx.metric_filters
+
+    # Build WHERE clause from dimension filters
     # Skip filters that reference filter-only dimensions (not available in final SELECT)
     where_clause: Optional[ast.Expression] = None
-    if ctx.filters:
+    if dimension_filters_raw:
         # Use base_metrics CTE for window function queries, otherwise first grain group CTE
         filter_cte = (
             window_metrics_cte_alias if window_metrics_cte_alias else cte_aliases[0]
@@ -1843,8 +1903,8 @@ def generate_metrics_sql(
 
         # Filter out filters that reference filter-only dimensions
         # Those filters are already applied in the grain group CTEs
-        applicable_filters = []
-        for f in ctx.filters:
+        applicable_dimension_filters = []
+        for f in dimension_filters_raw:
             filter_ast = parse_filter(f)
             # Check if any column ref in this filter is a filter-only dimension
             refs_filter_only = False
@@ -1854,14 +1914,40 @@ def generate_metrics_sql(
                     refs_filter_only = True
                     break
             if not refs_filter_only:
-                applicable_filters.append(f)
+                applicable_dimension_filters.append(f)
 
-        if applicable_filters:
+        if applicable_dimension_filters:
             where_clause = parse_and_resolve_filters(
-                applicable_filters,
+                applicable_dimension_filters,
                 dimension_aliases,
                 cte_alias=filter_cte,
             )
+
+    # Build HAVING clause from metric filters
+    # Metric filters are applied after aggregation on computed metric values
+    # Use full aggregation expressions (not aliases) for SQL dialect portability
+    having_clause: Optional[ast.Expression] = None
+    if metric_filters_raw:
+        # Parse and resolve metric filters
+        # Replace metric references with their full aggregation expressions
+        parsed_metric_filters = []
+        for f in metric_filters_raw:
+            filter_ast = parse_filter(f)
+
+            # Replace metric column references with their full aggregation expressions
+            # This ensures compatibility across all SQL dialects (some don't support aliases in HAVING)
+            # Use the AST's built-in replace() method for clean, robust replacement
+            for col in filter_ast.find_all(ast.Column):
+                full_name = get_column_full_name(col)
+                if full_name and full_name in metric_expr_asts:  # pragma: no branch
+                    # Replace this column node with the metric's full expression
+                    metric_expr = metric_expr_asts[full_name].expr_ast
+                    filter_ast.replace(from_=col, to=metric_expr, copy=True)
+
+            parsed_metric_filters.append(filter_ast)
+
+        if parsed_metric_filters:  # pragma: no branch
+            having_clause = combine_filters(parsed_metric_filters)
 
     # Build the final SELECT
     select_ast = ast.Select(
@@ -1869,6 +1955,7 @@ def generate_metrics_sql(
         from_=from_clause,
         where=where_clause,
         group_by=group_by,
+        having=having_clause,
     )
 
     # Build the final Query with all CTEs

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -43,6 +43,12 @@ class BuildContext:
     dialect: Dialect = Dialect.SPARK
     alias_registry: AliasRegistry = field(default_factory=AliasRegistry)
 
+    # Filter classification (populated early in setup)
+    # Dimension filters are applied in WHERE clauses (before aggregation)
+    # Metric filters are applied in HAVING clauses (after aggregation)
+    dimension_filters: list[str] = field(default_factory=list)
+    metric_filters: list[str] = field(default_factory=list)
+
     # Whether to use materialized tables when available (default: True)
     # Set to False when building SQL for materialization to avoid circular references
     use_materialized: bool = True

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -219,6 +219,10 @@ def add_dimensions_from_filters(ctx: "BuildContext") -> None:
     for filter resolution but should not appear in the output projection. These are
     tracked in ctx.filter_dimensions.
 
+    This function processes ALL filters (both dimension and metric filters) because
+    it's called BEFORE filter classification. Metric filters that reference dimensions
+    (rare but possible) will have those dimensions added, which is correct.
+
     Args:
         ctx: BuildContext with filters and dimensions lists to update
     """

--- a/datajunction-server/tests/construction/build_v3/having_clause_test.py
+++ b/datajunction-server/tests/construction/build_v3/having_clause_test.py
@@ -1,0 +1,669 @@
+"""
+Tests for HAVING clause support (metric filters).
+
+These tests verify that filters on aggregated metrics are correctly
+translated to HAVING clauses in the generated SQL.
+"""
+
+import pytest
+
+from tests.construction.build_v3 import assert_sql_equal
+
+
+class TestHavingClauseBasic:
+    """Basic HAVING clause tests with single metric filters."""
+
+    @pytest.mark.asyncio
+    async def test_single_metric_filter_basic(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test basic metric filter generates HAVING clause.
+
+        Query: Show categories where total_revenue > 10000
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.total_revenue > 10000"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        # Verify HAVING clause is present
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+            ),
+            order_details_0 AS (
+                SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                GROUP BY t2.category
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.category
+            HAVING SUM(order_details_0.line_total_sum_e1f61696) > 10000
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_metric_filter_with_less_than(
+        self,
+        client_with_build_v3,
+    ):
+        """Test metric filter with < operator."""
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.order_count"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.order_count < 100"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.product_id
+              FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT
+                product_id,
+                category
+              FROM default.v3.products
+            ),
+            order_details_0 AS (
+              SELECT
+                t2.category,
+                t1.order_id
+              FROM v3_order_details t1
+              LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+              GROUP BY  t2.category, t1.order_id
+            )
+            SELECT
+              order_details_0.category AS category,
+              COUNT( DISTINCT order_details_0.order_id) AS order_count
+            FROM order_details_0
+            GROUP BY  order_details_0.category
+            HAVING  COUNT( DISTINCT order_details_0.order_id) < 100
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_metric_filter_with_greater_equal(
+        self,
+        client_with_build_v3,
+    ):
+        """Test metric filter with >= operator."""
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_quantity"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.total_quantity >= 500"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+            ),
+            order_details_0 AS (
+                SELECT t2.category, SUM(t1.quantity) quantity_sum_06b64d2e
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                GROUP BY t2.category
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.quantity_sum_06b64d2e) AS total_quantity
+            FROM order_details_0
+            GROUP BY order_details_0.category
+            HAVING SUM(order_details_0.quantity_sum_06b64d2e) >= 500
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_metric_filter_with_equality(
+        self,
+        client_with_build_v3,
+    ):
+        """Test metric filter with = operator."""
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.order_count"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.order_count = 50"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.product_id
+              FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT
+                product_id,
+                category
+              FROM default.v3.products
+            ),
+            order_details_0 AS (
+              SELECT
+                t2.category,
+                t1.order_id
+              FROM v3_order_details t1
+              LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+              GROUP BY  t2.category, t1.order_id
+            )
+            SELECT
+              order_details_0.category AS category,
+              COUNT( DISTINCT order_details_0.order_id) AS order_count
+            FROM order_details_0
+            GROUP BY  order_details_0.category
+            HAVING  COUNT(DISTINCT order_details_0.order_id) = 50
+            """,
+        )
+
+
+class TestHavingClauseMultipleFilters:
+    """Tests for multiple metric filters (compound HAVING clauses)."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_metric_filters_and(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test multiple metric filters combined with AND.
+
+        Query: Show categories with revenue > 5000 AND order_count > 20
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue", "v3.order_count"],
+                "dimensions": ["v3.product.category"],
+                "filters": [
+                    "v3.total_revenue > 5000",
+                    "v3.order_count > 20",
+                ],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT
+                product_id,
+                category
+              FROM default.v3.products
+            ),
+            order_details_0 AS (
+              SELECT
+                t2.category,
+                t1.order_id,
+                SUM(t1.line_total) line_total_sum_e1f61696
+              FROM v3_order_details t1
+              LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+              GROUP BY  t2.category, t1.order_id
+            )
+            SELECT
+              order_details_0.category AS category,
+              SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue,
+              COUNT( DISTINCT order_details_0.order_id) AS order_count
+            FROM order_details_0
+            GROUP BY  order_details_0.category
+            HAVING
+              SUM(order_details_0.line_total_sum_e1f61696) > 5000
+              AND COUNT( DISTINCT order_details_0.order_id) > 20
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_metric_filter_between(
+        self,
+        client_with_build_v3,
+    ):
+        """Test metric filter with BETWEEN operator."""
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.total_revenue BETWEEN 1000 AND 10000"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+            ),
+            order_details_0 AS (
+                SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                GROUP BY t2.category
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.category
+            HAVING SUM(order_details_0.line_total_sum_e1f61696) BETWEEN 1000 AND 10000
+            """,
+        )
+
+
+class TestHavingClauseMixedFilters:
+    """Tests for queries with both dimension filters (WHERE) and metric filters (HAVING)."""
+
+    @pytest.mark.asyncio
+    async def test_dimension_and_metric_filters(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test query with both dimension and metric filters.
+
+        Query: Show Electronics category products with revenue > 5000
+        - Dimension filter: category = 'Electronics' → WHERE
+        - Metric filter: total_revenue > 5000 → HAVING
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": [
+                    "v3.product.category = 'Electronics'",  # dimension filter
+                    "v3.total_revenue > 5000",  # metric filter
+                ],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        # Verify both WHERE and HAVING are present
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+            ),
+            order_details_0 AS (
+                SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                WHERE  t2.category = 'Electronics'
+                GROUP BY t2.category
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            WHERE order_details_0.category = 'Electronics'
+            GROUP BY order_details_0.category
+            HAVING SUM(order_details_0.line_total_sum_e1f61696) > 5000
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_complex_mixed_filters(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test complex query with multiple dimension and metric filters.
+
+        Filters:
+        - Dimension: category IN ('Electronics', 'Clothing')
+        - Dimension: status = 'completed'
+        - Metric: total_revenue > 10000
+        - Metric: order_count >= 50
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue", "v3.order_count"],
+                "dimensions": ["v3.product.category", "v3.order_details.status"],
+                "filters": [
+                    "v3.product.category IN ('Electronics', 'Clothing')",
+                    "v3.order_details.status = 'completed'",
+                    "v3.total_revenue > 10000",
+                    "v3.order_count >= 50",
+                ],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                o.status,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT
+                product_id,
+                category
+              FROM default.v3.products
+            ),
+            order_details_0 AS (
+              SELECT
+                t2.category,
+                t1.status,
+                t1.order_id,
+                SUM(t1.line_total) line_total_sum_e1f61696
+              FROM v3_order_details t1
+              LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+              WHERE  t2.category IN ('Electronics', 'Clothing') AND t1.status = 'completed'
+              GROUP BY  t2.category, t1.status, t1.order_id
+            )
+            SELECT
+              order_details_0.category AS category,
+              order_details_0.status AS status,
+              SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue,
+              COUNT(DISTINCT order_details_0.order_id) AS order_count
+            FROM order_details_0
+            WHERE  order_details_0.category IN ('Electronics', 'Clothing') AND order_details_0.status = 'completed'
+            GROUP BY  order_details_0.category, order_details_0.status
+            HAVING  SUM(order_details_0.line_total_sum_e1f61696) > 10000 AND COUNT( DISTINCT order_details_0.order_id) >= 50
+            """,
+        )
+
+
+class TestHavingClauseWithDerivedMetrics:
+    """Tests for HAVING clauses with derived metrics (ratios, percentages)."""
+
+    @pytest.mark.asyncio
+    async def test_derived_metric_filter(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test filter on a derived metric (ratio).
+
+        Query: Show categories where avg_order_value > 100
+        (avg_order_value = total_revenue / order_count)
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.avg_order_value"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.avg_order_value > 100"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT
+                product_id,
+                category
+              FROM default.v3.products
+            ),
+            order_details_0 AS (
+              SELECT
+                t2.category,
+                t1.order_id,
+                SUM(t1.line_total) line_total_sum_e1f61696
+              FROM v3_order_details t1 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+              GROUP BY  t2.category, t1.order_id
+            )
+            SELECT
+              order_details_0.category AS category,
+              SUM(order_details_0.line_total_sum_e1f61696) / NULLIF(COUNT( DISTINCT order_details_0.order_id), 0) AS avg_order_value
+            FROM order_details_0
+            GROUP BY  order_details_0.category
+            HAVING  SUM(order_details_0.line_total_sum_e1f61696) / NULLIF(COUNT( DISTINCT order_details_0.order_id), 0) > 100
+            """,
+        )
+
+
+class TestHavingClauseEdgeCases:
+    """Edge case tests for HAVING clause functionality."""
+
+    @pytest.mark.asyncio
+    async def test_metric_filter_no_dimensions(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test metric filter with no dimensions (global aggregation).
+
+        Query: Total revenue across all products, filtered to > 100000
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [],
+                "filters": ["v3.total_revenue > 100000"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+            )
+            SELECT SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            HAVING SUM(order_details_0.line_total_sum_e1f61696) > 100000
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_only_dimension_filters_no_having(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test that queries with only dimension filters don't generate HAVING.
+
+        This verifies backwards compatibility - existing queries still work.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.product.category = 'Electronics'"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        # Verify WHERE present, HAVING absent
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+            ),
+            order_details_0 AS (
+                SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                WHERE  t2.category = 'Electronics'
+                GROUP BY t2.category
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            WHERE order_details_0.category = 'Electronics'
+            GROUP BY order_details_0.category
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_only_dimension_with_metric_filter(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Test metric filter with a filter-only dimension.
+
+        Dimensions in output: [category]
+        Filters:
+        - subcategory = 'Smartphones' (filter-only dimension, not in output)
+        - total_revenue > 5000 (metric filter)
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": [
+                    "v3.product.subcategory = 'Smartphones'",
+                    "v3.total_revenue > 5000",
+                ],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category, subcategory
+                FROM default.v3.products
+            ),
+            order_details_0 AS (
+                SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                WHERE t2.subcategory = 'Smartphones'
+                GROUP BY t2.category
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.category
+            HAVING SUM(order_details_0.line_total_sum_e1f61696) > 5000
+            """,
+        )
+
+        # Output should only have category, not subcategory
+        column_names = [col["name"] for col in result["columns"]]
+        assert "category" in column_names
+        assert "subcategory" not in column_names


### PR DESCRIPTION
### Summary

This adds support for filtering on metrics to v3 SQL building.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1808 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
