### PR TITLE
Fix filter pushdown emitting `SELECT` aliases in `WHERE`

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -962,29 +962,36 @@ def _rewrite_filter_for_cte(
 ) -> str | None:
     """Rewrite a dimension filter for injection into a specific CTE.
 
-    Replaces each dimension reference (e.g., ``v3.product.category``)
-    with the table-qualified column name from the CTE's SELECT projection
-    (e.g., ``p.category``).
+    Replaces each dimension reference (e.g., ``v3.product.category``) with the
+    underlying table-qualified column name from the CTE's SELECT projection
+    (e.g., ``p.category``).  The underlying form is required because Spark SQL
+    (and standard SQL) cannot reference SELECT-list aliases in the same query's
+    WHERE clause — emitting the alias name produces a SQL error at execution
+    time.
 
     Returns the rewritten filter string, or None if the filter doesn't apply
-    to this CTE (its columns aren't in the CTE's output).
+    to this CTE (column missing, or projected via a non-column expression that
+    can't be safely inlined into WHERE).
     """
-    # Build CTE projection map: bare_col → qualified_col
     projection_map = _build_cte_projection_map(cte_query)
 
-    # Find the longest matching dim ref and resolve to bare col
     rewritten = filter_str
     matched = False
-    for dim_ref, bare_col in sorted(
+    for dim_ref, output_col in sorted(
         filter_column_aliases.items(),
         key=lambda x: -len(x[0]),
     ):
         if dim_ref not in rewritten:
             continue
-        if bare_col not in cte_output_cols:
+        if output_col not in cte_output_cols:
             continue
-        # Use the CTE's qualified version if available
-        qualified = projection_map.get(bare_col, bare_col)
+        # Resolve the output column to its underlying qualified form.  When
+        # the CTE projects a non-column expression under this name (e.g.
+        # ``some_fn(x) AS y``), pushdown isn't safe — skip this CTE and let
+        # the filter stay on the outer query.
+        qualified = projection_map.get(output_col)
+        if qualified is None:
+            continue
         rewritten = rewritten.replace(dim_ref, qualified)
         matched = True
         break  # One dim ref per filter (filters are single predicates)
@@ -993,22 +1000,39 @@ def _rewrite_filter_for_cte(
 
 
 def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str]:
-    """Build a map from bare column name to table-qualified name from a CTE's SELECT.
+    """Map a CTE's output column name to its underlying qualified reference.
 
-    For ``SELECT T.test_id, ...`` returns ``{"test_id": "T.test_id"}``.
-    For ``SELECT test_id, ...`` (no qualifier) returns ``{"test_id": "test_id"}``.
+    Output name is the SELECT-list alias when present, else the bare column
+    name.  Value is the form that's safe to reference in a WHERE clause
+    pushed into the same CTE — a table-qualified column when qualified in
+    the projection, else the bare column name.
+
+    Examples::
+
+        SELECT o.placed_on AS order_date
+          becomes {"order_date": "o.placed_on"}
+        SELECT T.test_id
+          becomes {"test_id": "T.test_id"}
+        SELECT test_id
+          becomes {"test_id": "test_id"}
+
+    Non-column projections (e.g. ``some_fn(x) AS y``) are intentionally
+    omitted — it isn't safe to inline a function call into WHERE without
+    knowing its side effects, so callers should treat a missing key as
+    "don't push this filter into this CTE".
     """
     result: dict[str, str] = {}
     if not cte_query.select:  # pragma: no cover
         return result
     for expr in cte_query.select.projection:
         inner = getattr(expr, "child", expr)
-        if isinstance(inner, ast.Column) and inner.name:
-            bare = inner.name.name
-            if inner.namespace:
-                result[bare] = f"{inner.namespace[0].name}.{bare}"
-            else:
-                result[bare] = bare
+        if not isinstance(inner, ast.Column) or not inner.name:
+            continue
+        bare = inner.name.name
+        underlying = f"{inner.namespace[0].name}.{bare}" if inner.namespace else bare
+        alias = getattr(expr, "alias", None)
+        output_name = alias.name if alias else bare
+        result[output_name] = underlying
     return result
 
 

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -4,6 +4,7 @@ CTE building and AST transformation utilities
 
 from __future__ import annotations
 
+import re
 from copy import deepcopy
 from typing import Optional
 
@@ -962,16 +963,20 @@ def _rewrite_filter_for_cte(
 ) -> str | None:
     """Rewrite a dimension filter for injection into a specific CTE.
 
-    Replaces each dimension reference (e.g., ``v3.product.category``) with the
-    underlying table-qualified column name from the CTE's SELECT projection
-    (e.g., ``p.category``).  The underlying form is required because Spark SQL
-    (and standard SQL) cannot reference SELECT-list aliases in the same query's
-    WHERE clause — emitting the alias name produces a SQL error at execution
-    time.
+    Resolves each dimension reference (e.g., ``v3.product.category``) to the
+    form that's safe in the CTE's WHERE clause.  Three cases:
 
-    Returns the rewritten filter string, or None if the filter doesn't apply
-    to this CTE (column missing, or projected via a non-column expression that
-    can't be safely inlined into WHERE).
+    1. CTE projects the column as a simple (possibly aliased) column: replace
+       with the underlying qualified form (e.g., ``p.category``).  This is the
+       correctness-critical case — emitting a SELECT-list alias in WHERE is
+       rejected by Spark SQL and standard SQL.
+    2. CTE doesn't project the column at all (pruned): fall through to the
+       bare column name.  Safe because the CTE's underlying source exposes
+       the column, even if it's not selected into the outer query.
+    3. CTE projects the column via a non-column expression (e.g.
+       ``SUM(x) AS y``): skip — inlining is unsafe.
+
+    Returns the rewritten filter string, or None if no dim_ref applies.
     """
     projection_map = _build_cte_projection_map(cte_query)
 
@@ -985,27 +990,44 @@ def _rewrite_filter_for_cte(
             continue
         if output_col not in cte_output_cols:
             continue
-        # Resolve the output column to its underlying qualified form.  When
-        # the CTE projects a non-column expression under this name (e.g.
-        # ``some_fn(x) AS y``), pushdown isn't safe — skip this CTE and let
-        # the filter stay on the outer query.
-        qualified = projection_map.get(output_col)
-        if qualified is None:
-            continue
-        rewritten = rewritten.replace(dim_ref, qualified)
+        if output_col in projection_map:
+            qualified = projection_map[output_col]
+            if qualified is None:
+                # Non-column expression under this alias — unsafe to inline.
+                continue
+        else:
+            # Column pruned from the CTE's SELECT; fall through to the bare
+            # name, which the underlying source still exposes.
+            qualified = output_col
+        # Word-boundary-safe replacement so a shorter dim_ref doesn't clobber
+        # a longer similarly-prefixed one (e.g. ``fact.orders.order_date`` must
+        # not match ``fact.orders.order_date_extended``).  SQL identifier chars
+        # are ASCII word chars plus underscore; dots terminate identifiers so
+        # we only guard against alnum/underscore on either side.
+        pattern = r"(?<![A-Za-z0-9_])" + re.escape(dim_ref) + r"(?![A-Za-z0-9_])"
+        rewritten = re.sub(pattern, qualified, rewritten)
         matched = True
         break  # One dim ref per filter (filters are single predicates)
 
     return rewritten if matched else None
 
 
-def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str]:
+def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str | None]:
     """Map a CTE's output column name to its underlying qualified reference.
 
     Output name is the SELECT-list alias when present, else the bare column
-    name.  Value is the form that's safe to reference in a WHERE clause
-    pushed into the same CTE — a table-qualified column when qualified in
-    the projection, else the bare column name.
+    name.  Value is either:
+
+    - A string — the form that's safe to reference in a WHERE clause pushed
+      into this CTE (a table-qualified column when qualified in the
+      projection, else the bare column name).
+    - ``None`` — the projection is a non-column expression under an alias
+      (e.g., ``SUM(x) AS y``); pushdown should skip this CTE to avoid
+      inlining an expression that would be semantically wrong in WHERE.
+
+    Columns that the CTE doesn't project at all are absent from the map;
+    callers should treat that as "fall through to the bare name" since the
+    CTE's underlying source still exposes them.
 
     Examples::
 
@@ -1013,26 +1035,26 @@ def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str]:
           becomes {"order_date": "o.placed_on"}
         SELECT T.test_id
           becomes {"test_id": "T.test_id"}
-        SELECT test_id
-          becomes {"test_id": "test_id"}
-
-    Non-column projections (e.g. ``some_fn(x) AS y``) are intentionally
-    omitted — it isn't safe to inline a function call into WHERE without
-    knowing its side effects, so callers should treat a missing key as
-    "don't push this filter into this CTE".
+        SELECT SUM(x) AS total
+          becomes {"total": None}
     """
-    result: dict[str, str] = {}
+    result: dict[str, str | None] = {}
     if not cte_query.select:  # pragma: no cover
         return result
     for expr in cte_query.select.projection:
         inner = getattr(expr, "child", expr)
-        if not isinstance(inner, ast.Column) or not inner.name:
-            continue
-        bare = inner.name.name
-        underlying = f"{inner.namespace[0].name}.{bare}" if inner.namespace else bare
         alias = getattr(expr, "alias", None)
-        output_name = alias.name if alias else bare
-        result[output_name] = underlying
+        if isinstance(inner, ast.Column) and inner.name:
+            bare = inner.name.name
+            underlying = (
+                f"{inner.namespace[0].name}.{bare}" if inner.namespace else bare
+            )
+            output_name = alias.name if alias else bare
+            result[output_name] = underlying
+        elif alias is not None:
+            # Non-column projection with an output name we can address;
+            # mark as unsafe to inline.
+            result[alias.name] = None
     return result
 
 

--- a/datajunction-server/tests/construction/build_v3/cte_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_test.py
@@ -1,5 +1,7 @@
 """Tests for cte.py - CTE building and AST transformation utilities."""
 
+import pytest
+
 from datajunction_server.construction.build_v3.cte import (
     _build_cte_projection_map,
     _rewrite_filter_for_cte,
@@ -381,16 +383,17 @@ class TestBuildCteProjectionMap:
             "order_date": "o.placed_on",
         }
 
-    def test_non_column_projections_omitted(self):
-        """Function calls and other non-column projections are skipped.
-
-        Callers should treat a missing entry as "don't push this filter into
-        this CTE" so we don't inline an arbitrary expression into WHERE.
+    def test_non_column_projection_maps_to_none(self):
+        """Aggregations and other non-column projections map to None so
+        callers can distinguish "unsafe to inline" from "not projected".
         """
         query = parse(
             "SELECT SUM(x) AS total, t.bare_col FROM t",
         )
-        assert _build_cte_projection_map(query) == {"bare_col": "t.bare_col"}
+        assert _build_cte_projection_map(query) == {
+            "total": None,
+            "bare_col": "t.bare_col",
+        }
 
 
 class TestRewriteFilterForCte:
@@ -439,3 +442,156 @@ class TestRewriteFilterForCte:
             cte_query=cte_query,
         )
         assert rewritten is None
+
+    def test_falls_through_to_bare_name_when_column_pruned(self):
+        """A column that's exposed by the DJ node but pruned from the CTE's
+        SELECT still has a WHERE-safe reference — the bare column name, which
+        the underlying source table exposes.  Column pruning trims what the
+        CTE returns to the outer query, it doesn't remove the column from the
+        underlying scan.
+        """
+        cte_query = parse("SELECT hard_hat_id, hire_date FROM src")
+        rewritten = _rewrite_filter_for_cte(
+            "default.hard_hat.state = 'AZ'",
+            filter_column_aliases={"default.hard_hat.state": "state"},
+            # The node exposes `state` even though this CTE pruned it out.
+            cte_output_cols={"hard_hat_id", "hire_date", "state"},
+            cte_query=cte_query,
+        )
+        assert rewritten == "state = 'AZ'"
+
+    def test_does_not_corrupt_substring_collisions(self):
+        """A shorter dim_ref must not rewrite inside a longer similarly-prefixed
+        reference.  ``fact.orders.order_date`` is in scope; an unrelated
+        ``fact.orders.order_date_extended`` elsewhere in the filter must be
+        left untouched.
+        """
+        cte_query = parse(
+            "SELECT o.placed_on AS order_date FROM src o",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date_extended > 0 OR fact.orders.order_date < 1",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten == ("fact.orders.order_date_extended > 0 OR o.placed_on < 1")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases below document DESIRED behavior via assert_sql_equal-style
+# assertions.  Marked xfail(strict=True) so the suite stays green today but
+# a future fix that starts passing them will be noticed.  See PR description.
+# ---------------------------------------------------------------------------
+
+
+class TestPushdownEdgeCases:
+    """Edge cases in filter pushdown that are not yet fully supported."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Compound predicates with AND across two dim refs aren't fully "
+        "rewritten; the loop breaks after the first match. Upstream filter "
+        "splitting usually prevents this, but OR-combined predicates can't be "
+        "split and would hit the bug.",
+    )
+    def test_multiple_dim_refs_in_one_predicate(self):
+        """A single filter string mentioning two dim refs should rewrite both.
+
+        Today only the first match is replaced — the second dim_ref survives
+        unrewritten and the emitted SQL references a name the CTE doesn't
+        expose.
+        """
+        cte_query = parse(
+            "SELECT o.placed_on AS order_date, o.status AS state FROM src o",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date >= 20260101 OR fact.orders.state = 'OPEN'",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+                "fact.orders.state": "state",
+            },
+            cte_output_cols={"order_date", "state"},
+            cte_query=cte_query,
+        )
+        assert rewritten == ("o.placed_on >= 20260101 OR o.status = 'OPEN'")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SQL identifiers are case-insensitive for unquoted names but "
+        "the projection map and alias lookup are case-sensitive dicts. Filter "
+        "rewritten against a different-cased column name should still work.",
+    )
+    def test_case_insensitive_column_match(self):
+        """Unquoted identifiers in SQL are case-insensitive; rewrites should follow."""
+        cte_query = parse(
+            "SELECT o.placed_on AS order_date FROM src o",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.ORDER_DATE > 0",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten == "o.placed_on > 0"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="_build_cte_projection_map only inspects cte_query.select.projection "
+        "— the first arm of a UNION. If arms differ or the set operation is "
+        "non-trivial we should skip pushdown rather than push a filter only "
+        "valid for one arm.",
+    )
+    def test_union_all_cte_is_handled_safely(self):
+        """A CTE built from UNION ALL should either (a) only push the filter
+        when all arms project the column identically, or (b) skip pushdown.
+        Today we silently build a map from only the first arm.
+        """
+        cte_query = parse(
+            """
+            SELECT a.placed_on AS order_date FROM src_a a
+            UNION ALL
+            SELECT b.order_date FROM src_b b
+            """,
+        )
+        # The two arms rename differently; rewrite against "order_date" is
+        # only valid for arm B.  Desired: either skip (return None) or fail
+        # explicitly rather than emit arm-A's rewrite silently.
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date > 0",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten is None, (
+            "Expected pushdown to refuse a UNION with asymmetric arms, "
+            f"got: {rewritten!r}"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Role-suffixed dim refs on an aliased column aren't tested; "
+        "strip_role_suffix handles the dim_ref lookup but the filter string "
+        "still carries the [role] suffix into the replacement.",
+    )
+    def test_role_suffix_on_aliased_column(self):
+        """A role-suffixed dim ref targeting an aliased column should rewrite
+        to the underlying qualified reference, stripping the role."""
+        cte_query = parse(
+            "SELECT o.placed_on AS order_date FROM src o",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date[order] >= 20260101",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten == "o.placed_on >= 20260101"

--- a/datajunction-server/tests/construction/build_v3/cte_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_test.py
@@ -395,6 +395,16 @@ class TestBuildCteProjectionMap:
             "bare_col": "t.bare_col",
         }
 
+    def test_unaliased_non_column_projection_is_omitted(self):
+        """A non-column projection without an alias has no addressable output
+        name, so it's simply skipped — not added to the map."""
+        query = parse(
+            "SELECT SUM(x), t.bare_col FROM t",
+        )
+        assert _build_cte_projection_map(query) == {
+            "bare_col": "t.bare_col",
+        }
+
 
 class TestRewriteFilterForCte:
     """Tests for _rewrite_filter_for_cte."""

--- a/datajunction-server/tests/construction/build_v3/cte_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_test.py
@@ -1,6 +1,8 @@
 """Tests for cte.py - CTE building and AST transformation utilities."""
 
 from datajunction_server.construction.build_v3.cte import (
+    _build_cte_projection_map,
+    _rewrite_filter_for_cte,
     get_column_full_name,
     inject_partition_by_into_windows,
     process_metric_combiner_expression,
@@ -349,3 +351,91 @@ class TestProcessMetricCombinerExpression:
         # Function should return without error; no PARTITION BY injected
         result_sql = str(result)
         assert "PARTITION BY" not in result_sql
+
+
+class TestBuildCteProjectionMap:
+    """Tests for _build_cte_projection_map — output-name → underlying ref."""
+
+    def test_unaliased_qualified_column(self):
+        """A table-qualified column maps its bare name to the qualified form."""
+        query = parse("SELECT t.test_id FROM some.table t")
+        assert _build_cte_projection_map(query) == {"test_id": "t.test_id"}
+
+    def test_unaliased_bare_column(self):
+        """A bare column maps its name to itself."""
+        query = parse("SELECT test_id FROM some.table")
+        assert _build_cte_projection_map(query) == {"test_id": "test_id"}
+
+    def test_aliased_column_uses_alias_as_key(self):
+        """An aliased column keys by the alias; the value is the underlying ref.
+
+        This is the load-bearing case for pushing filters into CTEs whose
+        output columns rename an upstream source column — the filter must
+        reference ``o.placed_on`` (valid in WHERE) rather than the alias
+        ``order_date`` (which Spark SQL rejects).
+        """
+        query = parse(
+            "SELECT o.placed_on AS order_date FROM src o",
+        )
+        assert _build_cte_projection_map(query) == {
+            "order_date": "o.placed_on",
+        }
+
+    def test_non_column_projections_omitted(self):
+        """Function calls and other non-column projections are skipped.
+
+        Callers should treat a missing entry as "don't push this filter into
+        this CTE" so we don't inline an arbitrary expression into WHERE.
+        """
+        query = parse(
+            "SELECT SUM(x) AS total, t.bare_col FROM t",
+        )
+        assert _build_cte_projection_map(query) == {"bare_col": "t.bare_col"}
+
+
+class TestRewriteFilterForCte:
+    """Tests for _rewrite_filter_for_cte."""
+
+    def test_rewrites_alias_to_underlying_reference(self):
+        """Filter on an aliased output column is rewritten to the qualified source.
+
+        Regression: previously produced ``WHERE order_date BETWEEN ...``,
+        which Spark SQL and other engines reject because SELECT-list aliases
+        aren't visible in the same query's WHERE.
+        """
+        cte_query = parse(
+            "SELECT o.placed_on AS order_date FROM src o",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date BETWEEN 20260216 AND 20260402",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten == "o.placed_on BETWEEN 20260216 AND 20260402"
+
+    def test_skips_non_column_projection(self):
+        """Pushdown is skipped when the target column is projected via a function."""
+        cte_query = parse(
+            "SELECT SUM(x) AS total FROM t",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "v3.metric.total > 0",
+            filter_column_aliases={"v3.metric.total": "total"},
+            cte_output_cols={"total"},
+            cte_query=cte_query,
+        )
+        assert rewritten is None
+
+    def test_returns_none_when_column_absent(self):
+        """Filter targeting a column the CTE doesn't output returns None."""
+        cte_query = parse("SELECT foo FROM t")
+        rewritten = _rewrite_filter_for_cte(
+            "v3.dim.bar = 'x'",
+            filter_column_aliases={"v3.dim.bar": "bar"},
+            cte_output_cols={"foo"},
+            cte_query=cte_query,
+        )
+        assert rewritten is None


### PR DESCRIPTION
### Summary

When a CTE aliased an upstream column (e.g. `SELECT o.placed_on AS order_date`) and a dimension filter referenced that output name, pushdown inserted the alias into the CTE's WHERE clause. Most SQL engines reject this because select aliases aren't visible in the same query's where clause, so the generated SQL failed at execution.

This PR changes it so that pushdown now rewrites to the underlying qualified reference (e.g. `o.placed_on`), and skips entirely when the projection is a non-column expression (e.g. `SUM(x) AS y`) that can't be safely inlined into WHERE (the filter stays on the outer query in that case).

* Before: `WHERE order_date BETWEEN 20260216 AND 20260402`
* After: `WHERE o.placed_on BETWEEN 20260216 AND 20260402`

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
