### PR TITLE
Add better GraphQL observability for data loaders

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/dataloaders.py
+++ b/datajunction-server/datajunction_server/api/graphql/dataloaders.py
@@ -12,6 +12,7 @@ from strawberry.dataloader import DataLoader
 from starlette.requests import Request
 
 from datajunction_server.api.graphql.resolvers.nodes import load_node_options
+from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.construction.build_v3.loaders import find_upstream_node_names
 from datajunction_server.database.collection import Collection as DBCollection
 from datajunction_server.database.namespace import NodeNamespace
@@ -31,6 +32,55 @@ from datajunction_server.sql.parsing import ast
 from datajunction_server.utils import session_context
 
 logger = logging.getLogger(__name__)
+
+
+class InstrumentedDataLoader(DataLoader):
+    """
+    DataLoader subclass that emits per-loader hit/miss counters and
+    batch-size counts via the metrics provider.
+
+    Metrics (all tagged with ``loader=<name>``):
+      - ``dj.graphql.dataloader.hits``     — load() returned a cached future
+      - ``dj.graphql.dataloader.misses``   — load() queued a fresh fetch
+      - ``dj.graphql.dataloader.batches``  — number of batched fetches
+      - ``dj.graphql.dataloader.items``    — total keys across batched fetches
+
+    Average batch size is ``items.rate / batches.rate`` in Atlas; cache hit
+    rate is ``hits.rate / (hits.rate + misses.rate)``.
+    """
+
+    def __init__(self, name: str, *, load_fn, **kwargs):
+        self._loader_name = name
+
+        async def instrumented_load_fn(keys):
+            provider = get_metrics_provider()
+            provider.counter(
+                "dj.graphql.dataloader.batches",
+                tags={"loader": name},
+            )
+            provider.counter(
+                "dj.graphql.dataloader.items",
+                value=len(keys),
+                tags={"loader": name},
+            )
+            return await load_fn(keys)
+
+        super().__init__(load_fn=instrumented_load_fn, **kwargs)
+
+    def load(self, key):
+        provider = get_metrics_provider()
+        cached = self.cache_map.get(key) if self.cache else None
+        if cached is not None and not cached.cancelled():
+            provider.counter(
+                "dj.graphql.dataloader.hits",
+                tags={"loader": self._loader_name},
+            )
+        else:
+            provider.counter(
+                "dj.graphql.dataloader.misses",
+                tags={"loader": self._loader_name},
+            )
+        return super().load(key)
 
 
 async def batch_load_nodes(
@@ -121,7 +171,8 @@ def create_node_by_name_loader(request: Request) -> DataLoader[str, DBNode | Non
     Returns:
         A DataLoader instance for batching node lookups
     """
-    return DataLoader(
+    return InstrumentedDataLoader(
+        "node_by_name",
         load_fn=lambda keys: batch_load_nodes_by_name_only(keys, request),
     )
 
@@ -180,7 +231,8 @@ def create_collection_nodes_loader(
     Returns:
         A DataLoader instance for batching collection node lookups
     """
-    return DataLoader(
+    return InstrumentedDataLoader(
+        "collection_nodes",
         load_fn=lambda keys: batch_load_collection_nodes(keys, request),
     )
 
@@ -245,7 +297,8 @@ def create_git_info_loader(
     will be resolved with at most 2 DB queries (ancestors + FK hops)
     instead of one query per node.
     """
-    return DataLoader(
+    return InstrumentedDataLoader(
+        "git_info",
         load_fn=lambda keys: batch_load_git_info(keys, request),
     )
 
@@ -372,6 +425,7 @@ def create_extracted_measures_loader(
     batch_load_extracted_measures(ids) — collapsing N sessions + N extractions
     into 1 session + N extractions sharing nodes_cache and parent_map.
     """
-    return DataLoader(
+    return InstrumentedDataLoader(
+        "extracted_measures",
         load_fn=lambda keys: batch_load_extracted_measures(keys, request),
     )

--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -1,5 +1,6 @@
 """DJ graphql"""
 
+import inspect
 import logging
 import time
 from functools import wraps
@@ -60,6 +61,10 @@ from datajunction_server.utils import get_session, get_settings
 
 logger = logging.getLogger(__name__)
 
+# Resolvers that take longer than this are logged at WARNING with their path
+# so slow fields are visible without enabling per-resolver timing for everyone.
+SLOW_RESOLVER_THRESHOLD_MS = 500.0
+
 
 def log_resolver(func):
     """
@@ -107,15 +112,22 @@ class GraphQLErrorReporter(SchemaExtension):
     data (the spec way) that don't bubble as Python exceptions.
 
     For each error it:
-      - emits ``dj.graphql.errors`` with ``operation`` and ``error_type`` tags
+      - emits ``dj.graphql.errors`` with ``operation``, ``operation_name``,
+        and ``error_type`` tags
       - logs at ERROR level with the message, path, and the original
         exception's traceback (when one is attached)
 
-    ``operation`` is the top-level field path the error is attached to, or
-    ``unknown`` if the error has no path (e.g. parse / validation).
-    ``error_type`` is the underlying exception class name when the error
-    was caused by a raised exception, or ``GraphQLError`` when it's a
-    programmatic GraphQL error returned as data.
+    Also wraps every resolver with ``resolve`` so any single field that runs
+    longer than ``SLOW_RESOLVER_THRESHOLD_MS`` is logged at WARNING.
+
+    Tag semantics:
+      - ``operation`` — top-level field path the error is attached to,
+        or ``unknown`` if the error has no path (e.g. parse / validation).
+      - ``operation_name`` — the client-supplied name on the GraphQL operation
+        (``query Foo { ... }`` → ``Foo``); ``anonymous`` when omitted.
+      - ``error_type`` — the underlying exception class name when the error
+        was caused by a raised exception, or ``GraphQLError`` when it's a
+        programmatic GraphQL error returned as data.
     """
 
     def on_operation(self):
@@ -123,14 +135,18 @@ class GraphQLErrorReporter(SchemaExtension):
         result = getattr(self.execution_context, "result", None)
         if not result or not getattr(result, "errors", None):
             return
+        operation_name = (
+            getattr(self.execution_context, "operation_name", None) or "anonymous"
+        )
         for error in result.errors:
             path = getattr(error, "path", None)
             operation = str(path[0]) if path else "unknown"
             original = getattr(error, "original_error", None)
             error_type = type(original).__name__ if original else "GraphQLError"
             logger.error(
-                "[GQL] status=error operation=%s error_type=%s path=%s message=%s",
+                "[GQL] status=error operation=%s operation_name=%s error_type=%s path=%s message=%s",
                 operation,
+                operation_name,
                 error_type,
                 path,
                 error.message,
@@ -138,8 +154,28 @@ class GraphQLErrorReporter(SchemaExtension):
             )
             get_metrics_provider().counter(
                 "dj.graphql.errors",
-                tags={"operation": operation, "error_type": error_type},
+                tags={
+                    "operation": operation,
+                    "operation_name": operation_name,
+                    "error_type": error_type,
+                },
             )
+
+    async def resolve(self, _next, root, info, *args, **kwargs):
+        start = time.monotonic()
+        try:
+            result = _next(root, info, *args, **kwargs)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
+        finally:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            if elapsed_ms >= SLOW_RESOLVER_THRESHOLD_MS:
+                logger.warning(
+                    "[GQL] slow_resolver path=%s elapsed_ms=%.1f",
+                    info.path.as_list(),
+                    elapsed_ms,
+                )
 
 
 async def get_context(

--- a/datajunction-server/tests/api/graphql/test_dataloaders.py
+++ b/datajunction-server/tests/api/graphql/test_dataloaders.py
@@ -4,12 +4,18 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from datajunction_server.api.graphql.dataloaders import (
+    InstrumentedDataLoader,
     batch_load_extracted_measures,
     batch_load_git_info,
     batch_load_nodes,
     batch_load_nodes_by_name_only,
     create_git_info_loader,
     create_node_by_name_loader,
+)
+from datajunction_server.instrumentation.provider import (
+    MetricsProvider,
+    get_metrics_provider,
+    set_metrics_provider,
 )
 
 
@@ -265,25 +271,15 @@ async def test_batch_load_nodes_by_name_only_with_missing(
     assert result[2] is None
 
 
-@patch("datajunction_server.api.graphql.dataloaders.DataLoader")
-def test_create_node_by_name_loader(mock_dataloader):
-    """Test create_node_by_name_loader creates DataLoader with correct load_fn"""
-    mock_request = MagicMock()
-    mock_loader_instance = MagicMock()
-    mock_dataloader.return_value = mock_loader_instance
+def test_create_node_by_name_loader():
+    """create_node_by_name_loader returns an InstrumentedDataLoader named 'node_by_name'."""
+    from datajunction_server.api.graphql.dataloaders import InstrumentedDataLoader
 
+    mock_request = MagicMock()
     result = create_node_by_name_loader(mock_request)
 
-    # Verify DataLoader was called
-    assert mock_dataloader.called
-    call_kwargs = mock_dataloader.call_args[1]
-
-    # Verify load_fn is set correctly
-    assert "load_fn" in call_kwargs
-    assert callable(call_kwargs["load_fn"])
-
-    # Verify result is the DataLoader instance
-    assert result == mock_loader_instance
+    assert isinstance(result, InstrumentedDataLoader)
+    assert result._loader_name == "node_by_name"
 
 
 @pytest.mark.asyncio
@@ -397,20 +393,15 @@ async def test_batch_load_git_info_no_git_branch(mock_session_context):
     assert result[0] is None
 
 
-@patch("datajunction_server.api.graphql.dataloaders.DataLoader")
-def test_create_git_info_loader(mock_dataloader):
-    """Test create_git_info_loader creates DataLoader with correct load_fn."""
-    mock_request = MagicMock()
-    mock_loader_instance = MagicMock()
-    mock_dataloader.return_value = mock_loader_instance
+def test_create_git_info_loader():
+    """create_git_info_loader returns an InstrumentedDataLoader named 'git_info'."""
+    from datajunction_server.api.graphql.dataloaders import InstrumentedDataLoader
 
+    mock_request = MagicMock()
     result = create_git_info_loader(mock_request)
 
-    assert mock_dataloader.called
-    call_kwargs = mock_dataloader.call_args[1]
-    assert "load_fn" in call_kwargs
-    assert callable(call_kwargs["load_fn"])
-    assert result == mock_loader_instance
+    assert isinstance(result, InstrumentedDataLoader)
+    assert result._loader_name == "git_info"
 
 
 @pytest.mark.asyncio
@@ -443,3 +434,102 @@ async def test_batch_load_extracted_measures_missing_ids(
     assert result == [None]
     # Only the nr_stmt query ran; the bulk Node load was skipped.
     assert mock_session.execute.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# InstrumentedDataLoader: hit/miss + batch metrics
+# ---------------------------------------------------------------------------
+
+
+class _SpyProvider(MetricsProvider):
+    def __init__(self) -> None:
+        self.counters: list[tuple] = []
+
+    def counter(self, name, value=1, tags=None):
+        self.counters.append((name, value, tags))
+
+    def gauge(self, name, value, tags=None):  # pragma: no cover
+        pass
+
+    def timer(self, name, value_ms, tags=None):  # pragma: no cover
+        pass
+
+
+@pytest.fixture
+def spy_metrics():
+    original = get_metrics_provider()
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+    yield spy
+    set_metrics_provider(original)
+
+
+@pytest.mark.asyncio
+async def test_instrumented_dataloader_misses_then_hit(spy_metrics):
+    """First load is a miss + batch fetch; second load of the same key is a cache hit."""
+
+    async def load_fn(keys):
+        return [f"v:{k}" for k in keys]
+
+    loader = InstrumentedDataLoader("test_loader", load_fn=load_fn)
+
+    assert await loader.load("a") == "v:a"
+    # Strawberry caches resolved futures, so a second load is a hit.
+    assert await loader.load("a") == "v:a"
+
+    miss_counts = [
+        c for c in spy_metrics.counters if c[0] == "dj.graphql.dataloader.misses"
+    ]
+    hit_counts = [
+        c for c in spy_metrics.counters if c[0] == "dj.graphql.dataloader.hits"
+    ]
+    batch_counts = [
+        c for c in spy_metrics.counters if c[0] == "dj.graphql.dataloader.batches"
+    ]
+    item_counts = [
+        c for c in spy_metrics.counters if c[0] == "dj.graphql.dataloader.items"
+    ]
+
+    assert miss_counts == [
+        ("dj.graphql.dataloader.misses", 1, {"loader": "test_loader"}),
+    ]
+    assert hit_counts == [
+        ("dj.graphql.dataloader.hits", 1, {"loader": "test_loader"}),
+    ]
+    assert batch_counts == [
+        ("dj.graphql.dataloader.batches", 1, {"loader": "test_loader"}),
+    ]
+    assert item_counts == [
+        ("dj.graphql.dataloader.items", 1, {"loader": "test_loader"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_instrumented_dataloader_batches_distinct_keys(spy_metrics):
+    """Concurrent loads of distinct keys are batched into a single fetch sized by len(keys)."""
+    import asyncio
+
+    async def load_fn(keys):
+        return [f"v:{k}" for k in keys]
+
+    loader = InstrumentedDataLoader("batched", load_fn=load_fn)
+
+    results = await asyncio.gather(
+        loader.load("a"),
+        loader.load("b"),
+        loader.load("c"),
+    )
+    assert results == ["v:a", "v:b", "v:c"]
+
+    item_counts = [
+        c for c in spy_metrics.counters if c[0] == "dj.graphql.dataloader.items"
+    ]
+    batch_counts = [
+        c for c in spy_metrics.counters if c[0] == "dj.graphql.dataloader.batches"
+    ]
+    assert batch_counts == [
+        ("dj.graphql.dataloader.batches", 1, {"loader": "batched"}),
+    ]
+    assert item_counts == [
+        ("dj.graphql.dataloader.items", 3, {"loader": "batched"}),
+    ]

--- a/datajunction-server/tests/api/graphql/test_main.py
+++ b/datajunction-server/tests/api/graphql/test_main.py
@@ -42,10 +42,11 @@ def spy_metrics():
     set_metrics_provider(original)
 
 
-def _run_on_operation(errors):
+def _run_on_operation(errors, *, operation_name=None):
     """Drive GraphQLErrorReporter.on_operation to completion with the given errors."""
     extension = GraphQLErrorReporter(execution_context=MagicMock())
     extension.execution_context = MagicMock()
+    extension.execution_context.operation_name = operation_name
     if errors is None:
         extension.execution_context.result = None
     else:
@@ -82,13 +83,17 @@ def test_error_reporter_python_exception(spy_metrics):
     error = GraphQLError("boom", path=["findNodes", 0, "name"], original_error=original)
 
     with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
-        _run_on_operation([error])
+        _run_on_operation([error], operation_name="LoadDashboard")
 
     assert spy_metrics.counters == [
         (
             "dj.graphql.errors",
             1,
-            {"operation": "findNodes", "error_type": "ValueError"},
+            {
+                "operation": "findNodes",
+                "operation_name": "LoadDashboard",
+                "error_type": "ValueError",
+            },
         ),
     ]
     mock_logger.error.assert_called_once()
@@ -97,7 +102,7 @@ def test_error_reporter_python_exception(spy_metrics):
 
 
 def test_error_reporter_programmatic_error(spy_metrics):
-    """A spec-side error with no path and no original_error tags as unknown / GraphQLError."""
+    """A spec-side error with no path / no original / no operation name tags as anonymous."""
     error = GraphQLError("validation failed")
 
     with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
@@ -107,12 +112,70 @@ def test_error_reporter_programmatic_error(spy_metrics):
         (
             "dj.graphql.errors",
             1,
-            {"operation": "unknown", "error_type": "GraphQLError"},
+            {
+                "operation": "unknown",
+                "operation_name": "anonymous",
+                "error_type": "GraphQLError",
+            },
         ),
     ]
     mock_logger.error.assert_called_once()
     _, kwargs = mock_logger.error.call_args
     assert kwargs["exc_info"] is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_logs_slow_resolvers():
+    """Resolvers exceeding the threshold are logged at WARNING with their path."""
+    from datajunction_server.api.graphql.main import GraphQLErrorReporter
+
+    extension = GraphQLErrorReporter(execution_context=MagicMock())
+
+    async def slow_next(_root, _info):
+        return "ok"
+
+    info = MagicMock()
+    info.path.as_list.return_value = ["findNodes", 0, "name"]
+
+    with (
+        patch("datajunction_server.api.graphql.main.logger") as mock_logger,
+        patch(
+            "datajunction_server.api.graphql.main.time.monotonic",
+            side_effect=[0.0, 1.0],  # 1000ms elapsed
+        ),
+    ):
+        result = await extension.resolve(slow_next, None, info)
+
+    assert result == "ok"
+    mock_logger.warning.assert_called_once()
+    args, _ = mock_logger.warning.call_args
+    assert args[1] == ["findNodes", 0, "name"]
+    assert args[2] == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_resolve_silent_for_fast_resolvers():
+    """Fast resolvers do not produce slow-resolver warnings."""
+    from datajunction_server.api.graphql.main import GraphQLErrorReporter
+
+    extension = GraphQLErrorReporter(execution_context=MagicMock())
+
+    def sync_next(_root, _info):
+        return 42
+
+    info = MagicMock()
+
+    with (
+        patch("datajunction_server.api.graphql.main.logger") as mock_logger,
+        patch(
+            "datajunction_server.api.graphql.main.time.monotonic",
+            side_effect=[0.0, 0.001],  # 1ms — well under the threshold
+        ),
+    ):
+        result = await extension.resolve(sync_next, None, info)
+
+    assert result == 42
+    mock_logger.warning.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This PR  centralizes GraphQL error observability and adds per-resolver / per-DataLoader instrumentation. It replaces the `dj.graphql.errors` counter that only fired for top-level resolver Python exceptions with a Strawberry SchemaExtension that sees every error in the response (parse/validation errors, permission denials, nested-field resolver errors etc).

#### New tag semantics

- `operation`: top-level GraphQL field (e.g. `findNodes`); unknown for parse/validation errors with no path.
- `operation_name`: client-supplied query name (`query LoadDashboard { ... }` maps to `LoadDashboard`) or anonymous if omitted. This provides a per-caller-feature view.
- `error_type`: underlying Python exception class (e.g. `ValueError`, `DJNodeNotFound`) when an exception caused the error, otherwise GraphQLError for spec-side errors returned as data.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
