### PR TITLE
Add parent column type re-parsing to bulk validation

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -25,9 +25,30 @@ from datajunction_server.errors import (
     ErrorCode,
     DJException,
 )
-from datajunction_server.sql.parsing.backends.antlr4 import parse, ast
+from datajunction_server.sql.parsing.backends.antlr4 import parse, ast, parse_rule
+from datajunction_server.sql.parsing.types import ListType, MapType, StructType
 
 logger = logging.getLogger(__name__)
+
+
+def _reparse_column_types(dependency_nodes: Dict[str, Node]) -> None:
+    """
+    Re-parse column types for dependency nodes to ensure map/list/struct types are
+    fully parsed before type inference. Mutates column types in place.
+
+    Mirrors the logic in validate_node_data (internal/validation.py lines 114-130).
+    """
+    for node in dependency_nodes.values():
+        if node.current:
+            for col in node.current.columns:
+                if isinstance(col.type, str) or (
+                    type(col.type).__name__ == "ColumnType"
+                    and not isinstance(col.type, (MapType, ListType, StructType))
+                ):
+                    try:
+                        col.type = parse_rule(str(col.type), "dataType")
+                    except Exception:
+                        pass
 
 
 @dataclass
@@ -429,6 +450,7 @@ async def bulk_validate_node_data(
     path that skips SQL parsing and dependency extraction.
     """
     validate_start = time.perf_counter()
+    _reparse_column_types(dependency_nodes)
     context = ValidationContext(
         session=session,
         node_graph=node_graph,

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from datajunction_server.internal.deployment.validation import (
     NodeSpecBulkValidator,
     ValidationContext,
+    _reparse_column_types,
 )
 from datajunction_server.models.deployment import ColumnSpec, TransformSpec, MetricSpec
 from datajunction_server.models.node import NodeType, NodeStatus
@@ -18,7 +19,7 @@ from datajunction_server.database.user import User, OAuthProvider
 from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.column import Column
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
-from datajunction_server.sql.parsing.types import IntegerType, StringType
+from datajunction_server.sql.parsing.types import IntegerType, MapType, StringType
 from datajunction_server.errors import ErrorCode
 
 
@@ -390,3 +391,52 @@ class TestValidateQuery:
             e for e in result.errors if e.code == ErrorCode.INVALID_PARENT
         )
         assert invalid_parent_node.name in invalid_parent_err.message
+
+
+class TestReparseColumnTypes:
+    """Tests for _reparse_column_types helper (PR 2)."""
+
+    def _make_node(self, columns: list) -> Node:
+        """Build a minimal in-memory Node with a current revision."""
+        node = Node(name="test.node", type=NodeType.SOURCE)
+        revision = NodeRevision(
+            name=node.name,
+            type=node.type,
+            version="v1",
+            columns=columns,
+        )
+        node.current = revision
+        return node
+
+    def test_string_type_is_reparsed(self):
+        """Column with a string type like 'MAP<string,bigint>' is parsed to MapType."""
+        col = Column(name="tags", type="MAP<string, bigint>", order=0)
+        node = self._make_node([col])
+        _reparse_column_types({node.name: node})
+        assert isinstance(col.type, MapType)
+
+    def test_already_parsed_type_is_unchanged(self):
+        """Column already holding a parsed type object is left alone."""
+        col = Column(name="id", type=IntegerType(), order=0)
+        original_type = col.type
+        node = self._make_node([col])
+        _reparse_column_types({node.name: node})
+        assert col.type is original_type
+
+    def test_unparseable_string_is_left_unchanged(self):
+        """If parse_rule raises, the original type value is preserved."""
+        col = Column(name="weird", type="NOT_A_VALID_TYPE_$$$$", order=0)
+        node = self._make_node([col])
+        _reparse_column_types({node.name: node})
+        # Should not raise; type is still the original string
+        assert col.type == "NOT_A_VALID_TYPE_$$$$"
+
+    def test_node_without_current_is_skipped(self):
+        """Node with no current revision doesn't cause an error."""
+        node = Node(name="orphan", type=NodeType.SOURCE)
+        node.current = None
+        _reparse_column_types({node.name: node})  # Should not raise
+
+    def test_empty_dict_is_noop(self):
+        """Empty dependency_nodes dict is handled without error."""
+        _reparse_column_types({})  # Should not raise


### PR DESCRIPTION
### Summary

The single node validation path reparses types for every parent column's type string to ensure that `MapType` / `ListType` / `StructType` strings are fully parsed before type inference. The bulk validator should do the same.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #1940 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
