### PR TITLE
Ensure that client tests also run when server files change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run Tests
         if: |
-          (matrix.library == 'client' && needs.changes.outputs.client == 'true') ||
+          (matrix.library == 'client' && (needs.changes.outputs.client == 'true' || needs.changes.outputs.server == 'true')) ||
           (matrix.library == 'server' && needs.changes.outputs.server == 'true') ||
           (matrix.library == 'djqs' && needs.changes.outputs.djqs == 'true') ||
           (matrix.library == 'djrs' && needs.changes.outputs.djrs == 'true')


### PR DESCRIPTION
### Summary

At the moment the test matrix is configured so that the client tests only run when client files change. However, we need to also trigger them when server files change, since the client tests use the server directly and can become out-of-sync with server changes if we don't run them.

This fix ensures that client tests also run whenever there are any server file changes.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
