### PR TITLE
Enable decoupling of source nodes and warehouse table schema

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -164,6 +164,10 @@ async def create_a_source_node(
         type=NodeType.SOURCE,
         current_version=0,
         created_by_id=current_user.id,
+        # YAML-managed sources can opt out of warehouse introspection by
+        # passing missing_table=True. /nodes/{name}/refresh/ then short-circuits
+        # at internal/nodes.py:3621-3623 instead of overwriting the YAML schema.
+        missing_table=data.missing_table,
     )
     catalog = await get_catalog_by_name(session=session, name=data.catalog)
 
@@ -1152,6 +1156,18 @@ async def update_any_node(
 
     if data.owners and data.owners != [owner.username for owner in node.owners]:
         await update_owners(session, node, data.owners, current_user, save_history)
+
+    # Source-only: ``missing_table`` lives on Node (not NodeRevision) and the
+    # column-rewriting refresh flow mutates it in place. Honor an explicit
+    # PATCH so a warehouse-introspected source can be flipped to a
+    # YAML-managed one (and back) without going through delete+create.
+    if (
+        node.type == NodeType.SOURCE  # type: ignore
+        and data.missing_table is not None
+        and node.missing_table != data.missing_table  # type: ignore
+    ):
+        node.missing_table = data.missing_table  # type: ignore
+        session.add(node)
 
     if node.type == NodeType.CUBE:  # type: ignore
         node = await Node.get_cube_by_name(session, name)

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -164,9 +164,9 @@ async def create_a_source_node(
         type=NodeType.SOURCE,
         current_version=0,
         created_by_id=current_user.id,
-        # YAML-managed sources can opt out of warehouse introspection by
-        # passing missing_table=True. /nodes/{name}/refresh/ then short-circuits
-        # at internal/nodes.py:3621-3623 instead of overwriting the YAML schema.
+        # YAML-managed sources can opt out of warehouse introspection by passing
+        # missing_table=True. /nodes/{name}/refresh/ then short-circuits instead
+        # of overwriting the YAML schema.
         missing_table=data.missing_table,
     )
     catalog = await get_catalog_by_name(session=session, name=data.catalog)
@@ -1157,10 +1157,8 @@ async def update_any_node(
     if data.owners and data.owners != [owner.username for owner in node.owners]:
         await update_owners(session, node, data.owners, current_user, save_history)
 
-    # Source-only: ``missing_table`` lives on Node (not NodeRevision) and the
-    # column-rewriting refresh flow mutates it in place. Honor an explicit
-    # PATCH so a warehouse-introspected source can be flipped to a
-    # YAML-managed one (and back) without going through delete+create.
+    # Honor an explicit PATCH so that a warehouse-introspected source can be
+    # flipped to a YAML-managed one (and back).
     if (
         node.type == NodeType.SOURCE  # type: ignore
         and data.missing_table is not None

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1830,6 +1830,82 @@ class TestNodeCRUD:
         assert data["name"] == "default.public.basic.comments"
 
     @pytest.mark.asyncio
+    async def test_patch_source_node_to_yaml_managed(
+        self,
+        module__client_with_basic,
+    ):
+        """
+        PATCH ``missing_table=True`` on an existing warehouse-tracked source
+        flips it to YAML-managed. Subsequent /refresh/ calls then short-circuit
+        instead of overwriting the YAML-declared columns.
+        """
+        # Create a warehouse-tracked source (missing_table defaults to False).
+        create = await module__client_with_basic.post(
+            "/nodes/source/",
+            json={
+                "name": "basic.source.convert_target",
+                "description": "Source we'll later flip to YAML-managed",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "label", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "public",
+                "schema_": "basic",
+                "table": "convert_target",
+            },
+        )
+        assert create.status_code in (200, 201), create.json()
+        assert create.json()["missing_table"] is False
+
+        # Convert: flip missing_table to True via PATCH.
+        patch = await module__client_with_basic.patch(
+            "/nodes/basic.source.convert_target/",
+            json={"missing_table": True},
+        )
+        assert patch.status_code == 200, patch.json()
+        assert patch.json()["missing_table"] is True
+
+        # Round-trip: GET should reflect the new flag.
+        fetched = await module__client_with_basic.get(
+            "/nodes/basic.source.convert_target/",
+        )
+        assert fetched.json()["missing_table"] is True
+
+    @pytest.mark.asyncio
+    async def test_create_source_node_with_missing_table(
+        self,
+        module__client_with_basic,
+    ):
+        """
+        ``missing_table=True`` in the create payload is honored on the new node.
+
+        Use case: YAML-managed sources where the column list is the source of
+        truth and DJ shouldn't introspect the warehouse. Setting the flag at
+        create time keeps the node out of the auto-refresh self-rewrite loop.
+        """
+        response = await module__client_with_basic.post(
+            "/nodes/source/",
+            json={
+                "name": "basic.source.yaml_managed",
+                "description": "YAML-managed source with no real warehouse table",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "label", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "public",
+                "schema_": "basic",
+                "table": "yaml_managed",
+                "missing_table": True,
+            },
+        )
+        assert response.status_code in (200, 201), response.json()
+        data = response.json()
+        assert data["missing_table"] is True
+        assert [c["name"] for c in data["columns"]] == ["id", "label"]
+
+    @pytest.mark.asyncio
     async def test_refresh_source_node(
         self,
         module__client_with_roads,


### PR DESCRIPTION
### Summary

Allow source nodes to opt out of warehouse-table introspection via `missing_table=True` on create and update. The use case is typically for YAML-managed sources where the column list and dimension links are owned by a YAML definition, not by reflecting a physical table. This supports converting an existing warehouse-tracked source into a YAML-managed one without delete/recreate.

Note: `Node.missing_table` already existed and was already wired into the refresh flow ([internal/nodes.py:3621-3623](https://github.com/DataJunction/dj/blob/1f5023783258b9f0d4e98dd165f48bb57676d94d/datajunction-server/datajunction_server/internal/nodes.py#L3621-L3623) short-circuits the column-rewrite when the flag is set). What was missing was just letting callers set it explicitly via a REST call.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
