### PR TITLE
python client shouldn't raise 404s upon deletion

### DIFF
--- a/datajunction-clients/python/datajunction/builder.py
+++ b/datajunction-clients/python/datajunction/builder.py
@@ -99,6 +99,8 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
                 "cascade": cascade,
             },
         )
+        if response.status_code == 404:
+            return
         if not response.status_code < 400:
             raise DJClientException(response.json()["message"])
 
@@ -176,6 +178,8 @@ class DJBuilder(DJClient):  # pylint: disable=too-many-public-methods
             timeout=self._timeout,
             params={"delete_git_branch": delete_git_branch},
         )
+        if response.status_code == 404:
+            return
         if not response.status_code < 400:
             raise DJClientException(response.json()["message"])
 

--- a/datajunction-clients/python/tests/test_builder.py
+++ b/datajunction-clients/python/tests/test_builder.py
@@ -1038,18 +1038,43 @@ class TestDJBuilder:  # pylint: disable=too-many-public-methods, protected-acces
                 params={"delete_git_branch": True},
             )
 
-    def test_delete_branch_error(self, client):
+    def test_delete_branch_404_is_idempotent(self, client):
         """
-        Verifies that delete_branch raises on error.
+        Verifies that delete_branch treats a 404 as success — DELETE is idempotent.
         """
         mock_response = MagicMock(
             status_code=404,
             json=lambda: {"message": "Branch not found"},
         )
         with patch.object(client._session, "request", return_value=mock_response):
-            with pytest.raises(DJClientException) as exc_info:
+            assert (
                 client.delete_branch(namespace="myns", branch_name="nonexistent")
-            assert "Branch not found" in str(exc_info.value)
+                is None
+            )
+
+    def test_delete_branch_error(self, client):
+        """
+        Verifies that delete_branch raises on non-404 errors.
+        """
+        mock_response = MagicMock(
+            status_code=500,
+            json=lambda: {"message": "Internal server error"},
+        )
+        with patch.object(client._session, "request", return_value=mock_response):
+            with pytest.raises(DJClientException) as exc_info:
+                client.delete_branch(namespace="myns", branch_name="feature-x")
+            assert "Internal server error" in str(exc_info.value)
+
+    def test_delete_namespace_404_is_idempotent(self, client):
+        """
+        Verifies that delete_namespace treats a 404 as success — DELETE is idempotent.
+        """
+        mock_response = MagicMock(
+            status_code=404,
+            json=lambda: {"message": "Namespace not found"},
+        )
+        with patch.object(client._session, "request", return_value=mock_response):
+            assert client.delete_namespace(namespace="nonexistent") is None
 
     #
     # Git config


### PR DESCRIPTION
### Summary

In the python client, calling `delete_branch` or `delete_namespace` raised `DJClientException` on 404s, forcing callers to either pre-check existence or wrap calls in try/except to handle the resource-already-absent case. That's not how `DELETE` should behave; it's defined as idempotent in HTTP semantics.

With this fix, both methods now treat 404 as success and return None. Other 4xx/5xx responses still raise as before.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
