### PR TITLE
Add various metrics for compile and deployment

### DIFF
--- a/datajunction-server/datajunction_server/construction/utils.py
+++ b/datajunction-server/datajunction_server/construction/utils.py
@@ -2,6 +2,7 @@
 Utilities used around construction
 """
 
+import time
 from typing import TYPE_CHECKING, Optional, Set, Union
 
 from sqlalchemy import select
@@ -24,6 +25,7 @@ async def get_dj_node(
     current: bool = True,
 ) -> NodeRevision:
     """Return the DJ Node with a given name from a set of node types"""
+    start = time.monotonic()
     query = select(Node).filter(Node.name == node_name)
     if kinds:
         query = query.filter(Node.type.in_(kinds))  # type: ignore
@@ -53,6 +55,14 @@ async def get_dj_node(
                 message=f"No node `{node_name}` exists of kind {kind_msg}.",
             ),
         ) from no_result_exc
+    finally:
+        from datajunction_server.instrumentation.provider import get_metrics_provider  # noqa: PLC0415
+
+        get_metrics_provider().timer(
+            "dj.compile.get_dj_node_ms",
+            (time.monotonic() - start) * 1000,
+        )
+        get_metrics_provider().counter("dj.compile.get_dj_node_count")
     return match.current if match and current else match
 
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1110,6 +1110,7 @@ class DeploymentOrchestrator:
         plan: DeploymentPlan,
     ) -> tuple[list[DeploymentResult], dict[str, Node]]:
         """Deploy nodes in the plan"""
+        start = time.perf_counter()
 
         deployed_results, deployed_nodes = [], {}
 
@@ -1143,10 +1144,19 @@ class DeploymentOrchestrator:
                 self.registry.add_nodes(nodes)
 
         logger.info("Finished deploying %d non-cube nodes", len(deployed_nodes))
+        get_metrics_provider().timer(
+            "dj.deployment.deploy_nodes_ms",
+            (time.perf_counter() - start) * 1000,
+        )
+        get_metrics_provider().gauge(
+            "dj.deployment.deploy_nodes_count",
+            len(deployed_nodes),
+        )
         return deployed_results, deployed_nodes
 
     async def _deploy_links(self, plan: DeploymentPlan) -> list[DeploymentResult]:
         """Deploy dimension links for nodes in the plan"""
+        start = time.perf_counter()
         deployed_links = []
 
         # Load dimension nodes — serve from registry if already deployed, DB otherwise
@@ -1202,6 +1212,14 @@ class DeploymentOrchestrator:
                 deployed_links.append(link_result)
         await self.session.flush()
         logger.info("Finished deploying %d dimension links", len(deployed_links))
+        get_metrics_provider().timer(
+            "dj.deployment.deploy_links_ms",
+            (time.perf_counter() - start) * 1000,
+        )
+        get_metrics_provider().gauge(
+            "dj.deployment.deploy_links_count",
+            len(deployed_links),
+        )
         return deployed_links
 
     async def _bulk_delete_links(self, to_delete, node_spec) -> list[DeploymentResult]:
@@ -1473,10 +1491,19 @@ class DeploymentOrchestrator:
             )
         self.registry.add_nodes(all_nodes)
 
+        elapsed_ms = (time.perf_counter() - start) * 1000
         logger.info(
             "Deployed %d cubes in %.3fs",
             len(nodes),
-            time.perf_counter() - start,
+            elapsed_ms / 1000,
+        )
+        get_metrics_provider().timer(
+            "dj.deployment.deploy_cubes_ms",
+            elapsed_ms,
+        )
+        get_metrics_provider().gauge(
+            "dj.deployment.deploy_cubes_count",
+            len(nodes),
         )
         return deployment_results
 

--- a/datajunction-server/datajunction_server/internal/impact.py
+++ b/datajunction-server/datajunction_server/internal/impact.py
@@ -3,6 +3,7 @@ Downstream impact propagation for deployments.
 """
 
 import logging
+import time
 
 from sqlalchemy import select
 from sqlalchemy.sql.operators import is_
@@ -10,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from datajunction_server.database.node import Node, NodeRevision, NodeRelationship
+from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.models.impact import DownstreamImpact, ImpactType
 from datajunction_server.models.node import NodeStatus
 
@@ -39,6 +41,7 @@ async def propagate_impact(
     Returns:
         List of DownstreamImpact describing each affected downstream node.
     """
+    start = time.perf_counter()
     all_root_names = changed_node_names | deleted_node_names
     if not all_root_names:
         return []
@@ -169,9 +172,25 @@ async def propagate_impact(
         frontier_ids = next_frontier
         depth += 1
 
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    will_invalidate_count = sum(
+        1 for r in results if r.impact_type == ImpactType.WILL_INVALIDATE
+    )
     logger.info(
         "Impact analysis: %d downstream nodes (%d will_invalidate)",
         len(results),
-        sum(1 for r in results if r.impact_type == ImpactType.WILL_INVALIDATE),
+        will_invalidate_count,
+    )
+    get_metrics_provider().timer(
+        "dj.deployment.propagate_impact_ms",
+        elapsed_ms,
+    )
+    get_metrics_provider().gauge(
+        "dj.deployment.propagate_impact.nodes_affected",
+        len(results),
+    )
+    get_metrics_provider().gauge(
+        "dj.deployment.propagate_impact.will_invalidate",
+        will_invalidate_count,
     )
     return results

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -3,6 +3,7 @@ import asyncio
 import collections
 import decimal
 import logging
+import time as _time
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -39,6 +40,7 @@ from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.utils import refresh_if_needed
 from datajunction_server.construction.utils import get_dj_node, to_namespaced_name
+from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.database.attributetype import ColumnAttribute
 from datajunction_server.database.column import Column as DBColumn
 from datajunction_server.database.dimensionlink import DimensionLink
@@ -1179,6 +1181,16 @@ class Column(Aliasable, Named, Expression):
         if self.is_compiled():
             return
 
+        _start = _time.monotonic()
+        try:
+            return await self._compile_inner(ctx)
+        finally:
+            get_metrics_provider().timer(
+                "dj.compile.column_compile_ms",
+                (_time.monotonic() - _start) * 1000,
+            )
+
+    async def _compile_inner(self, ctx: CompileContext):
         # check if the column was already given a table
         if self.table and isinstance(self.table.parent, Column):
             await self.table.add_ref_column(self, ctx)
@@ -1700,6 +1712,7 @@ class Table(TableExpression, Named):
         if self.is_compiled():
             return
 
+        _start = _time.monotonic()
         self._is_compiled = True
 
         table_name = self.identifier(quotes=False)
@@ -1750,6 +1763,11 @@ class Table(TableExpression, Named):
             # Don't cache failed lookups - the node might be created later
             # Only the pattern-based checks above should add to the cache
             ctx.exception.errors.append(exc.dj_error)
+        finally:
+            get_metrics_provider().timer(
+                "dj.compile.table_compile_ms",
+                (_time.monotonic() - _start) * 1000,
+            )
 
 
 class Operation(Expression):
@@ -3151,6 +3169,16 @@ class Query(TableExpression, UnNamed):
         if self._is_compiled:
             return
 
+        _start = _time.monotonic()
+        try:
+            return await self._compile_query_inner(ctx)
+        finally:
+            get_metrics_provider().timer(
+                "dj.compile.query_compile_ms",
+                (_time.monotonic() - _start) * 1000,
+            )
+
+    async def _compile_query_inner(self, ctx: CompileContext):
         # A Query whose select is an InlineTable arises from (VALUES ...) AS alias(cols).
         # Its columns are already set on the InlineTable; just expose them and return.
         if isinstance(self.select, InlineTable):


### PR DESCRIPTION
### Summary

Metrics added include:
* `dj.compile.get_dj_node_ms`: Per-call latency of `get_dj_node`
* `dj.compile.get_dj_node_count`: Number of `get_dj_node` calls
* `dj.compile.table_compile_ms`: Per-table compilation time
* `dj.compile.column_compile_ms`: Per-column compilation time 
* `dj.compile.query_compile_ms`: Full query compilation time
* `dj.deployment.deploy_nodes_ms`: Time to deploy all non-cube nodes
* `dj.deployment.deploy_nodes_count`: Number of nodes deployed
* `dj.deployment.deploy_links_ms`: Time to deploy dimension links
* `dj.deployment.deploy_links_count`: Number of links deployed
* `dj.deployment.deploy_cubes_ms`: Time to deploy cubes
* `dj.deployment.deploy_cubes_count`: Number of cubes deployed
* `dj.deployment.propagate_impact_ms`: Time spent in impact propagation BFS
* `dj.deployment.propagate_impact.nodes_affected`: Total downstream nodes affected
* `dj.deployment.propagate_impact.will_invalidate`: Nodes that will be invalid

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
