### PR TITLE
Expose any errors from verifying commits

### DIFF
--- a/datajunction-server/datajunction_server/internal/git/github_service.py
+++ b/datajunction-server/datajunction_server/internal/git/github_service.py
@@ -615,7 +615,10 @@ class GitHubService:
                 headers=self.headers,
                 timeout=30.0,
             )
-            return resp.status_code == 200
+            if resp.status_code == 404:
+                return False
+            self._handle_error(resp, f"verify commit {commit_sha} in {repo_path}")
+            return True
 
     async def download_archive(
         self,


### PR DESCRIPTION
### Summary

If deployment fails because we are unable to verify a commit (for git-only namespace deployments), this will expose the error that was returned to the user rather than just failing with no clear error. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
