### PR TITLE
Enable type coercion for pre-agg availability posting

### DIFF
--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -5,7 +5,7 @@ Models for pre-aggregation API requests and responses.
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from datajunction_server.enum import StrEnum
 from datajunction_server.models.materialization import MaterializationStrategy
@@ -132,6 +132,14 @@ class UpdatePreAggregationAvailabilityRequest(BaseModel):
         default_factory=list,
         description="Detailed partition-level availability",
     )
+
+    @field_validator("min_temporal_partition", "max_temporal_partition", mode="before")
+    @classmethod
+    def coerce_temporal_partition_to_str(cls, value):
+        """Coerce int partition values (e.g., 20260428) to strings."""
+        if value is None:
+            return value
+        return [str(part) for part in value]
 
     class Config:
         populate_by_name = True

--- a/datajunction-server/tests/models/preaggregation_test.py
+++ b/datajunction-server/tests/models/preaggregation_test.py
@@ -1,0 +1,73 @@
+"""Tests for pre-aggregation request models."""
+
+from datajunction_server.models.preaggregation import (
+    UpdatePreAggregationAvailabilityRequest,
+)
+
+
+def _base_payload(**overrides):
+    payload = {
+        "catalog": "default",
+        "schema": "public",
+        "table": "my_preagg",
+        "valid_through_ts": 1714329600,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_partition_values_coerced_from_ints():
+    """Query services post date partition values as ints (e.g. 20260428).
+
+    The validator must coerce them to strings to satisfy the field's
+    ``Optional[List[str]]`` typing.
+    """
+    req = UpdatePreAggregationAvailabilityRequest(
+        **_base_payload(
+            min_temporal_partition=[20260101],
+            max_temporal_partition=[20260428, 20260429],
+        ),
+    )
+    assert req.min_temporal_partition == ["20260101"]
+    assert req.max_temporal_partition == ["20260428", "20260429"]
+
+
+def test_partition_values_passthrough_when_strings():
+    """String partition values must round-trip unchanged."""
+    req = UpdatePreAggregationAvailabilityRequest(
+        **_base_payload(
+            min_temporal_partition=["20260101"],
+            max_temporal_partition=["20260428"],
+        ),
+    )
+    assert req.min_temporal_partition == ["20260101"]
+    assert req.max_temporal_partition == ["20260428"]
+
+
+def test_partition_values_none_passthrough():
+    """An explicit ``None`` for a partition list must not be coerced."""
+    req = UpdatePreAggregationAvailabilityRequest(
+        **_base_payload(
+            min_temporal_partition=None,
+            max_temporal_partition=None,
+        ),
+    )
+    assert req.min_temporal_partition is None
+    assert req.max_temporal_partition is None
+
+
+def test_partition_values_default_empty_list():
+    """Omitting the fields keeps the default empty-list factory."""
+    req = UpdatePreAggregationAvailabilityRequest(**_base_payload())
+    assert req.min_temporal_partition == []
+    assert req.max_temporal_partition == []
+
+
+def test_partition_values_mixed_int_and_str():
+    """Heterogeneous lists are normalized to strings element-by-element."""
+    req = UpdatePreAggregationAvailabilityRequest(
+        **_base_payload(
+            min_temporal_partition=[20260101, "20260102"],
+        ),
+    )
+    assert req.min_temporal_partition == ["20260101", "20260102"]


### PR DESCRIPTION
### Summary

Adds a pre-validation coercion to `UpdatePreAggregationAvailabilityRequest` so that integer partition values sent by query services (e.g. 20260428) are automatically converted to strings before pydantic's string-type check runs.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
