### PR TITLE
Drop DJ server support for python 3.10

### DIFF
--- a/.github/workflows/generate-openapi-client.yml
+++ b/.github/workflows/generate-openapi-client.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install DJ
         run: |

--- a/.github/workflows/generate-openapi-spec.yml
+++ b/.github/workflows/generate-openapi-spec.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Set up Node
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,12 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         library: ['client', 'server', 'djqs', 'djrs']
         exclude:
-          # datajunction-server requires Python >= 3.11
+          # datajunction-server requires Python >= 3.11; the client depends on
+          # datajunction-server (workspace dep), so it inherits the same floor.
           - python-version: '3.10'
             library: server
+          - python-version: '3.10'
+            library: client
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,10 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         library: ['client', 'server', 'djqs', 'djrs']
+        exclude:
+          # datajunction-server requires Python >= 3.11
+          - python-version: '3.10'
+            library: server
 
     steps:
       - uses: actions/checkout@v4

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -85,11 +85,10 @@ dependencies = [
     # JWT for GitHub App authentication
     "pyjwt[crypto]>=2.8.0",
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 readme = "README.md"
 license = {text = "MIT"}
 classifiers = [
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
### Summary

We're getting quite close to full [end-of-life for python 3.10](https://endoflife.date/python), so it seems reasonable to drop the test suite from the DJ server matrix.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
