### PR TITLE
Speed up git sync process and catch a few deployment issues

### DIFF
--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -187,7 +187,7 @@ class DeploymentService:
         """
         console = console or self.console
 
-        deployment_spec = self._reconstruct_deployment_spec(source_path)
+        deployment_spec, file_errors = self._reconstruct_deployment_spec(source_path)
 
         base_namespace = deployment_spec.get("namespace") or ""
         branch = DeploymentService._detect_git_branch(cwd=source_path)
@@ -256,6 +256,14 @@ class DeploymentService:
                 project_name=deployment_spec.get("namespace", source_path),
                 errors=[r.__dict__ for r in (errors if errors else deployment.results)],
             )
+        if file_errors:
+            console.print()
+            console.rule("[red bold]Errors[/red bold]", style="red", align="left")
+            for err in file_errors:
+                console.print(f"[red]  {err}[/red]")
+            raise DJClientException(
+                "Fix file name mismatches before deploying.",
+            )
 
     def get_impact(
         self,
@@ -271,7 +279,7 @@ class DeploymentService:
         would be affected (unless display=False), then returns the raw response dict.
         """
         console = console or self.console
-        deployment_spec = self._reconstruct_deployment_spec(source_path)
+        deployment_spec, file_errors = self._reconstruct_deployment_spec(source_path)
         deployment_spec["namespace"] = namespace or deployment_spec.get("namespace")
         source = deployment_spec.get("source", {})
         branch = DeploymentService._detect_git_branch(cwd=source_path)
@@ -293,6 +301,11 @@ class DeploymentService:
                 console,
                 verbose=verbose,
             )
+        if file_errors:
+            console.print()
+            console.rule("[red bold]Errors[/red bold]", style="red", align="left")
+            for err in file_errors:
+                console.print(f"[red]  {err}[/red]")
         return data
 
     @staticmethod
@@ -413,18 +426,35 @@ class DeploymentService:
         output_path.write_text(content, encoding="utf-8")
         return len(entries)
 
-    def _collect_nodes_from_dir(self, base_dir: str | Path) -> list[dict[str, Any]]:
+    def _collect_nodes_from_dir(
+        self,
+        base_dir: str | Path,
+    ) -> tuple[list[dict[str, Any]], list[str]]:
         """
         Recursively collect all node YAML files under base_dir/nodes.
+        Returns (nodes, warnings) where warnings are filename mismatch messages.
         """
         nodes = []
+        warnings = []
         nodes_dir = Path(base_dir)
         for path in nodes_dir.rglob("*.yaml"):
             if path.name == "dj.yaml":
                 continue
             node_dict = DeploymentService.read_yaml_file(path)
+
+            # Check filename matches node name
+            node_name = node_dict.get("name", "")
+            if node_name:
+                short_name = node_name.replace("${prefix}", "").split(".")[-1]
+                file_stem = path.stem
+                if file_stem != short_name:
+                    warnings.append(
+                        f"  {path.relative_to(nodes_dir)}: node '{node_name}' "
+                        f"(expected: {short_name}.yaml)",
+                    )
+
             nodes.append(node_dict)
-        return nodes
+        return nodes, warnings
 
     def _read_project_yaml(self, base_dir: str | Path) -> dict[str, Any]:
         """
@@ -435,20 +465,24 @@ class DeploymentService:
             return DeploymentService.read_yaml_file(project_path)
         return {}
 
-    def _reconstruct_deployment_spec(self, base_dir: str | Path) -> dict[str, Any]:
+    def _reconstruct_deployment_spec(
+        self,
+        base_dir: str | Path,
+    ) -> tuple[dict[str, Any], list[str]]:
         """
         Reads exported YAML files and reconstructs a DeploymentSpec-compatible dict.
+        Returns (deployment_spec, warnings).
         """
         project_metadata = self._read_project_yaml(base_dir)
-        nodes = self._collect_nodes_from_dir(base_dir)
+        nodes, warnings = self._collect_nodes_from_dir(base_dir)
 
         # Deduplicate nodes by name (keep last occurrence)
         seen_names: dict[str, dict] = {}
         for node in nodes:
             node_name = node.get("name", "")
             if node_name in seen_names:
-                print(  # pragma: no cover
-                    f"WARNING: Duplicate node '{node_name}' found, keeping last occurrence",
+                warnings.append(
+                    f"  Duplicate node '{node_name}', keeping last occurrence",
                 )
             seen_names[node_name] = node
         nodes = list(seen_names.values())
@@ -464,7 +498,7 @@ class DeploymentService:
         if source:  # pragma: no branch
             deployment_spec["source"] = source
 
-        return deployment_spec
+        return deployment_spec, warnings
 
     @staticmethod
     def _detect_git_branch(cwd: str | Path | None = None) -> str | None:

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1476,3 +1476,60 @@ def test_djdeploymentfailure_str_with_no_errors():
     exc = DJDeploymentFailure(project_name="my.namespace", errors=[])
     assert str(exc) == exc.message
     assert "my.namespace" in str(exc)
+
+
+def test_push_raises_on_file_name_mismatch(monkeypatch, tmp_path):
+    """push() raises after successful deploy if filename doesn't match node name."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    # File is "wrong.yaml" but node name is "foo.bar" (short name "bar")
+    (tmp_path / "wrong.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+
+    client = MagicMock()
+    client.deploy.return_value = {
+        "uuid": "abc",
+        "status": "success",
+        "results": [],
+        "namespace": "foo",
+    }
+
+    svc = DeploymentService(client, console=Console(file=io.StringIO()))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    with pytest.raises(DJClientException, match="Fix file name mismatches"):
+        svc.push(tmp_path)
+
+
+def test_collect_nodes_skips_validation_for_unnamed_node(tmp_path):
+    """A YAML file with no 'name' field should still be collected without warnings."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    (tmp_path / "unnamed.yaml").write_text(yaml.safe_dump({"query": "SELECT 1"}))
+
+    svc = DeploymentService(MagicMock())
+    spec, warnings = svc._reconstruct_deployment_spec(tmp_path)
+
+    # Node should be collected
+    assert len(spec["nodes"]) == 1
+    assert spec["nodes"][0]["query"] == "SELECT 1"
+    # No warnings since there's no name to validate
+    assert warnings == []
+
+
+def test_collect_nodes_warns_on_duplicate_names(tmp_path):
+    """Duplicate node names produce a deduplication warning."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    (tmp_path / "bar.yaml").write_text(
+        yaml.safe_dump({"name": "foo.bar", "query": "SELECT 1"}),
+    )
+    (sub / "bar.yaml").write_text(
+        yaml.safe_dump({"name": "foo.bar", "query": "SELECT 2"}),
+    )
+
+    svc = DeploymentService(MagicMock())
+    spec, warnings = svc._reconstruct_deployment_spec(tmp_path)
+
+    # Should deduplicate, keeping last occurrence
+    assert len(spec["nodes"]) == 1
+    # Should have a duplicate warning
+    assert any("Duplicate node" in w for w in warnings)

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -674,7 +674,7 @@ def test_reconstruct_deployment_spec(tmp_path):
     node_file.write_text(yaml.safe_dump({"name": "foo.bar", "query": "SELECT 1"}))
 
     svc = DeploymentService(MagicMock())
-    spec = svc._reconstruct_deployment_spec(tmp_path)
+    spec, warnings = svc._reconstruct_deployment_spec(tmp_path)
     assert spec["namespace"] == "foo"
     assert spec["tags"] == ["t1"]
     assert spec["nodes"][0]["name"] == "foo.bar"
@@ -684,7 +684,7 @@ def test_reconstruct_deployment_spec(tmp_path):
 def test_push_waits_until_success(monkeypatch, tmp_path):
     # Create a fake project structure so _reconstruct_deployment_spec returns something
     (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
-    (tmp_path / "foo.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
 
     # Fake client that returns "pending" once then "success"
     client = MagicMock()
@@ -707,7 +707,7 @@ def test_push_waits_until_success(monkeypatch, tmp_path):
 def test_push_force_sets_flag_in_spec(monkeypatch, tmp_path):
     """push(force=True) must include {"force": True} in the spec sent to client.deploy."""
     (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
-    (tmp_path / "foo.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
 
     client = MagicMock()
     client.deploy.return_value = {
@@ -729,7 +729,7 @@ def test_push_force_sets_flag_in_spec(monkeypatch, tmp_path):
 def test_push_without_force_does_not_set_flag(monkeypatch, tmp_path):
     """push() without force must not include force in the spec (server default handles it)."""
     (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
-    (tmp_path / "foo.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
 
     client = MagicMock()
     client.deploy.return_value = {
@@ -751,7 +751,7 @@ def test_push_without_force_does_not_set_flag(monkeypatch, tmp_path):
 def test_push_times_out(monkeypatch, tmp_path):
     # minimal project structure so _reconstruct_deployment_spec works
     (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
-    (tmp_path / "foo.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
 
     # Fake client: deploy returns a uuid, check_deployment always 'pending'
     client = MagicMock()
@@ -788,7 +788,7 @@ def test_push_times_out(monkeypatch, tmp_path):
 @pytest.mark.timeout(2)
 def test_push_raises_on_failed_deployment(monkeypatch, tmp_path):
     (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
-    (tmp_path / "foo.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
 
     failed_results = [
         {
@@ -1009,7 +1009,7 @@ class TestBuildDeploymentSource:
         monkeypatch.setenv("DJ_DEPLOY_BRANCH", "feature-branch")
 
         svc = DeploymentService(MagicMock())
-        spec = svc._reconstruct_deployment_spec(tmp_path)
+        spec, warnings = svc._reconstruct_deployment_spec(tmp_path)
 
         assert "source" in spec
         assert spec["source"]["type"] == "git"
@@ -1030,7 +1030,7 @@ class TestBuildDeploymentSource:
         monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
 
         svc = DeploymentService(MagicMock())
-        spec = svc._reconstruct_deployment_spec(tmp_path)
+        spec, warnings = svc._reconstruct_deployment_spec(tmp_path)
 
         # Now we always track local deploys
         assert "source" in spec
@@ -1330,7 +1330,9 @@ class TestPushBranchDetection:
     def test_push_derives_namespace_from_git_branch(self, monkeypatch, tmp_path):
         """When no namespace is passed, push() derives it from the git branch."""
         (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "project.main"}))
-        (tmp_path / "node.yaml").write_text(yaml.safe_dump({"name": "project.my_node"}))
+        (tmp_path / "my_node.yaml").write_text(
+            yaml.safe_dump({"name": "project.my_node"}),
+        )
 
         monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
         monkeypatch.setattr(
@@ -1356,7 +1358,9 @@ class TestPushBranchDetection:
     def test_push_explicit_namespace_overrides_git(self, monkeypatch, tmp_path):
         """An explicit namespace argument always wins over git detection."""
         (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "project.main"}))
-        (tmp_path / "node.yaml").write_text(yaml.safe_dump({"name": "project.my_node"}))
+        (tmp_path / "my_node.yaml").write_text(
+            yaml.safe_dump({"name": "project.my_node"}),
+        )
 
         monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
         monkeypatch.setattr(
@@ -1377,7 +1381,9 @@ class TestPushBranchDetection:
     def test_push_no_git_repo_uses_dj_yaml_namespace(self, monkeypatch, tmp_path):
         """When git is unavailable, falls back to the namespace in dj.yaml."""
         (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "project.main"}))
-        (tmp_path / "node.yaml").write_text(yaml.safe_dump({"name": "project.my_node"}))
+        (tmp_path / "my_node.yaml").write_text(
+            yaml.safe_dump({"name": "project.my_node"}),
+        )
 
         monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
         import subprocess as sp
@@ -1416,7 +1422,9 @@ class TestPushBranchDetection:
     def test_push_git_config_failure_is_warned_not_raised(self, monkeypatch, tmp_path):
         """When _set_namespace_git_config raises, push() prints a warning and continues."""
         (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "project.main"}))
-        (tmp_path / "node.yaml").write_text(yaml.safe_dump({"name": "project.my_node"}))
+        (tmp_path / "my_node.yaml").write_text(
+            yaml.safe_dump({"name": "project.my_node"}),
+        )
 
         monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
         monkeypatch.setattr(

--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -42,7 +42,6 @@ from datajunction_server.internal.namespaces import (
     inject_prefixes,
     node_spec_to_yaml,
     resolve_git_config,
-    _get_yaml_handler,
 )
 from datajunction_server.models.access import ResourceAction
 from datajunction_server.models.deployment import (
@@ -72,54 +71,38 @@ _node_spec_adapter = TypeAdapter(NodeUnion)
 
 def _specs_are_equivalent(existing_yaml: str, new_spec: NodeUnion) -> bool:
     """
-    Compare a YAML spec from git with a NodeSpec using the existing
-    semantic comparison logic from the deployment orchestrator.
-
-    Parses the existing YAML into a NodeSpec and uses the NodeSpec.__eq__
-    method which handles:
-    - AST-based query comparison (whitespace/formatting agnostic)
-    - Sorted dimension link comparison
-    - Column comparison with type inference handling
-    - Metric metadata comparison with defaults
-
-    Args:
-        existing_yaml: YAML string from git
-        new_spec: NodeSpec from current node (with ${prefix} placeholders and namespace set)
-
-    Returns:
-        True if the specs are semantically equivalent, False otherwise.
+    Compare a YAML spec from git with a NodeSpec using semantic comparison.
+    Uses PyYAML (fast C parser) instead of ruamel.yaml since we only need dicts.
+    Skips ANTLR4 SQL parsing when query strings are identical.
     """
     try:
-        yaml_handler = _get_yaml_handler()
-        existing_data = yaml_handler.load(existing_yaml)
+        import yaml as pyyaml
 
-        if not existing_data:
+        existing_dict = pyyaml.safe_load(existing_yaml)
+        if not existing_dict:
             return False
 
-        # Convert ruamel.yaml CommentedMap to regular dict for Pydantic
-        existing_dict = dict(existing_data)
-
-        # Parse the existing YAML into the appropriate NodeSpec subclass
-        # The discriminator field (node_type) determines which class to use
         existing_spec = _node_spec_adapter.validate_python(existing_dict)
-
-        # Inject the namespace into the parsed spec so rendered_name matches
-        # (NodeSpec.__eq__ compares rendered_name which depends on namespace)
         existing_spec.namespace = new_spec.namespace
 
-        # Use the NodeSpec's __eq__ which does semantic comparison
-        # (AST comparison for queries, sorted dimension links, etc.)
+        # Skip expensive AST parsing when query strings match
+        existing_query = getattr(existing_spec, "rendered_query", None)
+        new_query = getattr(new_spec, "rendered_query", None)
+        shared = False
+        if existing_query and new_query and existing_query.strip() == new_query.strip():
+            _sentinel = type("_EqSentinel", (), {"compare": lambda self, other: True})()
+            existing_spec._query_ast = _sentinel
+            _saved = new_spec._query_ast
+            new_spec._query_ast = _sentinel
+            shared = True
+
         result = new_spec == existing_spec
-        if not result:
-            _logger.debug(
-                "Specs differ for %s: new=%s, existing=%s",
-                new_spec.rendered_name,
-                new_spec.model_dump(exclude_none=True),
-                existing_spec.model_dump(exclude_none=True),
-            )
+
+        if shared:
+            new_spec._query_ast = _saved
+
         return result
     except Exception as e:
-        # If we can't parse, assume they're different (safer)
         _logger.debug("Failed to compare specs: %s", e)
         return False
 
@@ -530,17 +513,16 @@ async def sync_namespace_to_git(
                         # File couldn't be read - that's ok
                         pass
 
-                # Convert to YAML using the export format (with ${prefix})
-                yaml_content = node_spec_to_yaml(node_spec, existing_yaml=existing_yaml)
-
                 # Only include files that have actually changed (semantic comparison)
-                # Uses NodeSpec.__eq__ which does AST-based query comparison, etc.
                 if existing_yaml is not None and _specs_are_equivalent(
                     existing_yaml,
                     node_spec,
                 ):
                     skipped_unchanged += 1
                     continue
+
+                # Convert to YAML using the export format (with ${prefix})
+                yaml_content = node_spec_to_yaml(node_spec, existing_yaml=existing_yaml)
 
                 files_to_commit.append(
                     {

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -149,7 +149,6 @@ async def validate_node_data(
         for lambda_expr in query_ast.find_all(ast.Lambda):
             for ident in lambda_expr.identifiers:
                 local_aliases.add(ident.name)
-
         (
             dependencies_map,
             missing_parents_map,

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -364,6 +364,7 @@ class LinkableNodeSpec(NodeSpec):
                 compare_types=True if self.node_type == NodeType.SOURCE else False,
             )
             and dimension_links_equal
+            and set(self.primary_key or []) == set(other.primary_key or [])
         )
 
 


### PR DESCRIPTION
### Summary

#### Client: added filename mismatch validation

The client now checks that each YAML filename matches the node's short name (e.g., `bar.yaml` should contain a node whose name ends with `.bar`). Mismatches are collected as errors. It also warns on duplicate node names (we just take the last definition found).

Added three new tests: mismatch raises on push, unnamed nodes skip validation, duplicate names produce warnings.

#### Git sync performance optimization

The perf bottleneck was mostly with `_specs_are_equivalent`, which has been rewritten for performance:
- Replaced `ruamel.yaml` (slow) with `pyyaml.safe_load` (fast C parser) since only dicts are needed for comparison.
- Added a short-circuit for identical query strings: when rendered_query matches exactly, it injects a sentinel object to skip expensive ANTLR4 SQL AST parsing during spec equality checks.
- Removed verbose debug logging and docstring.
- YAML generation deferred until after spec equality checks returns false, avoiding unnecessary YAML serialization for unchanged nodes.

#### Primary key comparison fix

`LinkableNodeSpec` now also compares primary key fields. Previously, a primary key change wouldn't be detected as a difference during deployment comparison; only primary keys set as column attributes were detected.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
