### PR TITLE
Fix cube crash when requesting `columns`

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -108,11 +108,19 @@ async def _attach_raw_columns(session, nodes):
 
 
 def _is_cube_name_only_request(current_fields: dict) -> bool:
-    """Check if the current revision fields only need cube metric/dimension names."""
+    """Check if the current revision fields only need cube metric/dimension names.
+
+    The fast path replaces ``current.columns`` with lightweight ``_RawColumn``
+    stand-ins, so it's only safe when the client hasn't also asked for
+    ``columns`` or ``primary_key`` — both of which read attributes
+    (``display_name`` etc.) that ``_RawColumn`` doesn't carry.
+    """
     cube_metric_fields = current_fields.get("cube_metrics")
     cube_dimension_fields = current_fields.get("cube_dimensions")
     is_cube = cube_metric_fields is not None or cube_dimension_fields is not None
     if not is_cube:
+        return False
+    if "columns" in current_fields or "primary_key" in current_fields:
         return False
     return (cube_metric_fields is None or _is_name_only(cube_metric_fields)) and (
         cube_dimension_fields is None or _is_name_only(cube_dimension_fields)
@@ -401,10 +409,14 @@ def load_node_revision_options(node_revision_fields):
 
     # When cubeMetrics/cubeDimensions only need "name", we can skip loading
     # both cube_elements AND columns as ORM objects — the resolver will use
-    # raw column data fetched post-query instead.
+    # raw column data fetched post-query instead. Must match the fast-path
+    # predicate (_is_cube_name_only_request) so we don't noload
+    # cube_elements while also letting `_attach_raw_columns` be skipped.
     all_name_only = is_cube_request and (
         (cube_metric_fields is None or _is_name_only(cube_metric_fields))
         and (cube_dimension_fields is None or _is_name_only(cube_dimension_fields))
+        and "columns" not in node_revision_fields
+        and "primary_key" not in node_revision_fields
     )
 
     # Handle columns

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3230,3 +3230,63 @@ async def test_duplicate_field_selection_equivalent_to_merged(
     assert node["current"]["catalog"]["name"]
     assert node["current"]["columns"]
     assert all(col["name"] for col in node["current"]["columns"])
+
+
+@pytest.mark.asyncio
+async def test_cube_columns_and_cube_metrics_together(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Requesting ``columns { displayName }`` alongside ``cubeMetrics { name }``
+    on a cube must not crash. Regression for the case where the name-only
+    fast path overwrote ``current.columns`` with lightweight ``_RawColumn``
+    stand-ins — which don't carry ``display_name`` — even though the client
+    also asked for the full columns data.
+    """
+    response = await client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": [
+                "default.num_repair_orders",
+                "default.avg_repair_price",
+            ],
+            "dimensions": [
+                "default.hard_hat.city",
+                "default.hard_hat.state",
+            ],
+            "description": "Columns-and-metrics test cube",
+            "mode": "published",
+            "name": "default.columns_and_metrics_cube",
+        },
+    )
+    assert response.status_code < 400, response.json()
+
+    query = """
+    {
+        findNodes(names: ["default.columns_and_metrics_cube"]) {
+            current {
+                columns {
+                    name
+                    displayName
+                }
+                cubeMetrics {
+                    name
+                }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert "errors" not in data, data
+
+    node = data["data"]["findNodes"][0]
+    # Both sides of the request resolved cleanly.
+    assert node["current"]["columns"]
+    assert all(col["name"] and col["displayName"] for col in node["current"]["columns"])
+    metric_names = sorted(m["name"] for m in node["current"]["cubeMetrics"])
+    assert metric_names == [
+        "default.avg_repair_price",
+        "default.num_repair_orders",
+    ]

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3290,3 +3290,35 @@ async def test_cube_columns_and_cube_metrics_together(
         "default.avg_repair_price",
         "default.num_repair_orders",
     ]
+
+
+@pytest.mark.asyncio
+async def test_cube_name_only_fast_path_on_non_cube_node(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Requesting ``cubeMetrics``/``cubeDimensions`` on a non-cube node engages
+    the name-only fast path but finds no cube nodes in the result — the raw
+    column attachment should short-circuit cleanly rather than doing anything.
+    """
+    query = """
+    {
+        findNodes(names: ["default.num_repair_orders"]) {
+            name
+            type
+            current {
+                cubeMetrics { name }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert "errors" not in data, data
+
+    node = data["data"]["findNodes"][0]
+    assert node["name"] == "default.num_repair_orders"
+    assert node["type"] == "METRIC"
+    # Non-cube node: cubeMetrics resolver returns [] regardless of fast path.
+    assert node["current"]["cubeMetrics"] == []


### PR DESCRIPTION
### Summary

Querying a cube for both `columns { displayName }` and `cubeMetrics { name }` (or `cubeDimensions { name }`) crashed with `'_RawColumn' object has no attribute 'display_name'`:
```
  { findNodes(...) { current { columns { displayName } cubeMetrics { name } } } }
```

This is because the name-only cube fast path replaces `current.columns` with lightweight `_RawColumn` stand-ins to skip ORM hydration, but the predicate that gated the optimization only looked at the cube subfields, so a query that also requested full columns data still took the fast path and overwrote the real columns with the bare stand-ins.

The predicate now also check for `columns` / `primaryKey` at the same selection level, so the fast path is skipped whenever the client needs the real column data.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
