### PR TITLE
Fix parent name resolution in revalidate_node to use node names, not AST aliases

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3106,8 +3106,7 @@ async def revalidate_node(
 
     # Update parent relationships from validation
     parent_names = {
-        node_revision.name
-        for node_revision in node_validator.dependencies_map.keys()
+        node_revision.name for node_revision in node_validator.dependencies_map.keys()
     }
     if parent_names:
         _logger.info(f"Updating parents for {node.name} to: {parent_names}")

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5099,6 +5099,68 @@ class TestValidateNodes:
         ]
 
     @pytest.mark.asyncio
+    async def test_revalidate_restores_parents_when_query_uses_alias(
+        self,
+        session: AsyncSession,
+        client_with_roads: AsyncClient,
+    ):
+        """
+        Regression test: revalidate_node must use NodeRevision.name (from
+        dependencies_map.keys()) not str(ast.Table) (from .values()), which
+        includes the SQL alias and produces names like
+        "default.repair_orders AS ro" that never match DB rows.
+
+        Create a transform whose query aliases its source table, clear the
+        stored parent links, revalidate, and confirm the parent is restored.
+        """
+        response = await client_with_roads.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.test_alias_parent",
+                "query": (
+                    "SELECT ro.repair_order_id, ro.dispatcher_id "
+                    "FROM default.repair_orders AS ro"
+                ),
+                "description": "Transform using a table alias",
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201
+        assert response.json()["parents"] == [{"name": "default.repair_orders"}]
+
+        # Wipe the stored parent relationships to simulate drift
+        await session.execute(
+            text(
+                """
+                DELETE FROM noderelationship
+                WHERE child_id IN (
+                    SELECT id FROM noderevision WHERE name = 'default.test_alias_parent'
+                )
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        # Confirm they're gone
+        node_data = (
+            await client_with_roads.get("/nodes/default.test_alias_parent/")
+        ).json()
+        assert node_data["parents"] == []
+
+        # Revalidate — must restore the parent using the clean node name
+        result = await client_with_roads.post(
+            "/nodes/default.test_alias_parent/validate/",
+        )
+        assert result.status_code == 200
+        assert result.json()["status"] == "valid"
+
+        node_data = (
+            await client_with_roads.get("/nodes/default.test_alias_parent/")
+        ).json()
+        assert node_data["parents"] == [{"name": "default.repair_orders"}]
+
+    @pytest.mark.asyncio
     async def test_revalidate_sets_column_order_when_missing(
         self,
         session: AsyncSession,


### PR DESCRIPTION
### Summary

When `/nodes/{name}/validate` re-synced a node's parents, it was iterating over `dependencies_map.values()`, which are `ast.Table` objects that stringify with their SQL alias, and using those strings to look up parent nodes in the DB. The lookup always returned empty, so parent relationships were never updated on revalidation.

The fix iterates `dependencies_map.keys()` instead, which are NodeRevision objects whose `.name` is the clean, unaliased node name.
```
  before: str(ast.Table) -> "source.catalog.schema.table AS abc"
  after:  node_revision.name -> "source.catalog.schema.table"
```

Fixes a bug introduced in https://github.com/DataJunction/dj/pull/1817

### Test Plan

Adds a new unit test `test_revalidate_restores_parents_when_query_uses_alias` that catches this.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
