### PR TITLE
Make type inference engine handle full range of SQL patterns

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -13,6 +13,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Optional
 
+from datajunction_server.utils import SEPARATOR
+
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.sql.parsing import ast
@@ -366,20 +368,15 @@ def _resolve_lateral_element_types(
 
     arg = func.args[0]
 
-    # Resolve the argument's type — could be a column, function, or expression
-    col_type: Optional[ColumnType] = None
-    if isinstance(arg, ast.Column):
-        col_name = arg.name.name
-        for table_cols in from_scope.values():
-            if col_name in table_cols:
-                col_type = table_cols[col_name]
-                break
-    elif isinstance(arg, ast.Function):
-        # e.g., EXPLODE(SEQUENCE(1, 90)) — resolve the function's return type
-        scope = TypeScope(tables=from_scope, parent_map={})
+    # Resolve the argument's type using the standard expression resolver.
+    # Handles all cases uniformly:
+    #   EXPLODE(tags)            — Column reference to a ListType/MapType column
+    #   EXPLODE(SEQUENCE(1, 90)) — Function returning ListType via the registry
+    #   EXPLODE(col['key'])      — Subscript on a map/struct
+    scope = TypeScope(tables=from_scope, parent_map={})
+    try:
         col_type = _resolve_expr_type(arg, scope)
-
-    if col_type is None:
+    except (TypeResolutionError, Exception):
         return []
 
     if isinstance(col_type, ListType):
@@ -470,21 +467,21 @@ def _resolve_struct_chain(
 ) -> ColumnType:
     """Walk a chain of struct field accesses.
 
-    Given a StructType and a list of field names like ["cpm", "amount"],
-    resolves struct_col.cpm.amount by walking into nested structs.
+    Given a StructType and a list of field names like ["inner", "value"],
+    resolves struct_col.inner.value by walking into nested structs.
     """
     current = col_type
     traversed: list[str] = [root_name]
     for field_name in field_path:
         if not isinstance(current, StructType):  # pragma: no cover
             raise TypeResolutionError(
-                f"`{'_DOT_'.join(traversed)}` is not a struct type, "
+                f"`{SEPARATOR.join(traversed)}` is not a struct type, "
                 f"cannot access field `{field_name}`.",
             )
         if field_name not in current.fields_mapping:
             raise TypeResolutionError(
                 f"Field `{field_name}` not found in struct column "
-                f"`{'_DOT_'.join(traversed)}`. "
+                f"`{SEPARATOR.join(traversed)}`. "
                 f"Available fields: {list(current.fields_mapping.keys())}",
             )
         current = current.fields_mapping[field_name].type
@@ -497,7 +494,7 @@ def _resolve_struct_field(
     field_path: list[str],
     tables: TableScope,
 ) -> Optional[ColumnType]:
-    """Try to resolve a struct field access like metadata.name or deal_price.cpm.amount.
+    """Try to resolve a struct field access like metadata.name or data.inner.value.
 
     Searches all tables for a column named struct_col_name. If found and
     the column's type is a StructType, walks the field_path chain.
@@ -650,7 +647,7 @@ def _resolve_column_type(
                 return scope.tables[table_alias][col_name]
 
             # Multi-part namespace: table.struct_col[.nested...].field
-            # e.g., m.cancel_data.is_voluntary_cancel or t.deal_price.cpm.amount
+            # e.g., m.details.is_flag or t.data.inner.value
             if len(col.namespace) > 1:
                 struct_col_name = col.namespace[1].name
                 if struct_col_name in scope.tables[table_alias]:
@@ -677,7 +674,7 @@ def _resolve_column_type(
             )
 
         # Check if this is a struct field access (e.g., metadata.name or
-        # deal_price.cpm.amount). The first namespace part is the column name,
+        # data.inner.value). The first namespace part is the column name,
         # remaining namespace parts + col_name form the field path.
         field_path = [n.name for n in col.namespace[1:]] + [col_name]
         struct_result = _resolve_struct_field(table_alias, field_path, scope.tables)

--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -31,6 +31,8 @@ from datajunction_server.sql.parsing.types import (
 
 logger = logging.getLogger(__name__)
 
+_SENTINEL = object()
+
 # Type alias: maps node name → {column_name: ColumnType}
 ParentColumnsMap = dict[str, dict[str, ColumnType]]
 
@@ -151,8 +153,16 @@ def _resolve_query(
     for expr in select.projection:
         try:
             output.extend(_resolve_projection_expr(expr, scope))
-        except TypeResolutionError as exc:
+        except Exception as exc:
             scope.errors.append(str(exc))
+
+    # Flag any output columns with unresolved types
+    for col_name, col_type in output:
+        if isinstance(col_type, UnknownType):
+            scope.errors.append(
+                f"Unable to infer type for column `{col_name}`. "
+                f"This may indicate an unsupported function or expression.",
+            )
 
     # Validate column references in non-projection clauses
     _validate_non_projection_clauses(select, scope)
@@ -299,6 +309,11 @@ def _collect_tables_from_relation(
         result[sub_alias] = {name: typ for name, typ in sub_columns}
         errors.extend(sub_errors)
 
+    elif isinstance(node, ast.InlineTable):
+        alias = node.alias.name if node.alias else "__inline__"
+        inline_columns = _resolve_inline_table(ast.Query(select=node))  # type: ignore[arg-type]
+        result[alias] = {name: typ for name, typ in inline_columns}
+
     elif isinstance(node, ast.FunctionTableExpression):  # pragma: no branch
         alias = node.alias.name if node.alias else "__func_table__"
         func_cols = {col.name.name: UnknownType() for col in (node.column_list or [])}
@@ -346,18 +361,31 @@ def _resolve_lateral_element_types(
     from_scope: TableScope,
 ) -> list[ColumnType]:
     """Resolve element types for an EXPLODE/UNNEST function argument."""
-    if not func.args or not isinstance(func.args[0], ast.Column):
+    if not func.args:
         return []  # pragma: no cover
 
-    col_name = func.args[0].name.name
-    for table_cols in from_scope.values():
-        if col_name in table_cols:
-            col_type = table_cols[col_name]
-            if isinstance(col_type, ListType):
-                return [col_type.element.type]
-            if isinstance(col_type, MapType):
-                return [col_type.key.type, col_type.value.type]
-            return []
+    arg = func.args[0]
+
+    # Resolve the argument's type — could be a column, function, or expression
+    col_type: Optional[ColumnType] = None
+    if isinstance(arg, ast.Column):
+        col_name = arg.name.name
+        for table_cols in from_scope.values():
+            if col_name in table_cols:
+                col_type = table_cols[col_name]
+                break
+    elif isinstance(arg, ast.Function):
+        # e.g., EXPLODE(SEQUENCE(1, 90)) — resolve the function's return type
+        scope = TypeScope(tables=from_scope, parent_map={})
+        col_type = _resolve_expr_type(arg, scope)
+
+    if col_type is None:
+        return []
+
+    if isinstance(col_type, ListType):
+        return [col_type.element.type]
+    if isinstance(col_type, MapType):
+        return [col_type.key.type, col_type.value.type]
     return []
 
 
@@ -435,28 +463,52 @@ def _resolve_wildcard(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_struct_chain(
+    col_type: ColumnType,
+    field_path: list[str],
+    root_name: str,
+) -> ColumnType:
+    """Walk a chain of struct field accesses.
+
+    Given a StructType and a list of field names like ["cpm", "amount"],
+    resolves struct_col.cpm.amount by walking into nested structs.
+    """
+    current = col_type
+    traversed: list[str] = [root_name]
+    for field_name in field_path:
+        if not isinstance(current, StructType):  # pragma: no cover
+            raise TypeResolutionError(
+                f"`{'_DOT_'.join(traversed)}` is not a struct type, "
+                f"cannot access field `{field_name}`.",
+            )
+        if field_name not in current.fields_mapping:
+            raise TypeResolutionError(
+                f"Field `{field_name}` not found in struct column "
+                f"`{'_DOT_'.join(traversed)}`. "
+                f"Available fields: {list(current.fields_mapping.keys())}",
+            )
+        current = current.fields_mapping[field_name].type
+        traversed.append(field_name)
+    return current
+
+
 def _resolve_struct_field(
     struct_col_name: str,
-    field_name: str,
+    field_path: list[str],
     tables: TableScope,
 ) -> Optional[ColumnType]:
-    """Try to resolve a struct field access like metadata.name.
+    """Try to resolve a struct field access like metadata.name or deal_price.cpm.amount.
 
     Searches all tables for a column named struct_col_name. If found and
-    the column's type is a StructType, looks up field_name in its fields.
-    Returns the field type, or raises TypeResolutionError if the struct
-    exists but the field doesn't. Returns None if no struct column found.
+    the column's type is a StructType, walks the field_path chain.
+    Returns the resolved type, or raises TypeResolutionError if a field
+    doesn't exist. Returns None if no struct column found.
     """
     for table_cols in tables.values():
         if struct_col_name in table_cols:
             col_type = table_cols[struct_col_name]
             if isinstance(col_type, StructType):  # pragma: no branch
-                if field_name in col_type.fields_mapping:
-                    return col_type.fields_mapping[field_name].type
-                raise TypeResolutionError(
-                    f"Field `{field_name}` not found in struct column `{struct_col_name}`. "
-                    f"Available fields: {list(col_type.fields_mapping.keys())}",
-                )
+                return _resolve_struct_chain(col_type, field_path, struct_col_name)
     return None
 
 
@@ -506,7 +558,7 @@ def _validate_columns_in_clause(clause: ast.Node, scope: TypeScope):
     Walks the AST but stops recursing when it hits a Query or Select node
     (subquery). Appends errors to scope.errors.
     """
-    if isinstance(clause, (ast.Query, ast.Select)):
+    if isinstance(clause, (ast.Query, ast.Select, ast.Lambda)):
         return
     if isinstance(clause, ast.Column):
         try:
@@ -596,15 +648,39 @@ def _resolve_column_type(
         if table_alias in scope.tables:
             if col_name in scope.tables[table_alias]:
                 return scope.tables[table_alias][col_name]
+
+            # Multi-part namespace: table.struct_col[.nested...].field
+            # e.g., m.cancel_data.is_voluntary_cancel or t.deal_price.cpm.amount
+            if len(col.namespace) > 1:
+                struct_col_name = col.namespace[1].name
+                if struct_col_name in scope.tables[table_alias]:
+                    col_type = scope.tables[table_alias][struct_col_name]
+                    # Build the remaining field path: namespace[2:] + col_name
+                    field_path = [n.name for n in col.namespace[2:]] + [col_name]
+                    if isinstance(col_type, StructType):
+                        return _resolve_struct_chain(
+                            col_type,
+                            field_path,
+                            struct_col_name,
+                        )
+                    if not field_path[:-1]:  # pragma: no cover
+                        # Only one level deep but not a struct
+                        return UnknownType()
+                    raise TypeResolutionError(  # pragma: no cover
+                        f"`{table_alias}.{struct_col_name}` is not a struct type, "
+                        f"cannot access field `{field_path[0]}`.",
+                    )
+
             raise TypeResolutionError(
                 f"Column `{col_name}` not found in table `{table_alias}`. "
                 f"Available: {list(scope.tables[table_alias].keys())}",
             )
 
-        # Check if this is a struct field access (e.g., metadata.name where
-        # metadata is a StructType column). The namespace would be the column
-        # name, and col_name would be the struct field name.
-        struct_result = _resolve_struct_field(table_alias, col_name, scope.tables)
+        # Check if this is a struct field access (e.g., metadata.name or
+        # deal_price.cpm.amount). The first namespace part is the column name,
+        # remaining namespace parts + col_name form the field path.
+        field_path = [n.name for n in col.namespace[1:]] + [col_name]
+        struct_result = _resolve_struct_field(table_alias, field_path, scope.tables)
         if struct_result is not None:
             return struct_result
 
@@ -641,6 +717,50 @@ def _resolve_column_type(
 
 
 # ---------------------------------------------------------------------------
+# Higher-order function type inference
+# ---------------------------------------------------------------------------
+
+
+def _resolve_higher_order_function(
+    func: ast.Function,
+    scope: "TypeScope",
+) -> Optional[ColumnType]:
+    """Infer the return type of higher-order functions (AGGREGATE, FILTER, TRANSFORM).
+
+    These functions use lambda expressions whose parameters (c, acc, etc.) are
+    not in the table scope, so the AST's built-in type inference fails.  We
+    resolve the return type from the non-lambda arguments instead.
+
+    Returns None if the function is not a known higher-order function or if
+    the return type can't be determined.
+    """
+    name = (
+        func.name.name.upper() if hasattr(func.name, "name") else str(func.name).upper()
+    )
+    args = func.args
+
+    if name == "AGGREGATE" and len(args) >= 2:
+        # AGGREGATE(array, initial_value, merge_fn [, finish_fn])
+        # Return type = type of initial_value (the accumulator seed).
+        # The merge lambda must return the same type, and an optional
+        # finish lambda can transform it — but without resolving lambdas
+        # the initial value is our best signal.
+        return _resolve_expr_type(args[1], scope)
+
+    if name == "FILTER" and len(args) >= 1:
+        # FILTER(array, predicate) → same array type as input
+        return _resolve_expr_type(args[0], scope)
+
+    if name == "TRANSFORM" and len(args) >= 2:
+        # TRANSFORM(array, transform_fn) → array of transform return type.
+        # We can't resolve the lambda return type, so fall back to the
+        # array element type if it's known, otherwise UnknownType.
+        return _resolve_expr_type(args[0], scope)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Expression type resolution
 # ---------------------------------------------------------------------------
 
@@ -664,8 +784,11 @@ def _resolve_expr_type(
         return _resolve_column_type(expr, scope)
 
     if isinstance(expr, ast.Function):
+        # Resolve arg types ourselves and stamp _type on each arg AND all
+        # nested nodes so the function's dispatch mechanism can read them
+        # via .type without re-traversing the uncompiled AST.
+        _stamp_types_recursive(expr, scope)
         try:
-            _prepare_function_arg_types(expr, scope)
             result = expr.type
             if result is not None:  # pragma: no branch
                 return result
@@ -685,6 +808,11 @@ def _resolve_expr_type(
                     for a in expr.args
                 ],
             )
+        # Higher-order functions: infer return type from args when the AST
+        # can't resolve it (lambda body columns aren't in scope).
+        hof_result = _resolve_higher_order_function(expr, scope)
+        if hof_result is not None:
+            return hof_result
         return UnknownType()
 
     if isinstance(expr, ast.Cast):
@@ -712,6 +840,17 @@ def _resolve_expr_type(
                 left_type if not isinstance(left_type, UnknownType) else UnknownType()
             )
 
+    if isinstance(expr, ast.Subscript):
+        # Subscript: col['key'] (map or struct access) or col[0] (array access).
+        base_type = _resolve_expr_type(expr.expr, scope)
+        if isinstance(base_type, MapType):
+            return base_type.value.type
+        if isinstance(base_type, StructType) and isinstance(expr.index, ast.String):
+            field_name = expr.index.value.strip("'\"")
+            if field_name in base_type.fields_mapping:
+                return base_type.fields_mapping[field_name].type
+        return UnknownType()  # pragma: no cover
+
     if isinstance(expr, ast.Case):
         for case_result in expr.results:
             resolved = _resolve_expr_type(case_result, scope)
@@ -724,64 +863,48 @@ def _resolve_expr_type(
         return UnknownType()
 
     # Fallback: try the expression's own type property  # pragma: no cover
-    if hasattr(expr, "type"):  # pragma: no cover
-        result_type = expr.type  # type: ignore[attr-defined]  # pragma: no cover
+    try:  # pragma: no cover
+        result_type = getattr(expr, "type", None)  # pragma: no cover
         if isinstance(result_type, ColumnType):  # pragma: no cover
             return result_type  # pragma: no cover
+    except Exception:  # pragma: no cover
+        pass  # pragma: no cover
     return UnknownType()  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------
-# Function argument type resolution
+# Recursive type stamping
 # ---------------------------------------------------------------------------
 
 
-def _prepare_function_arg_types(
-    func: ast.Function,
-    scope: TypeScope,
-):
+def _stamp_types_recursive(node: ast.Node, scope: "TypeScope"):
+    """Set _type on all nodes in a subtree so the AST's dispatch chain works.
+
+    The function dispatch mechanism calls arg.type which chains through
+    Alias.type → child.type → Function.type → ... If any intermediate node
+    doesn't have _type set, it tries to resolve via the uncompiled AST and
+    fails. This function resolves types top-down using our scope and stamps
+    _type on every node that has the attribute.
     """
-    Set _type on function argument AST nodes so Function.infer_type can dispatch.
-
-    Mutates the AST in place. This is intentional - the AST is a throwaway object
-    created per validate_node_query call and discarded after.
-    """
-    for arg in func.args:
-        if isinstance(arg, ast.Column) and arg._type is None:
-            try:
-                arg._type = _resolve_column_type(arg, scope)
-            except TypeResolutionError as exc:
-                arg._type = UnknownType()
-                scope.errors.append(str(exc))
-        elif isinstance(arg, ast.Function):
-            _prepare_function_arg_types(arg, scope)
-        elif isinstance(arg, (ast.Wildcard, ast.Number, ast.String)):
-            pass
-        elif isinstance(arg, ast.Expression):  # pragma: no branch
-            _prepare_column_types_recursive(arg, scope)
-
-
-def _prepare_column_types_recursive(
-    node: ast.Node,
-    scope: TypeScope,
-):
-    """Set _type on all unresolved Column nodes in an AST subtree.
-
-    Mutates the AST in place so that expression .type properties (e.g., Case.type)
-    can resolve without hitting DJParseException. Same mutation contract as
-    _prepare_function_arg_types.
-    """
-    if isinstance(node, ast.Column) and node._type is None:
-        try:
-            node._type = _resolve_column_type(node, scope)
-        except TypeResolutionError as exc:
-            node._type = UnknownType()
-            scope.errors.append(str(exc))
-    if isinstance(node, ast.Function):
-        _prepare_function_arg_types(node, scope)
+    if isinstance(node, ast.Lambda):
         return
+    if isinstance(node, (ast.Query, ast.Select)):  # pragma: no cover
+        return
+
+    # Resolve and stamp this node's type
+    _type = getattr(node, "_type", _SENTINEL)
+    if _type is not _SENTINEL and _type is None:
+        try:
+            node._type = _resolve_expr_type(node, scope)  # type: ignore[union-attr]
+        except TypeResolutionError as exc:
+            node._type = UnknownType()  # type: ignore[union-attr]
+            scope.errors.append(str(exc))
+        except Exception:  # pragma: no cover
+            node._type = UnknownType()  # type: ignore[union-attr]
+
+    # Recurse into children
     for child in node.children:
-        _prepare_column_types_recursive(child, scope)
+        _stamp_types_recursive(child, scope)
 
 
 # ---------------------------------------------------------------------------

--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -556,7 +556,7 @@ def _validate_columns_in_clause(clause: ast.Node, scope: TypeScope):
     (subquery). Appends errors to scope.errors.
     """
     if isinstance(clause, (ast.Query, ast.Select, ast.Lambda)):
-        return
+        return  # pragma: no cover
     if isinstance(clause, ast.Column):
         try:
             _resolve_column_type(clause, scope)
@@ -650,7 +650,7 @@ def _resolve_column_type(
             # e.g., m.details.is_flag or t.data.inner.value
             if len(col.namespace) > 1:
                 struct_col_name = col.namespace[1].name
-                if struct_col_name in scope.tables[table_alias]:
+                if struct_col_name in scope.tables[table_alias]:  # pragma: no branch
                     col_type = scope.tables[table_alias][struct_col_name]
                     # Build the remaining field path: namespace[2:] + col_name
                     field_path = [n.name for n in col.namespace[2:]] + [col_name]

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -664,28 +664,28 @@ class TestStructFieldAccess:
         assert result.output_columns[2] == ("ts", BigIntType())
 
     def test_nested_struct_chain(self):
-        """deal_price.cpm.amount — two levels of struct nesting, no table alias."""
+        """data.nested.value — two levels of struct nesting, no table alias."""
         from datajunction_server.sql.parsing.types import StructType
         from datajunction_server.sql.parsing.ast import NestedField, Name
 
         source = _col_map(
             (
-                "default.deals",
+                "default.events",
                 [
                     ("id", IntegerType()),
                     (
-                        "deal_price",
+                        "data",
                         StructType(
                             NestedField(
-                                Name("cpm"),
+                                Name("nested"),
                                 StructType(
-                                    NestedField(Name("amount"), StringType(), True),
-                                    NestedField(Name("currency"), StringType(), True),
-                                    NestedField(Name("micros"), BigIntType(), True),
+                                    NestedField(Name("x"), StringType(), True),
+                                    NestedField(Name("y"), StringType(), True),
+                                    NestedField(Name("z"), BigIntType(), True),
                                 ),
                                 True,
                             ),
-                            NestedField(Name("deal_price_type"), StringType(), True),
+                            NestedField(Name("kind"), StringType(), True),
                         ),
                     ),
                 ],
@@ -694,23 +694,23 @@ class TestStructFieldAccess:
         result = validate_node_query(
             """SELECT
                 id,
-                deal_price.deal_price_type AS price_type,
-                deal_price.cpm.amount AS cpm_amount,
-                deal_price.cpm.currency AS cpm_currency,
-                deal_price.cpm.micros AS cpm_micros
-            FROM default.deals""",
+                data.kind AS kind,
+                data.nested.x AS ix,
+                data.nested.y AS iy,
+                data.nested.z AS iz
+            FROM default.events""",
             source,
         )
         assert not result.errors, result.errors
         assert len(result.output_columns) == 5
         assert result.output_columns[0] == ("id", IntegerType())
-        assert result.output_columns[1] == ("price_type", StringType())
-        assert result.output_columns[2] == ("cpm_amount", StringType())
-        assert result.output_columns[3] == ("cpm_currency", StringType())
-        assert result.output_columns[4] == ("cpm_micros", BigIntType())
+        assert result.output_columns[1] == ("kind", StringType())
+        assert result.output_columns[2] == ("ix", StringType())
+        assert result.output_columns[3] == ("iy", StringType())
+        assert result.output_columns[4] == ("iz", BigIntType())
 
     def test_table_qualified_nested_struct_chain(self):
-        """t.deal_price.cpm.amount — table alias + two levels of struct nesting."""
+        """t.price.details.val — table alias + two levels of struct nesting."""
         from datajunction_server.sql.parsing.types import StructType
         from datajunction_server.sql.parsing.ast import NestedField, Name
 

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -378,6 +378,7 @@ class TestConditionals:
             _col_map(ORDERS_COLS),
         )
         assert result.output_columns[0] == ("val", UnknownType())
+        assert any("Unable to infer type for column `val`" in e for e in result.errors)
 
     def test_coalesce(self):
         result = validate_node_query(
@@ -580,6 +581,208 @@ class TestStructFieldAccess:
         )
         assert result.errors == []
         assert result.output_columns[0] == ("name", StringType())
+
+    def test_table_qualified_struct_field(self):
+        """SELECT t.metadata.name FROM default.events t — table.struct.field access."""
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        struct_source = _col_map(
+            (
+                "default.events",
+                [
+                    ("event_id", IntegerType()),
+                    (
+                        "metadata",
+                        StructType(
+                            NestedField(Name("name"), StringType(), True),
+                            NestedField(Name("value"), IntegerType(), True),
+                        ),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT t.metadata.name FROM default.events t",
+            struct_source,
+        )
+        assert result.errors == []
+        assert result.output_columns[0] == ("name", StringType())
+
+    def test_struct_field_in_subquery_projects_flat_columns(self):
+        """Struct field access inside a subquery produces flat columns for the outer query.
+
+        Pattern: outer query references m.is_flag, where m is a subquery that
+        projects t.details.is_flag AS is_flag from a source with a struct column.
+        """
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        source = _col_map(
+            (
+                "default.events",
+                [
+                    ("id", IntegerType()),
+                    (
+                        "details",
+                        StructType(
+                            NestedField(Name("is_flag"), BooleanType(), True),
+                            NestedField(Name("ts"), BigIntType(), True),
+                        ),
+                    ),
+                    ("status", IntegerType()),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            """
+            SELECT m.id, m.is_flag, m.ts
+            FROM (
+                SELECT
+                    t.id,
+                    t.details.is_flag AS is_flag,
+                    t.details.ts AS ts
+                FROM default.events AS t
+                WHERE t.status = 1
+
+                UNION ALL
+
+                SELECT
+                    t.id,
+                    t.details.is_flag AS is_flag,
+                    t.details.ts AS ts
+                FROM default.events AS t
+                WHERE t.status = 0
+            ) AS m
+            """,
+            source,
+        )
+        assert not result.errors, result.errors
+        assert len(result.output_columns) == 3
+        assert result.output_columns[0] == ("id", IntegerType())
+        assert result.output_columns[1] == ("is_flag", BooleanType())
+        assert result.output_columns[2] == ("ts", BigIntType())
+
+    def test_nested_struct_chain(self):
+        """deal_price.cpm.amount — two levels of struct nesting, no table alias."""
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        source = _col_map(
+            (
+                "default.deals",
+                [
+                    ("id", IntegerType()),
+                    (
+                        "deal_price",
+                        StructType(
+                            NestedField(
+                                Name("cpm"),
+                                StructType(
+                                    NestedField(Name("amount"), StringType(), True),
+                                    NestedField(Name("currency"), StringType(), True),
+                                    NestedField(Name("micros"), BigIntType(), True),
+                                ),
+                                True,
+                            ),
+                            NestedField(Name("deal_price_type"), StringType(), True),
+                        ),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            """SELECT
+                id,
+                deal_price.deal_price_type AS price_type,
+                deal_price.cpm.amount AS cpm_amount,
+                deal_price.cpm.currency AS cpm_currency,
+                deal_price.cpm.micros AS cpm_micros
+            FROM default.deals""",
+            source,
+        )
+        assert not result.errors, result.errors
+        assert len(result.output_columns) == 5
+        assert result.output_columns[0] == ("id", IntegerType())
+        assert result.output_columns[1] == ("price_type", StringType())
+        assert result.output_columns[2] == ("cpm_amount", StringType())
+        assert result.output_columns[3] == ("cpm_currency", StringType())
+        assert result.output_columns[4] == ("cpm_micros", BigIntType())
+
+    def test_table_qualified_nested_struct_chain(self):
+        """t.deal_price.cpm.amount — table alias + two levels of struct nesting."""
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        source = _col_map(
+            (
+                "default.deals",
+                [
+                    ("id", IntegerType()),
+                    (
+                        "price",
+                        StructType(
+                            NestedField(
+                                Name("details"),
+                                StructType(
+                                    NestedField(Name("val"), DoubleType(), True),
+                                ),
+                                True,
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT t.id, t.price.details.val AS deep_val FROM default.deals t",
+            source,
+        )
+        assert not result.errors, result.errors
+        assert len(result.output_columns) == 2
+        assert result.output_columns[0] == ("id", IntegerType())
+        assert result.output_columns[1] == ("deep_val", DoubleType())
+
+    def test_three_level_struct_chain(self):
+        """a.b.c.d — three levels of struct nesting."""
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        source = _col_map(
+            (
+                "default.data",
+                [
+                    (
+                        "a",
+                        StructType(
+                            NestedField(
+                                Name("b"),
+                                StructType(
+                                    NestedField(
+                                        Name("c"),
+                                        StructType(
+                                            NestedField(
+                                                Name("d"),
+                                                IntegerType(),
+                                                True,
+                                            ),
+                                        ),
+                                        True,
+                                    ),
+                                ),
+                                True,
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT a.b.c.d AS deep FROM default.data",
+            source,
+        )
+        assert not result.errors, result.errors
+        assert result.output_columns[0] == ("deep", IntegerType())
 
     def test_struct_field_nonexistent(self):
         """SELECT metadata.nonexistent FROM default.events — bad struct field."""
@@ -1100,6 +1303,17 @@ class TestTableValuedFunctions:
         assert result.output_columns[1] == ("k", StringType())
         assert result.output_columns[2] == ("v", IntegerType())
 
+    def test_explode_sequence_function(self):
+        """LATERAL VIEW EXPLODE(SEQUENCE(1, 90)) infers IntegerType from SEQUENCE args."""
+        result = validate_node_query(
+            "SELECT h.horizon "
+            "FROM (SELECT 1 AS dummy) t "
+            "LATERAL VIEW EXPLODE(SEQUENCE(1, 90)) h AS horizon",
+            {},
+        )
+        assert not result.errors, result.errors
+        assert result.output_columns[0] == ("horizon", IntegerType())
+
     def test_explode_unresolvable_arg(self):
         """EXPLODE on a column not in scope → UnknownType."""
         result = validate_node_query(
@@ -1124,10 +1338,14 @@ class TestTableValuedFunctions:
         assert result.output_columns[0] == ("mural_id", IntegerType())
         assert result.output_columns[1][0] == "color_name"
         assert isinstance(result.output_columns[1][1], UnknownType)
+        assert any(
+            "Unable to infer type for column `color_name`" in e for e in result.errors
+        )
 
     def test_range_in_from(self):
         result = validate_node_query("SELECT id FROM RANGE(10) t(id)", {})
         assert result.output_columns[0] == ("id", UnknownType())
+        assert any("Unable to infer type for column `id`" in e for e in result.errors)
 
     def test_range_cross_join(self):
         result = validate_node_query(
@@ -1136,6 +1354,7 @@ class TestTableValuedFunctions:
         )
         assert result.output_columns[0] == ("user_id", IntegerType())
         assert result.output_columns[1] == ("idx", UnknownType())
+        assert any("Unable to infer type for column `idx`" in e for e in result.errors)
 
     def test_lateral_view_no_column_alias(self):
         """LATERAL VIEW EXPLODE(tags) t — no AS col_name."""
@@ -1155,6 +1374,48 @@ class TestTableValuedFunctions:
 
 
 class TestRegisteredFunctions:
+    def test_struct_constructor_simple(self):
+        """struct(col AS name) should infer StructType."""
+        result = validate_node_query(
+            "SELECT struct(user_id AS id) AS s FROM default.users",
+            _col_map(USERS_COLS),
+        )
+        assert not result.errors, result.errors
+        assert result.output_columns[0][0] == "s"
+
+    def test_struct_constructor_with_max(self):
+        """struct(MAX(col) AS name) should work."""
+        result = validate_node_query(
+            "SELECT struct(MAX(flag) AS max_flag) AS s FROM default.data d",
+            _col_map(("default.data", [("flag", IntegerType())])),
+        )
+        assert not result.errors, result.errors
+
+    def test_struct_constructor_with_if(self):
+        """struct(IF(flag = 1, 1, 0) AS name) should work."""
+        result = validate_node_query(
+            "SELECT struct(IF(flag = 1, 1, 0) AS val) AS s FROM default.data d",
+            _col_map(("default.data", [("flag", IntegerType())])),
+        )
+        assert not result.errors, result.errors
+
+    def test_struct_constructor_with_aggregation(self):
+        """struct(expr AS name, agg AS name) should infer StructType from its args."""
+        result = validate_node_query(
+            """SELECT
+                struct(
+                    d.dateint AS snapshot_date,
+                    MAX(IF(flag = 1, 1, 0)) AS is_active
+                ) AS status_struct
+            FROM default.data d""",
+            _col_map(
+                ("default.data", [("dateint", IntegerType()), ("flag", IntegerType())]),
+            ),
+        )
+        assert not result.errors, result.errors
+        assert len(result.output_columns) == 1
+        assert result.output_columns[0][0] == "status_struct"
+
     def test_hll_sketch_estimate(self):
         from datajunction_server.sql.parsing.types import LongType
 
@@ -1180,17 +1441,131 @@ class TestRegisteredFunctions:
         assert isinstance(result.output_columns[0][1], IntegerType)
 
     def test_unregistered_function(self):
-        """Unknown function gracefully falls back to UnknownType."""
+        """Unknown function produces UnknownType and an error."""
         result = validate_node_query(
             "SELECT SOME_UNKNOWN_FUNC(user_id) AS x FROM default.users",
             _col_map(USERS_COLS),
         )
         assert result.output_columns[0] == ("x", UnknownType())
+        assert any("Unable to infer type for column `x`" in e for e in result.errors)
 
 
 # ---------------------------------------------------------------------------
 # Inline tables (VALUES)
 # ---------------------------------------------------------------------------
+
+
+class TestSubscript:
+    """Subscript expressions: col['key'] for maps and structs."""
+
+    def test_struct_subscript(self):
+        """col['field'] on a StructType resolves the field type."""
+        from datajunction_server.sql.parsing.types import StructType
+        from datajunction_server.sql.parsing.ast import NestedField, Name
+
+        source = _col_map(
+            (
+                "default.data",
+                [
+                    ("id", IntegerType()),
+                    (
+                        "info",
+                        StructType(
+                            NestedField(Name("price"), DoubleType(), True),
+                            NestedField(Name("name"), StringType(), True),
+                        ),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT info['price'] AS p, info['name'] AS n FROM default.data",
+            source,
+        )
+        assert not result.errors, result.errors
+        assert result.output_columns[0] == ("p", DoubleType())
+        assert result.output_columns[1] == ("n", StringType())
+
+    def test_map_subscript(self):
+        """col['key'] on a MapType resolves to the value type."""
+        from datajunction_server.sql.parsing.types import MapType
+
+        source = _col_map(
+            (
+                "default.data",
+                [
+                    ("id", IntegerType()),
+                    ("props", MapType(StringType(), DoubleType())),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            "SELECT props['weight'] AS w FROM default.data",
+            source,
+        )
+        assert not result.errors, result.errors
+        assert result.output_columns[0] == ("w", DoubleType())
+
+
+class TestLambdaFunctions:
+    """Higher-order functions with lambda expressions (AGGREGATE, FILTER, TRANSFORM)."""
+
+    def test_aggregate_with_filter_and_lambda(self):
+        """AGGREGATE(FILTER(arr, c -> ...), init, (acc, c) -> ...) should not crash."""
+
+        source = _col_map(
+            (
+                "default.events",
+                [
+                    ("id", IntegerType()),
+                    (
+                        "scores",
+                        # Array of structs — represented as a ListType in practice,
+                        # but for this test UnknownType suffices since we just need
+                        # the query to not crash.
+                        UnknownType(),
+                    ),
+                ],
+            ),
+        )
+        result = validate_node_query(
+            """SELECT
+                id,
+                AGGREGATE(
+                    FILTER(scores, c -> c.name = 'X'),
+                    CAST(0.0 AS DOUBLE),
+                    (acc, c) -> CAST(acc + c.value AS DOUBLE)
+                ) AS total_score
+            FROM default.events""",
+            source,
+        )
+        assert not result.errors, result.errors
+        assert len(result.output_columns) == 2
+        assert result.output_columns[0] == ("id", IntegerType())
+        # AGGREGATE return type inferred from initial value CAST(0.0 AS DOUBLE)
+        assert result.output_columns[1] == ("total_score", DoubleType())
+
+    def test_filter_returns_same_type_as_input(self):
+        """FILTER(array, predicate) → same type as the array arg."""
+        source = _col_map(
+            ("default.events", [("id", IntegerType()), ("tags", UnknownType())]),
+        )
+        result = validate_node_query(
+            "SELECT FILTER(tags, t -> t > 0) AS filtered FROM default.events",
+            source,
+        )
+        assert result.output_columns[0][0] == "filtered"
+
+    def test_transform_returns_same_type_as_input(self):
+        """TRANSFORM(array, func) → same type as the array arg."""
+        source = _col_map(
+            ("default.events", [("id", IntegerType()), ("vals", UnknownType())]),
+        )
+        result = validate_node_query(
+            "SELECT TRANSFORM(vals, v -> v * 2) AS doubled FROM default.events",
+            source,
+        )
+        assert result.output_columns[0][0] == "doubled"
 
 
 class TestInlineTable:
@@ -1220,6 +1595,7 @@ class TestInlineTable:
         assert result.output_columns[0][0] == "id"
         assert isinstance(result.output_columns[0][1], IntegerType)
         assert result.output_columns[1] == ("val", UnknownType())
+        assert any("Unable to infer type for column `val`" in e for e in result.errors)
 
     def test_values_with_boolean(self):
         result = validate_node_query(
@@ -1244,6 +1620,26 @@ class TestInlineTable:
             assert len(result.output_columns) >= 1
         except TypeResolutionError:
             pass
+
+    def test_top_level_values_with_column_aliases(self):
+        """FROM VALUES ... AS t(col1, col2) — top-level InlineTable, not a subquery."""
+        result = validate_node_query(
+            """SELECT status_key, code, label
+            FROM VALUES
+              (0, 'A', 'Alpha'),
+              (1, 'B', 'Beta'),
+              (2, 'C', 'Gamma')
+            AS t(status_key, code, label)""",
+            {},
+        )
+        assert not result.errors
+        assert len(result.output_columns) == 3
+        assert result.output_columns[0][0] == "status_key"
+        assert isinstance(result.output_columns[0][1], IntegerType)
+        assert result.output_columns[1][0] == "code"
+        assert isinstance(result.output_columns[1][1], StringType)
+        assert result.output_columns[2][0] == "label"
+        assert isinstance(result.output_columns[2][1], StringType)
 
 
 # ---------------------------------------------------------------------------
@@ -1490,8 +1886,8 @@ class TestUnresolvableReferences:
 
     def test_function_nested_inside_case_arg(self):
         """SUM(CASE WHEN TRUE THEN COALESCE(amount, 0) ELSE 0 END)
-        — Function (COALESCE) inside CASE inside SUM triggers
-        _prepare_column_types_recursive hitting a Function node."""
+        — Function (COALESCE) inside CASE inside SUM requires recursive
+        type stamping through nested expressions."""
         result = validate_node_query(
             "SELECT SUM(CASE WHEN TRUE THEN COALESCE(amount, 0) ELSE 0 END) AS total "
             "FROM default.orders",
@@ -1506,6 +1902,9 @@ class TestUnresolvableReferences:
             _col_map(ORDERS_COLS),
         )
         assert result.output_columns[0] == ("total", UnknownType())
+        assert any(
+            "Unable to infer type for column `total`" in e for e in result.errors
+        )
 
     def test_binary_op_both_unresolvable(self):
         result = validate_node_query(
@@ -1513,6 +1912,7 @@ class TestUnresolvableReferences:
             _col_map(ORDERS_COLS),
         )
         assert result.output_columns[0] == ("z", UnknownType())
+        assert any("Unable to infer type for column `z`" in e for e in result.errors)
 
     def test_nested_case_with_bad_column(self):
         """SUM(CASE WHEN TRUE THEN nonexistent ELSE 0 END) — bare column doesn't exist."""


### PR DESCRIPTION
### Summary

The type inference engine (in `validate_node_query`) now handles the full range of SQL patterns encountered in real deployment queries:

  1. Struct field access: single level (`metadata.name`), table-qualified (`t.metadata.name`), and arbitrarily nested chains (`metadata.values.name.key`)
  2. Subscript expressions: map key access (`col['key']`) and struct field access via bracket notation (`struct_col['field']`)
  3. Inline tables like `FROM VALUES (...) AS t(col1, col2)`: specifically around handling top-level inline tables, not wrapped in a subquery
  4. Lambda/higher-order functions like `AGGREGATE`, `FILTER`, `TRANSFORM`: the lambda expression parameters are correctly excluded from column resolution

This change also modifies things to handle function arg type inference with recursive type stamping. Function arg types are resolved top-down and stamped on every AST node before dispatch, replacing the old fragile approach that only set types on leaf Column nodes.

Additionally, unknown type is now an error, and these errors are collected for later use. Any output column with an unresolved type is flagged, forcing proper function support rather than silently deploying with unknown types.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
