### PR TITLE
Replace Fuse.js global search with server-side trigram search

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_04_18_0000-5a8b4c2d1e0f_add_search_trigram_indexes.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_04_18_0000-5a8b4c2d1e0f_add_search_trigram_indexes.py
@@ -1,0 +1,74 @@
+"""add GIN trigram indexes for search
+
+Revision ID: 5a8b4c2d1e0f
+Revises: 4f516e88e4d0
+Create Date: 2026-04-18 00:00:00.000000+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+from alembic import op
+
+revision = "5a8b4c2d1e0f"
+down_revision = "4f516e88e4d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_noderevision_name_trgm",
+            ["name"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={"name": "gin_trgm_ops"},
+        )
+        batch_op.create_index(
+            "ix_noderevision_description_trgm",
+            ["description"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={"description": "gin_trgm_ops"},
+        )
+    with op.batch_alter_table("tag", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_tag_name_trgm",
+            ["name"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={"name": "gin_trgm_ops"},
+        )
+        batch_op.create_index(
+            "ix_tag_description_trgm",
+            ["description"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={"description": "gin_trgm_ops"},
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("tag", schema=None) as batch_op:
+        batch_op.drop_index(
+            "ix_tag_description_trgm",
+            postgresql_using="gin",
+            postgresql_ops={"description": "gin_trgm_ops"},
+        )
+        batch_op.drop_index(
+            "ix_tag_name_trgm",
+            postgresql_using="gin",
+            postgresql_ops={"name": "gin_trgm_ops"},
+        )
+    with op.batch_alter_table("noderevision", schema=None) as batch_op:
+        batch_op.drop_index(
+            "ix_noderevision_description_trgm",
+            postgresql_using="gin",
+            postgresql_ops={"description": "gin_trgm_ops"},
+        )
+        batch_op.drop_index(
+            "ix_noderevision_name_trgm",
+            postgresql_using="gin",
+            postgresql_ops={"name": "gin_trgm_ops"},
+        )

--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -35,7 +35,11 @@ from datajunction_server.api.graphql.queries.sql import (
     measures_sql,
     materialization_plan,
 )
-from datajunction_server.api.graphql.queries.tags import list_tag_types, list_tags
+from datajunction_server.api.graphql.queries.tags import (
+    list_tag_types,
+    list_tags,
+    search_tags,
+)
 from datajunction_server.api.graphql.scalars import Connection
 from datajunction_server.api.graphql.scalars.catalog_engine import (
     Catalog,
@@ -186,6 +190,13 @@ class Query:
     list_tags: list[Tag] = strawberry.field(
         resolver=log_resolver(list_tags),
         description="Find DJ node tags based on the search parameters.",
+    )
+    search_tags: list[Tag] = strawberry.field(
+        resolver=log_resolver(search_tags),
+        description=(
+            "Trigram-ranked search across tag name, display name, and description. "
+            "Used by the global search bar for tag autocomplete."
+        ),
     )
     list_tag_types: list[str] = strawberry.field(
         resolver=log_resolver(list_tag_types),

--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -20,6 +20,16 @@ logger = logging.getLogger(__name__)
 
 
 async def find_nodes(
+    search: Annotated[
+        str | None,
+        strawberry.argument(
+            description=(
+                "Full-text search across node name, display name, and description. "
+                "Results are ranked by pg_trgm similarity and boosted toward the "
+                "main branch when a node exists in a git-backed namespace."
+            ),
+        ),
+    ] = None,
     fragment: Annotated[
         str | None,
         strawberry.argument(
@@ -148,10 +158,22 @@ async def find_nodes(
         limit=limit,
         order_by=order_by,
         ascending=ascending,
+        search=search,
     )
 
 
 async def find_nodes_paginated(
+    search: Annotated[
+        str | None,
+        strawberry.argument(
+            description=(
+                "Full-text search across node name, display name, and description. "
+                "When set, results are filtered by trigram match. Ranking by "
+                "similarity is applied only on the unpaginated `findNodes` query; "
+                "paginated results keep the normal sort order."
+            ),
+        ),
+    ] = None,
     fragment: Annotated[
         str | None,
         strawberry.argument(
@@ -274,6 +296,7 @@ async def find_nodes_paginated(
         statuses=statuses,
         has_materialization=has_materialization,
         orphaned_dimension=orphaned_dimension,
+        search=search,
     )
     return Connection.from_list(
         items=nodes_list,

--- a/datajunction-server/datajunction_server/api/graphql/queries/tags.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/tags.py
@@ -2,10 +2,23 @@
 Tags related queries.
 """
 
+from typing import Annotated
+
+import strawberry
 from strawberry.types import Info
 
 from datajunction_server.api.graphql.scalars.tag import Tag
 from datajunction_server.database.tag import Tag as DBTag
+
+
+def _to_graphql_tag(db_tag: DBTag) -> Tag:
+    return Tag(  # type: ignore
+        name=db_tag.name,
+        display_name=db_tag.display_name,
+        description=db_tag.description,
+        tag_type=db_tag.tag_type,
+        tag_metadata=db_tag.tag_metadata,
+    )
 
 
 async def list_tags(
@@ -19,16 +32,31 @@ async def list_tags(
     """
     session = info.context["session"]  # type: ignore
     db_tags = await DBTag.find_tags(session, tag_names, tag_types)
-    return [
-        Tag(  # type: ignore
-            name=db_tag.name,
-            display_name=db_tag.display_name,
-            description=db_tag.description,
-            tag_type=db_tag.tag_type,
-            tag_metadata=db_tag.tag_metadata,
-        )
-        for db_tag in db_tags
-    ]
+    return [_to_graphql_tag(db_tag) for db_tag in db_tags]
+
+
+async def search_tags(
+    search: Annotated[
+        str,
+        strawberry.argument(
+            description="Query string to match against tag name, display name, and description.",
+        ),
+    ],
+    limit: Annotated[
+        int,
+        strawberry.argument(description="Maximum number of matching tags to return."),
+    ] = 10,
+    *,
+    info: Info = None,
+) -> list[Tag]:
+    """
+    Trigram-ranked search across tags, used by the global search bar.
+    """
+    if not search or not search.strip():
+        return []
+    session = info.context["session"]  # type: ignore
+    db_tags = await DBTag.search_tags(session, search.strip(), limit=limit)
+    return [_to_graphql_tag(db_tag) for db_tag in db_tags]
 
 
 async def list_tag_types(

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -133,6 +133,7 @@ async def find_nodes_by(
     statuses: Optional[List[NodeStatus]] = None,
     has_materialization: bool = False,
     orphaned_dimension: bool = False,
+    search: Optional[str] = None,
 ) -> List[DBNode]:
     """
     Finds nodes based on the search parameters. This function also tries to optimize
@@ -176,6 +177,7 @@ async def find_nodes_by(
         has_materialization=has_materialization,
         orphaned_dimension=orphaned_dimension,
         dimensions=dimensions,
+        search=search,
     )
 
     # For the name-only cube path, fetch column data as raw tuples instead

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -453,6 +453,11 @@ type Query {
 
   """Find nodes based on the search parameters."""
   findNodes(
+    """
+    Full-text search across node name, display name, and description. Results are ranked by pg_trgm similarity and boosted toward the main branch when a node exists in a git-backed namespace.
+    """
+    search: String = null
+
     """A fragment of a node name to search for"""
     fragment: String = null
 
@@ -505,6 +510,11 @@ type Query {
 
   """Find nodes based on the search parameters with pagination"""
   findNodesPaginated(
+    """
+    Full-text search across node name, display name, and description. When set, results are filtered by trigram match. Ranking by similarity is applied only on the unpaginated `findNodes` query; paginated results keep the normal sort order.
+    """
+    search: String = null
+
     """A fragment of a node name to search for"""
     fragment: String = null
 
@@ -616,6 +626,17 @@ type Query {
 
   """Find DJ node tags based on the search parameters."""
   listTags(tagNames: [String!] = null, tagTypes: [String!] = null): [Tag!]!
+
+  """
+  Trigram-ranked search across tag name, display name, and description. Used by the global search bar for tag autocomplete.
+  """
+  searchTags(
+    """Query string to match against tag name, display name, and description."""
+    search: String!
+
+    """Maximum number of matching tags to return."""
+    limit: Int! = 10
+  ): [Tag!]!
 
   """List all DJ node tag types"""
   listTagTypes: [String!]!

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -97,20 +97,42 @@ _SEARCH_WEIGHT_DESCRIPTION = 0.4
 _SEARCH_BOOST_MAIN = 1.0
 _SEARCH_BOOST_BRANCH = 0.5
 
+# Popularity factor: nodes with many dependents are more likely what the user
+# wants. Score is multiplied by (1 + w * ln(1 + child_count)); with w=0.2 a node
+# with 5 children gets ~1.4x, 50 children ~1.8x — firm preference without
+# swamping relevance entirely.
+_SEARCH_POPULARITY_WEIGHT = 0.2
 
-def _build_search_score(nr_alias, ns_alias, parent_ns_alias, query: str):
+# Queries shorter than this fall back to prefix matching; trigram similarity is
+# meaningless on single characters (every row matches).
+_SEARCH_MIN_FUZZY_LENGTH = 2
+
+
+def _build_search_score(
+    nr_alias,
+    ns_alias,
+    parent_ns_alias,
+    query: str,
+    *,
+    short_query: bool,
+    child_count_col,
+):
     """
     Build the relevance score SQL expression used to rank search results.
 
-    Score is the max pg_trgm similarity across name/display_name/description
-    with per-field weights, then multiplied by a main-branch boost: nodes on
-    a feature branch rank below equivalent matches on main.
+    For multi-char queries: max weighted pg_trgm similarity across
+    name/display_name/description.  For single-char queries: a flat relevance
+    of 1.0 so the prefix filter is ranked purely by branch + popularity.
+    Multiplied by a main-branch boost and a log-scaled popularity multiplier.
     """
-    base_score = func.greatest(
-        func.similarity(nr_alias.name, query) * _SEARCH_WEIGHT_NAME,
-        func.similarity(nr_alias.display_name, query) * _SEARCH_WEIGHT_DISPLAY_NAME,
-        func.similarity(nr_alias.description, query) * _SEARCH_WEIGHT_DESCRIPTION,
-    )
+    if short_query:
+        relevance = sa.literal(1.0)
+    else:
+        relevance = func.greatest(
+            func.similarity(nr_alias.name, query) * _SEARCH_WEIGHT_NAME,
+            func.similarity(nr_alias.display_name, query) * _SEARCH_WEIGHT_DISPLAY_NAME,
+            func.similarity(nr_alias.description, query) * _SEARCH_WEIGHT_DESCRIPTION,
+        )
     branch_boost = case(
         (parent_ns_alias.namespace.is_(None), _SEARCH_BOOST_MAIN),
         (parent_ns_alias.default_branch.is_(None), _SEARCH_BOOST_MAIN),
@@ -120,7 +142,10 @@ def _build_search_score(nr_alias, ns_alias, parent_ns_alias, query: str):
         ),
         else_=_SEARCH_BOOST_BRANCH,
     )
-    return base_score * branch_boost
+    popularity = 1.0 + _SEARCH_POPULARITY_WEIGHT * func.ln(
+        1 + func.coalesce(child_count_col, 0),
+    )
+    return relevance * branch_boost * popularity
 
 
 class NodeRelationship(Base):
@@ -770,19 +795,51 @@ class Node(Base):
                 parent_ns_alias,
                 ns_alias.parent_namespace == parent_ns_alias.namespace,
             )
-            pattern = f"%{search}%"
-            statement = statement.where(
-                sa.or_(
-                    NodeRevisionAlias.name.ilike(pattern),
-                    NodeRevisionAlias.display_name.ilike(pattern),
-                    NodeRevisionAlias.description.ilike(pattern),
-                ),
+
+            short_query = len(search) < _SEARCH_MIN_FUZZY_LENGTH
+            if short_query:
+                # Single-char queries fall back to prefix match; trigram
+                # similarity would return every row with that character.
+                prefix = f"{search}%"
+                statement = statement.where(
+                    sa.or_(
+                        NodeRevisionAlias.name.ilike(prefix),
+                        NodeRevisionAlias.display_name.ilike(prefix),
+                    ),
+                )
+            else:
+                pattern = f"%{search}%"
+                statement = statement.where(
+                    sa.or_(
+                        NodeRevisionAlias.name.ilike(pattern),
+                        NodeRevisionAlias.display_name.ilike(pattern),
+                        NodeRevisionAlias.description.ilike(pattern),
+                    ),
+                )
+
+            # Popularity proxy: number of NodeRelationship rows that reference
+            # this node as a parent (parent_id is a node.id, child_id a
+            # specific revision). Aggregated once via subquery and LEFT JOINed;
+            # absent rows coalesce to 0.
+            child_counts = (
+                select(
+                    NodeRelationship.parent_id.label("parent_id"),
+                    func.count().label("child_count"),
+                )
+                .group_by(NodeRelationship.parent_id)
+                .subquery()
+            )
+            statement = statement.outerjoin(
+                child_counts,
+                child_counts.c.parent_id == Node.id,
             )
             search_score_expr = _build_search_score(
                 NodeRevisionAlias,
                 ns_alias,
                 parent_ns_alias,
                 search,
+                short_query=short_query,
+                child_count_col=child_counts.c.child_count,
             )
 
         if node_types:

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -772,7 +772,7 @@ class Node(Base):
             )
             pattern = f"%{search}%"
             statement = statement.where(
-                or_(
+                sa.or_(
                     NodeRevisionAlias.name.ilike(pattern),
                     NodeRevisionAlias.display_name.ilike(pattern),
                     NodeRevisionAlias.description.ilike(pattern),

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import sqlalchemy as sa
 from pydantic import ConfigDict
-from sqlalchemy import JSON, and_, desc
+from sqlalchemy import JSON, and_, case, desc, func
 from sqlalchemy.orm import aliased
 
 from sqlalchemy import Column as SqlalchemyColumn
@@ -84,6 +84,43 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__name__)
+
+# Weights for the three searchable fields on NodeRevision. `name` is the
+# authoritative identifier and gets full weight; `display_name` is almost
+# as strong; `description` is a weaker signal and is discounted.
+_SEARCH_WEIGHT_NAME = 1.0
+_SEARCH_WEIGHT_DISPLAY_NAME = 0.9
+_SEARCH_WEIGHT_DESCRIPTION = 0.4
+
+# Main-branch nodes are the authoritative version of a node and get full score;
+# feature-branch nodes are halved so they sort below equivalent main matches.
+_SEARCH_BOOST_MAIN = 1.0
+_SEARCH_BOOST_BRANCH = 0.5
+
+
+def _build_search_score(nr_alias, ns_alias, parent_ns_alias, query: str):
+    """
+    Build the relevance score SQL expression used to rank search results.
+
+    Score is the max pg_trgm similarity across name/display_name/description
+    with per-field weights, then multiplied by a main-branch boost: nodes on
+    a feature branch rank below equivalent matches on main.
+    """
+    base_score = func.greatest(
+        func.similarity(nr_alias.name, query) * _SEARCH_WEIGHT_NAME,
+        func.similarity(nr_alias.display_name, query) * _SEARCH_WEIGHT_DISPLAY_NAME,
+        func.similarity(nr_alias.description, query) * _SEARCH_WEIGHT_DESCRIPTION,
+    )
+    branch_boost = case(
+        (parent_ns_alias.namespace.is_(None), _SEARCH_BOOST_MAIN),
+        (parent_ns_alias.default_branch.is_(None), _SEARCH_BOOST_MAIN),
+        (
+            ns_alias.git_branch == parent_ns_alias.default_branch,
+            _SEARCH_BOOST_MAIN,
+        ),
+        else_=_SEARCH_BOOST_BRANCH,
+    )
+    return base_score * branch_boost
 
 
 class NodeRelationship(Base):
@@ -641,6 +678,7 @@ class Node(Base):
         statuses: list[NodeStatus] | None = None,
         has_materialization: bool = False,
         orphaned_dimension: bool = False,
+        search: str | None = None,
     ) -> List["Node"]:
         """
         Finds a list of nodes by prefix
@@ -687,7 +725,9 @@ class Node(Base):
         order_by_node_revision = (
             order_by and getattr(order_by, "class_", None) is NodeRevision
         )
-        join_revision = True if fragment or order_by_node_revision or mode else False
+        join_revision = bool(
+            fragment or order_by_node_revision or mode or search,
+        )
         if join_revision:
             statement = statement.join(NodeRevisionAlias, Node.current)
             if order_by_node_revision:
@@ -715,6 +755,34 @@ class Node(Base):
                     Node.name.like(f"%{fragment}%"),
                     NodeRevisionAlias.display_name.ilike(f"%{fragment}%"),
                 ),
+            )
+
+        search_score_expr = None
+        if search:
+            from datajunction_server.database.namespace import NodeNamespace
+
+            ns_alias = aliased(NodeNamespace)
+            parent_ns_alias = aliased(NodeNamespace)
+            statement = statement.outerjoin(
+                ns_alias,
+                Node.namespace == ns_alias.namespace,
+            ).outerjoin(
+                parent_ns_alias,
+                ns_alias.parent_namespace == parent_ns_alias.namespace,
+            )
+            pattern = f"%{search}%"
+            statement = statement.where(
+                or_(
+                    NodeRevisionAlias.name.ilike(pattern),
+                    NodeRevisionAlias.display_name.ilike(pattern),
+                    NodeRevisionAlias.description.ilike(pattern),
+                ),
+            )
+            search_score_expr = _build_search_score(
+                NodeRevisionAlias,
+                ns_alias,
+                parent_ns_alias,
+                search,
             )
 
         if node_types:
@@ -824,6 +892,12 @@ class Node(Base):
                 order_by.asc() if ascending else order_by.desc(),
                 Node.created_at.asc(),
                 Node.id.asc(),
+            )
+        elif search_score_expr is not None:
+            statement = statement.order_by(
+                search_score_expr.desc(),
+                Node.created_at.desc(),
+                Node.id.desc(),
             )
         else:
             statement = statement.order_by(
@@ -956,6 +1030,18 @@ class NodeRevision(
             "display_name",
             postgresql_using="gin",
             postgresql_ops={"display_name": "gin_trgm_ops"},
+        ),
+        Index(
+            "ix_noderevision_name_trgm",
+            "name",
+            postgresql_using="gin",
+            postgresql_ops={"name": "gin_trgm_ops"},
+        ),
+        Index(
+            "ix_noderevision_description_trgm",
+            "description",
+            postgresql_using="gin",
+            postgresql_ops={"description": "gin_trgm_ops"},
         ),
     )
 

--- a/datajunction-server/datajunction_server/database/tag.py
+++ b/datajunction-server/datajunction_server/database/tag.py
@@ -104,26 +104,41 @@ class Tag(Base):
     ) -> list["Tag"]:
         """
         Trigram-ranked search across tag name, display name, and description.
-        Returned in descending similarity order.
+        Single-char queries fall back to prefix matching on name/display_name
+        since trigram similarity isn't meaningful at that length.
         """
-        pattern = f"%{search}%"
-        score = func.greatest(
-            func.similarity(Tag.name, search),
-            func.similarity(Tag.display_name, search) * 0.9,
-            func.similarity(Tag.description, search) * 0.4,
-        )
-        statement = (
-            select(Tag)
-            .where(
-                or_(
-                    Tag.name.ilike(pattern),
-                    Tag.display_name.ilike(pattern),
-                    Tag.description.ilike(pattern),
-                ),
+        if len(search) < 2:
+            prefix = f"{search}%"
+            statement = (
+                select(Tag)
+                .where(
+                    or_(
+                        Tag.name.ilike(prefix),
+                        Tag.display_name.ilike(prefix),
+                    ),
+                )
+                .order_by(Tag.name.asc())
+                .limit(limit)
             )
-            .order_by(score.desc(), Tag.name.asc())
-            .limit(limit)
-        )
+        else:
+            pattern = f"%{search}%"
+            score = func.greatest(
+                func.similarity(Tag.name, search),
+                func.similarity(Tag.display_name, search) * 0.9,
+                func.similarity(Tag.description, search) * 0.4,
+            )
+            statement = (
+                select(Tag)
+                .where(
+                    or_(
+                        Tag.name.ilike(pattern),
+                        Tag.display_name.ilike(pattern),
+                        Tag.description.ilike(pattern),
+                    ),
+                )
+                .order_by(score.desc(), Tag.name.asc())
+                .limit(limit)
+            )
         return (await session.execute(statement)).scalars().all()
 
     @classmethod

--- a/datajunction-server/datajunction_server/database/tag.py
+++ b/datajunction-server/datajunction_server/database/tag.py
@@ -2,7 +2,18 @@
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from sqlalchemy import JSON, BigInteger, Column, ForeignKey, Integer, String, select
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+    or_,
+    select,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, joinedload, mapped_column, relationship
 from sqlalchemy.sql.base import ExecutableOption
@@ -22,6 +33,20 @@ class Tag(Base):
     """
 
     __tablename__ = "tag"
+    __table_args__ = (
+        Index(
+            "ix_tag_name_trgm",
+            "name",
+            postgresql_using="gin",
+            postgresql_ops={"name": "gin_trgm_ops"},
+        ),
+        Index(
+            "ix_tag_description_trgm",
+            "description",
+            postgresql_using="gin",
+            postgresql_ops={"description": "gin_trgm_ops"},
+        ),
+    )
 
     id: Mapped[int] = mapped_column(
         BigInteger().with_variant(Integer, "sqlite"),
@@ -68,6 +93,37 @@ class Tag(Base):
             statement = statement.where(Tag.tag_type.in_(tag_types))
         if options:
             statement = statement.options(*options)
+        return (await session.execute(statement)).scalars().all()
+
+    @classmethod
+    async def search_tags(
+        cls,
+        session: AsyncSession,
+        search: str,
+        limit: int = 10,
+    ) -> list["Tag"]:
+        """
+        Trigram-ranked search across tag name, display name, and description.
+        Returned in descending similarity order.
+        """
+        pattern = f"%{search}%"
+        score = func.greatest(
+            func.similarity(Tag.name, search),
+            func.similarity(Tag.display_name, search) * 0.9,
+            func.similarity(Tag.description, search) * 0.4,
+        )
+        statement = (
+            select(Tag)
+            .where(
+                or_(
+                    Tag.name.ilike(pattern),
+                    Tag.display_name.ilike(pattern),
+                    Tag.description.ilike(pattern),
+                ),
+            )
+            .order_by(score.desc(), Tag.name.asc())
+            .limit(limit)
+        )
         return (await session.execute(statement)).scalars().all()
 
     @classmethod

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -5,7 +5,14 @@ Tests for the findNodes / findNodesPaginated GraphQL queries
 from unittest import mock
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.namespace import NodeNamespace
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import User
+from datajunction_server.models.node_type import NodeType
 
 
 @pytest.mark.asyncio
@@ -2590,3 +2597,249 @@ async def test_find_cubes_name_only_with_tag_filter(
     assert "default.hard_hat.city" in dim_names
     assert "default.hard_hat.state" in dim_names
     assert len(dim_names) == 2
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_with_search_by_name(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Search by name fragment filters and ranks nodes by trigram similarity.
+    """
+    query = """
+    query Search($q: String!) {
+        findNodes(search: $q, limit: 20) {
+            name
+            type
+        }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "repair_orders"}},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    names = [node["name"] for node in data["data"]["findNodes"]]
+    assert "default.repair_orders" in names
+    assert "default.repair_orders_fact" in names
+    # Unrelated nodes must be filtered out.
+    assert "default.contractors" not in names
+    assert "default.hard_hat" not in names
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_with_search_by_description(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+    current_user: User,
+) -> None:
+    """
+    Search hits against description, not just name / display_name.
+    """
+    node = Node(
+        name="default.search_description_target",
+        type=NodeType.METRIC,
+        current_version="v1",
+        namespace="default",
+        created_by_id=current_user.id,
+    )
+    revision = NodeRevision(
+        node=node,
+        name=node.name,
+        display_name="Totally Unrelated Label",
+        description="A zenon aardwolf lumbers past the idiosyncratic marmoset.",
+        type=NodeType.METRIC,
+        version="v1",
+        created_by_id=current_user.id,
+    )
+    session.add(revision)
+    await session.commit()
+
+    query = """
+    query Search($q: String!) {
+        findNodes(search: $q) { name }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "aardwolf"}},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    names = [node["name"] for node in data["data"]["findNodes"]]
+    assert names == ["default.search_description_target"]
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_with_search_combined_filter(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Search composes with other filters like nodeTypes.
+    """
+    query = """
+    query Search($q: String!) {
+        findNodes(search: $q, nodeTypes: [METRIC]) {
+            name
+            type
+        }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "repair"}},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    results = data["data"]["findNodes"]
+    assert results, "expected at least one metric matching 'repair'"
+    assert all(node["type"] == "METRIC" for node in results)
+    names = {node["name"] for node in results}
+    # Sample of repair metrics present in the ROADS fixture
+    assert {
+        "default.num_repair_orders",
+        "default.avg_repair_price",
+        "default.total_repair_cost",
+    } <= names
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_with_search_no_results(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Search with a string that matches nothing returns an empty list.
+    """
+    query = """
+    query Search($q: String!) {
+        findNodes(search: $q) { name }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "xyzzy_never_matches_anything"}},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"data": {"findNodes": []}}
+
+
+@pytest_asyncio.fixture
+async def search_with_branch_namespaces(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+    current_user: User,
+) -> AsyncClient:
+    """
+    Create a git-backed namespace pair and two identically-named nodes to verify
+    that the main-branch boost ranks the main node above the feature-branch one.
+    """
+    session.add_all(
+        [
+            NodeNamespace(
+                namespace="search_demo",
+                github_repo_path="corp/search_demo",
+                default_branch="main",
+                parent_namespace=None,
+            ),
+            NodeNamespace(
+                namespace="search_demo.main",
+                github_repo_path="corp/search_demo",
+                git_branch="main",
+                parent_namespace="search_demo",
+            ),
+            NodeNamespace(
+                namespace="search_demo.feature",
+                github_repo_path="corp/search_demo",
+                git_branch="feature",
+                parent_namespace="search_demo",
+            ),
+        ],
+    )
+    await session.commit()
+
+    main_rev = NodeRevision(
+        node=Node(
+            name="search_demo.main.revenue_boost",
+            type=NodeType.METRIC,
+            current_version="v1",
+            namespace="search_demo.main",
+            created_by_id=current_user.id,
+        ),
+        name="search_demo.main.revenue_boost",
+        display_name="Revenue Boost",
+        description="Revenue boost metric on main branch.",
+        type=NodeType.METRIC,
+        version="v1",
+        created_by_id=current_user.id,
+    )
+    feature_rev = NodeRevision(
+        node=Node(
+            name="search_demo.feature.revenue_boost",
+            type=NodeType.METRIC,
+            current_version="v1",
+            namespace="search_demo.feature",
+            created_by_id=current_user.id,
+        ),
+        name="search_demo.feature.revenue_boost",
+        display_name="Revenue Boost",
+        description="Revenue boost metric on feature branch.",
+        type=NodeType.METRIC,
+        version="v1",
+        created_by_id=current_user.id,
+    )
+    session.add_all([main_rev, feature_rev])
+    await session.commit()
+    return client_with_roads
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_with_search_main_branch_boost(
+    search_with_branch_namespaces: AsyncClient,
+) -> None:
+    """
+    When two nodes match a search query equally well but live on different
+    branches, the main-branch node ranks first.
+    """
+    query = """
+    query Search($q: String!) {
+        findNodes(search: $q, nodeTypes: [METRIC]) { name }
+    }
+    """
+    response = await search_with_branch_namespaces.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "revenue_boost"}},
+    )
+    assert response.status_code == 200
+    names = [node["name"] for node in response.json()["data"]["findNodes"]]
+    main_idx = names.index("search_demo.main.revenue_boost")
+    feature_idx = names.index("search_demo.feature.revenue_boost")
+    assert main_idx < feature_idx, names
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_paginated_with_search(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    findNodesPaginated applies the search filter alongside pagination.
+    """
+    query = """
+    query Search($q: String!) {
+        findNodesPaginated(search: $q, limit: 50) {
+            edges { node { name } }
+            pageInfo { hasNextPage }
+        }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "hard_hat"}},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]["findNodesPaginated"]
+    names = [edge["node"]["name"] for edge in data["edges"]]
+    assert "default.hard_hat" in names
+    assert "default.hard_hats" in names
+    # Node unrelated to hard_hat must not be included.
+    assert "default.contractors" not in names

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -2843,3 +2843,125 @@ async def test_find_nodes_paginated_with_search(
     assert "default.hard_hats" in names
     # Node unrelated to hard_hat must not be included.
     assert "default.contractors" not in names
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_with_single_char_search_prefix_mode(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Single-character queries use prefix match on name/display_name only;
+    trigram similarity is skipped. All returned names should start with 'h'.
+    """
+    query = """
+    query Search($q: String!) {
+        findNodes(search: $q, limit: 200) { name }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "h"}},
+    )
+    assert response.status_code == 200
+    names = [node["name"] for node in response.json()["data"]["findNodes"]]
+    # Plenty of `hard_hat*` and related nodes — assert non-empty and that the
+    # prefix filter actually restricted results.
+    assert names, "prefix search must return at least one match"
+    name_parts = [n.split(".")[-1] for n in names]
+    assert all(
+        part.lower().startswith("h")
+        or any(seg.lower().startswith("h") for seg in n.split("."))
+        for part, n in zip(name_parts, names)
+    ), f"unexpected non-h-prefix in {names}"
+    # Nodes whose name shares no 'h' prefix anywhere must not appear.
+    assert "default.contractors" not in names
+    assert "default.repair_orders" not in names
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_search_prefers_popular_nodes(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+    current_user: User,
+) -> None:
+    """
+    Between two nodes that match the query equally, the one with more
+    downstream dependents ranks first.
+    """
+    # Two fresh source-like nodes with identical-quality matches on "rare_term"
+    # so the only differentiator is popularity (children count).
+    popular = Node(
+        name="default.rare_term_popular",
+        type=NodeType.SOURCE,
+        current_version="v1",
+        namespace="default",
+        created_by_id=current_user.id,
+    )
+    popular_rev = NodeRevision(
+        node=popular,
+        name=popular.name,
+        display_name="Rare Term Popular",
+        description="rare_term",
+        type=NodeType.SOURCE,
+        version="v1",
+        created_by_id=current_user.id,
+    )
+    lonely = Node(
+        name="default.rare_term_lonely",
+        type=NodeType.SOURCE,
+        current_version="v1",
+        namespace="default",
+        created_by_id=current_user.id,
+    )
+    lonely_rev = NodeRevision(
+        node=lonely,
+        name=lonely.name,
+        display_name="Rare Term Lonely",
+        description="rare_term",
+        type=NodeType.SOURCE,
+        version="v1",
+        created_by_id=current_user.id,
+    )
+    session.add_all([popular_rev, lonely_rev])
+    await session.flush()
+
+    # Attach three "children" to the popular node via NodeRelationship;
+    # parent_id references node.id and child_id references noderevision.id.
+    from datajunction_server.database.node import NodeRelationship
+
+    for i in range(3):
+        child = Node(
+            name=f"default.rare_term_child_{i}",
+            type=NodeType.TRANSFORM,
+            current_version="v1",
+            namespace="default",
+            created_by_id=current_user.id,
+        )
+        child_rev = NodeRevision(
+            node=child,
+            name=child.name,
+            type=NodeType.TRANSFORM,
+            version="v1",
+            created_by_id=current_user.id,
+        )
+        session.add(child_rev)
+        await session.flush()
+        session.add(
+            NodeRelationship(parent_id=popular.id, child_id=child_rev.id),
+        )
+    await session.commit()
+
+    query = """
+    query Search($q: String!) {
+        findNodes(search: $q) { name }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "rare_term"}},
+    )
+    assert response.status_code == 200
+    names = [node["name"] for node in response.json()["data"]["findNodes"]]
+    popular_idx = names.index("default.rare_term_popular")
+    lonely_idx = names.index("default.rare_term_lonely")
+    assert popular_idx < lonely_idx, names

--- a/datajunction-server/tests/api/graphql/tags_test.py
+++ b/datajunction-server/tests/api/graphql/tags_test.py
@@ -311,3 +311,83 @@ async def test_tag_get_nodes(
             ],
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_search_tags_by_name(
+    client_with_tags: AsyncClient,
+) -> None:
+    """
+    searchTags matches by tag name.
+    """
+    query = """
+    query Q($q: String!) { searchTags(search: $q) { name } }
+    """
+    response = await client_with_tags.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "sales"}},
+    )
+    assert response.status_code == 200
+    names = [tag["name"] for tag in response.json()["data"]["searchTags"]]
+    assert names == ["sales_report"]
+
+
+@pytest.mark.asyncio
+async def test_search_tags_by_description(
+    client_with_tags: AsyncClient,
+) -> None:
+    """
+    searchTags matches by description.
+    """
+    query = """
+    query Q($q: String!) { searchTags(search: $q) { name } }
+    """
+    response = await client_with_tags.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "drink"}},
+    )
+    assert response.status_code == 200
+    names = sorted(tag["name"] for tag in response.json()["data"]["searchTags"])
+    assert names == ["coffee", "tea"]
+
+
+@pytest.mark.asyncio
+async def test_search_tags_empty_query_returns_empty(
+    client_with_tags: AsyncClient,
+) -> None:
+    """
+    Empty or whitespace-only search returns an empty list without querying.
+    """
+    query = """
+    query Q($q: String!) { searchTags(search: $q) { name } }
+    """
+    for q in ("", "   "):
+        response = await client_with_tags.post(
+            "/graphql",
+            json={"query": query, "variables": {"q": q}},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"data": {"searchTags": []}}
+
+
+@pytest.mark.asyncio
+async def test_search_tags_limit(
+    client_with_tags: AsyncClient,
+) -> None:
+    """
+    The limit argument caps the number of matching tags returned.
+    """
+    query = """
+    query Q($q: String!, $n: Int!) {
+        searchTags(search: $q, limit: $n) { name }
+    }
+    """
+    response = await client_with_tags.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "report", "n": 1}},
+    )
+    assert response.status_code == 200
+    tags = response.json()["data"]["searchTags"]
+    assert len(tags) == 1
+    # Either match is acceptable; both score similarly on 'report'
+    assert tags[0]["name"] in {"sales_report", "other_report"}

--- a/datajunction-server/tests/api/graphql/tags_test.py
+++ b/datajunction-server/tests/api/graphql/tags_test.py
@@ -371,6 +371,26 @@ async def test_search_tags_empty_query_returns_empty(
 
 
 @pytest.mark.asyncio
+async def test_search_tags_single_char_prefix_mode(
+    client_with_tags: AsyncClient,
+) -> None:
+    """
+    Single-character queries fall back to prefix match on name/display_name.
+    """
+    query = """
+    query Q($q: String!) { searchTags(search: $q) { name } }
+    """
+    response = await client_with_tags.post(
+        "/graphql",
+        json={"query": query, "variables": {"q": "c"}},
+    )
+    assert response.status_code == 200
+    names = [tag["name"] for tag in response.json()["data"]["searchTags"]]
+    # Only "coffee" starts with "c".
+    assert names == ["coffee"]
+
+
+@pytest.mark.asyncio
 async def test_search_tags_limit(
     client_with_tags: AsyncClient,
 ) -> None:

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -54,7 +54,6 @@
     "file-loader": "6.2.0",
     "fontfaceobserver": "2.3.0",
     "formik": "2.4.3",
-    "fuse.js": "6.6.2",
     "husky": "8.0.1",
     "i18next": "21.9.2",
     "i18next-browser-languagedetector": "6.1.5",

--- a/datajunction-ui/src/app/components/Search.jsx
+++ b/datajunction-ui/src/app/components/Search.jsx
@@ -1,67 +1,82 @@
-import { useState, useCallback, useContext, useRef } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import DJClientContext from '../providers/djclient';
-import Fuse from 'fuse.js';
 
 import './search.css';
 
+const DEBOUNCE_MS = 200;
+const MIN_QUERY_LENGTH = 2;
+
+const truncate = str => {
+  if (!str) return '';
+  return str.length > 100 ? str.substring(0, 90) + '...' : str;
+};
+
 export default function Search() {
-  const [fuse, setFuse] = useState();
   const [searchValue, setSearchValue] = useState('');
-  const [searchResults, setSearchResults] = useState([]);
+  const [nodes, setNodes] = useState([]);
+  const [tags, setTags] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
-  const hasLoadedRef = useRef(false);
+  const abortRef = useRef(null);
+  const debounceRef = useRef(null);
   const inputRef = useRef(null);
 
   const djClient = useContext(DJClientContext).DataJunctionAPI;
 
-  const truncate = str => {
-    if (str === null) {
-      return '';
-    }
-    return str.length > 100 ? str.substring(0, 90) + '...' : str;
-  };
-
-  // Lazy load search data only when user focuses on search input
-  const loadSearchData = useCallback(async () => {
-    if (hasLoadedRef.current || isLoading) return;
-    hasLoadedRef.current = true;
-    setIsLoading(true);
-
-    try {
-      const [data, tags] = await Promise.all([
-        djClient.nodeDetails(),
-        djClient.listTags(),
-      ]);
-      const allEntities = data.concat(
-        (tags || []).map(tag => {
-          tag.type = 'tag';
-          return tag;
-        }),
-      );
-      const fuseInstance = new Fuse(allEntities || [], {
-        keys: [
-          'name', // will be assigned a `weight` of 1
-          { name: 'description', weight: 2 },
-          { name: 'display_name', weight: 3 },
-          { name: 'type', weight: 4 },
-          { name: 'tag_type', weight: 5 },
-        ],
-      });
-      setFuse(fuseInstance);
-    } catch (error) {
-      console.error('Error fetching nodes or tags:', error);
-      hasLoadedRef.current = false; // Allow retry on error
-    } finally {
-      setIsLoading(false);
-    }
-  }, [djClient, isLoading]);
+  const runSearch = useCallback(
+    async query => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setIsLoading(true);
+      try {
+        const results = await djClient.globalSearch(query, {
+          signal: controller.signal,
+        });
+        if (!controller.signal.aborted) {
+          setNodes(results.nodes);
+          setTags(results.tags);
+        }
+      } catch (err) {
+        if (err.name !== 'AbortError') {
+          console.error('Search failed:', err);
+          setNodes([]);
+          setTags([]);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [djClient],
+  );
 
   const handleChange = e => {
-    setSearchValue(e.target.value);
-    if (fuse) {
-      setSearchResults(fuse.search(e.target.value).map(result => result.item));
+    const value = e.target.value;
+    setSearchValue(value);
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
     }
+    if (value.trim().length < MIN_QUERY_LENGTH) {
+      if (abortRef.current) abortRef.current.abort();
+      setNodes([]);
+      setTags([]);
+      setIsLoading(false);
+      return;
+    }
+    debounceRef.current = setTimeout(() => runSearch(value.trim()), DEBOUNCE_MS);
   };
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
+  const hasResults = nodes.length > 0 || tags.length > 0;
 
   return (
     <div>
@@ -69,33 +84,36 @@ export default function Search() {
         <input
           ref={inputRef}
           type="text"
-          placeholder={isLoading ? 'Loading...' : 'Search nodes...'}
+          placeholder={isLoading ? 'Searching...' : 'Search nodes and tags...'}
           name="search"
           value={searchValue}
           onChange={handleChange}
-          onFocus={loadSearchData}
         />
       </div>
-      {searchResults.length > 0 && (
+      {hasResults && (
         <div className="search-results">
-          {searchResults.slice(0, 20).map(item => {
-            const itemUrl =
-              item.type !== 'tag'
-                ? `/nodes/${item.name}`
-                : `/tags/${item.name}`;
-            return (
-              <a key={item.name} href={itemUrl}>
-                <div className="search-result-item">
-                  <span className={`node_type__${item.type} badge node_type`}>
-                    {item.type}
-                  </span>
-                  {item.display_name} (<b>{item.name}</b>){' '}
-                  {item.description ? '- ' : ' '}
-                  {truncate(item.description || '')}
-                </div>
-              </a>
-            );
-          })}
+          {nodes.map(item => (
+            <a key={`node-${item.name}`} href={`/nodes/${item.name}`}>
+              <div className="search-result-item">
+                <span className={`node_type__${item.type} badge node_type`}>
+                  {item.type}
+                </span>
+                {item.display_name} (<b>{item.name}</b>){' '}
+                {item.description ? '- ' : ' '}
+                {truncate(item.description)}
+              </div>
+            </a>
+          ))}
+          {tags.map(item => (
+            <a key={`tag-${item.name}`} href={`/tags/${item.name}`}>
+              <div className="search-result-item">
+                <span className="node_type__tag badge node_type">tag</span>
+                {item.display_name} (<b>{item.name}</b>){' '}
+                {item.description ? '- ' : ' '}
+                {truncate(item.description)}
+              </div>
+            </a>
+          ))}
         </div>
       )}
     </div>

--- a/datajunction-ui/src/app/components/Search.jsx
+++ b/datajunction-ui/src/app/components/Search.jsx
@@ -3,8 +3,10 @@ import DJClientContext from '../providers/djclient';
 
 import './search.css';
 
-const DEBOUNCE_MS = 200;
-const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 120;
+const MIN_QUERY_LENGTH = 1;
+const CACHE_MAX_ENTRIES = 50;
+const CACHE_TTL_MS = 60 * 1000;
 
 const truncate = str => {
   if (!str) return '';
@@ -19,11 +21,44 @@ export default function Search() {
   const abortRef = useRef(null);
   const debounceRef = useRef(null);
   const inputRef = useRef(null);
+  // LRU cache keyed on normalized query; Map preserves insertion order so the
+  // oldest entry is always the first key.
+  const cacheRef = useRef(new Map());
 
   const djClient = useContext(DJClientContext).DataJunctionAPI;
 
+  const readCache = useCallback(key => {
+    const entry = cacheRef.current.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.at > CACHE_TTL_MS) {
+      cacheRef.current.delete(key);
+      return null;
+    }
+    // Touch for LRU ordering.
+    cacheRef.current.delete(key);
+    cacheRef.current.set(key, entry);
+    return entry.value;
+  }, []);
+
+  const writeCache = useCallback((key, value) => {
+    const cache = cacheRef.current;
+    cache.set(key, { value, at: Date.now() });
+    while (cache.size > CACHE_MAX_ENTRIES) {
+      const oldest = cache.keys().next().value;
+      cache.delete(oldest);
+    }
+  }, []);
+
   const runSearch = useCallback(
     async query => {
+      const cached = readCache(query);
+      if (cached) {
+        if (abortRef.current) abortRef.current.abort();
+        setNodes(cached.nodes);
+        setTags(cached.tags);
+        setIsLoading(false);
+        return;
+      }
       if (abortRef.current) {
         abortRef.current.abort();
       }
@@ -37,6 +72,7 @@ export default function Search() {
         if (!controller.signal.aborted) {
           setNodes(results.nodes);
           setTags(results.tags);
+          writeCache(query, results);
         }
       } catch (err) {
         if (err.name !== 'AbortError') {
@@ -50,7 +86,7 @@ export default function Search() {
         }
       }
     },
-    [djClient],
+    [djClient, readCache, writeCache],
   );
 
   const handleChange = e => {
@@ -59,17 +95,24 @@ export default function Search() {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
     }
-    if (value.trim().length < MIN_QUERY_LENGTH) {
+    const trimmed = value.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
       if (abortRef.current) abortRef.current.abort();
       setNodes([]);
       setTags([]);
       setIsLoading(false);
       return;
     }
-    debounceRef.current = setTimeout(
-      () => runSearch(value.trim()),
-      DEBOUNCE_MS,
-    );
+    // Synchronous cache hit: render instantly without waiting for debounce.
+    const cached = readCache(trimmed);
+    if (cached) {
+      if (abortRef.current) abortRef.current.abort();
+      setNodes(cached.nodes);
+      setTags(cached.tags);
+      setIsLoading(false);
+      return;
+    }
+    debounceRef.current = setTimeout(() => runSearch(trimmed), DEBOUNCE_MS);
   };
 
   useEffect(() => {
@@ -94,7 +137,10 @@ export default function Search() {
         />
       </div>
       {hasResults && (
-        <div className="search-results">
+        <div
+          className="search-results"
+          style={isLoading ? { opacity: 0.6 } : undefined}
+        >
           {nodes.map(item => (
             <a key={`node-${item.name}`} href={`/nodes/${item.name}`}>
               <div className="search-result-item">

--- a/datajunction-ui/src/app/components/Search.jsx
+++ b/datajunction-ui/src/app/components/Search.jsx
@@ -66,7 +66,10 @@ export default function Search() {
       setIsLoading(false);
       return;
     }
-    debounceRef.current = setTimeout(() => runSearch(value.trim()), DEBOUNCE_MS);
+    debounceRef.current = setTimeout(
+      () => runSearch(value.trim()),
+      DEBOUNCE_MS,
+    );
   };
 
   useEffect(() => {

--- a/datajunction-ui/src/app/components/__tests__/Search.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/Search.test.jsx
@@ -1,334 +1,213 @@
 import React from 'react';
-import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import Search from '../Search';
 import DJClientContext from '../../providers/djclient';
 
-const mockDjClient = {
-  DataJunctionAPI: {
-    nodeDetails: jest.fn(),
-    listTags: jest.fn(),
+const mockNodes = [
+  {
+    name: 'default.test_node',
+    display_name: 'Test Node',
+    description: 'A test node for testing',
+    type: 'transform',
+    kind: 'node',
   },
+  {
+    name: 'default.another_node',
+    display_name: 'Another Node',
+    description: '',
+    type: 'metric',
+    kind: 'node',
+  },
+  {
+    name: 'default.long_description_node',
+    display_name: 'Long Description',
+    description:
+      'This is a very long description that exceeds 100 characters and should be truncated to prevent display issues in the search results interface',
+    type: 'dimension',
+    kind: 'node',
+  },
+];
+
+const mockTags = [
+  {
+    name: 'test_tag',
+    display_name: 'Test Tag',
+    description: 'A test tag',
+    type: 'tag',
+    tag_type: 'business',
+    kind: 'tag',
+  },
+];
+
+const makeClient = overrides => ({
+  DataJunctionAPI: {
+    globalSearch: jest
+      .fn()
+      .mockResolvedValue({ nodes: mockNodes, tags: mockTags }),
+    ...(overrides || {}),
+  },
+});
+
+const flushDebounce = async () => {
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+  });
 };
 
 describe('<Search />', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
   });
 
-  const mockNodes = [
-    {
-      name: 'default.test_node',
-      display_name: 'Test Node',
-      description: 'A test node for testing',
-      type: 'transform',
-    },
-    {
-      name: 'default.another_node',
-      display_name: 'Another Node',
-      description: null, // Test null description
-      type: 'metric',
-    },
-    {
-      name: 'default.long_description_node',
-      display_name: 'Long Description',
-      description:
-        'This is a very long description that exceeds 100 characters and should be truncated to prevent display issues in the search results interface',
-      type: 'dimension',
-    },
-  ];
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
-  const mockTags = [
-    {
-      name: 'test_tag',
-      display_name: 'Test Tag',
-      description: 'A test tag',
-      tag_type: 'business',
-    },
-  ];
-
-  it('renders search input', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue(mockTags);
-
+  it('renders the search input with the idle placeholder', () => {
+    const client = makeClient();
     const { getByPlaceholderText } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    expect(getByPlaceholderText('Search nodes...')).toBeInTheDocument();
+    expect(getByPlaceholderText('Search nodes and tags...')).toBeInTheDocument();
   });
 
-  it('fetches and initializes search data on focus (lazy loading)', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue(mockTags);
-
+  it('does not query the API for queries shorter than 2 characters', async () => {
+    const client = makeClient();
     const { getByPlaceholderText } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    // Data should NOT be fetched on mount
-    expect(mockDjClient.DataJunctionAPI.nodeDetails).not.toHaveBeenCalled();
-
-    // Focus on search input to trigger lazy loading
-    const searchInput = getByPlaceholderText('Search nodes...');
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.nodeDetails).toHaveBeenCalled();
-      expect(mockDjClient.DataJunctionAPI.listTags).toHaveBeenCalled();
+    fireEvent.change(getByPlaceholderText('Search nodes and tags...'), {
+      target: { value: 'a' },
     });
+    await flushDebounce();
+    expect(client.DataJunctionAPI.globalSearch).not.toHaveBeenCalled();
   });
 
-  it('displays search results when typing', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue(mockTags);
-
-    const { getByPlaceholderText, getByText } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+  it('calls globalSearch after the debounce interval for a non-trivial query', async () => {
+    const client = makeClient();
+    const { getByPlaceholderText } = render(
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.nodeDetails).toHaveBeenCalled();
+    fireEvent.change(getByPlaceholderText('Search nodes and tags...'), {
+      target: { value: 'test' },
     });
-
-    fireEvent.change(searchInput, { target: { value: 'test' } });
-
-    await waitFor(() => {
-      expect(getByText(/Test Node/)).toBeInTheDocument();
-    });
+    await flushDebounce();
+    expect(client.DataJunctionAPI.globalSearch).toHaveBeenCalledWith(
+      'test',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
-  it('displays nodes with correct URLs', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue(mockTags);
-
-    const { getByPlaceholderText, container } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+  it('renders both node and tag results returned by the server', async () => {
+    const client = makeClient();
+    const { getByPlaceholderText, container, findByText } = render(
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.nodeDetails).toHaveBeenCalled();
+    fireEvent.change(getByPlaceholderText('Search nodes and tags...'), {
+      target: { value: 'test' },
     });
-
-    fireEvent.change(searchInput, { target: { value: 'node' } });
-
-    await waitFor(() => {
-      const links = container.querySelectorAll('a[href^="/nodes/"]');
-      expect(links.length).toBeGreaterThan(0);
-    });
+    await flushDebounce();
+    await findByText(/Test Node/);
+    expect(
+      container.querySelector('a[href="/nodes/default.test_node"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('a[href="/tags/test_tag"]'),
+    ).toBeInTheDocument();
   });
 
-  it('displays tags with correct URLs', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue([]);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue(mockTags);
-
-    const { getByPlaceholderText, container } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+  it('truncates descriptions longer than 100 characters', async () => {
+    const client = makeClient({
+      globalSearch: jest
+        .fn()
+        .mockResolvedValue({ nodes: [mockNodes[2]], tags: [] }),
+    });
+    const { getByPlaceholderText, findByText } = render(
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.listTags).toHaveBeenCalled();
+    fireEvent.change(getByPlaceholderText('Search nodes and tags...'), {
+      target: { value: 'long' },
     });
-
-    fireEvent.change(searchInput, { target: { value: 'tag' } });
-
-    await waitFor(() => {
-      const links = container.querySelectorAll('a[href^="/tags/"]');
-      expect(links.length).toBeGreaterThan(0);
-    });
+    await flushDebounce();
+    await findByText(/\.\.\./);
   });
 
-  it('truncates long descriptions', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue([]);
-
-    const { getByPlaceholderText, getByText } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+  it('clears results when the query drops below the minimum length', async () => {
+    const client = makeClient();
+    const { getByPlaceholderText, container, findByText } = render(
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
+    const input = getByPlaceholderText('Search nodes and tags...');
+    fireEvent.change(input, { target: { value: 'test' } });
+    await flushDebounce();
+    await findByText(/Test Node/);
+    fireEvent.change(input, { target: { value: 'x' } });
     await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.nodeDetails).toHaveBeenCalled();
-    });
-
-    fireEvent.change(searchInput, { target: { value: 'long' } });
-
-    await waitFor(() => {
-      expect(getByText(/\.\.\./)).toBeInTheDocument();
+      expect(container.querySelector('.search-result-item')).toBeNull();
     });
   });
 
-  it('handles null descriptions', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue([]);
-
-    const { getByPlaceholderText, getByText } = render(
-      <DJClientContext.Provider value={mockDjClient}>
-        <Search />
-      </DJClientContext.Provider>,
-    );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.nodeDetails).toHaveBeenCalled();
-    });
-
-    fireEvent.change(searchInput, { target: { value: 'another' } });
-
-    await waitFor(() => {
-      expect(getByText(/Another Node/)).toBeInTheDocument();
-    });
-  });
-
-  it('limits search results to 20 items', async () => {
-    const manyNodes = Array.from({ length: 30 }, (_, i) => ({
-      name: `default.node${i}`,
-      display_name: `Node ${i}`,
-      description: `Description ${i}`,
-      type: 'transform',
-    }));
-
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(manyNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue([]);
-
-    const { getByPlaceholderText, container } = render(
-      <DJClientContext.Provider value={mockDjClient}>
-        <Search />
-      </DJClientContext.Provider>,
-    );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.nodeDetails).toHaveBeenCalled();
-    });
-
-    fireEvent.change(searchInput, { target: { value: 'node' } });
-
-    await waitFor(() => {
-      const results = container.querySelectorAll('.search-result-item');
-      expect(results.length).toBeLessThanOrEqual(20);
-    });
-  });
-
-  it('handles error when fetching nodes', async () => {
+  it('logs an error but does not throw when the request fails', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-    mockDjClient.DataJunctionAPI.nodeDetails.mockRejectedValue(
-      new Error('Network error'),
-    );
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue([]);
-
+    const client = makeClient({
+      globalSearch: jest.fn().mockRejectedValue(new Error('boom')),
+    });
     const { getByPlaceholderText } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    // Focus to trigger lazy loading
-    const searchInput = getByPlaceholderText('Search nodes...');
-    fireEvent.focus(searchInput);
-
+    fireEvent.change(getByPlaceholderText('Search nodes and tags...'), {
+      target: { value: 'test' },
+    });
+    await flushDebounce();
     await waitFor(() => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error fetching nodes or tags:',
+        'Search failed:',
         expect.any(Error),
       );
     });
-
     consoleErrorSpy.mockRestore();
   });
 
-  it('renders search input inside nav-search-box container', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue([]);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue([]);
-
-    const { container } = render(
-      <DJClientContext.Provider value={mockDjClient}>
-        <Search />
-      </DJClientContext.Provider>,
-    );
-
-    const searchBox = container.querySelector('.nav-search-box');
-    expect(searchBox).toBeInTheDocument();
-    expect(searchBox.querySelector('input')).toBeInTheDocument();
-  });
-
-  it('handles empty tags array', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue(null);
-
+  it('aborts the in-flight request when a new query is typed', async () => {
+    const aborts = [];
+    const client = makeClient({
+      globalSearch: jest.fn((q, { signal }) => {
+        return new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            aborts.push(q);
+            reject(err);
+          });
+        });
+      }),
+    });
     const { getByPlaceholderText } = render(
-      <DJClientContext.Provider value={mockDjClient}>
+      <DJClientContext.Provider value={client}>
         <Search />
       </DJClientContext.Provider>,
     );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.listTags).toHaveBeenCalled();
-    });
-
-    // Should not throw an error
-    expect(searchInput).toBeInTheDocument();
-  });
-
-  it('shows description separator correctly', async () => {
-    mockDjClient.DataJunctionAPI.nodeDetails.mockResolvedValue(mockNodes);
-    mockDjClient.DataJunctionAPI.listTags.mockResolvedValue([]);
-
-    const { getByPlaceholderText, container } = render(
-      <DJClientContext.Provider value={mockDjClient}>
-        <Search />
-      </DJClientContext.Provider>,
-    );
-
-    const searchInput = getByPlaceholderText('Search nodes...');
-    // Focus to trigger lazy loading
-    fireEvent.focus(searchInput);
-
-    await waitFor(() => {
-      expect(mockDjClient.DataJunctionAPI.nodeDetails).toHaveBeenCalled();
-    });
-
-    fireEvent.change(searchInput, { target: { value: 'test' } });
-
-    await waitFor(() => {
-      const results = container.querySelector('.search-result-item');
-      expect(results).toBeInTheDocument();
-    });
+    const input = getByPlaceholderText('Search nodes and tags...');
+    fireEvent.change(input, { target: { value: 'aaa' } });
+    await flushDebounce();
+    fireEvent.change(input, { target: { value: 'bbb' } });
+    await flushDebounce();
+    await waitFor(() => expect(aborts).toContain('aaa'));
+    expect(client.DataJunctionAPI.globalSearch).toHaveBeenCalledTimes(2);
   });
 });

--- a/datajunction-ui/src/app/components/__tests__/Search.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/Search.test.jsx
@@ -71,7 +71,9 @@ describe('<Search />', () => {
         <Search />
       </DJClientContext.Provider>,
     );
-    expect(getByPlaceholderText('Search nodes and tags...')).toBeInTheDocument();
+    expect(
+      getByPlaceholderText('Search nodes and tags...'),
+    ).toBeInTheDocument();
   });
 
   it('does not query the API for queries shorter than 2 characters', async () => {

--- a/datajunction-ui/src/app/components/__tests__/Search.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/Search.test.jsx
@@ -50,7 +50,7 @@ const makeClient = overrides => ({
 
 const flushDebounce = async () => {
   await act(async () => {
-    jest.advanceTimersByTime(300);
+    jest.advanceTimersByTime(200);
   });
 };
 
@@ -76,7 +76,7 @@ describe('<Search />', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not query the API for queries shorter than 2 characters', async () => {
+  it('does not query the API for an empty string', async () => {
     const client = makeClient();
     const { getByPlaceholderText } = render(
       <DJClientContext.Provider value={client}>
@@ -84,10 +84,27 @@ describe('<Search />', () => {
       </DJClientContext.Provider>,
     );
     fireEvent.change(getByPlaceholderText('Search nodes and tags...'), {
-      target: { value: 'a' },
+      target: { value: '   ' },
     });
     await flushDebounce();
     expect(client.DataJunctionAPI.globalSearch).not.toHaveBeenCalled();
+  });
+
+  it('queries the API for single-character input (server handles prefix)', async () => {
+    const client = makeClient();
+    const { getByPlaceholderText } = render(
+      <DJClientContext.Provider value={client}>
+        <Search />
+      </DJClientContext.Provider>,
+    );
+    fireEvent.change(getByPlaceholderText('Search nodes and tags...'), {
+      target: { value: 'h' },
+    });
+    await flushDebounce();
+    expect(client.DataJunctionAPI.globalSearch).toHaveBeenCalledWith(
+      'h',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it('calls globalSearch after the debounce interval for a non-trivial query', async () => {
@@ -145,7 +162,7 @@ describe('<Search />', () => {
     await findByText(/\.\.\./);
   });
 
-  it('clears results when the query drops below the minimum length', async () => {
+  it('clears results when the input is cleared', async () => {
     const client = makeClient();
     const { getByPlaceholderText, container, findByText } = render(
       <DJClientContext.Provider value={client}>
@@ -156,7 +173,7 @@ describe('<Search />', () => {
     fireEvent.change(input, { target: { value: 'test' } });
     await flushDebounce();
     await findByText(/Test Node/);
-    fireEvent.change(input, { target: { value: 'x' } });
+    fireEvent.change(input, { target: { value: '' } });
     await waitFor(() => {
       expect(container.querySelector('.search-result-item')).toBeNull();
     });
@@ -183,6 +200,24 @@ describe('<Search />', () => {
       );
     });
     consoleErrorSpy.mockRestore();
+  });
+
+  it('serves a repeated query from cache without calling the server again', async () => {
+    const client = makeClient();
+    const { getByPlaceholderText } = render(
+      <DJClientContext.Provider value={client}>
+        <Search />
+      </DJClientContext.Provider>,
+    );
+    const input = getByPlaceholderText('Search nodes and tags...');
+    fireEvent.change(input, { target: { value: 'test' } });
+    await flushDebounce();
+    expect(client.DataJunctionAPI.globalSearch).toHaveBeenCalledTimes(1);
+    fireEvent.change(input, { target: { value: 'other' } });
+    await flushDebounce();
+    fireEvent.change(input, { target: { value: 'test' } });
+    await flushDebounce();
+    expect(client.DataJunctionAPI.globalSearch).toHaveBeenCalledTimes(2);
   });
 
   it('aborts the in-flight request when a new query is typed', async () => {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1775,7 +1775,10 @@ export const DataJunctionAPI = {
     return await response.json();
   },
 
-  globalSearch: async function (query, { signal, nodeLimit = 10, tagLimit = 5 } = {}) {
+  globalSearch: async function (
+    query,
+    { signal, nodeLimit = 10, tagLimit = 5 } = {},
+  ) {
     const gqlQuery = `
       query GlobalSearch($q: String!, $nodeLimit: Int!, $tagLimit: Int!) {
         findNodes(search: $q, limit: $nodeLimit) {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1774,6 +1774,54 @@ export const DataJunctionAPI = {
     });
     return await response.json();
   },
+
+  globalSearch: async function (query, { signal, nodeLimit = 10, tagLimit = 5 } = {}) {
+    const gqlQuery = `
+      query GlobalSearch($q: String!, $nodeLimit: Int!, $tagLimit: Int!) {
+        findNodes(search: $q, limit: $nodeLimit) {
+          name
+          type
+          current {
+            displayName
+            description
+          }
+        }
+        searchTags(search: $q, limit: $tagLimit) {
+          name
+          displayName
+          description
+          tagType
+        }
+      }
+    `;
+    const response = await fetch(DJ_GQL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      signal,
+      body: JSON.stringify({
+        query: gqlQuery,
+        variables: { q: query, nodeLimit, tagLimit },
+      }),
+    });
+    const result = await response.json();
+    const nodes = (result?.data?.findNodes || []).map(node => ({
+      name: node.name,
+      display_name: node.current?.displayName || node.name,
+      description: node.current?.description || '',
+      type: node.type?.toLowerCase() || '',
+      kind: 'node',
+    }));
+    const tags = (result?.data?.searchTags || []).map(tag => ({
+      name: tag.name,
+      display_name: tag.displayName || tag.name,
+      description: tag.description || '',
+      type: 'tag',
+      tag_type: tag.tagType,
+      kind: 'tag',
+    }));
+    return { nodes, tags };
+  },
   users: async function () {
     return await (
       await fetch(`${DJ_URL}/users?with_activity=true`, {

--- a/datajunction-ui/yarn.lock
+++ b/datajunction-ui/yarn.lock
@@ -7820,11 +7820,6 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-fuse.js@6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
-  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
-
 generator-function@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"


### PR DESCRIPTION
### Summary

Typing in the nav search bar used to pull the full node + tag catalog into the browser on focus and filter in-memory via Fuse. This can get very large as the number of nodes grows, and the upper limit means that many new nodes are undiscoverable via search.

This PR switches the search to a GraphQL `findNodes(search:)` + `searchTags(search:)`, each backed by GIN indexes. The per-request payload drops significantly and trigram lookups are sub-10 ms.

Ranking combines three signals:
- `pg_trgm` similarity across `name` / `display_name` / `description`. Single-char queries fall back to `ILIKE` prefix match so "h" still gives useful results.
- Main-branch boost: nodes in a feature-branch namespace rank at 0.5× versus the equivalent main-branch node.
- Popularity: `1 + 0.2 * ln(1 + child_count)` via a `LEFT JOIN` on NodeRelationship dependents (e.g., a metric feeding many cubes ranks above one nothing references).

To close the gap versus instant in-memory Fuse, the client adds a 50-entry / 60 s LRU cache keyed on query (backspacing to a previous query renders synchronously, no network).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
