### PR TITLE
Enable bulk validation for required dimensions

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -277,19 +277,20 @@ async def get_query(
     return query_ast
 
 
-async def find_required_dimensions(
-    session: AsyncSession,
+def _resolve_required_dimensions(
     required_dimensions: list[str],
     parent_columns: list[Column],
+    dim_nodes: Dict[str, "Node"],
 ) -> Tuple[Set[str], List[Column]]:
     """
-    Find Column objects for required dimension paths.
+    Pure resolution of required_dimensions strings against pre-fetched nodes.
 
     Required dimensions can be specified as:
-    - Full path: "dimensions.date.dateint" -> look up dimension node and find column
-    - Short name: "status" -> find in parent_columns
+    - Full path: "dimensions.date.dateint" -> look up in dim_nodes, find column
+    - Short name: "status"                 -> find in parent_columns
 
-    Uses a single DB query to fetch all needed dimension nodes.
+    Called by find_required_dimensions (after its DB fetch) and by the bulk
+    deployment validator (with its batch-prefetched _all_dim_nodes cache).
 
     Returns:
         Tuple of (invalid dimension paths, matched Column objects)
@@ -297,7 +298,6 @@ async def find_required_dimensions(
     invalid_required_dimensions: Set[str] = set()
     matched_columns: List[Column] = []
 
-    # Build lookup for parent columns
     parent_col_map = {col.name: col for col in parent_columns}
 
     # Separate full paths from short names
@@ -309,7 +309,6 @@ async def find_required_dimensions(
         if SEPARATOR in required_dim:
             dim_node_name, col_name = required_dim.rsplit(SEPARATOR, 1)
             # Strip role suffix if present (e.g., "week[order]" -> "week")
-            # Role is DJ-specific syntax, not part of actual column name
             if "[" in col_name:
                 col_name = col_name.split("[")[0]
             if dim_node_name not in full_paths:  # pragma: no cover
@@ -318,18 +317,54 @@ async def find_required_dimensions(
         else:
             short_names.append(required_dim)
 
-    # Handle short names from parent columns
     for short_name in short_names:
         if short_name in parent_col_map:
             matched_columns.append(parent_col_map[short_name])
         else:
             invalid_required_dimensions.add(short_name)  # pragma: no cover
 
-    # Single query to fetch all needed dimension nodes
-    if full_paths:
+    for dim_node_name, paths in full_paths.items():
+        dim_node = dim_nodes.get(dim_node_name)
+        if not dim_node or not dim_node.current:  # pragma: no cover
+            for full_path, _ in paths:
+                invalid_required_dimensions.add(full_path)
+            continue
+
+        dim_col_map = {col.name: col for col in dim_node.current.columns}
+        for full_path, col_name in paths:
+            if col_name in dim_col_map:
+                matched_columns.append(dim_col_map[col_name])
+            else:
+                invalid_required_dimensions.add(full_path)
+
+    return invalid_required_dimensions, matched_columns
+
+
+async def find_required_dimensions(
+    session: AsyncSession,
+    required_dimensions: list[str],
+    parent_columns: list[Column],
+) -> Tuple[Set[str], List[Column]]:
+    """
+    Find Column objects for required dimension paths.
+
+    Fetches all needed dimension nodes in a single DB query, then delegates
+    resolution to _resolve_required_dimensions.
+
+    Returns:
+        Tuple of (invalid dimension paths, matched Column objects)
+    """
+    # Collect dim node names from full-path entries so we can batch-fetch them
+    dim_node_names: Set[str] = set()
+    for required_dim in required_dimensions:
+        if SEPARATOR in required_dim:
+            dim_node_names.add(required_dim.rsplit(SEPARATOR, 1)[0])
+
+    dim_nodes: Dict[str, "Node"] = {}
+    if dim_node_names:
         result = await session.execute(
             select(Node)
-            .filter(Node.name.in_(full_paths.keys()))
+            .filter(Node.name.in_(dim_node_names))
             .options(
                 selectinload(Node.current).options(
                     selectinload(NodeRevision.columns),
@@ -338,25 +373,7 @@ async def find_required_dimensions(
         )
         dim_nodes = {node.name: node for node in result.scalars().all()}
 
-        # Match columns for each full path
-        for dim_node_name, paths in full_paths.items():
-            dim_node = dim_nodes.get(dim_node_name)
-            if not dim_node or not dim_node.current:  # pragma: no cover
-                # Node not found - all paths for this node are invalid
-                for full_path, _ in paths:
-                    invalid_required_dimensions.add(full_path)
-                continue
-
-            # Build column lookup for this dimension
-            dim_col_map = {col.name: col for col in dim_node.current.columns}
-
-            for full_path, col_name in paths:
-                if col_name in dim_col_map:
-                    matched_columns.append(dim_col_map[col_name])
-                else:
-                    invalid_required_dimensions.add(full_path)
-
-    return invalid_required_dimensions, matched_columns
+    return _resolve_required_dimensions(required_dimensions, parent_columns, dim_nodes)
 
 
 async def resolve_downstream_references(

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -9,8 +9,11 @@ from typing import Dict, List, Optional
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from datajunction_server.api.helpers import _resolve_required_dimensions
 from datajunction_server.internal.validation import validate_metric_query
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.models.node import NodeStatus, NodeType
@@ -27,6 +30,7 @@ from datajunction_server.errors import (
 )
 from datajunction_server.sql.parsing.backends.antlr4 import parse, ast, parse_rule
 from datajunction_server.sql.parsing.types import ListType, MapType, StructType
+from datajunction_server.utils import SEPARATOR
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +95,10 @@ class NodeSpecBulkValidator:
 
     def __init__(self, context: ValidationContext):
         self.context = context
+        # Populated by _prefetch_required_dimension_nodes before per-node validation.
+        # Keys: node name; values: Node objects (union of dependency_nodes + any
+        # extra dimension nodes fetched from DB for required_dimensions resolution).
+        self._all_dim_nodes: Dict[str, Node] = {}
 
     async def validate(self, node_specs: list[NodeSpec]) -> List[NodeValidationResult]:
         """
@@ -113,6 +121,11 @@ class NodeSpecBulkValidator:
 
         # Parse only specs that need it
         parsed_results = await self.parse_queries(specs_needing_parse)
+
+        # Pre-fetch dimension nodes for required_dimensions validation (PR 3).
+        # Must happen before the asyncio.gather so every validate_query_node call
+        # can read self._all_dim_nodes without issuing per-node DB queries.
+        await self._prefetch_required_dimension_nodes(specs_needing_parse)
 
         # Build results in original order
         results: List[NodeValidationResult] = [None] * len(node_specs)  # type: ignore
@@ -216,6 +229,11 @@ class NodeSpecBulkValidator:
                         message=f"References invalid parent node(s) {', '.join(invalid_parents)}",
                     ),
                 )
+
+            req_dim_error = self._check_required_dimensions(spec)
+            if req_dim_error is not None:
+                errors.append(req_dim_error)
+
             return NodeValidationResult(
                 spec=spec,
                 status=NodeStatus.VALID if not errors else NodeStatus.INVALID,
@@ -269,6 +287,78 @@ class NodeSpecBulkValidator:
                 code=ErrorCode.INVALID_SQL_QUERY,
                 message=str(exc),
             )
+
+    async def _prefetch_required_dimension_nodes(
+        self,
+        specs: list[NodeSpec],
+    ) -> None:
+        """
+        Collect all dimension node names referenced via required_dimensions across the
+        batch, fetch any not already in dependency_nodes in a single DB query, and
+        store the combined map in self._all_dim_nodes.
+        """
+        req_dim_node_names: set[str] = set()
+        for spec in specs:
+            for req_dim in getattr(spec, "required_dimensions", None) or []:
+                if SEPARATOR in req_dim:
+                    dim_node_name = req_dim.rsplit(SEPARATOR, 1)[0]
+                    req_dim_node_names.add(dim_node_name)
+
+        self._all_dim_nodes = dict(self.context.dependency_nodes)
+
+        missing = req_dim_node_names - set(self._all_dim_nodes)
+        if missing:
+            result = await self.context.session.execute(
+                select(Node)
+                .filter(Node.name.in_(missing))
+                .options(
+                    selectinload(Node.current).options(
+                        selectinload(NodeRevision.columns),
+                    ),
+                ),
+            )
+            for node in result.scalars().all():
+                self._all_dim_nodes[node.name] = node
+
+    def _check_required_dimensions(self, spec: NodeSpec) -> DJError | None:
+        """
+        Validate that every entry in required_dimensions resolves to a real column.
+
+        Delegates resolution to _resolve_required_dimensions (api/helpers.py).
+        The only bulk-validator-specific part is that self._all_dim_nodes was
+        pre-populated in a single batch query by _prefetch_required_dimension_nodes
+        rather than per-node.
+        """
+        required_dimensions = getattr(spec, "required_dimensions", None) or []
+        if not required_dimensions:
+            return None
+
+        dep_names = self.context.node_graph.get(spec.rendered_name, [])
+        parent_columns = [
+            col
+            for dep_name in dep_names
+            for dep_node in [self.context.dependency_nodes.get(dep_name)]
+            if dep_node and dep_node.current
+            for col in dep_node.current.columns
+        ]
+
+        invalid, _ = _resolve_required_dimensions(
+            required_dimensions,
+            parent_columns,
+            self._all_dim_nodes,
+        )
+
+        if not invalid:
+            return None
+
+        return DJError(
+            code=ErrorCode.INVALID_COLUMN,
+            message=(
+                "Node definition contains references to columns as "
+                "required dimensions that are not on parent nodes."
+            ),
+            debug={"invalid_required_dimensions": list(invalid)},
+        )
 
     def _infer_columns(
         self,

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -23,62 +23,64 @@ from datajunction_server.sql.parsing.types import IntegerType, MapType, StringTy
 from datajunction_server.errors import ErrorCode
 
 
+@pytest_asyncio.fixture
+async def user(session: AsyncSession) -> User:
+    """Create a test user"""
+    user = User(
+        username="testuser",
+        oauth_provider=OAuthProvider.BASIC,
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def catalog(session: AsyncSession) -> Catalog:
+    """Create a test catalog"""
+    catalog = Catalog(
+        name="test_catalog",
+        engines=[],
+    )
+    session.add(catalog)
+    await session.commit()
+    return catalog
+
+
+@pytest_asyncio.fixture
+async def parent_node(
+    session: AsyncSession,
+    user: User,
+    catalog: Catalog,
+) -> Node:
+    """Create a parent source node for dependencies"""
+    node = Node(
+        name="test.parent",
+        type=NodeType.SOURCE,
+        current_version="v1",
+        created_by_id=user.id,
+    )
+    node_revision = NodeRevision(
+        node=node,
+        name=node.name,
+        catalog_id=catalog.id,
+        type=node.type,
+        version="v1",
+        columns=[
+            Column(name="id", type=IntegerType(), order=0),
+            Column(name="name", type=StringType(), order=1),
+            Column(name="value", type=IntegerType(), order=2),
+        ],
+        created_by_id=user.id,
+    )
+    node.current = node_revision
+    session.add(node_revision)
+    await session.commit()
+    return node
+
+
 class TestValidateQuery:
     """Test validate_query_node exception handling with real database objects"""
-
-    @pytest_asyncio.fixture
-    async def user(self, session: AsyncSession) -> User:
-        """Create a test user"""
-        user = User(
-            username="testuser",
-            oauth_provider=OAuthProvider.BASIC,
-        )
-        session.add(user)
-        await session.commit()
-        return user
-
-    @pytest_asyncio.fixture
-    async def catalog(self, session: AsyncSession) -> Catalog:
-        """Create a test catalog"""
-        catalog = Catalog(
-            name="test_catalog",
-            engines=[],
-        )
-        session.add(catalog)
-        await session.commit()
-        return catalog
-
-    @pytest_asyncio.fixture
-    async def parent_node(
-        self,
-        session: AsyncSession,
-        user: User,
-        catalog: Catalog,
-    ) -> Node:
-        """Create a parent source node for dependencies"""
-        node = Node(
-            name="test.parent",
-            type=NodeType.SOURCE,
-            current_version="v1",
-            created_by_id=user.id,
-        )
-        node_revision = NodeRevision(
-            node=node,
-            name=node.name,
-            catalog_id=catalog.id,
-            type=node.type,
-            version="v1",
-            columns=[
-                Column(name="id", type=IntegerType(), order=0),
-                Column(name="name", type=StringType(), order=1),
-                Column(name="value", type=IntegerType(), order=2),
-            ],
-            created_by_id=user.id,
-        )
-        node.current = node_revision
-        session.add(node_revision)
-        await session.commit()
-        return node
 
     @pytest_asyncio.fixture
     async def validation_context(
@@ -440,3 +442,265 @@ class TestReparseColumnTypes:
     def test_empty_dict_is_noop(self):
         """Empty dependency_nodes dict is handled without error."""
         _reparse_column_types({})  # Should not raise
+
+
+class TestRequiredDimensions:
+    """Tests for required_dimensions validation (PR 3)."""
+
+    # ------------------------------------------------------------------ helpers
+
+    def _make_dim_node(
+        self,
+        name: str,
+        col_names: list[str],
+    ) -> Node:
+        node = Node(name=name, type=NodeType.DIMENSION)
+        revision = NodeRevision(
+            name=name,
+            type=NodeType.DIMENSION,
+            version="v1",
+            columns=[
+                Column(name=c, type=StringType(), order=i)
+                for i, c in enumerate(col_names)
+            ],
+        )
+        node.current = revision
+        return node
+
+    def _make_context(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ) -> ValidationContext:
+        dep_nodes = {parent_node.name: parent_node}
+        compile_context = ast.CompileContext(
+            session=session,
+            exception=ast.DJException(),
+            dependencies_cache=dep_nodes,
+        )
+        return ValidationContext(
+            session=session,
+            node_graph={"test.metric": [parent_node.name]},
+            dependency_nodes=dep_nodes,
+            compile_context=compile_context,
+        )
+
+    # ------------------------------------------------------------------ unit tests (no DB query needed)
+
+    @pytest.mark.asyncio
+    async def test_valid_full_path_in_dependency_nodes(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """required_dimensions full-path column found in dependency_nodes → VALID."""
+        dim_node = self._make_dim_node("test.dim", ["dateint"])
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(*) FROM test.parent",
+            required_dimensions=["test.dim.dateint"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        # Pre-populate as if _prefetch_required_dimension_nodes ran
+        validator._all_dim_nodes = {**context.dependency_nodes, "test.dim": dim_node}
+
+        parsed_ast = parse(spec.rendered_query)
+        result = await validator.validate_query_node(spec, parsed_ast)
+
+        assert result.status == NodeStatus.VALID
+        error_codes = [e.code for e in result.errors]
+        assert ErrorCode.INVALID_COLUMN not in error_codes
+
+    @pytest.mark.asyncio
+    async def test_invalid_column_not_found_on_dim_node(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """required_dimensions full-path column absent from dim node → INVALID."""
+        dim_node = self._make_dim_node("test.dim", ["dateint"])
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(*) FROM test.parent",
+            required_dimensions=["test.dim.nonexistent_col"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._all_dim_nodes = {**context.dependency_nodes, "test.dim": dim_node}
+
+        parsed_ast = parse(spec.rendered_query)
+        result = await validator.validate_query_node(spec, parsed_ast)
+
+        assert result.status == NodeStatus.INVALID
+        err = next(e for e in result.errors if e.code == ErrorCode.INVALID_COLUMN)
+        assert err.debug is not None
+        assert "test.dim.nonexistent_col" in err.debug["invalid_required_dimensions"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_dim_node_not_found(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """required_dimensions references a dim node that doesn't exist → INVALID."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(*) FROM test.parent",
+            required_dimensions=["ghost.dim.col"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        # _all_dim_nodes has no entry for "ghost.dim"
+        validator._all_dim_nodes = dict(context.dependency_nodes)
+
+        parsed_ast = parse(spec.rendered_query)
+        result = await validator.validate_query_node(spec, parsed_ast)
+
+        assert result.status == NodeStatus.INVALID
+        err = next(e for e in result.errors if e.code == ErrorCode.INVALID_COLUMN)
+        assert err.debug is not None
+        assert "ghost.dim.col" in err.debug["invalid_required_dimensions"]
+
+    @pytest.mark.asyncio
+    async def test_valid_short_name_in_parent_columns(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """required_dimensions short name found in parent columns → VALID."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT SUM(value) FROM test.parent",
+            # "value" is a column on parent_node (IntegerType)
+            required_dimensions=["value"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._all_dim_nodes = dict(context.dependency_nodes)
+
+        parsed_ast = parse(spec.rendered_query)
+        result = await validator.validate_query_node(spec, parsed_ast)
+
+        assert result.status == NodeStatus.VALID
+        error_codes = [e.code for e in result.errors]
+        assert ErrorCode.INVALID_COLUMN not in error_codes
+
+    @pytest.mark.asyncio
+    async def test_invalid_short_name_not_in_parent_columns(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """required_dimensions short name absent from all parent columns → INVALID."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(*) FROM test.parent",
+            required_dimensions=["no_such_col"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._all_dim_nodes = dict(context.dependency_nodes)
+
+        parsed_ast = parse(spec.rendered_query)
+        result = await validator.validate_query_node(spec, parsed_ast)
+
+        assert result.status == NodeStatus.INVALID
+        err = next(e for e in result.errors if e.code == ErrorCode.INVALID_COLUMN)
+        assert err.debug is not None
+        assert "no_such_col" in err.debug["invalid_required_dimensions"]
+
+    @pytest.mark.asyncio
+    async def test_no_required_dimensions_is_noop(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """Spec with no required_dimensions produces no INVALID_COLUMN error."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(*) FROM test.parent",
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._all_dim_nodes = dict(context.dependency_nodes)
+
+        parsed_ast = parse(spec.rendered_query)
+        result = await validator.validate_query_node(spec, parsed_ast)
+
+        error_codes = [e.code for e in result.errors]
+        assert ErrorCode.INVALID_COLUMN not in error_codes
+
+    # ------------------------------------------------------------------ DB-fetch path
+
+    @pytest_asyncio.fixture
+    async def dim_node_in_db(
+        self,
+        session: AsyncSession,
+        user: User,
+        catalog: Catalog,
+    ) -> Node:
+        """A dimension node that exists in the DB but is NOT in dependency_nodes."""
+        node = Node(
+            name="test.external_dim",
+            type=NodeType.DIMENSION,
+            current_version="v1",
+            created_by_id=user.id,
+        )
+        revision = NodeRevision(
+            node=node,
+            name=node.name,
+            catalog_id=catalog.id,
+            type=node.type,
+            version="v1",
+            columns=[Column(name="region", type=StringType(), order=0)],
+            created_by_id=user.id,
+        )
+        node.current = revision
+        session.add(revision)
+        await session.commit()
+        return node
+
+    @pytest.mark.asyncio
+    async def test_prefetch_fetches_dim_node_from_db(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        dim_node_in_db: Node,
+    ):
+        """_prefetch_required_dimension_nodes fetches a node not in dependency_nodes."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(*) FROM test.parent",
+            required_dimensions=["test.external_dim.region"],
+        )
+        validator = NodeSpecBulkValidator(context)
+
+        await validator._prefetch_required_dimension_nodes([spec])
+
+        assert "test.external_dim" in validator._all_dim_nodes
+        fetched = validator._all_dim_nodes["test.external_dim"]
+        assert fetched.current is not None
+        col_names = {c.name for c in fetched.current.columns}
+        assert "region" in col_names
+
+    @pytest.mark.asyncio
+    async def test_prefetch_with_no_required_dimensions(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """_prefetch_required_dimension_nodes with specs lacking required_dimensions is a noop."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(*) FROM test.parent",
+        )
+        validator = NodeSpecBulkValidator(context)
+        await validator._prefetch_required_dimension_nodes([spec])
+
+        # _all_dim_nodes is just a copy of dependency_nodes
+        assert set(validator._all_dim_nodes.keys()) == set(
+            context.dependency_nodes.keys(),
+        )


### PR DESCRIPTION
### Summary

The single node validation function verifies that any required dimensions declared for a metric are available, and the bulk validator should do the same thing.

In this change we refactor out the actual required dimensions validation logic from the bulk dimension node fetching logic, so that the bulk validation can pre-fetch the dimension nodes, and pass them into the same validation logic as the existing required dimensions check. After this change, bulk validation will mark a node as invalid if any required dimensions references can't be resolved. 

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1940 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
