### PR TITLE
Expand the workspace to surface team-owned nodes

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -75,6 +75,13 @@ async def find_nodes(
             description="Filter to nodes owned by this user",
         ),
     ] = None,
+    include_team: Annotated[
+        bool,
+        strawberry.argument(
+            description="When combined with ownedBy, also include nodes owned "
+            "by any group the user is a member of.",
+        ),
+    ] = False,
     missing_description: Annotated[
         bool,
         strawberry.argument(
@@ -140,6 +147,7 @@ async def find_nodes(
         namespace=namespace,
         mode=mode,
         owned_by=owned_by,
+        include_team=include_team,
         missing_description=missing_description,
         missing_owner=missing_owner,
         statuses=statuses,
@@ -207,6 +215,13 @@ async def find_nodes_paginated(
             description="Filter to nodes owned by this user",
         ),
     ] = None,
+    include_team: Annotated[
+        bool,
+        strawberry.argument(
+            description="When combined with ownedBy, also include nodes owned "
+            "by any group the user is a member of.",
+        ),
+    ] = False,
     missing_description: Annotated[
         bool,
         strawberry.argument(
@@ -269,6 +284,7 @@ async def find_nodes_paginated(
         ascending=ascending,
         mode=mode,
         owned_by=owned_by,
+        include_team=include_team,
         missing_description=missing_description,
         missing_owner=missing_owner,
         statuses=statuses,

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -22,6 +22,9 @@ from datajunction_server.database.node import Node as DBNode
 from datajunction_server.database.node import NodeRevision as DBNodeRevision
 from datajunction_server.api.graphql.resolvers.tags import tag_load_options
 from datajunction_server.api.graphql.resolvers.users import user_load_options
+from datajunction_server.internal.access.group_membership import (
+    get_group_membership_service,
+)
 from datajunction_server.models.node import NodeMode, NodeStatus, NodeType
 
 _CUBE_NAME_ONLY_FIELDS: frozenset[str] = frozenset({"name"})
@@ -127,6 +130,7 @@ async def find_nodes_by(
     ascending: bool = False,
     mode: Optional[NodeMode] = None,
     owned_by: Optional[str] = None,
+    include_team: bool = False,
     missing_description: bool = False,
     missing_owner: bool = False,
     dimensions: Optional[List[str]] = None,
@@ -154,6 +158,19 @@ async def find_nodes_by(
     is_cube_name_only = _is_cube_name_only_request(current_fields)
     info.context["cube_name_only"] = is_cube_name_only  # type: ignore
 
+    # When include_team is set with an ownedBy filter, expand to the user's
+    # groups so nodes owned directly by the user OR by any of their groups
+    # are returned. No-op when ownedBy is not set.
+    owned_by_list: Optional[List[str]] = None
+    if owned_by:
+        owned_by_list = [owned_by]
+        if include_team:
+            groups = await get_group_membership_service().get_user_groups(
+                session,
+                owned_by,
+            )
+            owned_by_list = list({owned_by, *groups})
+
     result = await DBNode.find_by(
         session,
         names,
@@ -169,7 +186,7 @@ async def find_nodes_by(
         ascending=ascending,
         options=options,
         mode=mode,
-        owned_by=owned_by,
+        owned_by=owned_by_list,
         missing_description=missing_description,
         missing_owner=missing_owner,
         statuses=statuses,

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -482,6 +482,11 @@ type Query {
     """Filter to nodes owned by this user"""
     ownedBy: String = null
 
+    """
+    When combined with ownedBy, also include nodes owned by any group the user is a member of.
+    """
+    includeTeam: Boolean! = false
+
     """Filter to nodes missing descriptions (for data quality checks)"""
     missingDescription: Boolean! = false
 
@@ -533,6 +538,11 @@ type Query {
 
     """Filter to nodes owned by this user"""
     ownedBy: String = null
+
+    """
+    When combined with ownedBy, also include nodes owned by any group the user is a member of.
+    """
+    includeTeam: Boolean! = false
 
     """Filter to nodes missing descriptions (for data quality checks)"""
     missingDescription: Boolean! = false

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -634,7 +634,7 @@ class Node(Base):
         ascending: bool = False,
         options: list[ExecutableOption] = None,
         mode: NodeMode | None = None,
-        owned_by: str | None = None,
+        owned_by: list[str] | None = None,
         missing_description: bool = False,
         missing_owner: bool = False,
         dimensions: list[str] | None = None,
@@ -733,12 +733,13 @@ class Node(Base):
                 Node.name.in_(select(edited_node_subquery.c.entity_name)),
             )
 
-        # Filter by owner username
+        # Filter by owner username (accepts one or more usernames; a node matches
+        # if any listed user or group is an owner).
         if owned_by:
             owned_node_subquery = (
                 select(NodeOwner.node_id)
                 .join(User, NodeOwner.user_id == User.id)
-                .where(User.username == owned_by)
+                .where(User.username.in_(owned_by))
                 .distinct()
                 .subquery()
             )

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -1871,6 +1871,158 @@ async def test_find_nodes_filter_by_owner(
     assert len(data["data"]["findNodes"]) > 0
 
 
+async def _setup_team_ownership(client: AsyncClient) -> None:
+    """
+    Shared setup for include_team tests. Registers a group, adds 'dj' as a
+    member, and re-assigns a single node to be owned exclusively by the group
+    so we can distinguish dj-only vs dj+team results.
+
+    Post-state (on top of the roads fixture):
+      - group 'team-analytics' exists with member 'dj'
+      - default.repair_order_details.owners == ['team-analytics']  (group only)
+      - default.repair_orders_fact still has 'dj' as an owner
+    """
+    # Register the group and add 'dj' as a member.
+    resp = await client.post("/groups/", params={"username": "team-analytics"})
+    assert resp.status_code == 201, resp.text
+
+    resp = await client.post(
+        "/groups/team-analytics/members/",
+        params={"member_username": "dj"},
+    )
+    assert resp.status_code == 201, resp.text
+
+    # Re-assign a node so the group is the sole owner (dj no longer owns it).
+    resp = await client.patch(
+        "/nodes/default.repair_order_details/",
+        json={"owners": ["team-analytics"]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert {o["username"] for o in resp.json()["owners"]} == {"team-analytics"}
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_filter_by_owner_include_team(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Test that ``includeTeam: true`` expands ``ownedBy`` to include nodes owned
+    by groups the user is a member of.
+    """
+    await _setup_team_ownership(client_with_roads)
+
+    query_template = """
+    {{
+        findNodes(ownedBy: "dj", includeTeam: {include_team}) {{
+            name
+            owners {{ username }}
+        }}
+    }}
+    """
+
+    # includeTeam: false — only nodes directly owned by 'dj'
+    resp = await client_with_roads.post(
+        "/graphql",
+        json={"query": query_template.format(include_team="false")},
+    )
+    assert resp.status_code == 200
+    names_without_team = {n["name"] for n in resp.json()["data"]["findNodes"]}
+    assert "default.repair_orders_fact" in names_without_team
+    assert "default.repair_order_details" not in names_without_team
+
+    # includeTeam: true — also includes nodes owned by the group
+    resp = await client_with_roads.post(
+        "/graphql",
+        json={"query": query_template.format(include_team="true")},
+    )
+    assert resp.status_code == 200
+    nodes_with_team = resp.json()["data"]["findNodes"]
+    names_with_team = {n["name"] for n in nodes_with_team}
+    assert "default.repair_orders_fact" in names_with_team
+    assert "default.repair_order_details" in names_with_team
+
+    # The team-owned node's owners reflect the group; dedupe: the result set
+    # is a superset of the dj-only set by exactly the team-owned nodes.
+    assert names_without_team.issubset(names_with_team)
+    extras = names_with_team - names_without_team
+    assert extras == {"default.repair_order_details"}
+
+    team_node = next(
+        n for n in nodes_with_team if n["name"] == "default.repair_order_details"
+    )
+    assert [o["username"] for o in team_node["owners"]] == ["team-analytics"]
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_filter_by_owner_include_team_noop_without_owner(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    ``includeTeam: true`` with no ``ownedBy`` is a no-op — the owner filter is
+    not applied. Sanity check that the default unfiltered result set matches.
+    """
+    await _setup_team_ownership(client_with_roads)
+
+    baseline = await client_with_roads.post(
+        "/graphql",
+        json={"query": "{ findNodes { name } }"},
+    )
+    with_flag = await client_with_roads.post(
+        "/graphql",
+        json={"query": "{ findNodes(includeTeam: true) { name } }"},
+    )
+    assert {n["name"] for n in baseline.json()["data"]["findNodes"]} == {
+        n["name"] for n in with_flag.json()["data"]["findNodes"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_paginated_filter_by_owner_include_team(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Paginated variant: ``includeTeam: true`` returns both user- and group-owned
+    nodes; ``includeTeam: false`` only returns directly-owned nodes.
+    """
+    await _setup_team_ownership(client_with_roads)
+
+    # Narrow with a name fragment so the assertion doesn't depend on ordering
+    # across the full result set.
+    query_template = """
+    {{
+        findNodesPaginated(
+            ownedBy: "dj",
+            includeTeam: {include_team},
+            fragment: "repair_order",
+            limit: 100,
+        ) {{
+            edges {{ node {{ name }} }}
+        }}
+    }}
+    """
+
+    resp = await client_with_roads.post(
+        "/graphql",
+        json={"query": query_template.format(include_team="false")},
+    )
+    names_without_team = {
+        e["node"]["name"] for e in resp.json()["data"]["findNodesPaginated"]["edges"]
+    }
+    assert "default.repair_order_details" not in names_without_team
+    # Sanity: dj still owns other repair_order* nodes.
+    assert names_without_team, "expected dj to still own some repair_order nodes"
+
+    resp = await client_with_roads.post(
+        "/graphql",
+        json={"query": query_template.format(include_team="true")},
+    )
+    names_with_team = {
+        e["node"]["name"] for e in resp.json()["data"]["findNodesPaginated"]["edges"]
+    }
+    assert "default.repair_order_details" in names_with_team
+    assert names_without_team.issubset(names_with_team)
+
+
 @pytest.mark.asyncio
 async def test_find_nodes_paginated_filter_by_owner(
     client_with_roads: AsyncClient,


### PR DESCRIPTION
### Summary

Nodes are often owned by groups, not individuals, so users browsing their workspace page miss everything their team owns. This PR adds an `includeTeam` arg to the `findNodes` / `findNodesPaginated` GraphQL queries. When paired with `ownedBy`, the filter also matches nodes owned by any group the user is a member of (resolved through the existing pluggable `GroupMembershipService`). The default behavior is unchanged: every existing `ownedBy: "dj"` call still returns only directly-owned nodes.

**Before** just dj's direct nodes:
```
findNodesPaginated(ownedBy: "dj") { edges { node { name } } }
```

**After** dj's nodes + nodes owned by any group dj belongs to:
```
findNodesPaginated(ownedBy: "dj", includeTeam: true) { edges { node { name } } }
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
