### PR TITLE
Fix mislabeled query version + add structured per-request SQL logging

### DIFF
--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -281,13 +281,32 @@ async def get_measures_sql_v3(
 
     response = _build_measures_response(result)
 
+    elapsed_ms = (time.monotonic() - _t0) * 1000
     _tags = {"query_type": "measures", "query_version": "v3"}
     get_metrics_provider().timer(
         "dj.sql.build_latency_ms",
-        (time.monotonic() - _t0) * 1000,
+        elapsed_ms,
         _tags,
     )
     get_metrics_provider().counter("dj.sql.requests", tags=_tags)
+
+    _logger.info(
+        "[SQL] endpoint=%s metrics=%s dimensions=%s filters=%s elapsed_ms=%.1f",
+        "/sql/measures/v3/",
+        metrics,
+        dimensions,
+        merged_filters,
+        elapsed_ms,
+        extra={
+            "endpoint": "/sql/measures/v3/",
+            "query_type": "measures",
+            "query_version": "v3",
+            "metrics": metrics,
+            "dimensions": dimensions,
+            "filters": merged_filters,
+            "elapsed_ms": elapsed_ms,
+        },
+    )
     return response
 
 
@@ -493,13 +512,32 @@ async def get_combined_measures_sql_v3(
             # Extract table references from the query
             source_tables.append(gg.parent_name)
 
+    elapsed_ms = (time.monotonic() - _t0) * 1000
     _tags = {"query_type": "measures_combined", "query_version": "v3"}
     get_metrics_provider().timer(
         "dj.sql.build_latency_ms",
-        (time.monotonic() - _t0) * 1000,
+        elapsed_ms,
         _tags,
     )
     get_metrics_provider().counter("dj.sql.requests", tags=_tags)
+
+    _logger.info(
+        "[SQL] endpoint=%s metrics=%s dimensions=%s filters=%s elapsed_ms=%.1f",
+        "/sql/measures/v3/combined",
+        metrics,
+        dimensions,
+        filters,
+        elapsed_ms,
+        extra={
+            "endpoint": "/sql/measures/v3/combined",
+            "query_type": "measures_combined",
+            "query_version": "v3",
+            "metrics": metrics,
+            "dimensions": dimensions,
+            "filters": filters,
+            "elapsed_ms": elapsed_ms,
+        },
+    )
     return CombinedMeasuresSQLResponse(
         sql=combined_result.sql,
         columns=[
@@ -639,13 +677,32 @@ async def get_metrics_sql_v3(
         matched_cube=matched_cube,
         query_parameters=json.loads(query_params) or None,
     )
+    elapsed_ms = (time.monotonic() - _t0) * 1000
     _tags = {"query_type": "metrics", "query_version": "v3"}
     get_metrics_provider().timer(
         "dj.sql.build_latency_ms",
-        (time.monotonic() - _t0) * 1000,
+        elapsed_ms,
         _tags,
     )
     get_metrics_provider().counter("dj.sql.requests", tags=_tags)
+
+    _logger.info(
+        "[SQL] endpoint=%s metrics=%s dimensions=%s filters=%s elapsed_ms=%.1f",
+        "/sql/metrics/v3/",
+        metrics,
+        dimensions,
+        merged_filters,
+        elapsed_ms,
+        extra={
+            "endpoint": "/sql/metrics/v3/",
+            "query_type": "metrics",
+            "query_version": "v3",
+            "metrics": metrics,
+            "dimensions": dimensions,
+            "filters": merged_filters,
+            "elapsed_ms": elapsed_ms,
+        },
+    )
 
     return V3TranslatedSQL(
         sql=result.sql,

--- a/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
+++ b/datajunction-server/datajunction_server/internal/caching/query_cache_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 import json
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 _VERSION_BY_TYPE: dict[QueryBuildType, str] = {
     QueryBuildType.METRICS: "v2",
-    QueryBuildType.MEASURES: "v3",
+    QueryBuildType.MEASURES: "v2",
     QueryBuildType.NODE: "v2",
 }
 settings = get_settings()
@@ -201,6 +202,7 @@ class QueryCacheManager(RefreshAheadCacheManager):
         in subclasses.
         """
         params = deepcopy(params)
+        _t0 = time.monotonic()
 
         async def _build_with_session(session: AsyncSession):
             access_checker = await build_access_checker_from_request(request, session)
@@ -231,14 +233,37 @@ class QueryCacheManager(RefreshAheadCacheManager):
                         access_checker,
                     )
 
-        # Use provided session or create a new one
-        if session:
-            return await _build_with_session(session)
-        async with session_context(
-            request,
-            session_label="SQL building",
-        ) as new_session:
-            return await _build_with_session(new_session)
+        try:
+            # Use provided session or create a new one
+            if session:
+                return await _build_with_session(session)
+            async with session_context(
+                request,
+                session_label="SQL building",
+            ) as new_session:
+                return await _build_with_session(new_session)
+        finally:
+            elapsed_ms = (time.monotonic() - _t0) * 1000
+            url = getattr(request, "url", None)
+            endpoint = getattr(url, "path", "") if url is not None else ""
+            query_version = _VERSION_BY_TYPE[self.query_type]
+            self.logger.info(
+                "[SQL] endpoint=%s metrics=%s dimensions=%s filters=%s elapsed_ms=%.1f",
+                endpoint,
+                params.nodes,
+                params.dimensions,
+                params.filters,
+                elapsed_ms,
+                extra={
+                    "endpoint": endpoint,
+                    "query_type": str(self.query_type),
+                    "query_version": query_version,
+                    "metrics": params.nodes,
+                    "dimensions": params.dimensions,
+                    "filters": params.filters,
+                    "elapsed_ms": elapsed_ms,
+                },
+            )
 
     @timed(
         "dj.cache.key_build_ms",

--- a/datajunction-server/tests/api/sql_instrumentation_test.py
+++ b/datajunction-server/tests/api/sql_instrumentation_test.py
@@ -1,0 +1,156 @@
+"""
+Tests for SQL endpoint instrumentation: structured per-request log lines emitted
+alongside ``dj.sql.build_latency_ms`` so slow requests can be replayed by
+metrics/dimensions/filters from log search (Radar) without parsing URLs.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+
+def _structured_extras(caplog) -> list[dict[str, Any]]:
+    """
+    Return a dict-of-extras for every log record we attached an ``endpoint``
+    extra to. Reading via getattr keeps type checkers happy — LogRecord doesn't
+    declare these attributes, but logging adds them when ``extra={}`` is passed.
+    """
+    out: list[dict[str, Any]] = []
+    for r in caplog.records:
+        endpoint = getattr(r, "endpoint", None)
+        if endpoint is None:
+            continue
+        out.append(
+            {
+                "endpoint": endpoint,
+                "query_type": getattr(r, "query_type", None),
+                "query_version": getattr(r, "query_version", None),
+                "metrics": getattr(r, "metrics", None),
+                "dimensions": getattr(r, "dimensions", None),
+                "filters": getattr(r, "filters", None),
+                "elapsed_ms": getattr(r, "elapsed_ms", None),
+            },
+        )
+    return out
+
+
+@pytest.mark.asyncio
+async def test_v3_measures_endpoint_emits_structured_log(
+    client_with_build_v3: AsyncClient,
+    caplog,
+):
+    """`/sql/measures/v3/` should emit a structured log with extra={...}."""
+    caplog.set_level(logging.INFO, logger="datajunction_server.api.sql")
+    response = await client_with_build_v3.get(
+        "/sql/measures/v3/",
+        params={
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+        },
+    )
+    assert response.status_code == 200
+
+    matching = [
+        e for e in _structured_extras(caplog) if e["endpoint"] == "/sql/measures/v3/"
+    ]
+    assert matching, "no structured log for /sql/measures/v3/"
+    extra = matching[-1]
+    assert extra["query_type"] == "measures"
+    assert extra["query_version"] == "v3"
+    assert extra["metrics"] == ["v3.total_revenue"]
+    assert extra["dimensions"] == ["v3.order_details.status"]
+    assert extra["filters"] is not None
+    assert isinstance(extra["elapsed_ms"], float)
+
+
+@pytest.mark.asyncio
+async def test_v3_metrics_endpoint_emits_structured_log(
+    client_with_build_v3: AsyncClient,
+    caplog,
+):
+    """`/sql/metrics/v3/` should emit a structured log with extra={...}."""
+    caplog.set_level(logging.INFO, logger="datajunction_server.api.sql")
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+        },
+    )
+    assert response.status_code == 200
+
+    matching = [
+        e for e in _structured_extras(caplog) if e["endpoint"] == "/sql/metrics/v3/"
+    ]
+    assert matching, "no structured log for /sql/metrics/v3/"
+    extra = matching[-1]
+    assert extra["query_type"] == "metrics"
+    assert extra["query_version"] == "v3"
+    assert extra["metrics"] is not None
+    assert extra["dimensions"] is not None
+    assert extra["filters"] is not None
+    assert isinstance(extra["elapsed_ms"], float)
+
+
+@pytest.mark.asyncio
+async def test_v3_combined_measures_endpoint_emits_structured_log(
+    client_with_build_v3: AsyncClient,
+    caplog,
+):
+    """`/sql/measures/v3/combined` should emit a structured log with extra={...}."""
+    caplog.set_level(logging.INFO, logger="datajunction_server.api.sql")
+    response = await client_with_build_v3.get(
+        "/sql/measures/v3/combined",
+        params={
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+        },
+    )
+    assert response.status_code == 200
+
+    matching = [
+        e
+        for e in _structured_extras(caplog)
+        if e["endpoint"] == "/sql/measures/v3/combined"
+    ]
+    assert matching, "no structured log for /sql/measures/v3/combined"
+    extra = matching[-1]
+    assert extra["query_type"] == "measures_combined"
+    assert extra["query_version"] == "v3"
+    assert extra["metrics"] is not None
+    assert extra["dimensions"] is not None
+    assert extra["filters"] is not None
+    assert isinstance(extra["elapsed_ms"], float)
+
+
+@pytest.mark.asyncio
+async def test_v2_measures_endpoint_emits_structured_log(
+    client_with_roads: AsyncClient,
+    caplog,
+):
+    """
+    The legacy `/sql/measures/v2/` endpoint routes through QueryCacheManager.
+    Its fallback() should emit a structured log (with extra={...}) tagged
+    query_version=v2 — matching the v2 builder it actually runs.
+    """
+    caplog.set_level(logging.INFO, logger="QueryCacheManager")
+    response = await client_with_roads.get(
+        "/sql/measures/v2",
+        params={
+            "metrics": ["default.num_repair_orders"],
+            "dimensions": ["default.dispatcher.company_name"],
+        },
+        headers={"Cache-Control": "no-cache, no-store"},
+    )
+    assert response.status_code == 200
+
+    matching = _structured_extras(caplog)
+    assert matching, "no structured log emitted by QueryCacheManager.fallback"
+    extra = matching[-1]
+    assert extra["query_version"] == "v2"
+    assert extra["metrics"] == ["default.num_repair_orders"]
+    assert extra["dimensions"] == ["default.dispatcher.company_name"]
+    assert extra["filters"] is not None
+    assert isinstance(extra["elapsed_ms"], float)

--- a/datajunction-server/tests/internal/caching/query_cache_manager_test.py
+++ b/datajunction-server/tests/internal/caching/query_cache_manager_test.py
@@ -50,6 +50,33 @@ async def test_cache_key_prefix_uses_query_type():
     assert manager.cache_key_prefix == "sql:measures"
 
 
+def test_measures_metric_tags_query_version_is_v2():
+    """
+    QueryBuildType.MEASURES routes through get_measures_query (the v2 builder),
+    so its emitted query_version tag must be "v2", not "v3". The /sql/measures/v3/
+    endpoint emits its own v3 tag directly and does not go through the cache manager.
+    """
+    cache = CachelibCache()
+    manager = QueryCacheManager(cache, QueryBuildType.MEASURES)
+    assert manager._metric_tags["query_version"] == "v2"
+
+
+def test_metric_tags_query_version_for_all_types():
+    """
+    Every cache-managed query type should emit query_version=v2, since they all
+    route through v2 SQL builders.
+    """
+    cache = CachelibCache()
+    for query_type in (
+        QueryBuildType.METRICS,
+        QueryBuildType.MEASURES,
+        QueryBuildType.NODE,
+    ):
+        assert (
+            QueryCacheManager(cache, query_type)._metric_tags["query_version"] == "v2"
+        )
+
+
 @pytest.mark.asyncio
 async def test_build_cache_key_calls_versioning():
     """


### PR DESCRIPTION
### Summary

Two related instrumentation fixes for SQL endpoints:

1. Bug fix where the wrong query builder version was being tagged for `/sql/measures/v2` calls. This bug caused every v2 measures call to emit `dj.sql.build_latency_ms` and `dj.cache.*` with `query_version=v3`.
2. Add structured per-request log alongside every `dj.sql.build_latency_ms` emit site. This lets us search the logs by metric/dimension to replay slow requests without parsing truncated URLs.


### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
