### PR TITLE
Consolidate GraphQL error logging into GraphQLErrorReporter

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -8,6 +8,7 @@ from datajunction_server.instrumentation.provider import get_metrics_provider
 
 import strawberry
 from fastapi import Depends, Request, BackgroundTasks
+from strawberry.extensions import SchemaExtension
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import Info
 
@@ -62,7 +63,12 @@ logger = logging.getLogger(__name__)
 
 def log_resolver(func):
     """
-    Adds generic logging to the GQL resolver.
+    Adds generic logging and per-resolver latency timing to the GQL resolver.
+
+    Note: dj.graphql.errors is NOT emitted from here. It's emitted by the
+    GraphQLErrorCounter schema extension below, which sees ALL errors that
+    end up in the response — including programmatic GraphQL errors that
+    don't bubble as Python exceptions (the common case in real traffic).
     """
 
     @wraps(func)
@@ -86,10 +92,6 @@ def log_resolver(func):
             logger.info("[GQL] %s", log_args)
             return result
         except Exception:  # pragma: no cover
-            get_metrics_provider().counter(  # pragma: no cover
-                "dj.graphql.errors",
-                tags={"operation": resolver_name},
-            )
             logger.error(  # pragma: no cover
                 "[GQL] status=error %s",
                 log_args,
@@ -104,6 +106,37 @@ def log_resolver(func):
             )
 
     return wrapper
+
+
+class GraphQLErrorCounter(SchemaExtension):
+    """
+    Strawberry extension that emits ``dj.graphql.errors`` for every error
+    that ends up in the GraphQL response — including programmatic
+    GraphQL errors returned as data (the spec way) that don't bubble as
+    Python exceptions.
+
+    Tags:
+      - ``operation``: the top-level field path the error is attached to,
+        or ``unknown`` if the error has no path (e.g. parse / validation).
+      - ``error_type``: the underlying exception class name when the error
+        was caused by a raised exception, or ``GraphQLError`` when it's
+        a programmatic GraphQL error returned as data.
+    """
+
+    def on_operation(self):
+        yield
+        result = getattr(self.execution_context, "result", None)
+        if not result or not getattr(result, "errors", None):
+            return
+        for error in result.errors:
+            path = getattr(error, "path", None)
+            operation = str(path[0]) if path else "unknown"
+            original = getattr(error, "original_error", None)
+            error_type = type(original).__name__ if original else "GraphQLError"
+            get_metrics_provider().counter(
+                "dj.graphql.errors",
+                tags={"operation": operation, "error_type": error_type},
+            )
 
 
 async def get_context(
@@ -221,6 +254,6 @@ class Query:
     )
 
 
-schema = strawberry.Schema(query=Query)
+schema = strawberry.Schema(query=Query, extensions=[GraphQLErrorCounter])
 
 graphql_app = GraphQLRouter(schema, context_getter=get_context)

--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -63,12 +63,11 @@ logger = logging.getLogger(__name__)
 
 def log_resolver(func):
     """
-    Adds generic logging and per-resolver latency timing to the GQL resolver.
-
-    Note: dj.graphql.errors is NOT emitted from here. It's emitted by the
-    GraphQLErrorCounter schema extension below, which sees ALL errors that
-    end up in the response — including programmatic GraphQL errors that
-    don't bubble as Python exceptions (the common case in real traffic).
+    Adds success-path logging and per-resolver latency timing to the GQL
+    resolver. Error logging and ``dj.graphql.errors`` emission live in
+    GraphQLErrorReporter — that single source of truth sees ALL errors
+    that end up in the response, including programmatic GraphQL errors
+    that don't bubble as Python exceptions.
     """
 
     @wraps(func)
@@ -91,13 +90,6 @@ def log_resolver(func):
             result = await func(*args, **kwargs)
             logger.info("[GQL] %s", log_args)
             return result
-        except Exception:  # pragma: no cover
-            logger.error(  # pragma: no cover
-                "[GQL] status=error %s",
-                log_args,
-                exc_info=True,
-            )
-            raise  # pragma: no cover
         finally:
             get_metrics_provider().timer(
                 "dj.graphql.query_ms",
@@ -108,19 +100,22 @@ def log_resolver(func):
     return wrapper
 
 
-class GraphQLErrorCounter(SchemaExtension):
+class GraphQLErrorReporter(SchemaExtension):
     """
-    Strawberry extension that emits ``dj.graphql.errors`` for every error
-    that ends up in the GraphQL response — including programmatic
-    GraphQL errors returned as data (the spec way) that don't bubble as
-    Python exceptions.
+    Strawberry extension that handles every error that ends up in the
+    GraphQL response — including programmatic GraphQL errors returned as
+    data (the spec way) that don't bubble as Python exceptions.
 
-    Tags:
-      - ``operation``: the top-level field path the error is attached to,
-        or ``unknown`` if the error has no path (e.g. parse / validation).
-      - ``error_type``: the underlying exception class name when the error
-        was caused by a raised exception, or ``GraphQLError`` when it's
-        a programmatic GraphQL error returned as data.
+    For each error it:
+      - emits ``dj.graphql.errors`` with ``operation`` and ``error_type`` tags
+      - logs at ERROR level with the message, path, and the original
+        exception's traceback (when one is attached)
+
+    ``operation`` is the top-level field path the error is attached to, or
+    ``unknown`` if the error has no path (e.g. parse / validation).
+    ``error_type`` is the underlying exception class name when the error
+    was caused by a raised exception, or ``GraphQLError`` when it's a
+    programmatic GraphQL error returned as data.
     """
 
     def on_operation(self):
@@ -133,6 +128,14 @@ class GraphQLErrorCounter(SchemaExtension):
             operation = str(path[0]) if path else "unknown"
             original = getattr(error, "original_error", None)
             error_type = type(original).__name__ if original else "GraphQLError"
+            logger.error(
+                "[GQL] status=error operation=%s error_type=%s path=%s message=%s",
+                operation,
+                error_type,
+                path,
+                error.message,
+                exc_info=original,
+            )
             get_metrics_provider().counter(
                 "dj.graphql.errors",
                 tags={"operation": operation, "error_type": error_type},
@@ -254,6 +257,6 @@ class Query:
     )
 
 
-schema = strawberry.Schema(query=Query, extensions=[GraphQLErrorCounter])
+schema = strawberry.Schema(query=Query, extensions=[GraphQLErrorReporter])
 
 graphql_app = GraphQLRouter(schema, context_getter=get_context)

--- a/datajunction-server/tests/api/graphql/test_main.py
+++ b/datajunction-server/tests/api/graphql/test_main.py
@@ -3,7 +3,116 @@
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from datajunction_server.api.graphql.main import get_context
+from graphql import GraphQLError
+
+from datajunction_server.api.graphql.main import (
+    GraphQLErrorReporter,
+    get_context,
+)
+from datajunction_server.instrumentation.provider import (
+    MetricsProvider,
+    get_metrics_provider,
+    set_metrics_provider,
+)
+
+
+class _SpyProvider(MetricsProvider):
+    """Records metrics calls so tests can assert against them."""
+
+    def __init__(self) -> None:
+        self.counters: list[tuple] = []
+
+    def counter(self, name, value=1, tags=None):
+        self.counters.append((name, value, tags))
+
+    def gauge(self, name, value, tags=None):  # pragma: no cover
+        pass
+
+    def timer(self, name, value_ms, tags=None):  # pragma: no cover
+        pass
+
+
+@pytest.fixture
+def spy_metrics():
+    """Swap in a spy provider for the duration of the test."""
+    original = get_metrics_provider()
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+    yield spy
+    set_metrics_provider(original)
+
+
+def _run_on_operation(errors):
+    """Drive GraphQLErrorReporter.on_operation to completion with the given errors."""
+    extension = GraphQLErrorReporter(execution_context=MagicMock())
+    extension.execution_context = MagicMock()
+    if errors is None:
+        extension.execution_context.result = None
+    else:
+        extension.execution_context.result.errors = errors
+    gen = extension.on_operation()
+    next(gen)  # advance past the pre-execution yield
+    with pytest.raises(StopIteration):
+        next(gen)  # post-execution body runs, then generator exits
+
+
+def test_error_reporter_no_result(spy_metrics):
+    """When the operation has no result (e.g. early failure), do nothing."""
+    with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
+        _run_on_operation(None)
+    assert spy_metrics.counters == []
+    mock_logger.error.assert_not_called()
+
+
+def test_error_reporter_no_errors(spy_metrics):
+    """When result has no errors, do nothing."""
+    with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
+        _run_on_operation([])
+    assert spy_metrics.counters == []
+    mock_logger.error.assert_not_called()
+
+
+def test_error_reporter_python_exception(spy_metrics):
+    """A resolver-raised Python exception emits the underlying class name and traceback."""
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        original = exc
+
+    error = GraphQLError("boom", path=["findNodes", 0, "name"], original_error=original)
+
+    with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
+        _run_on_operation([error])
+
+    assert spy_metrics.counters == [
+        (
+            "dj.graphql.errors",
+            1,
+            {"operation": "findNodes", "error_type": "ValueError"},
+        ),
+    ]
+    mock_logger.error.assert_called_once()
+    _, kwargs = mock_logger.error.call_args
+    assert kwargs["exc_info"] is original
+
+
+def test_error_reporter_programmatic_error(spy_metrics):
+    """A spec-side error with no path and no original_error tags as unknown / GraphQLError."""
+    error = GraphQLError("validation failed")
+
+    with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
+        _run_on_operation([error])
+
+    assert spy_metrics.counters == [
+        (
+            "dj.graphql.errors",
+            1,
+            {"operation": "unknown", "error_type": "GraphQLError"},
+        ),
+    ]
+    mock_logger.error.assert_called_once()
+    _, kwargs = mock_logger.error.call_args
+    assert kwargs["exc_info"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

<!-- What's this change about? -->
This change moves the GraphQL error counter to the right place to actually capture errors. It also turns it into the single source of truth for both error metrics and error logging.

We can remove the except block from the `log_resolver` decorator, which was unreachable in practice because programmatic GraphQL errors don't bubble up as Python exceptions.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
