### PR TITLE
Fix ForeignKeyViolation when deleting a branch namespace

### DIFF
--- a/datajunction-server/datajunction_server/api/branches.py
+++ b/datajunction-server/datajunction_server/api/branches.py
@@ -13,7 +13,7 @@ from typing import List
 from fastapi import Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_node_namespace
@@ -581,20 +581,28 @@ async def delete_branch(
     for node in nodes_to_delete:
         await session.delete(node)
 
-    # Delete the namespace record
-    await session.delete(branch_ns)
-
-    # Also delete any child namespaces
+    # Delete child namespaces before the branch namespace itself to satisfy
+    # the self-referential FK constraint (fk_nodenamespace_parent).
+    # This covers sub-namespaces created during deployment (e.g., project.branch.metrics).
     child_ns_query = select(NodeNamespace).where(
-        or_(
-            NodeNamespace.namespace == branch_namespace,
-            NodeNamespace.namespace.like(f"{branch_namespace}.%"),
-        ),
+        NodeNamespace.namespace.like(f"{branch_namespace}.%"),
     )
     child_result = await session.execute(child_ns_query)
     for child_ns in child_result.scalars().all():
-        if child_ns.namespace != branch_namespace:  # pragma: no branch
-            await session.delete(child_ns)
+        await session.delete(child_ns)
+
+    # Nullify parent_namespace on any remaining namespaces that reference this one
+    # (e.g., sibling branches created from this namespace as a git root). This
+    # handles the case where the referencing namespace name doesn't start with
+    # branch_namespace and so wasn't caught by the LIKE query above.
+    await session.execute(
+        update(NodeNamespace)
+        .where(NodeNamespace.parent_namespace == branch_namespace)
+        .values(parent_namespace=None),
+    )
+
+    # Delete the namespace record last
+    await session.delete(branch_ns)
 
     await session.commit()
 

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -1030,6 +1030,65 @@ class TestBranchManagement:
         assert response.status_code == HTTPStatus.NOT_FOUND
 
     @pytest.mark.asyncio
+    async def test_delete_branch_with_parent_namespace_fk(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """Deleting a branch that is referenced as parent_namespace by other namespaces
+        must not raise a ForeignKeyViolation (fk_nodenamespace_parent)."""
+        # Set up a git root namespace
+        await client_with_service_setup.post("/namespaces/fktest.main")
+        await client_with_service_setup.patch(
+            "/namespaces/fktest.main/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+            },
+        )
+
+        with patch(
+            "datajunction_server.api.branches.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.create_branch = AsyncMock(
+                return_value={"ref": "refs/heads/to-delete", "object": {"sha": "abc"}},
+            )
+            mock_github_class.return_value = mock_github
+
+            # Create the branch we'll later delete
+            await client_with_service_setup.post(
+                "/namespaces/fktest.main/branches",
+                json={"branch_name": "to-delete"},
+            )
+
+        # Create a second branch FROM the branch we're going to delete.
+        # This sets parent_namespace = "fktest.to_delete" on the new namespace,
+        # which is the exact condition that triggers the FK violation on delete.
+        with patch(
+            "datajunction_server.api.branches.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.create_branch = AsyncMock(
+                return_value={
+                    "ref": "refs/heads/child-branch",
+                    "object": {"sha": "def"},
+                },
+            )
+            mock_github_class.return_value = mock_github
+
+            await client_with_service_setup.post(
+                "/namespaces/fktest.to_delete/branches",
+                json={"branch_name": "child-branch"},
+            )
+
+        # Deleting fktest.to_delete should succeed even though fktest.child_branch
+        # (or the auto-created git-root placeholder) has parent_namespace pointing to it.
+        response = await client_with_service_setup.delete(
+            "/namespaces/fktest.main/branches/fktest.to_delete?delete_git_branch=false",
+        )
+        assert response.status_code == HTTPStatus.OK
+
+    @pytest.mark.asyncio
     async def test_create_branch_git_fails_namespace_succeeds(
         self,
         client_with_service_setup: AsyncClient,


### PR DESCRIPTION
### Summary

Deleting a branch namespace could fail with a `ForeignKeyViolation` on the `fk_nodenamespace_parent` constraint when the namespace being deleted was still referenced as `parent_namespace` by other rows in `nodenamespace`.

This had two causes:
1. Wrong deletion order. The branch namespace itself was deleted before its child namespaces (sub-namespaces created during deployment, e.g. `project.feature.metrics`). Since those children have `parent_namespace = "project.feature"`, Postgres rejected the parent delete.
2. Unreachable references. Other namespaces (e.g. branches created from this namespace as a git root) also have `parent_namespace` pointing to it, but their names don't match the `LIKE 'branch.%'` pattern so they weren't caught by the child cleanup query.

The fix deletes child namespaces (by name pattern) before deleting the branch, then nullifies parent_namespace on any remaining namespaces that still reference it before the final delete.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
