### PR TITLE
Fix dryrun namespace derivation to match push behavior

### DIFF
--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -309,10 +309,6 @@ class DeploymentService:
                 base_namespace,
                 branch,
             )
-        console.print(
-            f"[bold]Dry run namespace:[/bold] {deployment_spec.get('namespace')!r} "
-            f"(base={base_namespace!r}, branch={branch!r})",
-        )
         if display:
             print_deployment_header(
                 mode="dry run",

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -297,10 +297,21 @@ class DeploymentService:
         """
         console = console or self.console
         deployment_spec, file_errors = self._reconstruct_deployment_spec(source_path)
-        deployment_spec["namespace"] = namespace or deployment_spec.get("namespace")
+        base_namespace = deployment_spec.get("namespace") or ""
         source = deployment_spec.get("source", {})
         branch = os.getenv("DJ_DEPLOY_BRANCH") or DeploymentService._detect_git_branch(
             cwd=source_path,
+        )
+        if namespace:
+            deployment_spec["namespace"] = namespace
+        elif branch and base_namespace:
+            deployment_spec["namespace"] = DeploymentService._derive_namespace(
+                base_namespace,
+                branch,
+            )
+        console.print(
+            f"[bold]Dry run namespace:[/bold] {deployment_spec.get('namespace')!r} "
+            f"(base={base_namespace!r}, branch={branch!r})",
         )
         if display:
             print_deployment_header(

--- a/datajunction-clients/python/tests/test_cli.py
+++ b/datajunction-clients/python/tests/test_cli.py
@@ -1008,6 +1008,8 @@ class TestPushDeploymentSourceFlags:
             "dj",
             "push",
             "./deploy0",
+            "--namespace",
+            "repo_flag_test",
             "--repo",
             "github.com/test/repo",
         ]

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1197,6 +1197,35 @@ class TestGetImpact:
         call_args = mock_client.get_deployment_impact.call_args[0][0]
         assert call_args["namespace"] == "override.ns"
 
+    def test_get_impact_derives_namespace_from_git_branch(self, tmp_path, monkeypatch):
+        """get_impact should derive namespace from git branch, same as push."""
+        (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "project"}))
+        (tmp_path / "my_node.yaml").write_text(
+            yaml.safe_dump({"name": "project.my_node"}),
+        )
+
+        monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
+        monkeypatch.delenv("DJ_DEPLOY_BRANCH", raising=False)
+        monkeypatch.setattr(
+            "datajunction.deployment.subprocess.run",
+            lambda *a, **kw: mock.MagicMock(stdout="feature/new-metric\n"),
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_deployment_impact.return_value = {
+            "uuid": "dry_run",
+            "namespace": "project.feature_new_metric",
+            "status": "success",
+            "results": [],
+            "downstream_impacts": [],
+        }
+
+        svc = DeploymentService(mock_client, console=Console(file=io.StringIO()))
+        svc.get_impact(tmp_path)
+
+        call_args = mock_client.get_deployment_impact.call_args[0][0]
+        assert call_args["namespace"] == "project.feature_new_metric"
+
 
 class TestDetectGitBranch:
     """Tests for _detect_git_branch."""


### PR DESCRIPTION
### Summary

`dj push --dryrun` without `--namespace` flag used the top-level namespace from `dj.yaml` instead of deriving the branch-qualified namespace (e.g., `xyz.main`). This caused the server to process the wrong namespace, leading to hangs or incorrect impact analysis.

The fix applies the same namespace derivation logic that push already uses.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
