### PR TITLE
Fix git info inheritance for sub-namespaces

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -22,6 +22,7 @@ from datajunction_server.api.graphql.scalars.column import (
     Partition,
 )
 from datajunction_server.api.graphql.scalars.git_info import GitRepositoryInfo
+from datajunction_server.internal.namespaces import get_git_info_for_namespace
 from datajunction_server.api.graphql.scalars.materialization import (
     Backfill,
     MaterializationConfig,
@@ -461,11 +462,12 @@ class Node:
         return root.edited_by
 
     @strawberry.field
-    def git_info(self, root: "DBNode") -> Optional[GitRepositoryInfo]:
+    async def git_info(self, root: "DBNode", info: Info) -> Optional[GitRepositoryInfo]:
         """
         Git repository information for this node's namespace
         """
-        git_info_dict = root.git_info
+        session = info.context["session"]  # type: ignore
+        git_info_dict = await get_git_info_for_namespace(session, root.namespace)
         if git_info_dict:
             return GitRepositoryInfo.from_pydantic(  # type: ignore
                 PydanticGitRepositoryInfo(**git_info_dict),

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -50,6 +50,7 @@ from datajunction_server.internal.access.authorization import (
 )
 from datajunction_server.models.access import ResourceAction
 from datajunction_server.internal.history import ActivityType, EntityType
+from datajunction_server.internal.namespaces import get_git_info_for_namespace
 from datajunction_server.internal.nodes import (
     activate_node,
     create_a_cube,
@@ -332,10 +333,10 @@ async def get_node(
         raise_if_not_exists=True,
     )
     assert node is not None  # raise_if_not_exists=True ensures this
-    # Create NodeOutput and explicitly populate git_info from the Node property
     output = NodeOutput.model_validate(node)
-    if node.git_info:
-        output.git_info = GitRepositoryInfo(**node.git_info)
+    git_info = await get_git_info_for_namespace(session, node.namespace)
+    if git_info:
+        output.git_info = GitRepositoryInfo(**git_info)
     return output
 
 

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -341,58 +341,6 @@ class Node(Base):
             {entry.user for entry in self.history if entry.user},
         )
 
-    @property
-    def is_default_branch(self) -> bool:
-        """
-        Check if this node is from the default branch namespace.
-        Returns True for non-git namespaces or when on the default branch.
-        """
-        if not self.namespace_obj:  # pragma: no cover
-            return True  # Non-git namespaces are considered "default"
-
-        # Get the git config namespace (could be parent)
-        git_namespace = self.namespace_obj
-        if not git_namespace.github_repo_path and git_namespace.parent_namespace_obj:
-            git_namespace = git_namespace.parent_namespace_obj
-
-        if not git_namespace.default_branch:
-            return True  # No git config means default
-
-        # Compare branch from actual namespace with default from git config namespace
-        return self.namespace_obj.git_branch == git_namespace.default_branch
-
-    @property
-    def git_info(self) -> Optional[dict]:
-        """
-        Get git repository information for this node's namespace.
-        For child namespaces (e.g., prefix.main, prefix.feature), follows parent_namespace
-        to get the git repo configuration from the parent (e.g., prefix).
-        Returns None if no git configuration is found.
-        """
-        if not self.namespace_obj:  # pragma: no cover
-            return None
-
-        # Determine which namespace has the git config
-        git_namespace = self.namespace_obj
-        if not git_namespace.github_repo_path and git_namespace.parent_namespace_obj:
-            # This is a child namespace (e.g., prefix.main), use parent for git config
-            git_namespace = git_namespace.parent_namespace_obj
-
-        # If still no git config, return None
-        if not git_namespace.github_repo_path:
-            return None
-
-        # Use branch info from the actual namespace, repo info from git_namespace
-        return {
-            "repo": git_namespace.github_repo_path,
-            "branch": self.namespace_obj.git_branch,  # Branch from actual namespace
-            "default_branch": git_namespace.default_branch,
-            "path": git_namespace.git_path,
-            "is_default_branch": self.is_default_branch,
-            "parent_namespace": self.namespace_obj.parent_namespace,
-            "git_only": git_namespace.git_only,
-        }
-
     def upstream_cache_key(self, node_type: NodeType | None = None) -> str:
         base = f"upstream:{self.name}@{self.current_version}"
         return f"{base}:{node_type.value}" if node_type is not None else base

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 from datetime import datetime, timezone
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from sqlalchemy import or_, select, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -235,6 +235,43 @@ def get_parent_namespaces(namespace: str):
     """
     parts = namespace.split(SEPARATOR)
     return [SEPARATOR.join(parts[0:i]) for i in range(len(parts)) if parts[0:i]]
+
+
+async def get_git_info_for_namespace(
+    session: AsyncSession,
+    namespace: str,
+) -> Optional[dict]:
+    """
+    Return git repository info for a namespace by walking up the namespace
+    hierarchy (derived from the namespace string, not the parent_namespace FK).
+
+    Loads all ancestor NodeNamespace objects in one query, then walks from most
+    specific to least specific to find the first ancestor with git config.
+    """
+    ancestor_names = get_parent_namespaces(namespace) + [namespace]
+    stmt = select(NodeNamespace).where(NodeNamespace.namespace.in_(ancestor_names))
+    rows = (await session.execute(stmt)).scalars().all()
+    ns_map = {ns.namespace: ns for ns in rows}
+
+    # Walk from most specific to least specific to find git config
+    for name in reversed(ancestor_names):
+        ns = ns_map.get(name)
+        if ns and ns.github_repo_path:
+            actual_ns = ns_map.get(namespace)
+            return {
+                "repo": ns.github_repo_path,
+                "branch": actual_ns.git_branch if actual_ns else None,
+                "default_branch": ns.default_branch,
+                "path": ns.git_path,
+                "is_default_branch": (
+                    actual_ns.git_branch == ns.default_branch
+                    if actual_ns and actual_ns.git_branch and ns.default_branch
+                    else True
+                ),
+                "parent_namespace": actual_ns.parent_namespace if actual_ns else None,
+                "git_only": ns.git_only,
+            }
+    return None
 
 
 async def create_namespace(

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -1029,7 +1029,6 @@ class NodeOutput(GenericNodeOutputModel):
         """
         ORM options to successfully load this object
         """
-        from datajunction_server.database.namespace import NodeNamespace
         from datajunction_server.database.node import (
             Node,
             NodeRevision,
@@ -1040,11 +1039,6 @@ class NodeOutput(GenericNodeOutputModel):
             joinedload(Node.tags),
             selectinload(Node.created_by),
             selectinload(Node.owners),
-            # Load namespace and its parent for git_info using selectinload
-            # to avoid conflicts with FOR UPDATE queries (can't use joinedload)
-            selectinload(Node.namespace_obj).selectinload(
-                NodeNamespace.parent_namespace_obj,
-            ),
         ]
 
 


### PR DESCRIPTION
### Summary

Previously, `git_info` on a node was resolved by following the explicit parent_namespace FK on NodeNamespace. However, this FK is only set when explicitly configured (e.g. for branch namespaces like `product.feature_x` to `product`). Sub-namespaces created by convention (e.g. `product.main.cubes` for organizing nodes within `product.main`) never had this FK set, so they returned no git info even though a parent namespace had git config.

The root cause was that the `Node.git_info` property walked up via `namespace_obj.parent_namespace_obj`, which is None for sub-namespaces.

The fix replaces the property-based approach with an async `get_git_info_for_namespace` function that:
  1. Derives all ancestor namespace names by splitting the namespace string on `.`.
  2. Loads all ancestors in a single query
  3. Walks from most specific to least specific to find the first ancestor with a `github_repo_path`

Both the REST (`GET /nodes/{name}/`) and GraphQL resolvers have been updated to use the new function.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
