### PR TITLE
Set upper bound for dj.data polling and fix intermittent no data errors

### DIFF
--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -422,7 +422,8 @@ class DJClient(_internal.DJClient):
                 poll_interval = min(poll_interval * 2, 10)
 
             # Return results if the job has finished. If the server returned
-            # FINISHED with empty results, re-poll a few times before giving up.
+            # FINISHED with empty results, then re-poll a few
+            # times before giving up.
             if job_state == models.QueryState.FINISHED:
                 if results and not results.get("results"):
                     for attempt in range(3):

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -399,6 +399,76 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
                 async_=True,
             )
 
+        # FINISHED with empty results triggers re-poll retry; data arrives on second poll
+        finished_empty = type(
+            "R",
+            (),
+            {
+                "json": lambda self: {
+                    "state": "FINISHED",
+                    "results": [],
+                    "errors": [],
+                    "links": [],
+                },
+                "status_code": 200,
+            },
+        )()
+        finished_with_data = type(
+            "R",
+            (),
+            {
+                "json": lambda self: {
+                    "state": "FINISHED",
+                    "results": [
+                        {
+                            "columns": [
+                                {
+                                    "name": "default_DOT_hard_hat_DOT_city",
+                                    "type": "str",
+                                    "semantic_type": "dimension",
+                                    "semantic_entity": "default.hard_hat.city",
+                                    "semantic_name": "default.hard_hat.city",
+                                    "node": "default.hard_hat",
+                                },
+                                {
+                                    "name": "default_DOT_avg_repair_price",
+                                    "type": "float",
+                                    "semantic_type": "metric",
+                                    "semantic_name": "default.avg_repair_price",
+                                    "node": "default.avg_repair_price",
+                                },
+                            ],
+                            "rows": [["Foo", 1.0], ["Bar", 2.0]],
+                        },
+                    ],
+                    "errors": [],
+                    "links": [],
+                },
+                "status_code": 200,
+            },
+        )()
+        original_get = client._session.get
+        call_count = [0]
+
+        def mock_get(path, params=None, **kwargs):
+            if "/data/" in str(path):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    return finished_empty
+                return finished_with_data
+            return original_get(path, params=params, **kwargs)
+
+        client._session.get = mock_get
+        result = client.data(
+            metrics=["default.avg_repair_price"],
+            dimensions=["default.hard_hat.city"],
+        )
+        client._session.get = original_get
+        assert list(result.columns) == [
+            "default.hard_hat.city",
+            "default.avg_repair_price",
+        ]
+
         # Error propagation
         # with pytest.raises(DJClientException) as exc_info:
         #     client.data(


### PR DESCRIPTION
### Summary

The client was using unbounded exponential backoff when polling for query results (1s to 2s to 4s to ... to 128s+), causing it to appear hung even after the underlying job had finished. The polling interval is now capped at 10 seconds.

Additionally, as a client-side fallback, when a FINISHED response has no results, the client now re-polls up to 3 times (with 1s/2s/4s delays) before raising the exception.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
