### PR TITLE
Release v0.0.123

### DIFF
--- a/datajunction-clients/javascript/package-lock.json
+++ b/datajunction-clients/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datajunction",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datajunction",
-      "version": "0.0.122",
+      "version": "0.0.123",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.22.5",

--- a/datajunction-clients/javascript/package.json
+++ b/datajunction-clients/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "description": "A Javascript client for interacting with a DataJunction server",
   "module": "src/index.js",
   "scripts": {

--- a/datajunction-clients/python/datajunction/__about__.py
+++ b/datajunction-clients/python/datajunction/__about__.py
@@ -2,4 +2,4 @@
 Version for Hatch
 """
 
-__version__ = "0.0.122"
+__version__ = "0.0.123"

--- a/datajunction-query/djqs/__about__.py
+++ b/datajunction-query/djqs/__about__.py
@@ -2,4 +2,4 @@
 Version for Hatch
 """
 
-__version__ = "0.0.122"
+__version__ = "0.0.123"

--- a/datajunction-reflection/datajunction_reflection/__about__.py
+++ b/datajunction-reflection/datajunction_reflection/__about__.py
@@ -2,4 +2,4 @@
 Version for Hatch
 """
 
-__version__ = "0.0.122"
+__version__ = "0.0.123"

--- a/datajunction-server/datajunction_server/__about__.py
+++ b/datajunction-server/datajunction_server/__about__.py
@@ -2,4 +2,4 @@
 Version for Hatch
 """
 
-__version__ = "0.0.122"
+__version__ = "0.0.123"

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajunction-ui",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "description": "DataJunction UI",
   "module": "src/index.tsx",
   "repository": {


### PR DESCRIPTION
## Release v0.0.123

This PR bumps all package versions to v0.0.123.

**When merged**, packages will be automatically published to:
- PyPI: datajunction-server, datajunction-query, datajunction-reflection, datajunction
- npm: datajunction, datajunction-ui

A GitHub Release will also be created with auto-generated release notes.

---
*Auto-generated by Create Version Bump workflow*