### PR TITLE
Batch cube dimension validation via shared BFS

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
+++ b/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
@@ -1,0 +1,98 @@
+"""
+Batched dimension reachability for cube validation and impact propagation.
+
+Uses a single BFS query (via find_join_paths_batch) to determine which
+dimensions are reachable from a set of source nodes through the dimension
+link graph.  All subsequent lookups are pure in-memory.
+
+Used by:
+  - Cube validation: are all requested dimensions reachable from every metric?
+  - Dimension link propagation: which cubes lost dimension access after a link change?
+  - Cube filter validation: are filter dimensions reachable?
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.construction.build_v3.loaders import find_join_paths_batch
+
+
+class DimensionReachability:
+    """Batched dimension reachability — one BFS query, in-memory lookups."""
+
+    def __init__(
+        self,
+        paths: dict[tuple[int, str, str], list[int]],
+        local_names: dict[int, str] | None = None,
+    ):
+        self._paths = paths
+        # Fast lookup: source_rev_id → set of reachable dimension node names
+        self._reachable: dict[int, set[str]] = {}
+        for (src_id, dim_name, _role), _links in paths.items():
+            self._reachable.setdefault(src_id, set()).add(dim_name)
+        # Local dimensions: a node can always reach itself (its own columns
+        # are "local dimensions" that don't need a join path).
+        if local_names:
+            for rev_id, node_name in local_names.items():
+                self._reachable.setdefault(rev_id, set()).add(node_name)
+
+    @classmethod
+    async def build(
+        cls,
+        session: AsyncSession,
+        source_revision_ids: set[int],
+        target_dimension_names: set[str],
+        local_names: dict[int, str] | None = None,
+    ) -> DimensionReachability:
+        """One batched BFS query to build the reachability map.
+
+        Args:
+            source_revision_ids: Revision IDs of the source nodes to BFS from.
+            target_dimension_names: Dimension node names to search for.
+            local_names: Optional mapping of rev_id → node_name.  Each source
+                node is always reachable from itself (local dimensions).
+        """
+        if not source_revision_ids or not target_dimension_names:
+            return cls({}, local_names)
+        paths = await find_join_paths_batch(
+            session,
+            source_revision_ids,
+            target_dimension_names,
+        )
+        return cls(paths, local_names)
+
+    def is_reachable(self, source_rev_id: int, dim_name: str) -> bool:
+        """Check if a dimension is reachable from a source node."""
+        return dim_name in self._reachable.get(source_rev_id, set())
+
+    def reachable_from(self, source_rev_id: int) -> set[str]:
+        """All dimension names reachable from a source node."""
+        return self._reachable.get(source_rev_id, set())
+
+    def shared_dimensions(self, source_rev_ids: set[int]) -> set[str]:
+        """Intersection of reachable dimensions across all source nodes."""
+        if not source_rev_ids:
+            return set()
+        sets = [self.reachable_from(sid) for sid in source_rev_ids]
+        return set.intersection(*sets) if sets else set()
+
+    def unreachable_dimensions(
+        self,
+        source_rev_ids: set[int],
+        requested: set[str],
+    ) -> dict[str, set[int]]:
+        """For each requested dim, which source_rev_ids can't reach it?
+
+        Returns a dict mapping dim_name → set of source_rev_ids that lack
+        a path to it.  Empty dict means all dimensions are reachable from
+        all sources.
+        """
+        missing: dict[str, set[int]] = {}
+        for dim in requested:
+            unreachable_from = {
+                sid for sid in source_rev_ids if not self.is_reachable(sid, dim)
+            }
+            if unreachable_from:
+                missing[dim] = unreachable_from
+        return missing

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1567,16 +1567,11 @@ class DeploymentOrchestrator:
             self.session.add_all(revisions)
             await self.session.flush()
 
-        with timer.phase("    cubes: refresh"):
-            if all(spec._skip_validation for spec in cubes_to_deploy):
-                for node_obj, revision in zip(nodes, revisions):
-                    node_obj.current = revision
-                all_nodes = {node_obj.name: node_obj for node_obj in nodes}
-            else:
-                all_nodes = await self.refresh_nodes(
-                    [cube.rendered_name for cube in cubes_to_deploy],
-                )
-        self.registry.add_nodes(all_nodes)
+        # Wire node.current directly — no refresh needed since nothing
+        # downstream accesses cube_elements from the registry.
+        for node_obj, revision in zip(nodes, revisions):
+            node_obj.current = revision
+        self.registry.add_nodes({n.name: n for n in nodes})
 
         elapsed_ms = (time.perf_counter() - start) * 1000
         logger.info(
@@ -1900,8 +1895,7 @@ class DeploymentOrchestrator:
                 if p.current
             }
             requested_dim_nodes = {
-                dim.rsplit(SEPARATOR, 1)[0]
-                for dim in cube_spec.rendered_dimensions
+                dim.rsplit(SEPARATOR, 1)[0] for dim in cube_spec.rendered_dimensions
             }
             unreachable = reachability.unreachable_dimensions(
                 cube_parent_rev_ids,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -119,7 +119,7 @@ def _extract_dimension_refs_from_filters(
     for col in tree.find_all(ast.Column):
         if col.namespace and len(col.namespace) >= 1:
             node_name = SEPARATOR.join(n.name for n in col.namespace)
-            if SEPARATOR in node_name:
+            if SEPARATOR in node_name:  # pragma: no branch
                 refs.append((node_name, col.name.name))
     return refs
 
@@ -1682,7 +1682,7 @@ class DeploymentOrchestrator:
         all_parent_rev_ids: set[int] = set()
         for parents in metric_to_parents.values():
             for p in parents:
-                if p.current:
+                if p.current:  # pragma: no branch
                     all_parent_rev_ids.add(p.current.id)
                     local_names[p.current.id] = p.name
         all_dim_node_names = {
@@ -1994,7 +1994,7 @@ class DeploymentOrchestrator:
                 dim_node = self.registry.nodes.get(node_name) or dimension_mapping.get(
                     f"{node_name}{SEPARATOR}{col_name}",
                 )
-                if dim_node and dim_node.current:
+                if dim_node and dim_node.current:  # pragma: no branch
                     col_names = {c.name for c in dim_node.current.columns}
                     if col_name not in col_names:
                         dim_compat_errors.append(
@@ -2864,31 +2864,6 @@ class DeploymentOrchestrator:
                             except Exception:  # pragma: no cover
                                 pass  # pragma: no cover
         return dependency_nodes
-
-    async def refresh_nodes(self, node_names: list[str]) -> dict[str, Node]:
-        """
-        Re-fetch nodes after a flush so that ``node.current`` points to the
-        newly-created NodeRevision, with all sub-relationships eagerly loaded.
-
-        Used after cube creation where cube elements (cube_elements, etc.) must be
-        loaded fresh from DB.  For non-cube levels, ``bulk_deploy_nodes_in_level``
-        wires ``node.current`` directly from in-session objects instead.
-        """
-        refresh_start = time.perf_counter()
-        all_nodes = {
-            node.name: node
-            for node in await Node.get_by_names(
-                self.session,
-                node_names,
-                options=list(Node.cube_load_options()),
-            )
-        }
-        logger.info(
-            "Refreshed %d nodes in %.2fs",
-            len(all_nodes),
-            time.perf_counter() - refresh_start,
-        )
-        return all_nodes
 
     async def create_nodes_from_validation(
         self,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -42,13 +42,16 @@ from datajunction_server.internal.deployment.utils import (
     DeploymentContext,
 )
 from datajunction_server.internal.impact import propagate_impact
+from datajunction_server.internal.deployment.dimension_reachability import (
+    DimensionReachability,
+)
 from datajunction_server.internal.deployment.validation import (
     NodeValidationResult,
     CubeValidationData,
     bulk_validate_node_data,
 )
 from datajunction_server.internal.history import EntityType
-from datajunction_server.construction.build import validate_shared_dimensions
+from datajunction_server.sql.dag import get_metric_parents_map
 from datajunction_server.internal.nodes import (
     hard_delete_node,
 )
@@ -1595,7 +1598,7 @@ class DeploymentOrchestrator:
         self,
         cube_specs: list[CubeSpec],
     ) -> list[NodeValidationResult]:
-        """Bulk validate cube specifications efficiently with batched DB queries"""
+        """Bulk validate cube specifications with batched dimension reachability."""
         if not cube_specs:
             return []  # pragma: no cover
 
@@ -1604,7 +1607,7 @@ class DeploymentOrchestrator:
             cube_specs,
         )
 
-        # Batch load all metrics and dimensions
+        # Batch load (registry-first, DB fallback)
         metric_nodes_map, missing_metrics = await self._batch_load_metrics(
             all_metric_names,
         )
@@ -1612,17 +1615,74 @@ class DeploymentOrchestrator:
             all_dimension_names,
         )
 
-        # Validate each cube
-        # TODO: batch validate_shared_dimensions across all cubes to avoid
-        # redundant get_dimensions DB calls for shared parent nodes (~1.4s for 22 cubes)
+        # Resolve metric → non-metric parent mapping (batched).
+        # Replace DB-returned nodes with registry versions where available
+        # (registry nodes have .current eagerly loaded; DB nodes may not).
+        all_metric_nodes = list(metric_nodes_map.values())
+        raw_metric_to_parents = await get_metric_parents_map(
+            self.session,
+            all_metric_nodes,
+        )
+        metric_to_parents: dict[str, list[Node]] = {}
+        parents_needing_current: list[str] = []
+        for metric_name, parents in raw_metric_to_parents.items():
+            resolved = []
+            for p in parents:
+                registry_node = self.registry.nodes.get(p.name)
+                if registry_node:
+                    resolved.append(registry_node)
+                else:
+                    parents_needing_current.append(p.name)
+                    resolved.append(p)
+            metric_to_parents[metric_name] = resolved
+
+        # Batch-load .current for any parents not in the registry
+        if parents_needing_current:
+            loaded = await Node.get_by_names(
+                self.session,
+                parents_needing_current,
+                options=[joinedload(Node.current)],
+            )
+            loaded_map = {n.name: n for n in loaded}
+            for metric_name, parents in metric_to_parents.items():
+                metric_to_parents[metric_name] = [
+                    loaded_map.get(p.name, p) if p.name in loaded_map else p
+                    for p in parents
+                ]
+
+        # One batched BFS for dimension reachability across ALL cubes.
+        # local_names maps rev_id → node_name so each parent is always
+        # reachable from itself (local dimensions like hard_hat.state).
+        local_names: dict[int, str] = {}
+        all_parent_rev_ids: set[int] = set()
+        for parents in metric_to_parents.values():
+            for p in parents:
+                if p.current:
+                    all_parent_rev_ids.add(p.current.id)
+                    local_names[p.current.id] = p.name
+        all_dim_node_names = {
+            dim.rsplit(SEPARATOR, 1)[0]
+            for cube in cube_specs
+            for dim in (cube.rendered_dimensions or [])
+        }
+        reachability = await DimensionReachability.build(
+            self.session,
+            all_parent_rev_ids,
+            all_dim_node_names,
+            local_names=local_names,
+        )
+
+        # Per-cube validation — dimension checks are now pure in-memory
         validation_results = []
         for cube_spec in cube_specs:
-            validation_result = await self._validate_single_cube(
+            validation_result = self._validate_single_cube(
                 cube_spec,
                 metric_nodes_map,
                 missing_metrics,
                 missing_dimensions,
                 dimension_mapping,
+                reachability,
+                metric_to_parents,
             )
             validation_results.append(validation_result)
         return validation_results
@@ -1770,13 +1830,15 @@ class DeploymentOrchestrator:
             )
         return errors
 
-    async def _validate_single_cube(
+    def _validate_single_cube(
         self,
         cube_spec: CubeSpec,
         metric_nodes_map: dict[str, Node],
         missing_metrics: set[str],
         missing_dimensions: set[str],
         dimension_mapping: dict[str, Node],
+        reachability: "DimensionReachability",
+        metric_to_parents: dict[str, list[Node]],
     ) -> NodeValidationResult:
         cube_metric_nodes = [
             metric_nodes_map[metric_name]
@@ -1828,19 +1890,44 @@ class DeploymentOrchestrator:
                 dependencies=[],
             )
 
-        # Validate that each requested dimension is reachable from every metric
+        # Check dimension reachability using the pre-computed batched BFS
         dim_compat_errors: list[DJError] = []
         if cube_spec.rendered_dimensions:  # pragma: no branch
-            try:
-                await validate_shared_dimensions(
-                    self.session,
-                    cube_metric_nodes,
-                    cube_spec.rendered_dimensions,
+            cube_parent_rev_ids = {
+                p.current.id
+                for metric_name in (cube_spec.rendered_metrics or [])
+                for p in metric_to_parents.get(metric_name, [])
+                if p.current
+            }
+            requested_dim_nodes = {
+                dim.rsplit(SEPARATOR, 1)[0]
+                for dim in cube_spec.rendered_dimensions
+            }
+            unreachable = reachability.unreachable_dimensions(
+                cube_parent_rev_ids,
+                requested_dim_nodes,
+            )
+            # Build parent rev_id → name lookup for error messages
+            rev_id_to_parent = {
+                p.current.id: p.name
+                for parents in metric_to_parents.values()
+                for p in parents
+                if p.current
+            }
+            for dim_name, missing_from_ids in unreachable.items():
+                parent_names = sorted(
+                    rev_id_to_parent.get(rid, str(rid)) for rid in missing_from_ids
                 )
-            except DJInvalidInputException as exc:
-                # Collect the error but continue to build dimension data so we can
-                # write the cube with its elements intact (just marked INVALID).
-                dim_compat_errors = exc.errors
+                dim_compat_errors.append(
+                    DJError(
+                        code=ErrorCode.INVALID_DIMENSION,
+                        message=(
+                            f"The dimension attribute `{dim_name}` is not "
+                            f"reachable from parent node(s): {', '.join(parent_names)}. "
+                            f"Add a dimension link to make it available."
+                        ),
+                    ),
+                )
 
         # Get dimensions for this cube from batch-loaded data
         cube_dimension_nodes = []

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -94,6 +94,36 @@ from datajunction_server.utils import (
 logger = logging.getLogger(__name__)
 
 
+def _extract_dimension_refs_from_filters(
+    filters: list[str],
+) -> list[tuple[str, str]]:
+    """Extract (node_name, column_name) pairs from filter expressions.
+
+    Parses all filters as a single WHERE clause (joined with AND) and
+    collects namespaced column references.  For example,
+    ``ns.hard_hat.state = 'CA'`` yields ``('ns.hard_hat', 'state')``.
+
+    Returns a list of (node_name, column_name) tuples.  Dimension node
+    names are identified by having at least one SEPARATOR in the namespace.
+    """
+    from datajunction_server.sql.parsing.backends.antlr4 import parse, ast
+
+    if not filters:
+        return []
+    combined = " AND ".join(f"({f})" for f in filters)
+    try:
+        tree = parse(f"SELECT 1 WHERE {combined}")
+    except Exception:
+        return []  # Unparseable — skip, will be caught at query time
+    refs: list[tuple[str, str]] = []
+    for col in tree.find_all(ast.Column):
+        if col.namespace and len(col.namespace) >= 1:
+            node_name = SEPARATOR.join(n.name for n in col.namespace)
+            if SEPARATOR in node_name:
+                refs.append((node_name, col.name.name))
+    return refs
+
+
 def _diff_column_metadata(
     new_cols: "list | None",
     old_cols: "list | None",
@@ -1660,6 +1690,15 @@ class DeploymentOrchestrator:
             for cube in cube_specs
             for dim in (cube.rendered_dimensions or [])
         }
+        # Also include dimension nodes referenced in filters
+        for cube in cube_specs:
+            if cube.rendered_filters:
+                all_dim_node_names |= {
+                    node_name
+                    for node_name, _ in _extract_dimension_refs_from_filters(
+                        cube.rendered_filters,
+                    )
+                }
         reachability = await DimensionReachability.build(
             self.session,
             all_parent_rev_ids,
@@ -1885,15 +1924,24 @@ class DeploymentOrchestrator:
                 dependencies=[],
             )
 
+        # Collect parent revision IDs for this cube's metrics (used by both
+        # dimension and filter reachability checks below).
+        cube_parent_rev_ids = {
+            p.current.id
+            for metric_name in (cube_spec.rendered_metrics or [])
+            for p in metric_to_parents.get(metric_name, [])
+            if p.current
+        }
+        rev_id_to_parent = {
+            p.current.id: p.name
+            for parents in metric_to_parents.values()
+            for p in parents
+            if p.current
+        }
+
         # Check dimension reachability using the pre-computed batched BFS
         dim_compat_errors: list[DJError] = []
         if cube_spec.rendered_dimensions:  # pragma: no branch
-            cube_parent_rev_ids = {
-                p.current.id
-                for metric_name in (cube_spec.rendered_metrics or [])
-                for p in metric_to_parents.get(metric_name, [])
-                if p.current
-            }
             requested_dim_nodes = {
                 dim.rsplit(SEPARATOR, 1)[0] for dim in cube_spec.rendered_dimensions
             }
@@ -1901,13 +1949,6 @@ class DeploymentOrchestrator:
                 cube_parent_rev_ids,
                 requested_dim_nodes,
             )
-            # Build parent rev_id → name lookup for error messages
-            rev_id_to_parent = {
-                p.current.id: p.name
-                for parents in metric_to_parents.values()
-                for p in parents
-                if p.current
-            }
             for dim_name, missing_from_ids in unreachable.items():
                 parent_names = sorted(
                     rev_id_to_parent.get(rid, str(rid)) for rid in missing_from_ids
@@ -1922,6 +1963,50 @@ class DeploymentOrchestrator:
                         ),
                     ),
                 )
+
+        # Validate that dimensions referenced in filters are reachable
+        # and that the specific columns exist on those dimension nodes.
+        if cube_spec.rendered_filters and cube_parent_rev_ids:
+            filter_refs = _extract_dimension_refs_from_filters(
+                cube_spec.rendered_filters,
+            )
+            filter_dim_nodes = {node_name for node_name, _ in filter_refs}
+            unreachable_filter_dims = reachability.unreachable_dimensions(
+                cube_parent_rev_ids,
+                filter_dim_nodes,
+            )
+            for dim_name, missing_from_ids in unreachable_filter_dims.items():
+                parent_names = sorted(
+                    rev_id_to_parent.get(rid, str(rid)) for rid in missing_from_ids
+                )
+                dim_compat_errors.append(
+                    DJError(
+                        code=ErrorCode.INVALID_DIMENSION,
+                        message=(
+                            f"Filter references dimension `{dim_name}` which is not "
+                            f"reachable from parent node(s): {', '.join(parent_names)}. "
+                            f"Add a dimension link to make it available."
+                        ),
+                    ),
+                )
+            # Check that filter columns exist on the dimension nodes
+            for node_name, col_name in filter_refs:
+                dim_node = self.registry.nodes.get(node_name) or dimension_mapping.get(
+                    f"{node_name}{SEPARATOR}{col_name}",
+                )
+                if dim_node and dim_node.current:
+                    col_names = {c.name for c in dim_node.current.columns}
+                    if col_name not in col_names:
+                        dim_compat_errors.append(
+                            DJError(
+                                code=ErrorCode.INVALID_COLUMN,
+                                message=(
+                                    f"Filter references column `{col_name}` on "
+                                    f"dimension `{node_name}`, but that column does "
+                                    f"not exist. Available: {sorted(col_names)}"
+                                ),
+                            ),
+                        )
 
         # Get dimensions for this cube from batch-loaded data
         cube_dimension_nodes = []

--- a/datajunction-server/datajunction_server/internal/impact.py
+++ b/datajunction-server/datajunction_server/internal/impact.py
@@ -21,6 +21,9 @@ from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.database.node import Node, NodeRevision, NodeRelationship
 from datajunction_server.instrumentation.provider import get_metrics_provider
+from datajunction_server.internal.deployment.dimension_reachability import (
+    DimensionReachability,
+)
 from datajunction_server.internal.deployment.type_inference import (
     columns_signature_changed,
     parse_query,
@@ -29,8 +32,10 @@ from datajunction_server.internal.deployment.type_inference import (
 from datajunction_server.models.impact import DownstreamImpact, ImpactType
 from datajunction_server.models.node import NodeStatus
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.sql.dag import get_metric_parents_map
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.types import ColumnType
+from datajunction_server.utils import SEPARATOR
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +47,8 @@ class PropagationContext:
     namespace: str
     changed_by_id: dict[int, Node] = field(default_factory=dict)
     deleted_by_id: dict[int, Node] = field(default_factory=dict)
+    # Nodes whose dimension links changed (separate from query/column changes)
+    link_changed_by_id: dict[int, Node] = field(default_factory=dict)
 
     # Causality: node_id → set of root node IDs that caused it
     cause_map: dict[int, set[int]] = field(default_factory=dict)
@@ -86,6 +93,7 @@ async def propagate_impact(
         namespace,
         changed_node_names,
         deleted_node_names,
+        changed_link_node_names,
     )
 
     # Phase 1: discover affected nodes via SQL parent graph
@@ -118,6 +126,7 @@ async def _build_propagation_context(
     namespace: str,
     changed_node_names: set[str],
     deleted_node_names: frozenset[str],
+    changed_link_node_names: set[str] | None = None,
 ) -> PropagationContext:
     """Load root nodes and build the shared propagation context."""
     changed_nodes = (
@@ -138,24 +147,41 @@ async def _build_propagation_context(
         if deleted_node_names
         else []
     )
+    # Load nodes whose dimension links changed but that aren't already
+    # in changed_node_names (they may only have link changes, no query changes).
+    link_only_names = (
+        (changed_link_node_names or set()) - changed_node_names - deleted_node_names
+    )
+    link_changed_nodes = (
+        await Node.get_by_names(
+            session,
+            list(link_only_names),
+            options=[joinedload(Node.current)],
+        )
+        if link_only_names
+        else []
+    )
 
     changed_by_id = {n.id: n for n in changed_nodes}
     deleted_by_id = {n.id: n for n in deleted_nodes}
-    all_root_ids = set(changed_by_id) | set(deleted_by_id)
+    link_changed_by_id = {n.id: n for n in link_changed_nodes}
+    all_root_ids = set(changed_by_id) | set(deleted_by_id) | set(link_changed_by_id)
 
     cause_map = {nid: {nid} for nid in all_root_ids}
     root_id_to_name = {
         **{n.id: n.name for n in changed_nodes},
         **{n.id: n.name for n in deleted_nodes},
+        **{n.id: n.name for n in link_changed_nodes},
     }
 
     return PropagationContext(
         namespace=namespace,
         changed_by_id=changed_by_id,
         deleted_by_id=deleted_by_id,
+        link_changed_by_id=link_changed_by_id,
         cause_map=cause_map,
         root_id_to_name=root_id_to_name,
-        visited_nodes_by_id={**changed_by_id, **deleted_by_id},
+        visited_nodes_by_id={**changed_by_id, **deleted_by_id, **link_changed_by_id},
     )
 
 
@@ -173,7 +199,9 @@ async def _propagate_via_parent_graph(
     Returns impacts without mutating DB state — Phase 3 determines the actual
     impact type via revalidation.
     """
-    all_root_ids = set(ctx.changed_by_id) | set(ctx.deleted_by_id)
+    all_root_ids = (
+        set(ctx.changed_by_id) | set(ctx.deleted_by_id) | set(ctx.link_changed_by_id)
+    )
     frontier_ids = set(all_root_ids)
     visited_node_ids = set(frontier_ids)
     results: list[DownstreamImpact] = []
@@ -261,24 +289,18 @@ async def _propagate_via_dimension_links(
     ctx: PropagationContext,
     changed_link_node_names: set[str],
 ) -> list[DownstreamImpact]:
-    """Find nodes affected by dimension link changes.
+    """Find additional nodes affected by dimension link changes.
 
-    Dimension links create a separate dependency graph — a metric doesn't have
-    a NodeRelationship to the dimension node, it reaches it via DimensionLink.
-    When a link changes, metrics/cubes using that dimension path may break.
+    Link-changed nodes are already included in the Phase 1 BFS roots
+    (via ctx.link_changed_by_id), so downstream cubes are discovered
+    through the SQL parent graph.  Dimension reachability checking for
+    those cubes happens in the Phase 3 post-pass
+    (_check_cube_dimension_reachability).
 
-    Returns additional MAY_AFFECT impacts for nodes not already found in Phase 1.
+    This method handles any ADDITIONAL impacts not discoverable via
+    NodeRelationship — currently none, but reserved for future cases
+    like dimension-link-only dependencies.
     """
-    if not changed_link_node_names:
-        return []
-
-    # TODO: Implement dimension link graph traversal
-    # For now, return empty — dimension link propagation will be added
-    # in a follow-up once the Phase 1+3 refactor is validated.
-    logger.info(
-        "Dimension link changes detected for %d nodes (propagation not yet implemented)",
-        len(changed_link_node_names),
-    )
     return []
 
 
@@ -414,7 +436,153 @@ async def _revalidate_and_apply(
                 failed_names.add(impact.name)
             results.append(revalidated)
 
+    # Post-pass: check dimension reachability for any cubes in the results.
+    # A cube's query revalidation always passes (cubes have no query), but
+    # its dimension accessibility may have changed due to upstream link changes.
+    if ctx.link_changed_by_id:  # pragma: no cover
+        results = await _check_cube_dimension_reachability(
+            session,
+            ctx,
+            results,
+            loaded_nodes,
+        )
+
     return results
+
+
+async def _check_cube_dimension_reachability(
+    session: AsyncSession,
+    ctx: PropagationContext,
+    results: list[DownstreamImpact],
+    loaded_nodes: dict[str, Node],
+) -> list[DownstreamImpact]:
+    """Check dimension reachability for cubes discovered in the impact set.
+
+    When upstream dimension links change, a cube's query still validates
+    (cubes have no query) but its dimensions may become unreachable.
+    This post-pass uses DimensionReachability to detect that.
+
+    Prefers already-loaded nodes (from Phase 3 batch load and BFS visited
+    nodes) to avoid redundant DB queries.
+    """
+    # Find cube impacts that currently show MAY_AFFECT (passthrough from Phase 3)
+    cube_impacts = [
+        (i, r)
+        for i, r in enumerate(results)
+        if r.node_type == NodeType.CUBE and r.impact_type == ImpactType.MAY_AFFECT
+    ]
+    if not cube_impacts:
+        return results
+
+    # All nodes already in memory from Phase 1 BFS + Phase 3 batch load
+    known_nodes = {
+        **{n.name: n for n in ctx.visited_nodes_by_id.values()},
+        **loaded_nodes,
+    }
+
+    # Get cube nodes — prefer already-loaded, fall back to DB
+    cube_names = [r.name for _, r in cube_impacts]
+    cube_map: dict[str, Node] = {}
+    missing_cube_names: list[str] = []
+    for name in cube_names:
+        if name in known_nodes and known_nodes[name].current:
+            cube_map[name] = known_nodes[name]
+        else:
+            missing_cube_names.append(name)  # pragma: no cover
+    if missing_cube_names:  # pragma: no cover
+        db_cubes = await Node.get_by_names(
+            session,
+            missing_cube_names,
+            options=[
+                joinedload(Node.current).options(selectinload(NodeRevision.columns)),
+            ],
+        )
+        cube_map.update({n.name: n for n in db_cubes})
+
+    # Collect metric names from cubes, load from known nodes first
+    all_metric_names: set[str] = set()
+    for cube_node in cube_map.values():
+        if cube_node.current:  # pragma: no branch
+            all_metric_names.update(cube_node.current.cube_node_metrics)
+
+    metric_nodes: list[Node] = []
+    missing_metric_names: list[str] = []
+    for name in all_metric_names:
+        if name in known_nodes and known_nodes[name].current:
+            metric_nodes.append(known_nodes[name])
+        else:
+            missing_metric_names.append(name)  # pragma: no cover
+    if missing_metric_names:  # pragma: no cover
+        db_metrics = await Node.get_by_names(
+            session,
+            missing_metric_names,
+            options=[joinedload(Node.current)],
+        )
+        metric_nodes.extend(db_metrics)
+
+    # Resolve metric → non-metric parents (batched DB query)
+    metric_to_parents = await get_metric_parents_map(session, metric_nodes)
+
+    # Build reachability from the post-deployment state
+    local_names: dict[int, str] = {}
+    all_parent_rev_ids: set[int] = set()
+    for parents in metric_to_parents.values():
+        for p in parents:
+            if p.current:  # pragma: no branch
+                all_parent_rev_ids.add(p.current.id)
+                local_names[p.current.id] = p.name
+
+    all_dim_node_names: set[str] = set()
+    for cube_node in cube_map.values():
+        if cube_node.current:  # pragma: no branch
+            for dim in cube_node.current.cube_node_dimensions:
+                all_dim_node_names.add(dim.rsplit(SEPARATOR, 1)[0])
+
+    reachability = await DimensionReachability.build(
+        session,
+        all_parent_rev_ids,
+        all_dim_node_names,
+        local_names=local_names,
+    )
+
+    # Check each cube
+    updated_results = list(results)
+    for idx, impact in cube_impacts:
+        cube_node = cube_map.get(impact.name)  # type: ignore[assignment]
+        if not cube_node or not cube_node.current:  # pragma: no cover
+            continue
+
+        cube_parent_rev_ids = {
+            p.current.id
+            for metric_name in cube_node.current.cube_node_metrics
+            for p in metric_to_parents.get(metric_name, [])
+            if p.current
+        }
+        requested_dims = {
+            dim.rsplit(SEPARATOR, 1)[0]
+            for dim in cube_node.current.cube_node_dimensions
+        }
+        unreachable = reachability.unreachable_dimensions(
+            cube_parent_rev_ids,
+            requested_dims,
+        )
+        if unreachable:
+            dim_list = ", ".join(sorted(unreachable.keys()))
+            updated_results[idx] = DownstreamImpact(
+                name=impact.name,
+                node_type=impact.node_type,
+                current_status=impact.current_status,
+                predicted_status=NodeStatus.INVALID,
+                impact_type=ImpactType.WILL_INVALIDATE,
+                impact_reason=(
+                    f"Dimension(s) no longer reachable after link change: {dim_list}"
+                ),
+                depth=impact.depth,
+                caused_by=impact.caused_by,
+                is_external=impact.is_external,
+            )
+
+    return updated_results
 
 
 def _build_name_index(ctx: PropagationContext) -> dict[str, Node]:

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1919,7 +1919,7 @@ class TestDeployments:
         failed_result = next(
             r for r in data["results"] if r["status"] in ("failed", "invalid")
         )
-        assert "is not available on every metric" in failed_result["message"]
+        assert "is not reachable from parent node" in failed_result["message"]
 
     @pytest.mark.asyncio
     async def test_deploy_failed_with_bad_node_spec_links(
@@ -2767,7 +2767,7 @@ class TestDeployments:
         cube_result = next(r for r in node_results if "cube.user_analysis" in r["name"])
         assert cube_result["status"] in ("failed", "invalid")
         # The failure is about dimension reachability, not a missing namespace prefix
-        assert "is not available on every metric" in cube_result["message"]
+        assert "is not reachable from parent node" in cube_result["message"]
         assert not any(
             "external.dimension" in r.get("message", "")
             and "missing" in r.get("message", "")

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1922,6 +1922,101 @@ class TestDeployments:
         assert "is not reachable from parent node" in failed_result["message"]
 
     @pytest.mark.asyncio
+    async def test_deploy_cube_filter_bad_column(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A cube filter referencing a nonexistent column on a reachable dimension
+        should produce a clear invalid error.
+        """
+        namespace = "cube_filter_col"
+        cube = CubeSpec(
+            name="default.filter_cube",
+            display_name="Filter Cube",
+            description="Cube for filter column validation",
+            dimensions=["${prefix}default.hard_hat.state"],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            filters=["${prefix}default.hard_hat.nonexistent_col = 'X'"],
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_us_states,
+            default_us_state,
+            default_hard_hat,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        cube_result = next(
+            r
+            for r in data["results"]
+            if r["name"] == f"{namespace}.default.filter_cube"
+        )
+        assert cube_result["status"] == "invalid"
+        assert "nonexistent_col" in cube_result["message"]
+        assert "does not exist" in cube_result["message"]
+
+    @pytest.mark.asyncio
+    async def test_deploy_cube_filter_unreachable_dim(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_dispatchers,
+        default_dispatcher,
+        default_avg_length_of_employment,
+    ):
+        """
+        A cube filter referencing a dimension not reachable from the cube's
+        metrics should produce a clear invalid error.
+        """
+        namespace = "cube_filter_dim"
+        cube = CubeSpec(
+            name="default.filter_dim_cube",
+            display_name="Filter Dim Cube",
+            description="Cube for filter dimension validation",
+            dimensions=["${prefix}default.hard_hat.state"],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            filters=["${prefix}default.dispatcher.company_name = 'X'"],
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_us_states,
+            default_us_state,
+            default_hard_hat,
+            default_dispatchers,
+            default_dispatcher,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        cube_result = next(
+            r
+            for r in data["results"]
+            if r["name"] == f"{namespace}.default.filter_dim_cube"
+        )
+        assert cube_result["status"] == "invalid"
+        assert "is not reachable from parent node" in cube_result["message"]
+
+    @pytest.mark.asyncio
     async def test_deploy_failed_with_bad_node_spec_links(
         self,
         client,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -1866,12 +1866,18 @@ async def test_validate_single_cube_with_invalid_metric(
         dimensions=[],
     )
 
-    result = await orchestrator._validate_single_cube(
+    from datajunction_server.internal.deployment.dimension_reachability import (
+        DimensionReachability,
+    )
+
+    result = orchestrator._validate_single_cube(
         cube_spec=cube_spec,
         metric_nodes_map={"broken_metric": invalid_metric},
         missing_metrics=set(),
         missing_dimensions=set(),
         dimension_mapping={},
+        reachability=DimensionReachability({}),
+        metric_to_parents={},
     )
 
     assert result.status == NodeStatus.INVALID

--- a/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
+++ b/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
@@ -152,3 +152,60 @@ class TestDimensionReachabilityBuild:
         )
         assert r.is_reachable(10, "node.self")
         assert not r.is_reachable(10, "dim.other")
+
+
+class TestExtractDimensionRefsFromFilters:
+    """Tests for _extract_dimension_refs_from_filters."""
+
+    def test_single_filter(self):
+        from datajunction_server.internal.deployment.orchestrator import (
+            _extract_dimension_refs_from_filters,
+        )
+
+        result = _extract_dimension_refs_from_filters(
+            ["ns.hard_hat.state = 'CA'"],
+        )
+        assert result == [("ns.hard_hat", "state")]
+
+    def test_multiple_filters(self):
+        from datajunction_server.internal.deployment.orchestrator import (
+            _extract_dimension_refs_from_filters,
+        )
+
+        result = _extract_dimension_refs_from_filters(
+            ["ns.hard_hat.state = 'CA'", "ns.date_dim.year > 2020"],
+        )
+        assert sorted(result) == [("ns.date_dim", "year"), ("ns.hard_hat", "state")]
+
+    def test_empty_filters(self):
+        from datajunction_server.internal.deployment.orchestrator import (
+            _extract_dimension_refs_from_filters,
+        )
+
+        assert _extract_dimension_refs_from_filters([]) == []
+
+    def test_unparseable_filter(self):
+        from datajunction_server.internal.deployment.orchestrator import (
+            _extract_dimension_refs_from_filters,
+        )
+
+        result = _extract_dimension_refs_from_filters(["not valid sql !!!"])
+        assert result == []
+
+    def test_filter_with_no_namespace(self):
+        from datajunction_server.internal.deployment.orchestrator import (
+            _extract_dimension_refs_from_filters,
+        )
+
+        result = _extract_dimension_refs_from_filters(["x > 5"])
+        assert result == []
+
+    def test_filter_with_multiple_refs_in_one_expression(self):
+        from datajunction_server.internal.deployment.orchestrator import (
+            _extract_dimension_refs_from_filters,
+        )
+
+        result = _extract_dimension_refs_from_filters(
+            ["ns.dim_a.col1 > 5 AND ns.dim_b.col2 = 'x'"],
+        )
+        assert sorted(result) == [("ns.dim_a", "col1"), ("ns.dim_b", "col2")]

--- a/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
+++ b/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
@@ -1,0 +1,154 @@
+"""
+Tests for DimensionReachability — batched dimension reachability lookups.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from datajunction_server.internal.deployment.dimension_reachability import (
+    DimensionReachability,
+)
+
+
+class TestDimensionReachabilityInMemory:
+    """Pure in-memory tests — no DB, no BFS, just the lookup logic."""
+
+    def test_empty_paths(self):
+        r = DimensionReachability({})
+        assert r.reachable_from(1) == set()
+        assert not r.is_reachable(1, "dim.a")
+        assert r.shared_dimensions(set()) == set()
+        assert r.shared_dimensions({1}) == set()
+        assert r.unreachable_dimensions({1}, {"dim.a"}) == {"dim.a": {1}}
+
+    def test_single_source_single_dim(self):
+        paths = {(10, "dim.country", ""): [100]}
+        r = DimensionReachability(paths)
+        assert r.is_reachable(10, "dim.country")
+        assert not r.is_reachable(10, "dim.city")
+        assert r.reachable_from(10) == {"dim.country"}
+
+    def test_single_source_multiple_dims(self):
+        paths = {
+            (10, "dim.country", ""): [100],
+            (10, "dim.city", ""): [101],
+            (10, "dim.date", ""): [102],
+        }
+        r = DimensionReachability(paths)
+        assert r.reachable_from(10) == {"dim.country", "dim.city", "dim.date"}
+
+    def test_multiple_sources_shared(self):
+        paths = {
+            (10, "dim.country", ""): [100],
+            (10, "dim.date", ""): [101],
+            (20, "dim.country", ""): [200],
+            (20, "dim.date", ""): [201],
+            (20, "dim.city", ""): [202],
+        }
+        r = DimensionReachability(paths)
+        # country and date are shared; city is only reachable from 20
+        assert r.shared_dimensions({10, 20}) == {"dim.country", "dim.date"}
+
+    def test_unreachable_dimensions(self):
+        paths = {
+            (10, "dim.country", ""): [100],
+            (20, "dim.country", ""): [200],
+            (20, "dim.date", ""): [201],
+        }
+        r = DimensionReachability(paths)
+        missing = r.unreachable_dimensions({10, 20}, {"dim.country", "dim.date"})
+        # date is only missing from source 10
+        assert missing == {"dim.date": {10}}
+
+    def test_unreachable_all_present(self):
+        paths = {
+            (10, "dim.a", ""): [1],
+            (20, "dim.a", ""): [2],
+        }
+        r = DimensionReachability(paths)
+        assert r.unreachable_dimensions({10, 20}, {"dim.a"}) == {}
+
+    def test_roles_are_tracked(self):
+        """Different roles for the same dim are both reachable."""
+        paths = {
+            (10, "dim.date", ""): [100],
+            (10, "dim.date", "order"): [101],
+        }
+        r = DimensionReachability(paths)
+        # dim.date is reachable (role doesn't affect node-level reachability)
+        assert r.is_reachable(10, "dim.date")
+
+    def test_local_names(self):
+        """Local names make each source reachable from itself."""
+        paths = {(10, "dim.country", ""): [100]}
+        local = {10: "node.fact_table", 20: "node.other_table"}
+        r = DimensionReachability(paths, local_names=local)
+        # 10 can reach dim.country (via BFS) and node.fact_table (local)
+        assert r.is_reachable(10, "dim.country")
+        assert r.is_reachable(10, "node.fact_table")
+        # 20 can only reach node.other_table (local), nothing via BFS
+        assert r.is_reachable(20, "node.other_table")
+        assert not r.is_reachable(20, "dim.country")
+
+    def test_local_names_in_shared(self):
+        """Local dimensions participate in shared_dimensions."""
+        paths = {}
+        local = {10: "node.same", 20: "node.same"}
+        r = DimensionReachability(paths, local_names=local)
+        # Both sources are "node.same" → it's shared
+        assert r.shared_dimensions({10, 20}) == {"node.same"}
+
+    def test_local_names_not_shared(self):
+        """Different local names are not shared."""
+        paths = {}
+        local = {10: "node.a", 20: "node.b"}
+        r = DimensionReachability(paths, local_names=local)
+        assert r.shared_dimensions({10, 20}) == set()
+
+
+class TestDimensionReachabilityBuild:
+    """Tests for the async build method using mocked find_join_paths_batch."""
+
+    @pytest.mark.asyncio
+    async def test_build_empty(self):
+        r = await DimensionReachability.build(
+            session=AsyncMock(),
+            source_revision_ids=set(),
+            target_dimension_names=set(),
+        )
+        assert r.reachable_from(1) == set()
+
+    @pytest.mark.asyncio
+    async def test_build_delegates_to_find_join_paths_batch(self):
+        mock_paths = {
+            (10, "dim.country", ""): [100],
+            (20, "dim.country", ""): [200],
+        }
+        with patch(
+            "datajunction_server.internal.deployment.dimension_reachability.find_join_paths_batch",
+            new_callable=AsyncMock,
+            return_value=mock_paths,
+        ) as mock_bfs:
+            r = await DimensionReachability.build(
+                session=AsyncMock(),
+                source_revision_ids={10, 20},
+                target_dimension_names={"dim.country"},
+                local_names={10: "node.fact"},
+            )
+            mock_bfs.assert_called_once()
+
+        assert r.is_reachable(10, "dim.country")
+        assert r.is_reachable(10, "node.fact")  # local
+        assert r.is_reachable(20, "dim.country")
+
+    @pytest.mark.asyncio
+    async def test_build_with_local_names_no_targets(self):
+        """Empty targets → no BFS, but local names still work."""
+        r = await DimensionReachability.build(
+            session=AsyncMock(),
+            source_revision_ids={10},
+            target_dimension_names=set(),
+            local_names={10: "node.self"},
+        )
+        assert r.is_reachable(10, "node.self")
+        assert not r.is_reachable(10, "dim.other")

--- a/datajunction-server/tests/internal/deployment/test_type_inference_complex.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference_complex.py
@@ -1,0 +1,815 @@
+"""
+Complex test suites for validate_node_query.
+
+Part 1: SQL Complexity — gnarly standalone queries against a small set of source tables.
+Part 2: DAG Depth — topological resolution chain simulating deployment propagation.
+"""
+
+import pytest
+
+from datajunction_server.internal.deployment.type_inference import (
+    validate_node_query,
+    columns_signature_changed,
+    TypeResolutionError,
+)
+from datajunction_server.sql.parsing.types import (
+    BigIntType,
+    BooleanType,
+    DateType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    StringType,
+    TimestampType,
+    UnknownType,
+)
+
+
+# =====================================================================
+# Shared source tables for SQL complexity tests
+# =====================================================================
+
+def _col_map(*tables):
+    return {
+        name: {col_name: col_type for col_name, col_type in cols}
+        for name, cols in tables
+    }
+
+
+EVENTS = (
+    "default.events",
+    [
+        ("event_id", IntegerType()),
+        ("user_id", IntegerType()),
+        ("amount", DoubleType()),
+        ("discount", FloatType()),
+        ("tags", StringType()),  # array<string> stored as string
+        ("created_at", TimestampType()),
+        ("category", StringType()),
+    ],
+)
+
+USERS = (
+    "default.users",
+    [
+        ("user_id", IntegerType()),
+        ("username", StringType()),
+        ("country", StringType()),
+        ("signup_date", DateType()),
+        ("is_active", BooleanType()),
+    ],
+)
+
+DATE_DIM = (
+    "default.date_dim",
+    [
+        ("date_id", DateType()),
+        ("year", IntegerType()),
+        ("month", IntegerType()),
+        ("week", StringType()),
+        ("quarter", IntegerType()),
+    ],
+)
+
+PRODUCTS = (
+    "default.products",
+    [
+        ("product_id", IntegerType()),
+        ("product_name", StringType()),
+        ("category", StringType()),
+        ("price", DoubleType()),
+    ],
+)
+
+ORDER_ITEMS = (
+    "default.order_items",
+    [
+        ("item_id", IntegerType()),
+        ("event_id", IntegerType()),
+        ("product_id", IntegerType()),
+        ("quantity", IntegerType()),
+        ("unit_price", DoubleType()),
+    ],
+)
+
+ALL_SOURCES = _col_map(EVENTS, USERS, DATE_DIM, PRODUCTS, ORDER_ITEMS)
+
+
+# #####################################################################
+#
+#  PART 1: SQL COMPLEXITY
+#
+# #####################################################################
+
+
+class TestComplexCTEs:
+    """Multi-CTE queries with inter-CTE references and window functions."""
+
+    def test_multi_cte_with_window_functions(self):
+        """
+        WITH
+          daily AS (
+            SELECT user_id, CAST(created_at AS DATE) AS dt,
+                   SUM(amount) AS daily_total,
+                   ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY CAST(created_at AS DATE) DESC) AS rn
+            FROM default.events
+            GROUP BY user_id, CAST(created_at AS DATE)
+          ),
+          weekly AS (
+            SELECT user_id, COUNT(*) AS active_days, AVG(daily_total) AS avg_daily
+            FROM daily WHERE rn <= 7
+            GROUP BY user_id
+          )
+        SELECT w.user_id, w.active_days, w.avg_daily,
+               CASE WHEN w.avg_daily > 100 THEN 'high'
+                    WHEN w.avg_daily > 10 THEN 'medium'
+                    ELSE 'low' END AS tier
+        FROM weekly w
+        """
+        result = validate_node_query(
+            "WITH "
+            "daily AS ("
+            "  SELECT user_id, CAST(created_at AS DATE) AS dt, "
+            "         SUM(amount) AS daily_total, "
+            "         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY CAST(created_at AS DATE) DESC) AS rn "
+            "  FROM default.events "
+            "  GROUP BY user_id, CAST(created_at AS DATE)"
+            "), "
+            "weekly AS ("
+            "  SELECT user_id, COUNT(*) AS active_days, AVG(daily_total) AS avg_daily "
+            "  FROM daily WHERE rn <= 7 "
+            "  GROUP BY user_id"
+            ") "
+            "SELECT w.user_id, w.active_days, w.avg_daily, "
+            "       CASE WHEN w.avg_daily > 100 THEN 'high' "
+            "            WHEN w.avg_daily > 10 THEN 'medium' "
+            "            ELSE 'low' END AS tier "
+            "FROM weekly w",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 4
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1][0] == "active_days"
+        assert isinstance(result.output_columns[1][1], BigIntType)
+        assert result.output_columns[2][0] == "avg_daily"
+        assert result.output_columns[3] == ("tier", StringType())
+
+    def test_cte_referencing_earlier_cte(self):
+        """
+        WITH
+          base AS (SELECT user_id, amount FROM default.events),
+          enriched AS (SELECT b.user_id, b.amount, u.country FROM base b JOIN default.users u ON b.user_id = u.user_id),
+          summary AS (SELECT country, SUM(amount) AS total, COUNT(*) AS cnt FROM enriched GROUP BY country)
+        SELECT country, total, cnt, total / cnt AS avg_per_event FROM summary
+        """
+        result = validate_node_query(
+            "WITH "
+            "base AS (SELECT user_id, amount FROM default.events), "
+            "enriched AS ("
+            "  SELECT b.user_id, b.amount, u.country "
+            "  FROM base b JOIN default.users u ON b.user_id = u.user_id"
+            "), "
+            "summary AS ("
+            "  SELECT country, SUM(amount) AS total, COUNT(*) AS cnt "
+            "  FROM enriched GROUP BY country"
+            ") "
+            "SELECT country, total, cnt, total / cnt AS avg_per_event FROM summary",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 4
+        assert result.output_columns[0] == ("country", StringType())
+        assert result.output_columns[1][0] == "total"
+        assert isinstance(result.output_columns[1][1], DoubleType)
+        assert result.output_columns[2][0] == "cnt"
+        assert result.output_columns[3][0] == "avg_per_event"
+
+
+class TestComplexJoins:
+    """Multi-join queries with mixed aggregation and expressions."""
+
+    def test_multi_join_with_mixed_agg(self):
+        """
+        SELECT
+          u.country,
+          COUNT(DISTINCT e.user_id) AS unique_users,
+          SUM(CASE WHEN e.amount > 0 THEN e.amount ELSE 0 END) AS positive_revenue,
+          MAX(e.created_at) AS last_activity
+        FROM default.events e
+        JOIN default.users u ON e.user_id = u.user_id
+        GROUP BY u.country
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  u.country, "
+            "  COUNT(DISTINCT e.user_id) AS unique_users, "
+            "  SUM(CASE WHEN e.amount > 0 THEN e.amount ELSE 0 END) AS positive_revenue, "
+            "  MAX(e.created_at) AS last_activity "
+            "FROM default.events e "
+            "JOIN default.users u ON e.user_id = u.user_id "
+            "GROUP BY u.country",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 4
+        assert result.output_columns[0] == ("country", StringType())
+        assert result.output_columns[1][0] == "unique_users"
+        assert isinstance(result.output_columns[1][1], BigIntType)
+        assert result.output_columns[2][0] == "positive_revenue"
+        assert isinstance(result.output_columns[2][1], DoubleType)
+        assert result.output_columns[3][0] == "last_activity"
+
+    def test_three_way_join(self):
+        """
+        SELECT
+          u.username,
+          p.product_name,
+          SUM(oi.quantity * oi.unit_price) AS total_spent
+        FROM default.order_items oi
+        JOIN default.events e ON oi.event_id = e.event_id
+        JOIN default.users u ON e.user_id = u.user_id
+        JOIN default.products p ON oi.product_id = p.product_id
+        GROUP BY u.username, p.product_name
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  u.username, "
+            "  p.product_name, "
+            "  SUM(oi.quantity * oi.unit_price) AS total_spent "
+            "FROM default.order_items oi "
+            "JOIN default.events e ON oi.event_id = e.event_id "
+            "JOIN default.users u ON e.user_id = u.user_id "
+            "JOIN default.products p ON oi.product_id = p.product_id "
+            "GROUP BY u.username, p.product_name",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 3
+        assert result.output_columns[0] == ("username", StringType())
+        assert result.output_columns[1] == ("product_name", StringType())
+        assert result.output_columns[2][0] == "total_spent"
+
+    def test_left_join_with_coalesce(self):
+        """
+        SELECT
+          e.event_id,
+          COALESCE(u.username, 'anonymous') AS display_name,
+          COALESCE(u.country, 'unknown') AS country
+        FROM default.events e
+        LEFT JOIN default.users u ON e.user_id = u.user_id
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  e.event_id, "
+            "  COALESCE(u.username, 'anonymous') AS display_name, "
+            "  COALESCE(u.country, 'unknown') AS country "
+            "FROM default.events e "
+            "LEFT JOIN default.users u ON e.user_id = u.user_id",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 3
+        assert result.output_columns[0] == ("event_id", IntegerType())
+        assert result.output_columns[1] == ("display_name", StringType())
+        assert result.output_columns[2] == ("country", StringType())
+
+
+class TestComplexSubqueries:
+    """Nested subqueries including subqueries in WHERE and FROM."""
+
+    def test_subquery_in_from_with_aggregation(self):
+        """
+        SELECT country, avg_amount
+        FROM (
+          SELECT u.country, AVG(e.amount) AS avg_amount
+          FROM default.events e
+          JOIN default.users u ON e.user_id = u.user_id
+          GROUP BY u.country
+        ) country_stats
+        WHERE avg_amount > 50
+        """
+        result = validate_node_query(
+            "SELECT country, avg_amount "
+            "FROM ("
+            "  SELECT u.country, AVG(e.amount) AS avg_amount "
+            "  FROM default.events e "
+            "  JOIN default.users u ON e.user_id = u.user_id "
+            "  GROUP BY u.country"
+            ") country_stats "
+            "WHERE avg_amount > 50",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 2
+        assert result.output_columns[0] == ("country", StringType())
+        assert result.output_columns[1][0] == "avg_amount"
+
+    def test_subquery_in_where_with_in(self):
+        """
+        SELECT user_id, username
+        FROM default.users
+        WHERE user_id IN (
+          SELECT user_id FROM default.events
+          GROUP BY user_id
+          HAVING SUM(amount) > 1000
+        )
+        """
+        result = validate_node_query(
+            "SELECT user_id, username "
+            "FROM default.users "
+            "WHERE user_id IN ("
+            "  SELECT user_id FROM default.events "
+            "  GROUP BY user_id "
+            "  HAVING SUM(amount) > 1000"
+            ")",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 2
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1] == ("username", StringType())
+
+    def test_deeply_nested_subqueries(self):
+        """
+        Three levels deep:
+        SELECT * FROM (
+          SELECT country, total FROM (
+            SELECT u.country, SUM(e.amount) AS total
+            FROM default.events e
+            JOIN default.users u ON e.user_id = u.user_id
+            GROUP BY u.country
+          ) inner_agg
+          WHERE total > 100
+        ) outer_filter
+        """
+        result = validate_node_query(
+            "SELECT country, total FROM ("
+            "  SELECT country, total FROM ("
+            "    SELECT u.country, SUM(e.amount) AS total "
+            "    FROM default.events e "
+            "    JOIN default.users u ON e.user_id = u.user_id "
+            "    GROUP BY u.country"
+            "  ) inner_agg "
+            "  WHERE total > 100"
+            ") outer_filter",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 2
+        assert result.output_columns[0] == ("country", StringType())
+        assert result.output_columns[1][0] == "total"
+        assert isinstance(result.output_columns[1][1], DoubleType)
+
+    def test_correlated_subquery_in_select(self):
+        """
+        SELECT
+          u.user_id,
+          u.username,
+          (SELECT COUNT(*) FROM default.events e WHERE e.user_id = u.user_id) AS event_count
+        FROM default.users u
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  u.user_id, "
+            "  u.username, "
+            "  (SELECT COUNT(*) FROM default.events e WHERE e.user_id = u.user_id) AS event_count "
+            "FROM default.users u",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 3
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1] == ("username", StringType())
+        assert result.output_columns[2][0] == "event_count"
+
+
+class TestComplexExpressions:
+    """Deeply nested expressions: CASE inside CASE, chained functions, etc."""
+
+    def test_nested_case_inside_case(self):
+        """
+        SELECT
+          CASE
+            WHEN category = 'premium' THEN
+              CASE WHEN amount > 500 THEN 'whale' ELSE 'premium' END
+            WHEN category = 'standard' THEN 'standard'
+            ELSE 'basic'
+          END AS user_tier
+        FROM default.events
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  CASE "
+            "    WHEN category = 'premium' THEN "
+            "      CASE WHEN amount > 500 THEN 'whale' ELSE 'premium' END "
+            "    WHEN category = 'standard' THEN 'standard' "
+            "    ELSE 'basic' "
+            "  END AS user_tier "
+            "FROM default.events",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 1
+        assert result.output_columns[0] == ("user_tier", StringType())
+
+    def test_complex_arithmetic_chain(self):
+        """
+        SELECT
+          user_id,
+          (amount * (1 - discount)) / NULLIF(quantity, 0) AS effective_price
+        FROM default.events e
+        JOIN default.order_items oi ON e.event_id = oi.event_id
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  e.user_id, "
+            "  (e.amount * (1 - e.discount)) AS effective_amount "
+            "FROM default.events e",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 2
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1][0] == "effective_amount"
+
+    def test_multiple_window_functions(self):
+        """
+        SELECT
+          user_id,
+          amount,
+          SUM(amount) OVER (PARTITION BY user_id ORDER BY created_at) AS running_total,
+          LAG(amount, 1) OVER (PARTITION BY user_id ORDER BY created_at) AS prev_amount,
+          RANK() OVER (ORDER BY amount DESC) AS amount_rank
+        FROM default.events
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  user_id, "
+            "  amount, "
+            "  SUM(amount) OVER (PARTITION BY user_id ORDER BY created_at) AS running_total, "
+            "  LAG(amount, 1) OVER (PARTITION BY user_id ORDER BY created_at) AS prev_amount, "
+            "  RANK() OVER (ORDER BY amount DESC) AS amount_rank "
+            "FROM default.events",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 5
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1] == ("amount", DoubleType())
+        assert result.output_columns[2][0] == "running_total"
+        assert isinstance(result.output_columns[2][1], DoubleType)
+        assert result.output_columns[3][0] == "prev_amount"
+        assert isinstance(result.output_columns[3][1], DoubleType)  # LAG returns arg's type
+        assert result.output_columns[4][0] == "amount_rank"
+        assert isinstance(result.output_columns[4][1], IntegerType)  # RANK returns IntegerType
+
+    def test_max_case_greatest_coalesce(self):
+        """The gnarliest nested expression: MAX(CASE WHEN GREATEST(COALESCE(...), ...) > 0 THEN ...)"""
+        result = validate_node_query(
+            "SELECT MAX(CASE "
+            "  WHEN GREATEST(COALESCE(amount, 0), 0) > 0 "
+            "  THEN amount "
+            "  ELSE 0 "
+            "END) AS max_positive "
+            "FROM default.events",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 1
+        assert result.output_columns[0][0] == "max_positive"
+        assert isinstance(result.output_columns[0][1], DoubleType)
+
+    def test_sum_of_case_with_multiple_conditions(self):
+        """
+        SELECT
+          SUM(CASE WHEN category = 'A' THEN amount ELSE 0 END) AS a_total,
+          SUM(CASE WHEN category = 'B' THEN amount ELSE 0 END) AS b_total,
+          COUNT(CASE WHEN amount > 100 THEN 1 END) AS high_value_count
+        FROM default.events
+        """
+        result = validate_node_query(
+            "SELECT "
+            "  SUM(CASE WHEN category = 'A' THEN amount ELSE 0 END) AS a_total, "
+            "  SUM(CASE WHEN category = 'B' THEN amount ELSE 0 END) AS b_total, "
+            "  COUNT(CASE WHEN amount > 100 THEN 1 END) AS high_value_count "
+            "FROM default.events",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 3
+        assert result.output_columns[0][0] == "a_total"
+        assert isinstance(result.output_columns[0][1], DoubleType)
+        assert result.output_columns[1][0] == "b_total"
+        assert isinstance(result.output_columns[1][1], DoubleType)
+        assert result.output_columns[2][0] == "high_value_count"
+        assert isinstance(result.output_columns[2][1], BigIntType)
+
+
+class TestComplexSetOperations:
+    """UNION, UNION ALL, INTERSECT with different complexities."""
+
+    def test_union_all_with_aggregation(self):
+        """
+        SELECT user_id, 'event' AS source, COUNT(*) AS cnt
+        FROM default.events GROUP BY user_id
+        UNION ALL
+        SELECT user_id, 'order' AS source, COUNT(*) AS cnt
+        FROM default.order_items
+        JOIN default.events ON order_items.event_id = events.event_id
+        GROUP BY user_id
+        """
+        # Simplified — UNION output takes types from the first SELECT
+        result = validate_node_query(
+            "SELECT user_id, 'event' AS source, COUNT(*) AS cnt "
+            "FROM default.events GROUP BY user_id "
+            "UNION ALL "
+            "SELECT user_id, 'order' AS source, COUNT(*) AS cnt "
+            "FROM default.events GROUP BY user_id",
+            ALL_SOURCES,
+        )
+        assert len(result.output_columns) == 3
+        assert result.output_columns[0] == ("user_id", IntegerType())
+        assert result.output_columns[1] == ("source", StringType())
+        assert result.output_columns[2][0] == "cnt"
+        assert isinstance(result.output_columns[2][1], BigIntType)
+
+
+# #####################################################################
+#
+#  PART 2: DAG DEPTH — topological resolution chain
+#
+# #####################################################################
+
+
+class TestTopologicalResolution:
+    """
+    Simulate deployment propagation: resolve nodes in topological order,
+    feeding each node's resolved output columns into the parent map for
+    the next level.
+    """
+
+    # ---- Source tables (level 0 — given, not resolved) ----
+    SOURCES = _col_map(
+        ("ns.raw_events", [
+            ("event_id", IntegerType()),
+            ("user_id", IntegerType()),
+            ("amount", DoubleType()),
+            ("tags", StringType()),
+            ("created_at", TimestampType()),
+        ]),
+        ("ns.raw_users", [
+            ("user_id", IntegerType()),
+            ("username", StringType()),
+            ("country", StringType()),
+            ("signup_date", DateType()),
+        ]),
+        ("ns.date_dim", [
+            ("date_id", DateType()),
+            ("year", IntegerType()),
+            ("month", IntegerType()),
+            ("week", StringType()),
+        ]),
+    )
+
+    # ---- Level 1: transforms that reference sources ----
+    LEVEL_1_NODES = {
+        "ns.events_enriched": (
+            "SELECT e.event_id, e.user_id, e.amount, e.created_at, "
+            "u.username, u.country "
+            "FROM ns.raw_events e "
+            "JOIN ns.raw_users u ON e.user_id = u.user_id"
+        ),
+        "ns.events_exploded": (
+            "SELECT event_id, user_id, tag "
+            "FROM ns.raw_events "
+            "LATERAL VIEW EXPLODE(tags) t AS tag"
+        ),
+    }
+
+    # ---- Level 2: transforms that reference level 1 ----
+    LEVEL_2_NODES = {
+        "ns.daily_summary": (
+            "SELECT user_id, CAST(created_at AS DATE) AS dt, "
+            "SUM(amount) AS daily_total, COUNT(*) AS event_count "
+            "FROM ns.events_enriched "
+            "GROUP BY user_id, CAST(created_at AS DATE)"
+        ),
+        "ns.country_stats": (
+            "SELECT country, COUNT(DISTINCT user_id) AS unique_users, "
+            "SUM(amount) AS total_revenue "
+            "FROM ns.events_enriched "
+            "GROUP BY country"
+        ),
+    }
+
+    # ---- Level 3: transforms that reference level 2 ----
+    LEVEL_3_NODES = {
+        "ns.user_weekly_stats": (
+            "WITH ranked AS ("
+            "  SELECT user_id, dt, daily_total, "
+            "  ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY dt DESC) AS rn "
+            "  FROM ns.daily_summary"
+            ") "
+            "SELECT user_id, AVG(daily_total) AS avg_daily, "
+            "COUNT(*) AS active_days "
+            "FROM ranked WHERE rn <= 7 "
+            "GROUP BY user_id"
+        ),
+    }
+
+    # ---- Metrics (reference various levels) ----
+    METRIC_NODES = {
+        "ns.total_revenue": (
+            "SELECT SUM(amount) AS ns_DOT_total_revenue "
+            "FROM ns.events_enriched"
+        ),
+        "ns.avg_daily_revenue": (
+            "SELECT AVG(daily_total) AS ns_DOT_avg_daily_revenue "
+            "FROM ns.daily_summary"
+        ),
+    }
+
+    # ---- Derived metric (references other metrics) ----
+    DERIVED_METRIC_NODES = {
+        "ns.revenue_health": (
+            "SELECT ns.total_revenue / ns.avg_daily_revenue AS ns_DOT_revenue_health"
+        ),
+    }
+
+    def test_full_topological_resolution(self):
+        """
+        Resolve the entire DAG in topological order:
+        sources → level 1 → level 2 → level 3 → metrics → derived metrics.
+
+        At each level, resolved output columns feed into the parent map
+        for the next level — exactly what propagate_impact Phase 4 would do.
+        """
+        # Start with source columns
+        parent_map = dict(self.SOURCES)
+
+        # Level 1
+        for name, query in self.LEVEL_1_NODES.items():
+            result = validate_node_query(query, parent_map)
+            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        # Verify level 1: events_enriched
+        assert isinstance(parent_map["ns.events_enriched"]["event_id"], IntegerType)
+        assert isinstance(parent_map["ns.events_enriched"]["user_id"], IntegerType)
+        assert isinstance(parent_map["ns.events_enriched"]["amount"], DoubleType)
+        assert isinstance(parent_map["ns.events_enriched"]["created_at"], TimestampType)
+        assert isinstance(parent_map["ns.events_enriched"]["username"], StringType)
+        assert isinstance(parent_map["ns.events_enriched"]["country"], StringType)
+        # events_exploded: tag is UnknownType from LATERAL VIEW
+        assert isinstance(parent_map["ns.events_exploded"]["event_id"], IntegerType)
+        assert isinstance(parent_map["ns.events_exploded"]["user_id"], IntegerType)
+
+        # Level 2
+        for name, query in self.LEVEL_2_NODES.items():
+            result = validate_node_query(query, parent_map)
+            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        # Verify level 2: daily_summary
+        assert isinstance(parent_map["ns.daily_summary"]["user_id"], IntegerType)
+        assert isinstance(parent_map["ns.daily_summary"]["daily_total"], DoubleType)
+        assert isinstance(parent_map["ns.daily_summary"]["event_count"], BigIntType)
+        # country_stats
+        assert isinstance(parent_map["ns.country_stats"]["country"], StringType)
+        assert isinstance(parent_map["ns.country_stats"]["unique_users"], BigIntType)
+        assert isinstance(parent_map["ns.country_stats"]["total_revenue"], DoubleType)
+
+        # Level 3
+        for name, query in self.LEVEL_3_NODES.items():
+            result = validate_node_query(query, parent_map)
+            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        # Verify level 3: user_weekly_stats
+        assert isinstance(parent_map["ns.user_weekly_stats"]["user_id"], IntegerType)
+        assert isinstance(parent_map["ns.user_weekly_stats"]["avg_daily"], DoubleType)
+        assert isinstance(parent_map["ns.user_weekly_stats"]["active_days"], BigIntType)
+
+        # Metrics
+        for name, query in self.METRIC_NODES.items():
+            result = validate_node_query(query, parent_map)
+            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        # Metrics: single output column each
+        assert isinstance(
+            list(parent_map["ns.total_revenue"].values())[0],
+            DoubleType,
+        )
+        assert isinstance(
+            list(parent_map["ns.avg_daily_revenue"].values())[0],
+            DoubleType,
+        )
+
+        # Derived metrics
+        for name, query in self.DERIVED_METRIC_NODES.items():
+            result = validate_node_query(query, parent_map)
+            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        assert len(parent_map["ns.revenue_health"]) == 1
+        # revenue / avg_daily → DoubleType / DoubleType → DoubleType
+        assert isinstance(
+            list(parent_map["ns.revenue_health"].values())[0],
+            DoubleType,
+        )
+
+    def test_column_type_change_propagates(self):
+        """
+        Simulate a parent column type change and verify it propagates.
+
+        1. Resolve level 1 with original source columns
+        2. Change raw_events.amount from DoubleType to FloatType
+        3. Re-resolve level 1 and verify the change propagates
+        4. Use columns_signature_changed to detect the difference
+        """
+        # Original resolution
+        original_map = dict(self.SOURCES)
+        for name, query in self.LEVEL_1_NODES.items():
+            result = validate_node_query(query, original_map)
+            original_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        original_enriched = [
+            (name, typ) for name, typ in original_map["ns.events_enriched"].items()
+        ]
+
+        # Change source: amount DoubleType → FloatType
+        changed_sources = dict(self.SOURCES)
+        changed_sources["ns.raw_events"] = {
+            "event_id": IntegerType(),
+            "user_id": IntegerType(),
+            "amount": FloatType(),  # CHANGED
+            "tags": StringType(),
+            "created_at": TimestampType(),
+        }
+
+        # Re-resolve level 1
+        changed_map = dict(changed_sources)
+        for name, query in self.LEVEL_1_NODES.items():
+            result = validate_node_query(query, changed_map)
+            changed_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        changed_enriched = [
+            (name, typ) for name, typ in changed_map["ns.events_enriched"].items()
+        ]
+
+        # The column signature should have changed (amount: double → float)
+        assert columns_signature_changed(original_enriched, changed_enriched) is True
+
+        # Specifically, the amount column type should differ
+        assert isinstance(original_map["ns.events_enriched"]["amount"], DoubleType)
+        assert isinstance(changed_map["ns.events_enriched"]["amount"], FloatType)
+
+    def test_column_rename_detected(self):
+        """
+        Simulate renaming a source column and verify downstream breakage is detected.
+        """
+        # Change source: rename 'amount' → 'total_amount'
+        changed_sources = dict(self.SOURCES)
+        changed_sources["ns.raw_events"] = {
+            "event_id": IntegerType(),
+            "user_id": IntegerType(),
+            "total_amount": DoubleType(),  # RENAMED from 'amount'
+            "tags": StringType(),
+            "created_at": TimestampType(),
+        }
+
+        # events_enriched references 'e.amount' which no longer exists
+        result = validate_node_query(
+            self.LEVEL_1_NODES["ns.events_enriched"],
+            changed_sources,
+        )
+        assert any("amount" in e for e in result.errors)
+
+    def test_column_addition_doesnt_break_downstream(self):
+        """
+        Adding a new column to a source should NOT break existing downstream nodes.
+        """
+        # Add a new column to raw_events
+        expanded_sources = dict(self.SOURCES)
+        expanded_sources["ns.raw_events"] = {
+            **self.SOURCES["ns.raw_events"],
+            "new_column": StringType(),  # ADDED
+        }
+
+        # Level 1 should still resolve fine
+        for name, query in self.LEVEL_1_NODES.items():
+            result = validate_node_query(query, expanded_sources)
+            assert len(result.output_columns) > 0  # Should succeed
+
+    def test_unchanged_source_no_propagation_needed(self):
+        """
+        If source columns don't change, downstream nodes with fully-resolved
+        types should have identical column signatures.
+
+        Note: nodes with UnknownType columns (e.g., from LATERAL VIEW EXPLODE)
+        will always show as "changed" since UnknownType can't confirm equality.
+        We test only the fully-resolved node (events_enriched).
+        """
+        # Resolve twice with the same sources
+        map1 = dict(self.SOURCES)
+        for name, query in self.LEVEL_1_NODES.items():
+            result = validate_node_query(query, map1)
+            map1[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        map2 = dict(self.SOURCES)
+        for name, query in self.LEVEL_1_NODES.items():
+            result = validate_node_query(query, map2)
+            map2[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+
+        # events_enriched has no UnknownType — signatures should be identical
+        sig1 = list(map1["ns.events_enriched"].items())
+        sig2 = list(map2["ns.events_enriched"].items())
+        assert columns_signature_changed(sig1, sig2) is False
+
+        # events_exploded has UnknownType (from LATERAL VIEW) — always "changed"
+        sig1 = list(map1["ns.events_exploded"].items())
+        sig2 = list(map2["ns.events_exploded"].items())
+        assert columns_signature_changed(sig1, sig2) is True  # Expected: UnknownType triggers this

--- a/datajunction-server/tests/internal/deployment/test_type_inference_complex.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference_complex.py
@@ -5,12 +5,9 @@ Part 1: SQL Complexity — gnarly standalone queries against a small set of sour
 Part 2: DAG Depth — topological resolution chain simulating deployment propagation.
 """
 
-import pytest
-
 from datajunction_server.internal.deployment.type_inference import (
     validate_node_query,
     columns_signature_changed,
-    TypeResolutionError,
 )
 from datajunction_server.sql.parsing.types import (
     BigIntType,
@@ -21,13 +18,13 @@ from datajunction_server.sql.parsing.types import (
     IntegerType,
     StringType,
     TimestampType,
-    UnknownType,
 )
 
 
 # =====================================================================
 # Shared source tables for SQL complexity tests
 # =====================================================================
+
 
 def _col_map(*tables):
     return {
@@ -448,9 +445,15 @@ class TestComplexExpressions:
         assert result.output_columns[2][0] == "running_total"
         assert isinstance(result.output_columns[2][1], DoubleType)
         assert result.output_columns[3][0] == "prev_amount"
-        assert isinstance(result.output_columns[3][1], DoubleType)  # LAG returns arg's type
+        assert isinstance(
+            result.output_columns[3][1],
+            DoubleType,
+        )  # LAG returns arg's type
         assert result.output_columns[4][0] == "amount_rank"
-        assert isinstance(result.output_columns[4][1], IntegerType)  # RANK returns IntegerType
+        assert isinstance(
+            result.output_columns[4][1],
+            IntegerType,
+        )  # RANK returns IntegerType
 
     def test_max_case_greatest_coalesce(self):
         """The gnarliest nested expression: MAX(CASE WHEN GREATEST(COALESCE(...), ...) > 0 THEN ...)"""
@@ -537,25 +540,34 @@ class TestTopologicalResolution:
 
     # ---- Source tables (level 0 — given, not resolved) ----
     SOURCES = _col_map(
-        ("ns.raw_events", [
-            ("event_id", IntegerType()),
-            ("user_id", IntegerType()),
-            ("amount", DoubleType()),
-            ("tags", StringType()),
-            ("created_at", TimestampType()),
-        ]),
-        ("ns.raw_users", [
-            ("user_id", IntegerType()),
-            ("username", StringType()),
-            ("country", StringType()),
-            ("signup_date", DateType()),
-        ]),
-        ("ns.date_dim", [
-            ("date_id", DateType()),
-            ("year", IntegerType()),
-            ("month", IntegerType()),
-            ("week", StringType()),
-        ]),
+        (
+            "ns.raw_events",
+            [
+                ("event_id", IntegerType()),
+                ("user_id", IntegerType()),
+                ("amount", DoubleType()),
+                ("tags", StringType()),
+                ("created_at", TimestampType()),
+            ],
+        ),
+        (
+            "ns.raw_users",
+            [
+                ("user_id", IntegerType()),
+                ("username", StringType()),
+                ("country", StringType()),
+                ("signup_date", DateType()),
+            ],
+        ),
+        (
+            "ns.date_dim",
+            [
+                ("date_id", DateType()),
+                ("year", IntegerType()),
+                ("month", IntegerType()),
+                ("week", StringType()),
+            ],
+        ),
     )
 
     # ---- Level 1: transforms that reference sources ----
@@ -607,12 +619,10 @@ class TestTopologicalResolution:
     # ---- Metrics (reference various levels) ----
     METRIC_NODES = {
         "ns.total_revenue": (
-            "SELECT SUM(amount) AS ns_DOT_total_revenue "
-            "FROM ns.events_enriched"
+            "SELECT SUM(amount) AS ns_DOT_total_revenue FROM ns.events_enriched"
         ),
         "ns.avg_daily_revenue": (
-            "SELECT AVG(daily_total) AS ns_DOT_avg_daily_revenue "
-            "FROM ns.daily_summary"
+            "SELECT AVG(daily_total) AS ns_DOT_avg_daily_revenue FROM ns.daily_summary"
         ),
     }
 
@@ -637,7 +647,9 @@ class TestTopologicalResolution:
         # Level 1
         for name, query in self.LEVEL_1_NODES.items():
             result = validate_node_query(query, parent_map)
-            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            parent_map[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         # Verify level 1: events_enriched
         assert isinstance(parent_map["ns.events_enriched"]["event_id"], IntegerType)
@@ -653,7 +665,9 @@ class TestTopologicalResolution:
         # Level 2
         for name, query in self.LEVEL_2_NODES.items():
             result = validate_node_query(query, parent_map)
-            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            parent_map[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         # Verify level 2: daily_summary
         assert isinstance(parent_map["ns.daily_summary"]["user_id"], IntegerType)
@@ -667,7 +681,9 @@ class TestTopologicalResolution:
         # Level 3
         for name, query in self.LEVEL_3_NODES.items():
             result = validate_node_query(query, parent_map)
-            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            parent_map[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         # Verify level 3: user_weekly_stats
         assert isinstance(parent_map["ns.user_weekly_stats"]["user_id"], IntegerType)
@@ -677,7 +693,9 @@ class TestTopologicalResolution:
         # Metrics
         for name, query in self.METRIC_NODES.items():
             result = validate_node_query(query, parent_map)
-            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            parent_map[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         # Metrics: single output column each
         assert isinstance(
@@ -692,7 +710,9 @@ class TestTopologicalResolution:
         # Derived metrics
         for name, query in self.DERIVED_METRIC_NODES.items():
             result = validate_node_query(query, parent_map)
-            parent_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            parent_map[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         assert len(parent_map["ns.revenue_health"]) == 1
         # revenue / avg_daily → DoubleType / DoubleType → DoubleType
@@ -714,7 +734,9 @@ class TestTopologicalResolution:
         original_map = dict(self.SOURCES)
         for name, query in self.LEVEL_1_NODES.items():
             result = validate_node_query(query, original_map)
-            original_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            original_map[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         original_enriched = [
             (name, typ) for name, typ in original_map["ns.events_enriched"].items()
@@ -734,7 +756,9 @@ class TestTopologicalResolution:
         changed_map = dict(changed_sources)
         for name, query in self.LEVEL_1_NODES.items():
             result = validate_node_query(query, changed_map)
-            changed_map[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            changed_map[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         changed_enriched = [
             (name, typ) for name, typ in changed_map["ns.events_enriched"].items()
@@ -797,12 +821,16 @@ class TestTopologicalResolution:
         map1 = dict(self.SOURCES)
         for name, query in self.LEVEL_1_NODES.items():
             result = validate_node_query(query, map1)
-            map1[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            map1[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         map2 = dict(self.SOURCES)
         for name, query in self.LEVEL_1_NODES.items():
             result = validate_node_query(query, map2)
-            map2[name] = {col_name: col_type for col_name, col_type in result.output_columns}
+            map2[name] = {
+                col_name: col_type for col_name, col_type in result.output_columns
+            }
 
         # events_enriched has no UnknownType — signatures should be identical
         sig1 = list(map1["ns.events_enriched"].items())
@@ -812,4 +840,6 @@ class TestTopologicalResolution:
         # events_exploded has UnknownType (from LATERAL VIEW) — always "changed"
         sig1 = list(map1["ns.events_exploded"].items())
         sig2 = list(map2["ns.events_exploded"].items())
-        assert columns_signature_changed(sig1, sig2) is True  # Expected: UnknownType triggers this
+        assert (
+            columns_signature_changed(sig1, sig2) is True
+        )  # Expected: UnknownType triggers this

--- a/datajunction-server/tests/internal/impact_test.py
+++ b/datajunction-server/tests/internal/impact_test.py
@@ -1184,3 +1184,212 @@ async def test_propagate_impact_unparseable_query_falls_back_gracefully(
     # The node should either be MAY_AFFECT (if inline parse succeeds)
     # or WILL_INVALIDATE (if inline parse also fails)
     assert impact.impact_type in (ImpactType.MAY_AFFECT, ImpactType.WILL_INVALIDATE)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 post-pass: cube dimension reachability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_cube_dimension_reachability_no_cubes(session):
+    """No cube impacts → returns results unchanged."""
+    from datajunction_server.internal.impact import (
+        PropagationContext,
+        _check_cube_dimension_reachability,
+    )
+
+    ctx = PropagationContext(namespace="ns", link_changed_by_id={1: None})
+    results = [
+        DownstreamImpact(
+            name="ns.transform",
+            node_type=NodeType.TRANSFORM,
+            current_status=NodeStatus.VALID,
+            predicted_status=NodeStatus.VALID,
+            impact_type=ImpactType.MAY_AFFECT,
+            impact_reason="test",
+            depth=1,
+            caused_by=["ns.source"],
+            is_external=False,
+        ),
+    ]
+    out = await _check_cube_dimension_reachability(session, ctx, results, {})
+    assert out == results
+
+
+@pytest.mark.asyncio
+async def test_check_cube_dimension_reachability_cube_unreachable(
+    session,
+    current_user: User,
+):
+    """A cube whose dimension becomes unreachable after a link change
+    should be upgraded from MAY_AFFECT to WILL_INVALIDATE."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from datajunction_server.internal.impact import (
+        PropagationContext,
+        _check_cube_dimension_reachability,
+    )
+
+    # Build a mock cube node with dimensions and metrics
+    cube_node = MagicMock()
+    cube_node.name = "ns.my_cube"
+    cube_node.current.status = NodeStatus.VALID
+    cube_node.current.cube_node_metrics = ["ns.my_metric"]
+    cube_node.current.cube_node_dimensions = ["ns.some_dim.col"]
+
+    # Build a mock metric node
+    metric_node = MagicMock()
+    metric_node.name = "ns.my_metric"
+    metric_node.current.id = 100
+    metric_node.current_version = "v1.0"
+
+    # The link-changed node
+    link_node = MagicMock()
+    link_node.id = 999
+
+    ctx = PropagationContext(
+        namespace="ns",
+        link_changed_by_id={999: link_node},
+        visited_nodes_by_id={},
+    )
+
+    # Cube impact from Phase 1 — currently MAY_AFFECT
+    results = [
+        DownstreamImpact(
+            name="ns.my_cube",
+            node_type=NodeType.CUBE,
+            current_status=NodeStatus.VALID,
+            predicted_status=NodeStatus.VALID,
+            impact_type=ImpactType.MAY_AFFECT,
+            impact_reason="test",
+            depth=2,
+            caused_by=["ns.source"],
+            is_external=False,
+        ),
+    ]
+
+    loaded_nodes = {"ns.my_cube": cube_node, "ns.my_metric": metric_node}
+
+    # Mock get_metric_parents_map to return a parent with no dim path
+    parent_node = MagicMock()
+    parent_node.name = "ns.parent"
+    parent_node.current.id = 200
+
+    with (
+        patch(
+            "datajunction_server.internal.impact.get_metric_parents_map",
+            new_callable=AsyncMock,
+            return_value={"ns.my_metric": [parent_node]},
+        ),
+        patch(
+            "datajunction_server.internal.impact.DimensionReachability.build",
+            new_callable=AsyncMock,
+        ) as mock_build,
+    ):
+        from datajunction_server.internal.deployment.dimension_reachability import (
+            DimensionReachability,
+        )
+
+        # Empty reachability — ns.some_dim is NOT reachable from parent 200
+        mock_build.return_value = DimensionReachability(
+            {},
+            local_names={200: "ns.parent"},
+        )
+
+        out = await _check_cube_dimension_reachability(
+            session,
+            ctx,
+            results,
+            loaded_nodes,
+        )
+
+    assert len(out) == 1
+    assert out[0].impact_type == ImpactType.WILL_INVALIDATE
+    assert "ns.some_dim" in out[0].impact_reason
+    assert "no longer reachable" in out[0].impact_reason
+
+
+@pytest.mark.asyncio
+async def test_check_cube_dimension_reachability_cube_still_reachable(
+    session,
+    current_user: User,
+):
+    """A cube whose dimensions are still reachable stays MAY_AFFECT."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from datajunction_server.internal.impact import (
+        PropagationContext,
+        _check_cube_dimension_reachability,
+    )
+
+    cube_node = MagicMock()
+    cube_node.name = "ns.my_cube"
+    cube_node.current.status = NodeStatus.VALID
+    cube_node.current.cube_node_metrics = ["ns.my_metric"]
+    cube_node.current.cube_node_dimensions = ["ns.some_dim.col"]
+
+    metric_node = MagicMock()
+    metric_node.name = "ns.my_metric"
+    metric_node.current.id = 100
+    metric_node.current_version = "v1.0"
+
+    link_node = MagicMock()
+    link_node.id = 999
+
+    ctx = PropagationContext(
+        namespace="ns",
+        link_changed_by_id={999: link_node},
+        visited_nodes_by_id={},
+    )
+
+    results = [
+        DownstreamImpact(
+            name="ns.my_cube",
+            node_type=NodeType.CUBE,
+            current_status=NodeStatus.VALID,
+            predicted_status=NodeStatus.VALID,
+            impact_type=ImpactType.MAY_AFFECT,
+            impact_reason="test",
+            depth=2,
+            caused_by=["ns.source"],
+            is_external=False,
+        ),
+    ]
+
+    loaded_nodes = {"ns.my_cube": cube_node, "ns.my_metric": metric_node}
+
+    parent_node = MagicMock()
+    parent_node.name = "ns.parent"
+    parent_node.current.id = 200
+
+    with (
+        patch(
+            "datajunction_server.internal.impact.get_metric_parents_map",
+            new_callable=AsyncMock,
+            return_value={"ns.my_metric": [parent_node]},
+        ),
+        patch(
+            "datajunction_server.internal.impact.DimensionReachability.build",
+            new_callable=AsyncMock,
+        ) as mock_build,
+    ):
+        from datajunction_server.internal.deployment.dimension_reachability import (
+            DimensionReachability,
+        )
+
+        # Dimension IS reachable
+        mock_build.return_value = DimensionReachability(
+            {(200, "ns.some_dim", ""): [1]},
+            local_names={200: "ns.parent"},
+        )
+
+        out = await _check_cube_dimension_reachability(
+            session,
+            ctx,
+            results,
+            loaded_nodes,
+        )
+
+    assert len(out) == 1
+    assert out[0].impact_type == ImpactType.MAY_AFFECT  # unchanged


### PR DESCRIPTION
### Summary

Cube validation previously called `validate_shared_dimensions` per cube, which traversed the dimension link graph per parent node via `get_dimensions`, resulting in many redundant DB queries across cubes sharing the same metrics.

This PR changes it so that we have a single batched BFS (`find_join_paths_batch`) that runs across all cubes' metric parents and target dimensions, building a `DimensionReachability` lookup. Per-cube dimension checks become in-memory dict lookups.

This also removes the post-flush `refresh_nodes` call for cubes. Since nothing downstream needs the eagerly-loaded `cube_elements` from the registry, we can wire `node.current = revision` directly like non-cube nodes.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
