### PR TITLE
Filter pushdown should work with multi-ref filters

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -4,7 +4,6 @@ CTE building and AST transformation utilities
 
 from __future__ import annotations
 
-import re
 from copy import deepcopy
 from typing import Optional
 
@@ -951,7 +950,7 @@ def _resolve_pushdown_filters_for_cte(
         )
         if rewritten is None:
             continue
-        results.append(parse_filter(rewritten))
+        results.append(rewritten)
     return results
 
 
@@ -965,16 +964,39 @@ def _cte_has_set_operation(cte_query: ast.Query) -> bool:
     return bool(cte_query.select and cte_query.select.set_op)
 
 
-def _dim_ref_pattern(dim_ref: str) -> str:
-    """Word-boundary-safe regex for a dim ref.
+def _build_name(parts: list[str]) -> ast.Name:
+    """Build a nested ``ast.Name`` matching a dotted reference.
 
-    Prevents a shorter dim_ref from matching inside a longer similarly-prefixed
-    one (e.g. ``fact.orders.order_date`` must not match
-    ``fact.orders.order_date_extended``).  SQL identifier chars are ASCII
-    alnum + underscore; dots and brackets terminate identifiers so we guard
-    against alnum/underscore on either side only.
+    ``["o", "order_date"]`` becomes ``Name("order_date", namespace=Name("o"))``
+    which serializes as ``o.order_date``.
     """
-    return r"(?<![A-Za-z0-9_])" + re.escape(dim_ref) + r"(?![A-Za-z0-9_])"
+    if len(parts) == 1:
+        return ast.Name(parts[0])
+    return ast.Name(parts[-1], namespace=_build_name(parts[:-1]))
+
+
+def _column_from_qualified(qualified: str) -> ast.Column:
+    """Build an ``ast.Column`` node from a dotted reference like ``o.order_date``."""
+    return ast.Column(name=_build_name(qualified.split(SEPARATOR)))
+
+
+def _resolve_pushdown_form(
+    output_col: str,
+    cte_output_cols: set[str],
+    projection_map: dict[str, str | None],
+) -> str | None:
+    """Determine the WHERE-safe form for a filter column in a specific CTE.
+
+    Returns the WHERE-safe reference as a string (qualified or bare), or
+    ``None`` when the filter cannot be safely pushed into this CTE — either
+    because the column isn't exposed at all, or because the projection is a
+    non-column expression that can't be inlined into WHERE.
+    """
+    if output_col not in cte_output_cols:
+        return None
+    if output_col in projection_map:
+        return projection_map[output_col]  # may be None: unsafe projection
+    return output_col  # pruned from CTE SELECT; falls through to bare name
 
 
 def _rewrite_filter_for_cte(
@@ -982,7 +1004,7 @@ def _rewrite_filter_for_cte(
     filter_column_aliases: dict[str, str],
     cte_output_cols: set[str],
     cte_query: ast.Query,
-) -> str | None:
+) -> ast.Expression | None:
     """Rewrite a dimension filter for injection into a specific CTE.
 
     Resolves each dimension reference (e.g., ``v3.product.category``) to the
@@ -1003,7 +1025,7 @@ def _rewrite_filter_for_cte(
     ref's column isn't exposed by this CTE, the whole filter is skipped —
     pushing a partial OR-predicate into the wrong CTE produces invalid SQL.
 
-    Returns the rewritten filter string, or None when the filter can't be
+    Returns the rewritten filter AST, or None when the filter can't be
     safely pushed into this CTE.
     """
     # Set-operation CTEs can't be safely pushed into via the first arm alone.
@@ -1011,44 +1033,62 @@ def _rewrite_filter_for_cte(
         return None
 
     projection_map = _build_cte_projection_map(cte_query)
-    sorted_aliases = sorted(
-        filter_column_aliases.items(),
-        key=lambda x: -len(x[0]),
-    )
+    filter_ast = parse_filter(filter_str)
 
-    # First pass: find every dim ref that appears in the filter and determine
-    # its CTE-local rewrite.  ``working`` masks already-matched regions so a
-    # bare alias (e.g. ``a.b.c``) can't double-match inside a longer
-    # role-suffixed form (``a.b.c[role]``) we already matched.
-    working = filter_str
-    matches: list[tuple[str, str]] = []
-    for dim_ref, output_col in sorted_aliases:
-        pattern = _dim_ref_pattern(dim_ref)
-        if not re.search(pattern, working):
+    # First pass: plan the rewrites by walking the AST.  Role-qualified refs
+    # appear as Subscript(Column(base), Column/Lambda(role)) and are handled
+    # whole; plain Column refs are handled individually.  Collect rewrites
+    # into buffers so we can bail out atomically if any ref can't be pushed.
+    subscript_rewrites: list[tuple[ast.Subscript, ast.Column]] = []
+    column_rewrites: list[tuple[ast.Column, ast.Column]] = []
+    # Columns that are children of a rewritten Subscript — exclude from the
+    # plain-Column pass so we don't double-process them.
+    handled_col_ids: set[int] = set()
+
+    for subscript in filter_ast.find_all(ast.Subscript):
+        if not isinstance(subscript.expr, ast.Column):
+            continue  # pragma: no cover
+        base = get_column_full_name(subscript.expr)
+        role = extract_subscript_role(subscript)
+        if not role:
+            continue  # pragma: no cover
+        full_name = f"{base}[{role}]"
+        output_col = filter_column_aliases.get(
+            full_name,
+        ) or filter_column_aliases.get(base)
+        if output_col is None:
             continue
-        if output_col not in cte_output_cols:
-            # Filter references a column this CTE doesn't expose — pushing a
-            # partial rewrite would leave an unresolved name behind and break
-            # the SQL.  Leave the whole filter on the outer query.
+        form = _resolve_pushdown_form(output_col, cte_output_cols, projection_map)
+        if form is None:
             return None
-        if output_col in projection_map:
-            qualified = projection_map[output_col]
-            if qualified is None:
-                # Non-column projection; inlining into WHERE is semantically wrong.
-                return None
-        else:
-            qualified = output_col
-        matches.append((dim_ref, qualified))
-        working = re.sub(pattern, "\x00", working)
+        replacement = _column_from_qualified(form)
+        subscript_rewrites.append((subscript, replacement))
+        handled_col_ids.add(id(subscript.expr))
+        if isinstance(subscript.index, ast.Column):
+            handled_col_ids.add(id(subscript.index))
 
-    if not matches:
+    for col in filter_ast.find_all(ast.Column):
+        if id(col) in handled_col_ids:
+            continue
+        full_name = get_column_full_name(col)
+        if not full_name or full_name not in filter_column_aliases:
+            continue
+        output_col = filter_column_aliases[full_name]
+        form = _resolve_pushdown_form(output_col, cte_output_cols, projection_map)
+        if form is None:
+            return None
+        column_rewrites.append((col, _column_from_qualified(form)))
+
+    if not subscript_rewrites and not column_rewrites:
         return None
 
-    # Second pass: apply replacements to the original filter string.
-    rewritten = filter_str
-    for dim_ref, qualified in matches:
-        rewritten = re.sub(_dim_ref_pattern(dim_ref), qualified, rewritten)
-    return rewritten
+    # Second pass: apply.  Safe to mutate now that every ref has been validated.
+    for subscript, replacement in subscript_rewrites:
+        subscript.swap(replacement)
+    for col, replacement in column_rewrites:
+        col.swap(replacement)
+
+    return filter_ast
 
 
 def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str | None]:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -955,6 +955,28 @@ def _resolve_pushdown_filters_for_cte(
     return results
 
 
+def _cte_has_set_operation(cte_query: ast.Query) -> bool:
+    """Detect whether the CTE body is a UNION / INTERSECT / EXCEPT.
+
+    Projection inspection only sees the first arm, so a set operation with
+    asymmetric arms can't be safely pushed into.  Callers should skip
+    pushdown when this returns True.
+    """
+    return bool(cte_query.select and cte_query.select.set_op)
+
+
+def _dim_ref_pattern(dim_ref: str) -> str:
+    """Word-boundary-safe regex for a dim ref.
+
+    Prevents a shorter dim_ref from matching inside a longer similarly-prefixed
+    one (e.g. ``fact.orders.order_date`` must not match
+    ``fact.orders.order_date_extended``).  SQL identifier chars are ASCII
+    alnum + underscore; dots and brackets terminate identifiers so we guard
+    against alnum/underscore on either side only.
+    """
+    return r"(?<![A-Za-z0-9_])" + re.escape(dim_ref) + r"(?![A-Za-z0-9_])"
+
+
 def _rewrite_filter_for_cte(
     filter_str: str,
     filter_column_aliases: dict[str, str],
@@ -964,7 +986,7 @@ def _rewrite_filter_for_cte(
     """Rewrite a dimension filter for injection into a specific CTE.
 
     Resolves each dimension reference (e.g., ``v3.product.category``) to the
-    form that's safe in the CTE's WHERE clause.  Three cases:
+    form that's safe in the CTE's WHERE clause.  Three projection cases:
 
     1. CTE projects the column as a simple (possibly aliased) column: replace
        with the underlying qualified form (e.g., ``p.category``).  This is the
@@ -976,40 +998,57 @@ def _rewrite_filter_for_cte(
     3. CTE projects the column via a non-column expression (e.g.
        ``SUM(x) AS y``): skip — inlining is unsafe.
 
-    Returns the rewritten filter string, or None if no dim_ref applies.
-    """
-    projection_map = _build_cte_projection_map(cte_query)
+    Multi-predicate handling: a single filter may reference several dim refs
+    (``a.x = 1 OR b.y = 2``).  All matching refs are rewritten, but if ANY
+    ref's column isn't exposed by this CTE, the whole filter is skipped —
+    pushing a partial OR-predicate into the wrong CTE produces invalid SQL.
 
-    rewritten = filter_str
-    matched = False
-    for dim_ref, output_col in sorted(
+    Returns the rewritten filter string, or None when the filter can't be
+    safely pushed into this CTE.
+    """
+    # Set-operation CTEs can't be safely pushed into via the first arm alone.
+    if _cte_has_set_operation(cte_query):
+        return None
+
+    projection_map = _build_cte_projection_map(cte_query)
+    sorted_aliases = sorted(
         filter_column_aliases.items(),
         key=lambda x: -len(x[0]),
-    ):
-        if dim_ref not in rewritten:
+    )
+
+    # First pass: find every dim ref that appears in the filter and determine
+    # its CTE-local rewrite.  ``working`` masks already-matched regions so a
+    # bare alias (e.g. ``a.b.c``) can't double-match inside a longer
+    # role-suffixed form (``a.b.c[role]``) we already matched.
+    working = filter_str
+    matches: list[tuple[str, str]] = []
+    for dim_ref, output_col in sorted_aliases:
+        pattern = _dim_ref_pattern(dim_ref)
+        if not re.search(pattern, working):
             continue
         if output_col not in cte_output_cols:
-            continue
+            # Filter references a column this CTE doesn't expose — pushing a
+            # partial rewrite would leave an unresolved name behind and break
+            # the SQL.  Leave the whole filter on the outer query.
+            return None
         if output_col in projection_map:
             qualified = projection_map[output_col]
             if qualified is None:
-                # Non-column expression under this alias — unsafe to inline.
-                continue
+                # Non-column projection; inlining into WHERE is semantically wrong.
+                return None
         else:
-            # Column pruned from the CTE's SELECT; fall through to the bare
-            # name, which the underlying source still exposes.
             qualified = output_col
-        # Word-boundary-safe replacement so a shorter dim_ref doesn't clobber
-        # a longer similarly-prefixed one (e.g. ``fact.orders.order_date`` must
-        # not match ``fact.orders.order_date_extended``).  SQL identifier chars
-        # are ASCII word chars plus underscore; dots terminate identifiers so
-        # we only guard against alnum/underscore on either side.
-        pattern = r"(?<![A-Za-z0-9_])" + re.escape(dim_ref) + r"(?![A-Za-z0-9_])"
-        rewritten = re.sub(pattern, qualified, rewritten)
-        matched = True
-        break  # One dim ref per filter (filters are single predicates)
+        matches.append((dim_ref, qualified))
+        working = re.sub(pattern, "\x00", working)
 
-    return rewritten if matched else None
+    if not matches:
+        return None
+
+    # Second pass: apply replacements to the original filter string.
+    rewritten = filter_str
+    for dim_ref, qualified in matches:
+        rewritten = re.sub(_dim_ref_pattern(dim_ref), qualified, rewritten)
+    return rewritten
 
 
 def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str | None]:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1045,29 +1045,48 @@ def _rewrite_filter_for_cte(
     # plain-Column pass so we don't double-process them.
     handled_col_ids: set[int] = set()
 
+    # Users can write filters like v3.date.date_id[order] >= 20240101 where
+    # [order] is a role, a disambiguator when the same dimension is linked to
+    # the fact multiple times. A filter like that would be stored in the AST as:
+    #   BinaryOp(
+    #     >=,
+    #     Subscript(
+    #       expr=Column("v3.date.date_id"),
+    #       index=Column("order"),
+    #     ),
+    #     Literal(20240101),
+    #  )
     for subscript in filter_ast.find_all(ast.Subscript):
+        # Skip ones whose target isn't a Column as these are real SQL array subscripts, not role refs
         if not isinstance(subscript.expr, ast.Column):
             continue  # pragma: no cover
+        # Reconstruct the original role-qualified form: base = "v3.date.date_id", role = "order"
         base = get_column_full_name(subscript.expr)
         role = extract_subscript_role(subscript)
         if not role:
             continue  # pragma: no cover
         full_name = f"{base}[{role}]"
+
+        # Look up in the filter alias map. Prefers the role-specific key over the fallback.
         output_col = filter_column_aliases.get(
             full_name,
         ) or filter_column_aliases.get(base)
         if output_col is None:
-            continue
+            continue  # pragma: no cover
         form = _resolve_pushdown_form(output_col, cte_output_cols, projection_map)
         if form is None:
             return None
         replacement = _column_from_qualified(form)
         subscript_rewrites.append((subscript, replacement))
+
+        # Safety checks and queue for subscript to column swap
         handled_col_ids.add(id(subscript.expr))
         if isinstance(subscript.index, ast.Column):
             handled_col_ids.add(id(subscript.index))
 
+    # Handle dim refs that don't have a role qualifier
     for col in filter_ast.find_all(ast.Column):
+        # Skip columns accounted for in the subscript pass
         if id(col) in handled_col_ids:
             continue
         full_name = get_column_full_name(col)

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -39,7 +39,13 @@ def parse_dimension_ref(dim_ref: str) -> DimensionRef:
     - "v3.customer.name" -> node=v3.customer, col=name, role=None
     - "v3.customer.name[order]" -> node=v3.customer, col=name, role=order
     - "v3.date.month[customer->registration]" -> node=v3.date, col=month, role=customer->registration
+
+    A reference without an extractable node (e.g. a bare ``status``) is
+    rejected — DJ can't route the reference to a CTE without knowing the
+    owning node.
     """
+    from datajunction_server.errors import DJInvalidInputException
+
     # Extract role if present
     role = None
     if "[" in dim_ref:
@@ -50,12 +56,13 @@ def parse_dimension_ref(dim_ref: str) -> DimensionRef:
 
     # Split into node and column
     parts = dim_part.rsplit(SEPARATOR, 1)
-    if len(parts) == 2:
-        node_name, column_name = parts
-    else:  # pragma: no cover
-        # Assume single part is column name on current node
-        node_name = ""
-        column_name = parts[0]
+    if len(parts) != 2:
+        raise DJInvalidInputException(
+            f"Reference `{dim_ref}` is not fully qualified. Use the "
+            f"`node.column` form (e.g., `v3.order_details.status`) so DJ "
+            f"can route the reference to the correct node.",
+        )
+    node_name, column_name = parts
 
     return DimensionRef(node_name=node_name, column_name=column_name, role=role)
 

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -332,6 +332,12 @@ def add_dimensions_from_filters(ctx: "BuildContext") -> None:
         # so we don't also add the role-less version in the Column pass below.
         subscript_handled_refs: set[str] = set()
 
+        # Role markers inside subscripts are parsed as Column nodes (e.g. the
+        # `to` in `v3.location.country[to]`) but are not real filter column
+        # references — identify them so the second pass doesn't treat them
+        # as bare column refs and reject them.
+        role_marker_ids: set[int] = set()
+
         # First pass: handle Subscript nodes for role-qualified dimension refs.
         # SQL like "v3.location.country[customer->home]" is parsed as
         # Subscript(Column(v3.location.country), Lambda(customer->home)).
@@ -351,6 +357,17 @@ def add_dimensions_from_filters(ctx: "BuildContext") -> None:
 
             # Mark this base ref as handled so the Column pass skips it
             subscript_handled_refs.add(base_col_ref)
+
+            # Mark any Column nodes used as the role marker so we don't raise
+            # on them as bare refs.
+            if isinstance(subscript.index, ast.Column):
+                role_marker_ids.add(id(subscript.index))
+            for inner_col in (
+                subscript.index.find_all(ast.Column)
+                if hasattr(subscript.index, "find_all")
+                else []
+            ):
+                role_marker_ids.add(id(inner_col))
 
             if full_name in existing_dims:
                 continue
@@ -382,10 +399,13 @@ def add_dimensions_from_filters(ctx: "BuildContext") -> None:
         # Second pass: handle regular Column references.
         # Skip columns that were already added via the subscript pass above.
         for col in filter_ast.find_all(ast.Column):
-            full_name = get_column_full_name(col)
-            if not full_name or SEPARATOR not in full_name:
-                # Simple column name (e.g., "status") - will be resolved from parent node
+            # Role markers inside subscripts (e.g. `to` in `dim.col[to]`) are
+            # parsed as Columns but don't refer to real data columns.
+            if id(col) in role_marker_ids:
                 continue
+            full_name = get_column_full_name(col)
+            if not full_name:
+                continue  # pragma: no cover
 
             # Skip if already handled as a role-qualified subscript ref
             if full_name in subscript_handled_refs:

--- a/datajunction-server/tests/construction/build_v3/cte_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_test.py
@@ -427,7 +427,7 @@ class TestRewriteFilterForCte:
             cte_output_cols={"order_date"},
             cte_query=cte_query,
         )
-        assert rewritten == "o.placed_on BETWEEN 20260216 AND 20260402"
+        assert str(rewritten) == "o.placed_on BETWEEN 20260216 AND 20260402"
 
     def test_skips_non_column_projection(self):
         """Pushdown is skipped when the target column is projected via a function."""
@@ -468,7 +468,7 @@ class TestRewriteFilterForCte:
             cte_output_cols={"hard_hat_id", "hire_date", "state"},
             cte_query=cte_query,
         )
-        assert rewritten == "state = 'AZ'"
+        assert str(rewritten) == "state = 'AZ'"
 
     def test_does_not_corrupt_substring_collisions(self):
         """A shorter dim_ref must not rewrite inside a longer similarly-prefixed
@@ -487,7 +487,9 @@ class TestRewriteFilterForCte:
             cte_output_cols={"order_date"},
             cte_query=cte_query,
         )
-        assert rewritten == ("fact.orders.order_date_extended > 0 OR o.placed_on < 1")
+        assert str(rewritten) == (
+            "fact.orders.order_date_extended > 0 OR o.placed_on < 1"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -515,7 +517,7 @@ class TestPushdownEdgeCases:
             cte_output_cols={"order_date", "state"},
             cte_query=cte_query,
         )
-        assert rewritten == ("o.placed_on >= 20260101 OR o.status = 'OPEN'")
+        assert str(rewritten) == ("o.placed_on >= 20260101 OR o.status = 'OPEN'")
 
     def test_multiple_dim_refs_crossing_ctes_skip_entirely(self):
         """If an OR-combined predicate references a column this CTE doesn't
@@ -582,7 +584,7 @@ class TestPushdownEdgeCases:
             cte_output_cols={"order_date"},
             cte_query=cte_query,
         )
-        assert rewritten == "o.placed_on >= 20260101"
+        assert str(rewritten) == "o.placed_on >= 20260101"
 
     @pytest.mark.xfail(
         strict=True,
@@ -604,4 +606,4 @@ class TestPushdownEdgeCases:
             cte_output_cols={"order_date"},
             cte_query=cte_query,
         )
-        assert rewritten == "o.placed_on > 0"
+        assert str(rewritten) == "o.placed_on > 0"

--- a/datajunction-server/tests/construction/build_v3/cte_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_test.py
@@ -491,28 +491,17 @@ class TestRewriteFilterForCte:
 
 
 # ---------------------------------------------------------------------------
-# Edge cases below document DESIRED behavior via assert_sql_equal-style
-# assertions.  Marked xfail(strict=True) so the suite stays green today but
-# a future fix that starts passing them will be noticed.  See PR description.
+# Pushdown edge cases.  Kept-xfail entries document desired behavior for
+# future work; non-xfail entries assert currently-supported behavior.
 # ---------------------------------------------------------------------------
 
 
 class TestPushdownEdgeCases:
-    """Edge cases in filter pushdown that are not yet fully supported."""
+    """Edge cases in filter pushdown."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Compound predicates with AND across two dim refs aren't fully "
-        "rewritten; the loop breaks after the first match. Upstream filter "
-        "splitting usually prevents this, but OR-combined predicates can't be "
-        "split and would hit the bug.",
-    )
-    def test_multiple_dim_refs_in_one_predicate(self):
-        """A single filter string mentioning two dim refs should rewrite both.
-
-        Today only the first match is replaced — the second dim_ref survives
-        unrewritten and the emitted SQL references a name the CTE doesn't
-        expose.
+    def test_multiple_dim_refs_in_one_predicate_same_cte(self):
+        """A single filter referencing two dim refs both exposed by this CTE
+        rewrites both — we don't stop after the first match.
         """
         cte_query = parse(
             "SELECT o.placed_on AS order_date, o.status AS state FROM src o",
@@ -528,11 +517,79 @@ class TestPushdownEdgeCases:
         )
         assert rewritten == ("o.placed_on >= 20260101 OR o.status = 'OPEN'")
 
+    def test_multiple_dim_refs_crossing_ctes_skip_entirely(self):
+        """If an OR-combined predicate references a column this CTE doesn't
+        expose, the whole filter must stay on the outer query.  A partial
+        rewrite would leave an unresolved dim_ref inside the CTE and
+        produce invalid SQL.
+        """
+        cte_query = parse(
+            "SELECT o.placed_on AS order_date FROM src o",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date >= 20260101 OR fact.products.category = 'X'",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+                "fact.products.category": "category",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten is None
+
+    def test_union_all_cte_is_handled_safely(self):
+        """A CTE whose body is a UNION / UNION ALL has arms whose projections
+        may differ; ``_build_cte_projection_map`` only inspects the first.
+        Skip pushdown entirely for these rather than emit a rewrite valid
+        for only one arm.
+        """
+        cte_query = parse(
+            """
+            SELECT a.placed_on AS order_date FROM src_a a
+            UNION ALL
+            SELECT b.order_date FROM src_b b
+            """,
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date > 0",
+            filter_column_aliases={
+                "fact.orders.order_date": "order_date",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten is None
+
+    def test_role_suffix_on_aliased_column(self):
+        """A role-suffixed dim ref targeting an aliased column rewrites to
+        the underlying qualified reference and the role suffix is consumed
+        with the rest of the matched dim_ref.
+
+        Upstream ``_build_filter_column_aliases`` populates both the
+        role-suffixed key and a bare fallback; longest-first iteration
+        ensures the role-suffixed form is matched wholesale and replaced
+        before the bare key gets a chance.
+        """
+        cte_query = parse(
+            "SELECT o.placed_on AS order_date FROM src o",
+        )
+        rewritten = _rewrite_filter_for_cte(
+            "fact.orders.order_date[order] >= 20260101",
+            filter_column_aliases={
+                "fact.orders.order_date[order]": "order_date",
+                "fact.orders.order_date": "order_date",
+            },
+            cte_output_cols={"order_date"},
+            cte_query=cte_query,
+        )
+        assert rewritten == "o.placed_on >= 20260101"
+
     @pytest.mark.xfail(
         strict=True,
         reason="SQL identifiers are case-insensitive for unquoted names but "
-        "the projection map and alias lookup are case-sensitive dicts. Filter "
-        "rewritten against a different-cased column name should still work.",
+        "the projection map and alias lookup are case-sensitive dicts. "
+        "Filter rewritten against a different-cased column name should still "
+        "work but doesn't today.",
     )
     def test_case_insensitive_column_match(self):
         """Unquoted identifiers in SQL are case-insensitive; rewrites should follow."""
@@ -548,60 +605,3 @@ class TestPushdownEdgeCases:
             cte_query=cte_query,
         )
         assert rewritten == "o.placed_on > 0"
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason="_build_cte_projection_map only inspects cte_query.select.projection "
-        "— the first arm of a UNION. If arms differ or the set operation is "
-        "non-trivial we should skip pushdown rather than push a filter only "
-        "valid for one arm.",
-    )
-    def test_union_all_cte_is_handled_safely(self):
-        """A CTE built from UNION ALL should either (a) only push the filter
-        when all arms project the column identically, or (b) skip pushdown.
-        Today we silently build a map from only the first arm.
-        """
-        cte_query = parse(
-            """
-            SELECT a.placed_on AS order_date FROM src_a a
-            UNION ALL
-            SELECT b.order_date FROM src_b b
-            """,
-        )
-        # The two arms rename differently; rewrite against "order_date" is
-        # only valid for arm B.  Desired: either skip (return None) or fail
-        # explicitly rather than emit arm-A's rewrite silently.
-        rewritten = _rewrite_filter_for_cte(
-            "fact.orders.order_date > 0",
-            filter_column_aliases={
-                "fact.orders.order_date": "order_date",
-            },
-            cte_output_cols={"order_date"},
-            cte_query=cte_query,
-        )
-        assert rewritten is None, (
-            "Expected pushdown to refuse a UNION with asymmetric arms, "
-            f"got: {rewritten!r}"
-        )
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Role-suffixed dim refs on an aliased column aren't tested; "
-        "strip_role_suffix handles the dim_ref lookup but the filter string "
-        "still carries the [role] suffix into the replacement.",
-    )
-    def test_role_suffix_on_aliased_column(self):
-        """A role-suffixed dim ref targeting an aliased column should rewrite
-        to the underlying qualified reference, stripping the role."""
-        cte_query = parse(
-            "SELECT o.placed_on AS order_date FROM src o",
-        )
-        rewritten = _rewrite_filter_for_cte(
-            "fact.orders.order_date[order] >= 20260101",
-            filter_column_aliases={
-                "fact.orders.order_date": "order_date",
-            },
-            cte_output_cols={"order_date"},
-            cte_query=cte_query,
-        )
-        assert rewritten == "o.placed_on >= 20260101"

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -152,6 +152,102 @@ class TestFilterPushdownMultiple:
         )
 
 
+class TestFilterPushdownMultiRef:
+    """A single filter predicate can reference multiple dim refs (OR-combined)."""
+
+    @pytest.mark.asyncio
+    async def test_or_predicate_both_refs_in_same_cte_pushed_down(
+        self,
+        client_with_build_v3,
+    ):
+        """OR-combined refs that both resolve to the same CTE push down as
+        one predicate.  ``order_date`` is projected (needed for the outer
+        qualified reference) and uses the qualified ``o.order_date`` form in
+        WHERE; ``status`` is pruned from the projection but still filterable
+        via the bare column name on the underlying source.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": [
+                    "v3.date.date_id[order] >= 20240101 OR status = 'completed'",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT o.order_date,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              WHERE o.order_date >= 20240101 OR status = 'completed'
+            ),
+            v3_product AS (
+              SELECT product_id, category
+              FROM default.v3.products
+            )
+            SELECT t2.category,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            WHERE t1.order_date >= 20240101 OR t1.status = 'completed'
+            GROUP BY t2.category
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_or_predicate_crossing_ctes_stays_on_outer_query(
+        self,
+        client_with_build_v3,
+    ):
+        """An OR that mixes columns from different CTEs must not push into
+        either CTE — a partial rewrite would reference an unresolved name
+        inside a CTE.  The whole predicate stays on the outer WHERE.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": [
+                    "v3.product.category = 'Electronics' "
+                    "OR v3.date.date_id[order] >= 20240101",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT o.order_date,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT product_id, category
+              FROM default.v3.products
+            )
+            SELECT t2.category,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            WHERE t2.category = 'Electronics' OR t1.order_date >= 20240101
+            GROUP BY t2.category
+            """,
+        )
+
+
 class TestFilterPushdownEdgeCases:
     """Edge cases for filter pushdown."""
 

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -161,10 +161,9 @@ class TestFilterPushdownMultiRef:
         client_with_build_v3,
     ):
         """OR-combined refs that both resolve to the same CTE push down as
-        one predicate.  ``order_date`` is projected (needed for the outer
-        qualified reference) and uses the qualified ``o.order_date`` form in
-        WHERE; ``status`` is pruned from the projection but still filterable
-        via the bare column name on the underlying source.
+        one predicate.  Both refs are fully qualified — bare column refs in
+        filters are ambiguous across multi-parent builds and aren't a
+        supported input shape.
         """
         response = await client_with_build_v3.get(
             "/sql/measures/v3/",
@@ -172,7 +171,8 @@ class TestFilterPushdownMultiRef:
                 "metrics": ["v3.total_revenue"],
                 "dimensions": ["v3.product.category"],
                 "filters": [
-                    "v3.date.date_id[order] >= 20240101 OR status = 'completed'",
+                    "v3.date.date_id[order] >= 20240101 "
+                    "OR v3.order_details.status = 'completed'",
                 ],
             },
         )
@@ -183,11 +183,12 @@ class TestFilterPushdownMultiRef:
             WITH
             v3_order_details AS (
               SELECT o.order_date,
+                o.status,
                 oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-              WHERE o.order_date >= 20240101 OR status = 'completed'
+              WHERE o.order_date >= 20240101 OR o.status = 'completed'
             ),
             v3_product AS (
               SELECT product_id, category

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -2,6 +2,10 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from datajunction_server.errors import DJInvalidInputException
+
 from datajunction_server.construction.build_v3.cte import (
     filter_cte_projection,
     flatten_inner_ctes,
@@ -92,12 +96,12 @@ class TestDimensionRefParsing:
         assert ref.column_name == "country"
         assert ref.role == "customer->home"
 
-    def test_dimension_ref_just_column_name(self):
-        """Test parsing a bare column name (no node prefix)."""
-        ref = parse_dimension_ref("status")
-        assert ref.node_name == ""
-        assert ref.column_name == "status"
-        assert ref.role is None
+    def test_dimension_ref_just_column_name_raises(self):
+        """A bare reference with no node prefix can't be routed to a CTE;
+        ``parse_dimension_ref`` rejects it rather than returning a DimensionRef
+        with an empty ``node_name`` that would silently match the wrong node."""
+        with pytest.raises(DJInvalidInputException, match="not fully qualified"):
+            parse_dimension_ref("status")
 
 
 class TestMakeColumnRef:

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -2356,7 +2356,7 @@ class TestMeasuresSQLFilters:
             params={
                 "metrics": ["v3.total_revenue"],
                 "dimensions": ["v3.order_details.status"],
-                "filters": ["status = 'completed'"],
+                "filters": ["v3.order_details.status = 'completed'"],
             },
         )
 
@@ -2498,7 +2498,7 @@ class TestMeasuresSQLFilters:
             params={
                 "metrics": ["v3.total_revenue"],
                 "dimensions": ["v3.order_details.status"],
-                "filters": ["status IN ('completed', 'pending')"],
+                "filters": ["v3.order_details.status IN ('completed', 'pending')"],
             },
         )
 


### PR DESCRIPTION
### Summary

Builds on the earlier alias/substring fixes. Three correctness changes plus one refactor:
- Multi-reference predicates rewrite fully. Filters like `a.x = 1 OR b.y = 2` now rewrite every matching dim ref instead of stopping after the first. If any ref resolves to a column the target CTE doesn't expose, the whole filter stays on the outer query rather than pushing a partial rewrite with an unresolved name behind.
- Set-operation CTE bodies refuse pushdown. Transforms whose body is `UNION`/`INTERSECT`/`EXCEPT` have per-arm projections that can differ, and `_inject_filter_into_where` only mutates the first arm's WHERE. Pushing would under-filter the other arms.
- Bare column refs in filters now raise. parse_dimension_ref rejects references without a node prefix (e.g., `status = 'X'`) with a clear error directing the user to the fully-qualified form (`v3.order_details.status = 'X'`). Before, bare refs were silently routed to whichever parent node happened to expose a matching column, which is ambiguous in multi-parent builds.

The rewriter itself moved from regex substitution to a two-pass AST walk that swaps `Subscript` and `Column` nodes, then serializes once. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
