### PR TITLE
Rename `resolve_output_columns` to `validate_node_query` with full query validation

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -25,6 +25,7 @@ from datajunction_server.sql.parsing.types import (
     MapType,
     NullType,
     StringType,
+    StructType,
     UnknownType,
 )
 
@@ -434,6 +435,31 @@ def _resolve_wildcard(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_struct_field(
+    struct_col_name: str,
+    field_name: str,
+    tables: TableScope,
+) -> Optional[ColumnType]:
+    """Try to resolve a struct field access like metadata.name.
+
+    Searches all tables for a column named struct_col_name. If found and
+    the column's type is a StructType, looks up field_name in its fields.
+    Returns the field type, or raises TypeResolutionError if the struct
+    exists but the field doesn't. Returns None if no struct column found.
+    """
+    for table_cols in tables.values():
+        if struct_col_name in table_cols:
+            col_type = table_cols[struct_col_name]
+            if isinstance(col_type, StructType):
+                if field_name in col_type.fields_mapping:
+                    return col_type.fields_mapping[field_name].type
+                raise TypeResolutionError(
+                    f"Field `{field_name}` not found in struct column `{struct_col_name}`. "
+                    f"Available fields: {list(col_type.fields_mapping.keys())}",
+                )
+    return None
+
+
 def _validate_non_projection_clauses(select: ast.Select, scope: TypeScope):
     """Validate column references in WHERE, GROUP BY, HAVING, ORDER BY, and JOINs.
 
@@ -574,6 +600,13 @@ def _resolve_column_type(
                 f"Column `{col_name}` not found in table `{table_alias}`. "
                 f"Available: {list(scope.tables[table_alias].keys())}",
             )
+
+        # Check if this is a struct field access (e.g., metadata.name where
+        # metadata is a StructType column). The namespace would be the column
+        # name, and col_name would be the struct field name.
+        struct_result = _resolve_struct_field(table_alias, col_name, scope.tables)
+        if struct_result is not None:
+            return struct_result
 
         # Multi-part namespace not matching any FROM table - likely a DJ
         # dimension attribute reference (e.g., ads.report.dim.date.year).

--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -20,6 +20,9 @@ from datajunction_server.errors import DJNotImplementedException
 from datajunction_server.sql.parsing.types import (
     BooleanType,
     ColumnType,
+    IntegerType,
+    ListType,
+    MapType,
     NullType,
     StringType,
     UnknownType,
@@ -63,20 +66,6 @@ class QueryValidationResult:
 
 class TypeResolutionError(Exception):
     """Raised when type resolution fails (missing table, missing column, etc.)."""
-
-
-def resolve_output_columns(
-    query_str: str,
-    parent_columns_map: ParentColumnsMap,
-) -> OutputColumns:
-    """Convenience wrapper — raises TypeResolutionError on first error.
-
-    Prefer validate_node_query for new code.
-    """
-    result = validate_node_query(query_str, parent_columns_map)
-    if result.errors:
-        raise TypeResolutionError("; ".join(result.errors))
-    return result.output_columns
 
 
 def validate_node_query(
@@ -147,11 +136,15 @@ def _resolve_query(
         return [], []
 
     try:
-        tables = _build_table_scope(select, parent_columns_map, cte_registry)
+        tables, table_errors = _build_table_scope(
+            select,
+            parent_columns_map,
+            cte_registry,
+        )
     except TypeResolutionError as exc:
         return [], [str(exc)]
 
-    scope = TypeScope(tables=tables, parent_map=parent_columns_map)
+    scope = TypeScope(tables=tables, parent_map=parent_columns_map, errors=table_errors)
 
     output: OutputColumns = []
     for expr in select.projection:
@@ -162,6 +155,15 @@ def _resolve_query(
 
     # Validate column references in non-projection clauses
     _validate_non_projection_clauses(select, scope)
+
+    # Validate set operations (UNION/EXCEPT/INTERSECT right side)
+    if select.set_op and select.set_op.right:
+        _, set_op_errors = _resolve_query(
+            ast.Query(select=select.set_op.right),
+            parent_columns_map,
+            cte_registry,
+        )
+        scope.errors.extend(set_op_errors)
 
     return output, scope.errors
 
@@ -211,22 +213,27 @@ def _build_table_scope(
     select: ast.Select,
     parent_columns_map: ParentColumnsMap,
     cte_registry: dict[str, OutputColumns],
-) -> TableScope:
+) -> tuple[TableScope, list[str]]:
     """
     Build a mapping of table alias/name → {column_name: column_type} for all
-    tables available in this query's scope.
+    tables available in this query's scope. Returns (scope, errors).
     """
     if select.from_ is None:
-        return {"__derived__": _build_derived_scope(parent_columns_map)}
+        return {"__derived__": _build_derived_scope(parent_columns_map)}, []
 
     scope: TableScope = {}
+    errors: list[str] = []
     for relation in select.from_.relations:
-        scope.update(
-            _collect_tables_from_relation(relation, parent_columns_map, cte_registry),
+        tables, errs = _collect_tables_from_relation(
+            relation,
+            parent_columns_map,
+            cte_registry,
         )
+        scope.update(tables)
+        errors.extend(errs)
     for view in select.lateral_views:
         scope.update(_collect_lateral_view_columns(view, scope))
-    return scope
+    return scope, errors
 
 
 def _build_derived_scope(parent_columns_map: ParentColumnsMap) -> dict[str, ColumnType]:
@@ -248,27 +255,28 @@ def _collect_tables_from_relation(
     node: ast.Node,
     parent_columns_map: ParentColumnsMap,
     cte_registry: dict[str, OutputColumns],
-) -> TableScope:
-    """Collect table scopes from a FROM relation. Returns discovered tables."""
+) -> tuple[TableScope, list[str]]:
+    """Collect table scopes from a FROM relation. Returns (tables, errors)."""
     result: TableScope = {}
+    errors: list[str] = []
 
     if isinstance(node, ast.Relation):
-        result.update(
-            _collect_tables_from_relation(
-                node.primary,
-                parent_columns_map,
-                cte_registry,
-            ),
+        tables, errs = _collect_tables_from_relation(
+            node.primary,
+            parent_columns_map,
+            cte_registry,
         )
+        result.update(tables)
+        errors.extend(errs)
         for ext in node.extensions:
             if isinstance(ext, ast.Join):  # pragma: no branch
-                result.update(
-                    _collect_tables_from_relation(
-                        ext.right,
-                        parent_columns_map,
-                        cte_registry,
-                    ),
+                tables, errs = _collect_tables_from_relation(
+                    ext.right,
+                    parent_columns_map,
+                    cte_registry,
                 )
+                result.update(tables)
+                errors.extend(errs)
 
     elif isinstance(node, ast.Table):
         table_name = node.identifier(quotes=False)
@@ -286,8 +294,9 @@ def _collect_tables_from_relation(
 
     elif isinstance(node, ast.Query):
         sub_alias = node.alias.name if node.alias else "__subquery__"
-        sub_columns, _ = _resolve_query(node, parent_columns_map, cte_registry)
+        sub_columns, sub_errors = _resolve_query(node, parent_columns_map, cte_registry)
         result[sub_alias] = {name: typ for name, typ in sub_columns}
+        errors.extend(sub_errors)
 
     elif isinstance(node, ast.FunctionTableExpression):  # pragma: no branch
         alias = node.alias.name if node.alias else "__func_table__"
@@ -295,47 +304,36 @@ def _collect_tables_from_relation(
         if func_cols:  # pragma: no branch
             result[alias] = func_cols
 
-    return result
+    return result, errors
 
 
 def _collect_lateral_view_columns(
     view: ast.LateralView,
     from_scope: TableScope,
 ) -> TableScope:
-    """
-    Collect columns from a LATERAL VIEW (e.g., EXPLODE) expression.
-    Returns {alias: {col_name: type}} for the exploded columns.
+    """Collect columns from a LATERAL VIEW (e.g., EXPLODE) expression.
 
-    Attempts to resolve actual element types from the source column's
-    ListType/MapType. Falls back to UnknownType if the source type
-    can't be determined.
+    Resolves element types from the source column's ListType/MapType
+    when possible, falls back to UnknownType otherwise.
     """
-
     func = view.func
     alias = func.alias.name if func.alias else "__lateral__"
     col_list = func.column_list or []
     if not col_list:
         return {}
 
-    # Try to resolve the element type from the EXPLODE/POSEXPLODE arg
     element_types = _resolve_lateral_element_types(func, from_scope)
-
     func_name = func.name.name.upper() if hasattr(func, "name") and func.name else ""
     is_posexplode = "POS" in func_name
 
     lateral_cols: dict[str, ColumnType] = {}
     for i, col in enumerate(col_list):
-        if element_types:
-            if is_posexplode and i == 0:
-                from datajunction_server.sql.parsing.types import IntegerType
-
-                lateral_cols[col.name.name] = IntegerType()
-            elif is_posexplode and i == 1 and len(element_types) >= 1:
-                lateral_cols[col.name.name] = element_types[0]
-            elif not is_posexplode and i < len(element_types):
-                lateral_cols[col.name.name] = element_types[i]
-            else:
-                lateral_cols[col.name.name] = UnknownType()
+        if is_posexplode and i == 0:
+            lateral_cols[col.name.name] = IntegerType()
+        elif is_posexplode and i == 1 and element_types:
+            lateral_cols[col.name.name] = element_types[0]
+        elif not is_posexplode and i < len(element_types):
+            lateral_cols[col.name.name] = element_types[i]
         else:
             lateral_cols[col.name.name] = UnknownType()
 
@@ -346,22 +344,11 @@ def _resolve_lateral_element_types(
     func: ast.FunctionTableExpression,
     from_scope: TableScope,
 ) -> list[ColumnType]:
-    """Try to resolve the element types for an EXPLODE/UNNEST function.
-
-    Returns a list of ColumnType for the exploded columns, or empty list
-    if the source type can't be determined.
-    """
-    from datajunction_server.sql.parsing.types import ListType, MapType
-
-    if not func.args:
+    """Resolve element types for an EXPLODE/UNNEST function argument."""
+    if not func.args or not isinstance(func.args[0], ast.Column):
         return []
 
-    arg = func.args[0]
-    if not isinstance(arg, ast.Column):
-        return []
-
-    # Look up the column's type from the FROM scope
-    col_name = arg.name.name
+    col_name = func.args[0].name.name
     for table_cols in from_scope.values():
         if col_name in table_cols:
             col_type = table_cols[col_name]
@@ -370,7 +357,6 @@ def _resolve_lateral_element_types(
             if isinstance(col_type, MapType):
                 return [col_type.key.type, col_type.value.type]
             return []
-
     return []
 
 
@@ -411,6 +397,14 @@ def _resolve_projection_expr(
     if isinstance(expr, ast.Column):
         col_type = _resolve_column_type(expr, scope)
         return [(output_name, col_type)]
+
+    # Scalar subquery in projection: (SELECT ... ) AS alias
+    if isinstance(expr, ast.Query):
+        sub_columns, sub_errors = _resolve_query(expr, scope.parent_map, {})
+        scope.errors.extend(sub_errors)
+        if sub_columns:
+            return [(output_name, sub_columns[0][1])]
+        return [(output_name, UnknownType())]
 
     # For expressions (Function, BinaryOp, Cast, literals, etc.)
     col_type = _resolve_expr_type(expr, scope)
@@ -465,6 +459,16 @@ def _validate_non_projection_clauses(select: ast.Select, scope: TypeScope):
     if select.from_:
         for relation in select.from_.relations:
             _collect_join_conditions(relation, clauses_to_check)
+
+    # Window function OVER clauses (PARTITION BY, ORDER BY)
+    for proj_item in select.projection:
+        proj_node: ast.Node = proj_item  # type: ignore[assignment]
+        for func in proj_node.find_all(ast.Function):
+            if hasattr(func, "over") and func.over:
+                for partition_expr in func.over.partition_by:
+                    clauses_to_check.append(partition_expr)
+                for sort_item in func.over.order_by:
+                    clauses_to_check.append(sort_item.expr)
 
     for clause in clauses_to_check:
         _validate_columns_in_clause(clause, scope)
@@ -621,7 +625,7 @@ def _resolve_expr_type(
     Note: may mutate _type on AST Column nodes as a side effect, since the
     AST's built-in type properties (Function.infer_type, BinaryOp.type, etc.)
     read _type from child nodes. The AST is throwaway — parsed fresh per
-    resolve_output_columns call.
+    validate_node_query call.
     """
     if isinstance(expr, ast.Column):
         return _resolve_column_type(expr, scope)
@@ -707,14 +711,15 @@ def _prepare_function_arg_types(
     Set _type on function argument AST nodes so Function.infer_type can dispatch.
 
     Mutates the AST in place. This is intentional - the AST is a throwaway object
-    created per resolve_output_columns call and discarded after.
+    created per validate_node_query call and discarded after.
     """
     for arg in func.args:
         if isinstance(arg, ast.Column) and arg._type is None:
             try:
                 arg._type = _resolve_column_type(arg, scope)
-            except TypeResolutionError:
+            except TypeResolutionError as exc:
                 arg._type = UnknownType()
+                scope.errors.append(str(exc))
         elif isinstance(arg, ast.Function):
             _prepare_function_arg_types(arg, scope)
         elif isinstance(arg, (ast.Wildcard, ast.Number, ast.String)):
@@ -736,8 +741,9 @@ def _prepare_column_types_recursive(
     if isinstance(node, ast.Column) and node._type is None:
         try:
             node._type = _resolve_column_type(node, scope)
-        except TypeResolutionError:
+        except TypeResolutionError as exc:
             node._type = UnknownType()
+            scope.errors.append(str(exc))
     if isinstance(node, ast.Function):
         _prepare_function_arg_types(node, scope)
         return

--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -49,6 +49,17 @@ class TypeScope:
     # in FROM but can be referenced via dimension attributes.
     parent_map: ParentColumnsMap = field(default_factory=dict)
 
+    # Collected errors during resolution (instead of raising immediately)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class QueryValidationResult:
+    """Result of validating a node's query."""
+
+    output_columns: OutputColumns
+    errors: list[str] = field(default_factory=list)
+
 
 class TypeResolutionError(Exception):
     """Raised when type resolution fails (missing table, missing column, etc.)."""
@@ -58,8 +69,28 @@ def resolve_output_columns(
     query_str: str,
     parent_columns_map: ParentColumnsMap,
 ) -> OutputColumns:
+    """Convenience wrapper — raises TypeResolutionError on first error.
+
+    Prefer validate_node_query for new code.
     """
-    Resolve output column names and types for a SQL query.
+    result = validate_node_query(query_str, parent_columns_map)
+    if result.errors:
+        raise TypeResolutionError("; ".join(result.errors))
+    return result.output_columns
+
+
+def validate_node_query(
+    query_str: str,
+    parent_columns_map: ParentColumnsMap,
+) -> QueryValidationResult:
+    """
+    Validate that all column references in a SQL query resolve against
+    the provided parent columns, and return the output column types.
+
+    Checks all clauses: SELECT, WHERE, GROUP BY, HAVING, ORDER BY,
+    JOIN conditions, and CTE internals.
+
+    Collects all errors rather than stopping at the first one.
 
     Args:
         query_str: The SQL query to analyze.
@@ -67,45 +98,72 @@ def resolve_output_columns(
             column name→type mappings.
 
     Returns:
-        List of (column_name, column_type) for each projection column.
-
-    Raises:
-        TypeResolutionError: If a referenced table or column cannot be resolved.
+        QueryValidationResult with output_columns and any errors found.
     """
     try:
         query = parse(query_str)
     except Exception as exc:
-        raise TypeResolutionError(f"Failed to parse query: {exc}") from exc
+        return QueryValidationResult(
+            output_columns=[],
+            errors=[f"Failed to parse query: {exc}"],
+        )
 
     cte_registry: dict[str, OutputColumns] = {}
+    all_errors: list[str] = []
+
     for cte in query.ctes:
         cte_name = cte.alias_or_name.name
-        cte_columns = _resolve_query(cte, parent_columns_map, cte_registry)
+        cte_columns, cte_errors = _resolve_query(cte, parent_columns_map, cte_registry)
         cte_registry[cte_name] = cte_columns
+        all_errors.extend(cte_errors)
 
-    return _resolve_query(query, parent_columns_map, cte_registry)
+    output_columns, query_errors = _resolve_query(
+        query,
+        parent_columns_map,
+        cte_registry,
+    )
+    all_errors.extend(query_errors)
+
+    return QueryValidationResult(
+        output_columns=output_columns,
+        errors=all_errors,
+    )
 
 
 def _resolve_query(
     query: ast.Query,
     parent_columns_map: ParentColumnsMap,
     cte_registry: dict[str, OutputColumns],
-) -> OutputColumns:
-    """Resolve output columns for a single query (may be a subquery or CTE)."""
+) -> tuple[OutputColumns, list[str]]:
+    """Resolve output columns for a single query (may be a subquery or CTE).
+
+    Returns (output_columns, errors) — collects errors instead of raising.
+    """
     select = query.select
     if isinstance(select, ast.InlineTable):
-        return _resolve_inline_table(query)
+        return _resolve_inline_table(query), []
 
     if not isinstance(select, ast.Select):  # pragma: no cover
-        return []
+        return [], []
 
-    tables = _build_table_scope(select, parent_columns_map, cte_registry)
+    try:
+        tables = _build_table_scope(select, parent_columns_map, cte_registry)
+    except TypeResolutionError as exc:
+        return [], [str(exc)]
+
     scope = TypeScope(tables=tables, parent_map=parent_columns_map)
 
     output: OutputColumns = []
     for expr in select.projection:
-        output.extend(_resolve_projection_expr(expr, scope))
-    return output
+        try:
+            output.extend(_resolve_projection_expr(expr, scope))
+        except TypeResolutionError as exc:
+            scope.errors.append(str(exc))
+
+    # Validate column references in non-projection clauses
+    _validate_non_projection_clauses(select, scope)
+
+    return output, scope.errors
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +225,7 @@ def _build_table_scope(
             _collect_tables_from_relation(relation, parent_columns_map, cte_registry),
         )
     for view in select.lateral_views:
-        scope.update(_collect_lateral_view_columns(view))
+        scope.update(_collect_lateral_view_columns(view, scope))
     return scope
 
 
@@ -228,7 +286,7 @@ def _collect_tables_from_relation(
 
     elif isinstance(node, ast.Query):
         sub_alias = node.alias.name if node.alias else "__subquery__"
-        sub_columns = _resolve_query(node, parent_columns_map, cte_registry)
+        sub_columns, _ = _resolve_query(node, parent_columns_map, cte_registry)
         result[sub_alias] = {name: typ for name, typ in sub_columns}
 
     elif isinstance(node, ast.FunctionTableExpression):  # pragma: no branch
@@ -240,17 +298,80 @@ def _collect_tables_from_relation(
     return result
 
 
-def _collect_lateral_view_columns(view: ast.LateralView) -> TableScope:
+def _collect_lateral_view_columns(
+    view: ast.LateralView,
+    from_scope: TableScope,
+) -> TableScope:
     """
     Collect columns from a LATERAL VIEW (e.g., EXPLODE) expression.
     Returns {alias: {col_name: type}} for the exploded columns.
+
+    Attempts to resolve actual element types from the source column's
+    ListType/MapType. Falls back to UnknownType if the source type
+    can't be determined.
     """
+
     func = view.func
     alias = func.alias.name if func.alias else "__lateral__"
-    lateral_cols = {col.name.name: UnknownType() for col in (func.column_list or [])}
-    if lateral_cols:
-        return {alias: lateral_cols}
-    return {}
+    col_list = func.column_list or []
+    if not col_list:
+        return {}
+
+    # Try to resolve the element type from the EXPLODE/POSEXPLODE arg
+    element_types = _resolve_lateral_element_types(func, from_scope)
+
+    func_name = func.name.name.upper() if hasattr(func, "name") and func.name else ""
+    is_posexplode = "POS" in func_name
+
+    lateral_cols: dict[str, ColumnType] = {}
+    for i, col in enumerate(col_list):
+        if element_types:
+            if is_posexplode and i == 0:
+                from datajunction_server.sql.parsing.types import IntegerType
+
+                lateral_cols[col.name.name] = IntegerType()
+            elif is_posexplode and i == 1 and len(element_types) >= 1:
+                lateral_cols[col.name.name] = element_types[0]
+            elif not is_posexplode and i < len(element_types):
+                lateral_cols[col.name.name] = element_types[i]
+            else:
+                lateral_cols[col.name.name] = UnknownType()
+        else:
+            lateral_cols[col.name.name] = UnknownType()
+
+    return {alias: lateral_cols}
+
+
+def _resolve_lateral_element_types(
+    func: ast.FunctionTableExpression,
+    from_scope: TableScope,
+) -> list[ColumnType]:
+    """Try to resolve the element types for an EXPLODE/UNNEST function.
+
+    Returns a list of ColumnType for the exploded columns, or empty list
+    if the source type can't be determined.
+    """
+    from datajunction_server.sql.parsing.types import ListType, MapType
+
+    if not func.args:
+        return []
+
+    arg = func.args[0]
+    if not isinstance(arg, ast.Column):
+        return []
+
+    # Look up the column's type from the FROM scope
+    col_name = arg.name.name
+    for table_cols in from_scope.values():
+        if col_name in table_cols:
+            col_type = table_cols[col_name]
+            if isinstance(col_type, ListType):
+                return [col_type.element.type]
+            if isinstance(col_type, MapType):
+                return [col_type.key.type, col_type.value.type]
+            return []
+
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +433,69 @@ def _resolve_wildcard(
     for cols in tables.values():
         result.extend(cols.items())
     return result
+
+
+# ---------------------------------------------------------------------------
+# Non-projection clause validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_non_projection_clauses(select: ast.Select, scope: TypeScope):
+    """Validate column references in WHERE, GROUP BY, HAVING, ORDER BY, and JOINs.
+
+    Only validates columns that belong to this query's scope — columns inside
+    nested subqueries are validated when those subqueries are resolved.
+
+    Appends errors to scope.errors instead of raising.
+    """
+    clauses_to_check: list[ast.Node] = []
+
+    if select.where:
+        clauses_to_check.append(select.where)
+    for expr in select.group_by:
+        clauses_to_check.append(expr)
+    if select.having:
+        clauses_to_check.append(select.having)
+    if select.organization:
+        for item in select.organization.order:
+            clauses_to_check.append(item.expr)
+        for item in select.organization.sort:
+            clauses_to_check.append(item.expr)
+
+    if select.from_:
+        for relation in select.from_.relations:
+            _collect_join_conditions(relation, clauses_to_check)
+
+    for clause in clauses_to_check:
+        _validate_columns_in_clause(clause, scope)
+
+
+def _validate_columns_in_clause(clause: ast.Node, scope: TypeScope):
+    """Validate column references in a clause, skipping nested subqueries.
+
+    Walks the AST but stops recursing when it hits a Query or Select node
+    (subquery). Appends errors to scope.errors.
+    """
+    if isinstance(clause, (ast.Query, ast.Select)):
+        return
+    if isinstance(clause, ast.Column):
+        try:
+            _resolve_column_type(clause, scope)
+        except TypeResolutionError as exc:
+            scope.errors.append(str(exc))
+        return
+    for child in clause.children:
+        _validate_columns_in_clause(child, scope)
+
+
+def _collect_join_conditions(node: ast.Node, conditions: list[ast.Node]):
+    """Recursively collect JOIN ON conditions from a relation."""
+    if isinstance(node, ast.Relation):
+        for ext in node.extensions:
+            if isinstance(ext, ast.Join):
+                if ext.criteria and ext.criteria.on:
+                    conditions.append(ext.criteria.on)
+                _collect_join_conditions(ext.right, conditions)
 
 
 # ---------------------------------------------------------------------------

--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -347,7 +347,7 @@ def _resolve_lateral_element_types(
 ) -> list[ColumnType]:
     """Resolve element types for an EXPLODE/UNNEST function argument."""
     if not func.args or not isinstance(func.args[0], ast.Column):
-        return []
+        return []  # pragma: no cover
 
     col_name = func.args[0].name.name
     for table_cols in from_scope.values():
@@ -405,7 +405,7 @@ def _resolve_projection_expr(
         scope.errors.extend(sub_errors)
         if sub_columns:
             return [(output_name, sub_columns[0][1])]
-        return [(output_name, UnknownType())]
+        return [(output_name, UnknownType())]  # pragma: no cover
 
     # For expressions (Function, BinaryOp, Cast, literals, etc.)
     col_type = _resolve_expr_type(expr, scope)
@@ -450,7 +450,7 @@ def _resolve_struct_field(
     for table_cols in tables.values():
         if struct_col_name in table_cols:
             col_type = table_cols[struct_col_name]
-            if isinstance(col_type, StructType):
+            if isinstance(col_type, StructType):  # pragma: no branch
                 if field_name in col_type.fields_mapping:
                     return col_type.fields_mapping[field_name].type
                 raise TypeResolutionError(
@@ -522,7 +522,7 @@ def _collect_join_conditions(node: ast.Node, conditions: list[ast.Node]):
     """Recursively collect JOIN ON conditions from a relation."""
     if isinstance(node, ast.Relation):
         for ext in node.extensions:
-            if isinstance(ext, ast.Join):
+            if isinstance(ext, ast.Join):  # pragma: no branch
                 if ext.criteria and ext.criteria.on:
                     conditions.append(ext.criteria.on)
                 _collect_join_conditions(ext.right, conditions)

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -800,6 +800,51 @@ class TestTableValuedFunctions:
         assert result[1][0] == "pos"
         assert result[2][0] == "tag"
 
+    def test_explode_with_list_type(self):
+        """EXPLODE on a ListType column → element type is resolved."""
+        from datajunction_server.sql.parsing.types import ListType
+
+        typed_events = _col_map(
+            (
+                "default.events",
+                [
+                    ("event_id", IntegerType()),
+                    ("tags", ListType(element_type=StringType())),
+                ],
+            ),
+        )
+        result = resolve_output_columns(
+            "SELECT event_id, tag "
+            "FROM default.events "
+            "LATERAL VIEW EXPLODE(tags) t AS tag",
+            typed_events,
+        )
+        assert result[0] == ("event_id", IntegerType())
+        assert result[1] == ("tag", StringType())
+
+    def test_posexplode_with_list_type(self):
+        """POSEXPLODE on a ListType → pos is IntegerType, element is resolved."""
+        from datajunction_server.sql.parsing.types import ListType
+
+        typed_events = _col_map(
+            (
+                "default.events",
+                [
+                    ("event_id", IntegerType()),
+                    ("tags", ListType(element_type=StringType())),
+                ],
+            ),
+        )
+        result = resolve_output_columns(
+            "SELECT event_id, pos, tag "
+            "FROM default.events "
+            "LATERAL VIEW POSEXPLODE(tags) t AS pos, tag",
+            typed_events,
+        )
+        assert result[0] == ("event_id", IntegerType())
+        assert result[1] == ("pos", IntegerType())
+        assert result[2] == ("tag", StringType())
+
     def test_cross_join_unnest(self):
         murals = _col_map(
             ("default.murals", [("mural_id", IntegerType()), ("colors", StringType())]),
@@ -941,6 +986,51 @@ class TestInlineTable:
 
 
 class TestNonProjectionClauses:
+    def test_where_valid_column(self):
+        result = resolve_output_columns(
+            "SELECT username FROM default.users WHERE user_id > 10",
+            _col_map(USERS_COLS),
+        )
+        assert result[0] == ("username", StringType())
+
+    def test_where_invalid_column(self):
+        with pytest.raises(TypeResolutionError, match="nonexistent"):
+            resolve_output_columns(
+                "SELECT user_id FROM default.users WHERE nonexistent > 5",
+                _col_map(USERS_COLS),
+            )
+
+    def test_group_by_invalid_column(self):
+        with pytest.raises(TypeResolutionError, match="nonexistent"):
+            resolve_output_columns(
+                "SELECT user_id, COUNT(*) AS cnt "
+                "FROM default.orders GROUP BY nonexistent",
+                _col_map(ORDERS_COLS),
+            )
+
+    def test_having_invalid_column(self):
+        with pytest.raises(TypeResolutionError, match="nonexistent"):
+            resolve_output_columns(
+                "SELECT user_id FROM default.orders "
+                "GROUP BY user_id HAVING SUM(nonexistent) > 1",
+                _col_map(ORDERS_COLS),
+            )
+
+    def test_order_by_invalid_column(self):
+        with pytest.raises(TypeResolutionError, match="nonexistent"):
+            resolve_output_columns(
+                "SELECT user_id FROM default.orders ORDER BY nonexistent",
+                _col_map(ORDERS_COLS),
+            )
+
+    def test_join_condition_invalid_column(self):
+        with pytest.raises(TypeResolutionError, match="nonexistent"):
+            resolve_output_columns(
+                "SELECT u.user_id FROM default.users u "
+                "JOIN default.orders o ON u.user_id = o.nonexistent",
+                _col_map(USERS_COLS, ORDERS_COLS),
+            )
+
     def test_where_doesnt_add_columns(self):
         result = resolve_output_columns(
             "SELECT username FROM default.users WHERE user_id > 10",

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -1,17 +1,17 @@
 """
 Unit tests for the lightweight top-down type inference used by deployment propagation.
 
-resolve_output_columns takes a SQL query string and a map of parent node columns,
+validate_node_query takes a SQL query string and a map of parent node columns,
 and returns the output column names + types without any DB calls.
 """
 
-import pytest
-
 from datajunction_server.internal.deployment.type_inference import (
     columns_signature_changed,
-    resolve_output_columns,
+    validate_node_query,
     TypeResolutionError,
 )
+
+
 from datajunction_server.sql.parsing.types import (
     BigIntType,
     BooleanType,
@@ -74,31 +74,31 @@ ARRAY_NODE_COLS = (
 
 class TestSimpleSelect:
     def test_select_columns(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id, username FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("username", StringType()),
         ]
 
     def test_select_with_alias(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id AS id, username AS name FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("id", IntegerType()),
             ("name", StringType()),
         ]
 
     def test_select_star(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT * FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("username", StringType()),
             ("email", StringType()),
@@ -106,11 +106,11 @@ class TestSimpleSelect:
         ]
 
     def test_qualified_wildcard(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT u.* FROM default.users u",
             _col_map(USERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("username", StringType()),
             ("email", StringType()),
@@ -119,12 +119,12 @@ class TestSimpleSelect:
 
     def test_qualified_wildcard_multi_table(self):
         """SELECT u.* should only return users columns, not orders."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT u.* FROM default.users u "
             "JOIN default.orders o ON u.user_id = o.user_id",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("username", StringType()),
             ("email", StringType()),
@@ -132,11 +132,11 @@ class TestSimpleSelect:
         ]
 
     def test_both_table_stars(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT u.*, o.* FROM default.users u, default.orders o",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("username", StringType()),
             ("email", StringType()),
@@ -149,11 +149,11 @@ class TestSimpleSelect:
 
     def test_missing_wildcard_alias_falls_through(self):
         """SELECT missing.* falls through to all-table expansion."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT missing.* FROM default.users u",
             _col_map(USERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("username", StringType()),
             ("email", StringType()),
@@ -168,47 +168,47 @@ class TestSimpleSelect:
 
 class TestMultiTable:
     def test_qualified_columns(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT u.user_id, o.amount FROM default.users u, default.orders o",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("amount", DoubleType()),
         ]
 
     def test_unqualified_unambiguous(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT username, amount "
             "FROM default.users u "
             "JOIN default.orders o ON u.user_id = o.user_id",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("username", StringType()),
             ("amount", DoubleType()),
         ]
 
     def test_join_columns(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT u.username, o.amount "
             "FROM default.users u "
             "JOIN default.orders o ON u.user_id = o.user_id",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("username", StringType()),
             ("amount", DoubleType()),
         ]
 
     def test_self_join(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT a.user_id, b.username "
             "FROM default.users a "
             "JOIN default.users b ON a.user_id = b.user_id",
             _col_map(USERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("username", StringType()),
         ]
@@ -221,49 +221,49 @@ class TestMultiTable:
 
 class TestAggregations:
     def test_count_star(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT COUNT(*) AS cnt FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("cnt", BigIntType())
+        assert result.output_columns[0] == ("cnt", BigIntType())
 
     def test_sum(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(amount) AS total FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("total", DoubleType())
+        assert result.output_columns[0] == ("total", DoubleType())
 
     def test_avg(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT AVG(amount) AS avg_amount FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0][0] == "avg_amount"
-        assert isinstance(result[0][1], DoubleType)
+        assert result.output_columns[0][0] == "avg_amount"
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_group_by_with_agg(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id, SUM(amount) AS total FROM default.orders GROUP BY user_id",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
-        assert result[1][0] == "total"
-        assert isinstance(result[1][1], DoubleType)
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1][0] == "total"
+        assert isinstance(result.output_columns[1][1], DoubleType)
 
     def test_count_distinct(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT COUNT(DISTINCT user_id) AS unique_users FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("unique_users", BigIntType())
+        assert result.output_columns[0] == ("unique_users", BigIntType())
 
     def test_select_distinct(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT DISTINCT user_id FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
+        assert result.output_columns[0] == ("user_id", IntegerType())
 
 
 # ---------------------------------------------------------------------------
@@ -273,71 +273,71 @@ class TestAggregations:
 
 class TestExpressions:
     def test_arithmetic(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT amount * 2 AS doubled FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0][0] == "doubled"
-        assert isinstance(result[0][1], DoubleType)
+        assert result.output_columns[0][0] == "doubled"
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_arithmetic_without_alias(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT amount + 1 FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert len(result) == 1
-        assert isinstance(result[0][1], DoubleType)
+        assert len(result.output_columns) == 1
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_parenthesized_expression(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT (amount + 1) FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert len(result) == 1
-        assert isinstance(result[0][1], DoubleType)
+        assert len(result.output_columns) == 1
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_cast(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT CAST(user_id AS BIGINT) AS big_id FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("big_id", BigIntType())
+        assert result.output_columns[0] == ("big_id", BigIntType())
 
     def test_string_literal(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT 'hello' AS greeting FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("greeting", StringType())
+        assert result.output_columns[0] == ("greeting", StringType())
 
     def test_numeric_literal(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT 42 AS magic FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0][0] == "magic"
-        assert isinstance(result[0][1], IntegerType)
+        assert result.output_columns[0][0] == "magic"
+        assert isinstance(result.output_columns[0][1], IntegerType)
 
     def test_boolean_literal(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT TRUE AS flag FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("flag", BooleanType())
+        assert result.output_columns[0] == ("flag", BooleanType())
 
     def test_null_literal(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT NULL AS placeholder FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("placeholder", NullType())
+        assert result.output_columns[0] == ("placeholder", NullType())
 
     def test_alias_shadows_other_column(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id AS order_id FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("order_id", IntegerType())
+        assert result.output_columns[0] == ("order_id", IntegerType())
 
 
 # ---------------------------------------------------------------------------
@@ -347,52 +347,52 @@ class TestExpressions:
 
 class TestConditionals:
     def test_case_string_result(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT CASE WHEN amount > 100 THEN 'high' ELSE 'low' END AS tier "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("tier", StringType())
+        assert result.output_columns[0] == ("tier", StringType())
 
     def test_case_column_result(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT CASE WHEN amount > 100 THEN amount ELSE 0 END AS adjusted "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0][0] == "adjusted"
-        assert isinstance(result[0][1], DoubleType)
+        assert result.output_columns[0][0] == "adjusted"
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_case_else_fallback(self):
         """First THEN branch unresolvable, falls through to ELSE."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT CASE WHEN TRUE THEN default.dim.x ELSE amount END AS val "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("val", DoubleType())
+        assert result.output_columns[0] == ("val", DoubleType())
 
     def test_case_all_branches_unresolvable(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT CASE WHEN TRUE THEN default.dim.x END AS val FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("val", UnknownType())
+        assert result.output_columns[0] == ("val", UnknownType())
 
     def test_coalesce(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT COALESCE(email, username) AS contact FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("contact", StringType())
+        assert result.output_columns[0] == ("contact", StringType())
 
     def test_if_expression(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT IF(amount > 100, 'big', 'small') AS size FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0][0] == "size"
-        assert isinstance(result[0][1], StringType)
+        assert result.output_columns[0][0] == "size"
+        assert isinstance(result.output_columns[0][1], StringType)
 
 
 # ---------------------------------------------------------------------------
@@ -402,24 +402,24 @@ class TestConditionals:
 
 class TestWindowFunctions:
     def test_sum_over_partition(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id, SUM(amount) OVER (PARTITION BY user_id) AS running "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
-        assert result[1][0] == "running"
-        assert isinstance(result[1][1], DoubleType)
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1][0] == "running"
+        assert isinstance(result.output_columns[1][1], DoubleType)
 
     def test_row_number(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id, ROW_NUMBER() OVER (ORDER BY user_id) AS rn "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
-        assert result[1][0] == "rn"
-        assert isinstance(result[1][1], IntegerType)
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1][0] == "rn"
+        assert isinstance(result.output_columns[1][1], IntegerType)
 
 
 # ---------------------------------------------------------------------------
@@ -429,18 +429,18 @@ class TestWindowFunctions:
 
 class TestNestedFunctions:
     def test_upper_coalesce(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT UPPER(COALESCE(username, 'unknown')) AS name FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("name", StringType())
+        assert result.output_columns[0] == ("name", StringType())
 
     def test_cast_inside_sum(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(CAST(user_id AS BIGINT)) AS total FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("total", BigIntType())
+        assert result.output_columns[0] == ("total", BigIntType())
 
 
 # ---------------------------------------------------------------------------
@@ -450,26 +450,41 @@ class TestNestedFunctions:
 
 class TestSubqueries:
     def test_subquery(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT x FROM (SELECT user_id AS x FROM default.users) sub",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("x", IntegerType())
+        assert result.output_columns[0] == ("x", IntegerType())
 
     def test_nested_subquery(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT y FROM (SELECT x AS y FROM (SELECT user_id AS x FROM default.users) a) b",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("y", IntegerType())
+        assert result.output_columns[0] == ("y", IntegerType())
 
     def test_inner_column_not_visible_in_outer(self):
         """username is not in the subquery's output."""
-        with pytest.raises(TypeResolutionError):
-            resolve_output_columns(
-                "SELECT username FROM (SELECT user_id AS x FROM default.users) sub",
-                _col_map(USERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT username FROM (SELECT user_id AS x FROM default.users) sub",
+            _col_map(USERS_COLS),
+        )
+        assert result.errors
+
+    def test_subquery_in_from_with_bad_where(self):
+        """Subquery output is fine but its WHERE references a bad column."""
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
+            "SELECT x FROM ("
+            "  SELECT user_id AS x FROM default.users WHERE nonexistent > 5"
+            ") sub",
+            _col_map(USERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
+        assert result.output_columns[0] == ("x", IntegerType())
 
 
 # ---------------------------------------------------------------------------
@@ -479,38 +494,134 @@ class TestSubqueries:
 
 class TestCTEs:
     def test_simple_cte(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "WITH cte AS (SELECT user_id FROM default.users) SELECT user_id FROM cte",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
+        assert result.output_columns[0] == ("user_id", IntegerType())
 
     def test_cte_with_alias(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "WITH cte AS (SELECT user_id AS uid FROM default.users) SELECT uid FROM cte",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("uid", IntegerType())
+        assert result.output_columns[0] == ("uid", IntegerType())
 
     def test_multiple_ctes(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "WITH u AS (SELECT user_id FROM default.users), "
             "o AS (SELECT order_id, user_id FROM default.orders) "
             "SELECT u.user_id, o.order_id FROM u JOIN o ON u.user_id = o.user_id",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result == [
+        assert result.output_columns == [
             ("user_id", IntegerType()),
             ("order_id", IntegerType()),
         ]
 
     def test_cte_used_in_subquery(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "WITH cte AS (SELECT user_id, username FROM default.users) "
             "SELECT uid FROM (SELECT user_id AS uid FROM cte) sub",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("uid", IntegerType())
+        assert result.output_columns[0] == ("uid", IntegerType())
+
+    def test_cte_with_invalid_where(self):
+        """Invalid column in a CTE's WHERE clause is caught."""
+        result = validate_node_query(
+            "WITH cte AS (SELECT user_id FROM default.users WHERE nonexistent > 5) "
+            "SELECT user_id FROM cte",
+            _col_map(USERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
+
+    def test_cte_with_invalid_group_by(self):
+        """Invalid column in a CTE's GROUP BY clause is caught."""
+        result = validate_node_query(
+            "WITH cte AS (SELECT user_id, COUNT(*) AS cnt "
+            "FROM default.users GROUP BY nonexistent) "
+            "SELECT user_id FROM cte",
+            _col_map(USERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
+
+    def test_three_nested_ctes(self):
+        """Three CTEs, each with nested subqueries."""
+        result = validate_node_query(
+            "WITH "
+            "a AS ("
+            "  SELECT uid, total FROM ("
+            "    SELECT user_id AS uid, SUM(amount) AS total FROM ("
+            "      SELECT user_id, amount FROM default.orders"
+            "    ) raw "
+            "    GROUP BY user_id"
+            "  ) agg"
+            "), "
+            "b AS ("
+            "  SELECT uid, username FROM ("
+            "    SELECT a.uid, u.username FROM a "
+            "    JOIN default.users u ON a.uid = u.user_id"
+            "  ) enriched"
+            "), "
+            "c AS ("
+            "  SELECT username, total FROM ("
+            "    SELECT b.username, a.total FROM b "
+            "    JOIN a ON b.uid = a.uid "
+            "    WHERE a.total > 100"
+            "  ) filtered"
+            ") "
+            "SELECT username, total FROM c",
+            _col_map(USERS_COLS, ORDERS_COLS),
+        )
+        assert result.output_columns == [
+            ("username", StringType()),
+            ("total", DoubleType()),
+        ]
+
+    def test_cte_forward_reference(self):
+        """CTE 'a' references CTE 'b' which isn't defined yet → error."""
+        result = validate_node_query(
+            "WITH a AS (SELECT user_id FROM b), "
+            "b AS (SELECT user_id FROM default.users) "
+            "SELECT user_id FROM a",
+            _col_map(USERS_COLS),
+        )
+        assert result.errors
+
+    def test_same_column_name_across_ctes(self):
+        """Two CTEs both have 'user_id' — qualified references resolve correctly."""
+        result = validate_node_query(
+            "WITH a AS (SELECT user_id FROM default.users), "
+            "b AS (SELECT user_id FROM default.orders) "
+            "SELECT a.user_id, b.user_id FROM a, b",
+            _col_map(USERS_COLS, ORDERS_COLS),
+        )
+        assert result.output_columns == [
+            ("user_id", IntegerType()),
+            ("user_id", IntegerType()),
+        ]
+
+    def test_cte_inner_subquery_invalid_column(self):
+        """CTE has a subquery with a bad column reference.
+        Currently not caught — subquery errors inside _collect_tables_from_relation
+        are discarded. TODO: propagate subquery errors through table scope building.
+        """
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
+            "WITH a AS ("
+            "  SELECT x FROM ("
+            "    SELECT nonexistent AS x FROM default.users"
+            "  ) sub"
+            ") SELECT x FROM a",
+            _col_map(USERS_COLS),
+        )
+        # The inner subquery's "nonexistent" column causes a cascade:
+        # the subquery's output columns fail, which causes the outer CTE to fail too.
+        assert len(result.errors) >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -520,7 +631,7 @@ class TestCTEs:
 
 class TestDerivedMetrics:
     def test_single_metric_ref(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT default.total_revenue",
             _col_map(
                 (
@@ -529,11 +640,11 @@ class TestDerivedMetrics:
                 ),
             ),
         )
-        assert len(result) == 1
-        assert isinstance(result[0][1], DoubleType)
+        assert len(result.output_columns) == 1
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_multi_metric_expression(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT default.total_revenue + default.order_count AS combined",
             _col_map(
                 (
@@ -543,7 +654,7 @@ class TestDerivedMetrics:
                 ("default.order_count", [("default_DOT_order_count", BigIntType())]),
             ),
         )
-        assert result[0][0] == "combined"
+        assert result.output_columns[0][0] == "combined"
 
 
 # ---------------------------------------------------------------------------
@@ -553,7 +664,7 @@ class TestDerivedMetrics:
 
 class TestDimensionAttributes:
     def test_dim_attr_in_derived_metric(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT default.total_revenue, default.date_dim.week",
             _col_map(
                 (
@@ -563,11 +674,11 @@ class TestDimensionAttributes:
                 ("default.date_dim", [("week", StringType()), ("year", IntegerType())]),
             ),
         )
-        assert isinstance(result[0][1], DoubleType)
-        assert isinstance(result[1][1], StringType)
+        assert isinstance(result.output_columns[0][1], DoubleType)
+        assert isinstance(result.output_columns[1][1], StringType)
 
     def test_dim_attr_in_case_with_from(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(CASE WHEN default.date_dim.dateint = 20260101 "
             "THEN amount ELSE 0 END) AS filtered "
             "FROM default.orders",
@@ -579,10 +690,10 @@ class TestDimensionAttributes:
                 ),
             ),
         )
-        assert result[0][0] == "filtered"
+        assert result.output_columns[0][0] == "filtered"
 
     def test_dim_attr_in_where_with_from(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(amount) AS total "
             "FROM default.orders "
             "WHERE default.date_dim.year = 2026",
@@ -594,11 +705,11 @@ class TestDimensionAttributes:
                 ),
             ),
         )
-        assert result[0][0] == "total"
-        assert isinstance(result[0][1], DoubleType)
+        assert result.output_columns[0][0] == "total"
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_dim_attr_in_group_by_with_from(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT default.date_dim.year, SUM(amount) AS total "
             "FROM default.orders "
             "GROUP BY default.date_dim.year",
@@ -610,23 +721,23 @@ class TestDimensionAttributes:
                 ),
             ),
         )
-        assert isinstance(result[0][1], IntegerType)
-        assert result[1][0] == "total"
+        assert isinstance(result.output_columns[0][1], IntegerType)
+        assert result.output_columns[1][0] == "total"
 
     def test_dim_attr_not_in_map(self):
         """Dimension not in parent map → UnknownType fallback."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT default.date_dim.year, SUM(amount) AS total "
             "FROM default.orders "
             "GROUP BY default.date_dim.year",
             _col_map(ORDERS_COLS),
         )
-        assert isinstance(result[0][1], UnknownType)
-        assert result[1][0] == "total"
+        assert isinstance(result.output_columns[0][1], UnknownType)
+        assert result.output_columns[1][0] == "total"
 
     def test_dim_attr_in_aggregation(self):
         """SUM(default.date_dim.dateint) — dim attr as aggregation argument."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(default.date_dim.dateint) AS sum_dates FROM default.orders",
             _col_map(
                 ORDERS_COLS,
@@ -636,7 +747,7 @@ class TestDimensionAttributes:
                 ),
             ),
         )
-        assert result[0] == ("sum_dates", BigIntType())
+        assert result.output_columns[0] == ("sum_dates", BigIntType())
 
 
 # ---------------------------------------------------------------------------
@@ -647,7 +758,7 @@ class TestDimensionAttributes:
 class TestDeepNamespaces:
     def test_node_exists_but_column_doesnt(self):
         """Progressive prefix finds the node but the column name doesn't match."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT ads.report.dims.date.nonexistent_col FROM default.orders",
             _col_map(
                 ORDERS_COLS,
@@ -655,10 +766,10 @@ class TestDeepNamespaces:
             ),
         )
         # Node found but column missing → continues to shorter prefixes → UnknownType
-        assert isinstance(result[0][1], UnknownType)
+        assert isinstance(result.output_columns[0][1], UnknownType)
 
     def test_deep_namespace_dim_attr(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT ads.report.dims.date.year, SUM(amount) AS total "
             "FROM default.orders "
             "GROUP BY ads.report.dims.date.year",
@@ -670,11 +781,11 @@ class TestDeepNamespaces:
                 ),
             ),
         )
-        assert isinstance(result[0][1], IntegerType)
-        assert result[1][0] == "total"
+        assert isinstance(result.output_columns[0][1], IntegerType)
+        assert result.output_columns[1][0] == "total"
 
     def test_deep_namespace_derived_metric(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT ads.report.metrics.total_revenue",
             _col_map(
                 (
@@ -683,10 +794,10 @@ class TestDeepNamespaces:
                 ),
             ),
         )
-        assert isinstance(result[0][1], DoubleType)
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_deep_namespace_dim_in_aggregation(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(ads.report.dims.date.dateint) AS sum_dates FROM default.orders",
             _col_map(
                 ORDERS_COLS,
@@ -696,19 +807,19 @@ class TestDeepNamespaces:
                 ),
             ),
         )
-        assert result[0] == ("sum_dates", BigIntType())
+        assert result.output_columns[0] == ("sum_dates", BigIntType())
 
     def test_deep_namespace_not_in_map(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT ads.report.dims.date.year, amount FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert isinstance(result[0][1], UnknownType)
-        assert isinstance(result[1][1], DoubleType)
+        assert isinstance(result.output_columns[0][1], UnknownType)
+        assert isinstance(result.output_columns[1][1], DoubleType)
 
     def test_longest_prefix_wins(self):
         """Prefers ads.report.dims (longer) over ads.report."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT ads.report.dims.year FROM default.orders",
             _col_map(
                 ORDERS_COLS,
@@ -716,11 +827,11 @@ class TestDeepNamespaces:
                 ("ads.report.dims", [("year", IntegerType())]),
             ),
         )
-        assert isinstance(result[0][1], IntegerType)
+        assert isinstance(result.output_columns[0][1], IntegerType)
 
     def test_deep_namespace_derived_dim_attr(self):
         """Derived metric with deep namespace dim attr via progressive prefix."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT deep.ns.metric_a, deep.ns.dim.date.year",
             _col_map(
                 ("deep.ns.metric_a", [("deep_DOT_ns_DOT_metric_a", DoubleType())]),
@@ -730,8 +841,8 @@ class TestDeepNamespaces:
                 ),
             ),
         )
-        assert isinstance(result[0][1], DoubleType)
-        assert isinstance(result[1][1], IntegerType)
+        assert isinstance(result.output_columns[0][1], DoubleType)
+        assert isinstance(result.output_columns[1][1], IntegerType)
 
 
 # ---------------------------------------------------------------------------
@@ -741,25 +852,25 @@ class TestDeepNamespaces:
 
 class TestSetOperations:
     def test_union(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id FROM default.users UNION SELECT user_id FROM default.orders",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
+        assert result.output_columns[0] == ("user_id", IntegerType())
 
     def test_except(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id FROM default.users EXCEPT SELECT user_id FROM default.orders",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
+        assert result.output_columns[0] == ("user_id", IntegerType())
 
     def test_intersect(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id FROM default.users INTERSECT SELECT user_id FROM default.orders",
             _col_map(USERS_COLS, ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
+        assert result.output_columns[0] == ("user_id", IntegerType())
 
 
 # ---------------------------------------------------------------------------
@@ -769,36 +880,36 @@ class TestSetOperations:
 
 class TestTableValuedFunctions:
     def test_lateral_view_explode(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT event_id, tag "
             "FROM default.events "
             "LATERAL VIEW EXPLODE(tags) t AS tag",
             _col_map(ARRAY_NODE_COLS),
         )
-        assert result[0] == ("event_id", IntegerType())
-        assert result[1][0] == "tag"
-        assert isinstance(result[1][1], UnknownType)
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert result.output_columns[1][0] == "tag"
+        assert isinstance(result.output_columns[1][1], UnknownType)
 
     def test_lateral_view_outer_explode(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT event_id, tag "
             "FROM default.events "
             "LATERAL VIEW OUTER EXPLODE(tags) t AS tag",
             _col_map(ARRAY_NODE_COLS),
         )
-        assert result[0] == ("event_id", IntegerType())
-        assert result[1][0] == "tag"
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert result.output_columns[1][0] == "tag"
 
     def test_posexplode(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT event_id, pos, tag "
             "FROM default.events "
             "LATERAL VIEW POSEXPLODE(tags) t AS pos, tag",
             _col_map(ARRAY_NODE_COLS),
         )
-        assert result[0] == ("event_id", IntegerType())
-        assert result[1][0] == "pos"
-        assert result[2][0] == "tag"
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert result.output_columns[1][0] == "pos"
+        assert result.output_columns[2][0] == "tag"
 
     def test_explode_with_list_type(self):
         """EXPLODE on a ListType column → element type is resolved."""
@@ -813,14 +924,14 @@ class TestTableValuedFunctions:
                 ],
             ),
         )
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT event_id, tag "
             "FROM default.events "
             "LATERAL VIEW EXPLODE(tags) t AS tag",
             typed_events,
         )
-        assert result[0] == ("event_id", IntegerType())
-        assert result[1] == ("tag", StringType())
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert result.output_columns[1] == ("tag", StringType())
 
     def test_posexplode_with_list_type(self):
         """POSEXPLODE on a ListType → pos is IntegerType, element is resolved."""
@@ -835,50 +946,84 @@ class TestTableValuedFunctions:
                 ],
             ),
         )
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT event_id, pos, tag "
             "FROM default.events "
             "LATERAL VIEW POSEXPLODE(tags) t AS pos, tag",
             typed_events,
         )
-        assert result[0] == ("event_id", IntegerType())
-        assert result[1] == ("pos", IntegerType())
-        assert result[2] == ("tag", StringType())
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert result.output_columns[1] == ("pos", IntegerType())
+        assert result.output_columns[2] == ("tag", StringType())
+
+    def test_explode_with_map_type(self):
+        """EXPLODE on a MapType column → key and value types resolved."""
+        from datajunction_server.sql.parsing.types import MapType
+
+        typed_events = _col_map(
+            (
+                "default.events",
+                [
+                    ("event_id", IntegerType()),
+                    ("props", MapType(key_type=StringType(), value_type=IntegerType())),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT event_id, k, v "
+            "FROM default.events "
+            "LATERAL VIEW EXPLODE(props) t AS k, v",
+            typed_events,
+        )
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert result.output_columns[1] == ("k", StringType())
+        assert result.output_columns[2] == ("v", IntegerType())
+
+    def test_explode_unresolvable_arg(self):
+        """EXPLODE on a column not in scope → UnknownType."""
+        result = validate_node_query(
+            "SELECT event_id, tag "
+            "FROM default.events "
+            "LATERAL VIEW EXPLODE(nonexistent) t AS tag",
+            _col_map(ARRAY_NODE_COLS),
+        )
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert isinstance(result.output_columns[1][1], UnknownType)
 
     def test_cross_join_unnest(self):
         murals = _col_map(
             ("default.murals", [("mural_id", IntegerType()), ("colors", StringType())]),
         )
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT m.mural_id, t.color_name "
             "FROM default.murals m "
             "CROSS JOIN UNNEST(m.colors) t(color_id, color_name)",
             murals,
         )
-        assert result[0] == ("mural_id", IntegerType())
-        assert result[1][0] == "color_name"
-        assert isinstance(result[1][1], UnknownType)
+        assert result.output_columns[0] == ("mural_id", IntegerType())
+        assert result.output_columns[1][0] == "color_name"
+        assert isinstance(result.output_columns[1][1], UnknownType)
 
     def test_range_in_from(self):
-        result = resolve_output_columns("SELECT id FROM RANGE(10) t(id)", {})
-        assert result[0] == ("id", UnknownType())
+        result = validate_node_query("SELECT id FROM RANGE(10) t(id)", {})
+        assert result.output_columns[0] == ("id", UnknownType())
 
     def test_range_cross_join(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT u.user_id, r.idx FROM default.users u CROSS JOIN RANGE(5) r(idx)",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
-        assert result[1] == ("idx", UnknownType())
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1] == ("idx", UnknownType())
 
     def test_lateral_view_no_column_alias(self):
         """LATERAL VIEW EXPLODE(tags) t — no AS col_name."""
         try:
-            result = resolve_output_columns(
+            result = validate_node_query(
                 "SELECT event_id FROM default.events LATERAL VIEW EXPLODE(tags) t",
                 _col_map(ARRAY_NODE_COLS),
             )
-            assert result[0] == ("event_id", IntegerType())
+            assert result.output_columns[0] == ("event_id", IntegerType())
         except TypeResolutionError:
             pass  # Parser may not support this form
 
@@ -892,34 +1037,34 @@ class TestRegisteredFunctions:
     def test_hll_sketch_estimate(self):
         from datajunction_server.sql.parsing.types import LongType
 
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT hll_sketch_estimate(sketch_col) AS approx_count FROM default.sketches",
             _col_map(("default.sketches", [("sketch_col", StringType())])),
         )
-        assert result[0] == ("approx_count", LongType())
+        assert result.output_columns[0] == ("approx_count", LongType())
 
     def test_concat(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT CONCAT(username, '@', email) AS full_contact FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("full_contact", StringType())
+        assert result.output_columns[0] == ("full_contact", StringType())
 
     def test_length(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT LENGTH(username) AS name_len FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0][0] == "name_len"
-        assert isinstance(result[0][1], IntegerType)
+        assert result.output_columns[0][0] == "name_len"
+        assert isinstance(result.output_columns[0][1], IntegerType)
 
     def test_unregistered_function(self):
         """Unknown function gracefully falls back to UnknownType."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SOME_UNKNOWN_FUNC(user_id) AS x FROM default.users",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("x", UnknownType())
+        assert result.output_columns[0] == ("x", UnknownType())
 
 
 # ---------------------------------------------------------------------------
@@ -929,53 +1074,53 @@ class TestRegisteredFunctions:
 
 class TestInlineTable:
     def test_values_with_types(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT id, name FROM (VALUES (1, 'a'), (2, 'b')) AS t(id, name)",
             {},
         )
-        assert result[0][0] == "id"
-        assert isinstance(result[0][1], IntegerType)
-        assert result[1][0] == "name"
-        assert isinstance(result[1][1], StringType)
+        assert result.output_columns[0][0] == "id"
+        assert isinstance(result.output_columns[0][1], IntegerType)
+        assert result.output_columns[1][0] == "name"
+        assert isinstance(result.output_columns[1][1], StringType)
 
     def test_values_in_subquery(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT id FROM (VALUES (1, 'a'), (2, 'b')) AS t(id, name)",
             {},
         )
-        assert result[0][0] == "id"
-        assert isinstance(result[0][1], IntegerType)
+        assert result.output_columns[0][0] == "id"
+        assert isinstance(result.output_columns[0][1], IntegerType)
 
     def test_values_with_null(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT id, val FROM (VALUES (1, NULL), (2, 'b')) AS t(id, val)",
             {},
         )
-        assert result[0][0] == "id"
-        assert isinstance(result[0][1], IntegerType)
-        assert result[1] == ("val", UnknownType())
+        assert result.output_columns[0][0] == "id"
+        assert isinstance(result.output_columns[0][1], IntegerType)
+        assert result.output_columns[1] == ("val", UnknownType())
 
     def test_values_with_boolean(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT flag FROM (VALUES (TRUE), (FALSE)) AS t(flag)",
             {},
         )
-        assert result[0] == ("flag", BooleanType())
+        assert result.output_columns[0] == ("flag", BooleanType())
 
     def test_values_without_aliases(self):
         try:
-            result = resolve_output_columns("SELECT * FROM (VALUES (1, 2))", {})
-            assert len(result) >= 0
+            result = validate_node_query("SELECT * FROM (VALUES (1, 2))", {})
+            assert len(result.output_columns) >= 0
         except TypeResolutionError:
             pass
 
     def test_values_with_expression(self):
         try:
-            result = resolve_output_columns(
+            result = validate_node_query(
                 "SELECT x FROM (VALUES (1 + 2, 'a')) AS t(x, y)",
                 {},
             )
-            assert len(result) >= 1
+            assert len(result.output_columns) >= 1
         except TypeResolutionError:
             pass
 
@@ -987,64 +1132,96 @@ class TestInlineTable:
 
 class TestNonProjectionClauses:
     def test_where_valid_column(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT username FROM default.users WHERE user_id > 10",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("username", StringType())
+        assert result.output_columns[0] == ("username", StringType())
 
     def test_where_invalid_column(self):
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT user_id FROM default.users WHERE nonexistent > 5",
-                _col_map(USERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT user_id FROM default.users WHERE nonexistent > 5",
+            _col_map(USERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_group_by_invalid_column(self):
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT user_id, COUNT(*) AS cnt "
-                "FROM default.orders GROUP BY nonexistent",
-                _col_map(ORDERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT user_id, COUNT(*) AS cnt FROM default.orders GROUP BY nonexistent",
+            _col_map(ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_having_invalid_column(self):
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT user_id FROM default.orders "
-                "GROUP BY user_id HAVING SUM(nonexistent) > 1",
-                _col_map(ORDERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT user_id FROM default.orders "
+            "GROUP BY user_id HAVING SUM(nonexistent) > 1",
+            _col_map(ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_order_by_invalid_column(self):
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT user_id FROM default.orders ORDER BY nonexistent",
-                _col_map(ORDERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT user_id FROM default.orders ORDER BY nonexistent",
+            _col_map(ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_join_condition_invalid_column(self):
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT u.user_id FROM default.users u "
-                "JOIN default.orders o ON u.user_id = o.nonexistent",
-                _col_map(USERS_COLS, ORDERS_COLS),
+        result = validate_node_query(
+            "SELECT u.user_id FROM default.users u "
+            "JOIN default.orders o ON u.user_id = o.nonexistent",
+            _col_map(USERS_COLS, ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
+
+    def test_sort_by_invalid_column(self):
+        result = validate_node_query(
+            "SELECT user_id FROM default.orders SORT BY nonexistent",
+            _col_map(ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
+
+    def test_having_without_group_by(self):
+        """HAVING without GROUP BY — parser may accept or reject."""
+        try:
+            validate_node_query(
+                "SELECT user_id FROM default.orders HAVING COUNT(*) > 1",
+                _col_map(ORDERS_COLS),
             )
+        except TypeResolutionError:
+            pass  # Parser or validator rejected it — either way is fine
+
+    def test_window_function_invalid_partition_column(self):
+        """PARTITION BY nonexistent in a window function.
+        Currently not caught — OVER clause columns aren't validated.
+        TODO: validate PARTITION BY / ORDER BY inside window functions.
+        """
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
+            "SELECT SUM(amount) OVER (PARTITION BY nonexistent) AS total "
+            "FROM default.orders",
+            _col_map(ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_where_doesnt_add_columns(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT username FROM default.users WHERE user_id > 10",
             _col_map(USERS_COLS),
         )
-        assert result[0] == ("username", StringType())
+        assert result.output_columns[0] == ("username", StringType())
 
     def test_group_by_with_aggregation(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT user_id, COUNT(*) AS cnt FROM default.orders GROUP BY user_id",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("user_id", IntegerType())
-        assert result[1] == ("cnt", BigIntType())
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1] == ("cnt", BigIntType())
 
 
 # ---------------------------------------------------------------------------
@@ -1054,61 +1231,108 @@ class TestNonProjectionClauses:
 
 class TestErrors:
     def test_invalid_sql(self):
-        with pytest.raises(TypeResolutionError, match="Failed to parse"):
-            resolve_output_columns("NOT VALID SQL AT ALL !!!", {})
+        result = validate_node_query("NOT VALID SQL AT ALL !!!", {})
+        assert any("Failed to parse" in e for e in result.errors)
 
     def test_missing_table(self):
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT a FROM default.nonexistent",
-                _col_map(USERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT a FROM default.nonexistent",
+            _col_map(USERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_missing_column(self):
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT nonexistent FROM default.users",
-                _col_map(USERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT nonexistent FROM default.users",
+            _col_map(USERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_qualified_column_not_in_table(self):
         """SELECT u.nonexistent FROM default.users u — table exists but column doesn't."""
-        with pytest.raises(TypeResolutionError, match="nonexistent"):
-            resolve_output_columns(
-                "SELECT u.nonexistent FROM default.users u",
-                _col_map(USERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT u.nonexistent FROM default.users u",
+            _col_map(USERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
     def test_empty_parent_map(self):
-        with pytest.raises(TypeResolutionError):
-            resolve_output_columns("SELECT a FROM default.users", {})
+        result = validate_node_query("SELECT a FROM default.users", {})
+        assert result.errors
 
     def test_ambiguous_column(self):
-        with pytest.raises(TypeResolutionError, match="ambiguous"):
-            resolve_output_columns(
-                "SELECT user_id FROM default.users u, default.orders o",
-                _col_map(USERS_COLS, ORDERS_COLS),
-            )
+        result = validate_node_query(
+            "SELECT user_id FROM default.users u, default.orders o",
+            _col_map(USERS_COLS, ORDERS_COLS),
+        )
+        assert any("ambiguous" in e for e in result.errors)
 
     def test_wrong_table_alias(self):
         """wrong_alias.amount → UnknownType (treated as possible dim ref)."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT wrong_alias.amount FROM default.users u",
             _col_map(USERS_COLS),
         )
-        assert isinstance(result[0][1], UnknownType)
+        assert isinstance(result.output_columns[0][1], UnknownType)
 
     def test_derived_metric_dim_not_in_map(self):
-        with pytest.raises(TypeResolutionError, match="not found"):
-            resolve_output_columns(
-                "SELECT default.nonexistent_dim.col",
-                _col_map(
-                    (
-                        "default.total_revenue",
-                        [("default_DOT_total_revenue", DoubleType())],
-                    ),
+        result = validate_node_query(
+            "SELECT default.nonexistent_dim.col",
+            _col_map(
+                (
+                    "default.total_revenue",
+                    [("default_DOT_total_revenue", DoubleType())],
                 ),
-            )
+            ),
+        )
+        assert any("not found" in e for e in result.errors)
+
+    def test_multiple_errors_collected(self):
+        """Multiple bad columns → all errors collected, not just the first."""
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
+            "SELECT bad1, bad2 FROM default.users WHERE bad3 > 5",
+            _col_map(USERS_COLS),
+        )
+        # Should have errors for bad1, bad2 (projection) and bad3 (WHERE)
+        assert len(result.errors) >= 3
+        assert any("bad1" in e for e in result.errors)
+        assert any("bad2" in e for e in result.errors)
+        assert any("bad3" in e for e in result.errors)
+
+    def test_subquery_in_select_invalid_column(self):
+        """Scalar subquery in SELECT with bad column."""
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
+            "SELECT user_id, "
+            "(SELECT COUNT(nonexistent) FROM default.orders) AS cnt "
+            "FROM default.users",
+            _col_map(USERS_COLS, ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
+
+    def test_union_second_select_invalid_column(self):
+        """UNION where second SELECT has an invalid column.
+        Currently not caught — set_op right side isn't validated.
+        TODO: validate UNION/EXCEPT/INTERSECT right-side queries.
+        """
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
+            "SELECT user_id FROM default.users "
+            "UNION "
+            "SELECT nonexistent FROM default.orders",
+            _col_map(USERS_COLS, ORDERS_COLS),
+        )
+        assert any("nonexistent" in e for e in result.errors)
 
 
 # ---------------------------------------------------------------------------
@@ -1118,64 +1342,79 @@ class TestErrors:
 
 class TestUnresolvableReferences:
     def test_sum_of_nonexistent_column(self):
-        result = resolve_output_columns(
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
             "SELECT SUM(nonexistent) AS total FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("total", UnknownType())
+        assert any("nonexistent" in e for e in result.errors)
+        assert result.output_columns[0][0] == "total"
 
     def test_count_of_nonexistent_column(self):
-        """COUNT accepts any type, so still returns BigIntType."""
-        result = resolve_output_columns(
+        """COUNT accepts any type but the bad column is still an error."""
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
             "SELECT COUNT(nonexistent) AS cnt FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("cnt", BigIntType())
+        assert any("nonexistent" in e for e in result.errors)
+        assert result.output_columns[0][0] == "cnt"
+        assert isinstance(result.output_columns[0][1], BigIntType)
 
     def test_function_nested_inside_case_arg(self):
         """SUM(CASE WHEN TRUE THEN COALESCE(amount, 0) ELSE 0 END)
         — Function (COALESCE) inside CASE inside SUM triggers
         _prepare_column_types_recursive hitting a Function node."""
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(CASE WHEN TRUE THEN COALESCE(amount, 0) ELSE 0 END) AS total "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0][0] == "total"
-        assert isinstance(result[0][1], DoubleType)
+        assert result.output_columns[0][0] == "total"
+        assert isinstance(result.output_columns[0][1], DoubleType)
 
     def test_function_with_unresolvable_dim_arg(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(default.missing_dim.x) AS total FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("total", UnknownType())
+        assert result.output_columns[0] == ("total", UnknownType())
 
     def test_binary_op_both_unresolvable(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT default.dim_a.x + default.dim_b.y AS z FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0] == ("z", UnknownType())
+        assert result.output_columns[0] == ("z", UnknownType())
 
     def test_nested_case_with_bad_column(self):
         """SUM(CASE WHEN TRUE THEN nonexistent ELSE 0 END) — bare column doesn't exist."""
-        result = resolve_output_columns(
+        from datajunction_server.internal.deployment.type_inference import (
+            validate_node_query,
+        )
+
+        result = validate_node_query(
             "SELECT SUM(CASE WHEN TRUE THEN nonexistent ELSE 0 END) AS total "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0][0] == "total"
-        assert isinstance(result[0][1], (BigIntType, UnknownType))
+        assert any("nonexistent" in e for e in result.errors)
+        assert result.output_columns[0][0] == "total"
 
     def test_nested_expression_arg_unresolvable(self):
-        result = resolve_output_columns(
+        result = validate_node_query(
             "SELECT SUM(CASE WHEN TRUE THEN default.dim.x ELSE 0 END) AS total "
             "FROM default.orders",
             _col_map(ORDERS_COLS),
         )
-        assert result[0][0] == "total"
-        assert isinstance(result[0][1], (BigIntType, UnknownType))
+        assert result.output_columns[0][0] == "total"
+        assert isinstance(result.output_columns[0][1], (BigIntType, UnknownType))
 
 
 # ---------------------------------------------------------------------------
@@ -1187,8 +1426,8 @@ class TestIdempotency:
     def test_double_resolve_same_result(self):
         query = "SELECT user_id, username FROM default.users"
         parent_map = _col_map(USERS_COLS)
-        result1 = resolve_output_columns(query, parent_map)
-        result2 = resolve_output_columns(query, parent_map)
+        result1 = validate_node_query(query, parent_map)
+        result2 = validate_node_query(query, parent_map)
         assert result1 == result2
 
 

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -486,6 +486,127 @@ class TestSubqueries:
         assert any("nonexistent" in e for e in result.errors)
         assert result.output_columns[0] == ("x", IntegerType())
 
+    def test_correlated_subquery(self):
+        """Correlated subquery references outer query's column.
+        The inner subquery uses u.user_id from the outer FROM clause.
+        Currently the outer column resolves as UnknownType (dim ref fallback)
+        rather than being passed into the inner scope.
+        """
+        result = validate_node_query(
+            "SELECT u.user_id, "
+            "(SELECT COUNT(*) FROM default.orders o WHERE o.user_id = u.user_id) AS cnt "
+            "FROM default.users u",
+            _col_map(USERS_COLS, ORDERS_COLS),
+        )
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        # cnt is from COUNT(*) which always returns BigIntType
+        assert result.output_columns[1][0] == "cnt"
+        assert isinstance(result.output_columns[1][1], BigIntType)
+
+    def test_select_star_in_subquery(self):
+        """SELECT * inside a subquery — parent columns change, subquery output changes."""
+        result = validate_node_query(
+            "SELECT user_id, username FROM (  SELECT * FROM default.users) sub",
+            _col_map(USERS_COLS),
+        )
+        assert result.output_columns == [
+            ("user_id", IntegerType()),
+            ("username", StringType()),
+        ]
+
+    def test_select_star_in_subquery_column_added(self):
+        """Source gains a column — subquery SELECT * picks it up."""
+        extended_users = _col_map(
+            (
+                "default.users",
+                [
+                    ("user_id", IntegerType()),
+                    ("username", StringType()),
+                    ("email", StringType()),
+                    ("created_at", TimestampType()),
+                    ("new_col", BooleanType()),  # Added column
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT * FROM (SELECT * FROM default.users) sub",
+            extended_users,
+        )
+        col_names = [name for name, _ in result.output_columns]
+        assert "new_col" in col_names
+        assert len(result.output_columns) == 5
+
+
+# ---------------------------------------------------------------------------
+# Struct field access
+# ---------------------------------------------------------------------------
+
+
+STRUCT_SOURCE = _col_map(
+    (
+        "default.events",
+        [
+            ("event_id", IntegerType()),
+            ("metadata", StringType()),  # In real usage would be StructType
+        ],
+    ),
+)
+
+
+class TestStructFieldAccess:
+    def test_struct_field_resolves(self):
+        """SELECT metadata.name FROM default.events — struct field access."""
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        struct_source = _col_map(
+            (
+                "default.events",
+                [
+                    ("event_id", IntegerType()),
+                    (
+                        "metadata",
+                        StructType(
+                            NestedField(Name("name"), StringType(), True),
+                            NestedField(Name("value"), IntegerType(), True),
+                        ),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT metadata.name FROM default.events",
+            struct_source,
+        )
+        assert result.errors == []
+        assert result.output_columns[0] == ("name", StringType())
+
+    def test_struct_field_nonexistent(self):
+        """SELECT metadata.nonexistent FROM default.events — bad struct field."""
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        struct_source = _col_map(
+            (
+                "default.events",
+                [
+                    ("event_id", IntegerType()),
+                    (
+                        "metadata",
+                        StructType(
+                            NestedField(Name("name"), StringType(), True),
+                        ),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT metadata.nonexistent FROM default.events",
+            struct_source,
+        )
+        assert any("nonexistent" in e for e in result.errors)
+        assert any("struct" in e.lower() for e in result.errors)
+
 
 # ---------------------------------------------------------------------------
 # CTEs


### PR DESCRIPTION
### Summary

`resolve_output_columns` only checked column references in `SELECT` projections. `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`, join clauses, window function `OVER` clauses, `UNION` right-side queries, scalar subqueries, and struct field access were all unchecked. Since this is the only validation downstream nodes receive during deployment propagation, invalid queries can silently stay marked valid.

`validate_node_query` replaces it with comprehensive validation:
  - Returns `QueryValidationResult` and collects all errors instead of raising on the first one
  - Validates all SQL clauses: `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`, `JOIN ON`, `PARTITION BY`, `SORT BY`
  - Validates `UNION`/`EXCEPT`/`INTERSECT` right-side queries
  - Validates scalar subqueries in select projection
  - Propagates errors from subqueries in from clause and CTEs
  - Resolves `LATERAL VIEW EXPLODE` element types from `ListType`/`MapType` (was always unknown before)
  - Validates struct field access against `StructType` field definitions
  - Records column resolution errors in function arguments (previously silently set to unknown)

**Before**
```python
columns = resolve_output_columns(query, parent_map)  # raises on first error
```
**After**
```python
result = validate_node_query(query, parent_map)
result.output_columns  # list of (name, type)
result.errors          # all errors found across all clauses
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
