### PR TITLE
Fix GraphQL materialization plan crash and log_resolver traceback

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -84,7 +84,7 @@ def log_resolver(func):
             result = await func(*args, **kwargs)
             logger.info("[GQL] %s", log_args)
             return result
-        except Exception as exc:  # pragma: no cover
+        except Exception:  # pragma: no cover
             get_metrics_provider().counter(  # pragma: no cover
                 "dj.graphql.errors",
                 tags={"operation": resolver_name},
@@ -94,7 +94,7 @@ def log_resolver(func):
                 log_args,
                 exc_info=True,
             )
-            raise exc  # pragma: no cover
+            raise  # pragma: no cover
         finally:
             get_metrics_provider().timer(
                 "dj.graphql.query_ms",

--- a/datajunction-server/datajunction_server/api/graphql/queries/sql.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/sql.py
@@ -167,7 +167,9 @@ async def materialization_plan(
                     for dim in m.rule.level  # type: ignore
                 ]
                 grain_from_dims = [
-                    nodes_lookup[dim.rsplit(SEPARATOR, 1)[0]] for dim in dimensions
+                    nodes_lookup[dim.rsplit(SEPARATOR, 1)[0]]
+                    for dim in dimensions
+                    if dim.rsplit(SEPARATOR, 1)[0] in nodes_lookup
                 ]
                 grain_dimensions = grain_from_rules + grain_from_dims
 
@@ -190,6 +192,7 @@ async def materialization_plan(
                         ].current_version,
                     )
                     for ref in filter_refs
+                    if ref.rsplit(SEPARATOR, 1)[0] in nodes_lookup
                 ],
                 filters=cube.filters,
             )


### PR DESCRIPTION
### Summary

- `materialization_plan` crashes with `KeyError` when a dimension or filter referenced a node that didn't exist. After this change it silently skips missing nodes instead of crashing the entire query.
- `log_resolver` used `raise exc` which can lose the original traceback in some contexts. Changed to bare raise.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
