### PR TITLE
Always infer parent namespace from `dj.yaml`

### DIFF
--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -211,9 +211,9 @@ class DeploymentService:
         )
 
         if branch:
-            # Only set parent_namespace when we derived it from dj.yaml (not when
-            # --namespace was passed explicitly, since we can't reliably infer the parent)
-            parent_namespace = base_namespace if not namespace else None
+            # Use base_namespace from dj.yaml as parent, whether --namespace was
+            # passed explicitly or derived automatically
+            parent_namespace = base_namespace or None
             try:
                 self.client._set_namespace_git_config(
                     deployment_spec["namespace"],


### PR DESCRIPTION
### Summary

Previously, `push()` only set parent namespace on the namespace git config when the target namespace was auto-derived from dj.yaml + branch detection. When `--namespace` was passed explicitly (as CI scripts typically do), `parent_namespace` was skipped and left as null.

This meant that branch namespaces created by CI (e.g., `abc.branch1`) had no `parent_namespace` link back to their root (e.g., `abc`), breaking features that depend on the parent relationship like PR creation and branch management.

The fix uses the base namespace from `dj.yaml` as the parent in all cases. The project file already declares the root namespace, so there's no guessing needed.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
