### PR TITLE
Better Impact Propagation + Performance Improvements

### DIFF
--- a/datajunction-clients/python/datajunction/cli.py
+++ b/datajunction-clients/python/datajunction/cli.py
@@ -1477,7 +1477,8 @@ class DJCLI:
                     verbose=args.verbose,
                     force=args.force,
                 )
-            except DJDeploymentFailure:
+            except DJClientException as exc:
+                Console().print(f"[red bold]ERROR:[/red bold] {exc}")
                 raise SystemExit(1)
         elif args.command == "generate-codeowners":
             count = DeploymentService.build_codeowners(

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -251,7 +251,11 @@ class DeploymentService:
         if deployment.status == DeploymentStatus.SUCCESS:
             console.print("\nDeployment finished: [bold green]SUCCESS[/bold green]")
         if deployment.status == DeploymentStatus.FAILED:
-            errors = [r for r in deployment.results if r.status == ResultStatus.FAILED]
+            errors = [
+                r
+                for r in deployment.results
+                if r.status in (ResultStatus.FAILED, ResultStatus.INVALID)
+            ]
             raise DJDeploymentFailure(
                 project_name=deployment_spec.get("namespace", source_path),
                 errors=[r.__dict__ for r in (errors if errors else deployment.results)],

--- a/datajunction-clients/python/datajunction/rendering.py
+++ b/datajunction-clients/python/datajunction/rendering.py
@@ -179,7 +179,11 @@ def _render_result_rows(
     for result in regular_results:
         color = _RESULT_COLORS.get(result.status, TerminalColor.WHITE)
         icon = _RESULT_ICONS.get(result.status, " ")
-        if not verbose and result.operation == "noop":
+        if (
+            not verbose
+            and result.operation == "noop"
+            and result.status not in _ERROR_STATUSES
+        ):
             continue
         if rows:
             rows.append("\n")

--- a/datajunction-server/datajunction_server/api/deployments.py
+++ b/datajunction-server/datajunction_server/api/deployments.py
@@ -210,6 +210,7 @@ class InProcessExecutor(DeploymentExecutor):
                         in (
                             DeploymentResult.Status.SUCCESS,
                             DeploymentResult.Status.SKIPPED,
+                            DeploymentResult.Status.INVALID,
                         )
                         for r in results
                     )

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1,10 +1,10 @@
-import asyncio
 import logging
 import re
 import time
 from collections import Counter
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Coroutine, cast
+from typing import cast
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,7 +51,6 @@ from datajunction_server.internal.history import EntityType
 from datajunction_server.construction.build import validate_shared_dimensions
 from datajunction_server.internal.nodes import (
     hard_delete_node,
-    validate_complex_dimension_link,
 )
 from datajunction_server.models.base import labelize
 from datajunction_server.models.deployment import (
@@ -150,6 +149,53 @@ class _DryRunRollback(Exception):
     """Sentinel exception that triggers a SAVEPOINT rollback in dry_run mode."""
 
 
+class DeploymentTimer:
+    """Accumulates phase timings and logs a summary table at the end."""
+
+    def __init__(self):
+        self._phases: list[tuple[str, float, str]] = []  # (name, ms, detail)
+        self._start = time.perf_counter()
+
+    def record(self, name: str, elapsed_ms: float, detail: str = ""):
+        self._phases.append((name, elapsed_ms, detail))
+
+    @contextmanager
+    def phase(self, name: str):
+        """Context manager that records the elapsed time for a named phase.
+
+        Yields a mutable list — append a single string to set the detail:
+            with timer.phase("deploy nodes") as p:
+                results = await do_work()
+                p.append(f"{len(results)} nodes")
+        """
+        detail: list[str] = []
+        t = time.perf_counter()
+        yield detail
+        self.record(name, (time.perf_counter() - t) * 1000, detail[0] if detail else "")
+
+    def log_summary(self, namespace: str, deployment_id: str):
+        total_ms = (time.perf_counter() - self._start) * 1000
+        accounted = sum(ms for _, ms, _ in self._phases)
+        overhead = total_ms - accounted
+
+        lines = [f"Deployment timing summary for {namespace} [{deployment_id}]:"]
+        lines.append(f"  {'Phase':<40} {'Time':>10}  {'Detail'}")
+        lines.append(f"  {'─' * 40} {'─' * 10}  {'─' * 30}")
+        for name, ms, detail in self._phases:
+            pct = (ms / total_ms * 100) if total_ms > 0 else 0
+            lines.append(
+                f"  {name:<40} {ms:>8.0f}ms  {detail}  ({pct:.0f}%)",
+            )
+        if overhead > 100:  # Only show if meaningful
+            pct = (overhead / total_ms * 100) if total_ms > 0 else 0
+            lines.append(
+                f"  {'(unaccounted overhead)':<40} {overhead:>8.0f}ms  ({pct:.0f}%)",
+            )
+        lines.append(f"  {'─' * 40} {'─' * 10}")
+        lines.append(f"  {'TOTAL':<40} {total_ms:>8.0f}ms")
+        logger.info("\n".join(lines))
+
+
 @dataclass
 class DeploymentExecuteResult:
     """Return value of DeploymentOrchestrator.execute()."""
@@ -237,6 +283,7 @@ class DeploymentOrchestrator:
         self.errors: list[DJError] = []
         self.warnings: list[DJError] = []
         self.deployed_results: list[DeploymentResult] = []
+        self._timer = DeploymentTimer()
 
     @property
     def _history_user(self) -> str:
@@ -263,18 +310,30 @@ class DeploymentOrchestrator:
         (what downstream nodes would be affected).
         """
         start_total = time.perf_counter()
+        self._timer = DeploymentTimer()
         logger.info(
             "Starting deployment of %d nodes in namespace %s",
             len(self.deployment_spec.nodes),
             self.deployment_spec.namespace,
         )
-        await self._setup_deployment_resources()
-        await self._validate_deployment_resources()
+
+        with self._timer.phase("setup resources"):
+            await self._setup_deployment_resources()
+
+        with self._timer.phase("validate resources"):
+            await self._validate_deployment_resources()
 
         if await self._is_copy_fast_path():
-            deployment_plan = await self._build_copy_plan()
+            with self._timer.phase("build plan (copy fast-path)"):
+                deployment_plan = await self._build_copy_plan()
         else:
-            deployment_plan = await self._create_deployment_plan()
+            with self._timer.phase("build plan") as p:
+                deployment_plan, pre_results = await self._create_deployment_plan()
+                p.append(
+                    f"{len(deployment_plan.to_deploy)} to deploy, "
+                    f"{len(deployment_plan.to_delete)} to delete",
+                )
+            self.deployed_results.extend(pre_results)
         if deployment_plan.is_empty():
             return DeploymentExecuteResult(
                 results=await self._handle_no_changes(),
@@ -298,6 +357,7 @@ class DeploymentOrchestrator:
             len(self.deployed_results),
             _metrics_tags,
         )
+        self._timer.log_summary(self.deployment_spec.namespace, self.deployment_id)
         logger.info(
             "Completed deployment for %s [%s] in %.3fs",
             self.deployment_spec.namespace,
@@ -385,7 +445,6 @@ class DeploymentOrchestrator:
             return []
 
         if not missing_nodes:
-            logger.info("No missing nodes to auto-register")
             return []
 
         settings = get_settings()
@@ -886,56 +945,73 @@ class DeploymentOrchestrator:
             external_deps=external_dep_names,
         )
 
-    async def _create_deployment_plan(self) -> DeploymentPlan:
-        """Analyze existing nodes and create deployment plan"""
-        nodes_start = time.perf_counter()
+    async def _create_deployment_plan(
+        self,
+    ) -> tuple[DeploymentPlan, list[DeploymentResult]]:
+        """Analyze existing nodes and create deployment plan.
 
-        # Load existing nodes
-        all_nodes = await NodeNamespace.list_all_nodes(
-            self.session,
-            self.deployment_spec.namespace,
-            options=Node.cube_load_options(),
-        )
+        Returns (plan, pre_results) where pre_results are skip/invalid results
+        that should be added to deployed_results by the caller.
+        """
+        pre_results: list[DeploymentResult] = []
+
+        with self._timer.phase("  plan: load existing nodes") as p:
+            all_nodes = await NodeNamespace.list_all_nodes(
+                self.session,
+                self.deployment_spec.namespace,
+                options=Node.cube_load_options(),
+            )
+            p.append(f"{len(all_nodes)} nodes")
         self.registry.add_nodes({node.name: node for node in all_nodes})
-        existing_specs = {
-            node.name: await node.to_spec(self.session) for node in all_nodes
-        }
 
-        logger.info(
-            "Fetched %d existing nodes in %.3fs",
-            len(existing_specs),
-            time.perf_counter() - nodes_start,
-        )
+        with self._timer.phase("  plan: to_spec conversion") as p:
+            existing_specs = {
+                node.name: await node.to_spec(self.session) for node in all_nodes
+            }
+            p.append(f"{len(existing_specs)} specs")
 
-        # Determine what to deploy/skip/delete
-        to_deploy, to_skip, to_delete = self.filter_nodes_to_deploy(existing_specs)
+        with self._timer.phase("  plan: diff/filter") as p:
+            to_deploy, to_skip, to_delete = self.filter_nodes_to_deploy(existing_specs)
+            p.append(
+                f"{len(to_deploy)} deploy, {len(to_skip)} skip, {len(to_delete)} delete",
+            )
 
-        # Add skipped nodes to results
-        self.deployed_results.extend(
-            [
+        # Add skipped nodes to results - flag nodes that are still invalid
+        for node_spec in to_skip:
+            existing_node = self.registry.nodes.get(node_spec.rendered_name)
+            is_invalid = (
+                existing_node
+                and existing_node.current
+                and existing_node.current.status == NodeStatus.INVALID
+            )
+            pre_results.append(
                 DeploymentResult(
                     name=node_spec.rendered_name,
                     deploy_type=DeploymentResult.Type.NODE,
-                    status=DeploymentResult.Status.SKIPPED,
+                    status=DeploymentResult.Status.INVALID
+                    if is_invalid
+                    else DeploymentResult.Status.SKIPPED,
                     operation=DeploymentResult.Operation.NOOP,
-                    message=f"Node {node_spec.rendered_name} is unchanged.",
-                )
-                for node_spec in to_skip
-            ],
-        )
+                    message="Unchanged, still INVALID" if is_invalid else "Unchanged",
+                ),
+            )
 
         # Build deployment graph if needed
-        node_graph = {}
+        node_graph: dict[str, list[str]] = {}
         external_deps: set[str] = set()
         if to_deploy or to_delete:
-            node_graph = extract_node_graph(
-                [node for node in to_deploy if not isinstance(node, CubeSpec)],
-            )
-            (
-                external_deps,
-                auto_registered_sources,
-                missing_nodes,
-            ) = await self.check_external_deps(node_graph)
+            with self._timer.phase("  plan: extract node graph") as p:
+                node_graph = extract_node_graph(
+                    [node for node in to_deploy if not isinstance(node, CubeSpec)],
+                )
+                p.append(f"{len(node_graph)} nodes in graph")
+            with self._timer.phase("  plan: check external deps") as p:
+                (
+                    external_deps,
+                    auto_registered_sources,
+                    missing_nodes,
+                ) = await self.check_external_deps(node_graph)
+                p.append(f"{len(external_deps)} external")
 
             # Mark nodes whose deps or dimension links are missing as INVALID
             if missing_nodes:
@@ -944,9 +1020,8 @@ class DeploymentOrchestrator:
                     node_graph,
                     missing_nodes,
                 )
-                self.deployed_results.extend(invalid_from_missing)
+                pre_results.extend(invalid_from_missing)
 
-            # If sources were auto-registered, check which ones don't exist yet
             if auto_registered_sources:
                 logger.info(
                     "Checking if %d auto-registered sources already exist",
@@ -989,8 +1064,6 @@ class DeploymentOrchestrator:
                     )
                     to_deploy = sources_to_create + to_deploy
                 else:
-                    logger.info("All auto-registered sources already exist, skipping")
-                    # All sources already exist, just rebuild graph to include them
                     sources_to_create = []
 
                 # Add existing auto-registered sources to existing_specs so they can be found during link validation
@@ -1027,15 +1100,18 @@ class DeploymentOrchestrator:
                             second_missing,
                         )
                     )
-                    self.deployed_results.extend(invalid_from_missing)
+                    pre_results.extend(invalid_from_missing)
 
-        return DeploymentPlan(
-            to_deploy=to_deploy,
-            to_skip=to_skip,
-            to_delete=to_delete,
-            existing_specs=existing_specs,
-            node_graph=node_graph,
-            external_deps=external_deps,
+        return (
+            DeploymentPlan(
+                to_deploy=to_deploy,
+                to_skip=to_skip,
+                to_delete=to_delete,
+                existing_specs=existing_specs,
+                node_graph=node_graph,
+                external_deps=external_deps,
+            ),
+            pre_results,
         )
 
     async def _execute_deployment_plan(self, plan: DeploymentPlan) -> list:
@@ -1054,54 +1130,71 @@ class DeploymentOrchestrator:
             always reflects the post-deploy state).
         """
         downstream: list = []
+        timer = self._timer
         try:
             async with self.session.begin_nested():
                 if plan.to_deploy:
-                    deployed_results, deployed_nodes = await self._deploy_nodes(plan)
+                    with timer.phase("deploy nodes") as p:
+                        deployed_results, deployed_nodes = await self._deploy_nodes(
+                            plan,
+                        )
+                        p.append(f"{len(deployed_nodes)} nodes")
                     self.deployed_results.extend(deployed_results)
                     self.registry.add_nodes(deployed_nodes)
                     await self._update_deployment_status()
 
-                    deployed_links = await self._deploy_links(plan)
+                    with timer.phase("deploy links") as p:
+                        deployed_links = await self._deploy_links(plan)
+                        p.append(f"{len(deployed_links)} links")
                     self.deployed_results.extend(deployed_links)
                     await self._update_deployment_status()
 
-                    deployed_cubes = await self._deploy_cubes(plan)
+                    with timer.phase("deploy cubes") as p:
+                        deployed_cubes = await self._deploy_cubes(plan)
+                        p.append(f"{len(deployed_cubes)} cubes")
                     self.deployed_results.extend(deployed_cubes)
                     await self._update_deployment_status()
 
-                # Run impact propagation BEFORE deletions so deleted nodes'
-                # children are still reachable via NodeRelationship (cascade-deleted
-                # when the parent Node is removed).
+                # Run impact propagation before deletions so deleted nodes'
+                # children are still reachable via NodeRelationship.
                 changed_names = {
                     r.name
                     for r in self.deployed_results
                     if r.deploy_type == DeploymentResult.Type.NODE
                     and r.status != DeploymentResult.Status.SKIPPED
                 }
-                downstream = await propagate_impact(
-                    session=self.session,
-                    namespace=self.deployment_spec.namespace,
-                    changed_node_names=changed_names,
-                    deleted_node_names=frozenset(
-                        spec.rendered_name for spec in plan.to_delete
-                    ),
-                )
+                changed_link_names = {
+                    r.name.split(" -> ")[0]
+                    for r in self.deployed_results
+                    if r.deploy_type == DeploymentResult.Type.LINK
+                    and r.status != DeploymentResult.Status.SKIPPED
+                }
+                with timer.phase("propagate impact") as p:
+                    downstream = await propagate_impact(
+                        session=self.session,
+                        namespace=self.deployment_spec.namespace,
+                        changed_node_names=changed_names,
+                        deleted_node_names=frozenset(
+                            spec.rendered_name for spec in plan.to_delete
+                        ),
+                        changed_link_node_names=changed_link_names,
+                    )
+                    p.append(f"{len(downstream)} downstream")
 
+                # Hard-delete after impact propagation (cascade-deletes
+                # NodeRelationship rows that were needed for the BFS above).
                 if plan.to_delete:
-                    delete_results = await self._delete_nodes(plan.to_delete)
+                    with timer.phase("delete nodes") as p:
+                        delete_results = await self._delete_nodes(plan.to_delete)
+                        p.append(f"{len(delete_results)} deleted")
                     self.deployed_results.extend(delete_results)
                     await self._update_deployment_status()
 
                 if self.dry_run:  # pragma: no branch
                     raise _DryRunRollback()
-                # Wet-run: context manager releases the savepoint on clean exit
         except _DryRunRollback:
-            # Savepoint rolled back; outer transaction is still clean.
-            # ``downstream`` was captured before the rollback.
             pass
         else:
-            # Wet-run only: commit the outer transaction
             await self.session.commit()
         return downstream
 
@@ -1111,6 +1204,7 @@ class DeploymentOrchestrator:
     ) -> tuple[list[DeploymentResult], dict[str, Node]]:
         """Deploy nodes in the plan"""
         start = time.perf_counter()
+        timer = self._timer
 
         deployed_results, deployed_nodes = [], {}
 
@@ -1120,6 +1214,21 @@ class DeploymentOrchestrator:
             "Deploying nodes in topological order with %d levels",
             len(levels),
         )
+
+        # Load all dependencies once upfront (not per-level).
+        # The registry is checked first, so only external deps hit the DB.
+        t = time.perf_counter()
+        is_copy = all(s._skip_validation for s in plan.to_deploy)
+        dependency_nodes = await self.get_dependencies(
+            plan.node_graph,
+            skip_type_reparsing=is_copy,
+        )
+        if timer:
+            timer.record(
+                "    nodes: load dependencies (once)",
+                (time.perf_counter() - t) * 1000,
+                f"{len(dependency_nodes)} deps",
+            )
 
         # Deploy them level by level (excluding cubes which are handled separately)
         name_to_node_specs = {
@@ -1138,10 +1247,14 @@ class DeploymentOrchestrator:
                 level_results, nodes = await self.bulk_deploy_nodes_in_level(
                     node_specs,
                     plan.node_graph,
+                    dependency_nodes=dependency_nodes,
                 )
                 deployed_results.extend(level_results)
                 deployed_nodes.update(nodes)
                 self.registry.add_nodes(nodes)
+                # Update dependency_nodes with freshly deployed nodes
+                # so subsequent levels can see them
+                dependency_nodes.update(nodes)
 
         logger.info("Finished deploying %d non-cube nodes", len(deployed_nodes))
         get_metrics_provider().timer(
@@ -1157,6 +1270,7 @@ class DeploymentOrchestrator:
     async def _deploy_links(self, plan: DeploymentPlan) -> list[DeploymentResult]:
         """Deploy dimension links for nodes in the plan"""
         start = time.perf_counter()
+        timer = self._timer
         deployed_links = []
 
         # Load dimension nodes — serve from registry if already deployed, DB otherwise
@@ -1169,48 +1283,40 @@ class DeploymentOrchestrator:
             fetched = await Node.get_by_names(self.session, missing_dim_names)
             self.registry.add_nodes({n.name: n for n in fetched})
 
-        # Copy fast-path: all links came from already-validated sources — skip re-validation
-        is_copy = all(
-            spec._skip_validation
-            for spec in plan.to_deploy
-            if isinstance(spec, LinkableNodeSpec) and spec.dimension_links
-        )
-        if is_copy:
-            validation_results = {}
-        else:
-            validation_results = await self.validate_dimension_links(plan)
-
-        for node_spec in plan.to_deploy:
-            if not isinstance(node_spec, LinkableNodeSpec):
-                continue
-            existing_node_spec = cast(
-                LinkableNodeSpec,
-                plan.existing_specs.get(node_spec.rendered_name),
-            )
-            existing_node_links = (
-                existing_node_spec.links_mapping if existing_node_spec else {}
-            )
-            desired_node_links = node_spec.links_mapping
-
-            # Delete removed links
-            to_delete = {
-                existing_node_links[(dim, role)]
-                for (dim, role) in existing_node_links
-                if (dim, role) not in desired_node_links
-            }
-            self.deployed_results.extend(
-                await self._bulk_delete_links(to_delete, node_spec),
-            )
-
-            # Create or update links
-            for link_spec in node_spec.dimension_links or []:
-                link_result = await self._process_node_dimension_link(
-                    node_spec=node_spec,
-                    link_spec=link_spec,
-                    validation_results=validation_results,
+        with timer.phase("    links: process") as p:
+            for node_spec in plan.to_deploy:
+                if not isinstance(node_spec, LinkableNodeSpec):
+                    continue
+                existing_node_spec = cast(
+                    LinkableNodeSpec,
+                    plan.existing_specs.get(node_spec.rendered_name),
                 )
-                deployed_links.append(link_result)
-        await self.session.flush()
+                existing_node_links = (
+                    existing_node_spec.links_mapping if existing_node_spec else {}
+                )
+                desired_node_links = node_spec.links_mapping
+
+                # Delete removed links
+                to_delete = {
+                    existing_node_links[(dim, role)]
+                    for (dim, role) in existing_node_links
+                    if (dim, role) not in desired_node_links
+                }
+                deployed_links.extend(
+                    await self._bulk_delete_links(to_delete, node_spec),
+                )
+
+                # Create or update links
+                for link_spec in node_spec.dimension_links or []:
+                    link_result = await self._process_node_dimension_link(
+                        node_spec=node_spec,
+                        link_spec=link_spec,
+                    )
+                    deployed_links.append(link_result)
+            p.append(f"{len(deployed_links)} links")
+
+        with timer.phase("    links: DB flush"):
+            await self.session.flush()
         logger.info("Finished deploying %d dimension links", len(deployed_links))
         get_metrics_provider().timer(
             "dj.deployment.deploy_links_ms",
@@ -1278,7 +1384,6 @@ class DeploymentOrchestrator:
         self,
         node_spec: NodeSpec,
         link_spec: DimensionJoinLinkSpec | DimensionReferenceLinkSpec,
-        validation_results: dict[tuple[str, str, str | None], Exception | None],
     ) -> DeploymentResult:
         link_name = f"{node_spec.rendered_name} -> {link_spec.rendered_dimension_node}"
         node = self.registry.nodes.get(node_spec.rendered_name)
@@ -1296,8 +1401,8 @@ class DeploymentOrchestrator:
             )
 
         if node.current and node.current.status == NodeStatus.INVALID:
-            # Node is INVALID (no columns / bad SQL). Skip join-query validation and
-            # write the link aspirationally so it's already present once the node is fixed.
+            # Node is INVALID (no columns / bad SQL). Write the link aspirationally
+            # so it's already present once the node is fixed.
             # Reference links can't be created without a real column to point at.
             if link_spec.type == LinkType.JOIN:
                 result = await self._create_or_update_dimension_link(
@@ -1318,26 +1423,6 @@ class DeploymentOrchestrator:
                 message=(
                     f"Dimension link from {node.name} to {dimension_node.name} was not"
                     f" created because {node.name} is INVALID and has no columns"
-                ),
-            )
-
-        validation_error = validation_results.get(
-            (node.name, dimension_node.name, link_spec.role),
-        )
-        if isinstance(validation_error, Exception):
-            logger.error(
-                "Dimension link validation failed for %s: %s",
-                link_name,
-                validation_error,
-            )
-            return DeploymentResult(
-                name=link_name,
-                deploy_type=DeploymentResult.Type.LINK,
-                status=DeploymentResult.Status.FAILED,
-                operation=DeploymentResult.Operation.CREATE,
-                message=(
-                    f"Dimension link from {node.name} to"
-                    f" {dimension_node.name} is invalid: {validation_error}"
                 ),
             )
 
@@ -1457,38 +1542,38 @@ class DeploymentOrchestrator:
 
         logger.info("Starting bulk deployment of %d cubes", len(cubes_to_deploy))
         start = time.perf_counter()
+        timer = self._timer
 
-        # Copy fast-path: metric/dimension nodes are already in the registry with all
-        # column data set in-memory — no DB queries needed at all.
-        if all(spec._skip_validation for spec in cubes_to_deploy):
-            validation_results = [
-                self._build_copy_cube_validation_data(cube_spec)
-                for cube_spec in cubes_to_deploy
-            ]
-        else:
-            # Bulk validate cubes
-            validation_results = await self._bulk_validate_cubes(cubes_to_deploy)
+        with timer.phase("    cubes: validate"):
+            if all(spec._skip_validation for spec in cubes_to_deploy):
+                validation_results = [
+                    self._build_copy_cube_validation_data(cube_spec)
+                    for cube_spec in cubes_to_deploy
+                ]
+            else:
+                validation_results = await self._bulk_validate_cubes(cubes_to_deploy)
 
-        # Bulk create cubes from validation results
-        nodes, revisions, deployment_results = await self._create_cubes_from_validation(
-            validation_results,
-        )
+        with timer.phase("    cubes: create ORM objects"):
+            (
+                nodes,
+                revisions,
+                deployment_results,
+            ) = await self._create_cubes_from_validation(validation_results)
 
-        # Flush all cubes (commit happens at the end of _execute_deployment_plan)
-        self.session.add_all(nodes)
-        self.session.add_all(revisions)
-        await self.session.flush()
+        with timer.phase("    cubes: DB flush"):
+            self.session.add_all(nodes)
+            self.session.add_all(revisions)
+            await self.session.flush()
 
-        if all(spec._skip_validation for spec in cubes_to_deploy):
-            # Wire current directly from in-session objects (same as non-cube levels)
-            for node_obj, revision in zip(nodes, revisions):
-                node_obj.current = revision
-            all_nodes = {node_obj.name: node_obj for node_obj in nodes}
-        else:
-            # Refresh all deployed cube nodes with cube-specific load options
-            all_nodes = await self.refresh_nodes(
-                [cube.rendered_name for cube in cubes_to_deploy],
-            )
+        with timer.phase("    cubes: refresh"):
+            if all(spec._skip_validation for spec in cubes_to_deploy):
+                for node_obj, revision in zip(nodes, revisions):
+                    node_obj.current = revision
+                all_nodes = {node_obj.name: node_obj for node_obj in nodes}
+            else:
+                all_nodes = await self.refresh_nodes(
+                    [cube.rendered_name for cube in cubes_to_deploy],
+                )
         self.registry.add_nodes(all_nodes)
 
         elapsed_ms = (time.perf_counter() - start) * 1000
@@ -1528,7 +1613,9 @@ class DeploymentOrchestrator:
             all_dimension_names,
         )
 
-        # Validate each cube using the batch-loaded data
+        # Validate each cube
+        # TODO: batch validate_shared_dimensions across all cubes to avoid
+        # redundant get_dimensions DB calls for shared parent nodes (~1.4s for 22 cubes)
         validation_results = []
         for cube_spec in cube_specs:
             validation_result = await self._validate_single_cube(
@@ -1559,44 +1646,59 @@ class DeploymentOrchestrator:
         self,
         all_metric_names: set[str],
     ) -> tuple[dict[str, Node], set[str]]:
-        """Batch load all metrics"""
-        missing_metrics = set()
-        metric_nodes_map = {}
-        all_metric_nodes = await Node.get_by_names(
-            self.session,
-            list(all_metric_names),
-            options=[
-                joinedload(Node.current).options(
-                    selectinload(NodeRevision.columns),
-                    joinedload(NodeRevision.catalog),
-                    selectinload(NodeRevision.parents),
-                ),
-            ],
-            include_inactive=False,
-        )
-        metric_nodes_map = {node.name: node for node in all_metric_nodes}
-        missing_metrics = set(all_metric_names) - {
-            metric.name for metric in all_metric_nodes
-        }
+        """Batch load all metrics, serving from registry when available."""
+        metric_nodes_map: dict[str, Node] = {}
+        names_to_fetch: list[str] = []
+
+        for name in all_metric_names:
+            if name in self.registry.nodes:
+                metric_nodes_map[name] = self.registry.nodes[name]
+            else:
+                names_to_fetch.append(name)
+
+        if names_to_fetch:
+            db_nodes = await Node.get_by_names(
+                self.session,
+                names_to_fetch,
+                options=[
+                    joinedload(Node.current).options(
+                        selectinload(NodeRevision.columns),
+                        joinedload(NodeRevision.catalog),
+                        selectinload(NodeRevision.parents),
+                    ),
+                ],
+                include_inactive=False,
+            )
+            metric_nodes_map.update({node.name: node for node in db_nodes})
+
+        missing_metrics = all_metric_names - set(metric_nodes_map.keys())
         return metric_nodes_map, missing_metrics
 
     async def _batch_load_dimensions(
         self,
         all_dimension_names: set[str],
     ) -> tuple[dict[str, Node], set[str]]:
-        """Batch load all dimension attributes"""
+        """Batch load all dimension attributes, serving from registry when available."""
         missing_dimensions = set()
-        dimension_mapping = {}
         dimension_attributes: list[FullColumnName] = [
             FullColumnName(dimension_attribute)
             for dimension_attribute in all_dimension_names
         ]
         dimension_node_names = [attr.node_name for attr in dimension_attributes]
-        dimension_nodes: dict[str, Node] = {
-            node.name: node
-            for node in await Node.get_by_names(
+
+        # Serve from registry first, only fetch missing from DB
+        dimension_nodes: dict[str, Node] = {}
+        names_to_fetch: list[str] = []
+        for name in dimension_node_names:
+            if name in self.registry.nodes:
+                dimension_nodes[name] = self.registry.nodes[name]
+            elif name not in dimension_nodes:
+                names_to_fetch.append(name)
+
+        if names_to_fetch:
+            db_nodes = await Node.get_by_names(
                 self.session,
-                dimension_node_names,
+                names_to_fetch,
                 options=[
                     joinedload(Node.current).options(
                         selectinload(NodeRevision.columns).options(
@@ -1606,7 +1708,7 @@ class DeploymentOrchestrator:
                     ),
                 ],
             )
-        }
+            dimension_nodes.update({node.name: node for node in db_nodes})
         for attr in dimension_attributes:
             if attr.node_name not in dimension_nodes:
                 missing_dimensions.add(attr.name)
@@ -1900,7 +2002,6 @@ class DeploymentOrchestrator:
                     )
                 changelog, changed_fields = await self._generate_changelog(result)
                 if existing:
-                    logger.info("Updating cube node %s", cube_spec.rendered_name)
                     new_node = existing
                     new_node.current_version = str(
                         Version.parse(new_node.current_version).next_major_version(),
@@ -2253,8 +2354,6 @@ class DeploymentOrchestrator:
         self,
         existing_nodes_map: dict[str, NodeSpec],
     ):
-        filter_nodes_start = time.perf_counter()
-
         to_create: list[NodeSpec] = []
         to_update: list[NodeSpec] = []
         to_skip: list[NodeSpec] = []
@@ -2264,8 +2363,6 @@ class DeploymentOrchestrator:
             if not existing_spec:
                 to_create.append(node_spec)
             elif force or node_spec != existing_spec:
-                if existing_spec:  # pragma: no branch
-                    self._log_spec_diff(node_spec, existing_spec)
                 to_update.append(node_spec)
             else:
                 to_skip.append(node_spec)
@@ -2277,174 +2374,7 @@ class DeploymentOrchestrator:
             if name not in desired_node_names
         ]
 
-        logger.info("Creating %d new nodes", len(to_create))
-        logger.info("Updating %d existing nodes", len(to_update))
-        logger.info("Skipping %d nodes as they are unchanged", len(to_skip))
-        logger.info("Deleting %d nodes: %s", len(to_delete), to_delete)
-        logger.info(
-            "Filtered nodes to deploy in %.3fs",
-            time.perf_counter() - filter_nodes_start,
-        )
         return to_create + to_update, to_skip, to_delete
-
-    def _log_spec_diff(self, new_spec: "NodeSpec", existing_spec: "NodeSpec") -> None:
-        """Log what differs between the incoming spec and the existing one."""
-        from datajunction_server.models.deployment import (
-            CubeSpec,
-            LinkableNodeSpec,
-        )
-
-        name = new_spec.rendered_name
-        reasons: list[str] = []
-
-        # Base NodeSpec fields
-        if new_spec.node_type != existing_spec.node_type:
-            reasons.append(
-                f"node_type: {existing_spec.node_type!r} -> {new_spec.node_type!r}",
-            )
-        if (
-            new_spec.display_name is not None
-            and new_spec.display_name != existing_spec.display_name
-        ):
-            reasons.append(
-                f"display_name: {existing_spec.display_name!r} -> {new_spec.display_name!r}",
-            )
-        if bool(new_spec.description) != bool(existing_spec.description) or (
-            new_spec.description and new_spec.description != existing_spec.description
-        ):
-            reasons.append(
-                f"description: {existing_spec.description!r} -> {new_spec.description!r}",
-            )
-        if set(new_spec.owners) != set(existing_spec.owners):
-            reasons.append(
-                f"owners: {sorted(existing_spec.owners)} -> {sorted(new_spec.owners)}",
-            )
-        if set(new_spec.tags) != set(existing_spec.tags):
-            reasons.append(
-                f"tags: {sorted(existing_spec.tags)} -> {sorted(new_spec.tags)}",
-            )
-        if new_spec.mode != existing_spec.mode:
-            reasons.append(f"mode: {existing_spec.mode!r} -> {new_spec.mode!r}")
-
-        # Query-bearing nodes
-        if hasattr(new_spec, "query_ast") and hasattr(
-            existing_spec,
-            "query_ast",
-        ):  # pragma: no branch
-            try:
-                if not new_spec.rendered_spec().query_ast.compare(
-                    existing_spec.query_ast,
-                ):
-                    reasons.append("query changed")
-            except Exception:
-                reasons.append("query changed (comparison error)")
-
-        # Source-specific
-        if isinstance(new_spec, type(existing_spec)) and hasattr(new_spec, "catalog"):
-            if new_spec.catalog != getattr(existing_spec, "catalog", None):
-                reasons.append(
-                    f"catalog: {getattr(existing_spec, 'catalog', None)!r} -> {new_spec.catalog!r}",
-                )
-            if getattr(new_spec, "schema_", None) != getattr(
-                existing_spec,
-                "schema_",
-                None,
-            ):
-                reasons.append(
-                    f"schema: {getattr(existing_spec, 'schema_', None)!r} -> {getattr(new_spec, 'schema_', None)!r}",
-                )
-            if getattr(new_spec, "table", None) != getattr(
-                existing_spec,
-                "table",
-                None,
-            ):
-                reasons.append(
-                    f"table: {getattr(existing_spec, 'table', None)!r} -> {getattr(new_spec, 'table', None)!r}",
-                )
-
-        # Dimension links
-        if isinstance(new_spec, LinkableNodeSpec) and isinstance(
-            existing_spec,
-            LinkableNodeSpec,
-        ):
-            new_links = sorted(
-                new_spec.dimension_links or [],
-                key=lambda lnk: (lnk.rendered_dimension_node, lnk.role or ""),
-            )
-            old_links = sorted(
-                existing_spec.dimension_links or [],
-                key=lambda lnk: (lnk.rendered_dimension_node, lnk.role or ""),
-            )
-            if new_links != old_links:
-                old_names = [lnk.rendered_dimension_node for lnk in old_links]
-                new_names = [lnk.rendered_dimension_node for lnk in new_links]
-                reasons.append(f"dimension_links: {old_names} -> {new_names}")
-
-        # Cube-specific
-        if isinstance(new_spec, CubeSpec) and isinstance(existing_spec, CubeSpec):
-            new_metrics = set(new_spec.rendered_metrics)
-            old_metrics = set(existing_spec.rendered_metrics)
-            new_dims = set(new_spec.rendered_dimensions)
-            old_dims = set(existing_spec.rendered_dimensions)
-            if new_metrics != old_metrics:
-                reasons.append(
-                    f"metrics added={sorted(new_metrics - old_metrics)} removed={sorted(old_metrics - new_metrics)}",
-                )
-            if new_dims != old_dims:
-                reasons.append(
-                    f"dimensions added={sorted(new_dims - old_dims)} removed={sorted(old_dims - new_dims)}",
-                )
-
-        # custom_metadata
-        from datajunction_server.models.deployment import eq_or_fallback
-
-        if not eq_or_fallback(
-            new_spec.custom_metadata,
-            existing_spec.custom_metadata,
-            {},
-        ):
-            reasons.append(
-                f"custom_metadata: {existing_spec.custom_metadata!r} -> {new_spec.custom_metadata!r}",
-            )
-
-        # columns (for non-source nodes, compare without types)
-        if isinstance(new_spec, LinkableNodeSpec) and isinstance(
-            existing_spec,
-            LinkableNodeSpec,
-        ):
-            from datajunction_server.models.deployment import eq_columns
-
-            if not eq_columns(
-                new_spec.columns,
-                existing_spec.columns,
-                compare_types=(new_spec.node_type.value == "source"),
-            ):
-                new_cols = [
-                    (c.name, c.type, c.display_name, c.description, c.attributes)
-                    for c in (new_spec.columns or [])
-                ]
-                old_cols = [
-                    (c.name, c.type, c.display_name, c.description, c.attributes)
-                    for c in (existing_spec.columns or [])
-                ]
-                reasons.append(f"columns changed: old={old_cols} new={new_cols}")
-
-        if reasons:
-            logger.info("Node %s marked for update: %s", name, "; ".join(reasons))
-        else:
-            # Fall back to full model dump diff
-            new_dump = new_spec.rendered_spec().model_dump(mode="json")
-            old_dump = existing_spec.model_dump(mode="json")
-            differing_keys = [
-                k
-                for k in set(new_dump) | set(old_dump)
-                if new_dump.get(k) != old_dump.get(k)
-            ]
-            logger.info(
-                "Node %s marked for update (reason unclear). Differing keys in model_dump: %s",
-                name,
-                differing_keys,
-            )
 
     async def check_external_deps(
         self,
@@ -2540,7 +2470,6 @@ class DeploymentOrchestrator:
 
                 # Check against both original and normalized names
                 if dep in found_dep_names or normalized_dep in found_dep_names:
-                    logger.info("check_external_deps: dep %r found in DB → OK", dep)
                     continue
 
                 # For SQL deps only: allow a `node.column` reference to pass if the
@@ -2549,11 +2478,6 @@ class DeploymentOrchestrator:
                 if not is_dim_link:
                     parent = normalized_dep.rsplit(SEPARATOR, 1)[0]
                     if SEPARATOR in parent and parent in found_dep_names:
-                        logger.info(
-                            "check_external_deps: SQL dep %r cleared via parent %r",
-                            dep,
-                            parent,
-                        )
                         continue
 
                 # Check if this is a namespace prefix (some found node starts with dep.)
@@ -2655,51 +2579,11 @@ class DeploymentOrchestrator:
 
         return to_deploy, []
 
-    async def validate_dimension_links(self, plan: DeploymentPlan):
-        """
-        Validate all dimension links for nodes in the deployment plan.
-        Returns:
-            - Dictionary mapping (node_name, dimension_node_name, role) -> join result
-        """
-        start_validation = time.perf_counter()
-        validation_data = []
-        validation_tasks: list[Coroutine] = []
-        logger.info("Validating %d dimension links", len(validation_tasks))
-
-        for node_spec in plan.to_deploy:
-            if hasattr(node_spec, "dimension_links") and node_spec.dimension_links:
-                for link in node_spec.dimension_links:
-                    validation_data.append(
-                        {
-                            "node_name": node_spec.rendered_name,
-                            "dimension_node_name": link.rendered_dimension_node,
-                            "role": link.role,
-                        },
-                    )
-                    validation_tasks.append(
-                        self.validate_dimension_link(node_spec.rendered_name, link),
-                    )
-
-        results = await asyncio.gather(*validation_tasks, return_exceptions=True)
-        link_mapping = {
-            (
-                validation_data[idx]["node_name"],
-                validation_data[idx]["dimension_node_name"],
-                validation_data[idx]["role"],
-            ): result
-            for idx, result in enumerate(results)
-        }
-        logger.info(
-            "Finished validating %d dimension links in %.3fs",
-            len(link_mapping),
-            time.perf_counter() - start_validation,
-        )
-        return link_mapping
-
     async def bulk_deploy_nodes_in_level(
         self,
         node_specs: list[NodeSpec],
         node_graph: dict[str, list[str]],
+        dependency_nodes: dict[str, Node] | None = None,
     ) -> tuple[list[DeploymentResult], dict[str, Node]]:
         """
         Bulk deploy a list of nodes in a single transaction.
@@ -2709,41 +2593,49 @@ class DeploymentOrchestrator:
         """
         start = time.perf_counter()
         logger.info("Starting bulk deployment of %d nodes", len(node_specs))
-
+        timer = self._timer
         is_copy = all(s._skip_validation for s in node_specs)
-        dependency_nodes = await self.get_dependencies(
-            node_graph,
-            skip_type_reparsing=is_copy,
-        )
 
-        if is_copy:
-            # Copy fast-path: all specs are pre-validated — skip ValidationContext
-            # setup, NodeSpecBulkValidator, and _validate_dimension_link_specs entirely.
-            validation_results = [
-                NodeValidationResult(
-                    spec=spec,
-                    status=NodeStatus.VALID,
-                    inferred_columns=spec.columns or [],
-                    errors=[],
-                    dependencies=node_graph.get(spec.rendered_name, []),
+        if dependency_nodes is None:
+            with timer.phase("    nodes: load dependencies (once)"):
+                dependency_nodes = await self.get_dependencies(
+                    node_graph,
+                    skip_type_reparsing=is_copy,
                 )
-                for spec in node_specs
-            ]
-        else:
-            # Validate all node queries to determine columns, types, and dependencies
-            validation_results = await bulk_validate_node_data(
-                node_specs,
-                node_graph,
-                self.session,
-                dependency_nodes=dependency_nodes,
-            )
 
-        # Process validation results and create nodes
-        nodes, revisions, deployment_results = await self.create_nodes_from_validation(
-            validation_results,
-            dependency_nodes,
-            node_graph,
-        )
+        with timer.phase("    nodes: validate") as p:
+            if is_copy:
+                validation_results = [
+                    NodeValidationResult(
+                        spec=spec,
+                        status=NodeStatus.VALID,
+                        inferred_columns=spec.columns or [],
+                        errors=[],
+                        dependencies=node_graph.get(spec.rendered_name, []),
+                    )
+                    for spec in node_specs
+                ]
+            else:
+                validation_results = await bulk_validate_node_data(
+                    node_specs,
+                    node_graph,
+                    self.session,
+                    dependency_nodes=dependency_nodes,
+                )
+            p.append(f"{len(validation_results)} results")
+
+        with timer.phase("    nodes: create ORM objects") as p:
+            (
+                nodes,
+                revisions,
+                deployment_results,
+            ) = await self.create_nodes_from_validation(
+                validation_results,
+                dependency_nodes,
+                node_graph,
+            )
+            p.append(f"{len(nodes)} nodes")
+
         # Check for duplicates
         node_keys = [(n.name, n.namespace) for n in nodes]
         if len(node_keys) != len(set(node_keys)):
@@ -2753,9 +2645,12 @@ class DeploymentOrchestrator:
             raise DJInvalidDeploymentConfig(  # pragma: no cover
                 message=f"Duplicate nodes in deployment spec: {', '.join(duplicates)}",
             )
-        self.session.add_all(nodes)
-        self.session.add_all(revisions)
-        await self.session.flush()
+
+        with timer.phase("    nodes: DB flush") as p:
+            self.session.add_all(nodes)
+            self.session.add_all(revisions)
+            await self.session.flush()
+            p.append(f"{len(nodes)} nodes + {len(revisions)} revisions")
 
         # Wire node.current directly from the just-flushed revisions — avoids a
         # SELECT + N refresh round-trips.  All attributes we need (columns, catalog,
@@ -3095,17 +2990,6 @@ class DeploymentOrchestrator:
 
         if changed_fields:
             changelog.append("└─ Updated " + ", ".join(changed_fields))
-            rendered_spec = result.spec.rendered_spec()
-            for field in [f for f in changed_fields if f != "query"]:
-                old_val = getattr(existing_node_spec, field, None)
-                new_val = getattr(rendered_spec, field, None)
-                logger.info(
-                    "Node %s field %r changed: %r -> %r",
-                    result.spec.rendered_name,
-                    field,
-                    old_val,
-                    new_val,
-                )
 
         # If the node has dimension links and is being updated (even if link specs
         # didn't change), the links will be re-deployed — note this in the message.
@@ -3429,46 +3313,6 @@ class DeploymentOrchestrator:
             )
             node_revision.dimension_links.append(dimension_link)  # type: ignore
         return dimension_link, activity_type
-
-    async def validate_dimension_link(
-        self,
-        node_name: str,
-        link: DimensionJoinLinkSpec | DimensionReferenceLinkSpec,
-    ):
-        """Validate a single dimension link specification"""
-        dimension_node_name = link.rendered_dimension_node
-        if node_name not in self.registry.nodes:  # pragma: no cover
-            raise DJInvalidInputException(
-                message=f"Node {node_name} does not exist for linking.",
-            )
-        if dimension_node_name not in self.registry.nodes:
-            raise DJInvalidInputException(  # pragma: no cover
-                message=(
-                    f"Dimension node {dimension_node_name} does not"
-                    f" exist for linking to {node_name}"
-                ),
-            )
-        if link.type == LinkType.JOIN:
-            await validate_complex_dimension_link(
-                self.session,
-                self.registry.nodes.get(node_name),  # type: ignore
-                self.registry.nodes.get(dimension_node_name),  # type: ignore
-                JoinLinkInput(
-                    dimension_node=dimension_node_name,
-                    join_type=link.join_type,
-                    join_on=link.rendered_join_on,
-                    role=link.role,
-                    default_value=link.default_value,
-                    spark_hints=link.spark_hints,
-                ),
-                self.registry.nodes,
-            )
-        elif link.type == LinkType.REFERENCE:  # pragma: no cover
-            await validate_reference_dimension_link(
-                link,
-                self.registry.nodes.get(node_name),  # type: ignore
-                self.registry.nodes.get(dimension_node_name),  # type: ignore
-            )
 
 
 def tag_needs_update(existing_tag: Tag, tag_spec: TagSpec) -> bool:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1223,12 +1223,11 @@ class DeploymentOrchestrator:
             plan.node_graph,
             skip_type_reparsing=is_copy,
         )
-        if timer:
-            timer.record(
-                "    nodes: load dependencies (once)",
-                (time.perf_counter() - t) * 1000,
-                f"{len(dependency_nodes)} deps",
-            )
+        timer.record(
+            "    nodes: load dependencies (once)",
+            (time.perf_counter() - t) * 1000,
+            f"{len(dependency_nodes)} deps",
+        )
 
         # Deploy them level by level (excluding cubes which are handled separately)
         name_to_node_specs = {
@@ -1692,7 +1691,7 @@ class DeploymentOrchestrator:
         for name in dimension_node_names:
             if name in self.registry.nodes:
                 dimension_nodes[name] = self.registry.nodes[name]
-            elif name not in dimension_nodes:
+            elif name not in dimension_nodes:  # pragma: no branch
                 names_to_fetch.append(name)
 
         if names_to_fetch:

--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -18,6 +18,7 @@ from datajunction_server.utils import SEPARATOR
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.ast import fast_parse_mode
 from datajunction_server.errors import DJNotImplementedException
 from datajunction_server.sql.parsing.types import (
     BooleanType,
@@ -73,9 +74,15 @@ class TypeResolutionError(Exception):
     """Raised when type resolution fails (missing table, missing column, etc.)."""
 
 
+def parse_query(query_str: str) -> ast.Query:
+    """Parse a SQL query string into an AST. Thread-safe — suitable for threadpool."""
+    return parse(query_str)
+
+
 def validate_node_query(
     query_str: str,
     parent_columns_map: ParentColumnsMap,
+    pre_parsed: ast.Query | None = None,
 ) -> QueryValidationResult:
     """
     Validate that all column references in a SQL query resolve against
@@ -90,17 +97,23 @@ def validate_node_query(
         query_str: The SQL query to analyze.
         parent_columns_map: Pre-loaded map of parent node names to their
             column name→type mappings.
+        pre_parsed: Optional pre-parsed AST (from threadpool). Skips
+            ANTLR parsing if provided.
 
     Returns:
         QueryValidationResult with output_columns and any errors found.
     """
-    try:
-        query = parse(query_str)
-    except Exception as exc:
-        return QueryValidationResult(
-            output_columns=[],
-            errors=[f"Failed to parse query: {exc}"],
-        )
+    if pre_parsed is not None:
+        query = pre_parsed
+    else:
+        try:
+            with fast_parse_mode():
+                query = parse(query_str)
+        except Exception as exc:
+            return QueryValidationResult(
+                output_columns=[],
+                errors=[f"Failed to parse query: {exc}"],
+            )
 
     cte_registry: dict[str, OutputColumns] = {}
     all_errors: list[str] = []

--- a/datajunction-server/datajunction_server/internal/deployment/utils.py
+++ b/datajunction-server/datajunction_server/internal/deployment/utils.py
@@ -1,11 +1,11 @@
 from fastapi import Request, BackgroundTasks
 
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datajunction_server.internal.caching.interface import Cache
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.database.user import User
+from datajunction_server.database.node import NodeRevision
 from datajunction_server.models.deployment import (
     NodeSpec,
     CubeSpec,
@@ -15,6 +15,7 @@ from datajunction_server.models.deployment import (
 )
 from datajunction_server.utils import SEPARATOR
 from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.ast import fast_parse_mode
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.errors import DJGraphCycleException
 import logging
@@ -24,29 +25,44 @@ logger = logging.getLogger(__name__)
 
 def extract_node_graph(nodes: list[NodeSpec]) -> dict[str, list[str]]:
     """
-    Extract the node graph from a list of nodes
+    Extract the node graph from a list of nodes.
+
+    Parsed ASTs are cached on each spec for reuse by downstream validation.
+
+    Returns:
+        dependencies_map: node name → list of upstream dependency names.
     """
     logger.info("Extracting node graph for %d nodes", len(nodes))
     dependencies_map: dict[str, list[str]] = {}
-    with ThreadPoolExecutor() as executor:
-        futures = [executor.submit(_find_upstreams_for_node, node) for node in nodes]
-        for future in as_completed(futures):
-            name, deps = future.result()
-            dependencies_map[name] = deps
+    for node in nodes:
+        with fast_parse_mode():
+            name, deps, parsed = _find_upstreams_for_node(node)
+        dependencies_map[name] = deps
+        if parsed is not None:
+            node._query_ast = parsed
 
     logger.info("Extracted node graph with %d entries", len(dependencies_map))
     return dependencies_map
 
 
-def _find_upstreams_for_node(node: NodeSpec) -> tuple[str, list[str]]:
+def _find_upstreams_for_node(node: NodeSpec) -> tuple[str, list[str], ast.Query | None]:
     """
     Find the upstream dependencies for a given node.
+    Returns (name, deps, parsed_ast_or_none).
     """
     if (
         isinstance(node, (TransformSpec, DimensionSpec, MetricSpec))
         and node.rendered_query
     ):
-        query_ast = parse(node.rendered_query)
+        # For metrics, parse the aliased version so the AST can be reused
+        # by validation (which expects the metric-aliased form).
+        query_str = node.rendered_query
+        if isinstance(node, MetricSpec):
+            query_str = NodeRevision.format_metric_alias(
+                query_str,
+                node.rendered_name,
+            )
+        query_ast = parse(query_str)
         cte_names = [cte.alias_or_name.identifier() for cte in query_ast.ctes]
         tables = {
             t.name.identifier()
@@ -71,11 +87,11 @@ def _find_upstreams_for_node(node: NodeSpec) -> tuple[str, list[str]]:
                     if SEPARATOR in parent_path:  # Only if there's still a namespace
                         tables.add(parent_path)
 
-        return node.rendered_name, sorted(list(tables))
+        return node.rendered_name, sorted(list(tables)), query_ast
     if isinstance(node, CubeSpec):
         dimension_nodes = [dim.rsplit(".", 1)[0] for dim in node.rendered_dimensions]
-        return node.rendered_name, node.rendered_metrics + dimension_nodes
-    return node.rendered_name, []
+        return node.rendered_name, node.rendered_metrics + dimension_nodes, None
+    return node.rendered_name, [], None
 
 
 def topological_levels(

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -6,8 +6,6 @@ import logging
 from dataclasses import dataclass, field
 import time
 from typing import Dict, List, Optional
-import asyncio
-from concurrent.futures import ThreadPoolExecutor
 
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -15,10 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import _resolve_required_dimensions
 from datajunction_server.database.dimensionlink import DimensionLink
-from datajunction_server.internal.validation import (
-    update_ast_column_types,
-    validate_metric_query,
-)
+from datajunction_server.internal.deployment.type_inference import validate_node_query
+from datajunction_server.internal.validation import validate_metric_query
 from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.models.node import NodeStatus, NodeType
@@ -28,14 +24,13 @@ from datajunction_server.models.deployment import (
     LinkableNodeSpec,
     NodeSpec,
     ColumnSpec,
-    SourceSpec,
 )
 from datajunction_server.errors import (
     DJError,
     ErrorCode,
-    DJException,
 )
-from datajunction_server.sql.parsing.backends.antlr4 import parse, ast, parse_rule
+from datajunction_server.sql.parsing.backends.antlr4 import ast, parse_rule
+from datajunction_server.sql.parsing.ast import fast_parse_mode
 from datajunction_server.sql.parsing.types import ListType, MapType, StructType
 from datajunction_server.utils import SEPARATOR
 
@@ -69,7 +64,6 @@ class ValidationContext:
     session: AsyncSession
     node_graph: Dict[str, List[str]]
     dependency_nodes: Dict[str, Node]
-    compile_context: ast.CompileContext
 
 
 @dataclass
@@ -144,42 +138,30 @@ class NodeSpecBulkValidator:
                 specs_needing_parse.append(spec)
                 spec_indices.append(i)
 
-        # Parse only specs that need it
-        parsed_results = await self.parse_queries(specs_needing_parse)
-
-        # Pre-fetch dimension nodes for required_dimensions validation (PR 3).
-        # Must happen before the asyncio.gather so every validate_query_node call
-        # can read self._all_dim_nodes without issuing per-node DB queries.
+        # Pre-fetch dimension nodes for required_dimensions validation
         await self._prefetch_required_dimension_nodes(specs_needing_parse)
 
-        # Pre-fetch dimension sets for cross-fact derived metric validation (PR 4).
-        # Deduplicated: one get_dimensions call per unique base metric regardless
-        # of how many derived metrics in the batch share those base metrics.
+        # Pre-fetch dimension sets for cross-fact derived metric validation
         await self._prefetch_metric_dimensions(specs_needing_parse)
 
-        # Pre-fetch dimension nodes referenced in dimension_links so that
-        # _validate_dimension_link_specs can check dim node type and dim-side
-        # column existence without per-link DB queries.
+        # Pre-fetch dimension nodes referenced in dimension_links
         await self._prefetch_dimension_link_nodes(specs_needing_parse)
 
-        # Build results in original order
+        # Build results in original order.  Each spec's query_ast is lazily
+        # parsed and cached (pre-populated by extract_node_graph).
         results: List[NodeValidationResult] = [None] * len(node_specs)  # type: ignore
-
-        # Process specs needing full validation
-        validation_tasks = [
-            self.process_validation(spec, parsed_result)
-            for spec, parsed_result in zip(specs_needing_parse, parsed_results)
-        ]
-        parsed_validation_results = await asyncio.gather(*validation_tasks)
-        for idx, result in zip(spec_indices, parsed_validation_results):
-            results[idx] = result
+        for idx, spec in zip(spec_indices, specs_needing_parse):
+            results[idx] = self.process_validation(spec)
 
         # Process specs that can skip validation (fast path)
         for idx, spec in specs_skip_validation:
             results[idx] = self._validate_without_parsing(spec)
 
-        # Validate dimension link join_on expressions for all results.
-        self._validate_dimension_link_specs(results)
+        # Lightweight link validation (no Query.compile) — checks column
+        # existence using inferred columns. Uses fast_parse_mode to minimize
+        # ANTLR overhead for join_on parsing.
+        with fast_parse_mode():
+            self._validate_dimension_link_specs(results)
 
         return results
 
@@ -265,12 +247,13 @@ class NodeSpecBulkValidator:
             return
 
         try:
-            tree = DimensionLink.parse_join_sql(
-                link.rendered_join_on,
-                link.join_type,
-                node_name,
-                dim_name,
-            )
+            with fast_parse_mode():
+                tree = DimensionLink.parse_join_sql(
+                    link.rendered_join_on,
+                    link.join_type,
+                    node_name,
+                    dim_name,
+                )
         except Exception as exc:
             result.errors.append(
                 DJError(
@@ -416,31 +399,17 @@ class NodeSpecBulkValidator:
             dependencies=self.context.node_graph.get(spec.rendered_name, []),
         )
 
-    async def validate_source_node(self, spec: SourceSpec) -> NodeValidationResult:
-        """Handle source node validation - no query parsing needed"""
-        return NodeValidationResult(
-            spec=spec,
-            status=NodeStatus.VALID,
-            inferred_columns=spec.columns or [],
-            errors=[],
-            dependencies=[],
-        )
-
-    async def validate_query_node(
+    def validate_query_node(
         self,
         spec: NodeSpec,
-        parsed_ast: ast.Query,
     ) -> NodeValidationResult:
-        """
-        Validate nodes with queries (transform, dimension, metric)
+        """Validate nodes with queries (transform, dimension, metric).
+
+        Uses the lightweight validate_node_query (no DB calls) for column
+        type inference, then runs additional semantic checks.  The parsed AST
+        is read from spec.query_ast (lazily cached by extract_node_graph).
         """
         try:
-            await parsed_ast.bake_ctes().extract_dependencies(
-                self.context.compile_context,
-            )
-            update_ast_column_types(parsed_ast)
-            parsed_ast.select.add_aliases_to_unnamed_columns()
-
             # If _skip_validation is set (e.g., copying from validated source),
             # preserve the spec's columns to keep metadata like order
             skip_validation = getattr(spec, "_skip_validation", False)
@@ -448,16 +417,38 @@ class NodeSpecBulkValidator:
                 inferred_columns = spec.columns
                 errors = []
             else:
-                inferred_columns, type_inference_errors = self._infer_columns(
+                parent_columns_map = self._build_parent_columns_map(spec)
+                raw_query = spec.rendered_query or ""
+                query_str = (
+                    NodeRevision.format_metric_alias(
+                        raw_query,
+                        spec.rendered_name,
+                    )
+                    if spec.node_type == NodeType.METRIC
+                    else raw_query
+                )
+                validation = validate_node_query(
+                    query_str,
+                    parent_columns_map,
+                    pre_parsed=spec.query_ast,
+                )
+                type_inference_errors = [
+                    DJError(
+                        code=ErrorCode.TYPE_INFERENCE,
+                        message=msg,
+                    )
+                    for msg in validation.errors
+                ]
+                inferred_columns = self._to_column_specs(
+                    validation.output_columns,
                     spec,
-                    parsed_ast,
                 )
                 errors = [
                     err
                     for err in [
                         self._check_inferred_columns(inferred_columns),
                         self._check_primary_key(inferred_columns, spec),
-                        self._check_metric_query(spec, parsed_ast),
+                        self._check_metric_query(spec, spec.query_ast),
                     ]
                     if err is not None
                 ] + type_inference_errors
@@ -497,6 +488,57 @@ class NodeSpecBulkValidator:
         except Exception as exc:
             return self._create_error_result(spec, exc)
 
+    def _build_parent_columns_map(self, spec: NodeSpec) -> dict:
+        """Build parent_columns_map for validate_node_query from dependency nodes."""
+        from datajunction_server.sql.parsing.types import ColumnType
+
+        parent_map: dict[str, dict[str, ColumnType]] = {}
+        for parent_name in self.context.node_graph.get(spec.rendered_name, []):
+            parent_node = self.context.dependency_nodes.get(parent_name)
+            if parent_node and parent_node.current and parent_node.current.columns:
+                parent_map[parent_name] = {
+                    col.name: col.type for col in parent_node.current.columns
+                }
+        return parent_map
+
+    @staticmethod
+    def _to_column_specs(
+        output_columns: list,
+        spec: NodeSpec,
+    ) -> List[ColumnSpec]:
+        """Convert validate_node_query output to ColumnSpec list.
+
+        Merges inferred types with existing spec column metadata
+        (display_name, description, attributes, partition).
+        """
+        spec_map = {
+            col.name: col
+            for col in (
+                spec.columns if hasattr(spec, "columns") and spec.columns else []
+            )
+        }
+        result = []
+        for name, col_type in output_columns:
+            existing = spec_map.get(name)
+            if existing and existing.type:
+                # User-specified type takes precedence
+                result.append(existing)
+            elif existing:
+                # Preserve metadata, use inferred type
+                result.append(
+                    ColumnSpec(
+                        name=name,
+                        type=str(col_type),
+                        display_name=existing.display_name,
+                        description=existing.description,
+                        attributes=existing.attributes,
+                        partition=existing.partition,
+                    ),
+                )
+            else:
+                result.append(ColumnSpec(name=name, type=str(col_type)))
+        return result
+
     def _check_inferred_columns(self, columns: List[ColumnSpec]) -> DJError | None:
         """Check that inferred columns are not empty"""
         if not columns:
@@ -512,17 +554,18 @@ class NodeSpecBulkValidator:
         spec: LinkableNodeSpec,
     ) -> DJError | None:
         columns_map = {col.name: col for col in inferred_columns}
-        if isinstance(spec, LinkableNodeSpec) and not all(
-            key_col in columns_map for key_col in spec.primary_key
-        ):
-            return DJError(
-                code=ErrorCode.INVALID_SQL_QUERY,
-                message=(
-                    f"Some columns in the primary key {spec.primary_key} "
-                    "were not found in the list of available columns for the "
-                    f"node {spec.rendered_name}."
-                ),
-            )
+        if isinstance(spec, LinkableNodeSpec):
+            if not_in_pk := [
+                key_col for key_col in spec.primary_key if key_col not in columns_map
+            ]:
+                return DJError(
+                    code=ErrorCode.INVALID_SQL_QUERY,
+                    message=(
+                        f"Some columns in the primary key {not_in_pk} "
+                        "were not found in the list of available columns for the "
+                        f"node {spec.rendered_name}."
+                    ),
+                )
         return None
 
     def _check_metric_query(
@@ -756,80 +799,6 @@ class NodeSpecBulkValidator:
             ),
         )
 
-    def _infer_columns(
-        self,
-        spec: NodeSpec,
-        parsed_ast: ast.Query,
-    ) -> tuple[list[ColumnSpec], list[DJError]]:
-        """Infer column specifications from parsed AST.
-
-        Returns a tuple of (columns, type_inference_errors).
-        """
-        columns_spec_map = {
-            col.name: col
-            for col in (
-                spec.columns if hasattr(spec, "columns") and spec.columns else []
-            )
-        }
-        inferred_columns = []
-        type_inference_errors = []
-
-        for col in parsed_ast.select.projection:
-            column_name = col.alias_or_name.name  # type: ignore
-            col_spec = columns_spec_map.get(column_name)
-
-            try:
-                inferred_column = self._create_column_spec(
-                    column_name=column_name,
-                    ast_column=col,  # type: ignore
-                    existing_spec=col_spec,
-                )
-                inferred_columns.append(inferred_column)
-            except Exception as e:
-                logger.exception("Error inferring column %s: %s", column_name, e)
-                type_inference_errors.append(
-                    DJError(
-                        code=ErrorCode.TYPE_INFERENCE,
-                        message=f"Unable to infer type for column `{column_name}` "
-                        f"in node `{spec.rendered_name}`: {e}",
-                    ),
-                )
-
-        return inferred_columns, type_inference_errors
-
-    def _create_column_spec(
-        self,
-        column_name: str,
-        ast_column: ast.Column,
-        existing_spec: Optional[ColumnSpec],
-    ) -> ColumnSpec:
-        """Create a ColumnSpec from AST column and existing spec"""
-        # If existing spec has a type, use it. Otherwise infer from AST.
-        if existing_spec and existing_spec.type:
-            column_type = existing_spec.type
-        else:
-            inferred = ast_column.type
-            if inferred is None:
-                raise TypeError(
-                    f"Cannot resolve type of column `{column_name}` in node",
-                )
-            column_type = str(inferred)
-
-        if existing_spec:
-            return ColumnSpec(
-                name=column_name,
-                type=column_type,
-                display_name=existing_spec.display_name,
-                description=existing_spec.description,
-                attributes=existing_spec.attributes,
-                partition=existing_spec.partition,
-            )
-        else:
-            return ColumnSpec(
-                name=column_name,
-                type=column_type,
-            )
-
     def _create_error_result(
         self,
         spec: NodeSpec,
@@ -852,80 +821,20 @@ class NodeSpecBulkValidator:
             dependencies=[],
         )
 
-    @staticmethod
-    async def parse_queries(
-        node_specs: List[NodeSpec],
-    ) -> List[Optional[ast.Query] | Exception]:
-        """Parse all node queries in parallel using thread pool"""
-
-        def _parse_single_query(spec: NodeSpec) -> Optional[ast.Query] | Exception:
-            """Parse a single node query - runs in thread pool"""
-            try:
-                if spec.node_type == NodeType.SOURCE:
-                    return None  # Source nodes don't have queries to parse
-
-                query = (
-                    NodeRevision.format_metric_alias(
-                        spec.rendered_query,  # type: ignore
-                        spec.rendered_name,
-                    )
-                    if spec.node_type == NodeType.METRIC
-                    else spec.rendered_query
-                )
-                return parse(query)
-            except Exception as exc:  # pragma: no cover
-                logger.error(
-                    "Error parsing query for node %s: %s",
-                    spec.rendered_name,
-                    exc,
-                )
-                return exc
-
-        loop = asyncio.get_running_loop()
-        with ThreadPoolExecutor() as executor:
-            parse_tasks = [
-                loop.run_in_executor(executor, _parse_single_query, spec)
-                for spec in node_specs
-            ]
-            return await asyncio.gather(*parse_tasks)
-
-    async def process_validation(
+    def process_validation(
         self,
         spec: NodeSpec,
-        parsed_result: Optional[ast.Query] | Exception,
     ) -> NodeValidationResult:
-        """Process a single node validation"""
-
-        # Handle parsing errors
-        if isinstance(parsed_result, Exception):
-            return NodeValidationResult(  # pragma: no cover
+        """Route a spec to the appropriate validation method."""
+        if spec.node_type == NodeType.SOURCE:
+            return NodeValidationResult(
                 spec=spec,
-                status=NodeStatus.INVALID,
-                inferred_columns=[],
-                errors=[
-                    DJError(
-                        code=ErrorCode.INVALID_SQL_QUERY,
-                        message=str(parsed_result),
-                    ),
-                ],
+                status=NodeStatus.VALID,
+                inferred_columns=spec.columns or [],
+                errors=[],
                 dependencies=[],
             )
-
-        # Handle SOURCE nodes (no query)
-        if parsed_result is None and spec.node_type == NodeType.SOURCE:
-            return await self.validate_source_node(spec)
-
-        # Handle nodes with queries
-        if parsed_result is not None:
-            return await self.validate_query_node(spec, parsed_result)
-
-        return NodeValidationResult(  # pragma: no cover
-            spec=spec,
-            status=NodeStatus.VALID,
-            inferred_columns=spec.columns or [],
-            errors=[],
-            dependencies=[],
-        )
+        return self.validate_query_node(spec)
 
 
 async def bulk_validate_node_data(
@@ -933,13 +842,15 @@ async def bulk_validate_node_data(
     node_graph: Dict[str, List[str]],
     session: AsyncSession,
     dependency_nodes: Dict[str, Node],
-    column_overrides: Dict[str, list] | None = None,
 ) -> List[NodeValidationResult]:
     """
     Bulk validate node specifications.
 
     For specs with pre-typed columns (from copying valid nodes), uses a fast
     path that skips SQL parsing and dependency extraction.
+
+    Reuses ASTs cached on spec._query_ast (set by extract_node_graph)
+    instead of re-parsing queries.
     """
     validate_start = time.perf_counter()
     # Skip column type reparsing for copy fast-path: all specs are pre-validated,
@@ -952,12 +863,6 @@ async def bulk_validate_node_data(
         session=session,
         node_graph=node_graph,
         dependency_nodes=dependency_nodes,
-        compile_context=ast.CompileContext(
-            session=session,
-            exception=DJException(),
-            dependencies_cache=dependency_nodes,
-            column_overrides=column_overrides or {},
-        ),
     )
     validator = NodeSpecBulkValidator(context)
 

--- a/datajunction-server/datajunction_server/internal/impact.py
+++ b/datajunction-server/datajunction_server/internal/impact.py
@@ -1,21 +1,54 @@
 """
 Downstream impact propagation for deployments.
+
+Structured in three phases:
+  Phase 1: BFS via SQL parent graph (NodeRelationship) — discovers all downstream nodes
+  Phase 2: BFS via dimension link graph (DimensionLink) — discovers additional affected nodes
+  Phase 3: Revalidate all downstream nodes using lightweight type inference
 """
 
+import asyncio
 import logging
 import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
 
 from sqlalchemy import select
 from sqlalchemy.sql.operators import is_
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.database.node import Node, NodeRevision, NodeRelationship
 from datajunction_server.instrumentation.provider import get_metrics_provider
+from datajunction_server.internal.deployment.type_inference import (
+    columns_signature_changed,
+    parse_query,
+    validate_node_query,
+)
 from datajunction_server.models.impact import DownstreamImpact, ImpactType
 from datajunction_server.models.node import NodeStatus
+from datajunction_server.models.node_type import NodeType
+from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.types import ColumnType
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PropagationContext:
+    """Shared state across all propagation phases."""
+
+    namespace: str
+    changed_by_id: dict[int, Node] = field(default_factory=dict)
+    deleted_by_id: dict[int, Node] = field(default_factory=dict)
+
+    # Causality: node_id → set of root node IDs that caused it
+    cause_map: dict[int, set[int]] = field(default_factory=dict)
+    root_id_to_name: dict[int, str] = field(default_factory=dict)
+
+    # All nodes visited during BFS (for parent column lookups in Phase 3)
+    visited_nodes_by_id: dict[int, Node] = field(default_factory=dict)
 
 
 async def propagate_impact(
@@ -23,12 +56,13 @@ async def propagate_impact(
     namespace: str,
     changed_node_names: set[str],
     deleted_node_names: frozenset[str] = frozenset(),
+    changed_link_node_names: set[str] | None = None,
 ) -> list[DownstreamImpact]:
-    """BFS downstream impact analysis with INVALID propagation.
+    """BFS downstream impact analysis with revalidation.
 
     Must be called inside the caller's active transaction (inside a SAVEPOINT for
     dry-runs).  For dry-runs the caller rolls back the SAVEPOINT, undoing both the
-    node changes and any INVALID markers written here.  For wet-runs the caller
+    node changes and any status changes written here.  For wet-runs the caller
     commits, persisting everything.
 
     Args:
@@ -37,15 +71,76 @@ async def propagate_impact(
         changed_node_names: Names of nodes that were created or updated.
         deleted_node_names: Names of nodes about to be deleted (still in DB at
             call time — caller must invoke this before hard_delete_node).
+        changed_link_node_names: Names of nodes whose dimension links changed.
 
     Returns:
         List of DownstreamImpact describing each affected downstream node.
     """
     start = time.perf_counter()
     all_root_names = changed_node_names | deleted_node_names
-    if not all_root_names:
+    if not all_root_names and not changed_link_node_names:
         return []
 
+    t0 = time.perf_counter()
+    ctx = await _build_propagation_context(
+        session,
+        namespace,
+        changed_node_names,
+        deleted_node_names,
+    )
+    t1 = time.perf_counter()
+    logger.info("propagate_impact: context built in %.1fms", (t1 - t0) * 1000)
+
+    # Phase 1: discover affected nodes via SQL parent graph
+    parent_graph_impacts = await _propagate_via_parent_graph(session, ctx)
+    t2 = time.perf_counter()
+    logger.info(
+        "propagate_impact: Phase 1 (parent graph BFS) found %d nodes in %.1fms",
+        len(parent_graph_impacts),
+        (t2 - t1) * 1000,
+    )
+
+    # Phase 2: discover affected nodes via dimension link graph
+    link_impacts = await _propagate_via_dimension_links(
+        session,
+        ctx,
+        changed_link_node_names or set(),
+    )
+    t3 = time.perf_counter()
+    logger.info(
+        "propagate_impact: Phase 2 (dimension links) found %d nodes in %.1fms",
+        len(link_impacts),
+        (t3 - t2) * 1000,
+    )
+
+    # Merge discoveries
+    all_impacts = _merge_impacts(parent_graph_impacts, link_impacts)
+
+    # Phase 3: revalidate all downstream nodes and apply status changes
+    results = await _revalidate_and_apply(session, ctx, all_impacts)
+    t4 = time.perf_counter()
+    logger.info(
+        "propagate_impact: Phase 3 (revalidation) processed %d nodes in %.1fms",
+        len(results),
+        (t4 - t3) * 1000,
+    )
+
+    _emit_metrics(start, results)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Context building
+# ---------------------------------------------------------------------------
+
+
+async def _build_propagation_context(
+    session: AsyncSession,
+    namespace: str,
+    changed_node_names: set[str],
+    deleted_node_names: frozenset[str],
+) -> PropagationContext:
+    """Load root nodes and build the shared propagation context."""
     changed_nodes = (
         await Node.get_by_names(
             session,
@@ -65,33 +160,47 @@ async def propagate_impact(
         else []
     )
 
-    changed_by_id: dict[int, Node] = {n.id: n for n in changed_nodes}
-    deleted_by_id: dict[int, Node] = {n.id: n for n in deleted_nodes}
-    all_root_ids: set[int] = set(changed_by_id) | set(deleted_by_id)
+    changed_by_id = {n.id: n for n in changed_nodes}
+    deleted_by_id = {n.id: n for n in deleted_nodes}
+    all_root_ids = set(changed_by_id) | set(deleted_by_id)
 
-    # IDs whose invalidity propagates downstream:
-    # - Changed nodes that are now INVALID after deployment
-    # - All deleted nodes (their children lose a required parent)
-    invalidating_ids: set[int] = {
-        nid
-        for nid, n in changed_by_id.items()
-        if n.current and n.current.status == NodeStatus.INVALID
-    } | set(deleted_by_id)
-
-    # Causality tracking: node_id → set of root node IDs responsible
-    cause_map: dict[int, set[int]] = {nid: {nid} for nid in all_root_ids}
-    root_id_to_name: dict[int, str] = {
+    cause_map = {nid: {nid} for nid in all_root_ids}
+    root_id_to_name = {
         **{n.id: n.name for n in changed_nodes},
         **{n.id: n.name for n in deleted_nodes},
     }
 
-    frontier_ids: set[int] = set(all_root_ids)
-    visited_node_ids: set[int] = set(frontier_ids)
+    return PropagationContext(
+        namespace=namespace,
+        changed_by_id=changed_by_id,
+        deleted_by_id=deleted_by_id,
+        cause_map=cause_map,
+        root_id_to_name=root_id_to_name,
+        visited_nodes_by_id={**changed_by_id, **deleted_by_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: SQL parent graph BFS
+# ---------------------------------------------------------------------------
+
+
+async def _propagate_via_parent_graph(
+    session: AsyncSession,
+    ctx: PropagationContext,
+) -> list[DownstreamImpact]:
+    """BFS through NodeRelationship to find all downstream nodes.
+
+    Returns impacts without mutating DB state — Phase 3 determines the actual
+    impact type via revalidation.
+    """
+    all_root_ids = set(ctx.changed_by_id) | set(ctx.deleted_by_id)
+    frontier_ids = set(all_root_ids)
+    visited_node_ids = set(frontier_ids)
     results: list[DownstreamImpact] = []
     depth = 1
 
     while frontier_ids:
-        # Each row: (child_node_id, parent_node_id) for all frontier parents
         rows = (
             await session.execute(
                 select(NodeRevision.node_id, NodeRelationship.parent_id)
@@ -100,7 +209,6 @@ async def propagate_impact(
             )
         ).all()
 
-        # Group: child_node_id → set of frontier parent node IDs that triggered it
         child_to_parents: dict[int, set[int]] = {}
         for child_node_id, parent_id in rows:
             child_to_parents.setdefault(child_node_id, set()).add(parent_id)
@@ -126,45 +234,34 @@ async def propagate_impact(
         next_frontier: set[int] = set()
         for node in child_nodes:
             visited_node_ids.add(node.id)
+            ctx.visited_nodes_by_id[node.id] = node
             parent_ids = child_to_parents.get(node.id, set())
 
-            # Propagate causality: union of causes from all triggering parents
+            # Propagate causality
             node_causes: set[int] = set()
             for pid in parent_ids:
-                node_causes |= cause_map.get(pid, {pid})
-            cause_map[node.id] = node_causes
+                node_causes |= ctx.cause_map.get(pid, {pid})
+            ctx.cause_map[node.id] = node_causes
 
-            will_invalidate = bool(parent_ids & invalidating_ids)
-            impact_type = (
-                ImpactType.WILL_INVALIDATE if will_invalidate else ImpactType.MAY_AFFECT
-            )
             current_status = node.current.status if node.current else NodeStatus.INVALID
-            predicted_status = NodeStatus.INVALID if will_invalidate else current_status
-
-            if will_invalidate and current_status != NodeStatus.INVALID:
-                node.current.status = NodeStatus.INVALID
-                session.add(node.current)
-                invalidating_ids.add(node.id)
 
             cause_names = sorted(
-                root_id_to_name[cid] for cid in node_causes if cid in root_id_to_name
+                ctx.root_id_to_name[cid]
+                for cid in node_causes
+                if cid in ctx.root_id_to_name
             )
-            impact_reason = (
-                f"Dependent on invalid/deleted node(s): {', '.join(cause_names)}"
-                if will_invalidate
-                else f"Upstream node(s) changed: {', '.join(cause_names)}"
-            )
+
             results.append(
                 DownstreamImpact(
                     name=node.name,
                     node_type=node.type,
                     current_status=current_status,
-                    predicted_status=predicted_status,
-                    impact_type=impact_type,
-                    impact_reason=impact_reason,
+                    predicted_status=current_status,
+                    impact_type=ImpactType.MAY_AFFECT,
+                    impact_reason=f"Upstream node(s) changed: {', '.join(cause_names)}",
                     depth=depth,
                     caused_by=cause_names,
-                    is_external=not node.name.startswith(namespace + "."),
+                    is_external=not node.name.startswith(ctx.namespace + "."),
                 ),
             )
             next_frontier.add(node.id)
@@ -172,6 +269,411 @@ async def propagate_impact(
         frontier_ids = next_frontier
         depth += 1
 
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Dimension link graph
+# ---------------------------------------------------------------------------
+
+
+async def _propagate_via_dimension_links(
+    session: AsyncSession,
+    ctx: PropagationContext,
+    changed_link_node_names: set[str],
+) -> list[DownstreamImpact]:
+    """Find nodes affected by dimension link changes.
+
+    Dimension links create a separate dependency graph — a metric doesn't have
+    a NodeRelationship to the dimension node, it reaches it via DimensionLink.
+    When a link changes, metrics/cubes using that dimension path may break.
+
+    Returns additional MAY_AFFECT impacts for nodes not already found in Phase 1.
+    """
+    if not changed_link_node_names:
+        return []
+
+    # TODO: Implement dimension link graph traversal
+    # For now, return empty — dimension link propagation will be added
+    # in a follow-up once the Phase 1+3 refactor is validated.
+    logger.info(
+        "Dimension link changes detected for %d nodes (propagation not yet implemented)",
+        len(changed_link_node_names),
+    )
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Merge impacts
+# ---------------------------------------------------------------------------
+
+
+def _merge_impacts(
+    parent_impacts: list[DownstreamImpact],
+    link_impacts: list[DownstreamImpact],
+) -> list[DownstreamImpact]:
+    """Combine Phase 1 and Phase 2 results.
+
+    If the same node appears in both, keep the higher-severity impact
+    (WILL_INVALIDATE > MAY_AFFECT).
+    """
+    if not link_impacts:
+        return parent_impacts
+
+    by_name: dict[str, DownstreamImpact] = {}
+    for impact in parent_impacts:
+        by_name[impact.name] = impact
+
+    severity = {
+        ImpactType.WILL_INVALIDATE: 2,
+        ImpactType.MAY_AFFECT: 1,
+        ImpactType.UNCHANGED: 0,
+    }
+    for impact in link_impacts:
+        existing = by_name.get(impact.name)
+        if existing is None:
+            by_name[impact.name] = impact
+        elif severity.get(impact.impact_type, 0) > severity.get(
+            existing.impact_type,
+            0,
+        ):
+            by_name[impact.name] = impact
+
+    return list(by_name.values())
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Revalidate and apply
+# ---------------------------------------------------------------------------
+
+
+async def _revalidate_and_apply(
+    session: AsyncSession,
+    ctx: PropagationContext,
+    impacts: list[DownstreamImpact],
+) -> list[DownstreamImpact]:
+    """Revalidate all downstream nodes and apply status changes.
+
+    Every downstream node is revalidated using validate_node_query.
+    Nodes are processed level-by-level so that failures at depth N
+    cascade to children at depth N+1 (failed parents are excluded
+    from the parent_columns_map).
+    """
+    results: list[DownstreamImpact] = []
+    nodes_by_name = _build_name_index(ctx)
+
+    by_depth: dict[int, list[DownstreamImpact]] = defaultdict(list)
+    for impact in impacts:
+        by_depth[impact.depth].append(impact)
+
+    if not by_depth:
+        return results
+
+    # Collect queries to pre-parse from nodes we already visited in Phase 1
+    visited_by_name = {n.name: n for n in ctx.visited_nodes_by_id.values()}
+    queries_to_parse: dict[str, str] = {}
+    for impact in impacts:
+        node = visited_by_name.get(impact.name)
+        if (
+            node
+            and node.current
+            and node.current.query
+            and node.type != NodeType.SOURCE
+        ):
+            queries_to_parse[impact.name] = node.current.query
+
+    # Run DB load and ANTLR parsing concurrently:
+    # - DB load is async IO (awaitable)
+    # - ANTLR parsing is CPU-bound (threadpool)
+    all_names = [impact.name for impact in impacts]
+    t_load_start = time.perf_counter()
+
+    async def _parse_all_queries() -> dict[str, ast.Query | Exception]:
+        """Parse all queries in a threadpool."""
+        loop = asyncio.get_event_loop()
+        parsed: dict[str, ast.Query | Exception] = {}
+        with ThreadPoolExecutor(max_workers=min(8, len(queries_to_parse) or 1)) as pool:
+            futures = {
+                name: loop.run_in_executor(pool, parse_query, query_str)
+                for name, query_str in queries_to_parse.items()
+            }
+            for name, future in futures.items():
+                try:
+                    parsed[name] = await future
+                except Exception as exc:
+                    parsed[name] = exc
+        return parsed
+
+    loaded_nodes, pre_parsed = await asyncio.gather(
+        _batch_load_nodes_for_revalidation(session, all_names),
+        _parse_all_queries(),
+    )
+
+    t_load_end = time.perf_counter()
+    logger.info(
+        "  Phase 3: batch loaded %d nodes + pre-parsed %d queries in %.1fms",
+        len(loaded_nodes),
+        len(pre_parsed),
+        (t_load_end - t_load_start) * 1000,
+    )
+
+    # Seed with deleted and invalid root nodes — their children should
+    # not see their columns during revalidation.
+    failed_names: set[str] = {n.name for n in ctx.deleted_by_id.values()} | {
+        n.name
+        for n in ctx.changed_by_id.values()
+        if n.current and n.current.status == NodeStatus.INVALID
+    }
+
+    t_reval_start = time.perf_counter()
+    slowest_nodes: list[tuple[str, float]] = []
+    for depth in sorted(by_depth.keys()):
+        for impact in by_depth[depth]:
+            t_node = time.perf_counter()
+            # Use pre-parsed AST if available (parsed in threadpool)
+            parsed_ast = pre_parsed.get(impact.name)
+            if isinstance(parsed_ast, Exception):
+                parsed_ast = None  # Fall back to inline parse
+            revalidated = _revalidate_single_node(
+                impact,
+                loaded_nodes,
+                nodes_by_name,
+                session,
+                failed_names,
+                pre_parsed_query=parsed_ast,
+            )
+            node_ms = (time.perf_counter() - t_node) * 1000
+            if node_ms > 10:  # Only track nodes taking >10ms
+                slowest_nodes.append((impact.name, node_ms))
+            if revalidated.impact_type == ImpactType.WILL_INVALIDATE:
+                failed_names.add(impact.name)
+            results.append(revalidated)
+
+    t_reval_end = time.perf_counter()
+    logger.info(
+        "  Phase 3: revalidated %d nodes in %.1fms",
+        len(results),
+        (t_reval_end - t_reval_start) * 1000,
+    )
+    if slowest_nodes:
+        slowest_nodes.sort(key=lambda x: x[1], reverse=True)
+        for name, ms in slowest_nodes[:5]:
+            logger.info("  Phase 3: slow node %s took %.1fms", name, ms)
+
+    return results
+
+
+def _build_name_index(ctx: PropagationContext) -> dict[str, Node]:
+    """Build a name → Node lookup from visited nodes."""
+    return {node.name: node for node in ctx.visited_nodes_by_id.values()}
+
+
+async def _batch_load_nodes_for_revalidation(
+    session: AsyncSession,
+    node_names: list[str],
+) -> dict[str, Node]:
+    """Load nodes with their parents and columns for revalidation."""
+    if not node_names:  # pragma: no cover
+        return {}
+
+    nodes = await Node.get_by_names(
+        session,
+        node_names,
+        options=[
+            joinedload(Node.current).options(
+                selectinload(NodeRevision.columns),
+                selectinload(NodeRevision.parents).options(
+                    joinedload(Node.current).options(
+                        selectinload(NodeRevision.columns),
+                    ),
+                ),
+            ),
+        ],
+    )
+    return {n.name: n for n in nodes}
+
+
+def _revalidate_single_node(
+    impact: DownstreamImpact,
+    loaded_nodes: dict[str, Node],
+    nodes_by_name: dict[str, Node],
+    session: AsyncSession,
+    failed_names: set[str],
+    pre_parsed_query: ast.Query | None = None,
+) -> DownstreamImpact:
+    """Revalidate a single downstream node using validate_node_query.
+
+    Returns an updated DownstreamImpact with the correct predicted_status.
+    """
+    node = loaded_nodes.get(impact.name)
+    if not node or not node.current:  # pragma: no cover
+        return impact
+
+    # Source nodes don't have queries — they're always valid if their parent is
+    if node.type == NodeType.SOURCE:
+        return impact
+
+    query = node.current.query
+    if not query:  # pragma: no cover
+        return impact
+
+    # Build parent_columns_map from the node's parents (excluding failed ones)
+    parent_columns_map = _build_parent_columns_map(
+        node,
+        loaded_nodes,
+        nodes_by_name,
+        failed_names,
+    )
+
+    # Validate the query and resolve output columns
+    validation = validate_node_query(
+        query,
+        parent_columns_map,
+        pre_parsed=pre_parsed_query,
+    )
+
+    if validation.errors:
+        # Node's query has errors — it's now INVALID
+        logger.info(
+            "Node %s failed revalidation: %s",
+            impact.name,
+            "; ".join(validation.errors),
+        )
+        if node.current.status != NodeStatus.INVALID:
+            node.current.status = NodeStatus.INVALID
+            session.add(node.current)
+        return DownstreamImpact(
+            name=impact.name,
+            node_type=impact.node_type,
+            current_status=impact.current_status,
+            predicted_status=NodeStatus.INVALID,
+            impact_type=ImpactType.WILL_INVALIDATE,
+            impact_reason=f"Revalidation failed: {'; '.join(validation.errors)}",
+            depth=impact.depth,
+            caused_by=impact.caused_by,
+            is_external=impact.is_external,
+        )
+
+    new_columns = validation.output_columns
+
+    # Compare old columns with new
+    old_columns = [(col.name, col.type) for col in (node.current.columns or [])]
+
+    if not columns_signature_changed(old_columns, new_columns):
+        # Columns unchanged — node is fine
+        if impact.current_status == NodeStatus.INVALID and _all_parents_valid(
+            node,
+            loaded_nodes,
+            nodes_by_name,
+        ):
+            # Was INVALID, parents now VALID, columns resolve → recover
+            node.current.status = NodeStatus.VALID
+            session.add(node.current)
+            return DownstreamImpact(
+                name=impact.name,
+                node_type=impact.node_type,
+                current_status=impact.current_status,
+                predicted_status=NodeStatus.VALID,
+                impact_type=ImpactType.WILL_RECOVER,
+                impact_reason=f"Revalidated — upstream nodes now valid: {', '.join(impact.caused_by)}",
+                depth=impact.depth,
+                caused_by=impact.caused_by,
+                is_external=impact.is_external,
+            )
+        return impact
+
+    # Columns changed — update the node's columns
+    logger.info(
+        "Node %s columns changed during revalidation",
+        impact.name,
+    )
+    _update_node_columns(node, new_columns)
+    session.add(node.current)
+
+    if impact.current_status == NodeStatus.INVALID:
+        node.current.status = NodeStatus.VALID
+        return DownstreamImpact(
+            name=impact.name,
+            node_type=impact.node_type,
+            current_status=impact.current_status,
+            predicted_status=NodeStatus.VALID,
+            impact_type=ImpactType.WILL_RECOVER,
+            impact_reason=f"Revalidated with updated columns — upstream nodes changed: {', '.join(impact.caused_by)}",
+            depth=impact.depth,
+            caused_by=impact.caused_by,
+            is_external=impact.is_external,
+        )
+
+    return DownstreamImpact(
+        name=impact.name,
+        node_type=impact.node_type,
+        current_status=impact.current_status,
+        predicted_status=impact.current_status,
+        impact_type=ImpactType.MAY_AFFECT,
+        impact_reason=f"Column types changed — upstream nodes changed: {', '.join(impact.caused_by)}",
+        depth=impact.depth,
+        caused_by=impact.caused_by,
+        is_external=impact.is_external,
+    )
+
+
+def _build_parent_columns_map(
+    node: Node,
+    loaded_nodes: dict[str, Node],
+    nodes_by_name: dict[str, Node],
+    failed_names: set[str],
+) -> dict[str, dict[str, ColumnType]]:
+    """Build the parent_columns_map for validate_node_query.
+
+    Looks up parents from the loaded nodes first, then falls back to
+    the broader visited nodes index.  Parents that failed revalidation
+    are excluded so that their children fail naturally.
+    """
+    parent_map: dict[str, dict[str, ColumnType]] = {}
+    for parent in node.current.parents or []:
+        if parent.name in failed_names:
+            continue
+        parent_node = loaded_nodes.get(parent.name) or nodes_by_name.get(parent.name)
+        if parent_node and parent_node.current and parent_node.current.columns:
+            parent_map[parent.name] = {
+                col.name: col.type for col in parent_node.current.columns
+            }
+    return parent_map
+
+
+def _all_parents_valid(
+    node: Node,
+    loaded_nodes: dict[str, Node],
+    nodes_by_name: dict[str, Node],
+) -> bool:
+    """Check if all of a node's parents are VALID."""
+    for parent in node.current.parents or []:
+        parent_node = loaded_nodes.get(parent.name) or nodes_by_name.get(parent.name)
+        if not parent_node or not parent_node.current:  # pragma: no cover
+            return False
+        if parent_node.current.status != NodeStatus.VALID:  # pragma: no cover
+            return False
+    return True
+
+
+def _update_node_columns(
+    node: Node,
+    new_columns: list[tuple[str, ColumnType]],
+):
+    """Update a node's column types from validate_node_query results."""
+    col_type_map = {name: col_type for name, col_type in new_columns}
+    for col in node.current.columns or []:
+        if col.name in col_type_map:  # pragma: no branch
+            col.type = col_type_map[col.name]
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def _emit_metrics(start: float, results: list[DownstreamImpact]):
+    """Emit timing and count metrics."""
     elapsed_ms = (time.perf_counter() - start) * 1000
     will_invalidate_count = sum(
         1 for r in results if r.impact_type == ImpactType.WILL_INVALIDATE
@@ -193,4 +695,3 @@ async def propagate_impact(
         "dj.deployment.propagate_impact.will_invalidate",
         will_invalidate_count,
     )
-    return results

--- a/datajunction-server/datajunction_server/internal/impact.py
+++ b/datajunction-server/datajunction_server/internal/impact.py
@@ -81,24 +81,15 @@ async def propagate_impact(
     if not all_root_names and not changed_link_node_names:
         return []
 
-    t0 = time.perf_counter()
     ctx = await _build_propagation_context(
         session,
         namespace,
         changed_node_names,
         deleted_node_names,
     )
-    t1 = time.perf_counter()
-    logger.info("propagate_impact: context built in %.1fms", (t1 - t0) * 1000)
 
     # Phase 1: discover affected nodes via SQL parent graph
     parent_graph_impacts = await _propagate_via_parent_graph(session, ctx)
-    t2 = time.perf_counter()
-    logger.info(
-        "propagate_impact: Phase 1 (parent graph BFS) found %d nodes in %.1fms",
-        len(parent_graph_impacts),
-        (t2 - t1) * 1000,
-    )
 
     # Phase 2: discover affected nodes via dimension link graph
     link_impacts = await _propagate_via_dimension_links(
@@ -106,24 +97,12 @@ async def propagate_impact(
         ctx,
         changed_link_node_names or set(),
     )
-    t3 = time.perf_counter()
-    logger.info(
-        "propagate_impact: Phase 2 (dimension links) found %d nodes in %.1fms",
-        len(link_impacts),
-        (t3 - t2) * 1000,
-    )
 
     # Merge discoveries
     all_impacts = _merge_impacts(parent_graph_impacts, link_impacts)
 
     # Phase 3: revalidate all downstream nodes and apply status changes
     results = await _revalidate_and_apply(session, ctx, all_impacts)
-    t4 = time.perf_counter()
-    logger.info(
-        "propagate_impact: Phase 3 (revalidation) processed %d nodes in %.1fms",
-        len(results),
-        (t4 - t3) * 1000,
-    )
 
     _emit_metrics(start, results)
     return results
@@ -386,7 +365,6 @@ async def _revalidate_and_apply(
     # - DB load is async IO (awaitable)
     # - ANTLR parsing is CPU-bound (threadpool)
     all_names = [impact.name for impact in impacts]
-    t_load_start = time.perf_counter()
 
     async def _parse_all_queries() -> dict[str, ast.Query | Exception]:
         """Parse all queries in a threadpool."""
@@ -404,17 +382,10 @@ async def _revalidate_and_apply(
                     parsed[name] = exc
         return parsed
 
+    # Run DB load and ANTLR parsing concurrently
     loaded_nodes, pre_parsed = await asyncio.gather(
         _batch_load_nodes_for_revalidation(session, all_names),
         _parse_all_queries(),
-    )
-
-    t_load_end = time.perf_counter()
-    logger.info(
-        "  Phase 3: batch loaded %d nodes + pre-parsed %d queries in %.1fms",
-        len(loaded_nodes),
-        len(pre_parsed),
-        (t_load_end - t_load_start) * 1000,
     )
 
     # Seed with deleted and invalid root nodes — their children should
@@ -425,11 +396,8 @@ async def _revalidate_and_apply(
         if n.current and n.current.status == NodeStatus.INVALID
     }
 
-    t_reval_start = time.perf_counter()
-    slowest_nodes: list[tuple[str, float]] = []
     for depth in sorted(by_depth.keys()):
         for impact in by_depth[depth]:
-            t_node = time.perf_counter()
             # Use pre-parsed AST if available (parsed in threadpool)
             parsed_ast = pre_parsed.get(impact.name)
             if isinstance(parsed_ast, Exception):
@@ -442,23 +410,9 @@ async def _revalidate_and_apply(
                 failed_names,
                 pre_parsed_query=parsed_ast,
             )
-            node_ms = (time.perf_counter() - t_node) * 1000
-            if node_ms > 10:  # Only track nodes taking >10ms
-                slowest_nodes.append((impact.name, node_ms))
             if revalidated.impact_type == ImpactType.WILL_INVALIDATE:
                 failed_names.add(impact.name)
             results.append(revalidated)
-
-    t_reval_end = time.perf_counter()
-    logger.info(
-        "  Phase 3: revalidated %d nodes in %.1fms",
-        len(results),
-        (t_reval_end - t_reval_start) * 1000,
-    )
-    if slowest_nodes:
-        slowest_nodes.sort(key=lambda x: x[1], reverse=True)
-        for name, ms in slowest_nodes[:5]:
-            logger.info("  Phase 3: slow node %s took %.1fms", name, ms)
 
     return results
 

--- a/datajunction-server/datajunction_server/models/impact.py
+++ b/datajunction-server/datajunction_server/models/impact.py
@@ -13,6 +13,7 @@ class ImpactType(str, Enum):
     """Type of impact on a downstream node"""
 
     WILL_INVALIDATE = "will_invalidate"  # Certain to break
+    WILL_RECOVER = "will_recover"  # Was INVALID, will become VALID
     MAY_AFFECT = "may_affect"  # Might need revalidation
     UNCHANGED = "unchanged"  # No predicted impact
 

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -138,6 +138,29 @@ def to_sql(query: "Query", dialect: Optional["Dialect"] = None) -> str:
         return str(query)
 
 
+# When True, skip parent-pointer wiring in __post_init__ and __setattr__.
+# Set via fast_parse_mode() context manager for bulk parsing where parent
+# pointers aren't needed (graph extraction, type inference).
+_fast_parse = False
+
+
+@contextmanager
+def fast_parse_mode():
+    """Context manager that disables parent-pointer wiring during AST construction.
+
+    Parent pointers (Node.parent, Node.parent_key) are needed for AST mutation
+    (swap, compile) but not for read-only operations like extracting table names
+    or resolving column types. Skipping the wiring avoids O(n) fields() walks
+    and flatten() calls per node, giving ~2-3x speedup on parse-heavy paths.
+    """
+    global _fast_parse
+    _fast_parse = True
+    try:
+        yield
+    finally:
+        _fast_parse = False
+
+
 def flatten(maybe_iterables: Any) -> Iterator:
     """
     Flattens `maybe_iterables` by descending into items that are Iterable
@@ -185,7 +208,8 @@ class Node(ABC):
     _is_compiled: bool = False
 
     def __post_init__(self):
-        self.add_self_as_parent()
+        if not _fast_parse:
+            self.add_self_as_parent()
 
     @property
     def depth(self) -> int:
@@ -226,7 +250,7 @@ class Node(ABC):
         """
         Facilitates setting children using `.` syntax ensuring parent is attributed
         """
-        if key == "parent":
+        if _fast_parse or key == "parent":
             object.__setattr__(self, key, value)
             return
 

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -190,7 +190,11 @@ def parse_sql_with_sll_fallback(string, rule, converter=None, debug=False):
         return converter(tree) if converter else tree
     except Exception:
         # SLL failed, fall back to LL mode
-        logger.debug(f"SLL parsing failed, falling back to LL mode for query")
+        logger.info(
+            "SLL parsing failed, falling back to LL mode for query of length %d: %.60s...",
+            len(string),
+            string,
+        )
         return parse_sql(string, rule, converter, debug)
 
 

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1382,65 +1382,34 @@ class TestDeployments:
                 ],
             ),
         )
-        assert data == {
-            "status": "failed",
-            "uuid": mock.ANY,
-            "namespace": namespace,
-            "results": [
-                {
-                    "deploy_type": "node",
-                    "message": "Created source (v1.0)",
-                    "name": f"{namespace}.default.hard_hats",
-                    "status": "success",
-                    "operation": "create",
-                    "changed_fields": [],
-                },
-                {
-                    "deploy_type": "node",
-                    "message": "Created source (v1.0)",
-                    "name": f"{namespace}.default.us_states",
-                    "status": "success",
-                    "operation": "create",
-                    "changed_fields": [],
-                },
-                {
-                    "deploy_type": "node",
-                    "message": "Created dimension (v1.0)\n"
-                    "[invalid] Some columns in the primary key ['hard_hat_id'] were "
-                    "not found in the list of available columns for the node "
-                    f"{namespace}.default.hard_hat.; "
-                    f"Column 'state' referenced in join_on for "
-                    f"'{namespace}.default.us_state' not found on node "
-                    f"'{namespace}.default.hard_hat'",
-                    "name": f"{namespace}.default.hard_hat",
-                    "status": "invalid",
-                    "operation": "create",
-                    "changed_fields": [],
-                },
-                {
-                    "deploy_type": "node",
-                    "message": "Created dimension (v1.0)",
-                    "name": f"{namespace}.default.us_state",
-                    "status": "success",
-                    "operation": "create",
-                    "changed_fields": [],
-                },
-                {
-                    "deploy_type": "link",
-                    "message": "Join link successfully deployed\n"
-                    f"[invalid] Node '{namespace}.default.hard_hat' is INVALID "
-                    "— link may not function until the node is fixed",
-                    "name": f"{namespace}.default.hard_hat -> {namespace}.default.us_state",
-                    "operation": "create",
-                    "status": "success",
-                    "changed_fields": [],
-                },
-            ],
-            "created_at": None,
-            "created_by": None,
-            "downstream_impacts": [],
-            "source": None,
+        # Node is INVALID due to PK error; link validation error is reported
+        # separately during link deployment (not duplicated in node message)
+        assert data["uuid"] == mock.ANY
+        assert data["namespace"] == namespace
+
+        node_results = {
+            r["name"]: r for r in data["results"] if r["deploy_type"] == "node"
         }
+        link_results = {
+            r["name"]: r for r in data["results"] if r["deploy_type"] == "link"
+        }
+
+        # Sources created successfully
+        assert node_results[f"{namespace}.default.hard_hats"]["status"] == "success"
+        assert node_results[f"{namespace}.default.us_states"]["status"] == "success"
+        assert node_results[f"{namespace}.default.us_state"]["status"] == "success"
+
+        # Dimension with bad PK is INVALID
+        hard_hat = node_results[f"{namespace}.default.hard_hat"]
+        assert hard_hat["status"] == "invalid"
+        assert "primary key ['hard_hat_id']" in hard_hat["message"]
+
+        # Link is created but warns about INVALID node
+        link = link_results[
+            f"{namespace}.default.hard_hat -> {namespace}.default.us_state"
+        ]
+        assert link["status"] == "success"
+        assert "INVALID" in link["message"]
 
     @pytest.mark.asyncio
     async def test_deploy_with_dimension_link_removal(
@@ -1726,7 +1695,7 @@ class TestDeployments:
         )
         assert update_us_state == {
             "deploy_type": "node",
-            "message": "Node node_update.default.us_state is unchanged.",
+            "message": "Unchanged",
             "name": "node_update.default.us_state",
             "operation": "noop",
             "changed_fields": [],
@@ -1768,7 +1737,7 @@ class TestDeployments:
             client,
             DeploymentSpec(namespace=namespace, nodes=nodes_list),
         )
-        assert data["status"] == "failed"
+        assert data["status"] == "success"
         metric_result = next(
             res
             for res in data["results"]
@@ -1858,7 +1827,7 @@ class TestDeployments:
             client,
             DeploymentSpec(namespace=namespace, nodes=nodes_list),
         )
-        assert data["status"] == "failed"
+        assert data["status"] == "success"
         assert data["results"][-1] == {
             "deploy_type": "node",
             "message": "Updated cube (v2.0)\n[invalid] One or more dimensions not found for cube "
@@ -1946,7 +1915,7 @@ class TestDeployments:
             client,
             DeploymentSpec(namespace=namespace, nodes=nodes_list),
         )
-        assert data["status"] == "failed"
+        assert data["status"] == "success"
         failed_result = next(
             r for r in data["results"] if r["status"] in ("failed", "invalid")
         )
@@ -1997,7 +1966,7 @@ class TestDeployments:
             ),
         )
         assert data == {
-            "status": "failed",
+            "status": "success",
             "uuid": mock.ANY,
             "namespace": namespace,
             "results": [
@@ -2249,7 +2218,7 @@ class TestDeployments:
         assert data["results"] == [
             {
                 "deploy_type": "node",
-                "message": "Node node_update.default.us_states is unchanged.",
+                "message": "Unchanged",
                 "name": "node_update.default.us_states",
                 "operation": "noop",
                 "changed_fields": [],

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -4410,3 +4410,72 @@ class TestDeploymentRevalidation:
         assert len(restored_rows) == 1, (
             "_create_node_revision should have written correct parent relationships"
         )
+
+
+@pytest.mark.asyncio
+async def test_validate_reference_dimension_link_bad_attribute():
+    """
+    validate_reference_dimension_link raises when the dimension attribute
+    does not exist on the dimension node's columns.
+    """
+    from datajunction_server.internal.deployment.orchestrator import (
+        validate_reference_dimension_link,
+    )
+    from datajunction_server.errors import DJInvalidInputException
+
+    # Build a reference link pointing to a non-existent column
+    link = DimensionReferenceLinkSpec(
+        node_column="state",
+        dimension="ns.dim_node.nonexistent_col",
+    )
+    link.namespace = "ns"
+
+    # Build a minimal dim node with columns that do NOT include 'nonexistent_col'
+    dim_rev = MagicMock()
+    dim_rev.columns = [
+        MagicMock(name="id"),
+        MagicMock(name="state_short"),
+    ]
+    # MagicMock(name=...) sets the mock's internal name, not .name attribute
+    dim_rev.columns[0].name = "id"
+    dim_rev.columns[1].name = "state_short"
+
+    dim_node = MagicMock()
+    dim_node.current = dim_rev
+
+    node = MagicMock()
+    node.name = "ns.some_node"
+
+    with pytest.raises(DJInvalidInputException, match="nonexistent_col"):
+        await validate_reference_dimension_link(link, node, dim_node)
+
+
+@pytest.mark.asyncio
+async def test_validate_reference_dimension_link_good_attribute():
+    """
+    validate_reference_dimension_link does NOT raise when the dimension
+    attribute exists on the dimension node's columns.
+    """
+    from datajunction_server.internal.deployment.orchestrator import (
+        validate_reference_dimension_link,
+    )
+
+    link = DimensionReferenceLinkSpec(
+        node_column="state",
+        dimension="ns.dim_node.state_short",
+    )
+    link.namespace = "ns"
+
+    dim_rev = MagicMock()
+    dim_rev.columns = [MagicMock(), MagicMock()]
+    dim_rev.columns[0].name = "id"
+    dim_rev.columns[1].name = "state_short"
+
+    dim_node = MagicMock()
+    dim_node.current = dim_rev
+
+    node = MagicMock()
+    node.name = "ns.some_node"
+
+    # Should not raise
+    await validate_reference_dimension_link(link, node, dim_node)

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -582,7 +582,9 @@ class TestOrchestrationFlow:
             # Configure deployment plan
             mock_plan = Mock(spec=DeploymentPlan)
             mock_plan.is_empty.return_value = False
-            mock_create_plan.return_value = mock_plan
+            mock_plan.to_deploy = []
+            mock_plan.to_delete = []
+            mock_create_plan.return_value = (mock_plan, [])
 
             # Execute
             await orchestrator.execute()
@@ -606,7 +608,9 @@ class TestOrchestrationFlow:
             # Configure empty deployment plan
             mock_plan = Mock(spec=DeploymentPlan)
             mock_plan.is_empty.return_value = True
-            mock_create_plan.return_value = mock_plan
+            mock_plan.to_deploy = []
+            mock_plan.to_delete = []
+            mock_create_plan.return_value = (mock_plan, [])
 
             mock_handle_no_changes.return_value = []
 
@@ -1839,7 +1843,7 @@ async def test_create_deployment_plan_all_auto_sources_already_exist(
         "check_external_deps",
         side_effect=[(set(), [auto_source], []), (set(), [], [])],
     ):
-        plan = await orchestrator._create_deployment_plan()
+        plan, _ = await orchestrator._create_deployment_plan()
 
     # The existing source was found in DB and added to existing_specs (lines 743-747)
     assert "ext_cat.s.t" in plan.existing_specs
@@ -1915,7 +1919,6 @@ async def test_deploy_reference_link_on_invalid_node(
     result = await orch._process_node_dimension_link(
         node_spec=transform_spec,
         link_spec=ref_link,
-        validation_results={},
     )
 
     assert result.status == DeploymentResult.Status.FAILED
@@ -2101,58 +2104,3 @@ async def test_execute_deployment_plan_dry_run_savepoint_rollback(
 
     # Dry-run should roll back the SAVEPOINT and return empty downstream
     assert downstream == []
-
-
-@pytest.mark.asyncio
-async def test_process_node_dimension_link_validation_exception(
-    session,
-    current_user: User,
-    mock_deployment_context,
-):
-    """When validation_results contains an Exception for a link, the error branch
-    at orchestrator.py lines 1169-1174 is reached.
-    """
-    valid_node = MagicMock()
-    valid_node.name = "test.my_dim"
-    valid_node.current.status = NodeStatus.VALID
-    valid_node.current.columns = [MagicMock(name="col", type="string")]
-
-    dimension_node = MagicMock()
-    dimension_node.name = "test.some_dim"
-
-    join_link = DimensionJoinLinkSpec(
-        dimension_node="test.some_dim",
-        join_type="inner",
-        join_on="test.my_dim.col = test.some_dim.col",
-    )
-    join_link.namespace = "test"
-
-    transform_spec = TransformSpec(
-        name="my_dim",
-        namespace="test",
-        query="SELECT col FROM test.source_table",
-    )
-
-    orchestrator = DeploymentOrchestrator(
-        deployment_spec=DeploymentSpec(namespace="test", nodes=[]),
-        deployment_id="val-err-test",
-        session=session,
-        context=mock_deployment_context,
-        dry_run=True,
-    )
-    orchestrator.registry.nodes["test.my_dim"] = valid_node
-    orchestrator.registry.nodes["test.some_dim"] = dimension_node
-
-    validation_error = ValueError("Join path is broken")
-    validation_results: dict[tuple[str, str, str | None], Exception | None] = {
-        ("test.my_dim", "test.some_dim", None): validation_error,
-    }
-
-    result = await orchestrator._process_node_dimension_link(
-        node_spec=transform_spec,
-        link_spec=join_link,
-        validation_results=validation_results,
-    )
-
-    assert result.status == DeploymentResult.Status.FAILED
-    assert "Join path is broken" in result.message

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -1692,3 +1692,99 @@ class TestDimLinkValidationExtended:
         assert validator._dim_link_nodes["test.existing_dim"] is dim_node
         # Column names should be pre-computed for the dim link target
         assert "id" in validator._dim_link_col_names.get("test.existing_dim", set())
+
+
+class TestToColumnSpecsPreservesMetadata:
+    """Test _to_column_specs preserving display_name/description when type is None."""
+
+    @pytest.mark.asyncio
+    async def test_inferred_type_used_when_spec_type_is_none(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """
+        When a spec column has display_name and description but type=None,
+        _to_column_specs should use the inferred type while preserving metadata.
+        """
+        # Create a transform spec with columns that have metadata but no explicit type
+        spec = TransformSpec(
+            name="transform",
+            query="SELECT id, name FROM test.parent",
+            description="A test transform",
+            mode="published",
+            columns=[
+                ColumnSpec(
+                    name="id",
+                    type=None,
+                    display_name="User ID",
+                    description="The primary identifier",
+                ),
+                ColumnSpec(
+                    name="name",
+                    type=None,
+                    display_name="User Name",
+                    description="The user's full name",
+                ),
+            ],
+        )
+
+        context = ValidationContext(
+            session=session,
+            node_graph={"test.transform": ["test.parent"]},
+            dependency_nodes={parent_node.name: parent_node},
+        )
+        validator = NodeSpecBulkValidator(context)
+
+        # Inferred output columns from SQL parsing (simulating what type inference returns)
+        output_columns = [
+            ("id", IntegerType()),
+            ("name", StringType()),
+        ]
+        result = validator._to_column_specs(output_columns, spec)
+
+        # The inferred type should be used
+        assert result[0].type == str(IntegerType())
+        assert result[1].type == str(StringType())
+
+        # Metadata should be preserved
+        assert result[0].display_name == "User ID"
+        assert result[0].description == "The primary identifier"
+        assert result[1].display_name == "User Name"
+        assert result[1].description == "The user's full name"
+
+    @pytest.mark.asyncio
+    async def test_explicit_type_takes_precedence(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """When a spec column has an explicit type, it takes precedence over inferred."""
+        spec = TransformSpec(
+            name="transform",
+            query="SELECT id FROM test.parent",
+            description="A test transform",
+            mode="published",
+            columns=[
+                ColumnSpec(
+                    name="id",
+                    type="bigint",
+                    display_name="User ID",
+                    description="The primary identifier",
+                ),
+            ],
+        )
+
+        context = ValidationContext(
+            session=session,
+            node_graph={"test.transform": ["test.parent"]},
+            dependency_nodes={parent_node.name: parent_node},
+        )
+        validator = NodeSpecBulkValidator(context)
+
+        output_columns = [("id", IntegerType())]
+        result = validator._to_column_specs(output_columns, spec)
+
+        # Explicit type should win
+        assert result[0].type == "bigint"
+        assert result[0].display_name == "User ID"

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -31,7 +31,7 @@ from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User, OAuthProvider
 from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.column import Column
-from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
+from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.types import IntegerType, MapType, StringType
 from datajunction_server.errors import ErrorCode
 
@@ -103,18 +103,10 @@ class TestValidateQuery:
     ) -> ValidationContext:
         """Create a real ValidationContext with actual dependencies"""
 
-        # Create a real compile context
-        compile_context = ast.CompileContext(
-            session=session,
-            exception=ast.DJException(),
-            dependencies_cache={parent_node.name: parent_node},
-        )
-
         return ValidationContext(
             session=session,
             node_graph={"test.transform": ["test.parent"]},
             dependency_nodes={parent_node.name: parent_node},
-            compile_context=compile_context,
         )
 
     @pytest.fixture
@@ -146,24 +138,20 @@ class TestValidateQuery:
         validation_context: ValidationContext,
         transform_spec: TransformSpec,
     ):
-        """Test exception when parsing fails due to malformed SQL"""
+        """Test that a query referencing a missing table produces errors"""
         bad_spec = TransformSpec(
             name="bad_transform",
-            query="SELECT 1a FROM some_table",  # Invalid SQL
+            query="SELECT x FROM nonexistent.table",
             description="Bad transform",
             mode="published",
-            primary_key=["id"],  # To avoid primary key inference issues
+            primary_key=["id"],
         )
-        parsed_ast = parse(bad_spec.query)
         validator = NodeSpecBulkValidator(validation_context)
-        result = await validator.validate_query_node(bad_spec, parsed_ast)
+        result = validator.validate_query_node(bad_spec)
         assert result.spec == bad_spec
         assert result.status == NodeStatus.INVALID
-        assert result.inferred_columns == []
         error_codes = [e.code for e in result.errors]
         assert ErrorCode.TYPE_INFERENCE in error_codes
-        type_err = next(e for e in result.errors if e.code == ErrorCode.TYPE_INFERENCE)
-        assert "Unable to infer type for column `1a`" in type_err.message
 
     @pytest.mark.asyncio
     async def test_validate_query_node_later_exception(
@@ -174,7 +162,6 @@ class TestValidateQuery:
         """
         Test exception during later validation steps with real AST
         """
-        parsed_ast = parse("SELECT 1a FROM some_table")
         validator = NodeSpecBulkValidator(validation_context)
         # mock _check_inferred_columns to raise an exception
         with patch.object(
@@ -182,72 +169,30 @@ class TestValidateQuery:
             "_check_inferred_columns",
             side_effect=ValueError("Column inference failed"),
         ):
-            result = await validator.validate_query_node(transform_spec, parsed_ast)
+            result = validator.validate_query_node(transform_spec)
             assert result.status == NodeStatus.INVALID
             assert len(result.errors) == 1
             assert result.errors[0].code == ErrorCode.INVALID_SQL_QUERY
 
     @pytest.mark.asyncio
-    async def test_validate_query_node_dependency_extraction_failure(
+    async def test_validate_query_node_validate_node_query_failure(
         self,
         validation_context: ValidationContext,
         transform_spec: TransformSpec,
     ):
-        """Test exception during dependency extraction with real AST"""
-
-        # Parse a valid query
-        parsed_ast = parse(transform_spec.query)
-
-        # Mock the compile context to throw during extraction
-        with patch.object(
-            validation_context.compile_context,
-            "exception",
-            side_effect=Exception("Dependency extraction failed"),
-        ):
-            # Patch extract_dependencies to throw
-            with patch.object(
-                parsed_ast.bake_ctes(),
-                "extract_dependencies",
-                side_effect=Exception("Dependency extraction failed"),
-            ):
-                validator = NodeSpecBulkValidator(validation_context)
-
-                # This should hit the exception handler
-                result = await validator.validate_query_node(transform_spec, parsed_ast)
-
-        # Verify proper error handling
-        assert result.status == NodeStatus.INVALID
-        assert len(result.errors) == 1
-        assert result.errors[0].code == ErrorCode.INVALID_SQL_QUERY
-        assert "Dependency extraction failed" in result.errors[0].message
-
-    @pytest.mark.asyncio
-    async def test_validate_query_node_column_inference_failure(
-        self,
-        validation_context: ValidationContext,
-        transform_spec: TransformSpec,
-    ):
-        """Test exception during column inference with real objects"""
-
-        # Parse a valid query
-        parsed_ast = parse(transform_spec.query)
-
-        # Create validator and patch _infer_columns to fail
+        """Test exception during validate_node_query with real AST"""
         validator = NodeSpecBulkValidator(validation_context)
 
-        with patch.object(
-            validator,
-            "_infer_columns",
-            side_effect=AttributeError("Column inference failed - missing attribute"),
+        with patch(
+            "datajunction_server.internal.deployment.validation.validate_node_query",
+            side_effect=RuntimeError("Unexpected validation failure"),
         ):
-            # This should hit the exception handler
-            result = await validator.validate_query_node(transform_spec, parsed_ast)
+            result = validator.validate_query_node(transform_spec)
 
-        # Verify the exception was caught and handled
         assert result.status == NodeStatus.INVALID
         assert len(result.errors) == 1
         assert result.errors[0].code == ErrorCode.INVALID_SQL_QUERY
-        assert "Column inference failed" in result.errors[0].message
+        assert "Unexpected validation failure" in result.errors[0].message
 
     @pytest.mark.asyncio
     async def test_validate_query_node_metric_validation_exception(
@@ -258,7 +203,6 @@ class TestValidateQuery:
         """Test exception during metric-specific validation"""
 
         # Parse the metric query
-        parsed_ast = parse(metric_spec.query)
 
         # Create validator and patch metric validation to fail
         validator = NodeSpecBulkValidator(validation_context)
@@ -269,7 +213,7 @@ class TestValidateQuery:
             side_effect=ValueError("Metric validation failed"),
         ):
             # This should hit the exception handler
-            result = await validator.validate_query_node(metric_spec, parsed_ast)
+            result = validator.validate_query_node(metric_spec)
 
         # Verify proper error handling
         assert result.status == NodeStatus.INVALID
@@ -285,14 +229,11 @@ class TestValidateQuery:
     ):
         """Test the successful path to ensure our exception tests are meaningful"""
 
-        # Parse a valid query
-        parsed_ast = parse(transform_spec.query)
-
         # Create validator
         validator = NodeSpecBulkValidator(validation_context)
 
         # This should succeed (not hit exception handler)
-        result = await validator.validate_query_node(transform_spec, parsed_ast)
+        result = validator.validate_query_node(transform_spec)
 
         # Verify success (this ensures our exception tests are testing real failures)
         assert result.status in [
@@ -328,9 +269,8 @@ class TestValidateQuery:
         )
         spec._skip_validation = True  # Set the private flag
 
-        parsed_ast = parse(spec.query)
         validator = NodeSpecBulkValidator(validation_context)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        result = validator.validate_query_node(spec)
 
         # Should use the spec's columns directly without re-inference
         assert result.inferred_columns == spec.columns
@@ -377,16 +317,10 @@ class TestValidateQuery:
         invalid_parent_node: Node,
     ):
         """Transform whose parent is INVALID should itself be INVALID with INVALID_PARENT error"""
-        compile_context = ast.CompileContext(
-            session=session,
-            exception=ast.DJException(),
-            dependencies_cache={invalid_parent_node.name: invalid_parent_node},
-        )
         context = ValidationContext(
             session=session,
             node_graph={"test.child_transform": [invalid_parent_node.name]},
             dependency_nodes={invalid_parent_node.name: invalid_parent_node},
-            compile_context=compile_context,
         )
         spec = TransformSpec(
             name="test.child_transform",
@@ -395,9 +329,8 @@ class TestValidateQuery:
             mode="published",
         )
 
-        parsed_ast = parse(spec.query)
         validator = NodeSpecBulkValidator(context)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        result = validator.validate_query_node(spec)
 
         assert result.status == NodeStatus.INVALID
         error_codes = [e.code for e in result.errors]
@@ -558,11 +491,6 @@ class TestBulkValidateSkipValidation:
             session=session,
             node_graph={"test.direct": []},
             dependency_nodes={},
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache={},
-            ),
         )
         validator = NodeSpecBulkValidator(context)
         result = validator._validate_without_parsing(spec)
@@ -601,16 +529,10 @@ class TestRequiredDimensions:
         parent_node: Node,
     ) -> ValidationContext:
         dep_nodes = {parent_node.name: parent_node}
-        compile_context = ast.CompileContext(
-            session=session,
-            exception=ast.DJException(),
-            dependencies_cache=dep_nodes,
-        )
         return ValidationContext(
             session=session,
             node_graph={"test.metric": [parent_node.name]},
             dependency_nodes=dep_nodes,
-            compile_context=compile_context,
         )
 
     # ------------------------------------------------------------------ unit tests (no DB query needed)
@@ -634,7 +556,8 @@ class TestRequiredDimensions:
         validator._all_dim_nodes = {**context.dependency_nodes, "test.dim": dim_node}
 
         parsed_ast = parse(spec.rendered_query)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        spec._query_ast = parsed_ast
+        result = validator.validate_query_node(spec)
 
         assert result.status == NodeStatus.VALID
         error_codes = [e.code for e in result.errors]
@@ -656,9 +579,7 @@ class TestRequiredDimensions:
         )
         validator = NodeSpecBulkValidator(context)
         validator._all_dim_nodes = {**context.dependency_nodes, "test.dim": dim_node}
-
-        parsed_ast = parse(spec.rendered_query)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        result = validator.validate_query_node(spec)
 
         assert result.status == NodeStatus.INVALID
         err = next(e for e in result.errors if e.code == ErrorCode.INVALID_COLUMN)
@@ -681,9 +602,7 @@ class TestRequiredDimensions:
         validator = NodeSpecBulkValidator(context)
         # _all_dim_nodes has no entry for "ghost.dim"
         validator._all_dim_nodes = dict(context.dependency_nodes)
-
-        parsed_ast = parse(spec.rendered_query)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        result = validator.validate_query_node(spec)
 
         assert result.status == NodeStatus.INVALID
         err = next(e for e in result.errors if e.code == ErrorCode.INVALID_COLUMN)
@@ -706,9 +625,7 @@ class TestRequiredDimensions:
         )
         validator = NodeSpecBulkValidator(context)
         validator._all_dim_nodes = dict(context.dependency_nodes)
-
-        parsed_ast = parse(spec.rendered_query)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        result = validator.validate_query_node(spec)
 
         assert result.status == NodeStatus.VALID
         error_codes = [e.code for e in result.errors]
@@ -729,9 +646,7 @@ class TestRequiredDimensions:
         )
         validator = NodeSpecBulkValidator(context)
         validator._all_dim_nodes = dict(context.dependency_nodes)
-
-        parsed_ast = parse(spec.rendered_query)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        result = validator.validate_query_node(spec)
 
         assert result.status == NodeStatus.INVALID
         err = next(e for e in result.errors if e.code == ErrorCode.INVALID_COLUMN)
@@ -752,9 +667,7 @@ class TestRequiredDimensions:
         )
         validator = NodeSpecBulkValidator(context)
         validator._all_dim_nodes = dict(context.dependency_nodes)
-
-        parsed_ast = parse(spec.rendered_query)
-        result = await validator.validate_query_node(spec, parsed_ast)
+        result = validator.validate_query_node(spec)
 
         error_codes = [e.code for e in result.errors]
         assert ErrorCode.INVALID_COLUMN not in error_codes
@@ -874,18 +787,12 @@ class TestCrossFactDimensions:
             base_metric_a.name: base_metric_a,
             base_metric_b.name: base_metric_b,
         }
-        compile_context = ast.CompileContext(
-            session=session,
-            exception=ast.DJException(),
-            dependencies_cache=dep_nodes,
-        )
         return ValidationContext(
             session=session,
             node_graph={
                 "test.derived": [base_metric_a.name, base_metric_b.name],
             },
             dependency_nodes=dep_nodes,
-            compile_context=compile_context,
         )
 
     # ------------------------------------------------------------------ unit tests (direct method calls)
@@ -950,11 +857,6 @@ class TestCrossFactDimensions:
             session=session,
             node_graph={"test.derived": [ma.name]},
             dependency_nodes=dep_nodes,
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache=dep_nodes,
-            ),
         )
         spec = MetricSpec(
             name="test.derived",
@@ -994,11 +896,6 @@ class TestCrossFactDimensions:
             session=session,
             node_graph={},
             dependency_nodes={},
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache={},
-            ),
         )
         spec = TransformSpec(
             name="test.transform",
@@ -1068,11 +965,6 @@ class TestCrossFactDimensions:
                 "test.derived2": [ma.name, mb.name],
             },
             dependency_nodes=dep_nodes,
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache=dep_nodes,
-            ),
         )
         specs = [
             MetricSpec(
@@ -1111,11 +1003,6 @@ class TestCrossFactDimensions:
             session=session,
             node_graph={"test.simple_derived": [ma.name]},
             dependency_nodes=dep_nodes,
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache=dep_nodes,
-            ),
         )
         spec = MetricSpec(
             name="test.simple_derived",
@@ -1143,11 +1030,6 @@ def _make_validator(session: AsyncSession) -> NodeSpecBulkValidator:
         session=session,
         node_graph={},
         dependency_nodes={},
-        compile_context=ast.CompileContext(
-            session=session,
-            exception=ast.DJException(),
-            dependencies_cache={},
-        ),
     )
     return NodeSpecBulkValidator(context)
 
@@ -1722,11 +1604,6 @@ class TestDimLinkValidationExtended:
             session=session,
             node_graph={},
             dependency_nodes={},
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache={},
-            ),
         )
         spec = SourceSpec(
             name="facts",
@@ -1763,11 +1640,6 @@ class TestDimLinkValidationExtended:
             session=session,
             node_graph={},
             dependency_nodes={parent_node.name: parent_node},
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache={parent_node.name: parent_node},
-            ),
         )
         spec = SourceSpec(
             name="facts",
@@ -1797,11 +1669,6 @@ class TestDimLinkValidationExtended:
             session=session,
             node_graph={},
             dependency_nodes={dim_node.name: dim_node},
-            compile_context=ast.CompileContext(
-                session=session,
-                exception=ast.DJException(),
-                dependencies_cache={dim_node.name: dim_node},
-            ),
         )
         spec = SourceSpec(
             name="facts",
@@ -1825,22 +1692,3 @@ class TestDimLinkValidationExtended:
         assert validator._dim_link_nodes["test.existing_dim"] is dim_node
         # Column names should be pre-computed for the dim link target
         assert "id" in validator._dim_link_col_names.get("test.existing_dim", set())
-
-
-class TestCreateColumnSpecTypeError:
-    """Tests for _create_column_spec raising TypeError when type cannot be inferred (line 626)."""
-
-    def test_create_column_spec_raises_when_type_unresolvable(
-        self,
-        session: AsyncSession,
-    ):
-        """_create_column_spec raises TypeError when no existing_spec.type and AST column
-        has no resolvable type (line 626 - the raise TypeError branch)."""
-        validator = _make_validator(session)
-
-        # Create a mock AST column with no resolvable type
-        ast_col = MagicMock(spec=ast.Column)
-        ast_col.type = None
-
-        with pytest.raises(TypeError, match="Cannot resolve type"):
-            validator._create_column_spec("my_col", ast_col, existing_spec=None)

--- a/datajunction-server/tests/internal/deployment_test.py
+++ b/datajunction-server/tests/internal/deployment_test.py
@@ -38,7 +38,6 @@ from datajunction_server.errors import (
 )
 from datajunction_server.database.node import Node
 from datajunction_server.models.node import (
-    NodeMode,
     NodeType,
 )
 import pytest
@@ -534,7 +533,7 @@ def test_find_upstreams_for_derived_metric():
         node_type=NodeType.METRIC,
         query="SELECT example.metric_a / example.metric_b",
     )
-    name, upstreams = _find_upstreams_for_node(derived_metric)
+    name, upstreams, _ = _find_upstreams_for_node(derived_metric)
     assert name == "example.derived_ratio"
     # Should extract both the full metric reference and the parent namespace
     assert "example.metric_a" in upstreams
@@ -546,7 +545,7 @@ def test_find_upstreams_for_derived_metric():
         node_type=NodeType.METRIC,
         query="SELECT ns.other_metric * ns.dimension.column_value",
     )
-    name, upstreams = _find_upstreams_for_node(derived_with_dim)
+    name, upstreams, _ = _find_upstreams_for_node(derived_with_dim)
     assert name == "example.filtered_metric"
     # Should include both the full column reference and the parent (dimension node)
     assert "ns.other_metric" in upstreams
@@ -631,7 +630,7 @@ async def test_catalog_not_shadowed_by_virtual_catalog_parent(
     )
     orchestrator = create_orchestrator(session, current_user, [transform_spec])
     await orchestrator._setup_deployment_resources()
-    plan = await orchestrator._create_deployment_plan()
+    plan, _ = await orchestrator._create_deployment_plan()
     _, deployed_nodes = await orchestrator.bulk_deploy_nodes_in_level(
         [transform_spec],
         plan.node_graph,
@@ -1994,7 +1993,7 @@ async def test_auto_register_sources_success(session: AsyncSession):
     await orchestrator._validate_deployment_resources()
 
     # Auto-registration happens during deployment plan creation
-    plan = await orchestrator._create_deployment_plan()
+    plan, _ = await orchestrator._create_deployment_plan()
 
     # Verify query service was called
     mock_query_service.get_columns_for_tables_batch.assert_called_once_with(
@@ -2052,7 +2051,7 @@ async def test_auto_register_sources_disabled(session: AsyncSession):
 
     # With auto_register_sources=False, nodes with missing deps stay in to_deploy
     # so they are deployed as INVALID (not pre-filtered) and downstream impact is tracked.
-    plan = await orchestrator._create_deployment_plan()
+    plan, _ = await orchestrator._create_deployment_plan()
     assert any(spec.rendered_name == "test.my_transform" for spec in plan.to_deploy), (
         "Node with missing dep should remain in to_deploy for natural validation"
     )
@@ -2089,7 +2088,7 @@ async def test_auto_register_sources_catalog_not_found(session: AsyncSession):
 
     # auto_register_sources=True but catalog doesn't exist → node stays in to_deploy
     # so it is deployed as INVALID and its downstream impact is tracked.
-    plan = await orchestrator._create_deployment_plan()
+    plan, _ = await orchestrator._create_deployment_plan()
     assert any(spec.rendered_name == "test.my_transform" for spec in plan.to_deploy), (
         "Node with unregistrable dep should remain in to_deploy for natural validation"
     )
@@ -2371,239 +2370,6 @@ class TestDiffColumnMetadata:
         combined = " ".join(notes)
         assert "display_name" in combined
         assert "description changed" in combined
-
-
-class TestLogSpecDiff:
-    """Unit tests for DeploymentOrchestrator._log_spec_diff."""
-
-    def _make_orchestrator(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            DeploymentOrchestrator,
-        )
-        from datajunction_server.internal.deployment.utils import DeploymentContext
-
-        user = MagicMock()
-        user.username = "test"
-        context = DeploymentContext(current_user=user)
-        spec = DeploymentSpec(namespace="test")
-        return DeploymentOrchestrator(
-            deployment_spec=spec,
-            deployment_id="test-id",
-            session=MagicMock(),
-            context=context,
-        )
-
-    def test_node_type_change(self):
-        """node_type difference is logged (line 2273)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(namespace="test", name="node_a", query="SELECT 1 AS x")
-        old_spec = MetricSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT count(1) AS cnt",
-        )
-        # Should not raise
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_display_name_change(self):
-        """display_name difference is logged (line 2280)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            display_name="New Name",
-        )
-        old_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            display_name="Old Name",
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_description_change(self):
-        """description difference is logged (line 2286)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            description="New desc",
-        )
-        old_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            description=None,
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_owners_change(self):
-        """owners difference is logged (line 2290)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            owners=["alice"],
-        )
-        old_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            owners=["bob"],
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_tags_change(self):
-        """tags difference is logged (line 2294)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            tags=["new_tag"],
-        )
-        old_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            tags=[],
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_mode_change(self):
-        """mode difference is logged (line 2298)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            mode=NodeMode.DRAFT,
-        )
-        old_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            mode=NodeMode.PUBLISHED,
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_query_change(self):
-        """query difference is logged (line 2301->2306)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(namespace="test", name="node_a", query="SELECT 2 AS x")
-        old_spec = TransformSpec(namespace="test", name="node_a", query="SELECT 1 AS x")
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_source_catalog_change(self):
-        """Source catalog difference is logged (line 2313)."""
-        orch = self._make_orchestrator()
-        new_spec = SourceSpec(
-            namespace="test",
-            name="my_source",
-            catalog="new_cat",
-            schema_="s",
-            table="t",
-        )
-        old_spec = SourceSpec(
-            namespace="test",
-            name="my_source",
-            catalog="old_cat",
-            schema_="s",
-            table="t",
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_source_schema_change(self):
-        """Source schema difference is logged (line 2321)."""
-        orch = self._make_orchestrator()
-        new_spec = SourceSpec(
-            namespace="test",
-            name="my_source",
-            catalog="cat",
-            schema_="new_schema",
-            table="t",
-        )
-        old_spec = SourceSpec(
-            namespace="test",
-            name="my_source",
-            catalog="cat",
-            schema_="old_schema",
-            table="t",
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_source_table_change(self):
-        """Source table difference is logged (line 2329)."""
-        orch = self._make_orchestrator()
-        new_spec = SourceSpec(
-            namespace="test",
-            name="my_source",
-            catalog="cat",
-            schema_="s",
-            table="new_table",
-        )
-        old_spec = SourceSpec(
-            namespace="test",
-            name="my_source",
-            catalog="cat",
-            schema_="s",
-            table="old_table",
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_cube_metrics_change(self):
-        """Cube metrics difference is logged (lines 2357-2360)."""
-        orch = self._make_orchestrator()
-        new_spec = CubeSpec(
-            namespace="test",
-            name="my_cube",
-            metrics=["test.m1", "test.m2"],
-            dimensions=[],
-        )
-        old_spec = CubeSpec(
-            namespace="test",
-            name="my_cube",
-            metrics=["test.m1"],
-            dimensions=[],
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_cube_dimensions_change(self):
-        """Cube dimensions difference is logged (lines 2361-2364)."""
-        orch = self._make_orchestrator()
-        new_spec = CubeSpec(
-            namespace="test",
-            name="my_cube",
-            metrics=["test.m1"],
-            dimensions=["test.d2"],
-        )
-        old_spec = CubeSpec(
-            namespace="test",
-            name="my_cube",
-            metrics=["test.m1"],
-            dimensions=["test.d1"],
-        )
-        orch._log_spec_diff(new_spec, old_spec)
-
-    def test_custom_metadata_change(self):
-        """custom_metadata difference is logged (line 2374)."""
-        orch = self._make_orchestrator()
-        new_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            custom_metadata={"key": "new"},
-        )
-        old_spec = TransformSpec(
-            namespace="test",
-            name="node_a",
-            query="SELECT 1 AS x",
-            custom_metadata={"key": "old"},
-        )
-        orch._log_spec_diff(new_spec, old_spec)
 
 
 class TestFallbackCatalogAndInferCubeCatalog:

--- a/datajunction-server/tests/internal/impact_test.py
+++ b/datajunction-server/tests/internal/impact_test.py
@@ -1163,8 +1163,6 @@ async def test_propagate_impact_unparseable_query_falls_back_gracefully(
     await _persist(session, source, source_rev, child, child_rev)
     await _persist(session, _link(source, child_rev))
 
-    original_parse_query = None
-
     def _failing_parse_query(query_str):
         """Simulate a parse failure for any query."""
         raise RuntimeError("Simulated ANTLR parse failure")

--- a/datajunction-server/tests/internal/impact_test.py
+++ b/datajunction-server/tests/internal/impact_test.py
@@ -4,12 +4,19 @@ Unit tests for datajunction_server.internal.impact.propagate_impact
 
 import pytest
 
+from datajunction_server.database.column import Column as DBColumn
 from datajunction_server.database.node import Node, NodeRevision, NodeRelationship
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.user import User
-from datajunction_server.internal.impact import propagate_impact
-from datajunction_server.models.impact import ImpactType
+from datajunction_server.internal.impact import _merge_impacts, propagate_impact
+from datajunction_server.models.impact import DownstreamImpact, ImpactType
 from datajunction_server.models.node import NodeStatus, NodeType
+from datajunction_server.sql.parsing.types import (
+    BigIntType,
+    DoubleType,
+    IntegerType,
+    StringType,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -23,8 +30,10 @@ def _make_node(
     status: NodeStatus,
     user_id: int,
     version: str = "v1.0",
+    query: str = "SELECT 1",
+    columns: list[tuple[str, object]] | None = None,
 ) -> tuple[Node, NodeRevision]:
-    """Create an unsaved (Node, NodeRevision) pair."""
+    """Create an unsaved (Node, NodeRevision) pair with optional columns."""
     node = Node(
         name=name,
         type=node_type,
@@ -38,9 +47,13 @@ def _make_node(
         node=node,
         version=version,
         status=status,
-        query="SELECT 1",
+        query=query,
         created_by_id=user_id,
     )
+    if columns:
+        rev.columns = [
+            DBColumn(name=col_name, type=col_type) for col_name, col_type in columns
+        ]
     return node, rev
 
 
@@ -132,12 +145,15 @@ async def test_propagate_impact_invalid_parent_will_invalidate(
         NodeType.SOURCE,
         NodeStatus.INVALID,
         current_user.id,
+        columns=[("id", IntegerType())],
     )
     child, child_rev = _make_node(
         "ns.transform",
         NodeType.TRANSFORM,
         NodeStatus.VALID,
         current_user.id,
+        query="SELECT id FROM ns.source",
+        columns=[("id", IntegerType())],
     )
     await _persist(session, parent, parent_rev, child, child_rev)
     await _persist(session, _link(parent, child_rev))
@@ -166,12 +182,15 @@ async def test_propagate_impact_deleted_node_will_invalidate(
         NodeType.SOURCE,
         NodeStatus.VALID,
         current_user.id,
+        columns=[("id", IntegerType())],
     )
     child, child_rev = _make_node(
         "ns.transform",
         NodeType.TRANSFORM,
         NodeStatus.VALID,
         current_user.id,
+        query="SELECT id FROM ns.source",
+        columns=[("id", IntegerType())],
     )
     await _persist(session, parent, parent_rev, child, child_rev)
     await _persist(session, _link(parent, child_rev))
@@ -199,18 +218,23 @@ async def test_propagate_impact_transitive_invalidation(session, current_user: U
         NodeType.SOURCE,
         NodeStatus.INVALID,
         current_user.id,
+        columns=[("id", IntegerType())],
     )
     child1, child1_rev = _make_node(
         "ns.transform",
         NodeType.TRANSFORM,
         NodeStatus.VALID,
         current_user.id,
+        query="SELECT id FROM ns.source",
+        columns=[("id", IntegerType())],
     )
     child2, child2_rev = _make_node(
         "ns.metric",
         NodeType.METRIC,
         NodeStatus.VALID,
         current_user.id,
+        query="SELECT SUM(id) ns_DOT_metric FROM ns.transform",
+        columns=[("ns_DOT_metric", BigIntType())],
     )
     await _persist(session, root, root_rev, child1, child1_rev, child2, child2_rev)
     await _persist(session, _link(root, child1_rev), _link(child1, child2_rev))
@@ -267,12 +291,15 @@ async def test_propagate_impact_already_invalid_not_duplicated(
         NodeType.SOURCE,
         NodeStatus.INVALID,
         current_user.id,
+        columns=[("id", IntegerType())],
     )
     child, child_rev = _make_node(
         "ns.transform",
         NodeType.TRANSFORM,
         NodeStatus.INVALID,
         current_user.id,
+        query="SELECT id FROM ns.source",
+        columns=[("id", IntegerType())],
     )
     await _persist(session, parent, parent_rev, child, child_rev)
     await _persist(session, _link(parent, child_rev))
@@ -337,18 +364,23 @@ async def test_propagate_impact_cause_names_in_result(session, current_user: Use
         NodeType.SOURCE,
         NodeStatus.VALID,
         current_user.id,
+        columns=[("id", IntegerType())],
     )
     child, child_rev = _make_node(
         "ns.transform",
         NodeType.TRANSFORM,
         NodeStatus.VALID,
         current_user.id,
+        query="SELECT id FROM ns.source",
+        columns=[("id", IntegerType())],
     )
     grandchild, grandchild_rev = _make_node(
         "ns.metric",
         NodeType.METRIC,
         NodeStatus.VALID,
         current_user.id,
+        query="SELECT SUM(id) ns_DOT_metric FROM ns.transform",
+        columns=[("ns_DOT_metric", BigIntType())],
     )
     await _persist(
         session,
@@ -367,3 +399,731 @@ async def test_propagate_impact_cause_names_in_result(session, current_user: Use
     # Both should trace back to ns.source
     assert by_name["ns.transform"].caused_by == ["ns.source"]
     assert by_name["ns.metric"].caused_by == ["ns.source"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Revalidation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revalidation_recovery_invalid_to_valid(session, current_user: User):
+    """INVALID node with all parents now VALID and query resolves → WILL_RECOVER."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    # Transform was INVALID but parent is now VALID
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.INVALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    await _persist(session, source, source_rev, transform, transform_rev)
+    await _persist(session, _link(source, transform_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    impact = by_name["ns.transform"]
+    assert impact.impact_type == ImpactType.WILL_RECOVER
+    assert impact.current_status == NodeStatus.INVALID
+    assert impact.predicted_status == NodeStatus.VALID
+    assert transform_rev.status == NodeStatus.VALID
+
+
+@pytest.mark.asyncio
+async def test_revalidation_recovery_fails(session, current_user: User):
+    """INVALID node, parent VALID, but query references nonexistent column → stays INVALID."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", IntegerType())],
+    )
+    # Transform references 'nonexistent' which doesn't exist on source
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.INVALID,
+        current_user.id,
+        query="SELECT nonexistent FROM ns.source",
+        columns=[("nonexistent", StringType())],
+    )
+    await _persist(session, source, source_rev, transform, transform_rev)
+    await _persist(session, _link(source, transform_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    impact = by_name["ns.transform"]
+    assert impact.impact_type == ImpactType.WILL_INVALIDATE
+    assert impact.predicted_status == NodeStatus.INVALID
+
+
+@pytest.mark.asyncio
+async def test_revalidation_invalid_parent_still_invalid_no_recovery(
+    session,
+    current_user: User,
+):
+    """INVALID node with one parent still INVALID → no recovery attempt."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.INVALID,
+        current_user.id,
+        columns=[("user_id", IntegerType())],
+    )
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.INVALID,
+        current_user.id,
+        query="SELECT user_id FROM ns.source",
+        columns=[("user_id", IntegerType())],
+    )
+    await _persist(session, source, source_rev, transform, transform_rev)
+    await _persist(session, _link(source, transform_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    # Parent is INVALID → child gets WILL_INVALIDATE, not recovery
+    assert by_name["ns.transform"].impact_type == ImpactType.WILL_INVALIDATE
+
+
+@pytest.mark.asyncio
+async def test_revalidation_column_type_change(session, current_user: User):
+    """Parent column type changes (INT→BIGINT) → downstream columns updated."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    # Source with BIGINT now (was INT before, but deploy updated it)
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", BigIntType()), ("amount", DoubleType())],
+    )
+    # Transform still has old INT type
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    await _persist(session, source, source_rev, transform, transform_rev)
+    await _persist(session, _link(source, transform_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    impact = by_name["ns.transform"]
+    assert impact.impact_type == ImpactType.MAY_AFFECT
+    assert "Column types changed" in impact.impact_reason
+    # The transform's column type should be updated to BIGINT
+    col_types = {col.name: col.type for col in transform_rev.columns}
+    assert isinstance(col_types["user_id"], BigIntType)
+
+
+@pytest.mark.asyncio
+async def test_revalidation_column_renamed_breaks_downstream(
+    session,
+    current_user: User,
+):
+    """Parent column renamed → downstream can't resolve → WILL_INVALIDATE."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    # Source now has 'uid' instead of 'user_id'
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("uid", IntegerType()), ("amount", DoubleType())],
+    )
+    # Transform still references 'user_id'
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    await _persist(session, source, source_rev, transform, transform_rev)
+    await _persist(session, _link(source, transform_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    assert by_name["ns.transform"].impact_type == ImpactType.WILL_INVALIDATE
+    assert transform_rev.status == NodeStatus.INVALID
+
+
+@pytest.mark.asyncio
+async def test_revalidation_unchanged_columns_passthrough(
+    session,
+    current_user: User,
+):
+    """Parent query changed but column signature unchanged → node passes through."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    await _persist(session, source, source_rev, transform, transform_rev)
+    await _persist(session, _link(source, transform_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    # Columns unchanged, status unchanged → MAY_AFFECT passthrough
+    assert by_name["ns.transform"].impact_type == ImpactType.MAY_AFFECT
+    assert transform_rev.status == NodeStatus.VALID
+
+
+@pytest.mark.asyncio
+async def test_revalidation_source_node_skipped(session, current_user: User):
+    """Source nodes as MAY_AFFECT → skipped (no query to validate), passes through."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    parent_source, parent_source_rev = _make_node(
+        "ns.catalog_source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("id", IntegerType())],
+    )
+    # Another source that depends on the first (unusual but possible)
+    child_source, child_source_rev = _make_node(
+        "ns.derived_source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("id", IntegerType())],
+    )
+    await _persist(
+        session,
+        parent_source,
+        parent_source_rev,
+        child_source,
+        child_source_rev,
+    )
+    await _persist(session, _link(parent_source, child_source_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.catalog_source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.derived_source" in by_name
+    assert by_name["ns.derived_source"].impact_type == ImpactType.MAY_AFFECT
+    # Status should not change
+    assert child_source_rev.status == NodeStatus.VALID
+
+
+@pytest.mark.asyncio
+async def test_revalidation_three_level_cascade(session, current_user: User):
+    """Three-level chain: source → transform → metric.
+
+    Source column type changes (INT→BIGINT). Transform's output type changes.
+    Metric sees transform's updated type and its output type changes too.
+    """
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", BigIntType()), ("amount", DoubleType())],
+    )
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    metric, metric_rev = _make_node(
+        "ns.metric",
+        NodeType.METRIC,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT SUM(user_id) ns_DOT_metric FROM ns.transform",
+        columns=[("ns_DOT_metric", BigIntType())],
+    )
+    await _persist(
+        session,
+        source,
+        source_rev,
+        transform,
+        transform_rev,
+        metric,
+        metric_rev,
+    )
+    await _persist(
+        session,
+        _link(source, transform_rev),
+        _link(transform, metric_rev),
+    )
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    assert "ns.metric" in by_name
+
+    # Transform should have updated column types
+    transform_cols = {col.name: col.type for col in transform_rev.columns}
+    assert isinstance(transform_cols["user_id"], BigIntType)
+
+    # Metric should see the updated transform and still resolve
+    assert by_name["ns.metric"].impact_type in (
+        ImpactType.MAY_AFFECT,
+        ImpactType.WILL_RECOVER,
+    )
+
+
+@pytest.mark.asyncio
+async def test_revalidation_three_level_cascade_middle_breaks(
+    session,
+    current_user: User,
+):
+    """Three-level chain where middle node breaks.
+
+    Source column renamed → transform can't resolve → WILL_INVALIDATE.
+    Metric depends on transform → should also become WILL_INVALIDATE since
+    its parent is now INVALID.
+    """
+    session.add(NodeNamespace(namespace="ns"))
+
+    # Source renamed 'user_id' to 'uid'
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("uid", IntegerType()), ("amount", DoubleType())],
+    )
+    # Transform still references 'user_id'
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    metric, metric_rev = _make_node(
+        "ns.metric",
+        NodeType.METRIC,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT SUM(amount) ns_DOT_metric FROM ns.transform",
+        columns=[("ns_DOT_metric", DoubleType())],
+    )
+    await _persist(
+        session,
+        source,
+        source_rev,
+        transform,
+        transform_rev,
+        metric,
+        metric_rev,
+    )
+    await _persist(
+        session,
+        _link(source, transform_rev),
+        _link(transform, metric_rev),
+    )
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    assert "ns.metric" in by_name
+
+    # Transform breaks — column renamed
+    assert by_name["ns.transform"].impact_type == ImpactType.WILL_INVALIDATE
+    assert transform_rev.status == NodeStatus.INVALID
+
+    # Metric should also be WILL_INVALIDATE since its parent broke
+    assert by_name["ns.metric"].impact_type == ImpactType.WILL_INVALIDATE
+    assert metric_rev.status == NodeStatus.INVALID
+
+
+@pytest.mark.asyncio
+async def test_revalidation_recovery_with_column_type_change(
+    session,
+    current_user: User,
+):
+    """INVALID node recovers AND its column types change during recovery.
+
+    Source was updated (INT→BIGINT). Transform was INVALID but now resolves
+    with the new column types → WILL_RECOVER with updated columns.
+    """
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", BigIntType()), ("amount", DoubleType())],
+    )
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.INVALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    await _persist(session, source, source_rev, transform, transform_rev)
+    await _persist(session, _link(source, transform_rev))
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    impact = by_name["ns.transform"]
+    assert impact.impact_type == ImpactType.WILL_RECOVER
+    assert impact.current_status == NodeStatus.INVALID
+    assert impact.predicted_status == NodeStatus.VALID
+    assert transform_rev.status == NodeStatus.VALID
+    # Column types should be updated during recovery
+    col_types = {col.name: col.type for col in transform_rev.columns}
+    assert isinstance(col_types["user_id"], BigIntType)
+
+
+@pytest.mark.asyncio
+async def test_column_type_change_cascades_through_three_levels(
+    session,
+    current_user: User,
+):
+    """Column type changes propagate through multiple levels.
+
+    Source: user_id INT→BIGINT. Transform picks it up (INT→BIGINT).
+    Metric's SUM(user_id) output type also changes accordingly.
+    All nodes stay VALID, but types cascade downward.
+    """
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", BigIntType()), ("amount", DoubleType())],
+    )
+    transform, transform_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    metric, metric_rev = _make_node(
+        "ns.metric",
+        NodeType.METRIC,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT SUM(user_id) ns_DOT_metric FROM ns.transform",
+        columns=[("ns_DOT_metric", IntegerType())],
+    )
+    await _persist(
+        session,
+        source,
+        source_rev,
+        transform,
+        transform_rev,
+        metric,
+        metric_rev,
+    )
+    await _persist(
+        session,
+        _link(source, transform_rev),
+        _link(transform, metric_rev),
+    )
+
+    result = await propagate_impact(session, "ns", {"ns.source"})
+
+    by_name = {r.name: r for r in result}
+    # Transform's user_id should update from INT to BIGINT
+    assert by_name["ns.transform"].impact_type == ImpactType.MAY_AFFECT
+    transform_cols = {col.name: col.type for col in transform_rev.columns}
+    assert isinstance(transform_cols["user_id"], BigIntType)
+
+    # Metric's output type should also update (SUM(BIGINT) → BIGINT)
+    assert by_name["ns.metric"].impact_type == ImpactType.MAY_AFFECT
+    metric_cols = {col.name: col.type for col in metric_rev.columns}
+    assert isinstance(metric_cols["ns_DOT_metric"], BigIntType)
+
+
+@pytest.mark.asyncio
+async def test_mixed_valid_invalid_parents(session, current_user: User):
+    """Node with one VALID parent and one INVALID parent → WILL_INVALIDATE.
+
+    The INVALID parent is in failed_names, so its columns are excluded from the
+    parent_columns_map. The child's query references both parents → fails.
+    """
+    session.add(NodeNamespace(namespace="ns"))
+
+    valid_parent, valid_parent_rev = _make_node(
+        "ns.source_a",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("id", IntegerType())],
+    )
+    invalid_parent, invalid_parent_rev = _make_node(
+        "ns.source_b",
+        NodeType.SOURCE,
+        NodeStatus.INVALID,
+        current_user.id,
+        columns=[("name", StringType())],
+    )
+    child, child_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT a.id, b.name FROM ns.source_a a JOIN ns.source_b b ON a.id = b.id",
+        columns=[("id", IntegerType()), ("name", StringType())],
+    )
+    await _persist(
+        session,
+        valid_parent,
+        valid_parent_rev,
+        invalid_parent,
+        invalid_parent_rev,
+        child,
+        child_rev,
+    )
+    await _persist(
+        session,
+        _link(valid_parent, child_rev),
+        _link(invalid_parent, child_rev),
+    )
+
+    result = await propagate_impact(
+        session,
+        "ns",
+        {"ns.source_a", "ns.source_b"},
+    )
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    assert by_name["ns.transform"].impact_type == ImpactType.WILL_INVALIDATE
+    assert child_rev.status == NodeStatus.INVALID
+
+
+@pytest.mark.asyncio
+async def test_multiple_roots_same_downstream(session, current_user: User):
+    """Two changed parents both affect the same child — caused_by lists both."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    parent_a, parent_a_rev = _make_node(
+        "ns.source_a",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("id", IntegerType())],
+    )
+    parent_b, parent_b_rev = _make_node(
+        "ns.source_b",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("name", StringType())],
+    )
+    child, child_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT a.id, b.name FROM ns.source_a a JOIN ns.source_b b ON a.id = b.id",
+        columns=[("id", IntegerType()), ("name", StringType())],
+    )
+    await _persist(
+        session,
+        parent_a,
+        parent_a_rev,
+        parent_b,
+        parent_b_rev,
+        child,
+        child_rev,
+    )
+    await _persist(
+        session,
+        _link(parent_a, child_rev),
+        _link(parent_b, child_rev),
+    )
+
+    result = await propagate_impact(
+        session,
+        "ns",
+        {"ns.source_a", "ns.source_b"},
+    )
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    # Both roots should appear in caused_by
+    assert sorted(by_name["ns.transform"].caused_by) == [
+        "ns.source_a",
+        "ns.source_b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_propagate_impact_dimension_link_stub(session, current_user: User):
+    """Passing changed_link_node_names exercises the dimension link stub."""
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("id", IntegerType())],
+    )
+    await _persist(session, source, source_rev)
+
+    result = await propagate_impact(
+        session,
+        "ns",
+        set(),
+        frozenset(),
+        changed_link_node_names={"ns.source"},
+    )
+    assert result == []
+
+
+def test_merge_impacts_deduplicates_by_severity():
+    """_merge_impacts keeps the higher-severity impact when the same node appears in both."""
+    parent_impact = DownstreamImpact(
+        name="ns.child",
+        node_type=NodeType.TRANSFORM,
+        current_status=NodeStatus.VALID,
+        predicted_status=NodeStatus.VALID,
+        impact_type=ImpactType.MAY_AFFECT,
+        impact_reason="parent graph",
+        depth=1,
+        caused_by=["ns.root"],
+        is_external=False,
+    )
+    link_impact = DownstreamImpact(
+        name="ns.child",
+        node_type=NodeType.TRANSFORM,
+        current_status=NodeStatus.VALID,
+        predicted_status=NodeStatus.INVALID,
+        impact_type=ImpactType.WILL_INVALIDATE,
+        impact_reason="link graph",
+        depth=1,
+        caused_by=["ns.root"],
+        is_external=False,
+    )
+
+    # Higher severity (WILL_INVALIDATE) wins over MAY_AFFECT
+    merged = _merge_impacts([parent_impact], [link_impact])
+    assert len(merged) == 1
+    assert merged[0].impact_type == ImpactType.WILL_INVALIDATE
+    assert merged[0].impact_reason == "link graph"
+
+
+def test_merge_impacts_adds_new_from_link():
+    """_merge_impacts adds link-only impacts that don't appear in parent graph."""
+    parent_impact = DownstreamImpact(
+        name="ns.a",
+        node_type=NodeType.TRANSFORM,
+        current_status=NodeStatus.VALID,
+        predicted_status=NodeStatus.VALID,
+        impact_type=ImpactType.MAY_AFFECT,
+        impact_reason="parent graph",
+        depth=1,
+        caused_by=["ns.root"],
+        is_external=False,
+    )
+    link_only = DownstreamImpact(
+        name="ns.b",
+        node_type=NodeType.METRIC,
+        current_status=NodeStatus.VALID,
+        predicted_status=NodeStatus.VALID,
+        impact_type=ImpactType.MAY_AFFECT,
+        impact_reason="link graph",
+        depth=1,
+        caused_by=["ns.root"],
+        is_external=False,
+    )
+
+    merged = _merge_impacts([parent_impact], [link_only])
+    assert len(merged) == 2
+    by_name = {m.name: m for m in merged}
+    assert "ns.a" in by_name
+    assert "ns.b" in by_name
+
+
+def test_merge_impacts_lower_severity_kept():
+    """_merge_impacts keeps parent impact when link impact has lower severity."""
+    parent_impact = DownstreamImpact(
+        name="ns.child",
+        node_type=NodeType.TRANSFORM,
+        current_status=NodeStatus.VALID,
+        predicted_status=NodeStatus.INVALID,
+        impact_type=ImpactType.WILL_INVALIDATE,
+        impact_reason="parent graph",
+        depth=1,
+        caused_by=["ns.root"],
+        is_external=False,
+    )
+    link_impact = DownstreamImpact(
+        name="ns.child",
+        node_type=NodeType.TRANSFORM,
+        current_status=NodeStatus.VALID,
+        predicted_status=NodeStatus.VALID,
+        impact_type=ImpactType.MAY_AFFECT,
+        impact_reason="link graph",
+        depth=1,
+        caused_by=["ns.root"],
+        is_external=False,
+    )
+
+    merged = _merge_impacts([parent_impact], [link_impact])
+    assert len(merged) == 1
+    assert merged[0].impact_type == ImpactType.WILL_INVALIDATE
+    assert merged[0].impact_reason == "parent graph"

--- a/datajunction-server/tests/internal/impact_test.py
+++ b/datajunction-server/tests/internal/impact_test.py
@@ -2,6 +2,8 @@
 Unit tests for datajunction_server.internal.impact.propagate_impact
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from datajunction_server.database.column import Column as DBColumn
@@ -1127,3 +1129,60 @@ def test_merge_impacts_lower_severity_kept():
     assert len(merged) == 1
     assert merged[0].impact_type == ImpactType.WILL_INVALIDATE
     assert merged[0].impact_reason == "parent graph"
+
+
+@pytest.mark.asyncio
+async def test_propagate_impact_unparseable_query_falls_back_gracefully(
+    session,
+    current_user: User,
+):
+    """When a downstream node has a query that fails threadpool parsing,
+    the exception is caught (lines 381-382) and converted to None (line 404),
+    so the node falls back to inline parse in _revalidate_single_node.
+
+    We mock parse_query to raise for the child node to simulate an unparseable query.
+    """
+    session.add(NodeNamespace(namespace="ns"))
+
+    source, source_rev = _make_node(
+        "ns.source",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    # Child has a valid-looking query, but we'll make parse_query raise for it
+    child, child_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT user_id, amount FROM ns.source",
+        columns=[("user_id", IntegerType()), ("amount", DoubleType())],
+    )
+    await _persist(session, source, source_rev, child, child_rev)
+    await _persist(session, _link(source, child_rev))
+
+    original_parse_query = None
+
+    def _failing_parse_query(query_str):
+        """Simulate a parse failure for any query."""
+        raise RuntimeError("Simulated ANTLR parse failure")
+
+    with patch(
+        "datajunction_server.internal.impact.parse_query",
+        side_effect=_failing_parse_query,
+    ):
+        result = await propagate_impact(session, "ns", {"ns.source"})
+
+    # The child should still appear in results — the exception in threadpool parse
+    # is caught and the node falls back to inline parse (which also uses parse,
+    # but _revalidate_single_node catches inline parse failures too).
+    # The node should be handled gracefully, not crash.
+    assert len(result) >= 1
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    impact = by_name["ns.transform"]
+    # The node should either be MAY_AFFECT (if inline parse succeeds)
+    # or WILL_INVALIDATE (if inline parse also fails)
+    assert impact.impact_type in (ImpactType.MAY_AFFECT, ImpactType.WILL_INVALIDATE)


### PR DESCRIPTION
### Summary

#### Performance Improvements

Deployments of ~500 nodes dropped from ~23s to ~12s. The main optimizations:
- Cache parsed ASTs on specs, since `extract_node_graph` already parses every query via ANTLR to extract dependencies. The parsed ASTs are now cached on `spec._query_ast` and reused later, eliminating a full second parse pass that was taking ~6.5s.
- Remove `ThreadPoolExecutor` from graph extraction: ANTLR parsing is CPU-bound and given the GIL lock, the threadpool only added context-switching overhead.
- Single dependency load: `get_dependencies` was called per topological level and is now called once before the level loop with results updated incrementally.
- Wrap link validation in `fast_parse_mode`, which skips parent-pointer wiring during AST construction for ~10% parse speedup on dimension link validation.
- Add `DeploymentTimer`, which logs a timing summary table at the end of each deployment showing where time was spent, e.g.:
```
    build plan                                   6611ms  420 to deploy  (46%)
    deploy nodes                                 2550ms  398 nodes  (21%)
    deploy links                                 1010ms  479 links  (8%)
    deploy cubes                                 2121ms  22 cubes  (15%)
    propagate impact                               85ms  0 downstream  (1%)
    TOTAL                                       12639ms
```
- Remove dead code like `validate_dimension_link`, `validate_dimension_links`, and `validate_node_dimension_links_batch`

#### Propagate Impact Changes

This PR splits the `propagate_impact` function into three phases:

1. `_propagate_via_parent_graph`: This does a BFS through the SQL parent graph. It has the same logic as before but we've now extracted it into a pure function that returns impacts without DB mutations.
2. `_propagate_via_dimension_links`: This is a stub for dimension link graph traversal, which we'll implement in a follow-up PR.
3. `_revalidate_and_apply`: Revalidates affected nodes using the lightweight `resolve_output_columns` type inference (from #1992). This handles:
    - Recovery: invalid nodes whose parents are now valid get revalidated. If the query resolves, they recover to valid.
    - Column change detection: valid nodes whose parent column types changed get their output columns re-inferred and updated.
    - Cascading invalidation: if a node fails revalidation at depth N, its children at depth N+1 are automatically marked invalid without attempting revalidation.
    - Fast-path skip: source nodes and nodes with unchanged column signatures pass through without revalidation.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #1975 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
