### PR TITLE
Detect branch name in detached HEAD state during deployment

### DIFF
--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -520,6 +520,9 @@ class DeploymentService:
         """
         Returns the current git branch name, or None if not in a git repo or
         git is not available.
+
+        In detached HEAD state (common in CI), falls back to recovering the
+        branch from remote tracking refs (refs/remotes/origin/<branch>).
         """
         try:
             result = subprocess.run(
@@ -530,7 +533,24 @@ class DeploymentService:
                 cwd=cwd,
             )
             branch = result.stdout.strip()
-            return branch if branch and branch != "HEAD" else None
+            if branch and branch != "HEAD":
+                return branch
+            # Detached HEAD (common in CI) — find remote branches whose tip is
+            # exactly this commit.
+            result2 = subprocess.run(
+                ["git", "branch", "-r", "--points-at", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=cwd,
+            )
+            for line in result2.stdout.splitlines():
+                ref = line.strip()
+                if "/" in ref:  # pragma: no branch
+                    _, branch = ref.split("/", 1)
+                    if branch != "HEAD":  # pragma: no branch
+                        return branch
+            return None
         except (subprocess.CalledProcessError, FileNotFoundError):
             return None
 

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -759,10 +759,44 @@ class TestDetectGitBranch:
         )
         assert DeploymentService._detect_git_branch() is None
 
-    def test_returns_none_for_detached_head(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "remote_output,expected",
+        [
+            ("  origin/my-feature\n", "my-feature"),
+            ("  upstream/my-feature\n", "my-feature"),
+            ("  fork/my-feature\n", "my-feature"),
+        ],
+    )
+    def test_detached_head_falls_back_to_remote_ref(
+        self,
+        monkeypatch,
+        remote_output,
+        expected,
+    ):
+        calls = iter(
+            [
+                mock.MagicMock(stdout="HEAD\n"),  # git rev-parse --abbrev-ref HEAD
+                mock.MagicMock(stdout=remote_output),  # git branch -r --points-at HEAD
+            ],
+        )
         monkeypatch.setattr(
             "datajunction.deployment.subprocess.run",
-            lambda *a, **kw: mock.MagicMock(stdout="HEAD\n"),
+            lambda *a, **kw: next(calls),
+        )
+        assert DeploymentService._detect_git_branch() == expected
+
+    def test_detached_head_returns_none_when_no_remote_ref(self, monkeypatch):
+        calls = iter(
+            [
+                mock.MagicMock(stdout="HEAD\n"),  # git rev-parse --abbrev-ref HEAD
+                mock.MagicMock(
+                    stdout="",
+                ),  # git branch -r --points-at HEAD — no results
+            ],
+        )
+        monkeypatch.setattr(
+            "datajunction.deployment.subprocess.run",
+            lambda *a, **kw: next(calls),
         )
         assert DeploymentService._detect_git_branch() is None
 


### PR DESCRIPTION
### Summary

When deploying from CI, `git rev-parse --abbrev-ref HEAD` returns "HEAD" rather than a branch name. The client now falls back to `git branch -r --points-at HEAD` to recover the branch from remote tracking refs, so that the namespace auto-detection works correctly in pipelines that check out a detached HEAD.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
