### PR TITLE
Fix SQLAlchemy identity map conflict in deployment tag creation

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -586,7 +586,7 @@ class DeploymentOrchestrator:
                     tag_type=tag_spec.tag_type,
                     description=tag_spec.description,
                     display_name=tag_spec.display_name or labelize(tag_name),
-                    created_by=self.context.current_user,
+                    created_by_id=self.context.current_user.id,
                 )
                 self.session.add(tag)
             existing_tags[tag_name] = tag


### PR DESCRIPTION
### Summary

SQLAlchemy maintains an identity map per session, so only one instance of a given object (by primary key) can be tracked at a time. When a User object loaded in one context (e.g., request authentication) is later associated with a new ORM object being added to a different or reused session, SQLAlchemy raises InvalidRequestError because it finds two instances with the same primary key.

This PR fixes it by passing only the user's ID (a plain integer) rather than the ORM object itself when creating tags, so SQLAlchemy never needs to attach the User instance to the session at all.

### Test Plan

Confirmed via logs that the failing deployment was hitting this code path (tag creation with the affected user)

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
