### PR TITLE
Add instrumentation for SQL parsing, node validation, cube matching, GraphQL

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -1,7 +1,10 @@
 """DJ graphql"""
 
 import logging
+import time
 from functools import wraps
+
+from datajunction_server.instrumentation.provider import get_metrics_provider
 
 import strawberry
 from fastapi import Depends, Request, BackgroundTasks
@@ -69,17 +72,28 @@ def log_resolver(func):
         log_args = " ".join(
             [f"{tag}={value}" for tag, value in log_tags.items() if value],
         )
+        _start = time.monotonic()
         try:
             result = await func(*args, **kwargs)
             logger.info("[GQL] %s", log_args)
             return result
         except Exception as exc:  # pragma: no cover
+            get_metrics_provider().counter(  # pragma: no cover
+                "dj.graphql.errors",
+                tags={"operation": resolver_name},
+            )
             logger.error(  # pragma: no cover
                 "[GQL] status=error %s",
                 log_args,
                 exc_info=True,
             )
             raise exc  # pragma: no cover
+        finally:
+            get_metrics_provider().timer(
+                "dj.graphql.query_ms",
+                (time.monotonic() - _start) * 1000,
+                {"operation": resolver_name},
+            )
 
     return wrapper
 

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -41,6 +41,7 @@ from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.naming import amenable_name
 from datajunction_server.sql.parsing import ast
+from datajunction_server.instrumentation.provider import timed
 
 if TYPE_CHECKING:
     pass
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@timed("dj.cube_matching.ms")
 async def find_matching_cube(
     session: AsyncSession,
     metrics: list[str],

--- a/datajunction-server/datajunction_server/instrumentation/provider.py
+++ b/datajunction-server/datajunction_server/instrumentation/provider.py
@@ -17,6 +17,7 @@ Usage (emit a metric anywhere in the codebase)::
 """
 
 import functools
+import inspect
 import time
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Union
@@ -104,7 +105,9 @@ def timed(
     tags: Union[dict[str, Any], Callable[..., dict[str, Any]], None] = None,
 ):
     """
-    Decorator that times an async function and emits a timer metric on exit.
+    Decorator that times a function and emits a timer metric on exit.
+
+    Works on both async and sync functions.
 
     ``tags`` may be a plain dict for static tags, or a callable that receives
     the same ``(*args, **kwargs)`` as the decorated function and returns a dict.
@@ -116,19 +119,37 @@ def timed(
     """
 
     def decorator(fn):
-        @functools.wraps(fn)
-        async def wrapper(*args, **kwargs):
-            _start = time.monotonic()
-            try:
-                return await fn(*args, **kwargs)
-            finally:
-                resolved = tags(*args, **kwargs) if callable(tags) else tags
-                get_metrics_provider().timer(
-                    name,
-                    (time.monotonic() - _start) * 1000,
-                    resolved,
-                )
+        if inspect.iscoroutinefunction(fn):
 
-        return wrapper
+            @functools.wraps(fn)
+            async def async_wrapper(*args, **kwargs):
+                _start = time.monotonic()
+                try:
+                    return await fn(*args, **kwargs)
+                finally:
+                    resolved = tags(*args, **kwargs) if callable(tags) else tags
+                    get_metrics_provider().timer(
+                        name,
+                        (time.monotonic() - _start) * 1000,
+                        resolved,
+                    )
+
+            return async_wrapper
+        else:
+
+            @functools.wraps(fn)
+            def sync_wrapper(*args, **kwargs):
+                _start = time.monotonic()
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    resolved = tags(*args, **kwargs) if callable(tags) else tags
+                    get_metrics_provider().timer(
+                        name,
+                        (time.monotonic() - _start) * 1000,
+                        resolved,
+                    )
+
+            return sync_wrapper
 
     return decorator

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -18,6 +18,7 @@ from datajunction_server.errors import (
 from datajunction_server.models.base import labelize
 from datajunction_server.models.node import NodeRevisionBase, NodeStatus
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.instrumentation.provider import timed
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import SqlSyntaxError, parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
@@ -56,6 +57,10 @@ class NodeValidator:
         return updated_columns
 
 
+@timed(
+    "dj.node_validation.ms",
+    lambda data, session: {"node_type": str(data.type)},
+)
 async def validate_node_data(
     data: Union[NodeRevisionBase, NodeRevision],
     session: AsyncSession,

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -236,12 +236,23 @@ def parse(sql: Optional[str]) -> ast.Query:
     """
     Parse a string sql query into a DJ ast Query
     """
-    if not sql:
-        raise DJParseException("Empty query provided!")
+    import time as _time  # noqa: PLC0415
+
+    _start = _time.monotonic()
     try:
-        return cast(ast.Query, parse_rule(sql, "singleStatement"))
-    except SqlParsingError as exc:
-        raise DJParseException(message=f"Error parsing SQL `{sql}`: {exc}") from exc
+        if not sql:
+            raise DJParseException("Empty query provided!")
+        try:
+            return cast(ast.Query, parse_rule(sql, "singleStatement"))
+        except SqlParsingError as exc:
+            raise DJParseException(message=f"Error parsing SQL `{sql}`: {exc}") from exc
+    finally:
+        from datajunction_server.instrumentation.provider import get_metrics_provider  # noqa: PLC0415
+
+        get_metrics_provider().timer(
+            "dj.sql.parsing_ms",
+            (_time.monotonic() - _start) * 1000,
+        )
 
 
 def cached_parse(sql: Optional[str]) -> ast.Query:

--- a/datajunction-server/datajunction_server/utils.py
+++ b/datajunction-server/datajunction_server/utils.py
@@ -267,10 +267,9 @@ async def get_session(
                 logger.debug(
                     f"[QUERY_COUNT] Total queries in session{label_str}: {query_count['count']}",
                 )
-                get_metrics_provider().timer(
+                get_metrics_provider().counter(
                     "dj.db.query_count",
                     query_count["count"],
-                    {"session_label": session_label or ""},
                 )
     finally:
         # Remove event listener to avoid memory leaks

--- a/datajunction-server/tests/instrumentation/provider_test.py
+++ b/datajunction-server/tests/instrumentation/provider_test.py
@@ -9,6 +9,7 @@ from datajunction_server.instrumentation.provider import (
     NoOpMetricsProvider,
     get_metrics_provider,
     set_metrics_provider,
+    timed,
 )
 
 
@@ -72,3 +73,127 @@ def test_set_and_use_custom_provider():
     assert spy.counters == [("dj.cache.hit", 1, {"query_type": "METRICS"})]
     assert spy.gauges == [("dj.db.pool.checked_out", 5.0, None)]
     assert spy.timers == [("dj.request", 42.0, {"route": "/health"})]
+
+
+# ---------------------------------------------------------------------------
+# @timed decorator tests
+# ---------------------------------------------------------------------------
+
+
+def test_timed_sync_emits_timer():
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+
+    @timed("dj.test.sync_ms")
+    def do_work(x):
+        return x * 2
+
+    result = do_work(3)
+
+    assert result == 6
+    assert len(spy.timers) == 1
+    name, value_ms, tags = spy.timers[0]
+    assert name == "dj.test.sync_ms"
+    assert value_ms >= 0
+    assert tags is None
+
+
+@pytest.mark.asyncio
+async def test_timed_async_emits_timer():
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+
+    @timed("dj.test.async_ms")
+    async def do_work_async(x):
+        return x + 1
+
+    result = await do_work_async(5)
+
+    assert result == 6
+    assert len(spy.timers) == 1
+    name, value_ms, tags = spy.timers[0]
+    assert name == "dj.test.async_ms"
+    assert value_ms >= 0
+    assert tags is None
+
+
+def test_timed_sync_static_tags():
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+
+    @timed("dj.test.tagged_ms", {"query_type": "NODE"})
+    def do_work():
+        return 42
+
+    do_work()
+
+    assert spy.timers[0][2] == {"query_type": "NODE"}
+
+
+@pytest.mark.asyncio
+async def test_timed_async_callable_tags():
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+
+    @timed("dj.test.callable_tags_ms", lambda self, *a, **kw: {"kind": self.kind})
+    async def do_work(self):
+        return self.kind
+
+    class _Ctx:
+        kind = "METRICS"
+
+    await do_work(_Ctx())
+
+    assert spy.timers[0][2] == {"kind": "METRICS"}
+
+
+def test_timed_sync_emits_even_on_exception():
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+
+    @timed("dj.test.exc_ms")
+    def boom():
+        raise ValueError("oops")
+
+    with pytest.raises(ValueError):
+        boom()
+
+    assert len(spy.timers) == 1
+    assert spy.timers[0][0] == "dj.test.exc_ms"
+
+
+@pytest.mark.asyncio
+async def test_timed_async_emits_even_on_exception():
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+
+    @timed("dj.test.async_exc_ms")
+    async def async_boom():
+        raise RuntimeError("async oops")
+
+    with pytest.raises(RuntimeError):
+        await async_boom()
+
+    assert len(spy.timers) == 1
+    assert spy.timers[0][0] == "dj.test.async_exc_ms"
+
+
+def test_timed_preserves_function_name_and_docstring():
+    @timed("dj.test.meta_ms")
+    def my_function():
+        """My docstring."""
+        return 1
+
+    assert my_function.__name__ == "my_function"
+    assert my_function.__doc__ == "My docstring."
+
+
+@pytest.mark.asyncio
+async def test_timed_async_preserves_function_name():
+    @timed("dj.test.async_meta_ms")
+    async def my_async_function():
+        """Async docstring."""
+        return 2
+
+    assert my_async_function.__name__ == "my_async_function"
+    assert my_async_function.__doc__ == "Async docstring."


### PR DESCRIPTION
### Summary

Metrics added include:
- `dj.sql.parsing_ms`: times every call to `parse()` in `antlr4.py`, which is used by all SQL parsing across the codebase
- `dj.node_validation.ms`: times `validate_node_data()`, tagged with node type
- `dj.cube_matching.ms`: times `find_matching_cube()` in the V3 builder, useful for understanding materialized cube lookup cost
- `dj.graphql.query_ms` / `dj.graphql.errors`: provides per-operation breakdown for all GraphQL resolvers (previously only visible as a single `/graphql` route)

Fixes:
- `dj.db.query_count`: fixed from timer to counter, since the value is a count of DB queries per request, not a duration
- Extended `@timed` to support sync functions.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
