### PR TITLE
Push dimension filters into all upstream CTEs with table-qualified columns

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -7,12 +7,19 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Optional
 
-from datajunction_server.construction.build_v3.filters import extract_subscript_role
+from datajunction_server.construction.build_v3.filters import (
+    extract_subscript_role,
+    parse_filter,
+)
 from datajunction_server.construction.build_v3.materialization import (
     get_table_reference_parts_with_materialization,
     should_use_materialized_table,
 )
-from datajunction_server.construction.build_v3.types import BuildContext, GrainGroupSQL
+from datajunction_server.construction.build_v3.types import (
+    BuildContext,
+    GrainGroupSQL,
+    PushdownFilters,
+)
 from datajunction_server.construction.build_v3.utils import get_cte_name
 from datajunction_server.database.node import Node
 from datajunction_server.models.node_type import NodeType
@@ -65,9 +72,9 @@ def extract_dimension_node(dim_ref: str) -> str:
     Extract the dimension node name from a full dimension reference.
 
     For example:
-        "common.dimensions.time.date.dateint" -> "common.dimensions.time.date"
-        "common.dimensions.time.date.week_code" -> "common.dimensions.time.date"
-        "v3.product.hw_category" -> "v3.product"
+        "v3.date.date_id" -> "v3.date"
+        "v3.date.month" -> "v3.date"
+        "v3.product.category" -> "v3.product"
 
     Args:
         dim_ref: Full dimension reference (node.column format)
@@ -91,13 +98,13 @@ def build_alias_to_dimension_node(
 
     Args:
         dim_info: List of (original_dim_ref, col_alias) tuples
-            e.g., [("common.dimensions.time.date.dateint", "dateint"),
-                   ("common.dimensions.time.date.week_code", "week_code")]
+            e.g., [("v3.date.date_id", "date_id"),
+                   ("v3.date.month", "month")]
 
     Returns:
         Mapping from alias to dimension node
-            e.g., {"dateint": "common.dimensions.time.date",
-                   "week_code": "common.dimensions.time.date"}
+            e.g., {"date_id": "v3.date",
+                   "month": "v3.date"}
     """
     return {
         col_alias: extract_dimension_node(dim_ref) for dim_ref, col_alias in dim_info
@@ -502,27 +509,27 @@ def inject_partition_by_into_windows(
     2. Other columns from the same dimension node as the ORDER BY column
 
     The second rule is critical for period-over-period metrics. For example, if ordering
-    by week_code (from common.dimensions.time.date), we should NOT partition by dateint
-    (also from common.dimensions.time.date), because dateint is a finer grain that would
-    break the week-over-week comparison.
+    by month (from v3.date), we should NOT partition by date_id
+    (also from v3.date), because date_id is a finer grain that would
+    break the month-over-month comparison.
 
-    This ensures that comparisons (e.g., week-over-week) are done within each partition
-    (e.g., per country, per product) rather than across the entire result set.
+    This ensures that comparisons (e.g., month-over-month) are done within each partition
+    (e.g., per category, per product) rather than across the entire result set.
 
     IMPORTANT: This only applies to navigation/ranking functions (LAG, LEAD, RANK, etc.).
     Aggregate window functions (SUM, AVG, COUNT, MIN, MAX with OVER ()) are NOT modified,
-    as they often intentionally compute grand totals (e.g., for weighted CPM calculations).
+    as they often intentionally compute grand totals (e.g., for weighted average calculations).
 
     For example, given:
-        LAG(revenue, 1) OVER (ORDER BY week_code)
-    And requested dimensions: [category, dateint, week_code, month_code]
-    Where dateint, week_code, month_code are all from "common.dimensions.time.date"
+        LAG(revenue, 1) OVER (ORDER BY month)
+    And requested dimensions: [category, date_id, month, quarter]
+    Where date_id, month, quarter are all from "v3.date"
 
     This function transforms it to:
-        LAG(revenue, 1) OVER (PARTITION BY category ORDER BY week_code)
+        LAG(revenue, 1) OVER (PARTITION BY category ORDER BY month)
 
-    Note: dateint and month_code are excluded because they're from the same dimension
-    node as week_code.
+    Note: date_id and quarter are excluded because they're from the same dimension
+    node as month.
 
     But this is left unchanged:
         SUM(impressions) OVER ()  -- grand total, no partition injection
@@ -892,14 +899,131 @@ def flatten_inner_ctes(
     return extracted_ctes, inner_cte_renames
 
 
+# ---------------------------------------------------------------------------
+# Filter pushdown into CTEs
+# ---------------------------------------------------------------------------
+
+
+def _inject_filter_into_where(
+    query_ast: ast.Query,
+    filter_expr: ast.Expression,
+) -> None:
+    """AND a filter expression into a query's WHERE clause."""
+    if query_ast.select.where:
+        query_ast.select.where = ast.BinaryOp.And(
+            query_ast.select.where,
+            filter_expr,
+        )
+    else:
+        query_ast.select.where = filter_expr
+
+
+def _resolve_pushdown_filters_for_cte(
+    node: "Node",
+    cte_query: ast.Query,
+    pushdown_filters: list[str],
+    filter_column_aliases: dict[str, str],
+) -> list[ast.Expression]:
+    """Determine which user filters can be pushed into this CTE and return them.
+
+    For each filter, extracts the dimension references, resolves them to bare
+    column names via filter_column_aliases, and checks whether this CTE outputs
+    those columns.  If all referenced columns are present, the filter is rewritten
+    using the CTE's internal table-qualified column names and returned.
+
+    Returns a list of parsed filter AST expressions ready for injection.
+    """
+    node_output_cols = (
+        {col.name for col in (node.current.columns or [])} if node.current else set()
+    )
+
+    if not node_output_cols:  # pragma: no cover
+        return []
+
+    results: list[ast.Expression] = []
+    for filter_str in pushdown_filters:
+        rewritten = _rewrite_filter_for_cte(
+            filter_str,
+            filter_column_aliases,
+            node_output_cols,
+            cte_query,
+        )
+        if rewritten is None:
+            continue
+        results.append(parse_filter(rewritten))
+    return results
+
+
+def _rewrite_filter_for_cte(
+    filter_str: str,
+    filter_column_aliases: dict[str, str],
+    cte_output_cols: set[str],
+    cte_query: ast.Query,
+) -> str | None:
+    """Rewrite a dimension filter for injection into a specific CTE.
+
+    Replaces each dimension reference (e.g., ``v3.product.category``)
+    with the table-qualified column name from the CTE's SELECT projection
+    (e.g., ``p.category``).
+
+    Returns the rewritten filter string, or None if the filter doesn't apply
+    to this CTE (its columns aren't in the CTE's output).
+    """
+    # Build CTE projection map: bare_col → qualified_col
+    projection_map = _build_cte_projection_map(cte_query)
+
+    # Find the longest matching dim ref and resolve to bare col
+    rewritten = filter_str
+    matched = False
+    for dim_ref, bare_col in sorted(
+        filter_column_aliases.items(),
+        key=lambda x: -len(x[0]),
+    ):
+        if dim_ref not in rewritten:
+            continue
+        if bare_col not in cte_output_cols:
+            continue
+        # Use the CTE's qualified version if available
+        qualified = projection_map.get(bare_col, bare_col)
+        rewritten = rewritten.replace(dim_ref, qualified)
+        matched = True
+        break  # One dim ref per filter (filters are single predicates)
+
+    return rewritten if matched else None
+
+
+def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str]:
+    """Build a map from bare column name to table-qualified name from a CTE's SELECT.
+
+    For ``SELECT T.test_id, ...`` returns ``{"test_id": "T.test_id"}``.
+    For ``SELECT test_id, ...`` (no qualifier) returns ``{"test_id": "test_id"}``.
+    """
+    result: dict[str, str] = {}
+    if not cte_query.select:  # pragma: no cover
+        return result
+    for expr in cte_query.select.projection:
+        inner = getattr(expr, "child", expr)
+        if isinstance(inner, ast.Column) and inner.name:
+            bare = inner.name.name
+            if inner.namespace:
+                result[bare] = f"{inner.namespace[0].name}.{bare}"
+            else:
+                result[bare] = bare
+    return result
+
+
 def collect_node_ctes(
     ctx: BuildContext,
     nodes_to_include: list[Node],
     needed_columns_by_node: Optional[dict[str, set[str]]] = None,
     injected_filters: Optional[dict[str, ast.Expression]] = None,
+    pushdown: Optional[PushdownFilters] = None,
 ) -> tuple[list[tuple[str, ast.Query]], list[str]]:
     """
     Collect CTEs for all non-source nodes, recursively expanding table references.
+
+    When ``pushdown`` is provided, each CTE independently checks whether any
+    user-supplied dimension filter can be pushed into its WHERE clause.
 
     This handles the full dependency chain:
     - Source nodes -> replaced with physical table names (catalog.schema.table)
@@ -1030,16 +1154,20 @@ def collect_node_ctes(
         if needed_cols:  # pragma: no branch
             query_ast = filter_cte_projection(query_ast, needed_cols)
 
-        # Inject pushed-down filter (e.g. temporal partition) into this CTE's WHERE clause
+        # Inject filters into this CTE's WHERE clause from two sources:
+        # (1) Temporal/explicit filters targeted at this node by name
+        # (2) User dimension filters that reference columns this CTE outputs
         if injected_filters and node.name in injected_filters:
-            injected = injected_filters[node.name]
-            if query_ast.select.where:  # pragma: no cover
-                query_ast.select.where = ast.BinaryOp.And(
-                    query_ast.select.where,
-                    injected,
-                )
-            else:
-                query_ast.select.where = injected
+            _inject_filter_into_where(query_ast, injected_filters[node.name])
+
+        if pushdown:
+            for filter_ast in _resolve_pushdown_filters_for_cte(
+                node,
+                query_ast,
+                pushdown.filters,
+                pushdown.column_aliases,
+            ):
+                _inject_filter_into_where(query_ast, filter_ast)
 
         ctes.append((cte_name, query_ast))
 

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -27,7 +27,6 @@ from datajunction_server.construction.build_v3.dimensions import (
 )
 from datajunction_server.construction.build_v3.filters import (
     parse_and_resolve_filters,
-    parse_filter,
 )
 from datajunction_server.construction.build_v3.utils import (
     extract_columns_from_expression,
@@ -47,6 +46,7 @@ from datajunction_server.construction.build_v3.types import (
     DecomposedMetricInfo,
     GrainGroup,
     GrainGroupSQL,
+    PushdownFilters,
     ResolvedDimension,
 )
 from datajunction_server.database.node import Node
@@ -890,28 +890,20 @@ def build_select_ast(
                 parent_node,
             )
 
-    # Push dimension filters into upstream CTEs when possible.
-    # If a filter references a dimension that maps to a FK column on the parent
-    # (e.g., date.dateint -> event_utc_date), push it into the
-    # parent's CTE so the engine doesn't scan the full table before filtering.
-    if all_filters:
-        _push_dimension_filters_to_ctes(
-            all_filters,
-            filter_column_aliases,
-            parent_node,
-            main_alias,
-            injected_cte_filters,
-            nodes_for_ctes=nodes_for_ctes,
-        )
-
-    # Build CTEs for all non-source nodes with column filtering.
-    # This runs after filter pushdown so that the CTE builder injects
-    # pushed-down filters into WHERE clauses.
+    # Build CTEs for all non-source nodes.  User dimension filters and their
+    # resolution map are passed through so each CTE can independently decide
+    # whether to push a filter into its own WHERE clause.
     ctes, scanned_sources = collect_node_ctes(
         ctx,
         nodes_for_ctes,
         needed_columns_by_node,
         injected_filters=injected_cte_filters or None,
+        pushdown=PushdownFilters(
+            filters=all_filters,
+            column_aliases=filter_column_aliases,
+        )
+        if all_filters
+        else None,
     )
 
     # Combine user filters with temporal filter
@@ -945,88 +937,6 @@ def build_select_ast(
         query.ctes = cte_list
 
     return query, scanned_sources
-
-
-def _push_dimension_filters_to_ctes(
-    filters: list[str],
-    filter_column_aliases: dict[str, str],
-    parent_node: Node,
-    main_alias: str,
-    injected_cte_filters: dict[str, ast.Expression],
-    nodes_for_ctes: list[Node] | None = None,
-) -> None:
-    """Push user-supplied filters into the appropriate CTE.
-
-    For each filter, extracts the dimension node name from the filter reference
-    (e.g., ``date.dateint`` from ``date.dateint IN (20250101)``), rewrites the
-    column reference to the FK column name, and injects the filter into that node's CTE.
-
-    If the filter resolves to a FK column on the parent node (via dimension link),
-    it goes into the parent's CTE instead.
-
-    Mutates ``injected_cte_filters`` in place.
-    """
-    from datajunction_server.construction.build_v3.dimensions import (
-        parse_dimension_ref,
-    )
-
-    # Build set of node names that become CTEs (non-source)
-    cte_node_names: set[str] = set()
-    if parent_node.type != NodeType.SOURCE:  # pragma: no branch
-        cte_node_names.add(parent_node.name)
-    for node in nodes_for_ctes or []:  # pragma: no branch
-        if node.type != NodeType.SOURCE:  # pragma: no branch
-            cte_node_names.add(node.name)
-
-    parent_col_names = (
-        {col.name for col in (parent_node.current.columns or [])}
-        if parent_node.current
-        else set()
-    )
-
-    for filter_str in filters:
-        # Find the dimension reference in the filter to determine the target node
-        target: str | None = None
-        fk_col: str | None = None
-
-        for dim_ref, resolved_col in filter_column_aliases.items():  # pragma: no branch
-            if dim_ref not in filter_str:
-                continue
-            # Check if this resolves to a parent FK column (via dimension link)
-            if resolved_col in parent_col_names and parent_node.name in cte_node_names:
-                target = parent_node.name
-                fk_col = resolved_col
-                break
-            # Otherwise, extract the dimension node name from the reference
-            parsed = parse_dimension_ref(dim_ref)
-            if (
-                parsed.node_name and parsed.node_name in cte_node_names
-            ):  # pragma: no branch
-                target = parsed.node_name
-                fk_col = resolved_col
-                break
-
-        if not target or not fk_col:  # pragma: no cover
-            continue
-
-        # Rewrite the filter using the resolved column name
-        rewritten = filter_str
-        for dim_ref, resolved_col in filter_column_aliases.items():
-            if dim_ref in rewritten:
-                rewritten = rewritten.replace(dim_ref, resolved_col)
-
-        try:
-            pushdown_ast = parse_filter(rewritten)
-        except Exception:  # pragma: no cover
-            continue
-
-        if target in injected_cte_filters:
-            injected_cte_filters[target] = ast.BinaryOp.And(
-                injected_cte_filters[target],
-                pushdown_ast,
-            )
-        else:
-            injected_cte_filters[target] = pushdown_ast
 
 
 def build_temporal_filter(

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -150,6 +150,25 @@ class BuildContext:
 
 
 @dataclass
+class PushdownFilters:
+    """User-supplied dimension filters to push into upstream CTEs.
+
+    Built by ``build_select_ast`` during outer-query filter resolution, then
+    passed to ``collect_node_ctes`` so each CTE can independently decide which
+    filters apply to it.
+
+    Attributes:
+        filters: Raw filter strings (e.g. ``["v3.date.date_id[order] >= 20240101"]``).
+        column_aliases: Map from dimension ref to bare column name.  Identity
+            for most dimensions (``category`` → ``category``), but differs when
+            a FK rename is involved (``date_id`` → ``order_date``).
+    """
+
+    filters: list[str]
+    column_aliases: dict[str, str]
+
+
+@dataclass
 class ColumnMetadata:
     """
     Metadata about a column in the generated SQL.

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1233,6 +1233,7 @@ async def test_cube_only_no_metrics_no_dims(client_with_repairs_cube: AsyncClien
         ),
         default_hard_hat_to_delete AS (
           SELECT hard_hat_id, hire_date FROM default.roads.hard_hats
+          WHERE state = 'AZ'
         ),
         default_municipality_dim AS (
           SELECT m.municipality_id AS municipality_id, local_region
@@ -1340,6 +1341,7 @@ async def test_cube_only_no_metrics_no_dims(client_with_repairs_cube: AsyncClien
         ),
         default_hard_hat_to_delete AS (
           SELECT hard_hat_id, hire_date FROM default.roads.hard_hats
+          WHERE state = 'AZ'
         ),
         default_municipality_dim AS (
           SELECT m.municipality_id AS municipality_id, local_region

--- a/datajunction-server/tests/construction/build_v3/combiners_test.py
+++ b/datajunction-server/tests/construction/build_v3/combiners_test.py
@@ -1687,7 +1687,7 @@ class TestCombinedMeasuresSQLEndpoint:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'active'
+                WHERE o.status = 'active'
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1

--- a/datajunction-server/tests/construction/build_v3/djsql_test.py
+++ b/datajunction-server/tests/construction/build_v3/djsql_test.py
@@ -374,7 +374,7 @@ class TestDJSQLFilterOnlyDimensions:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'completed'
+                WHERE o.status = 'completed'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -41,7 +41,7 @@ class TestFilterPushdownToParentCTE:
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-              WHERE order_date >= 20240101
+              WHERE o.order_date >= 20240101
             ),
             v3_product AS (
               SELECT product_id, category
@@ -135,7 +135,7 @@ class TestFilterPushdownMultiple:
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-              WHERE order_date >= 20240101
+              WHERE o.order_date >= 20240101
             ),
             v3_product AS (
               SELECT product_id, category
@@ -215,7 +215,7 @@ class TestFilterPushdownEdgeCases:
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-              WHERE status = 'completed'
+              WHERE o.status = 'completed'
             )
             SELECT t1.status,
               SUM(t1.line_total) line_total_sum_e1f61696

--- a/datajunction-server/tests/construction/build_v3/having_clause_test.py
+++ b/datajunction-server/tests/construction/build_v3/having_clause_test.py
@@ -422,7 +422,7 @@ class TestHavingClauseMixedFilters:
                 oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-              WHERE status = 'completed'
+              WHERE o.status = 'completed'
             ),
             v3_product AS (
               SELECT

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -2369,7 +2369,7 @@ class TestMeasuresSQLFilters:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'completed'
+                WHERE o.status = 'completed'
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -2439,7 +2439,7 @@ class TestMeasuresSQLFilters:
                 SELECT o.status, oi.product_id, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'completed'
+                WHERE o.status = 'completed'
             ),
             v3_product AS (
                 SELECT product_id, category
@@ -2511,7 +2511,7 @@ class TestMeasuresSQLFilters:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status IN ('completed', 'pending')
+                WHERE o.status IN ('completed', 'pending')
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -2782,7 +2782,7 @@ class TestTemporalFilters:
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE order_date > 20200101
+                WHERE o.order_date > 20200101
             )
             SELECT t1.order_date date_id, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
@@ -4015,7 +4015,7 @@ class TestFilterOnlyDimensions:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'completed'
+                WHERE o.status = 'completed'
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -985,7 +985,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'completed'
+                WHERE o.status = 'completed'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1025,7 +1025,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status IN ('active', 'completed')
+                WHERE o.status IN ('active', 'completed')
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1065,7 +1065,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status != 'cancelled'
+                WHERE o.status != 'cancelled'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1105,7 +1105,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status LIKE 'act%'
+                WHERE o.status LIKE 'act%'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -1148,7 +1148,7 @@ class TestMetricsSQLDerived:
                 SELECT o.status, oi.product_id, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'active'
+                WHERE o.status = 'active'
             ),
             v3_product AS (
                 SELECT product_id, category
@@ -3549,7 +3549,7 @@ class TestFilterOnlyDimensions:
                 SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE status = 'completed'
+                WHERE o.status = 'completed'
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
@@ -4563,7 +4563,7 @@ class TestMetricsSQLEdgeCases:
                        oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE customer_id = 42
+                WHERE o.customer_id = 42
             ),
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696


### PR DESCRIPTION
### Summary

Dimension filters were only pushed into a single pre-computed target CTE, missing other upstream CTEs that output the same column. Filters now resolve column names via dimension links, then push into every upstream CTE that outputs the resolved column.

Pushed-down filters used bare column names (`WHERE order_date >= 20240101`), which can be ambiguous in multi-source CTEs. They now use the CTE's own table-qualified names (`WHERE o.order_date >= 20240101`).

**Before:** one CTE, bare column
```
WITH
  default_hard_hat_to_delete AS (SELECT ... FROM hard_hats)
  v3_order_details AS (SELECT ... WHERE order_date >= 20240101)
```

**After:** all matching CTEs, table-qualified
```
WITH
  default_hard_hat_to_delete AS (SELECT ... FROM hard_hats WHERE state = 'AZ')
  v3_order_details AS (SELECT ... WHERE o.order_date >= 20240101)
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
