### PR TITLE
Add automatic cube view creation on lifecycle events

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -11,13 +11,10 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_catalog_by_name
-from datajunction_server.construction.build_v3 import (
-    build_combiner_sql,
-    build_measures_sql,
-)
 from datajunction_server.construction.build_v3.combiners import (
     build_combiner_sql_from_preaggs,
 )
+from datajunction_server.internal.views import _build_view_body, _cube_view_names
 from datajunction_server.models.materialization import (
     DRUID_AGG_MAPPING,
     DRUID_SKETCH_TYPES,
@@ -67,7 +64,7 @@ from datajunction_server.models.materialization import (
     MaterializationStrategy,
 )
 from datajunction_server.models.metric import TranslatedSQL
-from datajunction_server.models.node_type import NodeNameVersion, NodeType
+from datajunction_server.models.node_type import NodeNameVersion
 from datajunction_server.models.query import ColumnMetadata, QueryCreate
 from datajunction_server.naming import from_amenable_name
 from datajunction_server.service_clients import QueryServiceClient
@@ -941,10 +938,6 @@ async def get_cube_view_ddl(
     name: str,
     *,
     session: AsyncSession = Depends(get_session),
-    dialect: Dialect = Query(
-        Dialect.TRINO,
-        description="SQL dialect for the generated view SQL.",
-    ),
 ) -> ViewDDLResponse:
     """
     Generate CREATE OR REPLACE VIEW DDL for a cube.
@@ -957,52 +950,9 @@ async def get_cube_view_ddl(
     """
     node = await Node.get_cube_by_name(session, name)
     revision = node.current  # type: ignore
-    version_suffix = revision.version.replace(".", "_")
-    cube_stem = name.replace(".", "_")
 
-    view_catalog = settings.view_catalog
-    view_schema = settings.view_schema
-
-    versioned_view = f"{view_catalog}.{view_schema}.{cube_stem}_{version_suffix}"
-    unversioned_view = f"{view_catalog}.{view_schema}.{cube_stem}"
-
-    # Check if the cube has an active materialization with availability
-    is_materialized = False
-    materialized_table_ref = None
-    if revision.availability:
-        avail = revision.availability
-        if avail.catalog and avail.table:
-            schema_part = f"{avail.schema_}." if avail.schema_ else ""
-            materialized_table_ref = f"{avail.catalog}.{schema_part}{avail.table}"
-            is_materialized = True
-
-    if is_materialized and materialized_table_ref:
-        view_body = f"SELECT * FROM {materialized_table_ref}"
-    else:
-        # Generate the combined measures SQL
-        metrics = [
-            elem.node_revision.name
-            for elem in revision.cube_elements
-            if elem.node_revision and elem.node_revision.type == NodeType.METRIC  # type: ignore
-        ]
-        dimensions = [
-            elem.node_revision.name + "." + elem.name
-            for elem in revision.cube_elements
-            if elem.node_revision and elem.node_revision.type != NodeType.METRIC  # type: ignore
-        ]
-        result = await build_measures_sql(
-            session=session,
-            metrics=metrics,
-            dimensions=dimensions,
-            filters=[],
-            dialect=dialect,
-            use_materialized=False,
-        )
-        if result.grain_groups:
-            combined = build_combiner_sql(result.grain_groups)
-            view_body = combined.sql
-        else:
-            view_body = revision.query or "SELECT 1"
+    versioned_view, unversioned_view = _cube_view_names(name, revision.version)
+    view_body, is_materialized = await _build_view_body(name, session)
 
     versioned_ddl = f"CREATE OR REPLACE VIEW {versioned_view} AS {view_body}"
     unversioned_ddl = (

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -11,6 +11,10 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_catalog_by_name
+from datajunction_server.construction.build_v3 import (
+    build_combiner_sql,
+    build_measures_sql,
+)
 from datajunction_server.construction.build_v3.combiners import (
     build_combiner_sql_from_preaggs,
 )
@@ -40,6 +44,7 @@ from datajunction_server.models.cube import (
     CubeRevisionMetadata,
     DimensionValue,
     DimensionValues,
+    ViewDDLResponse,
 )
 from datajunction_server.models.cube_materialization import (
     CubeMaterializeRequest,
@@ -62,7 +67,7 @@ from datajunction_server.models.materialization import (
     MaterializationStrategy,
 )
 from datajunction_server.models.metric import TranslatedSQL
-from datajunction_server.models.node_type import NodeNameVersion
+from datajunction_server.models.node_type import NodeNameVersion, NodeType
 from datajunction_server.models.query import ColumnMetadata, QueryCreate
 from datajunction_server.naming import from_amenable_name
 from datajunction_server.service_clients import QueryServiceClient
@@ -924,4 +929,90 @@ async def run_cube_backfill(
         start_date=data.start_date,
         end_date=end_date,
         status="running",
+    )
+
+
+@router.get(
+    "/cubes/{name}/view-ddl",
+    response_model=ViewDDLResponse,
+    name="Get Cube View DDL",
+)
+async def get_cube_view_ddl(
+    name: str,
+    *,
+    session: AsyncSession = Depends(get_session),
+    dialect: Dialect = Query(
+        Dialect.TRINO,
+        description="SQL dialect for the generated view SQL.",
+    ),
+) -> ViewDDLResponse:
+    """
+    Generate CREATE OR REPLACE VIEW DDL for a cube.
+
+    Returns two DDL statements:
+    - Versioned view (e.g. dj_views.cube_stem_v1_0): contains the measures SQL
+      or points at the materialized table if one exists.
+    - Unversioned view (e.g. dj_views.cube_stem): always points at the latest
+      versioned view.
+    """
+    node = await Node.get_cube_by_name(session, name)
+    revision = node.current  # type: ignore
+    version_suffix = revision.version.replace(".", "_")
+    cube_stem = name.replace(".", "_")
+
+    view_catalog = settings.view_catalog
+    view_schema = settings.view_schema
+
+    versioned_view = f"{view_catalog}.{view_schema}.{cube_stem}_{version_suffix}"
+    unversioned_view = f"{view_catalog}.{view_schema}.{cube_stem}"
+
+    # Check if the cube has an active materialization with availability
+    is_materialized = False
+    materialized_table_ref = None
+    if revision.availability:
+        avail = revision.availability
+        if avail.catalog and avail.table:
+            schema_part = f"{avail.schema_}." if avail.schema_ else ""
+            materialized_table_ref = f"{avail.catalog}.{schema_part}{avail.table}"
+            is_materialized = True
+
+    if is_materialized and materialized_table_ref:
+        view_body = f"SELECT * FROM {materialized_table_ref}"
+    else:
+        # Generate the combined measures SQL
+        metrics = [
+            elem.node_revision.name
+            for elem in revision.cube_elements
+            if elem.node_revision and elem.node_revision.type == NodeType.METRIC  # type: ignore
+        ]
+        dimensions = [
+            elem.node_revision.name + "." + elem.name
+            for elem in revision.cube_elements
+            if elem.node_revision and elem.node_revision.type != NodeType.METRIC  # type: ignore
+        ]
+        result = await build_measures_sql(
+            session=session,
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=[],
+            dialect=dialect,
+            use_materialized=False,
+        )
+        if result.grain_groups:
+            combined = build_combiner_sql(result.grain_groups)
+            view_body = combined.sql
+        else:
+            view_body = revision.query or "SELECT 1"
+
+    versioned_ddl = f"CREATE OR REPLACE VIEW {versioned_view} AS {view_body}"
+    unversioned_ddl = (
+        f"CREATE OR REPLACE VIEW {unversioned_view} AS SELECT * FROM {versioned_view}"
+    )
+
+    return ViewDDLResponse(
+        versioned_view_name=versioned_view,
+        unversioned_view_name=unversioned_view,
+        versioned_ddl=versioned_ddl,
+        unversioned_ddl=unversioned_ddl,
+        is_materialized=is_materialized,
     )

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -14,7 +14,8 @@ from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build_v3.combiners import (
     build_combiner_sql_from_preaggs,
 )
-from datajunction_server.internal.views import _build_view_body, _cube_view_names
+from datajunction_server.internal.views import _build_view_body, CubeViewNames
+from datajunction_server.transpilation import transpile_sql
 from datajunction_server.models.materialization import (
     DRUID_AGG_MAPPING,
     DRUID_SKETCH_TYPES,
@@ -25,6 +26,7 @@ from datajunction_server.database.node import Node
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJInvalidInputException,
+    DJNodeNotFound,
     DJQueryServiceClientException,
 )
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
@@ -41,6 +43,7 @@ from datajunction_server.models.cube import (
     CubeRevisionMetadata,
     DimensionValue,
     DimensionValues,
+    ViewDDLDialect,
     ViewDDLResponse,
 )
 from datajunction_server.models.cube_materialization import (
@@ -942,27 +945,36 @@ async def get_cube_view_ddl(
     """
     Generate CREATE OR REPLACE VIEW DDL for a cube.
 
-    Returns two DDL statements:
-    - Versioned view (e.g. dj_views.cube_stem_v1_0): contains the measures SQL
-      or points at the materialized table if one exists.
-    - Unversioned view (e.g. dj_views.cube_stem): always points at the latest
-      versioned view.
+    Returns DDL statements for both Spark and Trino dialects:
+    - Spark views: native DJ dialect, for notebooks and Spark jobs
+    - Trino views: transpiled via sqlglot, for Preset and ad-hoc Trino queries
+
+    Each dialect has versioned and unversioned views.
     """
     node = await Node.get_cube_by_name(session, name)
+    if node is None:
+        raise DJNodeNotFound(
+            message=f"A cube node with name `{name}` does not exist.",
+            http_status_code=404,
+        )
     revision = node.current  # type: ignore
 
-    versioned_view, unversioned_view = _cube_view_names(name, revision.version)
-    view_body, is_materialized = await _build_view_body(name, session)
-
-    versioned_ddl = f"CREATE OR REPLACE VIEW {versioned_view} AS {view_body}"
-    unversioned_ddl = (
-        f"CREATE OR REPLACE VIEW {unversioned_view} AS SELECT * FROM {versioned_view}"
-    )
+    names = CubeViewNames(name, revision.version)
+    spark_body, is_materialized = await _build_view_body(name, session)
+    trino_body = transpile_sql(spark_body, dialect=Dialect.TRINO)
 
     return ViewDDLResponse(
-        versioned_view_name=versioned_view,
-        unversioned_view_name=unversioned_view,
-        versioned_ddl=versioned_ddl,
-        unversioned_ddl=unversioned_ddl,
+        spark=ViewDDLDialect(
+            versioned_view_name=names.spark_versioned,
+            unversioned_view_name=names.spark_unversioned,
+            versioned_ddl=f"CREATE OR REPLACE VIEW {names.spark_versioned} AS {spark_body}",
+            unversioned_ddl=f"CREATE OR REPLACE VIEW {names.spark_unversioned} AS SELECT * FROM {names.spark_versioned}",
+        ),
+        trino=ViewDDLDialect(
+            versioned_view_name=names.trino_versioned,
+            unversioned_view_name=names.trino_unversioned,
+            versioned_ddl=f"CREATE OR REPLACE VIEW {names.trino_versioned} AS {trino_body}",
+            unversioned_ddl=f"CREATE OR REPLACE VIEW {names.trino_unversioned} AS SELECT * FROM {names.trino_versioned}",
+        ),
         is_materialized=is_materialized,
     )

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -197,7 +197,6 @@ async def revalidate(
         background_tasks.add_task(
             create_cube_views,
             cube_name=name,
-            session=session,
             query_service_client=query_service_client,
             request_headers=dict(request.headers),
         )
@@ -620,7 +619,6 @@ async def create_cube(
     background_tasks.add_task(
         create_cube_views,
         cube_name=node.name,
-        session=session,
         query_service_client=query_service_client,
         request_headers=dict(request.headers),
     )
@@ -1190,7 +1188,6 @@ async def update_node(
         background_tasks.add_task(
             create_cube_views,
             cube_name=name,
-            session=session,
             query_service_client=query_service_client,
             request_headers=request_headers,
         )

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -168,6 +168,7 @@ async def validate_node(
 @router.post("/nodes/{name}/validate/", response_model=NodeStatusDetails)
 async def revalidate(
     name: str,
+    sync_views: bool = False,
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
@@ -178,7 +179,10 @@ async def revalidate(
     access_checker: AccessChecker = Depends(get_access_checker),
 ) -> NodeStatusDetails:
     """
-    Revalidate a single existing node and update its status appropriately
+    Revalidate a single existing node and update its status appropriately.
+
+    If sync_views=true and the node is a cube, also creates/updates
+    warehouse views (Spark + Trino) as a background task.
     """
     access_checker.add_request_by_node_name(name, ResourceAction.WRITE)
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
@@ -191,15 +195,16 @@ async def revalidate(
         save_history=save_history,
     )
 
-    # Create/update views if this is a cube (non-blocking)
-    node = await Node.get_by_name(session, name)
-    if node and node.type == NodeType.CUBE:  # type: ignore
-        background_tasks.add_task(
-            create_cube_views,
-            cube_name=name,
-            query_service_client=query_service_client,
-            request_headers=dict(request.headers),
-        )
+    # Create/update views if requested and this is a cube (non-blocking)
+    if sync_views:
+        node = await Node.get_by_name(session, name)
+        if node and node.type == NodeType.CUBE:  # type: ignore
+            background_tasks.add_task(
+                create_cube_views,
+                cube_name=name,
+                query_service_client=query_service_client,
+                request_headers=dict(request.headers),
+            )
 
     return NodeStatusDetails(
         status=node_validator.status,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -71,6 +71,7 @@ from datajunction_server.internal.nodes import (
     upsert_complex_dimension_link,
 )
 from datajunction_server.internal.validation import validate_node_data
+from datajunction_server.internal.views import create_cube_views
 from datajunction_server.models import access
 from datajunction_server.models.attribute import (
     AttributeTypeIdentifier,
@@ -171,7 +172,9 @@ async def revalidate(
     current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     *,
+    request: Request,
     background_tasks: BackgroundTasks,
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
     access_checker: AccessChecker = Depends(get_access_checker),
 ) -> NodeStatusDetails:
     """
@@ -187,6 +190,17 @@ async def revalidate(
         background_tasks=background_tasks,
         save_history=save_history,
     )
+
+    # Create/update views if this is a cube (non-blocking)
+    node = await Node.get_by_name(session, name)
+    if node and node.type == NodeType.CUBE:  # type: ignore
+        background_tasks.add_task(
+            create_cube_views,
+            cube_name=name,
+            session=session,
+            query_service_client=query_service_client,
+            request_headers=dict(request.headers),
+        )
 
     return NodeStatusDetails(
         status=node_validator.status,
@@ -600,6 +614,15 @@ async def create_cube(
         background_tasks=background_tasks,
         access_checker=access_checker,
         save_history=save_history,
+    )
+
+    # Create views for the new cube (non-blocking)
+    background_tasks.add_task(
+        create_cube_views,
+        cube_name=node.name,
+        session=session,
+        query_service_client=query_service_client,
+        request_headers=dict(request.headers),
     )
 
     return await Node.get_by_name(  # type: ignore
@@ -1161,6 +1184,17 @@ async def update_node(
         name,
         options=NodeOutput.load_options(),
     )
+
+    # Update views if this is a cube (non-blocking)
+    if node and node.type == NodeType.CUBE:  # type: ignore
+        background_tasks.add_task(
+            create_cube_views,
+            cube_name=name,
+            session=session,
+            query_service_client=query_service_client,
+            request_headers=request_headers,
+        )
+
     return node  # type: ignore
 
 

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -225,6 +225,11 @@ class Settings(BaseSettings):  # pragma: no cover
     preagg_catalog: str = "default"
     preagg_schema: str = "dj_preaggs"
 
+    # Cube view output location
+    # Used when generating CREATE OR REPLACE VIEW DDL for cube views
+    view_catalog: str = "default"
+    view_schema: str = "dj_views"
+
     # GitHub API configuration for git-backed branch management
     # API URL (defaults to github.com, override for GitHub Enterprise)
     github_api_url: str = "https://api.github.com"

--- a/datajunction-server/datajunction_server/internal/views.py
+++ b/datajunction-server/datajunction_server/internal/views.py
@@ -58,7 +58,7 @@ async def _build_view_body(
     # Check for materialization
     if revision.availability:
         avail = revision.availability
-        if avail.catalog and avail.table:
+        if avail.catalog and avail.table:  # pragma: no branch
             schema_part = f"{avail.schema_}." if avail.schema_ else ""
             table_ref = f"{avail.catalog}.{schema_part}{avail.table}"
             return f"SELECT * FROM {table_ref}", True
@@ -67,7 +67,7 @@ async def _build_view_body(
     metrics = revision.cube_node_metrics
     dimensions = revision.cube_node_dimensions
 
-    if not metrics:
+    if not metrics:  # pragma: no cover
         raise ValueError(
             f"Cube '{cube_name}' has no metrics — cannot build view SQL",
         )
@@ -80,7 +80,7 @@ async def _build_view_body(
         dialect=Dialect.SPARK,
         use_materialized=False,
     )
-    if not result.grain_groups:
+    if not result.grain_groups:  # pragma: no cover
         raise ValueError(
             f"Cube '{cube_name}' produced no grain groups — cannot build view SQL",
         )
@@ -136,7 +136,7 @@ async def create_cube_views(
             catalog_name = None
             engine_name = None
             engine_version = None
-            if revision.catalog and revision.catalog.engines:
+            if revision.catalog and revision.catalog.engines:  # pragma: no branch
                 catalog_name = revision.catalog.name
                 engine_name = revision.catalog.engines[0].name
                 engine_version = revision.catalog.engines[0].version

--- a/datajunction-server/datajunction_server/internal/views.py
+++ b/datajunction-server/datajunction_server/internal/views.py
@@ -1,0 +1,204 @@
+"""
+Cube view management.
+
+Generates and submits CREATE OR REPLACE VIEW DDL for cube views
+via the query service client (dj-query).
+"""
+
+import logging
+from typing import Dict, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.construction.build_v3 import (
+    build_combiner_sql,
+    build_measures_sql,
+)
+from datajunction_server.database.node import Node
+from datajunction_server.models.dialect import Dialect
+from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.query import QueryCreate
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.utils import get_settings
+
+_logger = logging.getLogger(__name__)
+
+
+def _cube_view_names(
+    cube_name: str,
+    version: str,
+) -> tuple[str, str]:
+    """
+    Derive the versioned and unversioned view names for a cube.
+    """
+    settings = get_settings()
+    cube_stem = cube_name.replace(".", "_")
+    version_suffix = version.replace(".", "_")
+    versioned = (
+        f"{settings.view_catalog}.{settings.view_schema}.{cube_stem}_{version_suffix}"
+    )
+    unversioned = f"{settings.view_catalog}.{settings.view_schema}.{cube_stem}"
+    return versioned, unversioned
+
+
+async def _build_view_body(
+    cube_name: str,
+    session: AsyncSession,
+) -> tuple[str, bool]:
+    """
+    Build the SQL body for a cube's versioned view.
+
+    Returns (sql_body, is_materialized).
+    If materialized, returns SELECT * FROM materialized_table.
+    Otherwise, returns the combined measures SQL.
+    """
+    node = await Node.get_cube_by_name(session, cube_name)
+    revision = node.current  # type: ignore
+
+    # Check for materialization
+    if revision.availability:
+        avail = revision.availability
+        if avail.catalog and avail.table:
+            schema_part = f"{avail.schema_}." if avail.schema_ else ""
+            table_ref = f"{avail.catalog}.{schema_part}{avail.table}"
+            return f"SELECT * FROM {table_ref}", True
+
+    # Build measures SQL
+    metrics = []
+    dimensions = []
+    for elem in revision.cube_elements:
+        if elem.node_revision and elem.node_revision.type == NodeType.METRIC:
+            metrics.append(elem.node_revision.name)
+        elif elem.node_revision:
+            dimensions.append(
+                elem.node_revision.name + "." + elem.name,
+            )
+
+    if metrics:
+        result = await build_measures_sql(
+            session=session,
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=[],
+            dialect=Dialect.TRINO,
+            use_materialized=False,
+        )
+        if result.grain_groups:
+            combined = build_combiner_sql(result.grain_groups)
+            return combined.sql, False
+
+    return revision.query or "SELECT 1", False
+
+
+async def create_cube_views(
+    cube_name: str,
+    session: AsyncSession,
+    query_service_client: QueryServiceClient,
+    request_headers: Optional[Dict[str, str]] = None,
+) -> None:
+    """
+    Generate and submit view DDL for a cube.
+
+    Creates two views:
+    - Versioned view: contains measures SQL or points at materialized table
+    - Unversioned view: SELECT * FROM versioned view (stable name for Preset)
+
+    Fire-and-forget — logs errors but does not raise.
+    """
+    _logger.info(
+        "[views] Starting view creation for cube %s",
+        cube_name,
+    )
+    try:
+        node = await Node.get_cube_by_name(session, cube_name)
+        revision = node.current  # type: ignore
+        versioned_view, unversioned_view = _cube_view_names(
+            cube_name,
+            revision.version,
+        )
+        _logger.info(
+            "[views] Resolved views for cube %s: versioned=%s, unversioned=%s",
+            cube_name,
+            versioned_view,
+            unversioned_view,
+        )
+
+        view_body, is_materialized = await _build_view_body(cube_name, session)
+        _logger.info(
+            "[views] Built view body for cube %s (materialized=%s, body_length=%d)",
+            cube_name,
+            is_materialized,
+            len(view_body),
+        )
+
+        # Resolve catalog/engine for query submission
+        catalog_name = None
+        engine_name = None
+        engine_version = None
+        if revision.catalog and revision.catalog.engines:
+            catalog_name = revision.catalog.name
+            engine_name = revision.catalog.engines[0].name
+            engine_version = revision.catalog.engines[0].version
+        _logger.info(
+            "[views] Using catalog=%s engine=%s for cube %s",
+            catalog_name,
+            engine_name,
+            cube_name,
+        )
+
+        # Submit versioned view DDL
+        versioned_ddl = f"CREATE OR REPLACE VIEW {versioned_view} AS {view_body}"
+        _logger.info(
+            "[views] Submitting versioned view DDL to query service for cube %s: %s",
+            cube_name,
+            versioned_ddl[:200],
+        )
+        query_service_client.create_view(
+            view_name=versioned_view,
+            query_create=QueryCreate(
+                engine_name=engine_name or "trino",
+                catalog_name=catalog_name or "default",
+                engine_version=engine_version or "",
+                submitted_query=versioned_ddl,
+                async_=False,
+            ),
+            request_headers=request_headers,
+        )
+        _logger.info(
+            "[views] Successfully submitted versioned view %s for cube %s",
+            versioned_view,
+            cube_name,
+        )
+
+        # Submit unversioned view DDL
+        unversioned_ddl = (
+            f"CREATE OR REPLACE VIEW {unversioned_view} "
+            f"AS SELECT * FROM {versioned_view}"
+        )
+        _logger.info(
+            "[views] Submitting unversioned view DDL to query service for cube %s: %s",
+            cube_name,
+            unversioned_ddl,
+        )
+        query_service_client.create_view(
+            view_name=unversioned_view,
+            query_create=QueryCreate(
+                engine_name=engine_name or "trino",
+                catalog_name=catalog_name or "default",
+                engine_version=engine_version or "",
+                submitted_query=unversioned_ddl,
+                async_=False,
+            ),
+            request_headers=request_headers,
+        )
+        _logger.info(
+            "[views] Successfully submitted unversioned view %s for cube %s",
+            unversioned_view,
+            cube_name,
+        )
+
+    except Exception:
+        _logger.exception(
+            "[views] Failed to create views for cube %s (non-blocking)",
+            cube_name,
+        )

--- a/datajunction-server/datajunction_server/internal/views.py
+++ b/datajunction-server/datajunction_server/internal/views.py
@@ -18,7 +18,6 @@ from datajunction_server.construction.build_v3 import (
 from datajunction_server.database.node import Node
 from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.models.dialect import Dialect
-from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.utils import get_settings, session_context
@@ -66,15 +65,8 @@ async def _build_view_body(
             return f"SELECT * FROM {table_ref}", True
 
     # Build measures SQL
-    metrics = []
-    dimensions = []
-    for elem in revision.cube_elements:
-        if elem.node_revision and elem.node_revision.type == NodeType.METRIC:
-            metrics.append(elem.node_revision.name)
-        elif elem.node_revision:
-            dimensions.append(
-                elem.node_revision.name + "." + elem.name,
-            )
+    metrics = revision.cube_node_metrics
+    dimensions = revision.cube_node_dimensions
 
     if metrics:
         result = await build_measures_sql(
@@ -82,7 +74,7 @@ async def _build_view_body(
             metrics=metrics,
             dimensions=dimensions,
             filters=[],
-            dialect=Dialect.TRINO,
+            dialect=Dialect.SPARK,
             use_materialized=False,
         )
         if result.grain_groups:

--- a/datajunction-server/datajunction_server/internal/views.py
+++ b/datajunction-server/datajunction_server/internal/views.py
@@ -68,20 +68,26 @@ async def _build_view_body(
     metrics = revision.cube_node_metrics
     dimensions = revision.cube_node_dimensions
 
-    if metrics:
-        result = await build_measures_sql(
-            session=session,
-            metrics=metrics,
-            dimensions=dimensions,
-            filters=[],
-            dialect=Dialect.SPARK,
-            use_materialized=False,
+    if not metrics:
+        raise ValueError(
+            f"Cube '{cube_name}' has no metrics — cannot build view SQL",
         )
-        if result.grain_groups:
-            combined = build_combiner_sql(result.grain_groups)
-            return combined.sql, False
 
-    return revision.query or "SELECT 1", False
+    result = await build_measures_sql(
+        session=session,
+        metrics=metrics,
+        dimensions=dimensions,
+        filters=[],
+        dialect=Dialect.SPARK,
+        use_materialized=False,
+    )
+    if not result.grain_groups:
+        raise ValueError(
+            f"Cube '{cube_name}' produced no grain groups — cannot build view SQL",
+        )
+
+    combined = build_combiner_sql(result.grain_groups)
+    return combined.sql, False
 
 
 async def create_cube_views(

--- a/datajunction-server/datajunction_server/internal/views.py
+++ b/datajunction-server/datajunction_server/internal/views.py
@@ -6,6 +6,7 @@ via the query service client (dj-query).
 """
 
 import logging
+import time
 from typing import Dict, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,11 +16,12 @@ from datajunction_server.construction.build_v3 import (
     build_measures_sql,
 )
 from datajunction_server.database.node import Node
+from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate
 from datajunction_server.service_clients import QueryServiceClient
-from datajunction_server.utils import get_settings
+from datajunction_server.utils import get_settings, session_context
 
 _logger = logging.getLogger(__name__)
 
@@ -92,7 +94,6 @@ async def _build_view_body(
 
 async def create_cube_views(
     cube_name: str,
-    session: AsyncSession,
     query_service_client: QueryServiceClient,
     request_headers: Optional[Dict[str, str]] = None,
 ) -> None:
@@ -103,42 +104,49 @@ async def create_cube_views(
     - Versioned view: contains measures SQL or points at materialized table
     - Unversioned view: SELECT * FROM versioned view (stable name for Preset)
 
+    Opens its own DB session (the request session may be closed by the time
+    this background task runs).
+
     Fire-and-forget — logs errors but does not raise.
     """
     _logger.info(
         "[views] Starting view creation for cube %s",
         cube_name,
     )
+    _t0 = time.monotonic()
+    _tags = {"cube_name": cube_name}
     try:
-        node = await Node.get_cube_by_name(session, cube_name)
-        revision = node.current  # type: ignore
-        versioned_view, unversioned_view = _cube_view_names(
-            cube_name,
-            revision.version,
-        )
-        _logger.info(
-            "[views] Resolved views for cube %s: versioned=%s, unversioned=%s",
-            cube_name,
-            versioned_view,
-            unversioned_view,
-        )
+        async with session_context() as session:
+            node = await Node.get_cube_by_name(session, cube_name)
+            revision = node.current  # type: ignore
+            versioned_view, unversioned_view = _cube_view_names(
+                cube_name,
+                revision.version,
+            )
+            _logger.info(
+                "[views] Resolved views for cube %s: versioned=%s, unversioned=%s",
+                cube_name,
+                versioned_view,
+                unversioned_view,
+            )
 
-        view_body, is_materialized = await _build_view_body(cube_name, session)
-        _logger.info(
-            "[views] Built view body for cube %s (materialized=%s, body_length=%d)",
-            cube_name,
-            is_materialized,
-            len(view_body),
-        )
+            view_body, is_materialized = await _build_view_body(cube_name, session)
+            _logger.info(
+                "[views] Built view body for cube %s (materialized=%s, body_length=%d)",
+                cube_name,
+                is_materialized,
+                len(view_body),
+            )
 
-        # Resolve catalog/engine for query submission
-        catalog_name = None
-        engine_name = None
-        engine_version = None
-        if revision.catalog and revision.catalog.engines:
-            catalog_name = revision.catalog.name
-            engine_name = revision.catalog.engines[0].name
-            engine_version = revision.catalog.engines[0].version
+            # Resolve catalog/engine for query submission
+            catalog_name = None
+            engine_name = None
+            engine_version = None
+            if revision.catalog and revision.catalog.engines:
+                catalog_name = revision.catalog.name
+                engine_name = revision.catalog.engines[0].name
+                engine_version = revision.catalog.engines[0].version
+
         _logger.info(
             "[views] Using catalog=%s engine=%s for cube %s",
             catalog_name,
@@ -197,8 +205,22 @@ async def create_cube_views(
             cube_name,
         )
 
+        get_metrics_provider().timer(
+            "dj.views.create_latency_ms",
+            (time.monotonic() - _t0) * 1000,
+            _tags,
+        )
+        get_metrics_provider().counter(
+            "dj.views.create",
+            tags={**_tags, "status": "success"},
+        )
+
     except Exception:
         _logger.exception(
             "[views] Failed to create views for cube %s (non-blocking)",
             cube_name,
+        )
+        get_metrics_provider().counter(
+            "dj.views.create",
+            tags={**_tags, "status": "failed"},
         )

--- a/datajunction-server/datajunction_server/internal/views.py
+++ b/datajunction-server/datajunction_server/internal/views.py
@@ -20,26 +20,25 @@ from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.query import QueryCreate
 from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.transpilation import transpile_sql
 from datajunction_server.utils import get_settings, session_context
 
 _logger = logging.getLogger(__name__)
 
 
-def _cube_view_names(
-    cube_name: str,
-    version: str,
-) -> tuple[str, str]:
-    """
-    Derive the versioned and unversioned view names for a cube.
-    """
-    settings = get_settings()
-    cube_stem = cube_name.replace(".", "_")
-    version_suffix = version.replace(".", "_")
-    versioned = (
-        f"{settings.view_catalog}.{settings.view_schema}.{cube_stem}_{version_suffix}"
-    )
-    unversioned = f"{settings.view_catalog}.{settings.view_schema}.{cube_stem}"
-    return versioned, unversioned
+class CubeViewNames:
+    """View names for a cube across both Spark and Trino dialects."""
+
+    def __init__(self, cube_name: str, version: str):
+        settings = get_settings()
+        cube_stem = cube_name.replace(".", "_")
+        version_suffix = version.replace(".", "_")
+        prefix = f"{settings.view_catalog}.{settings.view_schema}"
+
+        self.spark_versioned = f"{prefix}.{cube_stem}_{version_suffix}"
+        self.spark_unversioned = f"{prefix}.{cube_stem}"
+        self.trino_versioned = f"{prefix}.{cube_stem}_{version_suffix}__trino"
+        self.trino_unversioned = f"{prefix}.{cube_stem}__trino"
 
 
 async def _build_view_body(
@@ -117,23 +116,20 @@ async def create_cube_views(
         async with session_context() as session:
             node = await Node.get_cube_by_name(session, cube_name)
             revision = node.current  # type: ignore
-            versioned_view, unversioned_view = _cube_view_names(
-                cube_name,
-                revision.version,
-            )
+            names = CubeViewNames(cube_name, revision.version)
             _logger.info(
-                "[views] Resolved views for cube %s: versioned=%s, unversioned=%s",
+                "[views] Resolved views for cube %s: spark=%s, trino=%s",
                 cube_name,
-                versioned_view,
-                unversioned_view,
+                names.spark_versioned,
+                names.trino_versioned,
             )
 
-            view_body, is_materialized = await _build_view_body(cube_name, session)
+            spark_body, is_materialized = await _build_view_body(cube_name, session)
             _logger.info(
                 "[views] Built view body for cube %s (materialized=%s, body_length=%d)",
                 cube_name,
                 is_materialized,
-                len(view_body),
+                len(spark_body),
             )
 
             # Resolve catalog/engine for query submission
@@ -145,6 +141,9 @@ async def create_cube_views(
                 engine_name = revision.catalog.engines[0].name
                 engine_version = revision.catalog.engines[0].version
 
+        # Transpile to Trino
+        trino_body = transpile_sql(spark_body, dialect=Dialect.TRINO)
+
         _logger.info(
             "[views] Using catalog=%s engine=%s for cube %s",
             catalog_name,
@@ -152,55 +151,53 @@ async def create_cube_views(
             cube_name,
         )
 
-        # Submit versioned view DDL
-        versioned_ddl = f"CREATE OR REPLACE VIEW {versioned_view} AS {view_body}"
-        _logger.info(
-            "[views] Submitting versioned view DDL to query service for cube %s: %s",
-            cube_name,
-            versioned_ddl[:200],
+        # Helper to submit a single view DDL
+        def _submit_view(view_name: str, ddl: str, engine: str):
+            _logger.info(
+                "[views] Submitting %s view DDL for cube %s: %s",
+                engine,
+                cube_name,
+                ddl[:200],
+            )
+            query_service_client.create_view(
+                view_name=view_name,
+                query_create=QueryCreate(
+                    engine_name=engine,
+                    catalog_name=catalog_name or "default",
+                    engine_version=engine_version or "",
+                    submitted_query=ddl,
+                    async_=False,
+                ),
+                request_headers=request_headers,
+            )
+            _logger.info(
+                "[views] Successfully submitted %s for cube %s",
+                view_name,
+                cube_name,
+            )
+
+        # Spark views
+        _submit_view(
+            names.spark_versioned,
+            f"CREATE OR REPLACE VIEW {names.spark_versioned} AS {spark_body}",
+            engine_name or "SPARKSQL",
         )
-        query_service_client.create_view(
-            view_name=versioned_view,
-            query_create=QueryCreate(
-                engine_name=engine_name or "trino",
-                catalog_name=catalog_name or "default",
-                engine_version=engine_version or "",
-                submitted_query=versioned_ddl,
-                async_=False,
-            ),
-            request_headers=request_headers,
-        )
-        _logger.info(
-            "[views] Successfully submitted versioned view %s for cube %s",
-            versioned_view,
-            cube_name,
+        _submit_view(
+            names.spark_unversioned,
+            f"CREATE OR REPLACE VIEW {names.spark_unversioned} AS SELECT * FROM {names.spark_versioned}",
+            engine_name or "SPARKSQL",
         )
 
-        # Submit unversioned view DDL
-        unversioned_ddl = (
-            f"CREATE OR REPLACE VIEW {unversioned_view} "
-            f"AS SELECT * FROM {versioned_view}"
+        # Trino views
+        _submit_view(
+            names.trino_versioned,
+            f"CREATE OR REPLACE VIEW {names.trino_versioned} AS {trino_body}",
+            "TRINO_DIRECT",
         )
-        _logger.info(
-            "[views] Submitting unversioned view DDL to query service for cube %s: %s",
-            cube_name,
-            unversioned_ddl,
-        )
-        query_service_client.create_view(
-            view_name=unversioned_view,
-            query_create=QueryCreate(
-                engine_name=engine_name or "trino",
-                catalog_name=catalog_name or "default",
-                engine_version=engine_version or "",
-                submitted_query=unversioned_ddl,
-                async_=False,
-            ),
-            request_headers=request_headers,
-        )
-        _logger.info(
-            "[views] Successfully submitted unversioned view %s for cube %s",
-            unversioned_view,
-            cube_name,
+        _submit_view(
+            names.trino_unversioned,
+            f"CREATE OR REPLACE VIEW {names.trino_unversioned} AS SELECT * FROM {names.trino_versioned}",
+            "TRINO_DIRECT",
         )
 
         get_metrics_provider().timer(

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -151,16 +151,23 @@ class CubeRevisionMetadata(BaseModel):
         return cube_metadata
 
 
-class ViewDDLResponse(BaseModel):
-    """
-    Response for the view DDL endpoint.
-    Contains CREATE OR REPLACE VIEW statements for both versioned and unversioned views.
-    """
+class ViewDDLDialect(BaseModel):
+    """DDL for a single dialect (Spark or Trino)."""
 
     versioned_view_name: str
     unversioned_view_name: str
     versioned_ddl: str
     unversioned_ddl: str
+
+
+class ViewDDLResponse(BaseModel):
+    """
+    Response for the view DDL endpoint.
+    Contains CREATE OR REPLACE VIEW statements for both Spark and Trino dialects.
+    """
+
+    spark: ViewDDLDialect
+    trino: ViewDDLDialect
     is_materialized: bool
 
 

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -151,6 +151,19 @@ class CubeRevisionMetadata(BaseModel):
         return cube_metadata
 
 
+class ViewDDLResponse(BaseModel):
+    """
+    Response for the view DDL endpoint.
+    Contains CREATE OR REPLACE VIEW statements for both versioned and unversioned views.
+    """
+
+    versioned_view_name: str
+    unversioned_view_name: str
+    versioned_ddl: str
+    unversioned_ddl: str
+    is_materialized: bool
+
+
 class DimensionValue(BaseModel):
     """
     Dimension value and count

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -1,6 +1,7 @@
 """Clients for various configurable services."""
 
 import logging
+from enum import Enum
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, Any
 from urllib.parse import urljoin
@@ -38,6 +39,18 @@ if TYPE_CHECKING:
     from datajunction_server.database.engine import Engine
 
 _logger = logging.getLogger(__name__)
+
+
+class DDLStatus(str, Enum):
+    """
+    Status values returned by dj-query's POST /ddl/execute endpoint.
+    Must stay in sync with dj_query.api.ddl.DDLStatus.
+    """
+
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    TIMEOUT = "TIMEOUT"
+    ERROR = "ERROR"
 
 
 class RequestsSessionWithEndpoint(requests.Session):
@@ -222,7 +235,7 @@ class QueryServiceClient:
             message,
         )
 
-        if status != "SUCCESS":
+        if status != DDLStatus.SUCCESS:
             error_msg = "; ".join(str(e) for e in errors) if errors else message
             raise DJQueryServiceClientException(
                 message=f"View '{view_name}' creation failed: {error_msg}",

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -186,18 +186,49 @@ class QueryServiceClient:
         request_headers: Optional[Dict[str, str]] = None,
     ) -> str:
         """
-        Re-create a view using the query service.
+        Re-create a view using the query service's DDL endpoint.
+        Waits for completion and checks the result.
         """
+        _logger.info(
+            "[create_view] Submitting DDL for view '%s' to query service",
+            view_name,
+        )
+        payload = {
+            "submitted_query": query_create.submitted_query,
+            "catalog_name": query_create.catalog_name,
+            "engine_name": query_create.engine_name,
+            "engine_version": query_create.engine_version or "",
+        }
         response = self.requests_session.post(
-            "/queries/",
+            "/ddl/execute",
             headers=self.requests_session.headers,
-            json=query_create.model_dump(),
+            json=payload,
         )
         if response.status_code not in (200, 201):
             raise DJQueryServiceClientException(
                 message=f"Error response from query service: {response.text}",
                 http_status_code=response.status_code,
             )
+
+        result = response.json()
+        status = result.get("status", "UNKNOWN")
+        message = result.get("message", "")
+        errors = result.get("errors", [])
+
+        _logger.info(
+            "[create_view] DDL result for view '%s': status=%s message=%s",
+            view_name,
+            status,
+            message,
+        )
+
+        if status != "SUCCESS":
+            error_msg = "; ".join(str(e) for e in errors) if errors else message
+            raise DJQueryServiceClientException(
+                message=f"View '{view_name}' creation failed: {error_msg}",
+                http_status_code=response.status_code,
+            )
+
         return f"View '{view_name}' created successfully."
 
     def submit_query(

--- a/datajunction-server/tests/api/cube_views_test.py
+++ b/datajunction-server/tests/api/cube_views_test.py
@@ -8,7 +8,38 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
+from datajunction_server.instrumentation.provider import (
+    MetricsProvider,
+    get_metrics_provider,
+    set_metrics_provider,
+)
 from datajunction_server.utils import get_query_service_client
+
+
+class _SpyProvider(MetricsProvider):
+    """Records counter/timer calls so tests can assert against them."""
+
+    def __init__(self) -> None:
+        self.counters: list[tuple] = []
+        self.timers: list[tuple] = []
+
+    def counter(self, name, value=1, tags=None):
+        self.counters.append((name, value, tags))
+
+    def gauge(self, name, value, tags=None):  # pragma: no cover
+        pass
+
+    def timer(self, name, value_ms, tags=None):
+        self.timers.append((name, value_ms, tags))
+
+
+@pytest.fixture
+def spy_metrics():
+    original = get_metrics_provider()
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+    yield spy
+    set_metrics_provider(original)
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -96,6 +127,68 @@ class TestViewDDLEndpoint:
             "/cubes/default.nonexistent_cube/view-ddl",
         )
         assert response.status_code >= 400
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_materialized_cube(
+        self,
+        module__client_with_roads: AsyncClient,
+    ):
+        """When a cube has an availability state, versioned DDL is SELECT * FROM the materialized table."""
+        cube_name = "default.materialized_view_cube"
+        response = await module__client_with_roads.post(
+            "/nodes/cube/",
+            json={
+                "metrics": ["default.num_repair_orders"],
+                "dimensions": ["default.hard_hat.country"],
+                "description": "Materialized cube for view DDL test",
+                "mode": "published",
+                "name": cube_name,
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        availability = await module__client_with_roads.post(
+            f"/data/{cube_name}/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "roads",
+                "table": "materialized_view_cube_table",
+                "valid_through_ts": 20260101,
+            },
+        )
+        assert availability.status_code == 200, availability.json()
+
+        response = await module__client_with_roads.get(
+            f"/cubes/{cube_name}/view-ddl",
+        )
+        assert response.status_code == 200
+
+        versioned = "default.dj_views.default_materialized_view_cube_v1_0"
+        unversioned = "default.dj_views.default_materialized_view_cube"
+        materialized_table = "default.roads.materialized_view_cube_table"
+        assert response.json() == {
+            "spark": {
+                "versioned_view_name": versioned,
+                "unversioned_view_name": unversioned,
+                "versioned_ddl": (
+                    f"CREATE OR REPLACE VIEW {versioned} "
+                    f"AS SELECT * FROM {materialized_table}"
+                ),
+                "unversioned_ddl": (
+                    f"CREATE OR REPLACE VIEW {unversioned} AS SELECT * FROM {versioned}"
+                ),
+            },
+            "trino": {
+                "versioned_view_name": f"{versioned}__trino",
+                "unversioned_view_name": f"{unversioned}__trino",
+                "versioned_ddl": mock.ANY,
+                "unversioned_ddl": (
+                    f"CREATE OR REPLACE VIEW {unversioned}__trino "
+                    f"AS SELECT * FROM {versioned}__trino"
+                ),
+            },
+            "is_materialized": True,
+        }
 
 
 class TestViewCreationOnLifecycle:
@@ -241,5 +334,52 @@ class TestViewCreationOnLifecycle:
             assert response.status_code == 200, response.json()
 
             assert create_view_calls == []
+        finally:
+            qs_client.create_view = original_create_view
+
+    @pytest.mark.asyncio
+    async def test_view_creation_failure_is_swallowed(
+        self,
+        module__client_with_roads: AsyncClient,
+        spy_metrics,
+    ):
+        """If create_view raises, the cube create still succeeds and the failure metric is emitted."""
+        qs_client = module__client_with_roads.app.dependency_overrides[
+            get_query_service_client
+        ]()
+
+        original_create_view = qs_client.create_view
+
+        def failing_create_view(view_name, query_create, request_headers=None):
+            raise RuntimeError("query service exploded")
+
+        qs_client.create_view = failing_create_view
+
+        try:
+            response = await module__client_with_roads.post(
+                "/nodes/cube/",
+                json={
+                    "metrics": ["default.num_repair_orders"],
+                    "dimensions": ["default.hard_hat.country"],
+                    "description": "Cube whose view creation will fail",
+                    "mode": "published",
+                    "name": "default.failing_view_cube",
+                },
+            )
+            # Cube create succeeds — view creation is fire-and-forget.
+            assert response.status_code == 201, response.json()
+
+            failure_counters = [
+                c
+                for c in spy_metrics.counters
+                if c[0] == "dj.views.create" and c[2].get("status") == "failed"
+            ]
+            assert failure_counters == [
+                (
+                    "dj.views.create",
+                    1,
+                    {"cube_name": "default.failing_view_cube", "status": "failed"},
+                ),
+            ]
         finally:
             qs_client.create_view = original_create_view

--- a/datajunction-server/tests/api/cube_views_test.py
+++ b/datajunction-server/tests/api/cube_views_test.py
@@ -1,0 +1,342 @@
+"""
+Tests for cube view DDL generation and lifecycle hooks.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from datajunction_server.utils import get_query_service_client
+
+
+@pytest_asyncio.fixture(scope="module")
+async def client_with_cube(module__client_with_roads: AsyncClient):
+    """
+    Create a simple cube for view DDL tests.
+    """
+    response = await module__client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": [
+                "default.num_repair_orders",
+                "default.total_repair_cost",
+            ],
+            "dimensions": [
+                "default.hard_hat.country",
+                "default.hard_hat.state",
+            ],
+            "description": "Test cube for view DDL",
+            "mode": "published",
+            "name": "default.view_test_cube",
+        },
+    )
+    assert response.status_code == 201, response.json()
+    return module__client_with_roads
+
+
+class TestViewDDLEndpoint:
+    """Tests for GET /cubes/{name}/view-ddl"""
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_returns_correct_names(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """View DDL endpoint returns correctly formatted view names."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl",
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        # Check view names follow the convention
+        assert "default_view_test_cube" in data["versioned_view_name"]
+        assert "default_view_test_cube" in data["unversioned_view_name"]
+
+        # Versioned should have version suffix, unversioned should not
+        assert "_v1_0" in data["versioned_view_name"]
+        assert "_v1_0" not in data["unversioned_view_name"]
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_contains_create_or_replace(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """View DDL should contain CREATE OR REPLACE VIEW statements."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl",
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["versioned_ddl"].startswith("CREATE OR REPLACE VIEW")
+        assert data["unversioned_ddl"].startswith("CREATE OR REPLACE VIEW")
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_unversioned_points_at_versioned(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """Unversioned view DDL should SELECT * FROM the versioned view."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl",
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert f"SELECT * FROM {data['versioned_view_name']}" in data["unversioned_ddl"]
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_not_materialized(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """Cube without materialization should have is_materialized=False."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_materialized"] is False
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_versioned_contains_measures_sql(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """Versioned DDL should contain measures SQL (SELECT with aggregations)."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl",
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        # The measures SQL should contain aggregation-related SQL
+        versioned_ddl = data["versioned_ddl"].upper()
+        assert "SELECT" in versioned_ddl
+        assert "FROM" in versioned_ddl
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_no_double_v_in_name(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """View names should not contain double 'v' (e.g. _vv1_0)."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "_vv" not in data["versioned_view_name"]
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_nonexistent_cube(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """Should return error for a non-existent cube."""
+        response = await client_with_cube.get(
+            "/cubes/default.nonexistent_cube/view-ddl",
+        )
+        assert response.status_code >= 400
+
+    @pytest.mark.asyncio
+    async def test_view_ddl_with_dialect(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """View DDL should accept a dialect parameter."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl?dialect=trino",
+        )
+        assert response.status_code == 200
+
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl?dialect=spark",
+        )
+        assert response.status_code == 200
+
+
+class TestViewCreationOnLifecycle:
+    """Tests that view creation is triggered on cube lifecycle events."""
+
+    @pytest.mark.asyncio
+    async def test_create_cube_triggers_view_creation(
+        self,
+        module__client_with_roads: AsyncClient,
+    ):
+        """Creating a cube should trigger background view creation."""
+        qs_client = module__client_with_roads.app.dependency_overrides[
+            get_query_service_client
+        ]()
+
+        # Track create_view calls
+        original_create_view = qs_client.create_view
+        create_view_calls = []
+
+        def tracking_create_view(view_name, query_create, request_headers=None):
+            create_view_calls.append(view_name)
+            return original_create_view(view_name, query_create, request_headers)
+
+        qs_client.create_view = tracking_create_view
+
+        try:
+            response = await module__client_with_roads.post(
+                "/nodes/cube/",
+                json={
+                    "metrics": ["default.num_repair_orders"],
+                    "dimensions": ["default.hard_hat.country"],
+                    "description": "Cube to test view lifecycle",
+                    "mode": "published",
+                    "name": "default.lifecycle_test_cube",
+                },
+            )
+            assert response.status_code == 201, response.json()
+
+            # Background task should have called create_view for both views
+            versioned_calls = [
+                c for c in create_view_calls if "lifecycle_test_cube_v" in c
+            ]
+            unversioned_calls = [
+                c
+                for c in create_view_calls
+                if "lifecycle_test_cube" in c
+                and "_v" not in c.split("lifecycle_test_cube")[1]
+            ]
+            assert len(versioned_calls) >= 1, (
+                f"Expected versioned view creation, got calls: {create_view_calls}"
+            )
+            assert len(unversioned_calls) >= 1, (
+                f"Expected unversioned view creation, got calls: {create_view_calls}"
+            )
+        finally:
+            qs_client.create_view = original_create_view
+
+    @pytest.mark.asyncio
+    async def test_validate_cube_triggers_view_creation(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """Revalidating a cube should trigger background view creation."""
+        qs_client = client_with_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+
+        original_create_view = qs_client.create_view
+        create_view_calls = []
+
+        def tracking_create_view(view_name, query_create, request_headers=None):
+            create_view_calls.append(view_name)
+            return original_create_view(view_name, query_create, request_headers)
+
+        qs_client.create_view = tracking_create_view
+
+        try:
+            response = await client_with_cube.post(
+                "/nodes/default.view_test_cube/validate/",
+            )
+            assert response.status_code == 200, response.json()
+
+            # Should have triggered view creation
+            cube_calls = [c for c in create_view_calls if "view_test_cube" in c]
+            assert len(cube_calls) >= 2, (
+                f"Expected at least 2 create_view calls (versioned + unversioned), "
+                f"got: {create_view_calls}"
+            )
+        finally:
+            qs_client.create_view = original_create_view
+
+    @pytest.mark.asyncio
+    async def test_update_cube_triggers_view_creation(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """Updating a cube should trigger background view creation."""
+        qs_client = client_with_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+
+        original_create_view = qs_client.create_view
+        create_view_calls = []
+
+        def tracking_create_view(view_name, query_create, request_headers=None):
+            create_view_calls.append(view_name)
+            return original_create_view(view_name, query_create, request_headers)
+
+        qs_client.create_view = tracking_create_view
+
+        try:
+            # Minor update (description change)
+            response = await client_with_cube.patch(
+                "/nodes/default.view_test_cube",
+                json={
+                    "description": "Updated description for view test",
+                },
+            )
+            assert response.status_code == 200, response.json()
+
+            # Should have triggered view creation
+            cube_calls = [c for c in create_view_calls if "view_test_cube" in c]
+            assert len(cube_calls) >= 2, (
+                f"Expected at least 2 create_view calls (versioned + unversioned), "
+                f"got: {create_view_calls}"
+            )
+        finally:
+            qs_client.create_view = original_create_view
+
+    @pytest.mark.asyncio
+    async def test_update_non_cube_does_not_trigger_view_creation(
+        self,
+        module__client_with_roads: AsyncClient,
+    ):
+        """Updating a non-cube node should NOT trigger view creation."""
+        qs_client = module__client_with_roads.app.dependency_overrides[
+            get_query_service_client
+        ]()
+
+        original_create_view = qs_client.create_view
+        create_view_calls = []
+
+        def tracking_create_view(view_name, query_create, request_headers=None):
+            create_view_calls.append(view_name)
+            return original_create_view(view_name, query_create, request_headers)
+
+        qs_client.create_view = tracking_create_view
+
+        try:
+            # Update a metric node (not a cube)
+            response = await module__client_with_roads.patch(
+                "/nodes/default.num_repair_orders",
+                json={
+                    "description": "Updated metric description",
+                },
+            )
+            assert response.status_code == 200, response.json()
+
+            # Should NOT have triggered any view creation
+            assert len(create_view_calls) == 0, (
+                f"Expected no create_view calls for non-cube update, "
+                f"got: {create_view_calls}"
+            )
+        finally:
+            qs_client.create_view = original_create_view
+
+
+class TestViewSettings:
+    """Tests for view catalog/schema settings."""
+
+    @pytest.mark.asyncio
+    async def test_view_settings_used_in_ddl(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """View DDL should use the configured view_catalog and view_schema."""
+        response = await client_with_cube.get(
+            "/cubes/default.view_test_cube/view-ddl",
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        # Default settings: view_catalog="default", view_schema="dj_views"
+        assert data["versioned_view_name"].startswith("default.dj_views.")
+        assert data["unversioned_view_name"].startswith("default.dj_views.")

--- a/datajunction-server/tests/api/cube_views_test.py
+++ b/datajunction-server/tests/api/cube_views_test.py
@@ -258,16 +258,49 @@ class TestViewCreationOnLifecycle:
 
         try:
             response = await client_with_cube.post(
-                "/nodes/default.view_test_cube/validate/",
+                "/nodes/default.view_test_cube/validate/?sync_views=true",
             )
             assert response.status_code == 200, response.json()
 
             assert sorted(c for c in create_view_calls if "view_test_cube" in c) == [
                 SPARK_UNVERSIONED,
-                TRINO_UNVERSIONED,
                 SPARK_VERSIONED,
+                TRINO_UNVERSIONED,
                 TRINO_VERSIONED,
             ]
+        finally:
+            qs_client.create_view = original_create_view
+
+    @pytest.mark.asyncio
+    async def test_validate_cube_without_sync_views_does_not_create_views(
+        self,
+        client_with_cube: AsyncClient,
+    ):
+        """Revalidating without sync_views=true does NOT create views."""
+        qs_client = client_with_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+
+        original_create_view = qs_client.create_view
+        create_view_calls: list[str] = []
+
+        def tracking_create_view(view_name, query_create, request_headers=None):
+            create_view_calls.append(view_name)
+            return original_create_view(view_name, query_create, request_headers)
+
+        qs_client.create_view = tracking_create_view
+
+        try:
+            response = await client_with_cube.post(
+                "/nodes/default.view_test_cube/validate/",
+            )
+            assert response.status_code == 200, response.json()
+
+            cube_calls = [c for c in create_view_calls if "view_test_cube" in c]
+            assert len(cube_calls) == 0, (
+                f"Expected no create_view calls without sync_views, "
+                f"got: {create_view_calls}"
+            )
         finally:
             qs_client.create_view = original_create_view
 

--- a/datajunction-server/tests/api/cube_views_test.py
+++ b/datajunction-server/tests/api/cube_views_test.py
@@ -264,10 +264,39 @@ class TestViewCreationOnLifecycle:
 
             assert sorted(c for c in create_view_calls if "view_test_cube" in c) == [
                 SPARK_UNVERSIONED,
-                SPARK_VERSIONED,
                 TRINO_UNVERSIONED,
+                SPARK_VERSIONED,
                 TRINO_VERSIONED,
             ]
+        finally:
+            qs_client.create_view = original_create_view
+
+    @pytest.mark.asyncio
+    async def test_validate_non_cube_with_sync_views_does_not_create_views(
+        self,
+        module__client_with_roads: AsyncClient,
+    ):
+        """sync_views=true on a non-cube node still skips view creation."""
+        qs_client = module__client_with_roads.app.dependency_overrides[
+            get_query_service_client
+        ]()
+
+        original_create_view = qs_client.create_view
+        create_view_calls: list[str] = []
+
+        def tracking_create_view(view_name, query_create, request_headers=None):
+            create_view_calls.append(view_name)
+            return original_create_view(view_name, query_create, request_headers)
+
+        qs_client.create_view = tracking_create_view
+
+        try:
+            response = await module__client_with_roads.post(
+                "/nodes/default.num_repair_orders/validate/?sync_views=true",
+            )
+            assert response.status_code == 200, response.json()
+
+            assert create_view_calls == []
         finally:
             qs_client.create_view = original_create_view
 

--- a/datajunction-server/tests/api/cube_views_test.py
+++ b/datajunction-server/tests/api/cube_views_test.py
@@ -204,11 +204,12 @@ class TestViewCreationOnLifecycle:
             )
             assert response.status_code == 200, response.json()
 
+            # PATCH bumps the cube revision (v1.0 → v1.1).
             assert sorted(c for c in create_view_calls if "view_test_cube" in c) == [
                 SPARK_UNVERSIONED,
                 TRINO_UNVERSIONED,
-                SPARK_VERSIONED,
-                TRINO_VERSIONED,
+                "default.dj_views.default_view_test_cube_v1_1",
+                "default.dj_views.default_view_test_cube_v1_1__trino",
             ]
         finally:
             qs_client.create_view = original_create_view

--- a/datajunction-server/tests/api/cube_views_test.py
+++ b/datajunction-server/tests/api/cube_views_test.py
@@ -2,6 +2,8 @@
 Tests for cube view DDL generation and lifecycle hooks.
 """
 
+from unittest import mock
+
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
@@ -34,127 +36,66 @@ async def client_with_cube(module__client_with_roads: AsyncClient):
     return module__client_with_roads
 
 
+SPARK_VERSIONED = "default.dj_views.default_view_test_cube_v1_0"
+SPARK_UNVERSIONED = "default.dj_views.default_view_test_cube"
+TRINO_VERSIONED = "default.dj_views.default_view_test_cube_v1_0__trino"
+TRINO_UNVERSIONED = "default.dj_views.default_view_test_cube__trino"
+
+
 class TestViewDDLEndpoint:
     """Tests for GET /cubes/{name}/view-ddl"""
 
     @pytest.mark.asyncio
-    async def test_view_ddl_returns_correct_names(
+    async def test_view_ddl_response_shape(
         self,
         client_with_cube: AsyncClient,
     ):
-        """View DDL endpoint returns correctly formatted view names."""
+        """The endpoint returns versioned + unversioned views for both dialects."""
         response = await client_with_cube.get(
             "/cubes/default.view_test_cube/view-ddl",
         )
         assert response.status_code == 200
+
+        assert response.json() == {
+            "spark": {
+                "versioned_view_name": SPARK_VERSIONED,
+                "unversioned_view_name": SPARK_UNVERSIONED,
+                "versioned_ddl": mock.ANY,
+                "unversioned_ddl": (
+                    f"CREATE OR REPLACE VIEW {SPARK_UNVERSIONED} "
+                    f"AS SELECT * FROM {SPARK_VERSIONED}"
+                ),
+            },
+            "trino": {
+                "versioned_view_name": TRINO_VERSIONED,
+                "unversioned_view_name": TRINO_UNVERSIONED,
+                "versioned_ddl": mock.ANY,
+                "unversioned_ddl": (
+                    f"CREATE OR REPLACE VIEW {TRINO_UNVERSIONED} "
+                    f"AS SELECT * FROM {TRINO_VERSIONED}"
+                ),
+            },
+            "is_materialized": False,
+        }
+        # versioned_ddl bodies are non-deterministic SQL; pin only the prefix.
         data = response.json()
-
-        # Check view names follow the convention
-        assert "default_view_test_cube" in data["versioned_view_name"]
-        assert "default_view_test_cube" in data["unversioned_view_name"]
-
-        # Versioned should have version suffix, unversioned should not
-        assert "_v1_0" in data["versioned_view_name"]
-        assert "_v1_0" not in data["unversioned_view_name"]
-
-    @pytest.mark.asyncio
-    async def test_view_ddl_contains_create_or_replace(
-        self,
-        client_with_cube: AsyncClient,
-    ):
-        """View DDL should contain CREATE OR REPLACE VIEW statements."""
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl",
+        assert data["spark"]["versioned_ddl"].startswith(
+            f"CREATE OR REPLACE VIEW {SPARK_VERSIONED} AS ",
         )
-        assert response.status_code == 200
-        data = response.json()
-
-        assert data["versioned_ddl"].startswith("CREATE OR REPLACE VIEW")
-        assert data["unversioned_ddl"].startswith("CREATE OR REPLACE VIEW")
-
-    @pytest.mark.asyncio
-    async def test_view_ddl_unversioned_points_at_versioned(
-        self,
-        client_with_cube: AsyncClient,
-    ):
-        """Unversioned view DDL should SELECT * FROM the versioned view."""
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl",
+        assert data["trino"]["versioned_ddl"].startswith(
+            f"CREATE OR REPLACE VIEW {TRINO_VERSIONED} AS ",
         )
-        assert response.status_code == 200
-        data = response.json()
-
-        assert f"SELECT * FROM {data['versioned_view_name']}" in data["unversioned_ddl"]
-
-    @pytest.mark.asyncio
-    async def test_view_ddl_not_materialized(
-        self,
-        client_with_cube: AsyncClient,
-    ):
-        """Cube without materialization should have is_materialized=False."""
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl",
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["is_materialized"] is False
-
-    @pytest.mark.asyncio
-    async def test_view_ddl_versioned_contains_measures_sql(
-        self,
-        client_with_cube: AsyncClient,
-    ):
-        """Versioned DDL should contain measures SQL (SELECT with aggregations)."""
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl",
-        )
-        assert response.status_code == 200
-        data = response.json()
-
-        # The measures SQL should contain aggregation-related SQL
-        versioned_ddl = data["versioned_ddl"].upper()
-        assert "SELECT" in versioned_ddl
-        assert "FROM" in versioned_ddl
-
-    @pytest.mark.asyncio
-    async def test_view_ddl_no_double_v_in_name(
-        self,
-        client_with_cube: AsyncClient,
-    ):
-        """View names should not contain double 'v' (e.g. _vv1_0)."""
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl",
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert "_vv" not in data["versioned_view_name"]
 
     @pytest.mark.asyncio
     async def test_view_ddl_nonexistent_cube(
         self,
         client_with_cube: AsyncClient,
     ):
-        """Should return error for a non-existent cube."""
+        """Non-existent cubes return a client error."""
         response = await client_with_cube.get(
             "/cubes/default.nonexistent_cube/view-ddl",
         )
         assert response.status_code >= 400
-
-    @pytest.mark.asyncio
-    async def test_view_ddl_with_dialect(
-        self,
-        client_with_cube: AsyncClient,
-    ):
-        """View DDL should accept a dialect parameter."""
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl?dialect=trino",
-        )
-        assert response.status_code == 200
-
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl?dialect=spark",
-        )
-        assert response.status_code == 200
 
 
 class TestViewCreationOnLifecycle:
@@ -165,14 +106,13 @@ class TestViewCreationOnLifecycle:
         self,
         module__client_with_roads: AsyncClient,
     ):
-        """Creating a cube should trigger background view creation."""
+        """Creating a cube submits all 4 views (spark+trino, versioned+unversioned)."""
         qs_client = module__client_with_roads.app.dependency_overrides[
             get_query_service_client
         ]()
 
-        # Track create_view calls
         original_create_view = qs_client.create_view
-        create_view_calls = []
+        create_view_calls: list[str] = []
 
         def tracking_create_view(view_name, query_create, request_headers=None):
             create_view_calls.append(view_name)
@@ -193,22 +133,14 @@ class TestViewCreationOnLifecycle:
             )
             assert response.status_code == 201, response.json()
 
-            # Background task should have called create_view for both views
-            versioned_calls = [
-                c for c in create_view_calls if "lifecycle_test_cube_v" in c
+            assert sorted(
+                c for c in create_view_calls if "lifecycle_test_cube" in c
+            ) == [
+                "default.dj_views.default_lifecycle_test_cube",
+                "default.dj_views.default_lifecycle_test_cube__trino",
+                "default.dj_views.default_lifecycle_test_cube_v1_0",
+                "default.dj_views.default_lifecycle_test_cube_v1_0__trino",
             ]
-            unversioned_calls = [
-                c
-                for c in create_view_calls
-                if "lifecycle_test_cube" in c
-                and "_v" not in c.split("lifecycle_test_cube")[1]
-            ]
-            assert len(versioned_calls) >= 1, (
-                f"Expected versioned view creation, got calls: {create_view_calls}"
-            )
-            assert len(unversioned_calls) >= 1, (
-                f"Expected unversioned view creation, got calls: {create_view_calls}"
-            )
         finally:
             qs_client.create_view = original_create_view
 
@@ -217,13 +149,13 @@ class TestViewCreationOnLifecycle:
         self,
         client_with_cube: AsyncClient,
     ):
-        """Revalidating a cube should trigger background view creation."""
+        """Revalidating a cube re-submits all 4 views."""
         qs_client = client_with_cube.app.dependency_overrides[
             get_query_service_client
         ]()
 
         original_create_view = qs_client.create_view
-        create_view_calls = []
+        create_view_calls: list[str] = []
 
         def tracking_create_view(view_name, query_create, request_headers=None):
             create_view_calls.append(view_name)
@@ -237,12 +169,12 @@ class TestViewCreationOnLifecycle:
             )
             assert response.status_code == 200, response.json()
 
-            # Should have triggered view creation
-            cube_calls = [c for c in create_view_calls if "view_test_cube" in c]
-            assert len(cube_calls) >= 2, (
-                f"Expected at least 2 create_view calls (versioned + unversioned), "
-                f"got: {create_view_calls}"
-            )
+            assert sorted(c for c in create_view_calls if "view_test_cube" in c) == [
+                SPARK_UNVERSIONED,
+                TRINO_UNVERSIONED,
+                SPARK_VERSIONED,
+                TRINO_VERSIONED,
+            ]
         finally:
             qs_client.create_view = original_create_view
 
@@ -251,13 +183,13 @@ class TestViewCreationOnLifecycle:
         self,
         client_with_cube: AsyncClient,
     ):
-        """Updating a cube should trigger background view creation."""
+        """Updating a cube re-submits all 4 views."""
         qs_client = client_with_cube.app.dependency_overrides[
             get_query_service_client
         ]()
 
         original_create_view = qs_client.create_view
-        create_view_calls = []
+        create_view_calls: list[str] = []
 
         def tracking_create_view(view_name, query_create, request_headers=None):
             create_view_calls.append(view_name)
@@ -266,21 +198,18 @@ class TestViewCreationOnLifecycle:
         qs_client.create_view = tracking_create_view
 
         try:
-            # Minor update (description change)
             response = await client_with_cube.patch(
                 "/nodes/default.view_test_cube",
-                json={
-                    "description": "Updated description for view test",
-                },
+                json={"description": "Updated description for view test"},
             )
             assert response.status_code == 200, response.json()
 
-            # Should have triggered view creation
-            cube_calls = [c for c in create_view_calls if "view_test_cube" in c]
-            assert len(cube_calls) >= 2, (
-                f"Expected at least 2 create_view calls (versioned + unversioned), "
-                f"got: {create_view_calls}"
-            )
+            assert sorted(c for c in create_view_calls if "view_test_cube" in c) == [
+                SPARK_UNVERSIONED,
+                TRINO_UNVERSIONED,
+                SPARK_VERSIONED,
+                TRINO_VERSIONED,
+            ]
         finally:
             qs_client.create_view = original_create_view
 
@@ -289,13 +218,13 @@ class TestViewCreationOnLifecycle:
         self,
         module__client_with_roads: AsyncClient,
     ):
-        """Updating a non-cube node should NOT trigger view creation."""
+        """Updating a non-cube node does not trigger view creation."""
         qs_client = module__client_with_roads.app.dependency_overrides[
             get_query_service_client
         ]()
 
         original_create_view = qs_client.create_view
-        create_view_calls = []
+        create_view_calls: list[str] = []
 
         def tracking_create_view(view_name, query_create, request_headers=None):
             create_view_calls.append(view_name)
@@ -304,39 +233,12 @@ class TestViewCreationOnLifecycle:
         qs_client.create_view = tracking_create_view
 
         try:
-            # Update a metric node (not a cube)
             response = await module__client_with_roads.patch(
                 "/nodes/default.num_repair_orders",
-                json={
-                    "description": "Updated metric description",
-                },
+                json={"description": "Updated metric description"},
             )
             assert response.status_code == 200, response.json()
 
-            # Should NOT have triggered any view creation
-            assert len(create_view_calls) == 0, (
-                f"Expected no create_view calls for non-cube update, "
-                f"got: {create_view_calls}"
-            )
+            assert create_view_calls == []
         finally:
             qs_client.create_view = original_create_view
-
-
-class TestViewSettings:
-    """Tests for view catalog/schema settings."""
-
-    @pytest.mark.asyncio
-    async def test_view_settings_used_in_ddl(
-        self,
-        client_with_cube: AsyncClient,
-    ):
-        """View DDL should use the configured view_catalog and view_schema."""
-        response = await client_with_cube.get(
-            "/cubes/default.view_test_cube/view-ddl",
-        )
-        assert response.status_code == 200
-        data = response.json()
-
-        # Default settings: view_catalog="default", view_schema="dj_views"
-        assert data["versioned_view_name"].startswith("default.dj_views.")
-        assert data["unversioned_view_name"].startswith("default.dj_views.")

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -327,6 +327,8 @@ def duckdb_conn() -> duckdb.DuckDBPyConnection:
             conn.execute("""ATTACH ':memory:' AS "default" """)
             conn.execute("""USE "default" """)
             conn.execute(mock_data.read())
+            # Schema target for cube view DDL submitted via mock_create_view.
+            conn.execute('CREATE SCHEMA IF NOT EXISTS "default".dj_views')
             yield conn
 
 

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -160,26 +160,14 @@ class TestQueryServiceClient:
 
     def test_query_service_client_create_view(self, mocker: MockerFixture) -> None:
         """
-        Test creating a view using the query service client.
+        Successful DDL submission goes to /ddl/execute and returns when status=SUCCESS.
         """
 
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "catalog_name": "public",
-            "engine_name": "postgres",
-            "engine_version": "15.2",
-            "id": "ef209eef-c31a-4089-aae6-833259a08e22",
-            "submitted_query": "CREATE OR REPLACE VIEW foo SELECT 1 as num",
-            "executed_query": "CREATE OR REPLACE VIEW foo SELECT 1 as num",
-            "scheduled": "2023-01-01T00:00:00.000000",
-            "started": "2023-01-01T00:00:00.000000",
-            "finished": "2023-01-01T00:00:00.000001",
-            "state": "FINISHED",
-            "progress": 1,
-            "results": [],
-            "next": None,
-            "previous": None,
+            "status": "SUCCESS",
+            "message": "View foo created",
             "errors": [],
         }
 
@@ -188,7 +176,6 @@ class TestQueryServiceClient:
             return_value=mock_response,
         )
 
-        # successful request
         query_service_client = QueryServiceClient(uri=self.endpoint)
         query_create = QueryCreate(
             catalog_name="default",
@@ -203,24 +190,21 @@ class TestQueryServiceClient:
         )
 
         mock_request.assert_called_with(
-            "/queries/",
+            "/ddl/execute",
             headers=ANY,
             json={
+                "submitted_query": "CREATE OR REPLACE VIEW foo SELECT 1 as num",
                 "catalog_name": "default",
                 "engine_name": "postgres",
                 "engine_version": "15.2",
-                "submitted_query": "CREATE OR REPLACE VIEW foo SELECT 1 as num",
-                "async_": False,
             },
         )
 
-    def test_query_service_client_create_view_with_failure(
+    def test_query_service_client_create_view_http_error(
         self,
         mocker: MockerFixture,
     ) -> None:
-        """
-        Test creating a view using the query service client with a filed response.
-        """
+        """A non-200 HTTP response raises DJQueryServiceClientException."""
 
         mock_response = MagicMock()
         mock_response.status_code = 500
@@ -230,7 +214,6 @@ class TestQueryServiceClient:
             return_value=mock_response,
         )
 
-        # successful request
         query_service_client = QueryServiceClient(uri=self.endpoint)
         query_create = QueryCreate(
             catalog_name="default",
@@ -250,15 +233,51 @@ class TestQueryServiceClient:
         )
 
         mock_request.assert_called_with(
-            "/queries/",
+            "/ddl/execute",
             headers=ANY,
             json={
+                "submitted_query": "CREATE OR REPLACE VIEW foo SELECT 1 as num",
                 "catalog_name": "default",
                 "engine_name": "postgres",
                 "engine_version": "15.2",
-                "submitted_query": "CREATE OR REPLACE VIEW foo SELECT 1 as num",
-                "async_": False,
             },
+        )
+
+    def test_query_service_client_create_view_ddl_failure_status(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """A 200 response with status!=SUCCESS raises with the upstream error list."""
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "FAILED",
+            "message": "Schema does not exist",
+            "errors": ["dj_views.foo not found", "permission denied"],
+        }
+        mocker.patch(
+            "datajunction_server.service_clients.RequestsSessionWithEndpoint.post",
+            return_value=mock_response,
+        )
+
+        query_service_client = QueryServiceClient(uri=self.endpoint)
+        query_create = QueryCreate(
+            catalog_name="default",
+            engine_name="postgres",
+            engine_version="15.2",
+            submitted_query="CREATE OR REPLACE VIEW foo SELECT 1 as num",
+            async_=False,
+        )
+
+        with pytest.raises(DJQueryServiceClientException) as exc_info:
+            query_service_client.create_view(
+                view_name="foo",
+                query_create=query_create,
+            )
+        assert (
+            "View 'foo' creation failed: dj_views.foo not found; permission denied"
+            in str(exc_info.value)
         )
 
     def test_query_service_client_submit_query(self, mocker: MockerFixture) -> None:


### PR DESCRIPTION
### Summary

With this change, every DJ cube automatically gets 4 views (Spark + Trino, versioned + unversioned), which are created as background tasks when a cube is created or updated. Also includes a new `GET /cubes/{name}/view-ddl` endpoint that returns the DDL for all 4 views.

The views are submitted to the query service via the existing `query_service_client.create_view()`, which makes a `POST /ddl/execute` call.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
