### PR TITLE
Source Druid `timestampSpec` from the cube's own partition declaration

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -12,8 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build_v3.combiners import (
+    _reorder_partition_column_last,
     build_combiner_sql_from_preaggs,
 )
+from datajunction_server.construction.build_v3.cte import strip_role_suffix
 from datajunction_server.internal.views import _build_view_body, CubeViewNames
 from datajunction_server.transpilation import transpile_sql
 from datajunction_server.models.materialization import (
@@ -455,6 +457,8 @@ async def materialize_cube(
             http_status_code=HTTPStatus.NOT_FOUND,
         )
 
+    cube_tps = cube_revision.temporal_partition_columns()
+
     # Build combined SQL from pre-agg tables
     try:
         (
@@ -474,16 +478,19 @@ async def materialize_cube(
             http_status_code=HTTPStatus.BAD_REQUEST,
         ) from e
 
-    # For incremental strategy, we need a temporal partition
+    # For incremental strategy, we need a temporal partition — either the cube
+    # has one declared on its own column, or the upstream pre-aggs surface one.
     if (
         data.strategy == MaterializationStrategy.INCREMENTAL_TIME
         and not temporal_partition_info
+        and not cube_tps
     ):
         raise DJInvalidInputException(
             message=(
-                "Could not auto-detect temporal partition from pre-aggregations. "
-                "Please ensure the source nodes have temporal partitions configured, "
-                "or use FULL materialization strategy."
+                "Could not determine temporal partition for cube. Either declare "
+                "one on the cube via POST /nodes/{cube}/columns/{dim_ref}/partition "
+                "or ensure source nodes / pre-aggs have temporal partitions configured. "
+                "Otherwise use FULL materialization strategy."
             ),
             http_status_code=HTTPStatus.BAD_REQUEST,
         )
@@ -517,25 +524,83 @@ async def materialize_cube(
         if col.semantic_type in ("metric", "metric_component", "measure")
     ]
 
-    # Build timestamp spec from auto-detected temporal partition.
-    # For FULL strategy without a temporal partition, these stay None and Druid
-    # ingests everything as a single ALL-granularity segment.
-    timestamp_column = (
-        temporal_partition_info.column_name if temporal_partition_info else None
-    )
-    timestamp_format = (
-        temporal_partition_info.format if temporal_partition_info else None
-    )
-    segment_granularity = (
-        temporal_partition_info.granularity.upper()
-        if temporal_partition_info and temporal_partition_info.granularity
-        else "ALL"
-    )
+    # Source the Druid timestampSpec from the cube's own partition declaration
+    # The cube column stores the dim-attr FQN while the combined SQL output
+    # uses the short, role-aliased name. Resolve the output name by matching against
+    # `semantic_name` in the combiner's column metadata — stripping the
+    # optional `[role]` suffix so a dim attr selected with any role still
+    # matches the cube column.
+    #
+    # For FULL pre-aggs the upstream `temporal_partition_info` comes back empty
+    # (FULL pre-aggs don't carry source-column partition info), so the cube-side
+    # declaration is the only reliable source. Fall back to the upstream-derived
+    # value when the cube hasn't declared one.
+    if cube_tps:
+        cube_tp = cube_tps[0]
+        cube_partition_ref = cube_tp.name
+        # Look up the actual output column name by semantic identity
+        output_col = next(
+            (
+                c
+                for c in combined_result.columns
+                if c.semantic_name
+                and strip_role_suffix(c.semantic_name) == cube_partition_ref
+            ),
+            None,
+        )
+        if output_col is None:
+            output_names = sorted(c.name for c in combined_result.columns)
+            raise DJInvalidInputException(
+                message=(
+                    f"Cube partition column '{cube_partition_ref}' was not found "
+                    f"in the combined query output. Make sure the partition is set "
+                    f"on a dimension that's actually selected by the cube. "
+                    f"Available output columns: {output_names}"
+                ),
+                http_status_code=HTTPStatus.BAD_REQUEST,
+            )
+        timestamp_column = output_col.name
+        timestamp_format = cube_tp.partition.format if cube_tp.partition else None
+        segment_granularity = (
+            str(cube_tp.partition.granularity.value).upper()
+            if cube_tp.partition and cube_tp.partition.granularity
+            else "ALL"
+        )
+        # `build_combiner_sql_from_preaggs` only reorders when its own
+        # auto-detect succeeded. When we sourced the partition from the cube
+        # instead, apply the same reorder so Hive/Spark INSERT OVERWRITE
+        # PARTITION still gets the partition column last.
+        if not temporal_partition_info:
+            combined_result = _reorder_partition_column_last(
+                combined_result,
+                timestamp_column,
+            )
+    elif temporal_partition_info:
+        timestamp_column = temporal_partition_info.column_name
+        timestamp_format = temporal_partition_info.format
+        segment_granularity = (
+            temporal_partition_info.granularity.upper()
+            if temporal_partition_info.granularity
+            else "ALL"
+        )
+    else:
+        raise DJInvalidInputException(
+            message=(
+                f"Cube '{name}' has no temporal partition declared. Druid requires "
+                f"a timestampSpec, so set one via "
+                f"POST /nodes/{name}/columns/{{dim_ref}}/partition with format and "
+                f"granularity before materializing."
+            ),
+            http_status_code=HTTPStatus.BAD_REQUEST,
+        )
 
-    # Validate that the timestamp column is in the output columns
+    # Validate that the timestamp column is in the output columns. The cube
+    # path resolves through `semantic_name` and already errors above if the
+    # cube partition wasn't selected, so this primarily guards the
+    # upstream-derived fallback.
     all_output_col_names = {col.name for col in combined_result.columns}
     if timestamp_column and timestamp_column not in all_output_col_names:
-        raise DJInvalidInputException(  # pragma: no cover
+        raise DJInvalidInputException(
             message=(
                 f"Detected temporal partition column '{timestamp_column}' is not in the "
                 f"combined query output columns ({all_output_col_names}). "

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -4344,6 +4344,193 @@ class TestCubeMaterializeV2SuccessPaths:
         )
 
     @pytest.mark.asyncio
+    async def test_materialize_cube_partition_not_in_combined_output_fails(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        mocker,
+    ):
+        """
+        If the cube's declared partition column doesn't show up in the combined
+        SQL output (e.g., the user partitioned on a dim attr that isn't actually
+        selected by the cube), we should error out with a clear message rather
+        than emit a Druid spec referencing a missing column.
+        """
+        cube_name = "default.test_materialize_partition_missing_cube"
+        await make_a_test_cube(
+            client_with_repairs_cube,
+            cube_name,
+            with_materialization=False,
+        )
+        partition_response = await client_with_repairs_cube.post(
+            f"/nodes/{cube_name}/columns/default.hard_hat.hire_date/partition",
+            json={
+                "type_": "temporal",
+                "granularity": "day",
+                "format": "yyyyMMdd",
+            },
+        )
+        assert partition_response.status_code < 400, partition_response.json()
+
+        # Combined output is missing the partitioned dim attr entirely.
+        mock_columns = [
+            V3ColumnMetadata(
+                name="state",
+                type="string",
+                semantic_name="default.hard_hat.state",
+                semantic_type="dimension",
+            ),
+        ]
+        mock_combined_result = _create_mock_combined_result(
+            mocker,
+            columns=mock_columns,
+            shared_dimensions=["default.hard_hat.state"],
+            sql_string="SELECT state FROM preagg GROUP BY state",
+        )
+        mocker.patch(
+            "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
+            return_value=(
+                mock_combined_result,
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
+                None,
+            ),
+        )
+
+        response = await client_with_repairs_cube.post(
+            f"/cubes/{cube_name}/materialize",
+            json={"strategy": "full", "schedule": "0 0 * * *"},
+        )
+
+        assert response.status_code == 400
+        message = response.json()["message"]
+        assert "default.hard_hat.hire_date" in message
+        assert "not found in the combined query output" in message
+
+    @pytest.mark.asyncio
+    async def test_materialize_cube_full_no_partition_anywhere_fails(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        mocker,
+    ):
+        """
+        FULL strategy with neither a cube-side partition nor an upstream-derived
+        one must error out — Druid requires a `timestampSpec` to ingest.
+        """
+        cube_name = "default.test_materialize_full_no_partition_cube"
+        await make_a_test_cube(
+            client_with_repairs_cube,
+            cube_name,
+            with_materialization=False,
+        )
+
+        mock_columns = [
+            V3ColumnMetadata(
+                name="state",
+                type="string",
+                semantic_name="default.hard_hat.state",
+                semantic_type="dimension",
+            ),
+        ]
+        mock_combined_result = _create_mock_combined_result(
+            mocker,
+            columns=mock_columns,
+            shared_dimensions=["default.hard_hat.state"],
+            sql_string="SELECT state FROM preagg GROUP BY state",
+        )
+        mocker.patch(
+            "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
+            return_value=(
+                mock_combined_result,
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
+                None,
+            ),
+        )
+
+        response = await client_with_repairs_cube.post(
+            f"/cubes/{cube_name}/materialize",
+            json={"strategy": "full", "schedule": "0 0 * * *"},
+        )
+
+        assert response.status_code == 400
+        message = response.json()["message"]
+        assert "no temporal partition declared" in message
+        assert "Druid requires" in message
+
+    @pytest.mark.asyncio
+    async def test_materialize_cube_upstream_partition_column_missing_fails(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        mocker,
+    ):
+        """
+        When the cube has no partition declared and the upstream-derived
+        `temporal_partition_info.column_name` isn't in the combined output
+        either, the validator must reject the spec.
+        """
+        cube_name = "default.test_materialize_upstream_missing_col_cube"
+        await make_a_test_cube(
+            client_with_repairs_cube,
+            cube_name,
+            with_materialization=False,
+        )
+
+        mock_columns = [
+            V3ColumnMetadata(
+                name="state",
+                type="string",
+                semantic_name="default.hard_hat.state",
+                semantic_type="dimension",
+            ),
+        ]
+        mock_combined_result = _create_mock_combined_result(
+            mocker,
+            columns=mock_columns,
+            shared_dimensions=["default.hard_hat.state"],
+            sql_string="SELECT state FROM preagg GROUP BY state",
+        )
+        # Upstream surfaces a column that doesn't exist in the combined output.
+        mock_temporal_info = TemporalPartitionInfo(
+            column_name="not_in_output",
+            format="yyyyMMdd",
+            granularity="day",
+        )
+        mocker.patch(
+            "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
+            return_value=(
+                mock_combined_result,
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
+                mock_temporal_info,
+            ),
+        )
+
+        response = await client_with_repairs_cube.post(
+            f"/cubes/{cube_name}/materialize",
+            json={"strategy": "full", "schedule": "0 0 * * *"},
+        )
+
+        assert response.status_code == 400
+        message = response.json()["message"]
+        assert "not_in_output" in message
+        assert "combined query output columns" in message
+
+    @pytest.mark.asyncio
     async def test_materialize_cube_incremental_time_success(
         self,
         client_with_repairs_cube: AsyncClient,

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -4234,6 +4234,116 @@ class TestCubeMaterializeV2SuccessPaths:
         assert len(data["workflow_urls"]) == 1
 
     @pytest.mark.asyncio
+    async def test_materialize_cube_full_uses_cube_partition_with_role(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        mocker,
+    ):
+        """
+        FULL pre-aggs don't carry source-column partitions, so the cube-side
+        partition declaration is the only source of `timestampSpec`. When the
+        cube selects the dim attr via a role, the combined output column is
+        the role-aliased short name (e.g., `hire_date_order`) and its
+        `semantic_name` carries the `[role]` suffix
+        (e.g., `default.hard_hat.hire_date[order]`). The cube column itself
+        stores the bare dim attr fqn — so the lookup must strip the role
+        suffix to find the matching output column.
+        """
+        cube_name = "default.test_materialize_full_role_cube"
+        await make_a_test_cube(
+            client_with_repairs_cube,
+            cube_name,
+            with_materialization=False,
+        )
+        # Declare partition on the cube column (bare dim attr fqn).
+        partition_response = await client_with_repairs_cube.post(
+            f"/nodes/{cube_name}/columns/default.hard_hat.hire_date/partition",
+            json={
+                "type_": "temporal",
+                "granularity": "day",
+                "format": "yyyyMMdd",
+            },
+        )
+        assert partition_response.status_code < 400, partition_response.json()
+
+        # Combined output uses a role-aliased short name; semantic_name has [role].
+        mock_columns = [
+            V3ColumnMetadata(
+                name="hire_date_order",
+                type="int",
+                semantic_name="default.hard_hat.hire_date[order]",
+                semantic_type="dimension",
+            ),
+            V3ColumnMetadata(
+                name="total_repair_cost",
+                type="double",
+                semantic_name="default.total_repair_cost",
+                semantic_type="measure",
+            ),
+        ]
+        mock_combined_result = _create_mock_combined_result(
+            mocker,
+            columns=mock_columns,
+            shared_dimensions=["default.hard_hat.hire_date[order]"],
+            sql_string=(
+                "SELECT hire_date_order, SUM(cost) AS total_repair_cost "
+                "FROM preagg GROUP BY hire_date_order"
+            ),
+        )
+
+        # FULL pre-aggs return no upstream temporal partition info — exercising
+        # the cube-side path as the sole source of truth.
+        mocker.patch(
+            "datajunction_server.api.cubes.build_combiner_sql_from_preaggs",
+            return_value=(
+                mock_combined_result,
+                [
+                    PreAggSourceInfo(
+                        table_ref="catalog.schema.preagg_table1",
+                        parent_name="default.repair_orders",
+                        strategy=None,
+                    ),
+                ],
+                None,
+            ),
+        )
+        # The cube-side path calls _reorder_partition_column_last directly,
+        # which would otherwise touch the MagicMock's `query.select.projection`
+        # and zero out columns. We're not testing reorder here — return as-is.
+        mocker.patch(
+            "datajunction_server.api.cubes._reorder_partition_column_last",
+            side_effect=lambda result, _col: result,
+        )
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mocker.patch.object(
+            qs_client,
+            "materialize_cube_v2",
+            return_value=mocker.MagicMock(urls=["http://workflow/cube-workflow"]),
+        )
+
+        response = await client_with_repairs_cube.post(
+            f"/cubes/{cube_name}/materialize",
+            json={"strategy": "full", "schedule": "0 0 * * *"},
+        )
+
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        timestamp_spec = data["druid_spec"]["dataSchema"]["parser"]["parseSpec"][
+            "timestampSpec"
+        ]
+        # The role-stripped semantic_name matched the cube partition fqn, so
+        # the resolved timestamp column is the role-aliased SQL output name.
+        assert timestamp_spec["column"] == "hire_date_order"
+        assert timestamp_spec["format"] == "yyyyMMdd"
+        # Granularity from the cube's Partition row, not "ALL".
+        assert (
+            data["druid_spec"]["dataSchema"]["granularitySpec"]["segmentGranularity"]
+            == "DAY"
+        )
+
+    @pytest.mark.asyncio
     async def test_materialize_cube_incremental_time_success(
         self,
         client_with_repairs_cube: AsyncClient,


### PR DESCRIPTION
### Summary

For `FULL` cube materializations, the generated Druid spec was missing `timestampSpec` and `segmentGranularity` was falling through to "ALL". Druid hard-requires `timestampSpec`, so the spec was unusable.

The root cause: materialize_cube was sourcing temporal partition info exclusively from the upstream pre-aggs (via get_temporal_partitions(matching_preagg) on the parent node revision). `FULL` pre-aggs don't carry source-column partitions, so `temporal_partition_info` came back None even when the cube itself had a partition declared.

This switches the source of truth to the cube's own column-level Partition row (set via `POST /nodes/{cube}/columns/{dim_ref}/partition`), with the upstream-derived value retained as a fallback.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
