### PR TITLE
Respect cube filters in materialization and store workflow names for reliable deactivation

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_04_12_0000-4f516e88e4d0_add_workflow_names_to_preaggregation.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_04_12_0000-4f516e88e4d0_add_workflow_names_to_preaggregation.py
@@ -1,0 +1,27 @@
+"""add workflow_names to pre_aggregation
+
+Revision ID: 4f516e88e4d0
+Revises: c1d2e3f4a5b6
+Create Date: 2026-04-12 00:00:00.000000+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "4f516e88e4d0"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "pre_aggregation",
+        sa.Column("workflow_names", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("pre_aggregation", "workflow_names")

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -460,7 +460,7 @@ async def materialize_cube(
             session=session,
             metrics=cube_revision.cube_node_metrics,
             dimensions=cube_revision.cube_node_dimensions,
-            filters=None,
+            filters=cube_revision.cube_filters or None,
             dialect=Dialect.SPARK,
         )
     except Exception as e:  # pragma: no cover
@@ -612,6 +612,7 @@ async def materialize_cube(
             request_headers=request_headers,
         )
         workflow_urls = mat_result.urls
+        workflow_names = mat_result.workflow_names
         message = (
             f"Cube materialization workflow created. "
             f"Workflow waits on {len(preagg_tables)} pre-agg table(s) before Druid ingestion. "
@@ -624,6 +625,7 @@ async def materialize_cube(
             str(e),
         )
         workflow_urls = []
+        workflow_names = []
         message = (
             f"Cube materialization prepared (workflow creation failed: {e}). "
             f"Druid workflow should wait on {len(preagg_tables)} pre-agg table(s) before ingestion."
@@ -668,6 +670,7 @@ async def materialize_cube(
         timestamp_column=timestamp_column,
         timestamp_format=timestamp_format or "yyyyMMdd",
         workflow_urls=workflow_urls,
+        workflow_names=workflow_names,
     )
 
     if existing_mats:
@@ -756,25 +759,48 @@ async def deactivate_cube_materialization(
 
     mat = existing_mats[0]
 
-    # Try to deactivate the workflow in the query service
+    # Extract stored workflow names from the materialization config
+    mat_config = mat.config if isinstance(mat.config, dict) else {}
+    workflow_names = mat_config.get("workflow_names", [])
+
+    # Deactivate workflows in the query service using stored names
     request_headers = dict(request.headers)
-    try:
-        query_service_client.deactivate_cube_workflow(
-            name,
-            version=cube_revision.version,
-            request_headers=request_headers,
-        )
-        _logger.info(
-            "Deactivated workflow for cube=%s version=%s",
-            name,
-            cube_revision.version,
-        )
-    except Exception as e:
-        _logger.warning(
-            "Failed to deactivate workflow for cube=%s: %s (continuing with deletion)",
-            name,
-            str(e),
-        )
+    if workflow_names:
+        try:
+            query_service_client.deactivate_workflows(
+                workflow_names=workflow_names,
+                request_headers=request_headers,
+            )
+            _logger.info(
+                "Deactivated workflows for cube=%s: %s",
+                name,
+                workflow_names,
+            )
+        except Exception as e:
+            _logger.warning(
+                "Failed to deactivate workflows for cube=%s: %s (continuing with deletion)",
+                name,
+                str(e),
+            )
+    else:
+        # Fallback to old endpoint for backwards compatibility
+        try:
+            query_service_client.deactivate_cube_workflow(
+                name,
+                version=cube_revision.version,
+                request_headers=request_headers,
+            )
+            _logger.info(
+                "Deactivated workflow for cube=%s version=%s (legacy)",
+                name,
+                cube_revision.version,
+            )
+        except Exception as e:
+            _logger.warning(
+                "Failed to deactivate workflow for cube=%s: %s (continuing with deletion)",
+                name,
+                str(e),
+            )
 
     # Delete the materialization record
     await session.delete(mat)

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -776,7 +776,7 @@ async def deactivate_cube_materialization(
                 name,
                 workflow_names,
             )
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             _logger.warning(
                 "Failed to deactivate workflows for cube=%s: %s (continuing with deletion)",
                 name,

--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -201,6 +201,7 @@ async def _preagg_to_info(
         lookback_window=preagg.lookback_window,
         workflow_urls=preagg.workflow_urls,  # PydanticListType handles conversion
         workflow_status=preagg.workflow_status,
+        workflow_names=preagg.workflow_names,
         status=preagg.status,
         materialized_table_ref=preagg.materialized_table_ref,
         max_partition=preagg.max_partition,
@@ -877,6 +878,7 @@ async def materialize_preaggregation(
             preagg.workflow_urls = labeled_urls
 
     preagg.workflow_status = WorkflowStatus.ACTIVE
+    preagg.workflow_names = mat_result.get("workflow_names", [])
     # Also update schedule if it wasn't set (using default)
     if not preagg.schedule:
         preagg.schedule = schedule
@@ -1010,15 +1012,22 @@ async def delete_preagg_workflow(
         )
 
     request_headers = dict(request.headers)
-    output_table = _compute_output_table(
-        preagg.node_revision.name,
-        preagg.preagg_hash,
-    )
     try:
-        query_service_client.deactivate_preagg_workflow(
-            output_table,
-            request_headers=request_headers,
-        )
+        if preagg.workflow_names:
+            query_service_client.deactivate_workflows(
+                workflow_names=preagg.workflow_names,
+                request_headers=request_headers,
+            )
+        else:
+            # Fallback for preaggs created before workflow_names was stored
+            output_table = _compute_output_table(
+                preagg.node_revision.name,
+                preagg.preagg_hash,
+            )
+            query_service_client.deactivate_preagg_workflow(
+                output_table,
+                request_headers=request_headers,
+            )
     except Exception as e:
         _logger.exception(
             "Failed to deactivate workflow for preagg_id=%s: %s",
@@ -1035,6 +1044,7 @@ async def delete_preagg_workflow(
     preagg.lookback_window = None
     preagg.workflow_urls = None
     preagg.workflow_status = None
+    preagg.workflow_names = None
     await session.commit()
 
     _logger.info(
@@ -1128,14 +1138,25 @@ async def bulk_deactivate_preagg_workflows(
             continue
 
         try:
-            output_table = _compute_output_table(
-                preagg.node_revision.name,
-                preagg.preagg_hash,
-            )
-            query_service_client.deactivate_preagg_workflow(
-                output_table,
-                request_headers=request_headers,
-            )
+            if preagg.workflow_names:
+                query_service_client.deactivate_workflows(
+                    workflow_names=preagg.workflow_names,
+                    request_headers=request_headers,
+                )
+                workflow_name = (
+                    preagg.workflow_names[0] if preagg.workflow_names else None
+                )
+            else:
+                # Fallback for preaggs created before workflow_names was stored
+                output_table = _compute_output_table(
+                    preagg.node_revision.name,
+                    preagg.preagg_hash,
+                )
+                query_service_client.deactivate_preagg_workflow(
+                    output_table,
+                    request_headers=request_headers,
+                )
+                workflow_name = output_table
 
             # Clear workflow state
             preagg.strategy = None
@@ -1143,11 +1164,12 @@ async def bulk_deactivate_preagg_workflows(
             preagg.lookback_window = None
             preagg.workflow_urls = None
             preagg.workflow_status = None
+            preagg.workflow_names = None
 
             deactivated.append(
                 DeactivatedWorkflowInfo(
                     id=preagg.id,
-                    workflow_name=output_table,
+                    workflow_name=workflow_name,
                 ),
             )
 

--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -1009,15 +1009,11 @@ async def delete_preagg_workflow(
             message="No workflow exists for this pre-aggregation",
         )
 
-    # Compute output_table - the resource identifier that Query Service uses
+    request_headers = dict(request.headers)
     output_table = _compute_output_table(
         preagg.node_revision.name,
         preagg.preagg_hash,
     )
-
-    # Call query service to deactivate using the resource identifier (output_table)
-    # Query Service owns the workflow naming patterns and reconstructs them from output_table
-    request_headers = dict(request.headers)
     try:
         query_service_client.deactivate_preagg_workflow(
             output_table,
@@ -1131,24 +1127,11 @@ async def bulk_deactivate_preagg_workflows(
             skipped_count += 1
             continue
 
-        # Compute output_table for workflow identification
-        output_table = _compute_output_table(
-            preagg.node_revision.name,
-            preagg.preagg_hash,
-        )
-
-        # Extract workflow name from URLs if available
-        workflow_name = None
-        if preagg.workflow_urls:  # pragma: no branch
-            for wf_url in preagg.workflow_urls:  # pragma: no branch
-                if (
-                    hasattr(wf_url, "label") and wf_url.label == "scheduled"
-                ):  # pragma: no branch
-                    # Extract workflow name from URL path
-                    workflow_name = wf_url.url.split("/")[-1] if wf_url.url else None
-                    break
-
         try:
+            output_table = _compute_output_table(
+                preagg.node_revision.name,
+                preagg.preagg_hash,
+            )
             query_service_client.deactivate_preagg_workflow(
                 output_table,
                 request_headers=request_headers,
@@ -1164,7 +1147,7 @@ async def bulk_deactivate_preagg_workflows(
             deactivated.append(
                 DeactivatedWorkflowInfo(
                     id=preagg.id,
-                    workflow_name=workflow_name,
+                    workflow_name=output_table,
                 ),
             )
 

--- a/datajunction-server/datajunction_server/construction/build_v3/combiners.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/combiners.py
@@ -610,10 +610,14 @@ async def build_combiner_sql_from_preaggs(
             preagg_hash,
         )
 
-        # Build full table reference
-        full_table_ref = (
-            f"{settings.preagg_catalog}.{settings.preagg_schema}.{table_name}"
-        )
+        # Use the actual physical table ref from the pre-agg record if available,
+        # otherwise fall back to config defaults (for planning/previewing)
+        if matching_preagg and matching_preagg.materialized_table_ref:
+            full_table_ref = matching_preagg.materialized_table_ref
+        else:
+            full_table_ref = (
+                f"{settings.preagg_catalog}.{settings.preagg_schema}.{table_name}"
+            )
         preagg_table_refs.append(full_table_ref)
 
         # Create a modified grain group that reads from the pre-agg table

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -266,6 +266,13 @@ class PreAggregation(Base):
     # Workflow status: "active" | "paused" | None (no workflow)
     workflow_status: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
+    # Workflow names returned by the query service (used for deactivation)
+    workflow_names: Mapped[Optional[List[str]]] = mapped_column(
+        JSON,
+        nullable=True,
+        default=None,
+    )
+
     # === Availability ===
     availability_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey(

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -348,6 +348,7 @@ class PreAggregation(Base):
                         joinedload(DimensionLink.dimension),
                     ),
                 ),
+                joinedload(cls.availability),
             )
             .where(cls.grain_group_hash == grain_group_hash)
         )

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -166,7 +166,8 @@ async def build_cube_materialization(
         session=session,
         metrics=current_revision.cube_node_metrics,
         dimensions=current_revision.cube_node_dimensions,
-        filters=[
+        filters=(current_revision.cube_filters or [])
+        + [
             generate_partition_filter_sql(
                 temporal_partition,
                 upsert_input.lookback_window,  # type: ignore

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1246,6 +1246,11 @@ def has_minor_changes(
             and data.display_name
             and old_revision.display_name != data.display_name
         )
+        or (
+            data
+            and data.filters is not None
+            and data.filters != (old_revision.cube_filters or [])
+        )
     )
 
 

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -660,6 +660,10 @@ class DruidCubeV3Config(BaseModel):
         default_factory=list,
         description="URLs for the materialization workflow",
     )
+    workflow_names: List[str] = Field(
+        default_factory=list,
+        description="Workflow names for deactivation",
+    )
 
     @computed_field  # type: ignore[misc]
     @property

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -125,6 +125,7 @@ class MaterializationInfo(BaseModel):
 
     output_tables: List[str]
     urls: List[str]
+    workflow_names: List[str] = []
 
 
 class MaterializationConfigOutput(BaseModel):

--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -161,6 +161,7 @@ class PreAggregationInfo(BaseModel):
     workflow_status: Optional[str] = (
         None  # WorkflowStatus.ACTIVE | WorkflowStatus.PAUSED | None
     )
+    workflow_names: Optional[List[str]] = None  # Workflow names for deactivation
 
     # Availability (derived from AvailabilityState)
     status: str = "pending"  # "pending" | "running" | "active"

--- a/datajunction-server/datajunction_server/query_clients/http.py
+++ b/datajunction-server/datajunction_server/query_clients/http.py
@@ -182,6 +182,17 @@ class HttpQueryServiceClient(BaseQueryServiceClient):
             request_headers=request_headers,
         )
 
+    def deactivate_workflows(
+        self,
+        workflow_names: List[str],
+        request_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Deactivate workflows by exact names via HTTP query service."""
+        return self._client.deactivate_workflows(
+            workflow_names=workflow_names,
+            request_headers=request_headers,
+        )
+
     def run_preagg_backfill(
         self,
         backfill_input: "BackfillInput",

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -486,6 +486,37 @@ class QueryServiceClient:
         )
         return result
 
+    def deactivate_workflows(
+        self,
+        workflow_names: List[str],
+        request_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Deactivate workflows by their exact workflow names.
+
+        Uses POST /workflows/deactivate which takes explicit workflow names
+        rather than reconstructing them from cube/preagg identifiers.
+        """
+        response = self.requests_session.post(
+            "/workflows/deactivate",
+            json={"workflow_names": workflow_names},
+            headers=self.requests_session.headers,
+            timeout=20,
+        )
+        if response.status_code not in (200, 201, 204):
+            _logger.warning(
+                "[DJQS] Failed to deactivate workflows %s: %s",
+                workflow_names,
+                response.text,
+            )
+            return {"status": "failed", "message": response.text}
+        result = response.json() if response.text else {}
+        _logger.info(
+            "[DJQS] Deactivated workflows: %s",
+            workflow_names,
+        )
+        return result
+
     def run_preagg_backfill(
         self,
         backfill_input: "BackfillInput",

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2299,6 +2299,52 @@ async def test_updating_cube(
 
 
 @pytest.mark.asyncio
+async def test_updating_cube_filters(
+    client_with_repairs_cube: AsyncClient,
+):
+    """
+    Verify that cube filters can be updated via the PATCH endpoint and
+    that the change is detected as a minor version bump.
+    """
+    cube_name = "default.repairs_cube_filters_update"
+    await make_a_test_cube(
+        client_with_repairs_cube,
+        cube_name,
+    )
+
+    # Confirm the initial cube_filters
+    response = await client_with_repairs_cube.get(f"/cubes/{cube_name}/")
+    assert response.json()["cube_filters"] == ["default.hard_hat.state='AZ'"]
+
+    # Update only the filters
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={
+            "filters": ["default.hard_hat.state='CA'"],
+        },
+    )
+    data = response.json()
+    assert data["version"] == "v1.1"
+
+    # Verify the updated filters are returned from the /cubes/ endpoint
+    response = await client_with_repairs_cube.get(f"/cubes/{cube_name}/")
+    assert response.json()["cube_filters"] == ["default.hard_hat.state='CA'"]
+
+    # Clear filters entirely
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={
+            "filters": [],
+        },
+    )
+    data = response.json()
+    assert data["version"] == "v1.2"
+
+    response = await client_with_repairs_cube.get(f"/cubes/{cube_name}/")
+    assert response.json()["cube_filters"] is None
+
+
+@pytest.mark.asyncio
 async def test_updating_cube_with_existing_cube_materialization(
     client_with_repairs_cube: AsyncClient,
     module__query_service_client: QueryServiceClient,
@@ -3340,7 +3386,7 @@ async def test_cube_materialization_metadata(
         default_DOT_hard_hats.manager,
         default_DOT_hard_hats.contractor_id
       FROM roads.hard_hats AS default_DOT_hard_hats
-      WHERE  default_DOT_hard_hats.hire_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS TIMESTAMP)
+      WHERE  default_DOT_hard_hats.state = 'AZ' AND default_DOT_hard_hats.hire_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS TIMESTAMP)
     ),
     default_DOT_dispatcher AS (
       SELECT
@@ -3377,7 +3423,7 @@ async def test_cube_materialization_metadata(
       FROM default_DOT_repair_orders_fact INNER JOIN default_DOT_hard_hat ON default_DOT_repair_orders_fact.hard_hat_id = default_DOT_hard_hat.hard_hat_id
       INNER JOIN default_DOT_dispatcher ON default_DOT_repair_orders_fact.dispatcher_id = default_DOT_dispatcher.dispatcher_id
       INNER JOIN default_DOT_municipality_dim ON default_DOT_repair_orders_fact.municipality_id = default_DOT_municipality_dim.municipality_id
-      WHERE  default_DOT_hard_hat.hire_date = CAST(DATE_FORMAT(CAST(${dj_logical_timestamp} AS TIMESTAMP), 'yyyyMMdd') AS TIMESTAMP)
+      WHERE  default_DOT_hard_hat.state = 'AZ' AND default_DOT_hard_hat.hire_date = CAST(DATE_FORMAT(CAST(${dj_logical_timestamp} AS TIMESTAMP), 'yyyyMMdd') AS TIMESTAMP)
     )
 
     SELECT  default_DOT_repair_orders_fact_built.default_DOT_hard_hat_DOT_country,

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1542,6 +1542,7 @@ async def test_druid_cube_agg_materialization(
         "info": {
             "output_tables": ["common.a", "common.b"],
             "urls": ["http://fake.url/job"],
+            "workflow_names": [],
         },
     }
     called_kwargs_all = [
@@ -4526,7 +4527,7 @@ class TestCubeMaterializeV2SuccessPaths:
                   SUM(line_total_sum_e1f61696) line_total_sum_e1f61696,
                   hll_union_agg(customer_id_hll_23002251) customer_id_hll_23002251,
                   week_order
-                FROM default.dj_preaggs.v3_order_details_preagg_399a3bfd
+                FROM analytics.preaggs.v3_revenue_orders_by_week
                 GROUP BY  category, order_id, week_order
                 """,
             )
@@ -4729,6 +4730,100 @@ class TestCubeDeactivateSuccessPaths:
             f"/cubes/{cube_name}/materialize",
         )
         assert response.status_code == 200
+
+
+class TestCubeDeactivateWithStoredWorkflowNames:
+    """Tests for cube deactivation using stored workflow_names in config."""
+
+    @pytest.mark.asyncio
+    async def test_deactivate_cube_uses_stored_workflow_names(
+        self,
+        client_with_build_v3: AsyncClient,
+        mocker,
+    ):
+        """Deactivation calls deactivate_workflows when config has workflow_names."""
+        client = client_with_build_v3
+        cube_name = "v3.test_deactivate_wf_names_cube"
+
+        # Create a simple cube using build_v3 fixtures
+        response = await client.post(
+            "/nodes/cube/",
+            json={
+                "name": cube_name,
+                "display_name": "Test Deactivate WF Names Cube",
+                "description": "Cube for testing deactivation with workflow_names",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201, f"Failed to create cube: {response.text}"
+
+        mock_columns = [
+            V3ColumnMetadata(
+                name="category",
+                type="string",
+                semantic_name="v3.product.category",
+                semantic_type="dimension",
+            ),
+        ]
+
+        mock_combined_result = _create_mock_combined_result(
+            mocker,
+            columns=mock_columns,
+            shared_dimensions=["category"],
+            sql_string="SELECT category FROM preagg",
+        )
+
+        mock_temporal_info = TemporalPartitionInfo(
+            column_name="category",
+            format="yyyyMMdd",
+            granularity="day",
+        )
+
+        mocker.patch(
+            "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
+            return_value=(
+                mock_combined_result,
+                ["catalog.schema.preagg_table1"],
+                mock_temporal_info,
+            ),
+        )
+
+        mock_qs_client = mocker.MagicMock()
+        mock_qs_client.materialize_cube_v2.return_value = mocker.MagicMock(
+            urls=["http://workflow/cube-workflow"],
+            workflow_names=["cube_wf_name_1"],
+        )
+        client.app.dependency_overrides[get_query_service_client] = (
+            lambda: mock_qs_client
+        )
+
+        try:
+            # Create materialization (stores workflow_names in config)
+            response = await client.post(
+                f"/cubes/{cube_name}/materialize",
+                json={"strategy": "full", "schedule": "0 0 * * *"},
+            )
+            assert response.status_code == 200, f"Materialize failed: {response.text}"
+
+            # Now deactivate — should use deactivate_workflows, not deactivate_cube_workflow
+            response = await client.delete(
+                f"/cubes/{cube_name}/materialize",
+            )
+            assert response.status_code == 200
+            assert "deactivated" in response.json()["message"].lower()
+
+            # Verify the new deactivate_workflows path was used
+            mock_qs_client.deactivate_workflows.assert_called_once_with(
+                workflow_names=["cube_wf_name_1"],
+                request_headers=mocker.ANY,
+            )
+            # The old path should NOT have been called
+            mock_qs_client.deactivate_cube_workflow.assert_not_called()
+        finally:
+            if get_query_service_client in client.app.dependency_overrides:
+                del client.app.dependency_overrides[get_query_service_client]
 
 
 class TestCubeBackfillSuccessPaths:

--- a/datajunction-server/tests/api/files/materializations_test/spark_sql.full.materializations.json
+++ b/datajunction-server/tests/api/files/materializations_test/spark_sql.full.materializations.json
@@ -130,5 +130,6 @@
    ],
    "urls":[
       "http://fake.url/job"
-   ]
+   ],
+   "workflow_names":[]
 }

--- a/datajunction-server/tests/api/files/materializations_test/spark_sql.full.partition.materializations.json
+++ b/datajunction-server/tests/api/files/materializations_test/spark_sql.full.partition.materializations.json
@@ -130,5 +130,6 @@
    ],
    "urls":[
       "http://fake.url/job"
-   ]
+   ],
+   "workflow_names":[]
 }

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -247,6 +247,7 @@ async def test_crud_materialization(module__client_with_basic: AsyncClient):
         "info": {
             "output_tables": ["common.a", "common.b"],
             "urls": ["http://fake.url/job"],
+            "workflow_names": [],
         },
         "message": "The same materialization config with name "
         "`spark_sql__full` already exists for node "
@@ -1148,7 +1149,11 @@ async def test_spark_sql_full(
             ),
         ],
     )
-    assert response.json() == {"output_tables": [], "urls": ["http://fake.url/job"]}
+    assert response.json() == {
+        "output_tables": [],
+        "urls": ["http://fake.url/job"],
+        "workflow_names": [],
+    }
 
 
 @pytest.mark.asyncio
@@ -1261,7 +1266,11 @@ async def test_spark_sql_incremental(
             ),
         ],
     )
-    assert response.json() == {"output_tables": [], "urls": ["http://fake.url/job"]}
+    assert response.json() == {
+        "output_tables": [],
+        "urls": ["http://fake.url/job"],
+        "workflow_names": [],
+    }
 
     # [success] A transform/dimension with a time partition and additional usage of
     # DJ_LOGICAL_TIMESTAMP() should work

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -1203,6 +1203,37 @@ class TestDeletePreaggWorkflow:
         mock_qs_for_preaggs.deactivate_preagg_workflow.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_deactivate_workflow_with_stored_names(
+        self,
+        client_with_preaggs,
+        mock_qs_for_preaggs,
+    ):
+        """Test deactivation uses stored workflow_names when available."""
+        client = client_with_preaggs["client"]
+        session = client_with_preaggs["session"]
+        preagg5 = client_with_preaggs["preagg5"]
+
+        preagg = await session.get(PreAggregation, preagg5.id)
+        preagg.workflow_urls = [
+            WorkflowUrl(label="scheduled", url="http://scheduler/workflow/test-456"),
+        ]
+        preagg.workflow_status = "active"
+        preagg.workflow_names = ["my_scheduled_workflow"]
+        await session.commit()
+
+        response = await client.delete(f"/preaggs/{preagg5.id}/workflow")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "none"
+        assert "deactivated" in data["message"].lower()
+
+        # Verify deactivate_workflows was called with stored names
+        mock_qs_for_preaggs.deactivate_workflows.assert_called_once()
+        call_kwargs = mock_qs_for_preaggs.deactivate_workflows.call_args.kwargs
+        assert call_kwargs["workflow_names"] == ["my_scheduled_workflow"]
+
+    @pytest.mark.asyncio
     async def test_deactivate_workflow_not_found(self, client_with_preaggs):
         """Test deactivating workflow for non-existent pre-agg returns 404."""
         client = client_with_preaggs["client"]
@@ -1295,6 +1326,45 @@ class TestBulkDeactivateWorkflows:
         deactivated_ids = {item["id"] for item in data["deactivated"]}
         assert preagg8.id in deactivated_ids
         assert preagg9.id in deactivated_ids
+
+    @pytest.mark.asyncio
+    async def test_bulk_deactivate_with_stored_workflow_names(
+        self,
+        client_with_preaggs,
+        mock_qs_for_preaggs,
+    ):
+        """Bulk deactivate uses stored workflow_names when available."""
+        client = client_with_preaggs["client"]
+        session = client_with_preaggs["session"]
+        preagg8 = client_with_preaggs["preagg8"]
+        preagg9 = client_with_preaggs["preagg9"]
+
+        preagg8_obj = await session.get(PreAggregation, preagg8.id)
+        preagg8_obj.workflow_urls = [
+            WorkflowUrl(label="scheduled", url="http://scheduler/workflow/p8"),
+        ]
+        preagg8_obj.workflow_status = "active"
+        preagg8_obj.workflow_names = ["wf_preagg8"]
+
+        preagg9_obj = await session.get(PreAggregation, preagg9.id)
+        preagg9_obj.workflow_urls = [
+            WorkflowUrl(label="scheduled", url="http://scheduler/workflow/p9"),
+        ]
+        preagg9_obj.workflow_status = "active"
+        preagg9_obj.workflow_names = ["wf_preagg9"]
+        await session.commit()
+
+        response = await client.delete(
+            "/preaggs/workflows",
+            params={"node_name": "v3.page_views_enriched"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deactivated_count"] == 2
+
+        # Verify deactivate_workflows was called (not deactivate_preagg_workflow)
+        assert mock_qs_for_preaggs.deactivate_workflows.call_count == 2
 
     @pytest.mark.asyncio
     async def test_bulk_deactivate_stale_only(

--- a/datajunction-server/tests/construction/build_v3/combiners_test.py
+++ b/datajunction-server/tests/construction/build_v3/combiners_test.py
@@ -1313,27 +1313,16 @@ class TestBuildCombinerSqlFromPreaggs:
         # Should have pre-agg table references
         assert len(table_refs) >= 1
 
-        # The table reference should use the CORRECT pre-agg's hash, not the wrong one
-        # This verifies that the loop skipped the first pre-agg and found the second
-        correct_hash = compute_preagg_hash(
-            node_revision_id,
-            grain_columns,
-            correct_measures,
-        )
-        wrong_hash = compute_preagg_hash(
-            node_revision_id,
-            grain_columns,
-            wrong_measures,
-        )
-
-        # At least one table ref should contain the correct hash
+        # The table reference should use the CORRECT pre-agg's availability table,
+        # not the wrong one. This verifies the loop skipped the first pre-agg and
+        # found the second. Since matching preaggs with availability use the
+        # materialized_table_ref (catalog.schema.table), we check for those.
         table_refs_str = " ".join(table_refs)
-        assert correct_hash[:8] in table_refs_str, (
-            f"Expected correct hash {correct_hash[:8]} in table refs, "
-            f"but got {table_refs}"
+        assert "order_details_preagg_correct" in table_refs_str, (
+            f"Expected correct preagg table in table refs, but got {table_refs}"
         )
-        assert wrong_hash[:8] not in table_refs_str, (
-            f"Wrong hash {wrong_hash[:8]} should not be in table refs"
+        assert "order_details_preagg_wrong" not in table_refs_str, (
+            f"Wrong preagg table should not be in table refs, but got {table_refs}"
         )
 
 

--- a/datajunction-server/tests/query_clients/http_query_client_test.py
+++ b/datajunction-server/tests/query_clients/http_query_client_test.py
@@ -85,6 +85,22 @@ class TestHttpQueryServiceClientCubeV2Methods:
             request_headers={"X-Test": "1"},
         )
 
+    def test_deactivate_workflows(self, mock_client):
+        """Test deactivate_workflows delegates to underlying client."""
+        client, mock_inner = mock_client
+        mock_inner.deactivate_workflows.return_value = {"deactivated": 1}
+
+        result = client.deactivate_workflows(
+            workflow_names=["wf_one"],
+            request_headers={"X-Test": "1"},
+        )
+
+        mock_inner.deactivate_workflows.assert_called_once_with(
+            workflow_names=["wf_one"],
+            request_headers={"X-Test": "1"},
+        )
+        assert result == {"deactivated": 1}
+
     def test_run_cube_backfill(self, mock_client):
         """Test run_cube_backfill delegates to underlying client."""
         client, mock_inner = mock_client

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -928,6 +928,50 @@ class TestQueryServiceClient:
             )
         assert "Query service error" in str(exc_info.value)
 
+    def test_deactivate_workflows_success(self, mocker: MockerFixture) -> None:
+        """Test deactivate_workflows sends POST with workflow names."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"deactivated": 2}'
+        mock_response.json.return_value = {"deactivated": 2}
+
+        mock_request = mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.post",
+            return_value=mock_response,
+        )
+
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        response = query_service_client.deactivate_workflows(
+            workflow_names=["wf_one", "wf_two"],
+        )
+
+        mock_request.assert_called_with(
+            "/workflows/deactivate",
+            json={"workflow_names": ["wf_one", "wf_two"]},
+            headers=ANY,
+            timeout=20,
+        )
+        assert response == {"deactivated": 2}
+
+    def test_deactivate_workflows_failure(self, mocker: MockerFixture) -> None:
+        """Test deactivate_workflows returns failure on non-200 status."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.post",
+            return_value=mock_response,
+        )
+
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        response = query_service_client.deactivate_workflows(
+            workflow_names=["bad_wf"],
+        )
+
+        assert response["status"] == "failed"
+        assert "Internal Server Error" in response["message"]
+
     def test_run_preagg_backfill(self, mocker: MockerFixture) -> None:
         """
         Test run_preagg_backfill via query service client.


### PR DESCRIPTION
### Summary

Cube filters are now passed through to the materialization SQL builder, so materialized cubes only contain the filtered data instead of ignoring the filter clause. Updating a cube's filters is also detected as a minor change, triggering a version bump.

Workflow names returned by the query service are now stored on both cube materialization configs and pre-aggregation records (`workflow_names` column/field). Deactivation uses these stored names directly via a new `POST /workflows/deactivate` endpoint instead of reconstructing names from cube/preagg identifiers, which was fragile when naming patterns changed. It falls back to the old identifier-based deactivation for records created before this change.

Pre-aggregation table references now use the actual `materialized_table_ref` from the DB record when available, falling back to config defaults only for planning/previewing before a table exists.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1989 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
