### PR TITLE
Log deployment failure details before exiting in dj push

### DIFF
--- a/datajunction-clients/python/datajunction/cli.py
+++ b/datajunction-clients/python/datajunction/cli.py
@@ -1323,7 +1323,8 @@ class DJCLI:
                 return
             try:
                 self.push(args.directory, verbose=args.verbose, force=args.force)
-            except DJDeploymentFailure:
+            except DJDeploymentFailure as exc:
+                logger.error("Deployment failed: %s", exc)
                 raise SystemExit(1)
         elif args.command == "push":
             # Handle dry run first
@@ -1352,7 +1353,8 @@ class DJCLI:
                     verbose=args.verbose,
                     force=args.force,
                 )
-            except DJDeploymentFailure:
+            except DJDeploymentFailure as exc:
+                logger.error("Deployment failed: %s", exc)
                 raise SystemExit(1)
         elif args.command == "pull":
             self.pull(args.namespace, args.directory)


### PR DESCRIPTION
### Summary

When `dj push` failed, the exception was silently swallowed and the CLI exited with code 1 with no output, leaving users with no indication of what went wrong. The error message is now logged before the SystemExit.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
