### PR TITLE
Fix DetachedInstanceError on partitioned column GraphQL queries

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -188,23 +188,13 @@ class NodeRevision:
         """
         The columns of the node
         """
-        from sqlalchemy.orm.attributes import set_committed_value
-
-        def _build_partition(col):
-            if col.partition is None:
-                return None
-            # Force-populate the Partition.column back-ref so
-            # temporal_expression()'s `self.column.type` access doesn't hit a
-            # DetachedInstanceError — the joined-eager load on Column.partition
-            # doesn't reliably fill the reverse side post-resolver.
-            set_committed_value(col.partition, "column", col)
-            return Partition(
-                type_=col.partition.type_,
-                format=col.partition.format,
-                granularity=col.partition.granularity,
-                expression=col.partition.temporal_expression(),
-            )
-
+        # Pre-seed Partition.column back-ref so temporal_expression()'s
+        # self.column.type access doesn't trip DetachedInstanceError during
+        # post-resolver serialization. The joined-eager load on
+        # Column.partition doesn't reliably fill the reverse side.
+        for col in root.columns:
+            if col.partition is not None:
+                set_committed_value(col.partition, "column", col)
         return [
             Column(  # type: ignore
                 name=col.name,
@@ -216,7 +206,14 @@ class NodeRevision:
                     if col.dimension
                     else None
                 ),
-                partition=_build_partition(col),
+                partition=Partition(
+                    type_=col.partition.type_,  # type: ignore
+                    format=col.partition.format,
+                    granularity=col.partition.granularity,
+                    expression=col.partition.temporal_expression(),
+                )
+                if col.partition
+                else None,
             )
             for col in root.columns
             if (

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -188,6 +188,23 @@ class NodeRevision:
         """
         The columns of the node
         """
+        from sqlalchemy.orm.attributes import set_committed_value
+
+        def _build_partition(col):
+            if col.partition is None:
+                return None
+            # Force-populate the Partition.column back-ref so
+            # temporal_expression()'s `self.column.type` access doesn't hit a
+            # DetachedInstanceError — the joined-eager load on Column.partition
+            # doesn't reliably fill the reverse side post-resolver.
+            set_committed_value(col.partition, "column", col)
+            return Partition(
+                type_=col.partition.type_,
+                format=col.partition.format,
+                granularity=col.partition.granularity,
+                expression=col.partition.temporal_expression(),
+            )
+
         return [
             Column(  # type: ignore
                 name=col.name,
@@ -199,14 +216,7 @@ class NodeRevision:
                     if col.dimension
                     else None
                 ),
-                partition=Partition(
-                    type_=col.partition.type_,  # type: ignore
-                    format=col.partition.format,
-                    granularity=col.partition.granularity,
-                    expression=col.partition.temporal_expression(),
-                )
-                if col.partition
-                else None,
+                partition=_build_partition(col),
             )
             for col in root.columns
             if (

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3150,7 +3150,15 @@ async def revalidate_node(
             .scalars()
             .all()
         )
-        node.current.parents = list(parent_refs)  # type: ignore
+        # Only reassign when the PK set actually changed. Blind reassignment
+        # makes SA diff by Python identity, and a fresh select may return
+        # different ORM instances for the same rows, leading it to stage a
+        # DELETE+INSERT for an unchanged (parent_id, child_id) pair — the
+        # INSERT then races autoflush and hits the PK constraint.
+        current_parent_ids = {p.id for p in node.current.parents}  # type: ignore
+        target_parent_ids = {p.id for p in parent_refs}
+        if current_parent_ids != target_parent_ids:
+            node.current.parents = list(parent_refs)  # type: ignore
         _logger.info(f"Updated parents to: {[p.name for p in parent_refs]}")
     else:
         _logger.info(f"No parents found in dependencies for {node.name}")

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3201,6 +3201,24 @@ async def revalidate_node(
         )
 
         new_revision.status = node_validator.status
+        # Snapshot pending m2m state before compile — autoflush during
+        # compile has raced a phantom (parent_id, child_id) insert in CI.
+        # If it fires again, this log tells us exactly which objects SA
+        # thinks have dirty parent collections.
+        dirty_m2m = [
+            (type(obj).__name__, getattr(obj, "id", None), getattr(obj, "name", None))
+            for obj in session.dirty
+            if hasattr(obj, "parents")
+        ]
+        new_objs = [
+            (type(obj).__name__, getattr(obj, "name", None)) for obj in session.new
+        ]
+        _logger.info(
+            f"revalidate_node({node.name}) pre-compile session state: "
+            f"dirty_with_parents={dirty_m2m}, new={new_objs}, "
+            f"node.current.parents={[(p.id, p.name) for p in node.current.parents]}, "  # type: ignore
+            f"new_revision.parents={[(p.id, p.name) for p in new_revision.parents]}",
+        )
         new_revision.lineage = [
             lineage.model_dump()
             for lineage in await get_column_level_lineage(session, new_revision)

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3322,3 +3322,57 @@ async def test_cube_name_only_fast_path_on_non_cube_node(
     assert node["type"] == "METRIC"
     # Non-cube node: cubeMetrics resolver returns [] regardless of fast path.
     assert node["current"]["cubeMetrics"] == []
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_columns_with_partition(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Querying the ``partition`` subfield on a column with a configured partition
+    exercises the ``set_committed_value`` pre-seed of ``Partition.column`` —
+    without it, ``temporal_expression()`` trips ``DetachedInstanceError`` during
+    post-resolver serialization.
+    """
+    await client_with_roads.post(
+        "/nodes/default.repair_orders_fact/columns/order_date/partition",
+        json={"type_": "temporal", "granularity": "day", "format": "yyyyMMdd"},
+    )
+
+    query = """
+    {
+        findNodes(names: ["default.repair_orders_fact"]) {
+            name
+            current {
+                columns {
+                    name
+                    partition {
+                        type_
+                        format
+                        granularity
+                        expression
+                    }
+                }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert "errors" not in data, data
+
+    columns = data["data"]["findNodes"][0]["current"]["columns"]
+    order_date = next(c for c in columns if c["name"] == "order_date")
+    assert order_date["partition"] == {
+        "type_": "TEMPORAL",
+        "format": "yyyyMMdd",
+        "granularity": "day",
+        "expression": (
+            "CAST(DATE_FORMAT(CAST(${dj_logical_timestamp} AS TIMESTAMP), "
+            "'yyyyMMdd') AS TIMESTAMP)"
+        ),
+    }
+    # Columns without a partition should return None.
+    no_partition = next(c for c in columns if c["name"] == "repair_order_id")
+    assert no_partition["partition"] is None


### PR DESCRIPTION
### Summary

Querying columns `{ partition { expression } }` on a node with a temporal partition raised `DetachedInstanceError` during post-resolver serialization, because `Partition.temporal_expression()` reads back through `self.column.type` and the joined-eager load on `Column.partition` doesn't reliably populate the reverse side.

The columns resolver now pre-seeds Partition's column via `set_committed_value` before building the Strawberry DTOs.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
