### PR TITLE
1965 cube filters metadata

### DIFF
--- a/datajunction-clients/python/datajunction/client.py
+++ b/datajunction-clients/python/datajunction/client.py
@@ -528,6 +528,7 @@ class DJClient(_internal.DJClient):
         metrics = node_dict["cube_node_metrics"]
         node_dict["metrics"] = metrics
         node_dict["dimensions"] = dimensions
+        node_dict["filters"] = node_dict.get("cube_filters")
         return Cube.from_dict(dj_client=self, data=node_dict)
 
     def node(self, node_name: str):

--- a/datajunction-clients/python/tests/examples.py
+++ b/datajunction-clients/python/tests/examples.py
@@ -1107,6 +1107,8 @@ EXAMPLES = (  # type: ignore
             "name": "default.cube_two",
             "metrics": ["default.num_repair_orders"],
             "dimensions": ["default.municipality_dim.local_region"],
+            "filters": ["default.municipality_dim.state_id = 1"],
+            "custom_metadata": {"team": "data-eng"},
         },
     ),
     (

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -289,7 +289,7 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
         assert cube_two.type == "cube"
         assert cube_two.metrics == ["default.num_repair_orders"]
         assert cube_two.dimensions == ["default.municipality_dim.local_region"]
-        assert cube_two.filters is None
+        assert cube_two.filters == ["default.municipality_dim.state_id = 1"]
         assert cube_two.columns[0] == Column(
             name="default.num_repair_orders",
             type="bigint",

--- a/datajunction-clients/python/tests/test_client.py
+++ b/datajunction-clients/python/tests/test_client.py
@@ -679,3 +679,5 @@ class TestDJClient:  # pylint: disable=too-many-public-methods
         assert cube_two.name == "default.cube_two"
         assert cube_two.metrics == ["default.num_repair_orders"]
         assert cube_two.dimensions == ["default.municipality_dim.local_region"]
+        assert cube_two.filters == ["default.municipality_dim.state_id = 1"]
+        assert cube_two.custom_metadata == {"team": "data-eng"}

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -643,6 +643,7 @@ async def create_cube_node_revision(
         created_by_id=current_user.id,
         mode=data.mode,
         cube_filters=data.filters or None,
+        custom_metadata=data.custom_metadata,
     )
     return node_revision
 

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -110,6 +110,7 @@ class CubeRevisionMetadata(BaseModel):
     updated_at: UTCDatetime
     materializations: List[MaterializationConfigOutput]
     tags: Optional[List[TagOutput]] = None
+    custom_metadata: Optional[dict] = None
     measures: list[MetricMeasures] | None = None
 
     model_config = ConfigDict(


### PR DESCRIPTION
### Summary 

The `/cubes/{name}/ server` endpoint (CubeRevisionMetadata) was missing cube_filters and custom_metadata fields so those fields were always set to `None` on the python client. This change adds custom_metadata in the server response and correctly maps cube_filters to filters in the client so both fields are populated correctly.

###  Test Plan

- Updated unit tests
- Verified the client now shows cube.filters
 
###  Deployment Plan

The server should be deployed before the client so the new CubeRevisionMetadata fields are available. Client changes are backwards-compatible. 