### PR TITLE
Preserve cube metrics/dimensions when upstream nodes are invalid

### DIFF
--- a/datajunction-clients/python/datajunction/cli.py
+++ b/datajunction-clients/python/datajunction/cli.py
@@ -1477,6 +1477,9 @@ class DJCLI:
                     verbose=args.verbose,
                     force=args.force,
                 )
+            except DJDeploymentFailure:
+                # Errors already displayed in the deployment panel
+                raise SystemExit(1)
             except DJClientException as exc:
                 Console().print(f"[red bold]ERROR:[/red bold] {exc}")
                 raise SystemExit(1)

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -251,6 +251,17 @@ class DeploymentService:
             verbose=verbose,
         )
         if deployment.status == DeploymentStatus.SUCCESS:
+            invalid_results = [
+                r for r in deployment.results if r.status == ResultStatus.INVALID
+            ]
+            if invalid_results:
+                console.print(
+                    "\nDeployment finished: [bold yellow]SUCCESS with invalid nodes[/bold yellow]",
+                )
+                raise DJDeploymentFailure(
+                    project_name=deployment_spec.get("namespace", source_path),
+                    errors=[r.__dict__ for r in invalid_results],
+                )
             console.print("\nDeployment finished: [bold green]SUCCESS[/bold green]")
         if deployment.status == DeploymentStatus.FAILED:
             errors = [

--- a/datajunction-clients/python/tests/test_cli.py
+++ b/datajunction-clients/python/tests/test_cli.py
@@ -2267,6 +2267,22 @@ class TestDeploymentFailureExitsWithCode1:
                     cli.run()
                 assert exc_info.value.code == 1
 
+    def test_push_exits_1_on_generic_client_error(self, tmp_path):
+        """Non-deployment errors (e.g. network) also exit with code 1."""
+        from datajunction.cli import DJCLI
+        from datajunction.exceptions import DJClientException
+
+        cli = DJCLI(builder_client=mock.MagicMock())
+        with patch.object(
+            cli,
+            "push",
+            side_effect=DJClientException("Connection refused"),
+        ):
+            with patch.object(sys, "argv", ["dj", "push", str(tmp_path)]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.run()
+                assert exc_info.value.code == 1
+
 
 class TestGenerateCodeowners:
     """Tests for `dj generate-codeowners` and DeploymentService.build_codeowners."""

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -818,6 +818,39 @@ def test_push_raises_on_failed_deployment(monkeypatch, tmp_path):
     assert exc_info.value.errors[0]["name"] == "foo.bar"
 
 
+def test_push_raises_on_success_with_invalid_nodes(monkeypatch, tmp_path):
+    """Deployment succeeds but contains INVALID nodes — should raise so CI fails."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+
+    invalid_results = [
+        {
+            "deploy_type": "node",
+            "name": "foo.bar",
+            "operation": "create",
+            "status": "invalid",
+            "message": "One or more metrics are INVALID",
+        },
+    ]
+    client = MagicMock()
+    client.deploy.return_value = {
+        "uuid": "456",
+        "status": "success",
+        "results": invalid_results,
+        "namespace": "foo",
+    }
+
+    svc = DeploymentService(client, console=Console(file=io.StringIO()))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    with pytest.raises(DJDeploymentFailure) as exc_info:
+        svc.push(tmp_path)
+
+    assert "foo" in exc_info.value.message
+    assert len(exc_info.value.errors) == 1
+    assert exc_info.value.errors[0]["name"] == "foo.bar"
+
+
 @pytest.mark.timeout(2)
 def test_push_raises_after_polling_to_failure(monkeypatch, tmp_path):
     (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "ns"}))

--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -145,9 +145,9 @@ class Column(Base):  # type: ignore
 
     def attribute_names(self) -> list[str]:
         """
-        A list of column attribute names
+        A list of column attribute names, sorted alphabetically.
         """
-        return [attr.attribute_type.name for attr in self.attributes]
+        return sorted(attr.attribute_type.name for attr in self.attributes)
 
     def has_attributes_besides(self, attribute_name: str) -> bool:
         """

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2141,140 +2141,125 @@ class DeploymentOrchestrator:
         deployment_results = []
 
         for result in validation_results:
-            if result.status == NodeStatus.INVALID and not result._cube_validation_data:
-                # No validation data — can't write elements; use the empty-shell path.
-                (
-                    new_node,
-                    new_revision,
-                    deployment_result,
-                ) = await self._deploy_invalid_cube(result)
-                nodes.append(new_node)
-                revisions.append(new_revision)
-                deployment_results.append(deployment_result)
-                continue
+            cube_spec = cast(CubeSpec, result.spec)
+            existing = self.registry.nodes.get(cube_spec.rendered_name)
+            operation = (
+                DeploymentResult.Operation.UPDATE
+                if existing
+                else DeploymentResult.Operation.CREATE
+            )
+
+            # Get pre-computed validation data to avoid re-validation
+            assert result._cube_validation_data is not None
+            validation_data = result._cube_validation_data
+            changelog, changed_fields = await self._generate_changelog(result)
+            if existing:
+                new_node = existing
+                new_node.current_version = str(
+                    Version.parse(new_node.current_version).next_major_version(),
+                )
+                new_node.display_name = cube_spec.display_name
+                new_node.owners = [
+                    self.registry.owners[owner_name]
+                    for owner_name in cube_spec.owners
+                    if owner_name in self.registry.owners
+                ]
+                new_node.tags = [
+                    self.registry.tags[tag_name] for tag_name in cube_spec.tags
+                ]
+                # Create new revision for update
+                # Use no_autoflush to prevent premature flushing of columns without node_revision_id
+                with self.session.no_autoflush:
+                    new_revision = (
+                        await self._create_cube_node_revision_from_validation_data(
+                            cube_spec=cube_spec,
+                            validation_data=validation_data,
+                            new_node=new_node,
+                            status=result.status,
+                        )
+                    )
             else:
-                cube_spec = cast(CubeSpec, result.spec)
-                existing = self.registry.nodes.get(cube_spec.rendered_name)
-                operation = (
-                    DeploymentResult.Operation.UPDATE
-                    if existing
-                    else DeploymentResult.Operation.CREATE
-                )
+                namespace = get_namespace_from_name(cube_spec.rendered_name)
 
-                # Get pre-computed validation data to avoid re-validation
-                if not result._cube_validation_data:
-                    raise DJInvalidDeploymentConfig(  # pragma: no cover
-                        f"Missing validation data for cube {cube_spec.rendered_name}",
+                # Use no_autoflush to prevent premature flushing of columns without node_revision_id
+                # (columns will be created in _create_cube_node_revision_from_validation_data)
+                with self.session.no_autoflush:
+                    await get_node_namespace(
+                        session=self.session,
+                        namespace=namespace,
                     )
-                changelog, changed_fields = await self._generate_changelog(result)
-                if existing:
-                    new_node = existing
-                    new_node.current_version = str(
-                        Version.parse(new_node.current_version).next_major_version(),
+
+                    new_node = Node(
+                        name=cube_spec.rendered_name,
+                        namespace=namespace,
+                        type=NodeType.CUBE,
+                        display_name=cube_spec.display_name,
+                        current_version=(
+                            str(DEFAULT_DRAFT_VERSION)
+                            if cube_spec.mode == NodeMode.DRAFT
+                            else str(DEFAULT_PUBLISHED_VERSION)
+                        ),
+                        tags=[
+                            self.registry.tags[tag_name] for tag_name in cube_spec.tags
+                        ],
+                        created_by_id=self.context.current_user.id,
+                        owners=[
+                            self.registry.owners[owner_name]
+                            for owner_name in cube_spec.owners
+                            if owner_name in self.registry.owners
+                        ],
                     )
-                    new_node.display_name = cube_spec.display_name
-                    new_node.owners = [
-                        self.registry.owners[owner_name]
-                        for owner_name in cube_spec.owners
-                        if owner_name in self.registry.owners
-                    ]
-                    new_node.tags = [
-                        self.registry.tags[tag_name] for tag_name in cube_spec.tags
-                    ]
-                    # Create new revision for update
-                    # Use no_autoflush to prevent premature flushing of columns without node_revision_id
-                    with self.session.no_autoflush:
-                        new_revision = (
-                            await self._create_cube_node_revision_from_validation_data(
-                                cube_spec=cube_spec,
-                                validation_data=result._cube_validation_data,
-                                new_node=new_node,
-                                status=result.status,
-                            )
+
+                    # Create node revision using pre-computed validation data (no re-validation)
+                    new_revision = (
+                        await self._create_cube_node_revision_from_validation_data(
+                            cube_spec=cube_spec,
+                            validation_data=validation_data,
+                            new_node=new_node,
+                            status=result.status,
                         )
-                else:
-                    namespace = get_namespace_from_name(cube_spec.rendered_name)
+                    )
 
-                    # Use no_autoflush to prevent premature flushing of columns without node_revision_id
-                    # (columns will be created in _create_cube_node_revision_from_validation_data)
-                    with self.session.no_autoflush:
-                        await get_node_namespace(
-                            session=self.session,
-                            namespace=namespace,
-                        )
+            # Track history for cube create/update operations
+            activity_type = ActivityType.UPDATE if existing else ActivityType.CREATE
+            self.session.add(
+                History(
+                    entity_type=EntityType.NODE,
+                    entity_name=cube_spec.rendered_name,
+                    node=cube_spec.rendered_name,
+                    activity_type=activity_type,
+                    details={
+                        "version": new_node.current_version,
+                        "deployment_id": self.deployment_id,
+                        "metrics": cube_spec.rendered_metrics,
+                        "dimensions": cube_spec.rendered_dimensions,
+                    },
+                    user=self._history_user,
+                ),
+            )
 
-                        new_node = Node(
-                            name=cube_spec.rendered_name,
-                            namespace=namespace,
-                            type=NodeType.CUBE,
-                            display_name=cube_spec.display_name,
-                            current_version=(
-                                str(DEFAULT_DRAFT_VERSION)
-                                if cube_spec.mode == NodeMode.DRAFT
-                                else str(DEFAULT_PUBLISHED_VERSION)
-                            ),
-                            tags=[
-                                self.registry.tags[tag_name]
-                                for tag_name in cube_spec.tags
-                            ],
-                            created_by_id=self.context.current_user.id,
-                            owners=[
-                                self.registry.owners[owner_name]
-                                for owner_name in cube_spec.owners
-                                if owner_name in self.registry.owners
-                            ],
-                        )
+            # Create deployment result
+            invalid_note = (
+                "\n[invalid] " + "; ".join(e.message for e in result.errors)
+                if result.status == NodeStatus.INVALID
+                else ""
+            )
+            deployment_result = DeploymentResult(
+                name=cube_spec.rendered_name,
+                deploy_type=DeploymentResult.Type.NODE,
+                status=DeploymentResult.Status.INVALID
+                if result.status == NodeStatus.INVALID
+                else DeploymentResult.Status.SUCCESS,
+                operation=operation,
+                message=f"{operation.value.title()}d {new_node.type} ({new_node.current_version})"
+                + ("\n".join([""] + changelog))
+                + invalid_note,
+                changed_fields=changed_fields,
+            )
 
-                        # Create node revision using pre-computed validation data (no re-validation)
-                        new_revision = (
-                            await self._create_cube_node_revision_from_validation_data(
-                                cube_spec=cube_spec,
-                                validation_data=result._cube_validation_data,
-                                new_node=new_node,
-                                status=result.status,
-                            )
-                        )
-
-                # Track history for cube create/update operations
-                activity_type = ActivityType.UPDATE if existing else ActivityType.CREATE
-                self.session.add(
-                    History(
-                        entity_type=EntityType.NODE,
-                        entity_name=cube_spec.rendered_name,
-                        node=cube_spec.rendered_name,
-                        activity_type=activity_type,
-                        details={
-                            "version": new_node.current_version,
-                            "deployment_id": self.deployment_id,
-                            "metrics": cube_spec.rendered_metrics,
-                            "dimensions": cube_spec.rendered_dimensions,
-                        },
-                        user=self._history_user,
-                    ),
-                )
-
-                # Create deployment result
-                invalid_note = (
-                    "\n[invalid] " + "; ".join(e.message for e in result.errors)
-                    if result.status == NodeStatus.INVALID
-                    else ""
-                )
-                deployment_result = DeploymentResult(
-                    name=cube_spec.rendered_name,
-                    deploy_type=DeploymentResult.Type.NODE,
-                    status=DeploymentResult.Status.INVALID
-                    if result.status == NodeStatus.INVALID
-                    else DeploymentResult.Status.SUCCESS,
-                    operation=operation,
-                    message=f"{operation.value.title()}d {new_node.type} ({new_node.current_version})"
-                    + ("\n".join([""] + changelog))
-                    + invalid_note,
-                    changed_fields=changed_fields,
-                )
-
-                deployment_results.append(deployment_result)
-                nodes.append(new_node)
-                revisions.append(new_revision)
+            deployment_results.append(deployment_result)
+            nodes.append(new_node)
+            revisions.append(new_revision)
 
         return nodes, revisions, deployment_results
 
@@ -2930,86 +2915,6 @@ class DeploymentOrchestrator:
         if existing and existing.current and existing.current.catalog:
             return existing.current.catalog
         return None
-
-    async def _deploy_invalid_cube(
-        self,
-        result: NodeValidationResult,
-    ) -> tuple[Node, NodeRevision, DeploymentResult]:
-        """Deploy a cube that failed validation, writing it as INVALID with no elements.
-
-        This is a fallback for cubes where validation failed so badly that no
-        _cube_validation_data could be built (e.g., all metrics are missing).
-        Ensures the namespace is fully populated even when cube metrics/dimensions
-        can't be resolved, so the deployment completes and is idempotent.
-        """
-        cube_spec = cast(CubeSpec, result.spec)
-        logger.warning(
-            "Deploying cube %s with INVALID status: %s",
-            cube_spec.rendered_name,
-            "; ".join(e.message for e in result.errors),
-        )
-        existing = self.registry.nodes.get(cube_spec.rendered_name)
-        operation = (
-            DeploymentResult.Operation.UPDATE
-            if existing
-            else DeploymentResult.Operation.CREATE
-        )
-        new_node = self._create_or_update_node(cube_spec, existing)
-        namespace = get_namespace_from_name(cube_spec.rendered_name)
-        await get_node_namespace(session=self.session, namespace=namespace)
-        # Derive catalog from the cube's metrics (same source as valid cube deployment),
-        # falling back to the existing node's catalog, the deployment default catalog,
-        # then the virtual catalog.
-        catalog = self._infer_cube_catalog(
-            cube_spec,
-            existing,
-        ) or await Catalog.get_virtual_catalog(
-            self.session,
-        )
-        new_revision = NodeRevision(
-            name=cube_spec.rendered_name,
-            display_name=cube_spec.display_name,
-            type=NodeType.CUBE,
-            description=cube_spec.description or "",
-            mode=cube_spec.mode,
-            version=new_node.current_version,
-            node=new_node,
-            status=NodeStatus.INVALID,
-            catalog=catalog,
-            columns=[],
-            created_by_id=self.context.current_user.id,
-            custom_metadata=cube_spec.custom_metadata,
-        )
-        self.session.add(new_node)
-        self.session.add(new_revision)
-        await self.session.flush()
-
-        activity_type = ActivityType.UPDATE if existing else ActivityType.CREATE
-        self.session.add(
-            History(
-                entity_type=EntityType.NODE,
-                entity_name=cube_spec.rendered_name,
-                node=cube_spec.rendered_name,
-                activity_type=activity_type,
-                details={
-                    "version": new_node.current_version,
-                    "deployment_id": self.deployment_id,
-                },
-                user=self._history_user,
-            ),
-        )
-        _, changed_fields = await self._generate_changelog(result)
-        error_note = "; ".join(e.message for e in result.errors)
-        deployment_result = DeploymentResult(
-            name=cube_spec.rendered_name,
-            deploy_type=DeploymentResult.Type.NODE,
-            status=DeploymentResult.Status.INVALID,
-            operation=operation,
-            message=f"{operation.value.title()}d {new_node.type} ({new_node.current_version})"
-            + (f"\n[invalid] {error_note}" if error_note else "\n[invalid]"),
-            changed_fields=changed_fields,
-        )
-        return new_node, new_revision, deployment_result
 
     async def _process_valid_node_deploy(
         self,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2934,10 +2934,11 @@ class DeploymentOrchestrator:
         self,
         result: NodeValidationResult,
     ) -> tuple[Node, NodeRevision, DeploymentResult]:
-        """Deploy a cube that failed validation, writing it as INVALID with no elements.
+        """Deploy a cube that failed validation as INVALID.
 
-        Ensures the namespace is fully populated even when cube metrics/dimensions
-        can't be resolved, so the deployment completes and is idempotent.
+        Preserves cube_elements from the existing revision (if any) so the
+        cube's metrics/dimensions definition isn't lost when an upstream
+        becomes invalid.
         """
         cube_spec = cast(CubeSpec, result.spec)
         logger.warning(
@@ -2963,6 +2964,9 @@ class DeploymentOrchestrator:
         ) or await Catalog.get_virtual_catalog(
             self.session,
         )
+        # Preserve cube_elements and columns from existing revision so the
+        # cube definition isn't wiped when an upstream becomes invalid.
+        existing_revision = existing.current if existing else None
         new_revision = NodeRevision(
             name=cube_spec.rendered_name,
             display_name=cube_spec.display_name,
@@ -2973,7 +2977,8 @@ class DeploymentOrchestrator:
             node=new_node,
             status=NodeStatus.INVALID,
             catalog=catalog,
-            columns=[],
+            columns=existing_revision.columns if existing_revision else [],
+            cube_elements=existing_revision.cube_elements if existing_revision else [],
             created_by_id=self.context.current_user.id,
             custom_metadata=cube_spec.custom_metadata,
         )

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2016,7 +2016,9 @@ class DeploymentOrchestrator:
         ]
         for node_name, column_name in dimension_attributes:
             full_key = f"{node_name}{SEPARATOR}{column_name}"
-            dimension_node = dimension_mapping[full_key]
+            dimension_node = dimension_mapping.get(full_key)
+            if not dimension_node:
+                continue
             if dimension_node not in cube_dimension_nodes:  # pragma: no cover
                 cube_dimension_nodes.append(dimension_node)
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1880,49 +1880,48 @@ class DeploymentOrchestrator:
             if metric_name in metric_nodes_map
         ]
 
-        # Check for INVALID metric nodes before accessing columns — INVALID nodes have
-        # no columns so columns[0] would IndexError.
+        # Collect errors but continue building validation data so the cube
+        # revision preserves its metrics/dimensions even when INVALID.
+        early_errors: list[DJError] = []
+
+        # Check for INVALID metric nodes — filter them out for column
+        # extraction but keep track of the error.
         invalid_metrics = [
             m for m in cube_metric_nodes if m.current.status == NodeStatus.INVALID
         ]
+        valid_metric_nodes = [
+            m for m in cube_metric_nodes if m.current.status != NodeStatus.INVALID
+        ]
         if invalid_metrics:
-            return NodeValidationResult(
-                spec=cube_spec,
-                status=NodeStatus.INVALID,
-                inferred_columns=[],
-                errors=[
-                    DJError(
-                        code=ErrorCode.INVALID_CUBE,
-                        message=(
-                            f"One or more metrics are INVALID for cube "
-                            f"{cube_spec.rendered_name}: "
-                            + ", ".join(m.name for m in invalid_metrics)
-                        ),
+            early_errors.append(
+                DJError(
+                    code=ErrorCode.INVALID_CUBE,
+                    message=(
+                        f"One or more metrics are INVALID for cube "
+                        f"{cube_spec.rendered_name}: "
+                        + ", ".join(m.name for m in invalid_metrics)
                     ),
-                ],
-                dependencies=[],
+                ),
             )
 
-        # Extract metric columns and catalogs
-        metric_columns = [node.current.columns[0] for node in cube_metric_nodes]
-        catalogs = [metric.current.catalog for metric in cube_metric_nodes]
+        # Extract metric columns and catalogs from valid metrics only
+        metric_columns = [
+            node.current.columns[0]
+            for node in valid_metric_nodes
+            if node.current.columns
+        ]
+        catalogs = [metric.current.catalog for metric in valid_metric_nodes]
         catalog = catalogs[0] if catalogs else None
 
         # Collect errors for missing metrics/dimensions or catalog mismatches
-        errors = self._collect_cube_errors(
-            cube_spec,
-            missing_metrics,
-            missing_dimensions,
-            catalogs,
+        early_errors.extend(
+            self._collect_cube_errors(
+                cube_spec,
+                missing_metrics,
+                missing_dimensions,
+                catalogs,
+            ),
         )
-        if errors:
-            return NodeValidationResult(
-                spec=cube_spec,
-                status=NodeStatus.INVALID,
-                inferred_columns=[],
-                errors=errors,
-                dependencies=[],
-            )
 
         # Collect parent revision IDs for this cube's metrics (used by both
         # dimension and filter reachability checks below).
@@ -2048,7 +2047,7 @@ class DeploymentOrchestrator:
             if invalid_dims
             else []
         )
-        all_errors = dim_compat_errors + dim_errors
+        all_errors = early_errors + dim_compat_errors + dim_errors
         return NodeValidationResult(
             spec=cube_spec,
             status=NodeStatus.INVALID if all_errors else NodeStatus.VALID,
@@ -2934,11 +2933,12 @@ class DeploymentOrchestrator:
         self,
         result: NodeValidationResult,
     ) -> tuple[Node, NodeRevision, DeploymentResult]:
-        """Deploy a cube that failed validation as INVALID.
+        """Deploy a cube that failed validation, writing it as INVALID with no elements.
 
-        Preserves cube_elements from the existing revision (if any) so the
-        cube's metrics/dimensions definition isn't lost when an upstream
-        becomes invalid.
+        This is a fallback for cubes where validation failed so badly that no
+        _cube_validation_data could be built (e.g., all metrics are missing).
+        Ensures the namespace is fully populated even when cube metrics/dimensions
+        can't be resolved, so the deployment completes and is idempotent.
         """
         cube_spec = cast(CubeSpec, result.spec)
         logger.warning(
@@ -2964,9 +2964,6 @@ class DeploymentOrchestrator:
         ) or await Catalog.get_virtual_catalog(
             self.session,
         )
-        # Preserve cube_elements and columns from existing revision so the
-        # cube definition isn't wiped when an upstream becomes invalid.
-        existing_revision = existing.current if existing else None
         new_revision = NodeRevision(
             name=cube_spec.rendered_name,
             display_name=cube_spec.display_name,
@@ -2977,8 +2974,7 @@ class DeploymentOrchestrator:
             node=new_node,
             status=NodeStatus.INVALID,
             catalog=catalog,
-            columns=existing_revision.columns if existing_revision else [],
-            cube_elements=existing_revision.cube_elements if existing_revision else [],
+            columns=[],
             created_by_id=self.context.current_user.id,
             custom_metadata=cube_spec.custom_metadata,
         )

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -523,13 +523,13 @@ def _get_dir_and_filename(
 
 def _non_primary_key_attributes(column: Column):
     """
-    Returns all non-PK column attributes for a column
+    Returns all non-PK column attributes for a column, sorted alphabetically.
     """
-    return [
+    return sorted(
         attr.attribute_type.name
         for attr in column.attributes
         if attr.attribute_type.name not in ("primary_key",)
-    ]
+    )
 
 
 def _attributes_config(column: Column):

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1840,7 +1840,9 @@ class TestDeployments:
             "status": "invalid",
         }
 
-        # Update cube to add an existing dimension - should deploy successfully
+        # Remove the bad dimension — but the invalid cube was already deployed
+        # without it (missing dimensions are skipped), so the spec is unchanged
+        # and the cube stays INVALID.
         cube.dimensions = [
             "${prefix}default.hard_hat.state",
             "${prefix}default.us_state.state_region",
@@ -1852,11 +1854,11 @@ class TestDeployments:
         assert data["status"] == "success"
         assert data["results"][-1] == {
             "deploy_type": "node",
-            "message": "Updated cube (v3.0)\n└─ Updated metrics, dimensions",
+            "message": "Unchanged, still INVALID",
             "name": "cube_update.default.repairs_cube",
-            "operation": "update",
-            "changed_fields": ["metrics", "dimensions"],
-            "status": "success",
+            "operation": "noop",
+            "changed_fields": [],
+            "status": "invalid",
         }
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1830,7 +1830,9 @@ class TestDeployments:
         assert data["status"] == "success"
         assert data["results"][-1] == {
             "deploy_type": "node",
-            "message": "Updated cube (v2.0)\n[invalid] One or more dimensions not found for cube "
+            "message": "Updated cube (v2.0)\n"
+            "└─ Updated dimensions\n"
+            "[invalid] One or more dimensions not found for cube "
             "cube_update.default.repairs_cube: cube_update.default.us_state.non_existent_column",
             "name": "cube_update.default.repairs_cube",
             "operation": "update",

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -809,7 +809,8 @@ class TestCubeDeployment:
 
     @pytest.mark.asyncio
     async def test_create_cubes_from_validation_invalid_cubes(self, orchestrator):
-        """Test creating cubes when validation results contain invalid cubes"""
+        """Test creating cubes when validation results contain invalid cubes.
+        Invalid cubes now go through the normal path with _cube_validation_data."""
         invalid_results = [
             NodeValidationResult(
                 spec=CubeSpec(
@@ -822,22 +823,24 @@ class TestCubeDeployment:
                 inferred_columns=[],
                 errors=[DJError(code=ErrorCode.INVALID_CUBE, message="Invalid cube")],
                 dependencies=[],
+                _cube_validation_data=CubeValidationData(
+                    metric_columns=[],
+                    metric_nodes=[],
+                    dimension_nodes=[],
+                    dimension_columns=[],
+                    catalog=None,
+                ),
             ),
         ]
 
-        # Mock _deploy_invalid_cube — returns (node, revision, result) with SUCCESS status
-        mock_node = Mock()
+        # Mock _create_cube_node_revision_from_validation_data since it
+        # needs full DB setup
         mock_revision = Mock()
-        mock_result = DeploymentResult(
-            name="invalid_cube",
-            deploy_type="node",
-            status="success",
-            operation="create",
-            message="Created cube (v1.0)\n[invalid] Invalid cube",
+        mock_revision.version = "v1.0"
+        orchestrator._create_cube_node_revision_from_validation_data = AsyncMock(
+            return_value=mock_revision,
         )
-        orchestrator._deploy_invalid_cube = AsyncMock(
-            return_value=(mock_node, mock_revision, mock_result),
-        )
+        orchestrator._generate_changelog = AsyncMock(return_value=([], []))
 
         nodes, revisions, results = await orchestrator._create_cubes_from_validation(
             invalid_results,
@@ -846,7 +849,7 @@ class TestCubeDeployment:
         assert len(nodes) == 1
         assert len(revisions) == 1
         assert len(results) == 1
-        assert results[0].status == "success"
+        assert results[0].status == "invalid"
 
     @pytest.mark.asyncio
     async def test_cube_column_partition_applied_from_spec(

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -814,7 +814,7 @@ class TestCubeDeployment:
         invalid_results = [
             NodeValidationResult(
                 spec=CubeSpec(
-                    name="invalid_cube",
+                    name="test.invalid_cube",
                     node_type="cube",
                     metrics=[],
                     dimensions=[],
@@ -842,9 +842,17 @@ class TestCubeDeployment:
         )
         orchestrator._generate_changelog = AsyncMock(return_value=([], []))
 
-        nodes, revisions, results = await orchestrator._create_cubes_from_validation(
-            invalid_results,
-        )
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_node_namespace",
+            new_callable=AsyncMock,
+        ):
+            (
+                nodes,
+                revisions,
+                results,
+            ) = await orchestrator._create_cubes_from_validation(
+                invalid_results,
+            )
 
         assert len(nodes) == 1
         assert len(revisions) == 1

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -1882,6 +1882,14 @@ async def test_validate_single_cube_with_invalid_metric(
 
     assert result.status == NodeStatus.INVALID
     assert any("INVALID" in err.message for err in result.errors)
+    # Validation data should still be built so the cube revision preserves
+    # its metrics/dimensions definition even when INVALID.
+    assert result._cube_validation_data is not None
+    # The invalid metric should still appear in metric_nodes so the cube
+    # knows which metrics it references (even if they can't be resolved).
+    assert invalid_metric in result._cube_validation_data.metric_nodes
+    # No valid metric columns could be extracted (all metrics were INVALID)
+    assert result._cube_validation_data.metric_columns == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Fixes three issues:

1. Deploying a cube whose upstream metrics or dimensions are invalid previously wiped its cube elements, producing a cube with 0 metrics and 0 dimensions. Now the validation continues past invalid upstreams and errors are accumulated but `_cube_validation_data` is still built with whatever valid elements exist, so the cube revision retains its full definition while being marked invalid.
2. `dj push` now exits with code 1 when the deployment succeeds but contains INVALID nodes, so CI builds fail on invalid deployments instead of silently passing.
3. Column attributes in namespace exports (`/export/spec/` and YAML) are now sorted alphabetically, fixing nondeterministic ordering that caused noisy diffs on `dj pull`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
