### PR TITLE
Support `FULL` cube and pre-agg materialization end-to-end

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -454,7 +454,7 @@ async def materialize_cube(
     try:
         (
             combined_result,
-            preagg_table_refs,
+            preagg_sources,
             temporal_partition_info,
         ) = await build_combiner_sql_from_preaggs(
             session=session,
@@ -483,21 +483,19 @@ async def materialize_cube(
             http_status_code=HTTPStatus.BAD_REQUEST,
         )
 
-    # Build pre-agg table info
-    preagg_tables = []
-    for i, table_ref in enumerate(preagg_table_refs):
-        # Extract parent node from the grain groups used in combiner
-        parent_name = combined_result.columns[0].semantic_name or "unknown"
-        # Get grain from the combiner result
-        grain = combined_result.shared_dimensions
-
-        preagg_tables.append(
-            PreAggTableInfo(
-                table_ref=table_ref,
-                parent_node=parent_name,
-                grain=grain,
-            ),
+    # Build pre-agg table info. Strategy is threaded through so the QS workflow
+    # generator can pick the right wait dependency per pre-agg (VTTS for FULL,
+    # partition-keyed signal for INCREMENTAL_TIME).
+    grain = combined_result.shared_dimensions
+    preagg_tables = [
+        PreAggTableInfo(
+            table_ref=src.table_ref,
+            parent_node=src.parent_name,
+            grain=grain,
+            strategy=src.strategy,
         )
+        for src in preagg_sources
+    ]
 
     # Generate Druid datasource name (versioned to prevent overwrites)
     safe_name = name.replace(".", "_")
@@ -614,32 +612,23 @@ async def materialize_cube(
         lookback_window=effective_lookback,
     )
 
-    # Call the query service to create the workflow
+    # Call the query service to create the workflow.
+    # Let DJQueryServiceClientException (raised by the service client) propagate
+    # so the user sees the actual QS error response in the API response body —
+    # silently swallowing it leaves the materialization in a half-configured
+    # state with no visibility into what failed.
     request_headers = dict(request.headers)
-    try:
-        mat_result = query_service_client.materialize_cube_v2(
-            v2_input,
-            request_headers=request_headers,
-        )
-        workflow_urls = mat_result.urls
-        workflow_names = mat_result.workflow_names
-        message = (
-            f"Cube materialization workflow created. "
-            f"Workflow waits on {len(preagg_tables)} pre-agg table(s) before Druid ingestion. "
-            f"Workflow URLs: {workflow_urls}"
-        )
-    except Exception as e:
-        _logger.warning(
-            "Failed to create workflow for cube=%s: %s. Returning response without workflow.",
-            name,
-            str(e),
-        )
-        workflow_urls = []
-        workflow_names = []
-        message = (
-            f"Cube materialization prepared (workflow creation failed: {e}). "
-            f"Druid workflow should wait on {len(preagg_tables)} pre-agg table(s) before ingestion."
-        )
+    mat_result = query_service_client.materialize_cube_v2(
+        v2_input,
+        request_headers=request_headers,
+    )
+    workflow_urls = mat_result.urls
+    workflow_names = mat_result.workflow_names
+    message = (
+        f"Cube materialization workflow created. "
+        f"Workflow waits on {len(preagg_tables)} pre-agg table(s) before Druid ingestion. "
+        f"Workflow URLs: {workflow_urls}"
+    )
 
     # Persist materialization record on the cube's node revision
     materialization_name = "druid_cube_v3"

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -456,7 +456,7 @@ async def get_combined_measures_sql_v3(
         # Generate SQL that reads from pre-agg tables (deterministic names)
         (
             combined_result,
-            source_tables,
+            preagg_sources,
             _,
         ) = await build_combiner_sql_from_preaggs(  # pragma: no cover
             session=session,
@@ -465,6 +465,7 @@ async def get_combined_measures_sql_v3(
             filters=filters,
             dialect=dialect,
         )
+        source_tables = [src.table_ref for src in preagg_sources]  # pragma: no cover
     else:
         # Build the measures SQL to get grain groups (compute from scratch)
         result = await build_measures_sql(

--- a/datajunction-server/datajunction_server/construction/build_v3/combiners.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/combiners.py
@@ -42,6 +42,7 @@ from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import render_for_dialect, to_sql
 from datajunction_server.construction.build_v3.builder import build_measures_sql
 from datajunction_server.models.dialect import Dialect
+from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.utils import get_settings
 
 if TYPE_CHECKING:
@@ -499,13 +500,33 @@ class TemporalPartitionInfo:
     granularity: str | None  # Granularity (e.g., "day")
 
 
+@dataclass
+class PreAggSourceInfo:
+    """A pre-agg source feeding into the combined cube SQL.
+
+    Carries everything the cube workflow generator needs to wire a dependency
+    on this pre-agg — including its strategy, since FULL vs INCREMENTAL_TIME
+    determines whether to wait via VTTS or via partition-keyed signal.
+    """
+
+    table_ref: str  # Fully qualified table name (catalog.schema.table)
+    parent_name: str  # The node this pre-agg derives from
+    strategy: "MaterializationStrategy | None" = (
+        None  # None when no PreAggregation record matched
+    )
+
+
 async def build_combiner_sql_from_preaggs(
     session,
     metrics: list[str],
     dimensions: list[str],
     filters: list[str] | None = None,
     dialect=None,
-) -> tuple[CombinedGrainGroupResult, list[str], TemporalPartitionInfo | None]:
+) -> tuple[
+    CombinedGrainGroupResult,
+    list[PreAggSourceInfo],
+    TemporalPartitionInfo | None,
+]:
     """
     Build combined SQL that reads from pre-aggregation tables.
 
@@ -545,7 +566,7 @@ async def build_combiner_sql_from_preaggs(
         raise ValueError("No grain groups generated")
 
     ctx = result.ctx
-    preagg_table_refs = []
+    preagg_sources: list[PreAggSourceInfo] = []
     preagg_grain_groups = []
     temporal_partitions_found: list[TemporalPartitionInfo] = []
 
@@ -618,7 +639,13 @@ async def build_combiner_sql_from_preaggs(
             full_table_ref = (
                 f"{settings.preagg_catalog}.{settings.preagg_schema}.{table_name}"
             )
-        preagg_table_refs.append(full_table_ref)
+        preagg_sources.append(
+            PreAggSourceInfo(
+                table_ref=full_table_ref,
+                parent_name=gg.parent_name,
+                strategy=matching_preagg.strategy if matching_preagg else None,
+            ),
+        )
 
         # Create a modified grain group that reads from the pre-agg table
         # We need to build a simple SELECT from the pre-agg table with re-aggregation
@@ -679,7 +706,7 @@ async def build_combiner_sql_from_preaggs(
             temporal_partition_info.column_name,
         )
 
-    return combined_result, preagg_table_refs, temporal_partition_info
+    return combined_result, preagg_sources, temporal_partition_info
 
 
 def _reorder_partition_column_last(

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -445,9 +445,9 @@ class CubeMaterializeRequest(BaseModel):
         default=MaterializationStrategy.INCREMENTAL_TIME,
         description="Materialization strategy (FULL or INCREMENTAL_TIME)",
     )
-    lookback_window: str = Field(
+    lookback_window: Optional[str] = Field(
         default="1 DAY",
-        description="Lookback window for incremental materialization",
+        description="Lookback window for incremental materialization. Accepts null for FULL strategy.",
     )
     druid_datasource: Optional[str] = Field(
         default=None,
@@ -470,6 +470,14 @@ class PreAggTableInfo(BaseModel):
     )
     grain: List[str] = Field(
         description="Grain columns for this pre-agg",
+    )
+    strategy: Optional[MaterializationStrategy] = Field(
+        default=None,
+        description=(
+            "Materialization strategy of the pre-agg. Used by the cube "
+            "workflow generator to pick the right wait dependency: "
+            "partition-keyed signal for INCREMENTAL_TIME, VTTS-based for FULL."
+        ),
     )
 
 

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -348,14 +348,21 @@ class QueryServiceClient:
             timeout=30,
         )
         if response.status_code not in (200, 201):
-            _logger.exception(
+            _logger.error(
                 "[DJQS] Failed to schedule v2 cube materialization for"
-                " cube=%s with `POST /cubes/materialize/v2`: %s",
+                " cube=%s: status=%s body=%s",
                 materialization_input.cube_name,
+                response.status_code,
                 response.text,
-                exc_info=True,
             )
-            raise Exception(f"Query service error: {response.text}")
+            raise DJQueryServiceClientException(
+                message=(
+                    f"Query service rejected cube materialization for "
+                    f"'{materialization_input.cube_name}' "
+                    f"(status={response.status_code}): {response.text}"
+                ),
+                http_status_code=HTTPStatus.BAD_GATEWAY,
+            )
         result = response.json()
         _logger.info(
             "[DJQS] Scheduled v2 cube materialization for cube=%s with "
@@ -389,13 +396,20 @@ class QueryServiceClient:
             timeout=30,
         )
         if response.status_code not in (200, 201):
-            _logger.exception(
-                "[DJQS] Failed to create workflow for preagg_id=%s: %s",
+            _logger.error(
+                "[DJQS] Failed to create workflow for preagg_id=%s: status=%s body=%s",
                 materialization_input.preagg_id,
+                response.status_code,
                 response.text,
-                exc_info=True,
             )
-            raise Exception(f"Query service error: {response.text}")
+            raise DJQueryServiceClientException(
+                message=(
+                    f"Query service rejected pre-agg materialization for "
+                    f"preagg_id={materialization_input.preagg_id} "
+                    f"(status={response.status_code}): {response.text}"
+                ),
+                http_status_code=HTTPStatus.BAD_GATEWAY,
+            )
         result = response.json()
         _logger.info(
             "[DJQS] Created workflow for preagg_id=%s, output_table=%s, "

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -10,6 +10,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 
 from datajunction_server.construction.build_v3.combiners import (
+    PreAggSourceInfo,
     TemporalPartitionInfo,
 )
 from datajunction_server.models.cube import CubeElementMetadata
@@ -4114,7 +4115,13 @@ class TestCubeMaterializeV2SuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4189,7 +4196,13 @@ class TestCubeMaterializeV2SuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4252,7 +4265,13 @@ class TestCubeMaterializeV2SuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 None,  # No temporal partition!
             ),
         )
@@ -4305,7 +4324,13 @@ class TestCubeMaterializeV2SuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4371,7 +4396,13 @@ class TestCubeMaterializeV2SuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4662,7 +4693,13 @@ class TestCubeDeactivateSuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4737,7 +4774,13 @@ class TestCubeDeactivateSuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4822,7 +4865,13 @@ class TestCubeDeactivateWithStoredWorkflowNames:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4908,7 +4957,13 @@ class TestCubeBackfillSuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -4992,7 +5047,13 @@ class TestCubeBackfillSuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )
@@ -5063,7 +5124,13 @@ class TestCubeBackfillSuccessPaths:
             "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
             return_value=(
                 mock_combined_result,
-                ["catalog.schema.preagg_table1"],
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
                 mock_temporal_info,
             ),
         )

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -9,6 +9,7 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
+from datajunction_server.errors import DJQueryServiceClientException
 from datajunction_server.construction.build_v3.combiners import (
     PreAggSourceInfo,
     TemporalPartitionInfo,
@@ -4285,12 +4286,17 @@ class TestCubeMaterializeV2SuccessPaths:
         assert "temporal partition" in response.json()["message"].lower()
 
     @pytest.mark.asyncio
-    async def test_materialize_cube_query_service_failure_continues(
+    async def test_materialize_cube_query_service_failure_propagates(
         self,
         client_with_repairs_cube: AsyncClient,
         mocker,
     ):
-        """Test that query service failure returns response with empty workflow_urls."""
+        """Query service failures surface to the caller instead of being swallowed.
+
+        The endpoint deliberately stopped catching QS exceptions so the user sees
+        the actual upstream error rather than a half-configured materialization
+        with no workflow.
+        """
         cube_name = "default.test_materialize_qs_fail_cube"
         await make_a_test_cube(
             client_with_repairs_cube,
@@ -4335,14 +4341,16 @@ class TestCubeMaterializeV2SuccessPaths:
             ),
         )
 
-        # Mock query service to fail
         qs_client = client_with_repairs_cube.app.dependency_overrides[
             get_query_service_client
         ]()
         mocker.patch.object(
             qs_client,
             "materialize_cube_v2",
-            side_effect=Exception("Query service unavailable"),
+            side_effect=DJQueryServiceClientException(
+                message="Query service unavailable",
+                http_status_code=502,
+            ),
         )
 
         response = await client_with_repairs_cube.post(
@@ -4350,11 +4358,8 @@ class TestCubeMaterializeV2SuccessPaths:
             json={"strategy": "full", "schedule": "0 0 * * *"},
         )
 
-        # Should succeed but with empty workflow_urls
-        assert response.status_code == 200, response.json()
-        data = response.json()
-        assert data["workflow_urls"] == []
-        assert "workflow creation failed" in data["message"].lower()
+        assert response.status_code == 502, response.json()
+        assert "Query service unavailable" in response.json()["message"]
 
     @pytest.mark.asyncio
     async def test_materialize_cube_updates_existing_materialization(

--- a/datajunction-server/tests/construction/build_v3/combiners_test.py
+++ b/datajunction-server/tests/construction/build_v3/combiners_test.py
@@ -1075,7 +1075,7 @@ class TestBuildCombinerSqlFromPreaggs:
         Test basic pre-agg SQL generation flow.
         """
         # This should work with existing v3 metrics
-        result, table_refs, temporal_info = await build_combiner_sql_from_preaggs(
+        result, preagg_sources, temporal_info = await build_combiner_sql_from_preaggs(
             session=session,
             metrics=["v3.total_revenue"],
             dimensions=["v3.order_details.status"],
@@ -1085,10 +1085,10 @@ class TestBuildCombinerSqlFromPreaggs:
         assert result is not None
         assert result.grain_groups_combined >= 1
 
-        # Should have pre-agg table references
-        assert len(table_refs) >= 1
-        for ref in table_refs:
-            assert "_preagg_" in ref
+        # Should have pre-agg sources
+        assert len(preagg_sources) >= 1
+        for src in preagg_sources:
+            assert "_preagg_" in src.table_ref
 
         # SQL should reference the pre-agg tables
         assert result.sql is not None
@@ -1176,7 +1176,7 @@ class TestBuildCombinerSqlFromPreaggs:
         await session.flush()
 
         # Now call build_combiner_sql_from_preaggs
-        result, table_refs, temporal_info = await build_combiner_sql_from_preaggs(
+        result, preagg_sources, temporal_info = await build_combiner_sql_from_preaggs(
             session=session,
             metrics=["v3.total_revenue"],
             dimensions=["v3.order_details.status"],
@@ -1186,8 +1186,8 @@ class TestBuildCombinerSqlFromPreaggs:
         assert result is not None
         assert result.grain_groups_combined >= 1
 
-        # Should have pre-agg table references
-        assert len(table_refs) >= 1
+        # Should have pre-agg sources
+        assert len(preagg_sources) >= 1
 
         # If temporal partition was set up, temporal_info should be populated
         # (depends on whether order_date is in grain_columns or linked dimension)
@@ -1300,7 +1300,7 @@ class TestBuildCombinerSqlFromPreaggs:
         # Now call build_combiner_sql_from_preaggs
         # The metric v3.total_revenue uses line_total, so the first pre-agg
         # (with quantity) should be skipped, and the second one should be used
-        result, table_refs, temporal_info = await build_combiner_sql_from_preaggs(
+        result, preagg_sources, temporal_info = await build_combiner_sql_from_preaggs(
             session=session,
             metrics=["v3.total_revenue"],
             dimensions=["v3.order_details.status"],
@@ -1310,13 +1310,14 @@ class TestBuildCombinerSqlFromPreaggs:
         assert result is not None
         assert result.grain_groups_combined >= 1
 
-        # Should have pre-agg table references
-        assert len(table_refs) >= 1
+        # Should have pre-agg sources
+        assert len(preagg_sources) >= 1
 
         # The table reference should use the CORRECT pre-agg's availability table,
         # not the wrong one. This verifies the loop skipped the first pre-agg and
         # found the second. Since matching preaggs with availability use the
         # materialized_table_ref (catalog.schema.table), we check for those.
+        table_refs = [src.table_ref for src in preagg_sources]
         table_refs_str = " ".join(table_refs)
         assert "order_details_preagg_correct" in table_refs_str, (
             f"Expected correct preagg table in table refs, but got {table_refs}"

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -852,9 +852,10 @@ class TestQueryServiceClient:
         mock_input.model_dump.return_value = {"preagg_id": 123}
 
         query_service_client = QueryServiceClient(uri=self.endpoint)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(DJQueryServiceClientException) as exc_info:
             query_service_client.materialize_preagg(mock_input)
-        assert "Query service error" in str(exc_info.value)
+        assert "Query service rejected pre-agg materialization" in str(exc_info.value)
+        assert "Internal server error" in str(exc_info.value)
 
     def test_deactivate_preagg_workflow(self, mocker: MockerFixture) -> None:
         """
@@ -1103,9 +1104,10 @@ class TestQueryServiceClient:
         )
 
         query_service_client = QueryServiceClient(uri=self.endpoint)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(DJQueryServiceClientException) as exc_info:
             query_service_client.materialize_cube_v2(input_data)
-        assert "Query service error" in str(exc_info.value)
+        assert "Query service rejected cube materialization" in str(exc_info.value)
+        assert "Internal Server Error" in str(exc_info.value)
 
     def test_deactivate_cube_workflow_success(self, mocker: MockerFixture) -> None:
         """

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
@@ -286,6 +286,14 @@ export function QueryPlannerPage() {
         setDimensionsLoading(true);
         try {
           const dims = await djClient.commonDimensions(selectedMetrics);
+          // Server returns an error body (e.g. {message: "..."}) on 404/422 with
+          // a non-OK status, but commonDimensions() doesn't surface that — guard
+          // against passing a non-array into setCommonDimensions.
+          if (!Array.isArray(dims)) {
+            console.error('commonDimensions returned non-array:', dims);
+            setCommonDimensions([]);
+            return;
+          }
           setCommonDimensions(dims);
 
           // Apply pending dimensions from URL if we have them


### PR DESCRIPTION
### Summary

Picking the `FULL` strategy in the materialization flow now actually works for cubes across both the pre-agg and cube combiner stages. Plan-time validation also rejects nonsensical configurations early so users can't end up with an unwritable materialization.

The specific changes / bugfixes include:
- Make arguments like `lookback_window`, `timestamp_column`, `timestamp_format` optional, so that the query-service request is well-formed when there's no temporal partition.
- For `FULL`, the cube endpoint now drops `timestampSpec` from the Druid `parseSpec` and sets `segmentGranularity: "ALL"`. It zeroes out `lookback_window` regardless of what the request supplied.
- Each upstream pre-agg's strategy is threaded through `PreAggTableInfo` to the query service so the cube workflow generator can pick the right dependency per upstream.
- Query service errors now propagate back, so that when calls like `service_clients.materialize_cube_v2` and `materialize_preagg` raise, the query service response body is included and the user sees the real reason in the response.
- Plan-time validation in `POST /preaggs/plan` and `PATCH /preaggs/{id}/config`: when the strategy is incremental, the requested dimensions must resolve to the upstream's temporal partition column (directly or via a dimension link). This prevents creating a preagg whose output table can't be partitioned and so could never be loaded incrementally. Same check applied in `materialize_preaggregation` as defense.
- `get_temporal_partitions` no longer falls through to a phantom partition entry when no grain column resolves to it. Previously this could emit `PARTITIONED BY (col)` for an output table that didn't contain `col`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
