### PR TITLE
Fix deployment idempotency for dimension links and downstream validation

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2516,7 +2516,17 @@ class DeploymentOrchestrator:
             elif force or node_spec != existing_spec:
                 to_update.append(node_spec)
             else:
-                to_skip.append(node_spec)
+                # Re-deploy unchanged nodes that are stuck in INVALID state so
+                # they get revalidated (e.g. after an upstream fix).
+                existing_node = self.registry.nodes.get(node_spec.rendered_name)
+                if (
+                    existing_node
+                    and existing_node.current
+                    and existing_node.current.status == NodeStatus.INVALID
+                ):
+                    to_update.append(node_spec)
+                else:
+                    to_skip.append(node_spec)
 
         desired_node_names = {n.rendered_name for n in self.deployment_spec.nodes}
         to_delete = [
@@ -2803,11 +2813,30 @@ class DeploymentOrchestrator:
             await self.session.flush()
             p.append(f"{len(nodes)} nodes + {len(revisions)} revisions")
 
+        # Refresh dimension_links so the collection stays in sync after flush.
+        for revision in revisions:
+            await self.session.refresh(revision, ["dimension_links"])
+
         # Wire node.current directly from the just-flushed revisions — avoids a
         # SELECT + N refresh round-trips.  All attributes we need (columns, catalog,
         # status, parents) are already set on the in-session objects.
         for node_obj, revision in zip(nodes, revisions):
             node_obj.current = revision
+
+        # Parse string column types into proper ColumnType objects so that
+        # downstream impact propagation / type inference works correctly.
+        # Without this, in-memory columns carry raw strings like 'bigint'
+        # that haven't round-tripped through ColumnTypeDecorator.
+        from datajunction_server.sql.parsing.backends.antlr4 import parse_rule
+
+        for revision in revisions:
+            for col in revision.columns:
+                if isinstance(col.type, str):  # pragma: no cover
+                    try:
+                        col.type = parse_rule(col.type, "dataType")
+                    except Exception:
+                        pass
+
         all_nodes = {node_obj.name: node_obj for node_obj in nodes}
 
         logger.info(
@@ -3165,6 +3194,7 @@ class DeploymentOrchestrator:
                     DimensionLink(
                         node_revision=new_revision,
                         dimension_id=link.dimension_id,
+                        dimension=link.dimension,
                         join_sql=link.join_sql,
                         join_type=link.join_type,
                         join_cardinality=link.join_cardinality,
@@ -3317,8 +3347,11 @@ class DeploymentOrchestrator:
         """
         Create or update a dimension link on a node revision.
         """
-        # Find an existing dimension link if there is already one defined for this node
-        existing_link = [
+        # Find an existing dimension link. Use (dimension, role, join_sql) for an
+        # exact match first — this correctly handles multiple links to the same
+        # dimension with different join clauses (e.g., two date links with no role).
+        # Fall back to (dimension, role) only when no exact match exists.
+        candidates = [
             link  # type: ignore
             for link in node_revision.dimension_links  # type: ignore
             if link.dimension.name == dimension_node.name
@@ -3326,28 +3359,31 @@ class DeploymentOrchestrator:
         ]
         activity_type = ActivityType.CREATE
 
-        if existing_link:
-            if len(existing_link) >= 1:  # pragma: no cover
-                for dup_link in existing_link[1:]:
-                    await self.session.delete(dup_link)
-            # Update the existing dimension link
+        # Try exact match first (all fields identical → REFRESH/noop)
+        exact_match = [
+            link
+            for link in candidates
+            if link.join_sql == link_input.join_on
+            and link.join_type == join_type
+            and link.join_cardinality == link_input.join_cardinality
+            and link.default_value == link_input.default_value
+            and link.spark_hints == link_input.spark_hints
+        ]
+        if exact_match:
+            return exact_match[0], ActivityType.REFRESH
+
+        # No exact match — if there's exactly one candidate with the same
+        # (dimension, role), treat it as an update to that link.
+        if len(candidates) == 1:
             activity_type = ActivityType.UPDATE
-            dimension_link = existing_link[0]
-            if (
-                dimension_link.join_sql == link_input.join_on
-                and dimension_link.join_type == join_type
-                and dimension_link.join_cardinality == link_input.join_cardinality
-                and dimension_link.default_value == link_input.default_value
-                and dimension_link.spark_hints == link_input.spark_hints
-            ):
-                return dimension_link, ActivityType.REFRESH
+            dimension_link = candidates[0]
             dimension_link.join_sql = link_input.join_on
             dimension_link.join_type = join_type
             dimension_link.join_cardinality = link_input.join_cardinality
             dimension_link.default_value = link_input.default_value
             dimension_link.spark_hints = link_input.spark_hints
         else:
-            # If there is no existing link, create new dimension link object
+            # No single candidate to update — create a new dimension link object
             dimension_link = DimensionLink(
                 node_revision_id=node_revision.id,  # type: ignore
                 dimension_id=dimension_node.id,  # type: ignore

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1840,9 +1840,8 @@ class TestDeployments:
             "status": "invalid",
         }
 
-        # Remove the bad dimension — but the invalid cube was already deployed
-        # without it (missing dimensions are skipped), so the spec is unchanged
-        # and the cube stays INVALID.
+        # Remove the bad dimension — the cube is still INVALID from the previous
+        # deploy, so it gets re-deployed and should now succeed.
         cube.dimensions = [
             "${prefix}default.hard_hat.state",
             "${prefix}default.us_state.state_region",
@@ -1852,14 +1851,11 @@ class TestDeployments:
             DeploymentSpec(namespace=namespace, nodes=nodes_list),
         )
         assert data["status"] == "success"
-        assert data["results"][-1] == {
-            "deploy_type": "node",
-            "message": "Unchanged, still INVALID",
-            "name": "cube_update.default.repairs_cube",
-            "operation": "noop",
-            "changed_fields": [],
-            "status": "invalid",
-        }
+        cube_result = data["results"][-1]
+        assert cube_result["name"] == "cube_update.default.repairs_cube"
+        assert cube_result["deploy_type"] == "node"
+        assert cube_result["operation"] == "update"
+        assert cube_result["status"] == "success"
 
     @pytest.mark.asyncio
     async def test_deploy_cube_fails_with_unreachable_dimension(

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -48,6 +48,12 @@ from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.catalog import Catalog
+from datajunction_server.database.dimensionlink import (
+    JoinCardinality,
+    JoinType,
+)
+from datajunction_server.models.dimensionlink import JoinLinkInput
+from datajunction_server.models.history import ActivityType
 from datajunction_server.errors import DJError, DJInvalidDeploymentConfig, ErrorCode
 
 
@@ -2129,3 +2135,179 @@ async def test_execute_deployment_plan_dry_run_savepoint_rollback(
 
     # Dry-run should roll back the SAVEPOINT and return empty downstream
     assert downstream == []
+
+
+class TestCreateOrUpdateDimensionJoinLink:
+    """Tests for create_or_update_dimension_join_link idempotency."""
+
+    @pytest.mark.asyncio
+    async def test_exact_match_returns_refresh(
+        self,
+        session,
+        mock_deployment_context,
+    ):
+        """When a dimension link already exists with identical fields,
+        create_or_update_dimension_join_link should return REFRESH (noop)
+        without modifying the link."""
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
+            deployment_id="idempotency-test",
+            session=session,
+            context=mock_deployment_context,
+        )
+
+        # Create mock dimension node
+        dim_node = MagicMock()
+        dim_node.name = "default.date_dim"
+        dim_node.id = 42
+
+        # Create a mock node revision with an existing dimension link
+        existing_link = MagicMock()
+        existing_link.dimension = dim_node
+        existing_link.role = None
+        existing_link.join_sql = "t.date_id = default.date_dim.dateint"
+        existing_link.join_type = JoinType.LEFT
+        existing_link.join_cardinality = JoinCardinality.MANY_TO_ONE
+        existing_link.default_value = None
+        existing_link.spark_hints = None
+
+        node_revision = MagicMock()
+        node_revision.dimension_links = [existing_link]
+        node_revision.name = "default.my_transform"
+
+        link_input = JoinLinkInput(
+            dimension_node="default.date_dim",
+            join_on="t.date_id = default.date_dim.dateint",
+            join_type=JoinType.LEFT,
+        )
+
+        result_link, activity = await orchestrator.create_or_update_dimension_join_link(
+            node_revision=node_revision,
+            dimension_node=dim_node,
+            link_input=link_input,
+            join_type=JoinType.LEFT,
+        )
+
+        assert activity == ActivityType.REFRESH
+        assert result_link is existing_link
+
+    @pytest.mark.asyncio
+    async def test_multiple_links_same_dimension_no_role_idempotent(
+        self,
+        session,
+        mock_deployment_context,
+    ):
+        """Two links to the same dimension with role=None but different join_sql
+        should both return REFRESH on re-deploy (no reshuffling)."""
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
+            deployment_id="multi-link-test",
+            session=session,
+            context=mock_deployment_context,
+        )
+
+        dim_node = MagicMock()
+        dim_node.name = "default.date_dim"
+        dim_node.id = 42
+
+        # Two links to the same dimension, different join_sql, both role=None
+        link_epoch = MagicMock()
+        link_epoch.dimension = dim_node
+        link_epoch.role = None
+        link_epoch.join_sql = "t.epoch_date = default.date_dim.dateint"
+        link_epoch.join_type = JoinType.INNER
+        link_epoch.join_cardinality = JoinCardinality.MANY_TO_ONE
+        link_epoch.default_value = None
+        link_epoch.spark_hints = None
+
+        link_region = MagicMock()
+        link_region.dimension = dim_node
+        link_region.role = None
+        link_region.join_sql = "t.region_date = default.date_dim.dateint"
+        link_region.join_type = JoinType.INNER
+        link_region.join_cardinality = JoinCardinality.MANY_TO_ONE
+        link_region.default_value = None
+        link_region.spark_hints = None
+
+        node_revision = MagicMock()
+        node_revision.dimension_links = [link_epoch, link_region]
+        node_revision.name = "default.my_transform"
+
+        # Re-deploy first link (region_date)
+        link_input_region = JoinLinkInput(
+            dimension_node="default.date_dim",
+            join_on="t.region_date = default.date_dim.dateint",
+            join_type=JoinType.INNER,
+        )
+        result1, activity1 = await orchestrator.create_or_update_dimension_join_link(
+            node_revision=node_revision,
+            dimension_node=dim_node,
+            link_input=link_input_region,
+            join_type=JoinType.INNER,
+        )
+        assert activity1 == ActivityType.REFRESH
+        assert result1 is link_region
+
+        # Re-deploy second link (epoch_date)
+        link_input_epoch = JoinLinkInput(
+            dimension_node="default.date_dim",
+            join_on="t.epoch_date = default.date_dim.dateint",
+            join_type=JoinType.INNER,
+        )
+        result2, activity2 = await orchestrator.create_or_update_dimension_join_link(
+            node_revision=node_revision,
+            dimension_node=dim_node,
+            link_input=link_input_epoch,
+            join_type=JoinType.INNER,
+        )
+        assert activity2 == ActivityType.REFRESH
+        assert result2 is link_epoch
+
+    @pytest.mark.asyncio
+    async def test_single_candidate_gets_updated(
+        self,
+        session,
+        mock_deployment_context,
+    ):
+        """When there's exactly one link matching (dimension, role) but with
+        different join_sql, it should be updated (not duplicated)."""
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
+            deployment_id="update-test",
+            session=session,
+            context=mock_deployment_context,
+        )
+
+        dim_node = MagicMock()
+        dim_node.name = "default.date_dim"
+        dim_node.id = 42
+
+        existing_link = MagicMock()
+        existing_link.dimension = dim_node
+        existing_link.role = None
+        existing_link.join_sql = "t.old_date = default.date_dim.dateint"
+        existing_link.join_type = JoinType.LEFT
+        existing_link.join_cardinality = JoinCardinality.MANY_TO_ONE
+        existing_link.default_value = None
+        existing_link.spark_hints = None
+
+        node_revision = MagicMock()
+        node_revision.dimension_links = [existing_link]
+        node_revision.name = "default.my_transform"
+
+        link_input = JoinLinkInput(
+            dimension_node="default.date_dim",
+            join_on="t.new_date = default.date_dim.dateint",
+            join_type=JoinType.LEFT,
+        )
+
+        result_link, activity = await orchestrator.create_or_update_dimension_join_link(
+            node_revision=node_revision,
+            dimension_node=dim_node,
+            link_input=link_input,
+            join_type=JoinType.LEFT,
+        )
+
+        assert activity == ActivityType.UPDATE
+        assert result_link is existing_link
+        assert existing_link.join_sql == "t.new_date = default.date_dim.dateint"


### PR DESCRIPTION
### Summary

#### Dimension Link Reshuffling

When a node has multiple links to the same dimension with no role (e.g., two date links with different `join_on`), the matching logic used (dimension name, role) as the identity key. This caused it to treat distinct links as duplicates (deleting one and updating the other) on every push, which triggered downstream revalidation.

After `session.flush()` in `bulk_deploy_nodes_in_level`, SQLAlchemy expired the dimension links collection on new revisions. Later access in `_deploy_links` triggered a lazy load that silently failed in async context, causing the match to find 0 existing links and create duplicates.

#### Impact Propagation

Freshly deployed nodes had raw string column types (e.g., `'bigint'`) that hadn't round-tripped through ColumnTypeDecorator. When impact propagation passed these to `validate_node_query`, it would fail because it expected parsed `ColumnType` objects.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
