### PR TITLE
Enable full cube materialization

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -548,7 +548,7 @@ async def materialize_cube(
             "dimensions": sorted(dimension_columns),
         },
     }
-    if timestamp_column:
+    if timestamp_column:  # pragma: no branch
         parse_spec["timestampSpec"] = {
             "column": timestamp_column,
             "format": timestamp_format or "auto",

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -514,17 +514,19 @@ async def materialize_cube(
         if col.semantic_type in ("metric", "metric_component", "measure")
     ]
 
-    # Build timestamp spec from auto-detected temporal partition
+    # Build timestamp spec from auto-detected temporal partition.
+    # For FULL strategy without a temporal partition, these stay None and Druid
+    # ingests everything as a single ALL-granularity segment.
     timestamp_column = (
         temporal_partition_info.column_name if temporal_partition_info else None
     )
     timestamp_format = (
-        temporal_partition_info.format if temporal_partition_info else "auto"
+        temporal_partition_info.format if temporal_partition_info else None
     )
     segment_granularity = (
         temporal_partition_info.granularity.upper()
         if temporal_partition_info and temporal_partition_info.granularity
-        else "DAY"
+        else "ALL"
     )
 
     # Validate that the timestamp column is in the output columns
@@ -540,21 +542,22 @@ async def materialize_cube(
             http_status_code=HTTPStatus.BAD_REQUEST,
         )
 
+    parse_spec: dict = {
+        "format": "parquet",
+        "dimensionsSpec": {
+            "dimensions": sorted(dimension_columns),
+        },
+    }
+    if timestamp_column:
+        parse_spec["timestampSpec"] = {
+            "column": timestamp_column,
+            "format": timestamp_format or "auto",
+        }
+
     druid_spec = {
         "dataSchema": {
             "dataSource": druid_datasource,
-            "parser": {
-                "parseSpec": {
-                    "format": "parquet",
-                    "dimensionsSpec": {
-                        "dimensions": sorted(dimension_columns),
-                    },
-                    "timestampSpec": {
-                        "column": timestamp_column,
-                        "format": timestamp_format or "auto",
-                    },
-                },
-            },
+            "parser": {"parseSpec": parse_spec},
             "metricsSpec": _build_metrics_spec(
                 measure_columns,
                 combined_result.measure_components,
@@ -587,6 +590,13 @@ async def materialize_cube(
         for col in combined_result.columns
     ]
 
+    # lookback_window only applies to incremental strategies; drop it for FULL.
+    effective_lookback = (
+        data.lookback_window
+        if data.strategy == MaterializationStrategy.INCREMENTAL_TIME
+        else None
+    )
+
     # Build the v2 input for the query service
     v2_input = CubeMaterializationV2Input(
         cube_name=node.name,
@@ -598,10 +608,10 @@ async def materialize_cube(
         druid_datasource=druid_datasource,
         druid_spec=druid_spec,
         timestamp_column=timestamp_column,
-        timestamp_format=timestamp_format or "yyyyMMdd",
+        timestamp_format=timestamp_format,
         strategy=data.strategy,
         schedule=data.schedule,
-        lookback_window=data.lookback_window,
+        lookback_window=effective_lookback,
     )
 
     # Call the query service to create the workflow
@@ -668,7 +678,7 @@ async def materialize_cube(
         cube_metrics=cube_revision.cube_node_metrics,
         metrics=metrics_list,
         timestamp_column=timestamp_column,
-        timestamp_format=timestamp_format or "yyyyMMdd",
+        timestamp_format=timestamp_format,
         workflow_urls=workflow_urls,
         workflow_names=workflow_names,
     )
@@ -708,7 +718,7 @@ async def materialize_cube(
         druid_spec=druid_spec,
         strategy=data.strategy,
         schedule=data.schedule,
-        lookback_window=data.lookback_window,
+        lookback_window=effective_lookback,
         metric_combiners=combined_result.metric_combiners,
         workflow_urls=workflow_urls,
         message=message,

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -501,7 +501,7 @@ class CubeMaterializeResponse(BaseModel):
     # Materialization config
     strategy: MaterializationStrategy
     schedule: str
-    lookback_window: str
+    lookback_window: Optional[str] = None
 
     # Metric combiner expressions (metric_name -> combiner SQL)
     metric_combiners: Dict[str, str] = Field(
@@ -557,13 +557,14 @@ class CubeMaterializationV2Input(BaseModel):
         description="Druid ingestion spec",
     )
 
-    # Temporal partition info (for incremental)
-    timestamp_column: str = Field(
-        description="Name of the timestamp/partition column",
+    # Temporal partition info (only set for INCREMENTAL_TIME)
+    timestamp_column: Optional[str] = Field(
+        default=None,
+        description="Name of the timestamp/partition column. None for FULL strategy without a temporal partition.",
     )
-    timestamp_format: str = Field(
-        default="yyyyMMdd",
-        description="Format of the timestamp column",
+    timestamp_format: Optional[str] = Field(
+        default=None,
+        description="Format of the timestamp column. None when timestamp_column is None.",
     )
 
     # Materialization config
@@ -573,9 +574,9 @@ class CubeMaterializationV2Input(BaseModel):
     schedule: str = Field(
         description="Cron schedule (e.g., '0 0 * * *' for daily)",
     )
-    lookback_window: str = Field(
-        default="1 DAY",
-        description="Lookback window for incremental",
+    lookback_window: Optional[str] = Field(
+        default=None,
+        description="Lookback window for incremental. None for FULL strategy.",
     )
 
 
@@ -646,13 +647,14 @@ class DruidCubeV3Config(BaseModel):
         description="List of metrics with metric_expression for querying the materialized cube",
     )
 
-    # Temporal partition info
-    timestamp_column: str = Field(
-        description="Name of the timestamp/partition column",
+    # Temporal partition info (only set for INCREMENTAL_TIME)
+    timestamp_column: Optional[str] = Field(
+        default=None,
+        description="Name of the timestamp/partition column. None for FULL strategy without a temporal partition.",
     )
-    timestamp_format: str = Field(
-        default="yyyyMMdd",
-        description="Format of the timestamp column",
+    timestamp_format: Optional[str] = Field(
+        default=None,
+        description="Format of the timestamp column. None when timestamp_column is None.",
     )
 
     # Workflow tracking


### PR DESCRIPTION
### Summary

This PR lets cubes materialize without a temporal partition by treating "no partition" as a first-class case rather than falling through to incremental defaults. Two coupled changes:

In `api/cubes.py`, we handle the no-temporal-partition path in the Druid spec builder, with `timestamp_format` defaulting to `None` and `segment_granularity` defaulting to `ALL` so that Druid ingests the result as a single all-granularity segment. The `timestampSpec` block is omitted when there's no `timestamp_column`.

We also strip lookback window from any strategy other than `INCREMENTAL_TIME`, so `FULL` materializations don't carry an irrelevant lookback into the query-service payload or the response.

The net effect is that using `FULL` on a cube with no temporal partition now produces a valid Druid spec and v2/v3 payload (single ALL segment, no timestamp spec, no lookback), where it previously would have either rejected validation or shipped a malformed `timestampSpec`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
