### PR TITLE
Fix type inference for `LIKE` and other Predicate nodes

### DIFF
--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -279,6 +279,19 @@ async def get_measures_sql_v3(
         matched_cube=cube_node.current if cube_node else None,
     )
 
+    response = _build_measures_response(result)
+
+    _tags = {"query_type": "measures", "query_version": "v3"}
+    get_metrics_provider().timer(
+        "dj.sql.build_latency_ms",
+        (time.monotonic() - _t0) * 1000,
+        _tags,
+    )
+    get_metrics_provider().counter("dj.sql.requests", tags=_tags)
+    return response
+
+
+def _build_measures_response(result) -> MeasuresSQLResponse:
     # Build a unified component_aliases map from all grain groups
     # This maps component hash names -> actual SQL column aliases
     all_component_aliases: dict[str, str] = {}
@@ -373,13 +386,6 @@ async def get_measures_sql_v3(
             ),
         )
 
-    _tags = {"query_type": "measures", "query_version": "v3"}
-    get_metrics_provider().timer(
-        "dj.sql.build_latency_ms",
-        (time.monotonic() - _t0) * 1000,
-        _tags,
-    )
-    get_metrics_provider().counter("dj.sql.requests", tags=_tags)
     return MeasuresSQLResponse(
         grain_groups=grain_group_responses,
         metric_formulas=metric_formulas,

--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -79,6 +79,29 @@ def parse_query(query_str: str) -> ast.Query:
     return parse(query_str)
 
 
+def _unresolved_refs_in(expr: ast.Node) -> list[str]:
+    """Return a deduplicated, stable-ordered list of column references inside
+    ``expr`` whose resolved type is ``UnknownType``.
+
+    ``_resolve_projection_expr`` stamps ``_type`` on each AST node during type
+    resolution. After resolution, any leaf ``ast.Column`` whose ``_type`` is
+    ``UnknownType`` is a root cause for the expression's overall unresolved
+    type — pointing the user at those specific refs is more actionable than a
+    generic "unable to infer type" message.
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for col in expr.find_all(ast.Column):
+        col_type = getattr(col, "_type", None)
+        if col_type is None or not isinstance(col_type, UnknownType):
+            continue
+        rendered = str(col)
+        if rendered not in seen:
+            seen.add(rendered)
+            ordered.append(rendered)
+    return ordered
+
+
 def validate_node_query(
     query_str: str,
     parent_columns_map: ParentColumnsMap,
@@ -165,19 +188,30 @@ def _resolve_query(
     scope = TypeScope(tables=tables, parent_map=parent_columns_map, errors=table_errors)
 
     output: OutputColumns = []
+    expr_to_output: list[tuple[ast.Node, OutputColumns]] = []
     for expr in select.projection:
         try:
-            output.extend(_resolve_projection_expr(expr, scope))
+            resolved = _resolve_projection_expr(expr, scope)
+            expr_to_output.append((expr, resolved))
+            output.extend(resolved)
         except Exception as exc:
             scope.errors.append(str(exc))
 
-    # Flag any output columns with unresolved types
-    for col_name, col_type in output:
-        if isinstance(col_type, UnknownType):
-            scope.errors.append(
-                f"Unable to infer type for column `{col_name}`. "
-                f"This may indicate an unsupported function or expression.",
-            )
+    # Flag any output columns with unresolved types. When possible, point at
+    # the specific column references inside the expression whose types could
+    # not be resolved — that's the root cause the user has to fix.
+    for projection_expr, resolved in expr_to_output:
+        for col_name, col_type in resolved:
+            if isinstance(col_type, UnknownType):
+                unresolved = _unresolved_refs_in(projection_expr)
+                detail = (
+                    f" Unresolved column reference(s): {', '.join(unresolved)}."
+                    if unresolved
+                    else " This may indicate an unsupported function or expression."
+                )
+                scope.errors.append(
+                    f"Unable to infer type for column `{col_name}`.{detail}",
+                )
 
     # Validate column references in non-projection clauses
     _validate_non_projection_clauses(select, scope)
@@ -1042,14 +1076,36 @@ def _resolve_expr_type(
         return NullType()
 
     if isinstance(expr, ast.BinaryOp):
-        left_type = _resolve_expr_type(expr.left, scope)
-        _resolve_expr_type(expr.right, scope)
+        # Stamp types on the full subtree so the AST's BinaryOp.type property
+        # can read child `_type` and any error-reporting walker (see
+        # `_unresolved_refs_in`) can find leaf columns with UnknownType.
+        _stamp_types_recursive(expr, scope)
+        left_type = getattr(expr.left, "_type", None) or _resolve_expr_type(
+            expr.left,
+            scope,
+        )
         try:
             return expr.type
         except (DJParseException, TypeError, AttributeError):
             return (
                 left_type if not isinstance(left_type, UnknownType) else UnknownType()
             )
+
+    if isinstance(expr, ast.Predicate):
+        # LIKE, ILIKE, IN, BETWEEN, IS NULL, RLIKE, etc. Some Predicate
+        # subclasses (Like, Between) override `.type` to read `self.expr.type`
+        # from the AST, which requires `_type` to be stamped on child nodes.
+        # Without stamping, the property raises AttributeError and the
+        # expression silently becomes UnknownType. Stamp the subtree first
+        # so the AST's type property works, mirroring the Function path.
+        _stamp_types_recursive(expr, scope)
+        try:
+            result = expr.type
+            if isinstance(result, ColumnType):  # pragma: no branch
+                return result
+        except (DJParseException, TypeError, AttributeError):
+            pass
+        return BooleanType()
 
     if isinstance(expr, ast.Subscript):
         # Subscript: col['key'] (map/struct access) or col[0] (array access).

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -1967,6 +1967,18 @@ class TestUnresolvableReferences:
             )
             assert result.errors == [], f"{query} should not emit errors"
 
+    def test_predicate_type_property_raises_falls_back_to_boolean(self):
+        """Covers the except/return path in `_resolve_expr_type`'s Predicate
+        branch: `Like.type` raises `DJParseException` when its operand is
+        not a string, and we fall through to `return BooleanType()` since a
+        predicate's shape is still boolean-valued regardless of the type
+        error on its operand."""
+        result = validate_node_query(
+            "SELECT v LIKE 'pattern' AS r FROM default.t",
+            {"default.t": {"v": IntegerType()}},
+        )
+        assert result.output_columns == [("r", BooleanType())]
+
     def test_unresolved_refs_from_multi_part_namespace(self):
         """Multi-part namespaced refs that don't match any FROM table fall
         through to UnknownType (deferred dim-attribute resolution). When

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -1926,6 +1926,64 @@ class TestUnresolvableReferences:
         assert result.output_columns[0] == ("z", UnknownType())
         assert any("Unable to infer type for column `z`" in e for e in result.errors)
 
+    def test_unresolved_refs_are_named_in_error_message(self):
+        """A generic 'unable to infer type' message forces the user to re-scan
+        the projection to find the root cause. When the expression contains
+        leaf column refs that resolved to UnknownType (e.g. dim-attribute
+        paths that defer resolution to query-build time), they should be
+        listed in the error so the user can go straight to the broken ref."""
+        result = validate_node_query(
+            "SELECT SUM(default.missing_dim.x) AS total FROM default.orders",
+            _col_map(ORDERS_COLS),
+        )
+        assert result.output_columns[0] == ("total", UnknownType())
+        error = next(
+            e for e in result.errors if "Unable to infer type for column `total`" in e
+        )
+        assert "default.missing_dim.x" in error
+
+    def test_like_predicate_returns_boolean(self):
+        """Regression: `Like.type` needs `_type` stamped on its operand
+        because it reads `self.expr.type`. Before stamping was added for
+        Predicate nodes, a bare `col LIKE 'pattern'` (and AND-chains of
+        NOT LIKE) silently resolved to UnknownType and tripped the
+        'Unable to infer type' error. Exercises the path that broke the
+        `is_member_area = ... NOT LIKE ... AND ... NOT LIKE ...` pattern
+        in real user queries."""
+        col_map = {"default.t": {"v": StringType()}}
+        cases = [
+            "SELECT v LIKE '%x%' AS r FROM default.t",
+            "SELECT v NOT LIKE '%x%' AS r FROM default.t",
+            "SELECT v NOT LIKE '%x%' AND v NOT LIKE '%y%' AS r FROM default.t",
+            "SELECT v IS NULL AS r FROM default.t",
+            "SELECT v IN ('x','y') AS r FROM default.t",
+            "SELECT v RLIKE '.*' AS r FROM default.t",
+        ]
+        for query in cases:
+            result = validate_node_query(query, col_map)
+            assert result.output_columns == [("r", BooleanType())], (
+                f"{query} → expected ('r', BooleanType) but got "
+                f"{result.output_columns} (errors: {result.errors})"
+            )
+            assert result.errors == [], f"{query} should not emit errors"
+
+    def test_unresolved_refs_from_multi_part_namespace(self):
+        """Multi-part namespaced refs that don't match any FROM table fall
+        through to UnknownType (deferred dim-attribute resolution). When
+        surfaced in the error, the full namespaced form should appear so the
+        user sees exactly what was unresolved, not just the leaf name."""
+        result = validate_node_query(
+            "SELECT default.missing_dim_a.x + default.missing_dim_b.y AS z "
+            "FROM default.orders",
+            _col_map(ORDERS_COLS),
+        )
+        assert result.output_columns[0] == ("z", UnknownType())
+        error = next(
+            e for e in result.errors if "Unable to infer type for column `z`" in e
+        )
+        assert "default.missing_dim_a.x" in error
+        assert "default.missing_dim_b.y" in error
+
     def test_nested_case_with_bad_column(self):
         """SUM(CASE WHEN TRUE THEN nonexistent ELSE 0 END) — bare column doesn't exist."""
         from datajunction_server.internal.deployment.type_inference import (


### PR DESCRIPTION
### Summary

Predicate nodes (`LIKE`, `NOT LIKE`, `RLIKE`, `IN`, `BETWEEN`, `IS NULL`) had no case in `_resolve_expr_type`, so they fell through to a generic fallback that invoked `expr.type` without stamping `_type` on child nodes first. This ends up raising an AttributeError, gets swallowed, and silently leaks `UnknownType` upward. The result is that any bare col `LIKE` pattern (and any AND-chain built on top) resolved to UnknownType and tripped "Unable to infer type for column X" even when the expression was trivially boolean.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
