### PR TITLE
Optimize GraphQL findNodes query for cube-heavy workloads

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/dataloaders.py
+++ b/datajunction-server/datajunction_server/api/graphql/dataloaders.py
@@ -3,7 +3,7 @@ DataLoaders for batching and caching GraphQL queries.
 """
 
 import json
-from typing import Any
+from typing import Any, Optional
 
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -12,7 +12,12 @@ from starlette.requests import Request
 
 from datajunction_server.api.graphql.resolvers.nodes import load_node_options
 from datajunction_server.database.collection import Collection as DBCollection
+from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import Node as DBNode
+from datajunction_server.internal.namespaces import (
+    get_parent_namespaces,
+    resolve_git_info_from_map,
+)
 from datajunction_server.utils import session_context
 
 
@@ -165,4 +170,69 @@ def create_collection_nodes_loader(
     """
     return DataLoader(
         load_fn=lambda keys: batch_load_collection_nodes(keys, request),
+    )
+
+
+async def batch_load_git_info(
+    namespaces: list[str],
+    request: Request,
+) -> list[Optional[dict]]:
+    """
+    Batch load git info for multiple namespaces in a single query.
+
+    Collects all ancestor namespaces across all requested namespaces,
+    loads them in one query, then resolves git info for each from the
+    shared map.
+    """
+    # Collect all unique namespace names we need to look up
+    all_ancestor_names: set[str] = set()
+    for ns in namespaces:
+        ancestors = get_parent_namespaces(ns) + [ns]
+        all_ancestor_names.update(ancestors)
+
+    async with session_context(request) as session:
+        # Single query to load all namespace rows
+        stmt = select(NodeNamespace).where(
+            NodeNamespace.namespace.in_(all_ancestor_names),
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+        ns_map = {ns.namespace: ns for ns in rows}
+
+        # Handle FK hops: some branch namespaces point to a parent outside
+        # the string hierarchy. Collect missing parent_namespace values and
+        # load them in one extra query.
+        missing_fk_parents: set[str] = set()
+        for ns in namespaces:
+            ancestors = get_parent_namespaces(ns) + [ns]
+            for name in reversed(ancestors):
+                row = ns_map.get(name)
+                if row and row.git_branch:
+                    if row.parent_namespace and row.parent_namespace not in ns_map:
+                        missing_fk_parents.add(row.parent_namespace)
+                    break
+
+        if missing_fk_parents:
+            fk_stmt = select(NodeNamespace).where(
+                NodeNamespace.namespace.in_(missing_fk_parents),
+            )
+            fk_rows = (await session.execute(fk_stmt)).scalars().all()
+            for fk_row in fk_rows:
+                ns_map[fk_row.namespace] = fk_row
+
+    # Resolve git info for each requested namespace using the shared map
+    return [resolve_git_info_from_map(ns, ns_map) for ns in namespaces]
+
+
+def create_git_info_loader(
+    request: Request,
+) -> DataLoader[str, Optional[dict]]:
+    """
+    Create a DataLoader that batches git info lookups by namespace.
+
+    Multiple nodes sharing the same or overlapping namespace hierarchies
+    will be resolved with at most 2 DB queries (ancestors + FK hops)
+    instead of one query per node.
+    """
+    return DataLoader(
+        load_fn=lambda keys: batch_load_git_info(keys, request),
     )

--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -14,8 +14,9 @@ from strawberry.types import Info
 from datajunction_server.internal.caching.cachelib_cache import get_cache
 from datajunction_server.internal.access.authentication.http import DJHTTPBearer
 from datajunction_server.api.graphql.dataloaders import (
-    create_node_by_name_loader,
     create_collection_nodes_loader,
+    create_git_info_loader,
+    create_node_by_name_loader,
 )
 from datajunction_server.api.graphql.queries.catalogs import list_catalogs
 from datajunction_server.api.graphql.queries.collections import list_collections
@@ -119,6 +120,7 @@ async def get_context(
         "session": db_session,  # Keep for backward compatibility with existing code
         "node_loader": create_node_by_name_loader(request),
         "collection_nodes_loader": create_collection_nodes_loader(request),
+        "git_info_loader": create_git_info_loader(request),
         "settings": get_settings(),
         "request": request,
         "background_tasks": background_tasks,

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -17,15 +17,13 @@ from datajunction_server.api.graphql.scalars.sql import CubeDefinition
 from datajunction_server.api.graphql.utils import dedupe_append, extract_fields
 from datajunction_server.database.dimensionlink import DimensionLink
 
-from datajunction_server.database.node import Column, ColumnAttribute
+from datajunction_server.database.node import Column, ColumnAttribute, CubeRelationship
 from datajunction_server.database.node import Node as DBNode
 from datajunction_server.database.node import NodeRevision as DBNodeRevision
 from datajunction_server.api.graphql.resolvers.tags import tag_load_options
 from datajunction_server.api.graphql.resolvers.users import user_load_options
 from datajunction_server.models.node import NodeMode, NodeStatus, NodeType
 
-# cubeMetrics/cubeDimensions fields derivable from the cube's own columns
-# without loading cube_elements at all.
 _CUBE_NAME_ONLY_FIELDS: frozenset[str] = frozenset({"name"})
 
 
@@ -51,19 +49,18 @@ async def _attach_raw_columns(session, nodes):
     Fetch column data and metric names as raw rows and inject into each
     cube node's current revision, bypassing ORM hydration.
     """
-    from datajunction_server.database.node import CubeRelationship
-    from datajunction_server.models.node import NodeType as NodeType_
-
-    rev_ids = [
-        node.current.id
+    cube_nodes = [
+        node
         for node in nodes
-        if node.current is not None and node.type == NodeType_.CUBE
+        if node.current is not None and node.type == NodeType.CUBE
     ]
-    if not rev_ids:
+    if not cube_nodes:
         return
 
+    rev_ids = [node.current.id for node in cube_nodes]
+
     # Fetch cube's own columns as raw tuples
-    col_stmt = (
+    col_result = await session.execute(
         sa_select(
             Column.node_revision_id,
             Column.name,
@@ -72,10 +69,8 @@ async def _attach_raw_columns(session, nodes):
             Column.order,
         )
         .where(Column.node_revision_id.in_(rev_ids))
-        .order_by(Column.node_revision_id, Column.order)
+        .order_by(Column.node_revision_id, Column.order),
     )
-    col_result = await session.execute(col_stmt)
-
     cols_by_rev: dict[int, list] = {}
     for rev_id, name, dim_col, col_type, order in col_result:
         cols_by_rev.setdefault(rev_id, []).append(
@@ -84,33 +79,25 @@ async def _attach_raw_columns(session, nodes):
 
     # Fetch metric element names per cube via the cube join table.
     # Metrics have _DOT_ in the element column name; dimensions don't.
-    metric_stmt = (
+    metric_result = await session.execute(
         sa_select(CubeRelationship.cube_id, Column.name)
         .join(Column, Column.id == CubeRelationship.cube_element_id)
         .where(
             CubeRelationship.cube_id.in_(rev_ids),
             Column.name.like("%\\_DOT\\_%"),
-        )
+        ),
     )
-    metric_result = await session.execute(metric_stmt)
-
     metric_names_by_rev: dict[int, set[str]] = {}
     for cube_id, elem_name in metric_result:
         metric_names_by_rev.setdefault(cube_id, set()).add(
             elem_name.replace("_DOT_", "."),
         )
 
-    for node in nodes:
-        if (
-            node.current is not None and node.type == NodeType_.CUBE
-        ):  # pragma: no branch
-            rev_id = node.current.id
-            set_committed_value(
-                node.current,
-                "columns",
-                cols_by_rev.get(rev_id, []),
-            )
-            node.current._cube_metric_names = metric_names_by_rev.get(rev_id, set())
+    # Inject raw columns and metric names into each cube revision
+    for node in cube_nodes:
+        rev_id = node.current.id
+        set_committed_value(node.current, "columns", cols_by_rev.get(rev_id, []))
+        node.current._cube_metric_names = metric_names_by_rev.get(rev_id, set())
 
 
 def _is_cube_name_only_request(current_fields: dict) -> bool:

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -5,8 +5,10 @@ Node resolvers
 from collections import OrderedDict
 from typing import Any, List, Optional
 
+from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer, joinedload, load_only, noload, selectinload
+from sqlalchemy.orm.attributes import set_committed_value
 from strawberry.types import Info
 
 from datajunction_server.errors import DJNodeNotFound
@@ -30,6 +32,95 @@ _CUBE_NAME_ONLY_FIELDS: frozenset[str] = frozenset({"name"})
 def _is_name_only(fields) -> bool:
     """Check if requested fields are all derivable from column names alone."""
     return fields is not None and set(fields.keys()).issubset(_CUBE_NAME_ONLY_FIELDS)
+
+
+class _RawColumn:
+    """Lightweight stand-in for Column ORM objects in the name-only path."""
+
+    __slots__ = ("name", "dimension_column", "type", "order")
+
+    def __init__(self, name, dimension_column, col_type, order):
+        self.name = name
+        self.dimension_column = dimension_column
+        self.type = col_type
+        self.order = order
+
+
+async def _attach_raw_columns(session, nodes):
+    """
+    Fetch column data and metric names as raw rows and inject into each
+    cube node's current revision, bypassing ORM hydration.
+    """
+    from datajunction_server.database.node import CubeRelationship
+    from datajunction_server.models.node import NodeType as NodeType_
+
+    rev_ids = [
+        node.current.id
+        for node in nodes
+        if node.current is not None and node.type == NodeType_.CUBE
+    ]
+    if not rev_ids:
+        return
+
+    # Fetch cube's own columns as raw tuples
+    col_stmt = (
+        sa_select(
+            Column.node_revision_id,
+            Column.name,
+            Column.dimension_column,
+            Column.type,
+            Column.order,
+        )
+        .where(Column.node_revision_id.in_(rev_ids))
+        .order_by(Column.node_revision_id, Column.order)
+    )
+    col_result = await session.execute(col_stmt)
+
+    cols_by_rev: dict[int, list] = {}
+    for rev_id, name, dim_col, col_type, order in col_result:
+        cols_by_rev.setdefault(rev_id, []).append(
+            _RawColumn(name, dim_col, col_type, order),
+        )
+
+    # Fetch metric element names per cube via the cube join table.
+    # Metrics have _DOT_ in the element column name; dimensions don't.
+    metric_stmt = (
+        sa_select(CubeRelationship.cube_id, Column.name)
+        .join(Column, Column.id == CubeRelationship.cube_element_id)
+        .where(
+            CubeRelationship.cube_id.in_(rev_ids),
+            Column.name.like("%\\_DOT\\_%"),
+        )
+    )
+    metric_result = await session.execute(metric_stmt)
+
+    metric_names_by_rev: dict[int, set[str]] = {}
+    for cube_id, elem_name in metric_result:
+        metric_names_by_rev.setdefault(cube_id, set()).add(
+            elem_name.replace("_DOT_", "."),
+        )
+
+    for node in nodes:
+        if node.current is not None and node.type == NodeType_.CUBE:  # pragma: no branch
+            rev_id = node.current.id
+            set_committed_value(
+                node.current,
+                "columns",
+                cols_by_rev.get(rev_id, []),
+            )
+            node.current._cube_metric_names = metric_names_by_rev.get(rev_id, set())
+
+
+def _is_cube_name_only_request(current_fields: dict) -> bool:
+    """Check if the current revision fields only need cube metric/dimension names."""
+    cube_metric_fields = current_fields.get("cube_metrics")
+    cube_dimension_fields = current_fields.get("cube_dimensions")
+    is_cube = cube_metric_fields is not None or cube_dimension_fields is not None
+    if not is_cube:
+        return False
+    return (cube_metric_fields is None or _is_name_only(cube_metric_fields)) and (
+        cube_dimension_fields is None or _is_name_only(cube_dimension_fields)
+    )
 
 
 async def find_nodes_by(
@@ -60,14 +151,21 @@ async def find_nodes_by(
     """
     session = info.context["session"]  # type: ignore
     fields = extract_fields(info)
-    options = load_node_options(
+    node_fields = (
         fields["nodes"]
         if "nodes" in fields
         else fields["edges"]["node"]
         if "edges" in fields
-        else fields,
+        else fields
     )
-    return await DBNode.find_by(
+    options = load_node_options(node_fields)
+
+    # Signal to cube resolvers whether the name-only fast path is active
+    current_fields = node_fields.get("current") or {}
+    is_cube_name_only = _is_cube_name_only_request(current_fields)
+    info.context["cube_name_only"] = is_cube_name_only  # type: ignore
+
+    result = await DBNode.find_by(
         session,
         names,
         fragment,
@@ -90,6 +188,13 @@ async def find_nodes_by(
         orphaned_dimension=orphaned_dimension,
         dimensions=dimensions,
     )
+
+    # For the name-only cube path, fetch column data as raw tuples instead
+    # of ORM objects.  This avoids hydrating ~20k Column instances.
+    if is_cube_name_only and result:
+        await _attach_raw_columns(session, result)
+
+    return result
 
 
 async def get_node_by_name(
@@ -282,6 +387,14 @@ def load_node_revision_options(node_revision_fields):
         node_revision_fields.get("cube_dimensions") if node_revision_fields else None
     )
 
+    # When cubeMetrics/cubeDimensions only need "name", we can skip loading
+    # both cube_elements AND columns as ORM objects — the resolver will use
+    # raw column data fetched post-query instead.
+    all_name_only = is_cube_request and (
+        (cube_metric_fields is None or _is_name_only(cube_metric_fields))
+        and (cube_dimension_fields is None or _is_name_only(cube_dimension_fields))
+    )
+
     # Handle columns
     if "columns" in node_revision_fields or "primary_key" in node_revision_fields:
         # Full columns with all relationships needed for columns/primary_key queries
@@ -294,10 +407,8 @@ def load_node_revision_options(node_revision_fields):
                 joinedload(Column.partition),
             ),
         )
-    elif is_cube_request:
-        # Minimal columns for cube_metrics/cube_dimensions fast path.
-        # Needs: name (full dotted name), order (sorting), dimension_column
-        # (metric vs dimension), type (dimension type in DimensionAttribute).
+    elif is_cube_request and not all_name_only:
+        # Minimal ORM columns for cube element resolution
         options.append(
             selectinload(DBNodeRevision.columns).options(
                 load_only(
@@ -313,6 +424,8 @@ def load_node_revision_options(node_revision_fields):
             ),
         )
     else:
+        # Name-only cube path: columns injected as raw tuples post-query
+        # via _attach_raw_columns. No cube request: not needed.
         options.append(noload(DBNodeRevision.columns))
 
     # Handle catalog - has lazy="joined" by default which we want to prevent
@@ -368,12 +481,9 @@ def load_node_revision_options(node_revision_fields):
     # Handle cube_elements (only needed when cubeMetrics/cubeDimensions request
     # fields beyond just "name")
     if is_cube_request:
-        all_name_only = (
-            cube_metric_fields is None or _is_name_only(cube_metric_fields)
-        ) and (cube_dimension_fields is None or _is_name_only(cube_dimension_fields))
-
         if all_name_only:
-            # Skip cube_elements — resolvers derive names from root.columns
+            # Name-only: metric names fetched via raw query in
+            # _attach_raw_columns; no need to load cube_elements ORM objects.
             options.append(noload(DBNodeRevision.cube_elements))
         else:
             # Build cube element Column options

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -18,7 +18,18 @@ from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.node import Column, ColumnAttribute
 from datajunction_server.database.node import Node as DBNode
 from datajunction_server.database.node import NodeRevision as DBNodeRevision
+from datajunction_server.api.graphql.resolvers.tags import tag_load_options
+from datajunction_server.api.graphql.resolvers.users import user_load_options
 from datajunction_server.models.node import NodeMode, NodeStatus, NodeType
+
+# cubeMetrics/cubeDimensions fields derivable from the cube's own columns
+# without loading cube_elements at all.
+_CUBE_NAME_ONLY_FIELDS: frozenset[str] = frozenset({"name"})
+
+
+def _is_name_only(fields) -> bool:
+    """Check if requested fields are all derivable from column names alone."""
+    return fields is not None and set(fields.keys()).issubset(_CUBE_NAME_ONLY_FIELDS)
 
 
 async def find_nodes_by(
@@ -129,12 +140,20 @@ def load_node_options(fields):
         options.append(noload(DBNode.current))
 
     if "created_by" in fields:
-        options.append(selectinload(DBNode.created_by))
+        options.append(
+            joinedload(DBNode.created_by).options(
+                *user_load_options(fields["created_by"]),
+            ),
+        )
     else:
         options.append(noload(DBNode.created_by))
 
     if "owners" in fields:
-        options.append(selectinload(DBNode.owners))
+        options.append(
+            selectinload(DBNode.owners).options(
+                *user_load_options(fields["owners"]),
+            ),
+        )
     else:
         options.append(noload(DBNode.owners))
 
@@ -144,7 +163,9 @@ def load_node_options(fields):
         options.append(noload(DBNode.history))
 
     if "tags" in fields:
-        options.append(selectinload(DBNode.tags))
+        options.append(
+            selectinload(DBNode.tags).options(*tag_load_options(fields["tags"])),
+        )
     else:
         options.append(noload(DBNode.tags))
 
@@ -234,7 +255,20 @@ def load_node_revision_options(node_revision_fields):
     Based on the GraphQL query input fields, builds a list of node revision
     load options. Uses noload() to prevent lazy loading for unrequested fields.
     """
-    options = [defer(DBNodeRevision.query_ast)]
+    # Defer heavy columns not needed for most GraphQL queries
+    options = [
+        defer(DBNodeRevision.query_ast),
+        defer(DBNodeRevision.lineage),
+    ]
+    # query is also used by metric_metadata and extracted_measures resolvers
+    needs_query = (
+        "query" in node_revision_fields
+        or "metric_metadata" in node_revision_fields
+        or "extracted_measures" in node_revision_fields
+    )
+    if not needs_query:
+        options.append(defer(DBNodeRevision.query))
+
     is_cube_request = (
         "cube_metrics" in node_revision_fields
         or "cube_dimensions" in node_revision_fields
@@ -261,13 +295,15 @@ def load_node_revision_options(node_revision_fields):
             ),
         )
     elif is_cube_request:
-        # Minimal columns for cube_metrics/cube_dimensions
-        # Only load the columns we need: name, order, dimension_column
+        # Minimal columns for cube_metrics/cube_dimensions fast path.
+        # Needs: name (full dotted name), order (sorting), dimension_column
+        # (metric vs dimension), type (dimension type in DimensionAttribute).
         options.append(
             selectinload(DBNodeRevision.columns).options(
                 load_only(
                     Column.id,
                     Column.name,
+                    Column.type,
                     Column.order,
                     Column.dimension_column,
                 ),
@@ -329,28 +365,47 @@ def load_node_revision_options(node_revision_fields):
     else:
         options.append(noload(DBNodeRevision.required_dimensions))
 
-    # Handle cube_elements
-    if "cube_elements" in node_revision_fields or is_cube_request:
-        # Build optimized options for nested NodeRevision based on what's requested
-        # cube_metrics returns List[NodeRevision] - needs full serialization based on requested fields
-        # cube_dimensions returns List[DimensionAttribute] - only needs name, type from NodeRevision
-        if cube_metric_fields:
-            # cube_metrics needs full NodeRevision serialization
-            nested_options = build_cube_metrics_node_revision_options(
-                cube_metric_fields,
-            )
-        elif cube_dimension_fields:
-            # cube_dimensions only needs minimal NodeRevision fields
-            nested_options = build_cube_dimensions_node_revision_options()
-        else:
-            # cube_elements directly requested - load minimal
-            nested_options = build_cube_dimensions_node_revision_options()
+    # Handle cube_elements (only needed when cubeMetrics/cubeDimensions request
+    # fields beyond just "name")
+    if is_cube_request:
+        all_name_only = (
+            cube_metric_fields is None or _is_name_only(cube_metric_fields)
+        ) and (cube_dimension_fields is None or _is_name_only(cube_dimension_fields))
 
-        options.append(
-            selectinload(DBNodeRevision.cube_elements)
-            .selectinload(Column.node_revision)
-            .options(*nested_options),
-        )
+        if all_name_only:
+            # Skip cube_elements — resolvers derive names from root.columns
+            options.append(noload(DBNodeRevision.cube_elements))
+        else:
+            # Build cube element Column options
+            cube_col_options = [
+                load_only(
+                    Column.id,
+                    Column.name,
+                    Column.type,
+                    Column.order,
+                    Column.dimension_column,
+                    Column.node_revision_id,
+                ),
+                noload(Column.dimension),
+                noload(Column.partition),
+                noload(Column.measure),
+            ]
+
+            if cube_metric_fields and not _is_name_only(cube_metric_fields):
+                nested_options = build_cube_metrics_node_revision_options(
+                    cube_metric_fields,
+                )
+            else:
+                nested_options = build_cube_dimensions_node_revision_options()
+            cube_col_options.append(
+                selectinload(Column.node_revision).options(*nested_options),
+            )
+
+            options.append(
+                selectinload(DBNodeRevision.cube_elements).options(
+                    *cube_col_options,
+                ),
+            )
     else:
         options.append(noload(DBNodeRevision.cube_elements))
 
@@ -358,6 +413,7 @@ def load_node_revision_options(node_revision_fields):
     options.append(noload(DBNodeRevision.created_by))
     options.append(noload(DBNodeRevision.node))
     options.append(noload(DBNodeRevision.missing_parents))
+    options.append(noload(DBNodeRevision.frozen_measures))
     return options
 
 

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -101,7 +101,9 @@ async def _attach_raw_columns(session, nodes):
         )
 
     for node in nodes:
-        if node.current is not None and node.type == NodeType_.CUBE:  # pragma: no branch
+        if (
+            node.current is not None and node.type == NodeType_.CUBE
+        ):  # pragma: no branch
             rev_id = node.current.id
             set_committed_value(
                 node.current,

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/tags.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/tags.py
@@ -31,7 +31,7 @@ def tag_load_options(requested_fields=None):
         noload(DBTag.created_by),
         noload(DBTag.nodes),
     ]
-    if requested_fields:
+    if requested_fields:  # pragma: no branch
         cols = [DBTag.id] + [
             col
             for field, col in _TAG_FIELD_TO_COLUMN.items()

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/tags.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/tags.py
@@ -1,13 +1,44 @@
 """
-Node resolvers
+Tag resolvers
 """
 
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import load_only, noload
 
 from datajunction_server.database.node import Node as DBNode
 from datajunction_server.database.tag import Tag as DBTag
+
+# GraphQL TagBase fields → DB Tag columns. id is always included (PK).
+_TAG_FIELD_TO_COLUMN = {
+    "name": DBTag.name,
+    "tag_type": DBTag.tag_type,
+    "description": DBTag.description,
+    "display_name": DBTag.display_name,
+    "tag_metadata": DBTag.tag_metadata,
+}
+
+
+def tag_load_options(requested_fields=None):
+    """
+    Load options for Tag objects in GraphQL queries.
+
+    Restricts columns to those actually requested and suppresses
+    all relationships (created_by, nodes).
+    """
+    options = [
+        noload(DBTag.created_by),
+        noload(DBTag.nodes),
+    ]
+    if requested_fields:
+        cols = [DBTag.id] + [
+            col
+            for field, col in _TAG_FIELD_TO_COLUMN.items()
+            if field in requested_fields
+        ]
+        options.append(load_only(*cols))
+    return options
 
 
 async def get_nodes_by_tag(

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/users.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/users.py
@@ -1,0 +1,31 @@
+"""
+User resolvers — shared load options for the User model in GraphQL queries.
+"""
+
+from sqlalchemy.orm import load_only, noload
+
+from datajunction_server.database.user import User as DBUser
+
+# GraphQL User fields to DB User columns. Note that id is always included as it's the PK.
+_USER_FIELD_TO_COLUMN = {
+    "username": DBUser.username,
+    "email": DBUser.email,
+    "name": DBUser.name,
+    "oauth_provider": DBUser.oauth_provider,
+    "is_admin": DBUser.is_admin,
+}
+
+
+def user_load_options(requested_fields):
+    """Build load options for a User relationship based on requested fields."""
+    if not requested_fields:
+        return []
+    cols = [DBUser.id] + [
+        col for field, col in _USER_FIELD_TO_COLUMN.items() if field in requested_fields
+    ]
+    return [
+        load_only(*cols),
+        noload(DBUser.created_by),
+        noload(DBUser.notification_preferences),
+        noload(DBUser.role_assignments),
+    ]

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -22,7 +22,6 @@ from datajunction_server.api.graphql.scalars.column import (
     Partition,
 )
 from datajunction_server.api.graphql.scalars.git_info import GitRepositoryInfo
-from datajunction_server.internal.namespaces import get_git_info_for_namespace
 from datajunction_server.api.graphql.scalars.materialization import (
     Backfill,
     MaterializationConfig,
@@ -54,6 +53,19 @@ NodeStatus = strawberry.enum(NodeStatus_)
 NodeMode = strawberry.enum(NodeMode_)
 JoinType = strawberry.enum(JoinType_)
 JoinCardinality = strawberry.enum(JoinCardinality_)
+
+
+class _NameOnlyRevision:
+    """
+    Minimal stand-in returned by the cube_metrics fast path when only ``name``
+    is requested.  A plain object is ~100x cheaper to construct than a full
+    ``DBNodeRevision`` ORM instance.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
 
 
 @strawberry.enum
@@ -365,18 +377,30 @@ class NodeRevision:
 
     # Only cubes will have these fields
     @strawberry.field
-    def cube_metrics(self, root: "DBNodeRevision") -> List["NodeRevision"]:
+    def cube_metrics(self, root: "DBNodeRevision") -> List["NodeRevision"]:  # type: ignore[return-value]
         """
         Metrics for a cube node
         """
         if root.type != NodeType.CUBE:
             return []
         ordering = root.ordering()
+
+        # Fast path: when cube_elements were not loaded (name-only query),
+        # derive metric names from the cube's own columns.  Columns without
+        # dimension_column are metrics.
+        if not root.cube_elements:
+            stubs: list = [
+                _NameOnlyRevision(name=col.name)
+                for col in root.columns
+                if not col.dimension_column
+            ]
+            return sorted(stubs, key=lambda x: ordering[x.name])
+
         return sorted(
             [
                 node_revision
                 for _, node_revision in root.cube_elements_with_nodes()
-                if node_revision and node_revision.type == NodeType.METRIC
+                if node_revision and node_revision.type == NodeType_.METRIC
             ],
             key=lambda x: ordering[x.name],
         )
@@ -397,6 +421,32 @@ class NodeRevision:
         """
         if root.type != NodeType.CUBE:
             return []
+
+        # Fast path: when cube_elements were not loaded (name-only query),
+        # derive dimension names from the cube's own columns.  Columns with
+        # dimension_column set are dimensions; the column name already
+        # contains the full dotted path (e.g. "default.repair_order.repair_order_id").
+        if not root.cube_elements:
+            ordering = root.ordering()
+            return sorted(
+                [
+                    DimensionAttribute(  # type: ignore
+                        name=col.name + (col.dimension_column or ""),
+                        attribute=None,
+                        role=col.dimension_column,
+                        _dimension_node=None,
+                        type=str(col.type) if col.type else "",
+                        properties=[],
+                    )
+                    for col in root.columns
+                    if col.dimension_column
+                ],
+                key=lambda x: ordering.get(
+                    x.name,
+                    ordering.get(x.name.split("[")[0], 0),
+                ),
+            )
+
         dimension_to_roles = {col.name: col.dimension_column for col in root.columns}
         ordering = root.ordering()
         return sorted(
@@ -466,8 +516,8 @@ class Node:
         """
         Git repository information for this node's namespace
         """
-        session = info.context["session"]  # type: ignore
-        git_info_dict = await get_git_info_for_namespace(session, root.namespace)
+        git_info_loader = info.context["git_info_loader"]  # type: ignore
+        git_info_dict = await git_info_loader.load(root.namespace)
         if git_info_dict:
             return GitRepositoryInfo.from_pydantic(  # type: ignore
                 PydanticGitRepositoryInfo(**git_info_dict),

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -55,6 +55,9 @@ JoinType = strawberry.enum(JoinType_)
 JoinCardinality = strawberry.enum(JoinCardinality_)
 
 
+_DOT = "_DOT_"
+
+
 class _NameOnlyRevision:
     """
     Minimal stand-in returned by the cube_metrics fast path when only ``name``
@@ -377,7 +380,7 @@ class NodeRevision:
 
     # Only cubes will have these fields
     @strawberry.field
-    def cube_metrics(self, root: "DBNodeRevision") -> List["NodeRevision"]:  # type: ignore[return-value]
+    def cube_metrics(self, root: "DBNodeRevision", info: Info) -> List["NodeRevision"]:  # type: ignore[return-value]
         """
         Metrics for a cube node
         """
@@ -385,17 +388,17 @@ class NodeRevision:
             return []
         ordering = root.ordering()
 
-        # Fast path: when cube_elements were not loaded (name-only query),
-        # derive metric names from the cube's own columns.  Columns without
-        # dimension_column are metrics.
-        if not root.cube_elements:
+        # Name-only path: metric names pre-fetched by _attach_raw_columns.
+        if info.context.get("cube_name_only"):  # type: ignore
+            metric_names: set[str] = getattr(root, "_cube_metric_names", set())
             stubs: list = [
                 _NameOnlyRevision(name=col.name)
                 for col in root.columns
-                if not col.dimension_column
+                if col.name in metric_names
             ]
             return sorted(stubs, key=lambda x: ordering[x.name])
 
+        # Full path: node_revision loaded on each cube element
         return sorted(
             [
                 node_revision
@@ -415,18 +418,20 @@ class NodeRevision:
         return root.cube_filters or []
 
     @strawberry.field
-    def cube_dimensions(self, root: "DBNodeRevision") -> List[DimensionAttribute]:
+    def cube_dimensions(
+        self,
+        root: "DBNodeRevision",
+        info: Info,
+    ) -> List[DimensionAttribute]:
         """
         Dimensions for a cube node
         """
         if root.type != NodeType.CUBE:
             return []
 
-        # Fast path: when cube_elements were not loaded (name-only query),
-        # derive dimension names from the cube's own columns.  Columns with
-        # dimension_column set are dimensions; the column name already
-        # contains the full dotted path (e.g. "default.repair_order.repair_order_id").
-        if not root.cube_elements:
+        # Name-only path: metric names pre-fetched by _attach_raw_columns.
+        if info.context.get("cube_name_only"):  # type: ignore
+            metric_names: set[str] = getattr(root, "_cube_metric_names", set())
             ordering = root.ordering()
             return sorted(
                 [
@@ -439,7 +444,7 @@ class NodeRevision:
                         properties=[],
                     )
                     for col in root.columns
-                    if col.dimension_column
+                    if col.name not in metric_names
                 ],
                 key=lambda x: ordering.get(
                     x.name,
@@ -447,6 +452,7 @@ class NodeRevision:
                 ),
             )
 
+        # Full path: node_revision loaded on each cube element
         dimension_to_roles = {col.name: col.dimension_column for col in root.columns}
         ordering = root.ordering()
         return sorted(

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -48,7 +48,7 @@ from datajunction_server.database.history import History
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.metricmetadata import MetricMetadata
 from datajunction_server.database.nodeowner import NodeOwner
-from datajunction_server.database.tag import Tag
+from datajunction_server.database.tag import Tag, TagNodeRelationship
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJInvalidInputException,
@@ -652,14 +652,20 @@ class Node(Base):
 
         nodes_with_tags = []
         if tags:
+            # Only fetch node IDs — no need to load full Tag/Node objects
+            # or their relationships (created_by, etc.)
             statement = (
-                select(Tag).where(Tag.name.in_(tags)).options(joinedload(Tag.nodes))
+                select(Node.id)
+                .join(
+                    TagNodeRelationship,
+                    Node.id == TagNodeRelationship.node_id,
+                )
+                .join(Tag, Tag.id == TagNodeRelationship.tag_id)
+                .where(Tag.name.in_(tags))
             )
-            nodes_with_tags = [
-                node.id
-                for tag in (await session.execute(statement)).unique().scalars().all()
-                for node in tag.nodes
-            ]
+            nodes_with_tags = list(
+                (await session.execute(statement)).scalars().all(),
+            )
             if not nodes_with_tags:  # pragma: no cover
                 return []
 

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -2484,3 +2484,109 @@ async def test_is_derived_metric_field(
     parent_types = [p["type"].lower() for p in node["current"]["parents"]]
     assert "metric" in parent_types
     assert node["current"]["isDerivedMetric"] is True
+
+
+@pytest.mark.asyncio
+async def test_find_cubes_name_only_with_tag_filter(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test the name-only fast path for cubeMetrics/cubeDimensions with a tag
+    filter.  Exercises: tag ID pre-filter, raw column attachment, _DOT_
+    metric identification, git info DataLoader, user load_only, and tag noload.
+    """
+    # Create a tag
+    await client_with_roads.post(
+        "/tags/",
+        json={
+            "name": "cube_perf_test",
+            "tag_type": "test",
+            "description": "Tag for perf test",
+        },
+    )
+
+    # Create a cube
+    response = await client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": [
+                "default.num_repair_orders",
+                "default.avg_repair_price",
+            ],
+            "dimensions": [
+                "default.hard_hat.city",
+                "default.hard_hat.state",
+            ],
+            "description": "Name-only test cube",
+            "mode": "published",
+            "name": "default.name_only_cube",
+        },
+    )
+    assert response.status_code < 400, response.json()
+
+    # Tag the cube
+    response = await client_with_roads.post(
+        "/nodes/default.name_only_cube/tags/?tag_names=cube_perf_test",
+    )
+    assert response.status_code < 400, response.json()
+
+    query = """
+    {
+        findNodes(tags: ["cube_perf_test"], nodeTypes: [CUBE]) {
+            name
+            tags {
+                name
+            }
+            gitInfo {
+                repo
+                branch
+                defaultBranch
+                isDefaultBranch
+                path
+                parentNamespace
+                gitOnly
+            }
+            createdBy {
+                username
+            }
+            owners {
+                username
+            }
+            currentVersion
+            current {
+                description
+                displayName
+                cubeMetrics {
+                    name
+                }
+                cubeDimensions {
+                    name
+                }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]["findNodes"]) == 1
+    cube = data["data"]["findNodes"][0]
+
+    assert cube["name"] == "default.name_only_cube"
+    assert cube["createdBy"]["username"] == "dj"
+    assert cube["tags"] == [{"name": "cube_perf_test"}]
+    assert cube["currentVersion"] == "v1.0"
+    assert cube["current"]["description"] == "Name-only test cube"
+    assert cube["current"]["displayName"] == "Name Only Cube"
+    assert cube["gitInfo"] is None  # No git config in test fixture
+
+    metric_names = sorted(m["name"] for m in cube["current"]["cubeMetrics"])
+    assert metric_names == [
+        "default.avg_repair_price",
+        "default.num_repair_orders",
+    ]
+
+    dim_names = sorted(d["name"] for d in cube["current"]["cubeDimensions"])
+    assert "default.hard_hat.city" in dim_names
+    assert "default.hard_hat.state" in dim_names
+    assert len(dim_names) == 2

--- a/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
@@ -92,11 +92,11 @@ class TestLoadNodeOptions:
         assert has_noload_for(options, "current")
 
     def test_with_created_by(self):
-        """created_by field requested - should selectinload created_by."""
+        """created_by field requested - should joinedload created_by."""
         fields = {"created_by": {"username": {}}}
         options = load_node_options(fields)
 
-        assert has_selectinload_for(options, "created_by")
+        assert has_joinedload_for(options, "created_by")
 
     def test_with_owners(self):
         """owners field requested - should selectinload owners."""
@@ -140,7 +140,7 @@ class TestLoadNodeOptions:
 
         assert has_joinedload_for(options, "current")
         assert has_joinedload_for(options, "revisions")
-        assert has_selectinload_for(options, "created_by")
+        assert has_joinedload_for(options, "created_by")
         assert has_selectinload_for(options, "owners")
         assert has_selectinload_for(options, "history")
         assert has_selectinload_for(options, "tags")
@@ -252,12 +252,12 @@ class TestLoadNodeRevisionOptions:
         # Should load minimal columns for cube request
         assert has_selectinload_for(options, "columns")
 
-    def test_with_cube_elements_direct(self):
-        """cube_elements field requested directly - should selectinload."""
-        fields = {"cube_elements": {}}
+    def test_without_cube_request_noloads_cube_elements(self):
+        """No cube fields requested — cube_elements should be noloaded."""
+        fields = {"description": {}}
         options = load_node_revision_options(fields)
 
-        assert has_selectinload_for(options, "cube_elements")
+        assert has_noload_for(options, "cube_elements")
 
     def test_cube_request_loads_minimal_columns(self):
         """Cube requests should load columns (for matching cube elements)."""
@@ -450,7 +450,7 @@ class TestLoadOptionsIntegration:
 
         # Should load tags and created_by
         assert has_selectinload_for(options, "tags")
-        assert has_selectinload_for(options, "created_by")
+        assert has_joinedload_for(options, "created_by")
         # Should load current
         assert has_joinedload_for(options, "current")
         # Should noload unused relationships

--- a/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
@@ -259,12 +259,18 @@ class TestLoadNodeRevisionOptions:
 
         assert has_noload_for(options, "cube_elements")
 
-    def test_cube_request_loads_minimal_columns(self):
-        """Cube requests should load columns (for matching cube elements)."""
+    def test_cube_name_only_noloads_columns(self):
+        """Name-only cube requests noload columns (fetched as raw tuples post-query)."""
         fields = {"cube_metrics": {"name": {}}}
         options = load_node_revision_options(fields)
 
-        # Cube requests should selectinload columns with minimal fields
+        assert has_noload_for(options, "columns")
+
+    def test_cube_full_request_loads_minimal_columns(self):
+        """Non-name-only cube requests should selectinload columns."""
+        fields = {"cube_metrics": {"name": {}, "description": {}}}
+        options = load_node_revision_options(fields)
+
         assert has_selectinload_for(options, "columns")
 
     def test_query_ast_always_deferred(self):

--- a/datajunction-server/tests/api/graphql/resolvers/test_user_resolver.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_user_resolver.py
@@ -1,0 +1,15 @@
+"""Tests for user load options."""
+
+from datajunction_server.api.graphql.resolvers.users import user_load_options
+
+
+def test_user_load_options_with_fields():
+    """Requesting specific fields returns load_only + noloads."""
+    options = user_load_options({"username": None})
+    assert len(options) == 4  # load_only + 3 noloads
+
+
+def test_user_load_options_empty_fields():
+    """Empty/None requested_fields returns no options."""
+    assert user_load_options(None) == []
+    assert user_load_options({}) == []

--- a/datajunction-server/tests/api/graphql/test_dataloaders.py
+++ b/datajunction-server/tests/api/graphql/test_dataloaders.py
@@ -4,8 +4,10 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from datajunction_server.api.graphql.dataloaders import (
+    batch_load_git_info,
     batch_load_nodes,
     batch_load_nodes_by_name_only,
+    create_git_info_loader,
     create_node_by_name_loader,
 )
 
@@ -280,4 +282,105 @@ def test_create_node_by_name_loader(mock_dataloader):
     assert callable(call_kwargs["load_fn"])
 
     # Verify result is the DataLoader instance
+    assert result == mock_loader_instance
+
+
+@pytest.mark.asyncio
+@patch("datajunction_server.api.graphql.dataloaders.session_context")
+async def test_batch_load_git_info_with_fk_hop(mock_session_context):
+    """Test batch_load_git_info when a branch namespace has a parent_namespace
+    outside the string hierarchy, triggering the FK hop query."""
+    mock_session = AsyncMock()
+    mock_session_context.return_value.__aenter__.return_value = mock_session
+
+    # Create namespace mocks:
+    # "project" is the git root (has github_repo_path)
+    # "project.feature" is the branch namespace (has git_branch, parent_namespace
+    #   points to "other_root" which is outside the string ancestors)
+    # "other_root" is the FK hop target (has github_repo_path)
+    ns_project = MagicMock()
+    ns_project.namespace = "project"
+    ns_project.git_branch = None
+    ns_project.github_repo_path = None
+    ns_project.parent_namespace = None
+
+    ns_feature = MagicMock()
+    ns_feature.namespace = "project.feature"
+    ns_feature.git_branch = "feature-branch"
+    ns_feature.parent_namespace = "other_root"  # outside string hierarchy
+    ns_feature.github_repo_path = None
+
+    ns_other_root = MagicMock()
+    ns_other_root.namespace = "other_root"
+    ns_other_root.github_repo_path = "owner/repo"
+    ns_other_root.git_branch = None
+    ns_other_root.default_branch = "main"
+    ns_other_root.git_path = "/path"
+    ns_other_root.git_only = False
+    ns_other_root.parent_namespace = None
+
+    # First query returns project + project.feature (not other_root)
+    # Second query (FK hop) returns other_root
+    mock_result_1 = MagicMock()
+    mock_result_1.scalars.return_value.all.return_value = [ns_project, ns_feature]
+    mock_result_2 = MagicMock()
+    mock_result_2.scalars.return_value.all.return_value = [ns_other_root]
+    mock_session.execute.side_effect = [mock_result_1, mock_result_2]
+
+    mock_request = MagicMock()
+    result = await batch_load_git_info(
+        ["project.feature.cubes"],
+        mock_request,
+    )
+
+    # Two queries should have been executed (ancestors + FK hop)
+    assert mock_session.execute.call_count == 2
+    assert len(result) == 1
+    assert result[0] is not None
+    assert result[0]["repo"] == "owner/repo"
+    assert result[0]["branch"] == "feature-branch"
+
+
+@pytest.mark.asyncio
+@patch("datajunction_server.api.graphql.dataloaders.session_context")
+async def test_batch_load_git_info_no_fk_hop(mock_session_context):
+    """Test batch_load_git_info when no FK hop is needed (single query)."""
+    mock_session = AsyncMock()
+    mock_session_context.return_value.__aenter__.return_value = mock_session
+
+    ns_root = MagicMock()
+    ns_root.namespace = "project"
+    ns_root.git_branch = "main"
+    ns_root.github_repo_path = "owner/repo"
+    ns_root.parent_namespace = None
+    ns_root.default_branch = "main"
+    ns_root.git_path = "/"
+    ns_root.git_only = False
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [ns_root]
+    mock_session.execute.return_value = mock_result
+
+    mock_request = MagicMock()
+    result = await batch_load_git_info(["project"], mock_request)
+
+    # Only one query — no FK hop needed
+    assert mock_session.execute.call_count == 1
+    assert len(result) == 1
+    assert result[0]["repo"] == "owner/repo"
+
+
+@patch("datajunction_server.api.graphql.dataloaders.DataLoader")
+def test_create_git_info_loader(mock_dataloader):
+    """Test create_git_info_loader creates DataLoader with correct load_fn."""
+    mock_request = MagicMock()
+    mock_loader_instance = MagicMock()
+    mock_dataloader.return_value = mock_loader_instance
+
+    result = create_git_info_loader(mock_request)
+
+    assert mock_dataloader.called
+    call_kwargs = mock_dataloader.call_args[1]
+    assert "load_fn" in call_kwargs
+    assert callable(call_kwargs["load_fn"])
     assert result == mock_loader_instance

--- a/datajunction-server/tests/api/graphql/test_dataloaders.py
+++ b/datajunction-server/tests/api/graphql/test_dataloaders.py
@@ -370,6 +370,32 @@ async def test_batch_load_git_info_no_fk_hop(mock_session_context):
     assert result[0]["repo"] == "owner/repo"
 
 
+@pytest.mark.asyncio
+@patch("datajunction_server.api.graphql.dataloaders.session_context")
+async def test_batch_load_git_info_no_git_branch(mock_session_context):
+    """Test batch_load_git_info when no namespace has git_branch set."""
+    mock_session = AsyncMock()
+    mock_session_context.return_value.__aenter__.return_value = mock_session
+
+    ns_root = MagicMock()
+    ns_root.namespace = "project"
+    ns_root.git_branch = None
+    ns_root.github_repo_path = None
+    ns_root.parent_namespace = None
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [ns_root]
+    mock_session.execute.return_value = mock_result
+
+    mock_request = MagicMock()
+    result = await batch_load_git_info(["project"], mock_request)
+
+    # Only one query — no branch found, no FK hop
+    assert mock_session.execute.call_count == 1
+    assert len(result) == 1
+    assert result[0] is None
+
+
 @patch("datajunction_server.api.graphql.dataloaders.DataLoader")
 def test_create_git_info_loader(mock_dataloader):
     """Test create_git_info_loader creates DataLoader with correct load_fn."""


### PR DESCRIPTION
### Summary

The findNodes GraphQL query was slow when returning many cubes due to N+1 queries, unnecessary ORM hydration, and cascading relationship loads. This PR cuts that latency through several optimizations:

- `gitInfo` was being loaded in an N+1 pattern where each node's `gitInfo` resolver was querying ancestor namespaces individually. Now a single DataLoader batches all namespace lookups into 1-2 queries per request.
- Filtering by tags loaded full `Tag` and `Node` ORM objects (which triggered cascading `User.created_by` queries) just to collect node IDs. This is replaced with an explicit `SELECT node.id ... JOIN tagnoderelationship JOIN tag` query.
- When `cubeMetrics`/`cubeDimensions` only request name, both columns and cube_elements are fetched as raw SQL tuples instead of ORM objects. This avoids ORM hydration of numerous `Column` instances, which is quite slow. Metric vs dimension identification uses the `_DOT_` naming convention on cube element columns, queried via the cube join table.
- Introduced `user_load_options(fields)` and `tag_load_options(fields)` that restrict columns fetched and suppress unused relationships based on the GraphQL fields actually requested.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
