### PR TITLE
Keep setup as part of the deployment savepoint

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -340,9 +340,14 @@ class DeploymentOrchestrator:
         """
         Validate and deploy all resources and nodes into the specified namespace.
 
-        For dry_run=True the DB writes are rolled back; the returned result still
-        contains ``results`` (what would have changed) and ``downstream_impacts``
-        (what downstream nodes would be affected).
+        A single SAVEPOINT wraps setup, plan, and execution so that for
+        ``dry_run=True`` every DB write is rolled back — including setup-phase
+        writes (namespaces, tags, owners, catalogs, attributes) that would
+        otherwise leak. The outer transaction is committed only for wet-runs.
+
+        Returned ``results`` and ``downstream_impacts`` are populated inside
+        the SAVEPOINT; Python references stay live after rollback, so dry-run
+        callers still get the full impact analysis.
         """
         start_total = time.perf_counter()
         self._timer = DeploymentTimer()
@@ -352,30 +357,17 @@ class DeploymentOrchestrator:
             self.deployment_spec.namespace,
         )
 
-        with self._timer.phase("setup resources"):
-            await self._setup_deployment_resources()
-
-        with self._timer.phase("validate resources"):
-            await self._validate_deployment_resources()
-
-        if await self._is_copy_fast_path():
-            with self._timer.phase("build plan (copy fast-path)"):
-                deployment_plan = await self._build_copy_plan()
+        result = DeploymentExecuteResult(results=[], downstream_impacts=[])
+        try:
+            async with self.session.begin_nested():
+                result = await self._plan_and_execute()
+                if self.dry_run:
+                    raise _DryRunRollback()
+        except _DryRunRollback:
+            pass
         else:
-            with self._timer.phase("build plan") as p:
-                deployment_plan, pre_results = await self._create_deployment_plan()
-                p.append(
-                    f"{len(deployment_plan.to_deploy)} to deploy, "
-                    f"{len(deployment_plan.to_delete)} to delete",
-                )
-            self.deployed_results.extend(pre_results)
-        if deployment_plan.is_empty():
-            return DeploymentExecuteResult(
-                results=await self._handle_no_changes(),
-                downstream_impacts=[],
-            )
-
-        downstream = await self._execute_deployment_plan(deployment_plan)
+            if not self.dry_run:
+                await self.session.commit()
 
         elapsed_ms = (time.perf_counter() - start_total) * 1000
         _metrics_tags = {
@@ -399,6 +391,41 @@ class DeploymentOrchestrator:
             self.deployment_id,
             elapsed_ms / 1000,
         )
+        return result
+
+    async def _plan_and_execute(self) -> DeploymentExecuteResult:
+        """Inner body of ``execute`` — runs inside the orchestrator's SAVEPOINT.
+
+        Split out so that the caller (``execute``) owns transaction control:
+        wrapping setup + plan + execute in one ``begin_nested()`` ensures
+        dry-runs roll back all DB writes, including setup-phase writes
+        (namespaces, tags, owners, catalogs, attributes).
+        """
+        with self._timer.phase("setup resources"):
+            await self._setup_deployment_resources()
+
+        with self._timer.phase("validate resources"):
+            await self._validate_deployment_resources()
+
+        if await self._is_copy_fast_path():
+            with self._timer.phase("build plan (copy fast-path)"):
+                deployment_plan = await self._build_copy_plan()
+        else:
+            with self._timer.phase("build plan") as p:
+                deployment_plan, pre_results = await self._create_deployment_plan()
+                p.append(
+                    f"{len(deployment_plan.to_deploy)} to deploy, "
+                    f"{len(deployment_plan.to_delete)} to delete",
+                )
+            self.deployed_results.extend(pre_results)
+
+        if deployment_plan.is_empty():
+            return DeploymentExecuteResult(
+                results=await self._handle_no_changes(),
+                downstream_impacts=[],
+            )
+
+        downstream = await self._execute_deployment_plan(deployment_plan)
         return DeploymentExecuteResult(
             results=self.deployed_results,
             downstream_impacts=downstream,
@@ -1152,93 +1179,80 @@ class DeploymentOrchestrator:
     async def _execute_deployment_plan(self, plan: DeploymentPlan) -> list:
         """Execute the actual deployment based on the plan.
 
-        Uses a SAVEPOINT so that dry_run=True can roll back all DB writes,
-        including the INVALID markers written by ``propagate_impact``.  The
-        outer transaction is committed only for wet-runs.
+        Runs inside the caller's SAVEPOINT (see ``execute``). The caller
+        rolls back on dry-run and commits on wet-run.
 
-        ``propagate_impact`` is called inside the SAVEPOINT, after nodes are
-        deployed but before deletions, so it sees post-deploy DB state and
-        deleted nodes' children are still reachable via NodeRelationship.
+        ``propagate_impact`` is called after nodes are deployed but before
+        deletions, so it sees post-deploy DB state and deleted nodes'
+        children are still reachable via NodeRelationship.
 
         Returns:
-            Downstream impact list (computed before any rollback/commit so it
-            always reflects the post-deploy state).
+            Downstream impact list reflecting the post-deploy state.
         """
         downstream: list = []
         timer = self._timer
-        try:
-            async with self.session.begin_nested():
-                if plan.to_deploy:
-                    with timer.phase("deploy nodes") as p:
-                        deployed_results, deployed_nodes = await self._deploy_nodes(
-                            plan,
-                        )
-                        p.append(f"{len(deployed_nodes)} nodes")
-                    self.deployed_results.extend(deployed_results)
-                    self.registry.add_nodes(deployed_nodes)
-                    await self._update_deployment_status()
+        if plan.to_deploy:
+            with timer.phase("deploy nodes") as p:
+                deployed_results, deployed_nodes = await self._deploy_nodes(plan)
+                p.append(f"{len(deployed_nodes)} nodes")
+            self.deployed_results.extend(deployed_results)
+            self.registry.add_nodes(deployed_nodes)
+            await self._update_deployment_status()
 
-                    with timer.phase("deploy links") as p:
-                        deployed_links = await self._deploy_links(plan)
-                        p.append(f"{len(deployed_links)} links")
-                    self.deployed_results.extend(deployed_links)
-                    await self._update_deployment_status()
+            with timer.phase("deploy links") as p:
+                deployed_links = await self._deploy_links(plan)
+                p.append(f"{len(deployed_links)} links")
+            self.deployed_results.extend(deployed_links)
+            await self._update_deployment_status()
 
-                    with timer.phase("deploy cubes") as p:
-                        deployed_cubes = await self._deploy_cubes(plan)
-                        p.append(f"{len(deployed_cubes)} cubes")
-                    self.deployed_results.extend(deployed_cubes)
-                    await self._update_deployment_status()
+            with timer.phase("deploy cubes") as p:
+                deployed_cubes = await self._deploy_cubes(plan)
+                p.append(f"{len(deployed_cubes)} cubes")
+            self.deployed_results.extend(deployed_cubes)
+            await self._update_deployment_status()
 
-                    # Derive frozen measures for deployed metrics inline (not
-                    # background) so derived_expression and FrozenMeasure rows
-                    # are atomic with the rest of the deployment: committed or
-                    # rolled back together, and dry-run exercises derivation.
-                    with timer.phase("derive measures") as p:
-                        derived = await self._derive_measures_for_deployed_metrics()
-                        p.append(f"{derived} metrics")
+            # Derive frozen measures for deployed metrics inline so
+            # derived_expression and FrozenMeasure rows are atomic with
+            # the rest of the deployment.
+            with timer.phase("derive measures") as p:
+                derived = await self._derive_measures_for_deployed_metrics()
+                p.append(f"{derived} metrics")
 
-                # Run impact propagation before deletions so deleted nodes'
-                # children are still reachable via NodeRelationship.
-                changed_names = {
-                    r.name
-                    for r in self.deployed_results
-                    if r.deploy_type == DeploymentResult.Type.NODE
-                    and r.status != DeploymentResult.Status.SKIPPED
-                }
-                changed_link_names = {
-                    r.name.split(" -> ")[0]
-                    for r in self.deployed_results
-                    if r.deploy_type == DeploymentResult.Type.LINK
-                    and r.status != DeploymentResult.Status.SKIPPED
-                }
-                with timer.phase("propagate impact") as p:
-                    downstream = await propagate_impact(
-                        session=self.session,
-                        namespace=self.deployment_spec.namespace,
-                        changed_node_names=changed_names,
-                        deleted_node_names=frozenset(
-                            spec.rendered_name for spec in plan.to_delete
-                        ),
-                        changed_link_node_names=changed_link_names,
-                    )
-                    p.append(f"{len(downstream)} downstream")
+        # Run impact propagation before deletions so deleted nodes'
+        # children are still reachable via NodeRelationship.
+        changed_names = {
+            r.name
+            for r in self.deployed_results
+            if r.deploy_type == DeploymentResult.Type.NODE
+            and r.status != DeploymentResult.Status.SKIPPED
+        }
+        changed_link_names = {
+            r.name.split(" -> ")[0]
+            for r in self.deployed_results
+            if r.deploy_type == DeploymentResult.Type.LINK
+            and r.status != DeploymentResult.Status.SKIPPED
+        }
+        with timer.phase("propagate impact") as p:
+            downstream = await propagate_impact(
+                session=self.session,
+                namespace=self.deployment_spec.namespace,
+                changed_node_names=changed_names,
+                deleted_node_names=frozenset(
+                    spec.rendered_name for spec in plan.to_delete
+                ),
+                changed_link_node_names=changed_link_names,
+            )
+            p.append(f"{len(downstream)} downstream")
 
-                # Hard-delete after impact propagation (cascade-deletes
-                # NodeRelationship rows that were needed for the BFS above).
-                if plan.to_delete:
-                    with timer.phase("delete nodes") as p:
-                        delete_results = await self._delete_nodes(plan.to_delete)
-                        p.append(f"{len(delete_results)} deleted")
-                    self.deployed_results.extend(delete_results)
-                    await self._update_deployment_status()
+        # Hard-delete after impact propagation (cascade-deletes
+        # NodeRelationship rows that were needed for the BFS above).
+        if plan.to_delete:
+            with timer.phase("delete nodes") as p:
+                delete_results = await self._delete_nodes(plan.to_delete)
+                p.append(f"{len(delete_results)} deleted")
+            self.deployed_results.extend(delete_results)
+            await self._update_deployment_status()
 
-                if self.dry_run:  # pragma: no branch
-                    raise _DryRunRollback()
-        except _DryRunRollback:
-            pass
-        else:
-            await self.session.commit()
         return downstream
 
     async def _derive_measures_for_deployed_metrics(self) -> int:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -361,7 +361,7 @@ class DeploymentOrchestrator:
         try:
             async with self.session.begin_nested():
                 result = await self._plan_and_execute()
-                if self.dry_run:
+                if self.dry_run:  # pragma: no branch
                     raise _DryRunRollback()
         except _DryRunRollback:
             pass

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -366,8 +366,9 @@ class DeploymentOrchestrator:
         except _DryRunRollback:
             pass
         else:
-            if not self.dry_run:
-                await self.session.commit()
+            # `else` only fires when no _DryRunRollback was raised, which
+            # implies wet-run — commit the outer transaction.
+            await self.session.commit()
 
         elapsed_ms = (time.perf_counter() - start_total) * 1000
         _metrics_tags = {

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -3,6 +3,7 @@ Unit tests for DeploymentOrchestrator
 """
 
 import pytest
+from sqlalchemy import select
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 
 from datajunction_server.internal.deployment.orchestrator import (
@@ -2039,14 +2040,14 @@ class TestGenerateChangelog:
 
 
 @pytest.mark.asyncio
-async def test_execute_deployment_plan_wet_run_commits(
+async def test_execute_deployment_plan_runs_inside_caller_savepoint(
     session,
     current_user: User,
 ):
-    """When dry_run=False and the plan is empty (nothing to deploy/delete),
-    _execute_deployment_plan exits the SAVEPOINT cleanly and commits the
-    outer transaction (line 1201 — the wet-run commit path).
-    """
+    """``_execute_deployment_plan`` no longer owns the SAVEPOINT — it runs
+    inside the caller's (``execute``'s) SAVEPOINT. This test ensures the
+    method does not raise or commit on its own when invoked directly with
+    an empty plan, i.e. it's still safe to call without wrapping."""
     context = MagicMock(autospec=DeploymentContext)
     context.current_user = current_user
     context.save_history = AsyncMock()
@@ -2056,7 +2057,7 @@ async def test_execute_deployment_plan_wet_run_commits(
         deployment_id="wet-run-test",
         session=session,
         context=context,
-        dry_run=False,  # Wet-run mode — line 1193 branch is False
+        dry_run=False,
     )
 
     plan = DeploymentPlan(
@@ -2068,9 +2069,9 @@ async def test_execute_deployment_plan_wet_run_commits(
         external_deps=set(),
     )
 
-    # Should succeed without raising — the SAVEPOINT is committed and then
-    # session.commit() at line 1201 runs (wet-run path).
-    await orchestrator._execute_deployment_plan(plan)
+    # Should return a downstream list without raising.
+    downstream = await orchestrator._execute_deployment_plan(plan)
+    assert downstream == []
 
 
 @pytest.mark.asyncio
@@ -2095,46 +2096,40 @@ async def test_update_deployment_status_dry_run_noop(
 
 
 @pytest.mark.asyncio
-async def test_execute_deployment_plan_dry_run_savepoint_rollback(
+async def test_dry_run_rolls_back_setup_phase_writes(
     session,
     current_user: User,
     mock_deployment_context,
 ):
-    """When dry_run=True, _execute_deployment_plan raises _DryRunRollback inside
-    the SAVEPOINT, which rolls it back.
-
-    Covers orchestrator.py lines 967-970: except _DryRunRollback: pass
+    """Regression: ``execute`` must wrap ``_setup_deployment_resources`` in the
+    dry-run SAVEPOINT so setup-phase INSERTs (namespaces, tags, owners,
+    catalogs, attributes) roll back. Without this, a dry-run on a never-seen
+    namespace would persist a ``NodeNamespace`` row even though the rest of
+    the deployment rolled back — which is how ``.dryrun``-style orphaned
+    namespaces were leaking into the DB.
     """
+    from datajunction_server.database.namespace import NodeNamespace
+
+    namespace_name = "dryrun_savepoint_leak_test"
     orchestrator = DeploymentOrchestrator(
-        deployment_spec=DeploymentSpec(namespace="test", nodes=[]),
+        deployment_spec=DeploymentSpec(namespace=namespace_name, nodes=[]),
         deployment_id="dry-run-rollback-test",
         session=session,
         context=mock_deployment_context,
         dry_run=True,
     )
-    plan = DeploymentPlan(
-        to_deploy=[],
-        to_skip=[],
-        to_delete=[],
-        existing_specs={},
-        node_graph={},
-        external_deps=set(),
-    )
-    # Patch _deploy_nodes / _deploy_links / _deploy_cubes to avoid real DB work
-    with (
-        patch.object(
-            orchestrator,
-            "_deploy_nodes",
-            new=AsyncMock(return_value=([], [])),
-        ),
-        patch.object(orchestrator, "_deploy_links", new=AsyncMock(return_value=[])),
-        patch.object(orchestrator, "_deploy_cubes", new=AsyncMock(return_value=[])),
-        patch.object(orchestrator, "_delete_nodes", new=AsyncMock(return_value=[])),
-    ):
-        downstream = await orchestrator._execute_deployment_plan(plan)
+    await orchestrator.execute()
 
-    # Dry-run should roll back the SAVEPOINT and return empty downstream
-    assert downstream == []
+    # Namespace must NOT be persisted — the dry-run SAVEPOINT rolled it back.
+    existing = (
+        await session.execute(
+            select(NodeNamespace).where(NodeNamespace.namespace == namespace_name),
+        )
+    ).scalar_one_or_none()
+    assert existing is None, (
+        f"dry-run left NodeNamespace({namespace_name!r}) persisted — "
+        "setup-phase writes escaped the SAVEPOINT"
+    )
 
 
 class TestClassifyParents:


### PR DESCRIPTION
### Summary

This prevents the phantom creation of a `.dryrun` namespace by keeping the initial setup of namespaces, catalogs etc within the deployment savepoint.
 
### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
