### PR TITLE
Bugfixes: AST renderer, datetime parsing, instrumentation middleware

### DIFF
--- a/datajunction-server/datajunction_server/instrumentation/middleware.py
+++ b/datajunction-server/datajunction_server/instrumentation/middleware.py
@@ -5,14 +5,18 @@ Emits on every HTTP request:
   - dj.db.pool.size / checked_out / available / overflow  (gauges)
   - dj.request.in_flight  (gauge — concurrent requests in progress)
   - dj.request  (timer in ms, tagged with route + method + status_code)
+
+Implemented as a *pure ASGI* middleware (not a Starlette ``BaseHTTPMiddleware``
+subclass). ``BaseHTTPMiddleware`` runs ``call_next`` on a separate asyncio
+task, which on Python 3.12+ no longer copies the greenlet context that
+SQLAlchemy's async drivers need. Lazy-loaded ORM relationships then explode
+with ``MissingGreenlet`` while the response is being assembled. A pure ASGI
+middleware runs in the same task as the app, so the greenlet binding flows
+through cleanly.
 """
 
 import logging
 import time
-
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
 
 from datajunction_server.instrumentation.provider import get_metrics_provider
 
@@ -21,10 +25,17 @@ _in_flight: int = 0
 logger = logging.getLogger(__name__)
 
 
-class DJInstrumentationMiddleware(BaseHTTPMiddleware):
+class DJInstrumentationMiddleware:
     """Emit DB pool gauges and per-request timing on every HTTP request."""
 
-    async def dispatch(self, request: Request, call_next) -> Response:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
         global _in_flight
         provider = get_metrics_provider()
         _emit_pool_gauges(provider)
@@ -32,24 +43,32 @@ class DJInstrumentationMiddleware(BaseHTTPMiddleware):
         _in_flight += 1
         provider.gauge("dj.request.in_flight", _in_flight)
 
-        start = time.monotonic()
         status_code = 500
+
+        async def send_wrapper(message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        start = time.monotonic()
         try:
-            response = await call_next(request)
-            status_code = response.status_code
-            return response
+            await self.app(scope, receive, send_wrapper)
         finally:
             _in_flight -= 1
             provider.gauge("dj.request.in_flight", _in_flight)
             elapsed_ms = (time.monotonic() - start) * 1000
-            route = request.scope.get("route")
-            route_path = route.path if route else request.url.path
+            # ``scope["route"]`` is populated by Starlette's router when a
+            # route matches; for unmatched paths (e.g. 404) we fall back to
+            # the raw URL path from the scope.
+            route = scope.get("route")
+            route_path = route.path if route else scope.get("path", "")
             provider.timer(
                 "dj.request",
                 elapsed_ms,
                 {
                     "route": route_path,
-                    "method": request.method,
+                    "method": scope.get("method", ""),
                     "status_code": str(status_code),
                 },
             )

--- a/datajunction-server/datajunction_server/models/query.py
+++ b/datajunction-server/datajunction_server/models/query.py
@@ -10,7 +10,6 @@ from pydantic import (
     AliasChoices,
     AnyHttpUrl,
     Field,
-    field_validator,
     field_serializer,
     RootModel,
     ConfigDict,
@@ -151,27 +150,6 @@ class QueryWithResults(BaseModel):
     @field_serializer("links")
     def serialize_links(self, links: Optional[List[AnyHttpUrl]]) -> Optional[List[str]]:
         return [str(url) for url in links] if links else None
-
-    @field_validator("scheduled", mode="before")
-    def parse_scheduled_date_string(cls, value):
-        """
-        Convert string date values to datetime
-        """
-        return datetime.fromisoformat(value) if isinstance(value, str) else value
-
-    @field_validator("started", mode="before")
-    def parse_started_date_string(cls, value):
-        """
-        Convert string date values to datetime
-        """
-        return datetime.fromisoformat(value) if isinstance(value, str) else value
-
-    @field_validator("finished", mode="before")
-    def parse_finisheddate_string(cls, value):
-        """
-        Convert string date values to datetime
-        """
-        return datetime.fromisoformat(value) if isinstance(value, str) else value
 
 
 class QueryExtType(IntEnum):

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -2788,14 +2788,18 @@ class FunctionTable(FunctionTableExpression):
             else ""
         )
 
-        column_parens = False
-        if self.name.name.upper() == "UNNEST" or (
-            self.name.name.upper() == "EXPLODE"
-            and not isinstance(self.parent, LateralView)
-        ):
-            column_parens = True
-
-        column_list_str = f"({cols})" if column_parens else f"{cols}"
+        # UNNEST / EXPLODE outside a lateral view need their column list wrapped
+        # in parens (e.g. `UNNEST(arr) AS t(x)`). With no column list — common
+        # when EXPLODE is used as a scalar inside CAST(...) — we must NOT emit
+        # an empty `()`, which would render as `explode(arr)()` and fail to parse.
+        wraps_column_list = bool(cols) and (
+            self.name.name.upper() == "UNNEST"
+            or (
+                self.name.name.upper() == "EXPLODE"
+                and not isinstance(self.parent, LateralView)
+            )
+        )
+        column_list_str = f"({cols})" if wraps_column_list else f"{cols}"
         args_str = f"({', '.join(str(col) for col in self.args)})" if self.args else ""
         return f"{self.name}{args_str}{alias}{as_}{column_list_str}"
 

--- a/datajunction-server/tests/instrumentation/middleware_test.py
+++ b/datajunction-server/tests/instrumentation/middleware_test.py
@@ -151,6 +151,24 @@ def test_middleware_emits_request_timer_on_success():
     assert in_flight_values[-1] == 0  # back to 0 after exit
 
 
+@pytest.mark.asyncio
+async def test_middleware_passes_non_http_scope_through():
+    """Lifespan / websocket scopes must skip instrumentation and call the app."""
+    spy = _SpyProvider()
+    set_metrics_provider(spy)
+
+    received_scopes: list[dict] = []
+
+    async def inner_app(scope, receive, send):
+        received_scopes.append(scope)
+
+    middleware = DJInstrumentationMiddleware(inner_app)
+    await middleware({"type": "lifespan"}, lambda: None, lambda _msg: None)
+
+    assert received_scopes == [{"type": "lifespan"}]
+    assert spy.timers == []  # no dj.request timer for non-http scopes
+
+
 def test_middleware_uses_url_path_when_route_missing():
     """When no route is matched (e.g. 404), fall back to request.url.path."""
     spy = _SpyProvider()

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -216,6 +216,25 @@ async def test_ast_compile_explode(session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_ast_compile_explode_scalar_context(session: AsyncSession):
+    """
+    EXPLODE used as a scalar (e.g. inside CAST) must NOT render with a trailing
+    empty () — that produced ``explode(arr)()`` and crashed sqlglot. Repro of a
+    real cube view DDL bug.
+    """
+    query_str = "SELECT CAST(EXPLODE(SEQUENCE(0, 23)) AS INT) AS hour"
+    query = parse(query_str)
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+
+    rendered = str(query)
+    assert "explode(sequence(0, 23))()" not in rendered.lower()
+    assert compare_query_strings(rendered, query_str)
+
+
+@pytest.mark.asyncio
 async def test_ast_compile_lateral_view_explode1(session: AsyncSession):
     """
     Test lateral view explode


### PR DESCRIPTION
### Summary

Three independent fixes:

1. AST renderer: `EXPLODE`/`UNNEST` outside lateral views no longer emit a trailing empty `()` when there's no column list. We were producing `explode(arr)()` from a node like `SELECT explode(sequence(0, 23))`.
2. `QueryWithResults`'s datetime parsing: since Pydantic 2 already parses ISO 8601 (including the Z suffix) natively, we can remove the custom path.
3. `DJInstrumentationMiddleware`: rewritten as pure ASGI middleware.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
