### PR TITLE
Remove parsed-AST cache from bulk metric derivation

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/dataloaders.py
+++ b/datajunction-server/datajunction_server/api/graphql/dataloaders.py
@@ -370,7 +370,7 @@ def create_extracted_measures_loader(
     returning N metrics, Strawberry batches all per-node loader.load(nr_id)
     calls within a single event-loop tick into one
     batch_load_extracted_measures(ids) — collapsing N sessions + N extractions
-    into 1 session + N extractions sharing parsed_query_cache.
+    into 1 session + N extractions sharing nodes_cache and parent_map.
     """
     return DataLoader(
         load_fn=lambda keys: batch_load_extracted_measures(keys, request),

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -393,8 +393,8 @@ class NodeRevision:
 
         Uses the request-scoped extracted_measures_loader so that a GraphQL
         query returning N metrics batches all extractions into a single
-        session + shared parsed_query_cache (instead of opening N independent
-        sessions via resolver_session).
+        session + shared nodes_cache/parent_map (instead of opening N
+        independent sessions via resolver_session).
         """
         if root.type != NodeType.METRIC:
             return None

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -808,10 +808,6 @@ async def derive_frozen_measures_bulk(
                     nodes_cache.setdefault(grandparent.name, grandparent)
 
     # 3. Per-metric extract with caches — zero DB calls in this loop.
-    # No parsed_query_cache: deepcopy of cached AST nodes drops parent
-    # back-pointers, which makes _extract_base crash on
-    # ``func.parent.replace(...)``.  Re-parsing per metric is cheap relative
-    # to the DB work already saved.
     extraction_results: list[tuple[NodeRevision, list]] = []
     for rev in revisions:
         extractor = MetricComponentExtractor(rev.id)

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -750,7 +750,7 @@ async def derive_frozen_measures_bulk(
 
       * one query to load all target revisions + their parent chain eagerly,
       * zero-DB `MetricComponentExtractor.extract` calls (via the extractor's
-        `nodes_cache` / `parent_map` / `parsed_query_cache` params), and
+        `nodes_cache` / `parent_map` params), and
       * one batch `SELECT` against FrozenMeasure.name IN (...).
 
     Caller owns the transaction and commit; used by the deployment
@@ -807,9 +807,11 @@ async def derive_frozen_measures_bulk(
                 for grandparent in parent.current.parents:
                     nodes_cache.setdefault(grandparent.name, grandparent)
 
-    parsed_query_cache: dict[str, ast.Query] = {}
-
     # 3. Per-metric extract with caches — zero DB calls in this loop.
+    # No parsed_query_cache: deepcopy of cached AST nodes drops parent
+    # back-pointers, which makes _extract_base crash on
+    # ``func.parent.replace(...)``.  Re-parsing per metric is cheap relative
+    # to the DB work already saved.
     extraction_results: list[tuple[NodeRevision, list]] = []
     for rev in revisions:
         extractor = MetricComponentExtractor(rev.id)
@@ -818,7 +820,6 @@ async def derive_frozen_measures_bulk(
             nodes_cache=nodes_cache,
             parent_map=parent_map,
             metric_node=rev.node,
-            parsed_query_cache=parsed_query_cache,
         )
         rev.derived_expression = str(derived_sql)
         extraction_results.append((rev, measures))

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -727,11 +727,6 @@ class MetricComponentExtractor:
         else:
             metric_data = await self._load_metric_data(session)
 
-        # Parse queries (pure computation, no DB).  Each parse builds a fresh
-        # AST with intact ``parent`` back-pointers; do NOT swap this for a
-        # parsed-AST cache that returns ``deepcopy`` views — deepcopy drops
-        # parent links and breaks ``_extract_base``'s in-place rewrite at
-        # ``func.parent.replace(...)``.
         query_ast = parse(metric_data.query)
 
         # Initialize visited set for cycle detection

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -2,7 +2,6 @@
 
 import hashlib
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import cast
 
@@ -696,7 +695,6 @@ class MetricComponentExtractor:
         nodes_cache: dict[str, "Node"] | None = None,
         parent_map: dict[str, list[str]] | None = None,
         metric_node: "Node | None" = None,
-        parsed_query_cache: dict[str, ast.Query] | None = None,
         _visited: set[str] | None = None,
     ) -> tuple[list[MetricComponent], ast.Query]:
         """
@@ -714,8 +712,6 @@ class MetricComponentExtractor:
                 Required if nodes_cache is provided.
             metric_node: Optional metric Node object.
                 Required if nodes_cache is provided.
-            parsed_query_cache: Optional dict of query_string -> parsed AST.
-                Used to avoid re-parsing the same query multiple times.
         """
         # Use cache if available, otherwise query DB
         if (
@@ -731,18 +727,12 @@ class MetricComponentExtractor:
         else:
             metric_data = await self._load_metric_data(session)
 
-        # Helper to parse with cache
-        def cached_parse(query: str) -> ast.Query:
-            if parsed_query_cache is not None:
-                if query not in parsed_query_cache:  # pragma: no cover
-                    parsed_query_cache[query] = parse(query)
-
-                # Return a deep copy to avoid AST mutation issues
-                return deepcopy(parsed_query_cache[query])  # pragma: no cover
-            return parse(query)
-
-        # Parse queries (pure computation, no DB)
-        query_ast = cached_parse(metric_data.query)
+        # Parse queries (pure computation, no DB).  Each parse builds a fresh
+        # AST with intact ``parent`` back-pointers; do NOT swap this for a
+        # parsed-AST cache that returns ``deepcopy`` views — deepcopy drops
+        # parent links and breaks ``_extract_base``'s in-place rewrite at
+        # ``func.parent.replace(...)``.
+        query_ast = parse(metric_data.query)
 
         # Initialize visited set for cycle detection
         if _visited is None:
@@ -820,12 +810,11 @@ class MetricComponentExtractor:
                     nodes_cache=nodes_cache,
                     parent_map=parent_map,
                     metric_node=parent_node,
-                    parsed_query_cache=parsed_query_cache,
                     _visited=_visited,
                 )
             else:
                 # True base metric - decompose aggregations
-                base_ast = cached_parse(base_metric.query)
+                base_ast = parse(base_metric.query)
                 base_components, derived_ast = self._extract_base(base_ast)
 
             for comp in base_components:


### PR DESCRIPTION
### Summary

After the frozen measures storage change in #2050, deployments could cause errors like:
```
dj                 | Traceback (most recent call last):
dj                 |   File "/code/datajunction_server/api/deployments.py", line 199, in _run_deployment
dj                 |     execute_result = await deploy(
dj                 |   File "/code/datajunction_server/internal/deployment/deployment.py", line 32, in deploy
dj                 |     return await orchestrator.execute()
dj                 |   File "/code/datajunction_server/internal/deployment/orchestrator.py", line 378, in execute
dj                 |     downstream = await self._execute_deployment_plan(deployment_plan)
dj                 |   File "/code/datajunction_server/internal/deployment/orchestrator.py", line 1206, in _execute_deployment_plan
dj                 |     derived = await self._derive_measures_for_deployed_metrics()
dj                 |   File "/code/datajunction_server/internal/deployment/orchestrator.py", line 1301, in _derive_measures_for_deployed_metrics
dj                 |     await derive_frozen_measures_bulk(self.session, revision_ids)
dj                 |   File "/code/datajunction_server/internal/nodes.py", line 816, in derive_frozen_measures_bulk
dj                 |     measures, derived_sql = await extractor.extract(
dj                 |   File "/code/datajunction_server/sql/decompose.py", line 829, in extract
dj                 |     base_components, derived_ast = self._extract_base(base_ast)
dj                 |   File "/code/datajunction_server/sql/decompose.py", line 993, in _extract_base
dj                 |     func.parent.replace(from_=func, to=result.combiner)  # type: ignore
dj                 | AttributeError: 'NoneType' object has no attribute 'replace'
```

This is because `derive_frozen_measures_bulk` was passing a shared query cache into `MetricComponentExtractor.extract`, which returned deepcopy views of cached query ASTs. Because `Function.__deepcopy__` returns `self`, Function nodes ended up shared across copies with stale parent back-pointers, and `_extract_base` crashed at `func.parent.replace(from_=func, to=...)` during any deployment that touched metrics.

The fix drops the cache entirely: extract now always calls `parse(query)` fresh, which yields an AST with intact parent pointers. Re-parsing per metric is cheap relative to the DB work the bulk path already avoids. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
