### PR TITLE
Add tests for v3 SQL generation edge cases

### DIFF
--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -4150,6 +4150,39 @@ class TestValidateNodes:
             }
         ]
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="DJ's synchronous node-create path (validate_node_data in "
+        "internal/validation.py) silently accepts transforms with duplicate "
+        "output aliases; the deployment validator would reject the same ",
+    )
+    @pytest.mark.asyncio
+    async def test_transform_with_duplicate_output_aliases(
+        self,
+        client_with_roads: AsyncClient,
+    ) -> None:
+        """A transform query that projects two columns under the same output
+        alias is a SQL anti-pattern; node creation should reject it so the
+        bad spec never reaches downstream deploys.
+        """
+        resp = await client_with_roads.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.ambiguous_alias",
+                "description": "Two output columns sharing alias 'dup'.",
+                "query": """
+                    SELECT
+                        ro.repair_order_id,
+                        ro.dispatcher_id AS dup,
+                        ro.hard_hat_id AS dup
+                    FROM default.repair_orders ro
+                """,
+                "mode": "published",
+                "primary_key": ["repair_order_id"],
+            },
+        )
+        assert resp.status_code in (400, 422), resp.json()
+
     @pytest.mark.asyncio
     async def test_validating_invalid_sql(self, client: AsyncClient) -> None:
         """

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -151,6 +151,53 @@ class TestFilterPushdownMultiple:
             """,
         )
 
+    @pytest.mark.asyncio
+    async def test_two_filters_on_same_parent_cte_compose_as_and(
+        self,
+        client_with_build_v3,
+    ):
+        """Two user filters on distinct columns of the same parent compose
+        as AND in both the CTE's WHERE and the outer WHERE — no duplicates,
+        no dropped predicate.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": [
+                    "v3.date.date_id[order] >= 20240101",
+                    "v3.order_details.status = 'completed'",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT o.order_date,
+                o.status,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              WHERE o.order_date >= 20240101 AND o.status = 'completed'
+            ),
+            v3_product AS (
+              SELECT product_id, category
+              FROM default.v3.products
+            )
+            SELECT t2.category,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            WHERE t1.order_date >= 20240101 AND t1.status = 'completed'
+            GROUP BY t2.category
+            """,
+        )
+
 
 class TestFilterPushdownMultiRef:
     """A single filter predicate can reference multiple dim refs (OR-combined)."""

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -569,6 +569,46 @@ class TestDimensionJoins:
             "v3.location.country[customer->home]",
         ]
 
+    @pytest.mark.asyncio
+    async def test_dim_link_with_coalesce_in_join_sql(
+        self,
+        client_with_build_v3,
+    ):
+        """A dimension link whose ``join_sql`` uses ``COALESCE`` over two
+        fact columns should keep both FK columns in the parent CTE's
+        projection so the JOIN clause can reference them at the outer
+        level.  Documents whether DJ supports non-column expressions in
+        dim-link join_sql.
+        """
+        resp = await client_with_build_v3.post(
+            "/nodes/v3.order_details/link",
+            json={
+                "dimension_node": "v3.location",
+                "join_on": (
+                    "COALESCE(v3.order_details.from_location_id, "
+                    "v3.order_details.to_location_id) = v3.location.location_id"
+                ),
+                "role": "either",
+            },
+        )
+        if resp.status_code not in (200, 201):
+            pytest.skip(
+                f"COALESCE in dim-link join_sql not supported: {resp.json()}",
+            )
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.location.country[either]"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+        # Both referenced FK columns must be present so the JOIN's COALESCE
+        # can evaluate against them.
+        assert "from_location_id" in data["sql"]
+        assert "to_location_id" in data["sql"]
+
 
 class TestMeasuresSQLRoles:
     @pytest.mark.asyncio

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -603,11 +603,28 @@ class TestDimensionJoins:
             },
         )
         assert response.status_code == 200, response.json()
-        data = get_first_grain_group(response.json())
-        # Both referenced FK columns must be present so the JOIN's COALESCE
-        # can evaluate against them.
-        assert "from_location_id" in data["sql"]
-        assert "to_location_id" in data["sql"]
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_location AS (
+              SELECT location_id, country FROM default.v3.locations
+            ),
+            v3_order_details AS (
+              SELECT o.from_location_id,
+                o.to_location_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t2.country country_either,
+              SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_location t2
+              ON COALESCE(t1.from_location_id, t1.to_location_id) = t2.location_id
+            GROUP BY t2.country
+            """,
+        )
 
 
 class TestMeasuresSQLRoles:

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -2664,26 +2664,25 @@ class TestMetricsSQLNestedDerived:
             params={"metrics": ["v3.derived_tripled"]},
         )
         assert response.status_code == 200, response.json()
-        assert_sql_equal(
-            response.json()["sql"],
-            """
-            WITH
-            v3_order_details AS (
-              SELECT oi.quantity, oi.unit_price
-              FROM default.v3.orders o
-              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-            ),
-            order_details_0 AS (
-              SELECT SUM(t1.unit_price) unit_price_sum_55cff00f,
-                SUM(t1.quantity) quantity_sum_06b64d2e
-              FROM v3_order_details t1
-            )
-            SELECT SUM(order_details_0.quantity_sum_06b64d2e)
-                 + SUM(order_details_0.unit_price_sum_55cff00f)
-                 + SUM(order_details_0.quantity_sum_06b64d2e) AS derived_tripled
-            FROM order_details_0
-            """,
-        )
+        sql = response.json()["sql"]
+        # The set of atomic aggregates is stable but their SELECT-list order
+        # inside ``order_details_0`` varies run-to-run (set/dict iteration
+        # order of component aliases).  Assert structural invariants that
+        # don't depend on column order:
+        #   1. Parent CTE projects both source columns.
+        #   2. Grain-group CTE computes both SUMs (either order).
+        #   3. Outer expression fully inlines the 3-level chain:
+        #      derived_tripled = derived_doubled + base_qty
+        #                      = (base_qty + base_price_sum) + base_qty
+        assert "oi.quantity" in sql
+        assert "oi.unit_price" in sql
+        assert "SUM(t1.quantity) quantity_sum_06b64d2e" in sql
+        assert "SUM(t1.unit_price) unit_price_sum_55cff00f" in sql
+        assert (
+            "SUM(order_details_0.quantity_sum_06b64d2e) "
+            "+ SUM(order_details_0.unit_price_sum_55cff00f) "
+            "+ SUM(order_details_0.quantity_sum_06b64d2e) AS derived_tripled"
+        ) in sql
 
 
 class TestMetricsSQLCrossFactWindow:

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -2618,6 +2618,59 @@ class TestMetricsSQLNestedDerived:
             """,
         )
 
+    @pytest.mark.asyncio
+    async def test_three_level_metric_composition(self, client_with_build_v3):
+        """A metric that references another derived metric that itself
+        references base metrics.  Resolution walks all three levels; the
+        final SQL inlines the full expansion.
+
+        v3.base_qty = SUM(quantity)
+        v3.base_price_sum = SUM(unit_price)
+        v3.derived_doubled = v3.base_qty + v3.base_price_sum
+        v3.derived_tripled = v3.derived_doubled + v3.base_qty
+        """
+        for name, query in [
+            ("v3.base_qty", "SELECT SUM(quantity) FROM v3.order_details"),
+            ("v3.base_price_sum", "SELECT SUM(unit_price) FROM v3.order_details"),
+        ]:
+            r = await client_with_build_v3.post(
+                "/nodes/metric/",
+                json={"name": name, "query": query, "mode": "published"},
+            )
+            assert r.status_code == 201, r.json()
+        r = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.derived_doubled",
+                "query": "SELECT v3.base_qty + v3.base_price_sum",
+                "mode": "published",
+            },
+        )
+        assert r.status_code == 201, r.json()
+        r = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.derived_tripled",
+                "query": "SELECT v3.derived_doubled + v3.base_qty",
+                "mode": "published",
+            },
+        )
+        if r.status_code != 201:
+            pytest.skip(
+                f"3-level metric composition not supported: {r.json()}",
+            )
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={"metrics": ["v3.derived_tripled"]},
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+        # All three underlying components must appear: the 3-level chain is
+        # fully inlined.
+        assert "SUM(" in sql.upper()
+        assert "quantity" in sql
+        assert "unit_price" in sql
+
 
 class TestMetricsSQLCrossFactWindow:
     """Tests for window metrics that span multiple facts."""

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -2674,8 +2674,8 @@ class TestMetricsSQLNestedDerived:
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
             ),
             order_details_0 AS (
-              SELECT SUM(t1.quantity) quantity_sum_06b64d2e,
-                SUM(t1.unit_price) unit_price_sum_55cff00f
+              SELECT SUM(t1.unit_price) unit_price_sum_55cff00f,
+                SUM(t1.quantity) quantity_sum_06b64d2e
               FROM v3_order_details t1
             )
             SELECT SUM(order_details_0.quantity_sum_06b64d2e)

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -2664,12 +2664,26 @@ class TestMetricsSQLNestedDerived:
             params={"metrics": ["v3.derived_tripled"]},
         )
         assert response.status_code == 200, response.json()
-        sql = response.json()["sql"]
-        # All three underlying components must appear: the 3-level chain is
-        # fully inlined.
-        assert "SUM(" in sql.upper()
-        assert "quantity" in sql
-        assert "unit_price" in sql
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH
+            v3_order_details AS (
+              SELECT oi.quantity, oi.unit_price
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+              SELECT SUM(t1.quantity) quantity_sum_06b64d2e,
+                SUM(t1.unit_price) unit_price_sum_55cff00f
+              FROM v3_order_details t1
+            )
+            SELECT SUM(order_details_0.quantity_sum_06b64d2e)
+                 + SUM(order_details_0.unit_price_sum_55cff00f)
+                 + SUM(order_details_0.quantity_sum_06b64d2e) AS derived_tripled
+            FROM order_details_0
+            """,
+        )
 
 
 class TestMetricsSQLCrossFactWindow:

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -1,0 +1,104 @@
+"""Tests for set-operation (UNION/INTERSECT/EXCEPT) transform bodies.
+
+A transform whose query is a set operation stresses paths that usually
+only see a single SELECT: projection inspection, column pruning, filter
+pushdown, alias registry.  Filter pushdown refuses set-op CTEs
+(``_cte_has_set_operation``) because ``_inject_filter_into_where`` only
+mutates the first arm's WHERE and ``_build_cte_projection_map`` only sees
+the first arm's projection — partial pushdown would silently produce
+wrong data.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+
+@pytest_asyncio.fixture
+async def client_with_union_transform(client_with_build_v3: AsyncClient):
+    """Adds a UNION-ALL transform + a metric that reads from it.
+
+    Both arms select from v3.src_orders (same source) so the schemas are
+    identical — exercises the set-op code path without a second source.
+    """
+    resp = await client_with_build_v3.post(
+        "/nodes/transform/",
+        json={
+            "name": "v3.orders_unified",
+            "description": "Orders union'd across two arbitrary partitions "
+            "to exercise the set-op code path.",
+            "query": """
+                SELECT order_id, customer_id, order_date, status
+                FROM v3.src_orders
+                WHERE status = 'completed'
+                UNION ALL
+                SELECT order_id, customer_id, order_date, status
+                FROM v3.src_orders
+                WHERE status = 'shipped'
+            """,
+            "mode": "published",
+            "primary_key": ["order_id"],
+        },
+    )
+    assert resp.status_code == 201, resp.json()
+    resp = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.unified_order_count",
+            "query": "SELECT COUNT(DISTINCT order_id) FROM v3.orders_unified",
+            "mode": "published",
+        },
+    )
+    assert resp.status_code == 201, resp.json()
+    return client_with_build_v3
+
+
+class TestSetOperationTransforms:
+    """Transforms whose body is a UNION/INTERSECT/EXCEPT."""
+
+    @pytest.mark.asyncio
+    async def test_union_all_transform_metric_generates_sql(
+        self, client_with_union_transform,
+    ):
+        """A metric built on a UNION-ALL transform generates SQL without
+        choking on the set-op body — both arms land in the CTE intact.
+        """
+        response = await client_with_union_transform.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.unified_order_count"],
+                "dimensions": ["v3.orders_unified.status"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+        # Both arms preserved: each status literal must appear.
+        assert "'completed'" in sql
+        assert "'shipped'" in sql
+        # Set-op keyword survived.
+        assert "UNION ALL" in sql.upper()
+
+    @pytest.mark.asyncio
+    async def test_union_transform_filter_stays_on_outer_query(
+        self, client_with_union_transform,
+    ):
+        """Filter on a column of a UNION-ALL transform must NOT be pushed
+        into either arm — ``_cte_has_set_operation`` refuses and the filter
+        stays on the outer WHERE.  Both arms keep their original (unfiltered)
+        WHEREs.
+        """
+        response = await client_with_union_transform.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.unified_order_count"],
+                "dimensions": ["v3.orders_unified.status"],
+                "filters": ["v3.orders_unified.status = 'completed'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+        # The set-op CTE body preserves its per-arm WHEREs.
+        assert "'completed'" in sql  # present in arm 1 and outer WHERE
+        assert "'shipped'" in sql  # present in arm 2 unchanged
+        # Filter must land on the outer query (post-union).
+        assert "UNION ALL" in sql.upper()

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -13,6 +13,8 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
+from tests.construction.build_v3 import assert_sql_equal
+
 
 @pytest_asyncio.fixture
 async def client_with_union_transform(client_with_build_v3: AsyncClient):
@@ -56,12 +58,22 @@ async def client_with_union_transform(client_with_build_v3: AsyncClient):
 class TestSetOperationTransforms:
     """Transforms whose body is a UNION/INTERSECT/EXCEPT."""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Column pruning applies to only the first arm of a UNION ALL, "
+        "emitting arms with mismatched column counts (arm 1 pruned, arm 2 "
+        "intact) — invalid SQL.  The correct behavior is to skip pruning "
+        "entirely for set-op transform bodies so both arms preserve their "
+        "original projection.  Pinned here so the fix flips it to pass.",
+    )
     @pytest.mark.asyncio
     async def test_union_all_transform_metric_generates_sql(
-        self, client_with_union_transform,
+        self,
+        client_with_union_transform,
     ):
         """A metric built on a UNION-ALL transform generates SQL without
-        choking on the set-op body — both arms land in the CTE intact.
+        choking on the set-op body — both arms must land in the CTE
+        preserving the same column count.
         """
         response = await client_with_union_transform.get(
             "/sql/metrics/v3/",
@@ -71,21 +83,46 @@ class TestSetOperationTransforms:
             },
         )
         assert response.status_code == 200, response.json()
-        sql = response.json()["sql"]
-        # Both arms preserved: each status literal must appear.
-        assert "'completed'" in sql
-        assert "'shipped'" in sql
-        # Set-op keyword survived.
-        assert "UNION ALL" in sql.upper()
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH
+            v3_orders_unified AS (
+              SELECT order_id, customer_id, order_date, status
+              FROM default.v3.orders
+              WHERE status = 'completed'
+              UNION ALL
+              SELECT order_id, customer_id, order_date, status
+              FROM default.v3.orders
+              WHERE status = 'shipped'
+            ),
+            orders_unified_0 AS (
+              SELECT t1.status, t1.order_id
+              FROM v3_orders_unified t1
+              GROUP BY t1.status, t1.order_id
+            )
+            SELECT orders_unified_0.status AS status,
+              COUNT(DISTINCT orders_unified_0.order_id) AS unified_order_count
+            FROM orders_unified_0
+            GROUP BY orders_unified_0.status
+            """,
+        )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Same set-op column-pruning bug as above.  The filter-pushdown "
+        "refusal for set-op CTEs is correct (filter stays on outer query "
+        "only), but the CTE body still has mismatched arm column counts. "
+        "Flip to passing when the pruner skips set-op bodies.",
+    )
     @pytest.mark.asyncio
     async def test_union_transform_filter_stays_on_outer_query(
-        self, client_with_union_transform,
+        self,
+        client_with_union_transform,
     ):
         """Filter on a column of a UNION-ALL transform must NOT be pushed
-        into either arm — ``_cte_has_set_operation`` refuses and the filter
-        stays on the outer WHERE.  Both arms keep their original (unfiltered)
-        WHEREs.
+        into either arm.  The filter lands on the outer query's WHERE; the
+        set-op arms keep their original predicates untouched.
         """
         response = await client_with_union_transform.get(
             "/sql/metrics/v3/",
@@ -96,9 +133,29 @@ class TestSetOperationTransforms:
             },
         )
         assert response.status_code == 200, response.json()
-        sql = response.json()["sql"]
-        # The set-op CTE body preserves its per-arm WHEREs.
-        assert "'completed'" in sql  # present in arm 1 and outer WHERE
-        assert "'shipped'" in sql  # present in arm 2 unchanged
-        # Filter must land on the outer query (post-union).
-        assert "UNION ALL" in sql.upper()
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH
+            v3_orders_unified AS (
+              SELECT order_id, customer_id, order_date, status
+              FROM default.v3.orders
+              WHERE status = 'completed'
+              UNION ALL
+              SELECT order_id, customer_id, order_date, status
+              FROM default.v3.orders
+              WHERE status = 'shipped'
+            ),
+            orders_unified_0 AS (
+              SELECT t1.status, t1.order_id
+              FROM v3_orders_unified t1
+              WHERE t1.status = 'completed'
+              GROUP BY t1.status, t1.order_id
+            )
+            SELECT orders_unified_0.status AS status,
+              COUNT(DISTINCT orders_unified_0.order_id) AS unified_order_count
+            FROM orders_unified_0
+            WHERE orders_unified_0.status = 'completed'
+            GROUP BY orders_unified_0.status
+            """,
+        )

--- a/datajunction-server/tests/construction/build_v3/transform_query_shapes_test.py
+++ b/datajunction-server/tests/construction/build_v3/transform_query_shapes_test.py
@@ -12,6 +12,8 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
+from tests.construction.build_v3 import assert_sql_equal
+
 
 @pytest_asyncio.fixture
 async def client_with_edge_shapes(client_with_build_v3: AsyncClient):
@@ -100,23 +102,43 @@ class TestTransformQueryShapes:
 
     @pytest.mark.asyncio
     async def test_transform_with_derived_table_in_from(
-        self, client_with_edge_shapes,
+        self,
+        client_with_edge_shapes,
     ):
         """Transform whose FROM is ``(SELECT ... FROM src) inner_q``.
-        Column resolution must still find the underlying columns.
+        Column resolution must still find the underlying columns, and the
+        derived-table body is preserved verbatim inside the CTE.
         """
         response = await client_with_edge_shapes.get(
             "/sql/metrics/v3/",
             params={"metrics": ["v3.derived_table_count"]},
         )
         assert response.status_code == 200, response.json()
-        sql = response.json()["sql"]
-        assert "inner_q" in sql
-        assert "v3.src_orders" in sql or "default.v3.orders" in sql
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH
+            v3_orders_via_derived_table AS (
+              SELECT inner_q.order_id, inner_q.customer_id, inner_q.order_date
+              FROM (
+                SELECT order_id, customer_id, order_date, status
+                FROM default.v3.orders
+                WHERE status IS NOT NULL
+              ) inner_q
+            ),
+            orders_via_derived_table_0 AS (
+              SELECT COUNT(*) count_945ddca4
+              FROM v3_orders_via_derived_table t1
+            )
+            SELECT SUM(orders_via_derived_table_0.count_945ddca4) AS derived_table_count
+            FROM orders_via_derived_table_0
+            """,
+        )
 
     @pytest.mark.asyncio
     async def test_transform_with_window_function_projection(
-        self, client_with_edge_shapes,
+        self,
+        client_with_edge_shapes,
     ):
         """Transform projects ``ROW_NUMBER() OVER (...) AS rn``.  Metric
         aggregation on this transform must still generate valid SQL — the
@@ -127,23 +149,59 @@ class TestTransformQueryShapes:
             params={"metrics": ["v3.ranked_count"]},
         )
         assert response.status_code == 200, response.json()
-        sql = response.json()["sql"]
-        assert "ROW_NUMBER()" in sql.upper() or "ROW_NUMBER (" in sql.upper()
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH
+            v3_orders_ranked AS (
+              SELECT order_id, customer_id, order_date, status,
+                ROW_NUMBER() OVER (
+                  PARTITION BY customer_id ORDER BY order_date
+                ) AS rn
+              FROM default.v3.orders
+            ),
+            orders_ranked_0 AS (
+              SELECT COUNT(*) count_54f3e256
+              FROM v3_orders_ranked t1
+            )
+            SELECT SUM(orders_ranked_0.count_54f3e256) AS ranked_count
+            FROM orders_ranked_0
+            """,
+        )
 
     @pytest.mark.asyncio
     async def test_transform_with_self_join_multi_condition_on(
-        self, client_with_edge_shapes,
+        self,
+        client_with_edge_shapes,
     ):
-        """Self-join in the transform QUERY body with ``ON a.x = b.x
-        AND a.y > b.y``.  Both conditions must be preserved in the CTE
-        body; the multi-ref filter-pushdown fix would've broken if it
-        regressed onto the ON clause.
+        """Self-join in the transform QUERY body with
+        ``ON a.customer_id = b.customer_id AND a.order_date > b.order_date``.
+        Both ON conditions must be preserved verbatim in the CTE body.
         """
         response = await client_with_edge_shapes.get(
             "/sql/metrics/v3/",
             params={"metrics": ["v3.self_join_count"]},
         )
         assert response.status_code == 200, response.json()
-        sql = response.json()["sql"]
-        assert "a.customer_id = b.customer_id" in sql
-        assert "a.order_date > b.order_date" in sql
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH
+            v3_orders_self_joined AS (
+              SELECT a.order_id,
+                a.customer_id,
+                a.order_date AS curr_date,
+                b.order_date AS prev_date
+              FROM default.v3.orders a
+              JOIN default.v3.orders b
+                ON a.customer_id = b.customer_id
+                AND a.order_date > b.order_date
+            ),
+            orders_self_joined_0 AS (
+              SELECT COUNT(*) count_79d87a3f
+              FROM v3_orders_self_joined t1
+            )
+            SELECT SUM(orders_self_joined_0.count_79d87a3f) AS self_join_count
+            FROM orders_self_joined_0
+            """,
+        )

--- a/datajunction-server/tests/construction/build_v3/transform_query_shapes_test.py
+++ b/datajunction-server/tests/construction/build_v3/transform_query_shapes_test.py
@@ -1,0 +1,149 @@
+"""Tests for unusual transform-query shapes in build_v3 SQL generation.
+
+Covers shapes beyond the standard SELECT-FROM-JOIN mold: derived tables
+in FROM, window-function projections.  These paths go through the CTE
+builder and projection-map logic and used to be untested.
+
+Self-joins are exercised in ``test_self_join_sql_generation.py``;
+set-operation bodies live in ``set_operations_test.py``.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+
+@pytest_asyncio.fixture
+async def client_with_edge_shapes(client_with_build_v3: AsyncClient):
+    """Adds transforms with unusual query shapes + metrics on top of them."""
+    r1 = await client_with_build_v3.post(
+        "/nodes/transform/",
+        json={
+            "name": "v3.orders_via_derived_table",
+            "description": "FROM (SELECT ... FROM src) derived",
+            "query": """
+                SELECT inner_q.order_id, inner_q.customer_id, inner_q.order_date
+                FROM (
+                    SELECT order_id, customer_id, order_date, status
+                    FROM v3.src_orders
+                    WHERE status IS NOT NULL
+                ) inner_q
+            """,
+            "mode": "published",
+            "primary_key": ["order_id"],
+        },
+    )
+    assert r1.status_code == 201, r1.json()
+
+    r2 = await client_with_build_v3.post(
+        "/nodes/transform/",
+        json={
+            "name": "v3.orders_ranked",
+            "description": "Projects ROW_NUMBER() OVER (...) AS rn",
+            "query": """
+                SELECT
+                    order_id,
+                    customer_id,
+                    order_date,
+                    status,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY customer_id ORDER BY order_date
+                    ) AS rn
+                FROM v3.src_orders
+            """,
+            "mode": "published",
+            "primary_key": ["order_id"],
+        },
+    )
+    assert r2.status_code == 201, r2.json()
+
+    r3 = await client_with_build_v3.post(
+        "/nodes/transform/",
+        json={
+            "name": "v3.orders_self_joined",
+            "description": "Self-join with 2+ conditions in ON",
+            "query": """
+                SELECT
+                    a.order_id,
+                    a.customer_id,
+                    a.order_date AS curr_date,
+                    b.order_date AS prev_date
+                FROM v3.src_orders a
+                JOIN v3.src_orders b
+                  ON a.customer_id = b.customer_id
+                 AND a.order_date > b.order_date
+            """,
+            "mode": "published",
+            "primary_key": ["order_id"],
+        },
+    )
+    assert r3.status_code == 201, r3.json()
+
+    for name, query in [
+        (
+            "v3.derived_table_count",
+            "SELECT COUNT(*) FROM v3.orders_via_derived_table",
+        ),
+        ("v3.ranked_count", "SELECT COUNT(*) FROM v3.orders_ranked"),
+        ("v3.self_join_count", "SELECT COUNT(*) FROM v3.orders_self_joined"),
+    ]:
+        r = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={"name": name, "query": query, "mode": "published"},
+        )
+        assert r.status_code == 201, r.json()
+    return client_with_build_v3
+
+
+class TestTransformQueryShapes:
+    """Transform queries that don't fit the simple SELECT-FROM-JOIN mold."""
+
+    @pytest.mark.asyncio
+    async def test_transform_with_derived_table_in_from(
+        self, client_with_edge_shapes,
+    ):
+        """Transform whose FROM is ``(SELECT ... FROM src) inner_q``.
+        Column resolution must still find the underlying columns.
+        """
+        response = await client_with_edge_shapes.get(
+            "/sql/metrics/v3/",
+            params={"metrics": ["v3.derived_table_count"]},
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+        assert "inner_q" in sql
+        assert "v3.src_orders" in sql or "default.v3.orders" in sql
+
+    @pytest.mark.asyncio
+    async def test_transform_with_window_function_projection(
+        self, client_with_edge_shapes,
+    ):
+        """Transform projects ``ROW_NUMBER() OVER (...) AS rn``.  Metric
+        aggregation on this transform must still generate valid SQL — the
+        window expression survives into the CTE body.
+        """
+        response = await client_with_edge_shapes.get(
+            "/sql/metrics/v3/",
+            params={"metrics": ["v3.ranked_count"]},
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+        assert "ROW_NUMBER()" in sql.upper() or "ROW_NUMBER (" in sql.upper()
+
+    @pytest.mark.asyncio
+    async def test_transform_with_self_join_multi_condition_on(
+        self, client_with_edge_shapes,
+    ):
+        """Self-join in the transform QUERY body with ``ON a.x = b.x
+        AND a.y > b.y``.  Both conditions must be preserved in the CTE
+        body; the multi-ref filter-pushdown fix would've broken if it
+        regressed onto the ON clause.
+        """
+        response = await client_with_edge_shapes.get(
+            "/sql/metrics/v3/",
+            params={"metrics": ["v3.self_join_count"]},
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+        assert "a.customer_id = b.customer_id" in sql
+        assert "a.order_date > b.order_date" in sql


### PR DESCRIPTION
### Summary

This PR adds various tests around v3 SQL gen edge cases:

- Set-operation transforms: a transform whose body has `UNION ALL` does not support filter-pushdown today.
- Added test cases for various transform-query shapes (verifies the shape survives CTE building intact):
  - Derived table in `FROM` like `(FROM (SELECT …)`
  - A projected window function (`ROW_NUMBER() OVER (…) AS rn`)
  - A self-join with multi-condition on clause.
- Multi-filter composition into one CTE: two filters on the same parent (one via FK-rename, one via a qualified local column) both push into the parent's WHERE without duplication or drop.
- Three-level metric composition: C = B + A where B is itself derived from two base metrics. The resolution walks all three levels and inlines the full expansion.
- `COALESCE` in dimension-link join_sql: both FK columns stay in the parent CTE's projection so the JOIN can evaluate the COALESCE.
- Duplicate output aliases in a transform: pins the current silent-accept behavior as xfail which will be fixed with unifying validation across the single-node and bulk deployment methods.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
