### PR TITLE
Add multi-worktree support for running parallel DJ instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,9 @@ client_secret*
 Untitled*
 .notebook_executed
 
+# dev slot config
+.dev-port
+
 # postgres
 postgres_metadata
 postgres_superset

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Multi-worktree Docker Compose wrapper.
+# Each worktree can have a .dev-port file containing a slot number (1, 2, 3…).
+# The slot number determines port offsets so multiple DJ instances can run simultaneously.
+#
+# Slot 0 (default): DJ 8000, UI 3000, PG 5432
+# Slot 1:           DJ 8100, UI 3100, PG 5433
+# Slot 2:           DJ 8200, UI 3200, PG 5434
+# …
+#
+# Setup a new slot:
+#   git worktree add ../dj-slot-1
+#   echo 1 > ../dj-slot-1/.dev-port
+#   cd ../dj-slot-1
+#   ./dev.sh up          # DJ on :8100, UI on :3100, PG on :5433
+#
+# Check ports:
+#   ./dev.sh urls
+#
+# Reuse a slot for a new feature:
+#   ./dev.sh down
+#   git checkout -b next-feature
+#   ./dev.sh up          # same ports as before
+
+set -euo pipefail
+
+OFFSET=$(cat .dev-port 2>/dev/null || echo 0)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+export COMPOSE_PROJECT_NAME="dj-slot-${OFFSET}"
+export DJ_CONTAINER_PREFIX="dj-s${OFFSET}"
+export DJ_PORT=$((8000 + OFFSET * 100))
+export DJ_UI_PORT=$((3000 + OFFSET * 100))
+export DJ_PG_PORT=$((5432 + OFFSET))
+export DJ_QS_PORT=$((8001 + OFFSET * 100))
+export DJ_REDIS_PORT=$((6379 + OFFSET))
+export DJ_JUPYTER_PORT=$((8181 + OFFSET * 100))
+export DJ_TRINO_PORT=$((8080 + OFFSET * 100))
+
+case "${1:-}" in
+  urls)
+    echo "=== Slot $OFFSET | Branch: $BRANCH ==="
+    echo "DJ  : http://localhost:$DJ_PORT"
+    echo "UI  : http://localhost:$DJ_UI_PORT"
+    echo "PG  : localhost:$DJ_PG_PORT"
+    exit 0
+    ;;
+esac
+
+echo "=== Slot $OFFSET | Branch: $BRANCH ==="
+echo "DJ  : http://localhost:$DJ_PORT"
+echo "UI  : http://localhost:$DJ_UI_PORT"
+echo ""
+
+docker compose "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 
 services:
   dj:
-    container_name: dj
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}
     stdin_open: true
     tty: true
     networks:
@@ -25,7 +25,7 @@ services:
       - /code/.venv  # Isolate container venv from local
     command: /bin/sh -c "uv sync --extra uvicorn --extra transpilation --no-dev && uv run opentelemetry-instrument uvicorn datajunction_server.api.main:app --host 0.0.0.0 --port 8000 --reload"
     ports:
-      - "8000:8000"
+      - "${DJ_PORT:-8000}:8000"
     depends_on:
       - db-migration
       - postgres_metadata
@@ -40,7 +40,7 @@ services:
 
   dj-seed:
     image: python:3.11-slim
-    container_name: dj-seed
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-seed
     profiles: ["demo"]
     depends_on:
       - dj
@@ -55,7 +55,7 @@ services:
       "
 
   postgres_metadata:
-    container_name: postgres_metadata
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-postgres
     image: postgres:latest
     shm_size: 1g
     networks:
@@ -79,7 +79,7 @@ services:
       - POSTGRES_DB=dj
       - PGUSER=dj
     ports:
-      - "5432:5432"
+      - "${DJ_PG_PORT:-5432}:5432"
     healthcheck:
       test: [ "CMD", "pg_isready" ]
       interval: 10s
@@ -87,11 +87,11 @@ services:
       retries: 5
 
   djui:
-    container_name: djui
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-ui
     image: node:20
     working_dir: /usr/src/app
     ports:
-      - "3000:3000"
+      - "${DJ_UI_PORT:-3000}:3000"
     stdin_open: true
     volumes:
       - ./datajunction-ui:/usr/src/app/
@@ -104,7 +104,7 @@ services:
     command: sh -c "yarn && yarn webpack-start --host 0.0.0.0 --port 3000"
 
   djqs:
-    container_name: djqs
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-qs
     profiles: ["demo"]
     stdin_open: true
     tty: true
@@ -118,13 +118,13 @@ services:
       - /code/.venv  # Isolate container venv from local
     command: /bin/bash -c "uv sync --extra uvicorn --no-dev && uv run uvicorn djqs.api.main:app --host 0.0.0.0 --port 8001 --reload"
     ports:
-      - "8001:8001"
+      - "${DJ_QS_PORT:-8001}:8001"
     depends_on:
       - djqs-db-migration
       - postgres_metadata
 
   db-migration:
-    container_name: db-migration
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-db-migration
     networks:
       - core
     build:
@@ -142,7 +142,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   db-seed:
-    container_name: db-seed
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-db-seed
     networks:
       - core
     image: postgres:latest
@@ -159,7 +159,7 @@ services:
       "
 
   djqs-db-migration:
-    container_name: djqs-db-migration
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-qs-db-migration
     profiles: ["demo"]
     networks:
       - core
@@ -176,16 +176,16 @@ services:
         condition: service_healthy
 
   djrs-redis:
-    container_name: djrs-redis
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-rs-redis
     profiles: ["demo"]
     image: redis:6-alpine
     ports:
-      - "6379:6379"
+      - "${DJ_REDIS_PORT:-6379}:6379"
     networks:
       - djrs-network
 
   djrs-worker:
-    container_name: djrs-worker
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-rs-worker
     profiles: ["demo"]
     build:
       context: ./datajunction-reflection
@@ -201,7 +201,7 @@ services:
       - dj
 
   djrs-beat:
-    container_name: djrs-beat
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-rs-beat
     profiles: ["demo"]
     build:
       context: ./datajunction-reflection
@@ -218,12 +218,12 @@ services:
 
   jupyter-notebook:
     image: jupyter/scipy-notebook
-    container_name: jupyter
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-jupyter
     profiles: ["demo"]
     networks:
       - core
     ports:
-      - "8181:8888"
+      - "${DJ_JUPYTER_PORT:-8181}:8888"
     volumes:
       - ./notebooks:/home/jovyan/notebooks
       - ./datajunction-clients/python:/home/jovyan/notebooks/djclient
@@ -243,12 +243,12 @@ services:
       "
 
   dj-trino:
-    container_name: dj-trino
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-trino
     profiles: ["demo"]
     image: 'trinodb/trino:latest'
     hostname: trino-coordinator
     ports:
-      - '8080:8080'
+      - '${DJ_TRINO_PORT:-8080}:8080'
     networks:
       - djqs-network
 
@@ -303,6 +303,6 @@ services:
 
   superset-redis:
     image: redis:7
-    container_name: superset-redis
+    container_name: ${DJ_CONTAINER_PREFIX:-dj}-superset-redis
     restart: always
     profiles: ["superset"]


### PR DESCRIPTION
### Summary

This PR parameterizes all host-side ports and container names in `docker-compose.yml` with environment variables (defaulting to the current values), and adds a `dev.sh` wrapper that reads a `.dev-port` slot number to compute unique port offsets. This lets you run multiple isolated DJ stacks simultaneously (one per git worktree), each on different ports with separate postgres data and docker compose project names.

```
# Slot 0 (default): DJ :8000, UI :3000, PG :5432
# Slot 1:           DJ :8100, UI :3100, PG :5433

cd ../dj-slot-1
./dev.sh up
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP