### PR TITLE
Add a default server config for non-source nodes.

### DIFF
--- a/datajunction-server/datajunction_server/api/health.py
+++ b/datajunction-server/datajunction_server/api/health.py
@@ -62,3 +62,23 @@ async def health_check(
             status=await database_health(session),
         ),
     ]
+
+
+class ServerSettings(BaseModel):
+    """
+    Non-sensitive server configuration.
+    """
+
+    default_catalog: str | None
+    virtual_catalog: str
+
+
+@router.get("/settings/", response_model=ServerSettings)
+async def server_settings() -> ServerSettings:
+    """
+    Returns non-sensitive server configuration.
+    """
+    return ServerSettings(
+        default_catalog=settings.seed_setup.default_catalog_name,
+        virtual_catalog=settings.seed_setup.virtual_catalog_name,
+    )

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -90,6 +90,11 @@ class SeedSetup(BaseModel):
     # particular catalog. This typically applies to on-the-fly user-defined dimensions.
     virtual_catalog_name: str = "default"
 
+    # Server-level default catalog for non-source nodes when catalog can't be
+    # inferred from upstream parents. Takes precedence over virtual catalog.
+    # Configurable via env var SEED_SETUP__DEFAULT_CATALOG_NAME.
+    default_catalog_name: str | None = None
+
     # A "DJ System" catalog that contains all system tables modeled in DJ
     system_catalog_name: str = "dj_metadata"
 

--- a/datajunction-server/datajunction_server/database/catalog.py
+++ b/datajunction-server/datajunction_server/database/catalog.py
@@ -97,6 +97,16 @@ class Catalog(Base):
             )
         return catalog
 
+    @classmethod
+    async def get_default_catalog(cls, session: AsyncSession) -> Optional["Catalog"]:
+        """
+        Get the server-configured default catalog, or None if not set.
+        """
+        settings = get_settings()
+        if not settings.seed_setup.default_catalog_name:
+            return None
+        return await cls.get_by_name(session, settings.seed_setup.default_catalog_name)
+
 
 class CatalogEngines(Base):  # type: ignore
     """

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -884,6 +884,14 @@ class DeploymentOrchestrator:
             for node_spec in self.deployment_spec.nodes
             if node_spec.node_type == NodeType.SOURCE and node_spec.catalog
         }
+
+        # Also validate that configured default catalogs exist
+        if self.deployment_spec.default_catalog:
+            spec_catalog_names.add(self.deployment_spec.default_catalog)
+        settings = get_settings()
+        if settings.seed_setup.default_catalog_name:
+            spec_catalog_names.add(settings.seed_setup.default_catalog_name)
+
         missing_catalogs = spec_catalog_names - all_catalogs_map.keys()
         if missing_catalogs:
             self.errors.append(

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2979,12 +2979,16 @@ class DeploymentOrchestrator:
     def _fallback_catalog(self) -> Catalog | None:
         """Return the deployment's configured default catalog, if any.
 
+        Priority: deployment spec default_catalog > server default_catalog_name.
         Used when catalog can't be derived from parent nodes (e.g., invalid nodes
         whose parents are unresolvable). Callers should further fall back to the
         virtual catalog when this returns None.
         """
         if self.deployment_spec.default_catalog:
             return self.registry.catalogs.get(self.deployment_spec.default_catalog)
+        settings = get_settings()
+        if settings.seed_setup.default_catalog_name:
+            return self.registry.catalogs.get(settings.seed_setup.default_catalog_name)
         return None
 
     def _infer_cube_catalog(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -549,9 +549,15 @@ async def create_node_revision(
         raise DJException(
             f"Cannot create nodes with multi-catalog dependencies: {set(catalog_ids)}",
         )
+    default_catalog = await Catalog.get_default_catalog(session)
+    fallback_catalog_id = (
+        default_catalog.id
+        if default_catalog
+        else (await Catalog.get_virtual_catalog(session)).id
+    )
     catalog_id = next(
         iter(catalog_ids),
-        (await Catalog.get_virtual_catalog(session)).id,
+        fallback_catalog_id,
     )
     parent_refs = (
         (
@@ -2055,6 +2061,11 @@ async def create_new_revision_from_existing(
         ]
         if catalogs:
             new_revision.catalog_id = catalogs[0]
+        else:
+            default_catalog = await Catalog.get_default_catalog(session)
+            if default_catalog:
+                new_revision.catalog_id = default_catalog.id
+                new_revision.catalog = default_catalog
         new_revision.columns = node_validator.columns or []
         if new_revision.type == NodeType.METRIC and new_revision.columns:
             new_revision.columns[0].display_name = new_revision.display_name

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2063,9 +2063,13 @@ async def create_new_revision_from_existing(
             new_revision.catalog_id = catalogs[0]
         else:
             default_catalog = await Catalog.get_default_catalog(session)
-            if default_catalog:
-                new_revision.catalog_id = default_catalog.id
-                new_revision.catalog = default_catalog
+            fallback_catalog = (
+                default_catalog
+                if default_catalog
+                else await Catalog.get_virtual_catalog(session)
+            )
+            new_revision.catalog_id = fallback_catalog.id
+            new_revision.catalog = fallback_catalog
         new_revision.columns = node_validator.columns or []
         if new_revision.type == NodeType.METRIC and new_revision.columns:
             new_revision.columns[0].display_name = new_revision.display_name

--- a/datajunction-server/tests/api/health_test.py
+++ b/datajunction-server/tests/api/health_test.py
@@ -34,3 +34,15 @@ async def test_failed_health(
     response = await client.get("/health/")
     data = response.json()
     assert data == [{"name": "database", "status": "failed"}]
+
+
+@pytest.mark.asyncio
+async def test_server_settings(module__client: AsyncClient) -> None:
+    """
+    Test ``GET /settings/`` returns server configuration.
+    """
+    response = await module__client.get("/settings/")
+    data = response.json()
+    assert "default_catalog" in data
+    assert "virtual_catalog" in data
+    assert data["virtual_catalog"] == "default"

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -535,6 +535,58 @@ class TestNodeCRUD:
         ]
 
     @pytest.mark.asyncio
+    async def test_update_parentless_node_uses_default_catalog(
+        self,
+        client_with_roads: AsyncClient,
+        mocker,
+    ):
+        """
+        Test that updating a parentless dimension uses the server default catalog
+        when configured, instead of keeping the virtual catalog.
+        """
+        # First create a parentless dimension (gets virtual catalog)
+        response = await client_with_roads.post(
+            "/nodes/dimension/",
+            json={
+                "description": "Color codes",
+                "query": "SELECT 1 AS code, 'red' AS color UNION ALL SELECT 2, 'blue'",
+                "mode": "published",
+                "name": "default.colors",
+                "primary_key": ["code"],
+            },
+        )
+        assert response.status_code == 201
+        assert response.json()["catalog"]["name"] == "default"
+
+        # Patch the config to set a default catalog name, then update the node.
+        # The "default" catalog (id=1) already exists in the test DB; we configure
+        # the server setting to point at it so the fallback path is exercised.
+        from unittest.mock import patch as _patch
+
+        from datajunction_server.config import SeedSetup
+
+        patched_setup = SeedSetup(default_catalog_name="default")
+        with (
+            _patch(
+                "datajunction_server.internal.nodes.get_settings",
+            ) as mock_settings,
+            _patch(
+                "datajunction_server.database.catalog.get_settings",
+            ) as mock_settings2,
+        ):
+            mock_settings.return_value.seed_setup = patched_setup
+            mock_settings2.return_value.seed_setup = patched_setup
+            response = await client_with_roads.patch(
+                "/nodes/default.colors/",
+                json={"description": "Updated color codes"},
+            )
+        assert response.status_code == 200
+
+        # Verify the node now has the "default" catalog (from server default, not virtual fallback)
+        response = await client_with_roads.get("/nodes/default.colors/")
+        assert response.json()["catalog"]["name"] == "default"
+
+    @pytest.mark.asyncio
     async def test_deleting_node(
         self,
         client_with_basic: AsyncClient,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -514,6 +514,77 @@ class TestDeploymentPlanning:
         assert "catalog" not in result_catalogs
         assert len(orchestrator.errors) == 1
 
+    @pytest.mark.asyncio
+    async def test_setup_catalogs_validates_missing_server_default_catalog(
+        self,
+        session,
+        current_user,
+    ):
+        """
+        _setup_catalogs should report an error when the server-configured
+        default_catalog_name refers to a catalog that doesn't exist in the DB.
+        """
+        from unittest.mock import patch
+
+        deployment_spec = DeploymentSpec(
+            namespace="some.namespace",
+            nodes=[],
+        )
+        context = MagicMock(autospec=DeploymentContext)
+        context.current_user = current_user
+        context.save_history = AsyncMock()
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=deployment_spec,
+            deployment_id="test-deployment",
+            session=session,
+            context=context,
+        )
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = (
+                "nonexistent_catalog"
+            )
+            result_catalogs = await orchestrator._setup_catalogs()
+        assert "nonexistent_catalog" not in result_catalogs
+        assert len(orchestrator.errors) == 1
+        assert "nonexistent_catalog" in orchestrator.errors[0].message
+
+    @pytest.mark.asyncio
+    async def test_setup_catalogs_validates_missing_spec_default_catalog(
+        self,
+        session,
+        current_user,
+    ):
+        """
+        _setup_catalogs should report an error when the deployment spec's
+        default_catalog refers to a catalog that doesn't exist in the DB.
+        """
+        from unittest.mock import patch
+
+        deployment_spec = DeploymentSpec(
+            namespace="some.namespace",
+            nodes=[],
+            default_catalog="nonexistent_spec_catalog",
+        )
+        context = MagicMock(autospec=DeploymentContext)
+        context.current_user = current_user
+        context.save_history = AsyncMock()
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=deployment_spec,
+            deployment_id="test-deployment",
+            session=session,
+            context=context,
+        )
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = None
+            result_catalogs = await orchestrator._setup_catalogs()
+        assert "nonexistent_spec_catalog" not in result_catalogs
+        assert len(orchestrator.errors) == 1
+        assert "nonexistent_spec_catalog" in orchestrator.errors[0].message
+
     def test_filter_nodes_to_deploy_without_force(
         self,
         orchestrator,

--- a/datajunction-server/tests/internal/deployment_test.py
+++ b/datajunction-server/tests/internal/deployment_test.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 import random
 from typing import AsyncGenerator
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 import pytest_asyncio
 from datajunction_server.api.attributes import default_attribute_types
@@ -2404,7 +2404,11 @@ class TestFallbackCatalogAndInferCubeCatalog:
         """_fallback_catalog returns None when no default_catalog is configured."""
         spec = DeploymentSpec(namespace="test")
         orch = self._make_orchestrator(spec)
-        result = orch._fallback_catalog()
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = None
+            result = orch._fallback_catalog()
         assert result is None
 
     def test_infer_cube_catalog_uses_fallback(self):
@@ -2436,7 +2440,11 @@ class TestFallbackCatalogAndInferCubeCatalog:
             metrics=["test.m"],
             dimensions=[],
         )
-        result = orch._infer_cube_catalog(cube_spec, None)
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = None
+            result = orch._infer_cube_catalog(cube_spec, None)
         assert result == mock_catalog
 
     def test_infer_cube_catalog_uses_existing_node_catalog(self):
@@ -2456,7 +2464,11 @@ class TestFallbackCatalogAndInferCubeCatalog:
             metrics=["test.m"],
             dimensions=[],
         )
-        result = orch._infer_cube_catalog(cube_spec, existing)
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = None
+            result = orch._infer_cube_catalog(cube_spec, existing)
         assert result == mock_catalog
 
     def test_infer_cube_catalog_returns_none_when_all_fail(self):
@@ -2470,5 +2482,52 @@ class TestFallbackCatalogAndInferCubeCatalog:
             metrics=["test.m"],
             dimensions=[],
         )
-        result = orch._infer_cube_catalog(cube_spec, None)
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = None
+            result = orch._infer_cube_catalog(cube_spec, None)
+        assert result is None
+
+    def test_fallback_catalog_uses_server_default_when_spec_unset(self):
+        """_fallback_catalog uses server default_catalog_name when deployment spec has no default."""
+        mock_catalog = MagicMock()
+        spec = DeploymentSpec(namespace="test")
+        orch = self._make_orchestrator(spec)
+        orch.registry.catalogs["server_catalog"] = mock_catalog
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = (
+                "server_catalog"
+            )
+            result = orch._fallback_catalog()
+        assert result == mock_catalog
+
+    def test_fallback_catalog_spec_overrides_server_default(self):
+        """Deployment spec default_catalog takes priority over server default_catalog_name."""
+        spec_catalog = MagicMock()
+        server_catalog = MagicMock()
+        spec = DeploymentSpec(namespace="test", default_catalog="spec_catalog")
+        orch = self._make_orchestrator(spec)
+        orch.registry.catalogs["spec_catalog"] = spec_catalog
+        orch.registry.catalogs["server_catalog"] = server_catalog
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = (
+                "server_catalog"
+            )
+            result = orch._fallback_catalog()
+        assert result == spec_catalog
+
+    def test_fallback_catalog_none_when_no_defaults(self):
+        """_fallback_catalog returns None when neither spec nor server default is set."""
+        spec = DeploymentSpec(namespace="test")
+        orch = self._make_orchestrator(spec)
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator.get_settings",
+        ) as mock_settings:
+            mock_settings.return_value.seed_setup.default_catalog_name = None
+            result = orch._fallback_catalog()
         assert result is None

--- a/datajunction-server/tests/models/catalog_test.py
+++ b/datajunction-server/tests/models/catalog_test.py
@@ -2,6 +2,10 @@
 Tests for ``datajunction_server.models.catalog``.
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from datajunction_server.database.catalog import Catalog
 
 
@@ -18,3 +22,32 @@ def test_catalog_str_and_hash():
     druid = Catalog(id=3, name="druid")
     assert str(druid) == "druid"
     assert hash(druid) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_default_catalog_returns_none_when_not_configured():
+    """get_default_catalog returns None when default_catalog_name is not set."""
+    session = AsyncMock()
+    with patch(
+        "datajunction_server.database.catalog.get_settings",
+    ) as mock_settings:
+        mock_settings.return_value.seed_setup.default_catalog_name = None
+        result = await Catalog.get_default_catalog(session)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_default_catalog_returns_catalog_when_configured():
+    """get_default_catalog returns the named catalog when configured."""
+    mock_catalog = MagicMock(spec=Catalog)
+    session = AsyncMock()
+    with (
+        patch(
+            "datajunction_server.database.catalog.get_settings",
+        ) as mock_settings,
+        patch.object(Catalog, "get_by_name", return_value=mock_catalog) as mock_get,
+    ):
+        mock_settings.return_value.seed_setup.default_catalog_name = "my_catalog"
+        result = await Catalog.get_default_catalog(session)
+    mock_get.assert_awaited_once_with(session, "my_catalog")
+    assert result == mock_catalog


### PR DESCRIPTION
### Summary

<!-- What's this change about? -->

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
