### PR TITLE
Add instrumentation for various basic metrics

### DIFF
--- a/datajunction-server/datajunction_server/instrumentation/middleware.py
+++ b/datajunction-server/datajunction_server/instrumentation/middleware.py
@@ -3,6 +3,7 @@ Instrumentation middleware for the DJ server.
 
 Emits on every HTTP request:
   - dj.db.pool.size / checked_out / available / overflow  (gauges)
+  - dj.request.in_flight  (gauge — concurrent requests in progress)
   - dj.request  (timer in ms, tagged with route + method + status_code)
 """
 
@@ -15,6 +16,8 @@ from starlette.responses import Response
 
 from datajunction_server.instrumentation.provider import get_metrics_provider
 
+_in_flight: int = 0
+
 logger = logging.getLogger(__name__)
 
 
@@ -22,8 +25,12 @@ class DJInstrumentationMiddleware(BaseHTTPMiddleware):
     """Emit DB pool gauges and per-request timing on every HTTP request."""
 
     async def dispatch(self, request: Request, call_next) -> Response:
+        global _in_flight
         provider = get_metrics_provider()
         _emit_pool_gauges(provider)
+
+        _in_flight += 1
+        provider.gauge("dj.request.in_flight", _in_flight)
 
         start = time.monotonic()
         status_code = 500
@@ -32,6 +39,8 @@ class DJInstrumentationMiddleware(BaseHTTPMiddleware):
             status_code = response.status_code
             return response
         finally:
+            _in_flight -= 1
+            provider.gauge("dj.request.in_flight", _in_flight)
             elapsed_ms = (time.monotonic() - start) * 1000
             route = request.scope.get("route")
             route_path = route.path if route else request.url.path

--- a/datajunction-server/datajunction_server/instrumentation/provider.py
+++ b/datajunction-server/datajunction_server/instrumentation/provider.py
@@ -16,8 +16,10 @@ Usage (emit a metric anywhere in the codebase)::
     get_metrics_provider().counter("dj.cache.hit", tags={"query_type": "METRICS"})
 """
 
+import functools
+import time
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Callable, Union
 
 
 class MetricsProvider(ABC):
@@ -95,3 +97,38 @@ def set_metrics_provider(provider: MetricsProvider) -> None:
     """
     global _provider
     _provider = provider
+
+
+def timed(
+    name: str,
+    tags: Union[dict[str, Any], Callable[..., dict[str, Any]], None] = None,
+):
+    """
+    Decorator that times an async function and emits a timer metric on exit.
+
+    ``tags`` may be a plain dict for static tags, or a callable that receives
+    the same ``(*args, **kwargs)`` as the decorated function and returns a dict.
+    The callable form is useful for methods that need ``self`` attributes::
+
+        @timed("dj.sql.build_latency_ms",
+               lambda self, *a, **kw: {"query_type": str(self.query_type)})
+        async def fallback(self, ...): ...
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            _start = time.monotonic()
+            try:
+                return await fn(*args, **kwargs)
+            finally:
+                resolved = tags(*args, **kwargs) if callable(tags) else tags
+                get_metrics_provider().timer(
+                    name,
+                    (time.monotonic() - _start) * 1000,
+                    resolved,
+                )
+
+        return wrapper
+
+    return decorator

--- a/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
@@ -20,7 +20,7 @@ from datajunction_server.internal.access.authorization import (
 )
 from datajunction_server.internal.sql import build_sql_for_multiple_metrics
 from datajunction_server.models.sql import GeneratedSQL
-from datajunction_server.instrumentation.provider import get_metrics_provider
+from datajunction_server.instrumentation.provider import get_metrics_provider, timed
 from datajunction_server.utils import get_current_user, session_context, get_settings
 from datajunction_server.internal.sql import get_measures_query
 from datajunction_server.internal.sql import build_node_sql
@@ -173,6 +173,10 @@ class QueryCacheManager(RefreshAheadCacheManager):
 
         return result
 
+    @timed(
+        "dj.sql.build_latency_ms",
+        lambda self, *a, **kw: {"query_type": str(self.query_type)},
+    )
     async def fallback(
         self,
         request: Request,
@@ -217,13 +221,16 @@ class QueryCacheManager(RefreshAheadCacheManager):
         # Use provided session or create a new one
         if session:
             return await _build_with_session(session)
-        else:
-            async with session_context(
-                request,
-                session_label="SQL building",
-            ) as new_session:
-                return await _build_with_session(new_session)
+        async with session_context(
+            request,
+            session_label="SQL building",
+        ) as new_session:
+            return await _build_with_session(new_session)
 
+    @timed(
+        "dj.cache.key_build_ms",
+        lambda self, *a, **kw: {"query_type": str(self.query_type)},
+    )
     async def build_cache_key(
         self,
         request: Request,
@@ -264,12 +271,11 @@ class QueryCacheManager(RefreshAheadCacheManager):
         # Use provided session or create a new one
         if session:
             return await _build_key_with_session(session)
-        else:
-            async with session_context(
-                request,
-                session_label="cache key generation",
-            ) as new_session:
-                return await _build_key_with_session(new_session)
+        async with session_context(
+            request,
+            session_label="cache key generation",
+        ) as new_session:
+            return await _build_key_with_session(new_session)
 
     async def _refresh_cache_rate_limited(
         self,
@@ -289,13 +295,25 @@ class QueryCacheManager(RefreshAheadCacheManager):
         semaphore = _get_refresh_semaphore()
         async with semaphore:
             try:
-                await self._refresh_cache(key, request, params)
+                await self._timed_refresh(key, request, params)
             finally:
                 _pending_refresh_keys.discard(key)
                 get_metrics_provider().gauge(
                     "dj.cache.refresh.pending",
                     len(_pending_refresh_keys),
                 )
+
+    @timed(
+        "dj.cache.refresh_latency_ms",
+        lambda self, *a, **kw: {"query_type": str(self.query_type)},
+    )
+    async def _timed_refresh(
+        self,
+        key: str,
+        request: Request,
+        params: "QueryRequestParams",
+    ) -> None:
+        await self._refresh_cache(key, request, params)
 
     async def _build_measures_query(
         self,

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -2,8 +2,10 @@
 DAG related functions.
 """
 
+import functools
 import itertools
 import logging
+import time
 from collections import namedtuple
 from typing import Dict, List, Union, cast
 
@@ -31,6 +33,38 @@ from datajunction_server.utils import SEPARATOR, get_settings, refresh_if_needed
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+
+def _dag_timed(operation: str):
+    """
+    Local timing decorator for DAG traversal functions.
+
+    Uses a lazy import of ``get_metrics_provider`` to avoid the circular
+    dependency that arises when ``dag.py`` imports ``instrumentation.provider``
+    at module level (database → models → dag creates a cycle).
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            _start = time.monotonic()
+            try:
+                return await fn(*args, **kwargs)
+            finally:
+                from datajunction_server.instrumentation.provider import (  # noqa: PLC0415
+                    get_metrics_provider,
+                )
+
+                get_metrics_provider().timer(
+                    "dj.dag.traversal_ms",
+                    (time.monotonic() - _start) * 1000,
+                    {"operation": operation},
+                )
+
+        return wrapper
+
+    return decorator
+
 
 # State during BFS traversal of the dimensions DAG in _get_dimensions_dag_bfs.
 # node_id:    ID of the current Node (not NodeRevision)
@@ -70,6 +104,7 @@ def _node_output_options():
     ]
 
 
+@_dag_timed("get_downstream_nodes")
 async def get_downstream_nodes(
     session: AsyncSession,
     node_name: str,
@@ -162,6 +197,7 @@ async def get_downstream_nodes(
     return filtered[: settings.node_list_max]
 
 
+@_dag_timed("get_upstream_nodes")
 async def get_upstream_nodes(
     session: AsyncSession,
     node_name: Union[str, List[str]],
@@ -460,6 +496,7 @@ async def get_dimension_nodes(
     ]
 
 
+@_dag_timed("get_dimensions_dag")
 async def get_dimensions_dag(
     session: AsyncSession,
     node_revision: NodeRevision,
@@ -475,7 +512,12 @@ async def get_dimensions_dag(
     batched query per graph depth, avoiding Postgres recursive-CTE materialization overhead
     on wide/deep graphs.
     """
-    return await _get_dimensions_dag_bfs(session, node_revision, with_attributes, depth)
+    return await _get_dimensions_dag_bfs(
+        session,
+        node_revision,
+        with_attributes,
+        depth,
+    )
 
 
 async def _get_dimensions_dag_bfs(

--- a/datajunction-server/tests/instrumentation/middleware_test.py
+++ b/datajunction-server/tests/instrumentation/middleware_test.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import datajunction_server.instrumentation.middleware as mw_module
 from datajunction_server.instrumentation.middleware import (
     DJInstrumentationMiddleware,
     _emit_pool_gauges,
@@ -37,8 +38,10 @@ class _SpyProvider(MetricsProvider):
 @pytest.fixture(autouse=True)
 def reset_provider():
     original = get_metrics_provider()
+    original_in_flight = mw_module._in_flight
     yield
     set_metrics_provider(original)
+    mw_module._in_flight = original_in_flight
 
 
 def _make_app_with_route(status_code: int = 200) -> FastAPI:
@@ -137,6 +140,15 @@ def test_middleware_emits_request_timer_on_success():
     assert timer_tags["dj.request"]["status_code"] == "200"
     assert timer_tags["dj.request"]["method"] == "GET"
     assert timer_tags["dj.request"]["route"] == "/ping"
+
+    # in-flight should go up then back down to 0
+    gauge_names = [name for name, _, _ in spy.gauges]
+    assert "dj.request.in_flight" in gauge_names
+    in_flight_values = [
+        val for name, val, _ in spy.gauges if name == "dj.request.in_flight"
+    ]
+    assert in_flight_values[0] == 1  # incremented on entry
+    assert in_flight_values[-1] == 0  # back to 0 after exit
 
 
 def test_middleware_uses_url_path_when_route_missing():


### PR DESCRIPTION
### Summary

#### HTTP / Request Layer

In: `datajunction_server/instrumentation/middleware.py`

| Metric | Type | Tags | Description |
|--------|------|------|-------------|
| `dj.request` | timer (ms) | `route`, `method`, `status_code` | End-to-end latency for every HTTP request |
| `dj.request.in_flight` | gauge | — | Concurrent requests in progress (per instance) |
| `dj.db.pool.size` | gauge | — | Configured max pool size |
| `dj.db.pool.checked_out` | gauge | — | Active DB connections |
| `dj.db.pool.available` | gauge | — | Idle connections (`size - checked_out`) |
| `dj.db.pool.overflow` | gauge | — | Connections above pool size limit |

#### Database Layer

Source: `datajunction_server/utils.py`

| Metric | Type | Tags | Description |
|--------|------|------|-------------|
| `dj.db.query_count` | timer (count) | `session_label` | Number of DB queries issued per session/request |

#### Query Cache

In: `datajunction_server/internal/caching/query_cache_manager.py`

| Metric | Type | Tags | Description |
|--------|------|------|-------------|
| `dj.cache.hit` | counter | `query_type` | Cache hit on SQL build cache |
| `dj.cache.miss` | counter | `query_type` | Cache miss — fresh SQL build triggered |
| `dj.cache.refresh.pending` | gauge | — | Background refresh jobs currently queued |
| `dj.sql.build_latency_ms` | timer (ms) | `query_type` | Time to build SQL from scratch (cache miss path) |
| `dj.cache.key_build_ms` | timer (ms) | `query_type` | Time to compute the versioned cache key |
| `dj.cache.refresh_latency_ms` | timer (ms) | `query_type` | Time for a background refresh-ahead rebuild |

## DAG Traversal

In: `datajunction_server/sql/dag.py`

| Metric | Type | Tags | Description |
|--------|------|------|-------------|
| `dj.dag.traversal_ms` | timer (ms) | `operation` | Latency of DAG traversal functions |

`operation` values: `get_downstream_nodes`, `get_upstream_nodes`, `get_dimensions_dag`

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
