### PR TITLE
Respect `DJ_DEPLOY_BRANCH` env var in push and dryrun branch detection

### DIFF
--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -190,7 +190,9 @@ class DeploymentService:
         deployment_spec, file_errors = self._reconstruct_deployment_spec(source_path)
 
         base_namespace = deployment_spec.get("namespace") or ""
-        branch = DeploymentService._detect_git_branch(cwd=source_path)
+        branch = os.getenv("DJ_DEPLOY_BRANCH") or DeploymentService._detect_git_branch(
+            cwd=source_path,
+        )
         source = deployment_spec.get("source", {})
         if namespace:
             deployment_spec["namespace"] = namespace
@@ -286,7 +288,9 @@ class DeploymentService:
         deployment_spec, file_errors = self._reconstruct_deployment_spec(source_path)
         deployment_spec["namespace"] = namespace or deployment_spec.get("namespace")
         source = deployment_spec.get("source", {})
-        branch = DeploymentService._detect_git_branch(cwd=source_path)
+        branch = os.getenv("DJ_DEPLOY_BRANCH") or DeploymentService._detect_git_branch(
+            cwd=source_path,
+        )
         if display:
             print_deployment_header(
                 mode="dry run",


### PR DESCRIPTION
### Summary

The `push()` and `dryrun()` methods call `_detect_git_branch()` directly to determine the branch for namespace git config and display. Unlike `_build_deployment_source()` (which already checks `DJ_DEPLOY_BRANCH` first), these methods bypassed the env var and always ran `git rev-parse`. This causes incorrect branch names in CI environments where the checkout is a merge ref (e.g., `pull/N` instead of the actual branch name).

Now both methods check `DJ_DEPLOY_BRANCH` before falling back to auto-detection, consistent with how `_build_deployment_source()` already works.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
