### PR TITLE
Reduce extraneous loading for sql build v3

### DIFF
--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -250,8 +250,13 @@ async def get_measures_sql_v3(
     See also: `/sql/metrics/v3/` for the final combined query with metric expressions.
     """
     merged_filters = list(filters)
+    cube_node = None
     if cube:
-        cube_node = await Node.get_cube_by_name(session, cube)
+        cube_node = await Node.get_cube_by_name(
+            session,
+            cube,
+            for_measures_sql=True,
+        )
         if cube_node:
             if cube_node.current.cube_filters:
                 merged_filters = cube_node.current.cube_filters + merged_filters
@@ -271,6 +276,7 @@ async def get_measures_sql_v3(
         include_temporal_filters=include_temporal_filters,
         lookback_window=lookback_window,
         query_parameters=json.loads(query_params) or None,
+        matched_cube=cube_node.current if cube_node else None,
     )
 
     # Build a unified component_aliases map from all grain groups

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -261,13 +261,9 @@ async def get_measures_sql_v3(
             if cube_node.current.cube_filters:
                 merged_filters = cube_node.current.cube_filters + merged_filters
             if not metrics:
-                # Fast path: derive metric/dimension names from the cube's own
-                # columns (using the _DOT_ encoding) rather than traversing
-                # cube_elements → node_revision → node. This avoids firing the
-                # NodeRevision.node selectin cascade under load.
-                metrics = cube_node.current.cube_metric_names_fast()
+                metrics = cube_node.current.cube_node_metrics
                 if not dimensions:
-                    dimensions = cube_node.current.cube_dimension_names_fast()
+                    dimensions = cube_node.current.cube_node_dimensions
 
     _t0 = time.monotonic()
     result = await build_measures_sql(

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -261,9 +261,13 @@ async def get_measures_sql_v3(
             if cube_node.current.cube_filters:
                 merged_filters = cube_node.current.cube_filters + merged_filters
             if not metrics:
-                metrics = cube_node.current.cube_node_metrics
+                # Fast path: derive metric/dimension names from the cube's own
+                # columns (using the _DOT_ encoding) rather than traversing
+                # cube_elements → node_revision → node. This avoids firing the
+                # NodeRevision.node selectin cascade under load.
+                metrics = cube_node.current.cube_metric_names_fast()
                 if not dimensions:
-                    dimensions = cube_node.current.cube_node_dimensions
+                    dimensions = cube_node.current.cube_dimension_names_fast()
 
     _t0 = time.monotonic()
     result = await build_measures_sql(

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -102,27 +102,34 @@ async def extract_temporal_partition_columns(
     session: AsyncSession,
     metrics: list[str],
     dimensions: list[str],
+    matched_cube: Optional["NodeRevision"] = None,
 ) -> dict[str, Partition] | None:
     """
     Extract temporal partition columns from a matching cube.
 
-    Finds a cube that matches the given metrics and dimensions, and extracts
-    any columns marked as temporal partitions along with their partition metadata.
+    Finds a cube that matches the given metrics and dimensions (or uses a
+    pre-resolved `matched_cube` if provided, avoiding a second DB round-trip),
+    and extracts any columns marked as temporal partitions along with their
+    partition metadata.
 
     Args:
         session: Database session
         metrics: List of metric node names
         dimensions: List of dimension names
+        matched_cube: Optional pre-resolved cube revision. When supplied (e.g.
+            from an explicit `cube=` URL parameter), skips find_matching_cube.
 
     Returns:
         Dict mapping column names to partition objects, or None if no cube found or no temporal partitions
     """
-    matching_cube = await find_matching_cube(
-        session,
-        metrics,
-        dimensions,
-        require_availability=False,
-    )
+    matching_cube = matched_cube
+    if matching_cube is None:
+        matching_cube = await find_matching_cube(
+            session,
+            metrics,
+            dimensions,
+            require_availability=False,
+        )
 
     if not matching_cube:
         return None
@@ -213,6 +220,7 @@ async def setup_build_context(
     use_materialized: bool = True,
     include_temporal_filters: bool = False,
     lookback_window: str | None = None,
+    matched_cube: Optional["NodeRevision"] = None,
 ) -> BuildContext:
     """
     Create and initialize a BuildContext with all setup done.
@@ -244,6 +252,7 @@ async def setup_build_context(
             session,
             metrics,
             dimensions,
+            matched_cube=matched_cube,
         )
 
     ctx = BuildContext(
@@ -316,6 +325,7 @@ async def build_measures_sql(
     include_temporal_filters: bool = False,
     lookback_window: str | None = None,
     query_parameters: dict[str, Any] | None = None,
+    matched_cube: Optional["NodeRevision"] = None,
 ) -> GeneratedMeasuresSQL:
     """
     Build measures SQL for a set of metrics, dimensions, and filters.
@@ -355,6 +365,7 @@ async def build_measures_sql(
         use_materialized=use_materialized,
         include_temporal_filters=include_temporal_filters,
         lookback_window=lookback_window,
+        matched_cube=matched_cube,
     )
 
     # Build grain groups from context

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -123,7 +123,7 @@ async def extract_temporal_partition_columns(
         Dict mapping column names to partition objects, or None if no cube found or no temporal partitions
     """
     matching_cube = matched_cube
-    if matching_cube is None:
+    if matching_cube is None:  # pragma: no branch
         matching_cube = await find_matching_cube(
             session,
             metrics,

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -93,29 +93,23 @@ async def find_matching_cube(
             noload(Node.tags),  # Prevent Tag selectin chain
             joinedload(Node.current).options(
                 noload(NodeRevision.created_by),  # Prevent User N+1 queries
-                joinedload(NodeRevision.catalog).options(
-                    noload(Catalog.engines),  # Prevent Engine selectin chain
-                ),
+                # NOTE: don't noload Catalog.engines — find_matching_cube is
+                # also called from resolve_dialect_and_engine_for_metrics which
+                # later reads catalog.engines on the same Catalog instance.
+                # noload would poison the session identity map and break
+                # downstream engine resolution.
+                # NOTE: don't noload Column.attributes — Columns are identity-
+                # mapped by id and downstream code reads col.has_primary_key_
+                # attribute(); noload here would poison those reads.
                 selectinload(NodeRevision.cube_elements).options(
-                    noload(Column.attributes),
                     selectinload(Column.node_revision).options(
                         noload(NodeRevision.created_by),  # Prevent User N+1 queries
-                        joinedload(NodeRevision.catalog).options(
-                            noload(Catalog.engines),
-                        ),
                     ),
                 ),
                 joinedload(NodeRevision.availability),
                 selectinload(NodeRevision.materializations),
                 selectinload(NodeRevision.columns).options(
-                    noload(Column.attributes),
-                    selectinload(Column.partition)
-                    .selectinload(
-                        Partition.column,
-                    )
-                    .options(
-                        noload(Column.attributes),
-                    ),
+                    selectinload(Column.partition).selectinload(Partition.column),
                 ),
             ),
         )

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -90,19 +90,32 @@ async def find_matching_cube(
         )
         .options(
             noload(Node.created_by),  # Prevent User N+1 queries
+            noload(Node.tags),  # Prevent Tag selectin chain
             joinedload(Node.current).options(
                 noload(NodeRevision.created_by),  # Prevent User N+1 queries
+                joinedload(NodeRevision.catalog).options(
+                    noload(Catalog.engines),  # Prevent Engine selectin chain
+                ),
                 selectinload(NodeRevision.cube_elements).options(
+                    noload(Column.attributes),
                     selectinload(Column.node_revision).options(
                         noload(NodeRevision.created_by),  # Prevent User N+1 queries
+                        joinedload(NodeRevision.catalog).options(
+                            noload(Catalog.engines),
+                        ),
                     ),
                 ),
                 joinedload(NodeRevision.availability),
                 selectinload(NodeRevision.materializations),
-                selectinload(NodeRevision.columns)
-                .selectinload(Column.partition)
-                .selectinload(
-                    Partition.column,
+                selectinload(NodeRevision.columns).options(
+                    noload(Column.attributes),
+                    selectinload(Column.partition)
+                    .selectinload(
+                        Partition.column,
+                    )
+                    .options(
+                        noload(Column.attributes),
+                    ),
                 ),
             ),
         )

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -11,7 +11,6 @@ from sqlalchemy import select, text, bindparam
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, joinedload, load_only, noload
 
-from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.node import Node, NodeRevision, Column
 from datajunction_server.database.preaggregation import PreAggregation
@@ -280,14 +279,18 @@ async def load_dimension_links_batch(
                 noload(Node.tags),  # Prevent Tag selectin chain
                 joinedload(Node.current).options(
                     noload(NodeRevision.created_by),  # Prevent User N+1 queries
-                    # Load what's needed for table references, parsing, and type lookups
-                    joinedload(NodeRevision.catalog).options(
-                        noload(Catalog.engines),  # Prevent Engine selectin chain
-                    ),
+                    # Load what's needed for table references, parsing, and type lookups.
+                    # NOTE: don't noload Catalog.engines — this function is shared
+                    # across build_measures_sql and build_metrics_sql; the latter is
+                    # used by /data which reads catalog.engines downstream. noload
+                    # would poison the Catalog instance in the session identity map.
+                    joinedload(NodeRevision.catalog),
                     joinedload(NodeRevision.availability),
+                    # NOTE: don't noload Column.attributes — Columns are
+                    # identity-mapped and downstream paths read
+                    # col.has_primary_key_attribute().
                     selectinload(NodeRevision.columns).options(
                         load_only(Column.name, Column.type),
-                        noload(Column.attributes),
                     ),
                 ),
             ),
@@ -391,18 +394,18 @@ async def load_nodes(ctx: BuildContext) -> None:
                     NodeRevision.schema_,
                     NodeRevision.table,
                 ),
+                # NOTE: don't noload Column.attributes — Columns are identity-
+                # mapped and downstream code (get_native_grain) reads
+                # col.has_primary_key_attribute().
                 selectinload(NodeRevision.columns).options(
                     load_only(
                         Column.name,
                         Column.type,
                     ),
-                    noload(Column.attributes),
                 ),
-                joinedload(NodeRevision.catalog).options(
-                    noload(Catalog.engines),  # Prevent Engine selectin chain
-                ),
+                # NOTE: don't noload Catalog.engines — see load_dimension_links_batch.
+                joinedload(NodeRevision.catalog),
                 selectinload(NodeRevision.required_dimensions).options(
-                    noload(Column.attributes),
                     # Load the node_revision and node to reconstruct full dimension path
                     joinedload(Column.node_revision).options(
                         noload(NodeRevision.created_by),  # Prevent User N+1 queries
@@ -523,13 +526,13 @@ async def load_nodes(ctx: BuildContext) -> None:
                             NodeRevision.schema_,
                             NodeRevision.table,
                         ),
+                        # NOTE: don't noload Column.attributes — Columns are
+                        # identity-mapped and downstream reads primary-key attrs.
                         selectinload(NodeRevision.columns).options(
                             load_only(Column.name, Column.type),
-                            noload(Column.attributes),
                         ),
-                        joinedload(NodeRevision.catalog).options(
-                            noload(Catalog.engines),
-                        ),
+                        # NOTE: don't noload Catalog.engines — see load_dimension_links_batch.
+                        joinedload(NodeRevision.catalog),
                         joinedload(NodeRevision.availability),
                     ),
                 )

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -11,6 +11,7 @@ from sqlalchemy import select, text, bindparam
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, joinedload, load_only, noload
 
+from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.node import Node, NodeRevision, Column
 from datajunction_server.database.preaggregation import PreAggregation
@@ -276,13 +277,17 @@ async def load_dimension_links_batch(
         .options(
             joinedload(DimensionLink.dimension).options(
                 noload(Node.created_by),  # Prevent User N+1 queries
+                noload(Node.tags),  # Prevent Tag selectin chain
                 joinedload(Node.current).options(
                     noload(NodeRevision.created_by),  # Prevent User N+1 queries
                     # Load what's needed for table references, parsing, and type lookups
-                    joinedload(NodeRevision.catalog),
+                    joinedload(NodeRevision.catalog).options(
+                        noload(Catalog.engines),  # Prevent Engine selectin chain
+                    ),
                     joinedload(NodeRevision.availability),
                     selectinload(NodeRevision.columns).options(
                         load_only(Column.name, Column.type),
+                        noload(Column.attributes),
                     ),
                 ),
             ),
@@ -376,6 +381,8 @@ async def load_nodes(ctx: BuildContext) -> None:
                 Node.type,
                 Node.current_version,
             ),
+            noload(Node.created_by),  # Prevent User selectin chain on root Node
+            noload(Node.tags),  # Prevent Tag selectin chain on root Node
             joinedload(Node.current).options(
                 noload(NodeRevision.created_by),  # Prevent User N+1 queries
                 load_only(
@@ -389,14 +396,19 @@ async def load_nodes(ctx: BuildContext) -> None:
                         Column.name,
                         Column.type,
                     ),
+                    noload(Column.attributes),
                 ),
-                joinedload(NodeRevision.catalog),
+                joinedload(NodeRevision.catalog).options(
+                    noload(Catalog.engines),  # Prevent Engine selectin chain
+                ),
                 selectinload(NodeRevision.required_dimensions).options(
+                    noload(Column.attributes),
                     # Load the node_revision and node to reconstruct full dimension path
                     joinedload(Column.node_revision).options(
                         noload(NodeRevision.created_by),  # Prevent User N+1 queries
                         joinedload(NodeRevision.node).options(
                             noload(Node.created_by),  # Prevent User N+1 queries
+                            noload(Node.tags),  # Prevent Tag selectin chain
                         ),
                     ),
                 ),
@@ -405,6 +417,7 @@ async def load_nodes(ctx: BuildContext) -> None:
                     # Load dimension node for link matching in temporal filters
                     joinedload(DimensionLink.dimension).options(
                         noload(Node.created_by),  # Prevent User N+1 queries
+                        noload(Node.tags),  # Prevent Tag selectin chain
                     ),
                 ),
             ),
@@ -500,6 +513,8 @@ async def load_nodes(ctx: BuildContext) -> None:
                 .where(Node.deactivated_at.is_(None))
                 .options(
                     load_only(Node.name, Node.type, Node.current_version),
+                    noload(Node.created_by),
+                    noload(Node.tags),
                     joinedload(Node.current).options(
                         noload(NodeRevision.created_by),
                         load_only(
@@ -510,8 +525,11 @@ async def load_nodes(ctx: BuildContext) -> None:
                         ),
                         selectinload(NodeRevision.columns).options(
                             load_only(Column.name, Column.type),
+                            noload(Column.attributes),
                         ),
-                        joinedload(NodeRevision.catalog),
+                        joinedload(NodeRevision.catalog).options(
+                            noload(Catalog.engines),
+                        ),
                         joinedload(NodeRevision.availability),
                     ),
                 )

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -646,8 +646,9 @@ class Node(Base):
                 `build_measures_sql(..., matched_cube=...)`. Default False preserves
                 existing callers' behavior.
         """
+        options: list[ExecutableOption]
         if for_measures_sql:
-            options = (
+            options = [
                 # Top-level Node: suppress auto-selectin on created_by/tags
                 noload(Node.created_by),
                 noload(Node.tags),
@@ -675,9 +676,9 @@ class Node(Base):
                         noload(Column.attributes),
                     ),
                 ),
-            )
+            ]
         else:
-            options = (
+            options = [
                 joinedload(Node.current).options(
                     selectinload(NodeRevision.availability),
                     selectinload(NodeRevision.columns),
@@ -692,7 +693,7 @@ class Node(Base):
                     ),
                 ),
                 joinedload(Node.tags),
-            )
+            ]
 
         statement = select(Node).where(Node.name == name).options(*options)
         result = await session.execute(statement)

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -648,14 +648,14 @@ class Node(Base):
         """
         options: list[ExecutableOption]
         if for_measures_sql:
-            # Lean chain for the build_v3 measures-SQL path. We only need:
+            # Lean chain for the build_v3 measures-SQL path. Needed:
             #   - cube_filters (scalar on NodeRevision)
-            #   - self.columns (for cube_metric_names_fast / _dimensions_fast and
-            #     extract_temporal_partition_columns; partitions ride along via
-            #     Column.partition lazy="joined")
-            # Deliberately NOT loaded: cube_elements, their node_revision.node
-            # (the fast-path accessors derive metric names from column-name
-            # encoding without traversing to the underlying source nodes).
+            #   - cube_elements + their node_revision (for cube_node_metrics /
+            #     cube_node_dimensions which read node_revision.type and .name)
+            #   - self.columns (for extract_temporal_partition_columns;
+            #     partitions ride along via Column.partition lazy="joined")
+            # Skipped vs the default chain: availability, materializations,
+            # backfills, engines selectin — build_measures_sql doesn't use them.
             #
             # Deliberately NOT suppressed via noload (all would poison the
             # session identity map, breaking unrelated callers on shared
@@ -665,6 +665,11 @@ class Node(Base):
                 noload(Node.tags),
                 joinedload(Node.current).options(
                     noload(NodeRevision.created_by),
+                    selectinload(NodeRevision.cube_elements).options(
+                        selectinload(Column.node_revision).options(
+                            noload(NodeRevision.created_by),
+                        ),
+                    ),
                     selectinload(NodeRevision.columns),
                 ),
             ]
@@ -1619,40 +1624,6 @@ class NodeRevision(
         Cube node's dimension attributes
         """
         return self.cube_dimensions()
-
-    def cube_metric_names_fast(self) -> List[str]:
-        """
-        Fast path: derive metric node names from the cube's own column names
-        without traversing cube_elements → Column.node_revision → Node.
-
-        Metric columns encode the source node's dotted name with "_DOT_" as a
-        separator (e.g. "demo_metrics_DOT_total_thumbs" → "demo.metrics.total_thumbs");
-        dimension columns don't contain "_DOT_". Only valid when self.columns is
-        already loaded — callers that have the cube NodeRevision in hand with
-        columns eager-loaded can use this to avoid loading NodeRevision.node.
-        """
-        if self.type != NodeType.CUBE:
-            return []  # pragma: no cover
-        ordering = {
-            col.name.replace("_DOT_", SEPARATOR): (col.order or idx)
-            for idx, col in enumerate(self.columns)
-            if "_DOT_" in col.name
-        }
-        return sorted(ordering.keys(), key=lambda name: ordering[name])
-
-    def cube_dimension_names_fast(self) -> List[str]:
-        """
-        Fast path counterpart to cube_metric_names_fast. Dimension columns
-        lack the "_DOT_" metric encoding; build the dimension attribute string
-        from the column's name + dimension_column without touching nodes.
-        """
-        if self.type != NodeType.CUBE:
-            return []  # pragma: no cover
-        return [
-            col.name + (col.dimension_column or "")
-            for col in self.columns
-            if "_DOT_" not in col.name
-        ]
 
     def temporal_partition_columns(self) -> List[Column]:
         """

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -648,33 +648,24 @@ class Node(Base):
         """
         options: list[ExecutableOption]
         if for_measures_sql:
+            # Lean chain for the build_v3 measures-SQL path. We only need:
+            #   - cube_filters (scalar on NodeRevision)
+            #   - self.columns (for cube_metric_names_fast / _dimensions_fast and
+            #     extract_temporal_partition_columns; partitions ride along via
+            #     Column.partition lazy="joined")
+            # Deliberately NOT loaded: cube_elements, their node_revision.node
+            # (the fast-path accessors derive metric names from column-name
+            # encoding without traversing to the underlying source nodes).
+            #
+            # Deliberately NOT suppressed via noload (all would poison the
+            # session identity map, breaking unrelated callers on shared
+            # instances): Catalog.engines, Column.attributes, NodeRevision.node.
             options = [
-                # Top-level Node: suppress auto-selectin on created_by/tags
                 noload(Node.created_by),
                 noload(Node.tags),
                 joinedload(Node.current).options(
                     noload(NodeRevision.created_by),
-                    noload(NodeRevision.node),
-                    # NodeRevision.catalog is lazy="joined" — suppress its engines cascade
-                    joinedload(NodeRevision.catalog).options(
-                        noload(Catalog.engines),
-                    ),
-                    # Cube filters/metrics/dimensions: need cube_elements + their
-                    # node_revision (for metric.name), but skip attribute cascades
-                    selectinload(NodeRevision.cube_elements).options(
-                        noload(Column.attributes),
-                        selectinload(Column.node_revision).options(
-                            noload(NodeRevision.created_by),
-                            joinedload(NodeRevision.catalog).options(
-                                noload(Catalog.engines),
-                            ),
-                        ),
-                    ),
-                    # Columns for extract_temporal_partition_columns.
-                    # Column.partition is lazy="joined" so partitions ride along.
-                    selectinload(NodeRevision.columns).options(
-                        noload(Column.attributes),
-                    ),
+                    selectinload(NodeRevision.columns),
                 ),
             ]
         else:
@@ -1628,6 +1619,40 @@ class NodeRevision(
         Cube node's dimension attributes
         """
         return self.cube_dimensions()
+
+    def cube_metric_names_fast(self) -> List[str]:
+        """
+        Fast path: derive metric node names from the cube's own column names
+        without traversing cube_elements → Column.node_revision → Node.
+
+        Metric columns encode the source node's dotted name with "_DOT_" as a
+        separator (e.g. "demo_metrics_DOT_total_thumbs" → "demo.metrics.total_thumbs");
+        dimension columns don't contain "_DOT_". Only valid when self.columns is
+        already loaded — callers that have the cube NodeRevision in hand with
+        columns eager-loaded can use this to avoid loading NodeRevision.node.
+        """
+        if self.type != NodeType.CUBE:
+            return []  # pragma: no cover
+        ordering = {
+            col.name.replace("_DOT_", SEPARATOR): (col.order or idx)
+            for idx, col in enumerate(self.columns)
+            if "_DOT_" in col.name
+        }
+        return sorted(ordering.keys(), key=lambda name: ordering[name])
+
+    def cube_dimension_names_fast(self) -> List[str]:
+        """
+        Fast path counterpart to cube_metric_names_fast. Dimension columns
+        lack the "_DOT_" metric encoding; build the dimension attribute string
+        from the column's name + dimension_column without touching nodes.
+        """
+        if self.type != NodeType.CUBE:
+            return []  # pragma: no cover
+        return [
+            col.name + (col.dimension_column or "")
+            for col in self.columns
+            if "_DOT_" not in col.name
+        ]
 
     def temporal_partition_columns(self) -> List[Column]:
         """

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -630,14 +630,54 @@ class Node(Base):
         cls,
         session: AsyncSession,
         name: str,
+        for_measures_sql: bool = False,
     ) -> Optional["Node"]:
         """
-        Get a cube by name
+        Get a cube by name.
+
+        Args:
+            session: DB session
+            name: cube node name
+            for_measures_sql: If True, load only what the build_v3 measures/metrics
+                SQL pipeline needs (cube_filters, cube_elements for metric/dimension
+                names, columns with their joined partitions) and suppress selectin
+                cascades for availability, materializations, engines, tags, users,
+                and column attributes. Use this when the cube is fed directly into
+                `build_measures_sql(..., matched_cube=...)`. Default False preserves
+                existing callers' behavior.
         """
-        statement = (
-            select(Node)
-            .where(Node.name == name)
-            .options(
+        if for_measures_sql:
+            options = (
+                # Top-level Node: suppress auto-selectin on created_by/tags
+                noload(Node.created_by),
+                noload(Node.tags),
+                joinedload(Node.current).options(
+                    noload(NodeRevision.created_by),
+                    noload(NodeRevision.node),
+                    # NodeRevision.catalog is lazy="joined" — suppress its engines cascade
+                    joinedload(NodeRevision.catalog).options(
+                        noload(Catalog.engines),
+                    ),
+                    # Cube filters/metrics/dimensions: need cube_elements + their
+                    # node_revision (for metric.name), but skip attribute cascades
+                    selectinload(NodeRevision.cube_elements).options(
+                        noload(Column.attributes),
+                        selectinload(Column.node_revision).options(
+                            noload(NodeRevision.created_by),
+                            joinedload(NodeRevision.catalog).options(
+                                noload(Catalog.engines),
+                            ),
+                        ),
+                    ),
+                    # Columns for extract_temporal_partition_columns.
+                    # Column.partition is lazy="joined" so partitions ride along.
+                    selectinload(NodeRevision.columns).options(
+                        noload(Column.attributes),
+                    ),
+                ),
+            )
+        else:
+            options = (
                 joinedload(Node.current).options(
                     selectinload(NodeRevision.availability),
                     selectinload(NodeRevision.columns),
@@ -653,7 +693,8 @@ class Node(Base):
                 ),
                 joinedload(Node.tags),
             )
-        )
+
+        statement = select(Node).where(Node.name == name).options(*options)
         result = await session.execute(statement)
         node = result.unique().scalar_one_or_none()
         return node


### PR DESCRIPTION
### Summary

During SQL building, the ORM setup was loading unnecessary join relationships; this PR explicitly sets them to noload when we don't want the overfetching.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
