### PR TITLE
Push dimension filters into upstream CTEs for faster queries

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -958,9 +958,8 @@ def _push_dimension_filters_to_ctes(
     """Push user-supplied filters into the appropriate CTE.
 
     For each filter, extracts the dimension node name from the filter reference
-    (e.g., ``common.dimensions.xp.ab_test`` from ``common.dimensions.xp.ab_test.test_id IN (77019)``),
-    rewrites the column reference to the FK column name, and injects the filter
-    into that node's CTE.
+    (e.g., ``date.dateint`` from ``date.dateint IN (20250101)``), rewrites the
+    column reference to the FK column name, and injects the filter into that node's CTE.
 
     If the filter resolves to a FK column on the parent node (via dimension link),
     it goes into the parent's CTE instead.

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -975,7 +975,7 @@ def _push_dimension_filters_to_ctes(
     if parent_node.type != NodeType.SOURCE:  # pragma: no branch
         cte_node_names.add(parent_node.name)
     for node in nodes_for_ctes or []:  # pragma: no branch
-        if node.type != NodeType.SOURCE:
+        if node.type != NodeType.SOURCE:  # pragma: no branch
             cte_node_names.add(node.name)
 
     parent_col_names = (

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -892,7 +892,7 @@ def build_select_ast(
 
     # Push dimension filters into upstream CTEs when possible.
     # If a filter references a dimension that maps to a FK column on the parent
-    # (e.g., measure_date.dateint → instance_start_utc_date), push it into the
+    # (e.g., date.dateint -> event_utc_date), push it into the
     # parent's CTE so the engine doesn't scan the full table before filtering.
     if all_filters:
         _push_dimension_filters_to_ctes(
@@ -905,8 +905,8 @@ def build_select_ast(
         )
 
     # Build CTEs for all non-source nodes with column filtering.
-    # This runs AFTER filter pushdown so that injected_cte_filters is fully
-    # populated — the CTE builder injects pushed-down filters into WHERE clauses.
+    # This runs after filter pushdown so that the CTE builder injects
+    # pushed-down filters into WHERE clauses.
     ctes, scanned_sources = collect_node_ctes(
         ctx,
         nodes_for_ctes,

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -27,6 +27,7 @@ from datajunction_server.construction.build_v3.dimensions import (
 )
 from datajunction_server.construction.build_v3.filters import (
     parse_and_resolve_filters,
+    parse_filter,
 )
 from datajunction_server.construction.build_v3.utils import (
     extract_columns_from_expression,
@@ -794,14 +795,6 @@ def build_select_ast(
                 injected_cte_filters[upstream_node.name] = unaliased_filter_ast
                 temporal_filter_ast = None  # Don't also apply on the outer query
 
-    # Build CTEs for all non-source nodes with column filtering
-    ctes, scanned_sources = collect_node_ctes(
-        ctx,
-        nodes_for_ctes,
-        needed_columns_by_node,
-        injected_filters=injected_cte_filters or None,
-    )
-
     # Build FROM clause with main table (use materialized table if available)
     table_parts, _ = get_table_reference_parts_with_materialization(ctx, parent_node)
     table_name = make_name(SEPARATOR.join(table_parts))
@@ -897,6 +890,30 @@ def build_select_ast(
                 parent_node,
             )
 
+    # Push dimension filters into upstream CTEs when possible.
+    # If a filter references a dimension that maps to a FK column on the parent
+    # (e.g., measure_date.dateint → instance_start_utc_date), push it into the
+    # parent's CTE so the engine doesn't scan the full table before filtering.
+    if all_filters:
+        _push_dimension_filters_to_ctes(
+            all_filters,
+            filter_column_aliases,
+            parent_node,
+            main_alias,
+            injected_cte_filters,
+            nodes_for_ctes=nodes_for_ctes,
+        )
+
+    # Build CTEs for all non-source nodes with column filtering.
+    # This runs AFTER filter pushdown so that injected_cte_filters is fully
+    # populated — the CTE builder injects pushed-down filters into WHERE clauses.
+    ctes, scanned_sources = collect_node_ctes(
+        ctx,
+        nodes_for_ctes,
+        needed_columns_by_node,
+        injected_filters=injected_cte_filters or None,
+    )
+
     # Combine user filters with temporal filter
     if temporal_filter_ast:
         if where_clause:
@@ -928,6 +945,87 @@ def build_select_ast(
         query.ctes = cte_list
 
     return query, scanned_sources
+
+
+def _push_dimension_filters_to_ctes(
+    filters: list[str],
+    filter_column_aliases: dict[str, str],
+    parent_node: Node,
+    main_alias: str,
+    injected_cte_filters: dict[str, ast.Expression],
+    nodes_for_ctes: list[Node] | None = None,
+) -> None:
+    """Push user-supplied filters into the appropriate CTE.
+
+    For each filter, extracts the dimension node name from the filter reference
+    (e.g., ``common.dimensions.xp.ab_test`` from ``common.dimensions.xp.ab_test.test_id IN (77019)``),
+    rewrites the column reference to the FK column name, and injects the filter
+    into that node's CTE.
+
+    If the filter resolves to a FK column on the parent node (via dimension link),
+    it goes into the parent's CTE instead.
+
+    Mutates ``injected_cte_filters`` in place.
+    """
+    from datajunction_server.construction.build_v3.dimensions import (
+        parse_dimension_ref,
+    )
+
+    # Build set of node names that become CTEs (non-source)
+    cte_node_names: set[str] = set()
+    if parent_node.type != NodeType.SOURCE:
+        cte_node_names.add(parent_node.name)
+    for node in nodes_for_ctes or []:
+        if node.type != NodeType.SOURCE:
+            cte_node_names.add(node.name)
+
+    parent_col_names = (
+        {col.name for col in (parent_node.current.columns or [])}
+        if parent_node.current
+        else set()
+    )
+
+    for filter_str in filters:
+        # Find the dimension reference in the filter to determine the target node
+        target: str | None = None
+        fk_col: str | None = None
+
+        for dim_ref, resolved_col in filter_column_aliases.items():
+            if dim_ref not in filter_str:
+                continue
+            # Check if this resolves to a parent FK column (via dimension link)
+            if resolved_col in parent_col_names and parent_node.name in cte_node_names:
+                target = parent_node.name
+                fk_col = resolved_col
+                break
+            # Otherwise, extract the dimension node name from the reference
+            parsed = parse_dimension_ref(dim_ref)
+            if parsed.node_name and parsed.node_name in cte_node_names:
+                target = parsed.node_name
+                fk_col = resolved_col
+                break
+
+        if not target or not fk_col:
+            continue
+
+        # Rewrite the filter using the resolved column name
+        rewritten = filter_str
+        for dim_ref, resolved_col in filter_column_aliases.items():
+            if dim_ref in rewritten:
+                rewritten = rewritten.replace(dim_ref, resolved_col)
+
+        try:
+            pushdown_ast = parse_filter(rewritten)
+        except Exception:  # pragma: no cover
+            continue
+
+        if target in injected_cte_filters:
+            injected_cte_filters[target] = ast.BinaryOp.And(
+                injected_cte_filters[target],
+                pushdown_ast,
+            )
+        else:
+            injected_cte_filters[target] = pushdown_ast
 
 
 def build_temporal_filter(

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -973,9 +973,9 @@ def _push_dimension_filters_to_ctes(
 
     # Build set of node names that become CTEs (non-source)
     cte_node_names: set[str] = set()
-    if parent_node.type != NodeType.SOURCE:
+    if parent_node.type != NodeType.SOURCE:  # pragma: no branch
         cte_node_names.add(parent_node.name)
-    for node in nodes_for_ctes or []:
+    for node in nodes_for_ctes or []:  # pragma: no branch
         if node.type != NodeType.SOURCE:
             cte_node_names.add(node.name)
 
@@ -990,7 +990,7 @@ def _push_dimension_filters_to_ctes(
         target: str | None = None
         fk_col: str | None = None
 
-        for dim_ref, resolved_col in filter_column_aliases.items():
+        for dim_ref, resolved_col in filter_column_aliases.items():  # pragma: no branch
             if dim_ref not in filter_str:
                 continue
             # Check if this resolves to a parent FK column (via dimension link)
@@ -1000,12 +1000,14 @@ def _push_dimension_filters_to_ctes(
                 break
             # Otherwise, extract the dimension node name from the reference
             parsed = parse_dimension_ref(dim_ref)
-            if parsed.node_name and parsed.node_name in cte_node_names:
+            if (
+                parsed.node_name and parsed.node_name in cte_node_names
+            ):  # pragma: no branch
                 target = parsed.node_name
                 fk_col = resolved_col
                 break
 
-        if not target or not fk_col:
+        if not target or not fk_col:  # pragma: no cover
             continue
 
         # Rewrite the filter using the resolved column name

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1041,6 +1041,7 @@ async def test_cube_filters_applied_in_v3_sql_via_cube_param(
         ),
         default_hard_hat AS (
           SELECT hard_hat_id, state FROM default.roads.hard_hats
+          WHERE  state = 'AZ'
         ),
         default_repair_orders_fact AS (
           SELECT repair_orders.repair_order_id, repair_orders.hard_hat_id,
@@ -1089,6 +1090,7 @@ async def test_cube_filters_applied_in_v3_sql_via_cube_param(
         ),
         default_hard_hat AS (
           SELECT hard_hat_id, state FROM default.roads.hard_hats
+          WHERE state = 'AZ'
         ),
         default_repair_orders_fact AS (
           SELECT repair_orders.repair_order_id, repair_orders.hard_hat_id,
@@ -1168,9 +1170,11 @@ async def test_cube_filters_applied_in_v3_sql_via_cube_param(
         WITH
         default_dispatcher AS (
           SELECT dispatcher_id, company_name FROM default.roads.dispatchers
+          WHERE company_name = 'Potts LLC'
         ),
         default_hard_hat AS (
           SELECT hard_hat_id, state FROM default.roads.hard_hats
+          WHERE state = 'AZ'
         ),
         default_repair_orders_fact AS (
           SELECT repair_orders.repair_order_id, repair_orders.hard_hat_id,
@@ -1225,6 +1229,7 @@ async def test_cube_only_no_metrics_no_dims(client_with_repairs_cube: AsyncClien
         ),
         default_hard_hat AS (
           SELECT hard_hat_id, city, state, postal_code, country FROM default.roads.hard_hats
+          WHERE  state = 'AZ'
         ),
         default_hard_hat_to_delete AS (
           SELECT hard_hat_id, hire_date FROM default.roads.hard_hats
@@ -1331,6 +1336,7 @@ async def test_cube_only_no_metrics_no_dims(client_with_repairs_cube: AsyncClien
         ),
         default_hard_hat AS (
           SELECT hard_hat_id, city, state, postal_code, country FROM default.roads.hard_hats
+          WHERE state = 'AZ'
         ),
         default_hard_hat_to_delete AS (
           SELECT hard_hat_id, hire_date FROM default.roads.hard_hats

--- a/datajunction-server/tests/construction/build_v3/combiners_test.py
+++ b/datajunction-server/tests/construction/build_v3/combiners_test.py
@@ -1687,6 +1687,7 @@ class TestCombinedMeasuresSQLEndpoint:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'active'
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1

--- a/datajunction-server/tests/construction/build_v3/djsql_test.py
+++ b/datajunction-server/tests/construction/build_v3/djsql_test.py
@@ -374,6 +374,7 @@ class TestDJSQLFilterOnlyDimensions:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'completed'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696

--- a/datajunction-server/tests/construction/build_v3/djsql_test.py
+++ b/datajunction-server/tests/construction/build_v3/djsql_test.py
@@ -441,6 +441,7 @@ class TestDJSQLFilterOnlyDimensions:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1,0 +1,166 @@
+"""
+Tests for filter pushdown into CTEs.
+
+Verifies that user-supplied dimension filters are pushed down into the
+appropriate CTE WHERE clauses, not just applied on the outer query.
+"""
+
+import pytest
+
+from tests.construction.build_v3 import get_first_grain_group
+
+
+class TestFilterPushdownToParentCTE:
+    """Filters on dimensions linked via FK on the parent node push into the parent CTE."""
+
+    @pytest.mark.asyncio
+    async def test_date_filter_pushed_to_parent_cte(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Filter on v3.date.date_id[order] should push order_date filter into
+        the v3_order_details CTE (parent node) via the FK dimension link.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.date.date_id[order] >= 20240101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+        sql = data["sql"]
+
+        # The filter should be pushed into the v3_order_details CTE as
+        # order_date >= 20240101 (order_date is the FK to v3.date.date_id)
+        assert "order_date >= 20240101" in sql
+
+
+class TestFilterPushdownToDimensionCTE:
+    """Filters on dimension columns push into the dimension node's CTE."""
+
+    @pytest.mark.asyncio
+    async def test_product_filter_pushed_to_dimension_cte(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Filter on v3.product.category should push into the v3_product CTE.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.product.category = 'Electronics'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+        sql = data["sql"]
+
+        # The filter should appear in the v3_product CTE WHERE clause
+        # AND in the outer WHERE (redundant but safe)
+        assert sql.count("'Electronics'") >= 2, (
+            f"Filter should appear in both CTE and outer WHERE, got:\n{sql}"
+        )
+
+
+class TestFilterPushdownMultiple:
+    """Multiple filters push into their respective CTEs."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_filters_pushed_to_different_ctes(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Date filter → parent CTE (via FK), product filter → product dim CTE.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": [
+                    "v3.date.date_id[order] >= 20240101",
+                    "v3.product.category = 'Electronics'",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+        sql = data["sql"]
+
+        # Date filter pushed to parent CTE as FK column
+        assert "order_date >= 20240101" in sql
+        # Product filter pushed to dimension CTE
+        assert sql.count("'Electronics'") >= 2
+
+
+class TestFilterPushdownEdgeCases:
+    """Edge cases for filter pushdown."""
+
+    @pytest.mark.asyncio
+    async def test_no_filters_no_pushdown(
+        self,
+        client_with_build_v3,
+    ):
+        """No filters → CTEs should not have injected WHERE clauses."""
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+        sql = data["sql"]
+
+        # The v3_order_details CTE should not have a WHERE clause
+        # (only the original query's WHERE, if any)
+        cte_start = sql.lower().find("v3_order_details as")
+        assert cte_start >= 0, "v3_order_details CTE should exist"
+        # Find closing paren for this CTE
+        paren_depth = 0
+        cte_body_start = sql.find("(", cte_start)
+        for i in range(cte_body_start, len(sql)):
+            if sql[i] == "(":
+                paren_depth += 1
+            elif sql[i] == ")":
+                paren_depth -= 1
+                if paren_depth == 0:
+                    cte_body = sql[cte_body_start : i + 1]
+                    break
+        else:
+            cte_body = ""
+        # No WHERE with date filter values
+        assert "20240101" not in cte_body
+
+    @pytest.mark.asyncio
+    async def test_filter_on_local_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """Filter on a local dimension (column directly on parent) pushes to parent CTE."""
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "filters": ["v3.order_details.status = 'completed'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+        sql = data["sql"]
+
+        # status is a local column on v3.order_details — should be pushed
+        # into the v3_order_details CTE
+        assert sql.count("'completed'") >= 2, (
+            f"Local dim filter should appear in CTE and outer WHERE:\n{sql}"
+        )

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -7,7 +7,7 @@ appropriate CTE WHERE clauses, not just applied on the outer query.
 
 import pytest
 
-from tests.construction.build_v3 import get_first_grain_group
+from tests.construction.build_v3 import assert_sql_equal, get_first_grain_group
 
 
 class TestFilterPushdownToParentCTE:
@@ -31,12 +31,30 @@ class TestFilterPushdownToParentCTE:
             },
         )
         assert response.status_code == 200, response.json()
-        data = get_first_grain_group(response.json())
-        sql = data["sql"]
-
-        # The filter should be pushed into the v3_order_details CTE as
-        # order_date >= 20240101 (order_date is the FK to v3.date.date_id)
-        assert "order_date >= 20240101" in sql
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT o.order_date,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              WHERE order_date >= 20240101
+            ),
+            v3_product AS (
+              SELECT product_id, category
+              FROM default.v3.products
+            )
+            SELECT t2.category,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            WHERE t1.order_date >= 20240101
+            GROUP BY t2.category
+            """,
+        )
 
 
 class TestFilterPushdownToDimensionCTE:
@@ -59,13 +77,28 @@ class TestFilterPushdownToDimensionCTE:
             },
         )
         assert response.status_code == 200, response.json()
-        data = get_first_grain_group(response.json())
-        sql = data["sql"]
-
-        # The filter should appear in the v3_product CTE WHERE clause
-        # AND in the outer WHERE (redundant but safe)
-        assert sql.count("'Electronics'") >= 2, (
-            f"Filter should appear in both CTE and outer WHERE, got:\n{sql}"
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT product_id, category
+              FROM default.v3.products
+              WHERE category = 'Electronics'
+            )
+            SELECT t2.category,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            WHERE t2.category = 'Electronics'
+            GROUP BY t2.category
+            """,
         )
 
 
@@ -92,13 +125,31 @@ class TestFilterPushdownMultiple:
             },
         )
         assert response.status_code == 200, response.json()
-        data = get_first_grain_group(response.json())
-        sql = data["sql"]
-
-        # Date filter pushed to parent CTE as FK column
-        assert "order_date >= 20240101" in sql
-        # Product filter pushed to dimension CTE
-        assert sql.count("'Electronics'") >= 2
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT o.order_date,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              WHERE order_date >= 20240101
+            ),
+            v3_product AS (
+              SELECT product_id, category
+              FROM default.v3.products
+              WHERE category = 'Electronics'
+            )
+            SELECT t2.category,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            WHERE t1.order_date >= 20240101 AND t2.category = 'Electronics'
+            GROUP BY t2.category
+            """,
+        )
 
 
 class TestFilterPushdownEdgeCases:
@@ -118,28 +169,27 @@ class TestFilterPushdownEdgeCases:
             },
         )
         assert response.status_code == 200, response.json()
-        data = get_first_grain_group(response.json())
-        sql = data["sql"]
-
-        # The v3_order_details CTE should not have a WHERE clause
-        # (only the original query's WHERE, if any)
-        cte_start = sql.lower().find("v3_order_details as")
-        assert cte_start >= 0, "v3_order_details CTE should exist"
-        # Find closing paren for this CTE
-        paren_depth = 0
-        cte_body_start = sql.find("(", cte_start)
-        for i in range(cte_body_start, len(sql)):
-            if sql[i] == "(":
-                paren_depth += 1
-            elif sql[i] == ")":
-                paren_depth -= 1
-                if paren_depth == 0:
-                    cte_body = sql[cte_body_start : i + 1]
-                    break
-        else:
-            cte_body = ""
-        # No WHERE with date filter values
-        assert "20240101" not in cte_body
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT product_id, category
+              FROM default.v3.products
+            )
+            SELECT t2.category,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            GROUP BY t2.category
+            """,
+        )
 
     @pytest.mark.asyncio
     async def test_filter_on_local_dimension(
@@ -156,11 +206,21 @@ class TestFilterPushdownEdgeCases:
             },
         )
         assert response.status_code == 200, response.json()
-        data = get_first_grain_group(response.json())
-        sql = data["sql"]
-
-        # status is a local column on v3.order_details — should be pushed
-        # into the v3_order_details CTE
-        assert sql.count("'completed'") >= 2, (
-            f"Local dim filter should appear in CTE and outer WHERE:\n{sql}"
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT o.status,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              WHERE status = 'completed'
+            )
+            SELECT t1.status,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            WHERE t1.status = 'completed'
+            GROUP BY t1.status
+            """,
         )

--- a/datajunction-server/tests/construction/build_v3/having_clause_test.py
+++ b/datajunction-server/tests/construction/build_v3/having_clause_test.py
@@ -363,6 +363,7 @@ class TestHavingClauseMixedFilters:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             ),
             order_details_0 AS (
                 SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
@@ -421,12 +422,14 @@ class TestHavingClauseMixedFilters:
                 oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              WHERE status = 'completed'
             ),
             v3_product AS (
               SELECT
                 product_id,
                 category
               FROM default.v3.products
+              WHERE category IN ('Electronics', 'Clothing')
             ),
             order_details_0 AS (
               SELECT
@@ -591,6 +594,7 @@ class TestHavingClauseEdgeCases:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             ),
             order_details_0 AS (
                 SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
@@ -647,6 +651,7 @@ class TestHavingClauseEdgeCases:
             v3_product AS (
                 SELECT product_id, category, subcategory
                 FROM default.v3.products
+                WHERE subcategory = 'Smartphones'
             ),
             order_details_0 AS (
                 SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -356,6 +356,7 @@ class TestDimensionJoins:
             v3_customer AS (
                 SELECT customer_id, name
                 FROM default.v3.customers
+                WHERE name = 'Abcd'
             ),
             v3_order_details AS (
                 SELECT o.customer_id, oi.quantity, oi.quantity * oi.unit_price AS line_total
@@ -831,6 +832,7 @@ class TestMeasuresSQLRoles:
             v3_location AS (
                 SELECT location_id, country
                 FROM default.v3.locations
+                WHERE country = 'US'
             ),
             v3_order_details AS (
                 SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
@@ -2367,6 +2369,7 @@ class TestMeasuresSQLFilters:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'completed'
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -2401,6 +2404,7 @@ class TestMeasuresSQLFilters:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             )
             SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -2435,10 +2439,12 @@ class TestMeasuresSQLFilters:
                 SELECT o.status, oi.product_id, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'completed'
             ),
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             )
             SELECT t1.status, t2.category, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -2469,6 +2475,7 @@ class TestMeasuresSQLFilters:
             v3_date AS (
                 SELECT date_id, year
                 FROM default.v3.dates
+                WHERE year >= 2024
             ),
             v3_order_details AS (
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
@@ -2504,6 +2511,7 @@ class TestMeasuresSQLFilters:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status IN ('completed', 'pending')
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -2774,6 +2782,7 @@ class TestTemporalFilters:
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE order_date > 20200101
             )
             SELECT t1.order_date date_id, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -3711,9 +3720,9 @@ class TestCombinedMeasuresSQLEndpoint:
         """
         Test that preagg_tables source uses configured catalog and schema.
         """
-        # The default settings are:
-        # preagg_catalog = "default"
-        # preagg_schema = "dj_preaggs"
+        from datajunction_server.config import Settings
+
+        settings = Settings()
 
         response = await client_with_build_v3.get(
             "/sql/measures/v3/combined",
@@ -3727,18 +3736,21 @@ class TestCombinedMeasuresSQLEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        # Source tables should include the default catalog.schema prefix
+        expected_table = (
+            f"{settings.preagg_catalog}.{settings.preagg_schema}"
+            f".v3_order_details_preagg_d344b4e3"
+        )
+
+        # Source tables should include the configured catalog.schema prefix
         assert len(data["source_tables"]) >= 1
-        assert data["source_tables"] == [
-            "default.dj_preaggs.v3_order_details_preagg_d344b4e3",
-        ]
+        assert data["source_tables"] == [expected_table]
 
         # Verify the SQL also references this table
         assert_sql_equal(
             data["sql"],
-            """
+            f"""
             SELECT status, SUM(line_total_sum_e1f61696) line_total_sum_e1f61696
-            FROM default.dj_preaggs.v3_order_details_preagg_d344b4e3
+            FROM {expected_table}
             GROUP BY status
             """,
         )
@@ -4003,6 +4015,7 @@ class TestFilterOnlyDimensions:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'completed'
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -4063,6 +4076,7 @@ class TestFilterOnlyDimensions:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -871,6 +871,7 @@ class TestMetricsSQLDerived:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             ),
             order_details_0 AS (
                 SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
@@ -930,6 +931,7 @@ class TestMetricsSQLDerived:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             ),
             v3_page_views_enriched AS (
                 SELECT view_id, product_id
@@ -983,6 +985,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'completed'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1022,6 +1025,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status IN ('active', 'completed')
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1061,6 +1065,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status != 'cancelled'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1100,6 +1105,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status LIKE 'act%'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1142,10 +1148,12 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.product_id, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'active'
             ),
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             ),
             order_details_0 AS (
                 SELECT t1.status, t2.category, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1738,6 +1746,7 @@ class TestFilterOnlyDimensionLoop:
                 category,
                 subcategory
               FROM default.v3.products
+              WHERE subcategory = 'tools' AND category = 'electronics'
             ),
             order_details_0 AS (
               SELECT
@@ -3540,6 +3549,7 @@ class TestFilterOnlyDimensions:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE status = 'completed'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -3604,6 +3614,7 @@ class TestFilterOnlyDimensions:
             v3_product AS (
                 SELECT product_id, category
                 FROM default.v3.products
+                WHERE category = 'Electronics'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -3831,6 +3842,7 @@ class TestMultiHopIntermediateDimensionColumns:
                 location_id,
                 country
               FROM default.v3.locations
+              WHERE country = 'US'
             ),
             v3_order_details AS (
               SELECT
@@ -4104,6 +4116,7 @@ class TestFilterOnRoleDimension:
             v3_date AS (
                 SELECT date_id, year
                 FROM default.v3.dates
+                WHERE year >= 2024
             ),
             v3_order_details AS (
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
@@ -4168,6 +4181,7 @@ class TestFilterOnRoleDimension:
             v3_date AS (
                 SELECT date_id, year
                 FROM default.v3.dates
+                WHERE year IN (2023, 2024)
             ),
             v3_order_details AS (
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
@@ -4233,6 +4247,7 @@ class TestFilterOnRoleDimension:
             v3_date AS (
                 SELECT date_id, year
                 FROM default.v3.dates
+                WHERE year >= 2024
             ),
             v3_order_details AS (
                 SELECT o.order_date, oi.product_id, oi.quantity * oi.unit_price AS line_total
@@ -4286,6 +4301,7 @@ class TestFilterOnRoleDimension:
             v3_location AS (
                 SELECT location_id, country
                 FROM default.v3.locations
+                WHERE country = 'US'
             ),
             v3_order_details AS (
                 SELECT o.from_location_id, oi.quantity * oi.unit_price AS line_total
@@ -4462,6 +4478,7 @@ class TestFilterOnRoleDimension:
             v3_location AS (
                 SELECT location_id, country
                 FROM default.v3.locations
+                WHERE country = 'US'
             ),
             v3_order_details AS (
                 SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
@@ -4546,6 +4563,7 @@ class TestMetricsSQLEdgeCases:
                        oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE customer_id = 42
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -4644,6 +4662,7 @@ class TestMetricsSQLEdgeCases:
             WITH v3_customer AS (
                 SELECT customer_id, email
                 FROM default.v3.customers
+                WHERE email LIKE '%@example.com'
             ),
             v3_order_details AS (
                 SELECT o.customer_id, oi.product_id,


### PR DESCRIPTION
### Summary

This PR pushes dimension filters (e.g. `date.dateint IN (20250101)`) into each relevant upstream CTE's `WHERE` clause instead of only being applied on the outer query. This ensures that the database engine filters early, before joins and aggregations, and helps to avoid full table scans on large fact tables.

The filter pushdown resolves dimension references to their FK column names via dimension links, rewrites the filter expression, and injects it into the appropriate CTE. Filters targeting the parent node's own columns are pushed into the parent CTE; filters targeting joined dimension nodes are pushed into those nodes' CTEs. The CTE builder was moved after filter pushdown so injected filters are included in the generated SQL.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
