### PR TITLE
Expose cube filters on REST endpoint

### DIFF
--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -103,6 +103,7 @@ class CubeRevisionMetadata(BaseModel):
     cube_elements: List[CubeElementMetadata]
     cube_node_metrics: List[str]
     cube_node_dimensions: List[str]
+    cube_filters: Optional[List[str]] = None
     query: Optional[str] = None
     columns: List[ColumnOutput]
     sql_columns: Optional[List[ColumnOutput]] = None

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -603,6 +603,9 @@ async def test_create_cube(
     response = await client_with_repairs_cube.get("/cubes/default.repairs_cube")
     cube = response.json()
 
+    # Cube filters should be exposed on the /cubes/ endpoint
+    assert cube["cube_filters"] == ["default.hard_hat.state='AZ'"]
+
     # Make sure it matches the original metrics order
     metrics = [
         "default.discounted_orders_rate",


### PR DESCRIPTION
### Summary

Expose `cube_filters` on the `GET /cubes/{name}` endpoint.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
