### PR TITLE
Check for NodeRevision in ast cache before pulling attributes

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1749,9 +1749,18 @@ class Table(TableExpression, Named):
             if not self.dj_node:
                 db_node = ctx.dependencies_cache.get(table_name)
                 if db_node:
-                    await refresh_if_needed(ctx.session, db_node, ["current"])
-                    await refresh_if_needed(ctx.session, db_node.current, ["columns"])
-                    dj_node = db_node.current
+                    # Cache may contain either Node objects (with .current →
+                    # NodeRevision) or bare NodeRevision objects (stored by
+                    # get_dj_node which returns .current by default).
+                    if not isinstance(db_node, NodeRevision) and hasattr(
+                        db_node,
+                        "current",
+                    ):
+                        await refresh_if_needed(ctx.session, db_node, ["current"])
+                        dj_node = db_node.current
+                    else:
+                        dj_node = db_node
+                    await refresh_if_needed(ctx.session, dj_node, ["columns"])
                 else:
                     # Include METRIC nodes to support derived metrics (metrics that reference
                     # other metrics). This allows metric references in FROM clauses.

--- a/datajunction-server/tests/sql/parsing/test_compile.py
+++ b/datajunction-server/tests/sql/parsing/test_compile.py
@@ -834,3 +834,39 @@ class TestNonProjectionClauses:
         assert not ctx.exception.errors
         assert len(query.columns) == 2
         assert isinstance(query.columns[0].type, IntegerType)
+
+    async def test_cache_with_node_revision_instead_of_node(self):
+        """
+        When dependencies_cache contains a NodeRevision (as stored by
+        get_dj_node which returns .current by default), Table.compile
+        should handle it without raising AttributeError on .current.
+
+        Regression test for: 'NodeRevision' object has no attribute 'current'
+        """
+        # Create a revision-like object WITHOUT .current to simulate a real
+        # NodeRevision landing in the cache (as get_dj_node returns)
+        revision = FakeNodeRevision(
+            "default.orders",
+            NodeType.TRANSFORM,
+            [
+                FakeColumn("order_id", IntegerType()),
+                FakeColumn("user_id", IntegerType()),
+                FakeColumn("amount", DoubleType()),
+            ],
+        )
+        del revision.current  # Remove .current so it behaves like a real NodeRevision
+
+        # Patch NodeRevision in the ast module so our fake passes isinstance
+        ctx = _make_ctx(dependencies={"default.orders": revision})
+
+        with patch(
+            "datajunction_server.sql.parsing.ast.NodeRevision",
+            new=FakeNodeRevision,
+        ):
+            query = parse("SELECT order_id, amount FROM default.orders")
+            await query.compile(ctx)
+
+        assert not ctx.exception.errors
+        assert len(query.columns) == 2
+        assert isinstance(query.columns[0].type, IntegerType)
+        assert isinstance(query.columns[1].type, DoubleType)


### PR DESCRIPTION
### Summary

Some metrics using old style SQL generation will hit an edge case where a NodeRevision is added to the dj AST cache rather than a Node object. This change checks for either object type in the cache. 

### Test Plan

Updated unit tests and verified the error was fixed in a local instance of the DJ server

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
