### PR TITLE
Catch invalid column references in SQL gen requests

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -179,6 +179,7 @@ def apply_orderby_limit(
         )
 
         resolved_sort_items = []
+        unknown: list[str] = []
         for sort_item in sort_items:
             # Get semantic name from the sort expression
             if isinstance(sort_item.expr, ast.Column):
@@ -197,9 +198,26 @@ def apply_orderby_limit(
                     ),
                 )
             else:
-                logger.warning(
-                    f"[BuildV3] ORDER BY '{semantic_name}' not found in columns, skipping",
+                unknown.append(semantic_name)
+
+        if unknown:
+            from datajunction_server.errors import DJError, ErrorCode
+
+            available = sorted(semantic_to_output.keys())
+            unique_unknown = list(dict.fromkeys(unknown))
+            available_str = ", ".join(f"`{n}`" for n in available)
+            errors = [
+                DJError(
+                    code=ErrorCode.INVALID_ORDER_BY,
+                    message=(
+                        f"ORDER BY references unknown column `{ref}`. "
+                        f"Use one of the requested metric or dimension names: "
+                        f"{available_str}."
+                    ),
                 )
+                for ref in unique_unknown
+            ]
+            raise DJInvalidInputException(errors=errors)
 
         if resolved_sort_items:
             select.organization = ast.Organization(order=resolved_sort_items)

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -46,7 +46,7 @@ from datajunction_server.construction.build_v3.utils import (
     add_dimensions_from_metric_expressions,
 )
 from datajunction_server.database.partition import Partition
-from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.errors import DJError, DJInvalidInputException, ErrorCode
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.partition import PartitionType
 from datajunction_server.sql.parsing import ast
@@ -201,8 +201,6 @@ def apply_orderby_limit(
                 unknown.append(semantic_name)
 
         if unknown:
-            from datajunction_server.errors import DJError, ErrorCode
-
             available = sorted(semantic_to_output.keys())
             unique_unknown = list(dict.fromkeys(unknown))
             available_str = ", ".join(f"`{n}`" for n in available)

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -217,7 +217,11 @@ def apply_orderby_limit(
             ]
             raise DJInvalidInputException(errors=errors)
 
-        if resolved_sort_items:
+        # Always non-empty when ``orderby`` is non-empty: every sort_item
+        # either resolves (and goes into ``resolved_sort_items``) or fails
+        # (and we raise above). Kept explicit so the type checker sees the
+        # narrowing.
+        if resolved_sort_items:  # pragma: no branch
             select.organization = ast.Organization(order=resolved_sort_items)
 
     # Apply LIMIT

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -561,6 +561,7 @@ def build_synthetic_grain_group(
             ctx.dimension_filters,
             dimension_aliases,
             cte_alias=None,  # No CTE alias - selecting directly from cube table
+            nodes=ctx.nodes,
         )
 
     # Build SELECT ... FROM cube_table WHERE filters

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -4,6 +4,7 @@ Dimension + join path resolution and building functions
 
 from __future__ import annotations
 
+import difflib
 from http import HTTPStatus
 import logging
 from typing import Optional, cast
@@ -12,7 +13,12 @@ from datajunction_server.construction.build_v3.utils import (
     get_short_name,
     make_name,
 )
-from datajunction_server.errors import DJException
+from datajunction_server.errors import (
+    DJError,
+    DJException,
+    DJInvalidInputException,
+    ErrorCode,
+)
 from datajunction_server.construction.build_v3.materialization import (
     get_table_reference_parts_with_materialization,
 )
@@ -184,6 +190,50 @@ def can_skip_join_for_dimension(
     return False, None
 
 
+def _format_column_validation_error(
+    node: Node,
+    column_name: str,
+    original_ref: str,
+) -> str | None:
+    """
+    Return an error message string when ``column_name`` is not on ``node``,
+    or ``None`` when the column is valid (or the node has no loaded columns).
+
+    This is the non-raising form of ``_validate_column_on_node``. Use it when
+    you want to batch multiple validation errors into a single exception
+    instead of raising on the first failure.
+    """
+    if not node.current or not node.current.columns:  # pragma: no cover
+        return None
+
+    available = [col.name for col in node.current.columns]
+    if column_name in available:
+        return None
+
+    suggestions = difflib.get_close_matches(column_name, available, n=3, cutoff=0.6)
+    suffix = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+    return (
+        f"Column `{column_name}` does not exist on node `{node.name}` "
+        f"(referenced as `{original_ref}`).{suffix}"
+    )
+
+
+def _validate_column_on_node(
+    node: Node,
+    column_name: str,
+    original_ref: str,
+) -> None:
+    """
+    Raise DJInvalidInputException if ``column_name`` is not a column on ``node``.
+
+    Catches typos and stale references early, before they leak into generated
+    SQL where they only surface as engine-level errors at execution time.
+    """
+    message = _format_column_validation_error(node, column_name, original_ref)
+    if message is not None:
+        raise DJInvalidInputException(message)
+
+
 def resolve_dimensions(
     ctx: BuildContext,
     parent_node: Node,
@@ -197,6 +247,7 @@ def resolve_dimensions(
     Returns a list of ResolvedDimension objects with join path information.
     """
     resolved = []
+    column_errors: list[str] = []
 
     for dim in ctx.dimensions:
         dim_ref = parse_dimension_ref(dim)
@@ -213,6 +264,14 @@ def resolve_dimensions(
             dim_ref.node_name = parent_node.name
 
         if is_local:
+            err = _format_column_validation_error(
+                parent_node,
+                dim_ref.column_name,
+                dim,
+            )
+            if err is not None:
+                column_errors.append(err)
+                continue
             resolved.append(
                 ResolvedDimension(
                     original_ref=dim,
@@ -254,6 +313,17 @@ def resolve_dimensions(
                     f"Please create a dimension link between these nodes.",
                 )
 
+            # Validate column exists on the target dimension node before we
+            # commit to a column reference that might never resolve.
+            err = _format_column_validation_error(
+                join_path.target_dimension,
+                dim_ref.column_name,
+                dim,
+            )
+            if err is not None:
+                column_errors.append(err)
+                continue
+
             # Optimization: if requesting the join key column, skip the join
             can_skip, local_col = can_skip_join_for_dimension(
                 dim_ref,
@@ -285,6 +355,14 @@ def resolve_dimensions(
                         is_local=False,
                     ),
                 )
+
+    if column_errors:
+        raise DJInvalidInputException(
+            errors=[
+                DJError(code=ErrorCode.INVALID_COLUMN, message=msg)
+                for msg in column_errors
+            ],
+        )
 
     return resolved
 

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -199,9 +199,8 @@ def _format_column_validation_error(
     Return an error message string when ``column_name`` is not on ``node``,
     or ``None`` when the column is valid (or the node has no loaded columns).
 
-    This is the non-raising form of ``_validate_column_on_node``. Use it when
-    you want to batch multiple validation errors into a single exception
-    instead of raising on the first failure.
+    This batches multiple validation errors into a single exception instead
+    of raising on the first failure.
     """
     if not node.current or not node.current.columns:  # pragma: no cover
         return None
@@ -216,22 +215,6 @@ def _format_column_validation_error(
         f"Column `{column_name}` does not exist on node `{node.name}` "
         f"(referenced as `{original_ref}`).{suffix}"
     )
-
-
-def _validate_column_on_node(
-    node: Node,
-    column_name: str,
-    original_ref: str,
-) -> None:
-    """
-    Raise DJInvalidInputException if ``column_name`` is not a column on ``node``.
-
-    Catches typos and stale references early, before they leak into generated
-    SQL where they only surface as engine-level errors at execution time.
-    """
-    message = _format_column_validation_error(node, column_name, original_ref)
-    if message is not None:
-        raise DJInvalidInputException(message)
 
 
 def resolve_dimensions(

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -86,7 +86,8 @@ def _raise_for_unresolved_filter_refs(
     All ref-level messages are joined with newlines so the user sees every
     bad reference at once rather than fixing them one round-trip at a time.
     """
-    # Local import to avoid the dimensions <-> filters cycle at import time.
+    # Local import: ``dimensions`` -> ``utils`` -> ``filters`` is an existing
+    # import chain, so importing ``dimensions`` at module top would cycle.
     from datajunction_server.construction.build_v3.dimensions import (
         _format_column_validation_error,
         parse_dimension_ref,

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -200,7 +200,7 @@ def resolve_filter_references(
         # later flagged as an unresolved reference.
         if isinstance(subscript.index, ast.Column):
             role_marker_ids.add(id(subscript.index))
-        if hasattr(subscript.index, "find_all"):
+        if hasattr(subscript.index, "find_all"):  # pragma: no branch
             for inner_col in subscript.index.find_all(ast.Column):
                 role_marker_ids.add(id(inner_col))
 
@@ -251,7 +251,7 @@ def resolve_filter_references(
                     node.name = ast.Name(col_alias, namespace=ast.Name(cte_alias))
                 else:
                     node.name = ast.Name(col_alias)
-            elif full_ref:
+            elif full_ref:  # pragma: no branch
                 unresolved.append(full_ref)
 
         # Recursively process children

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -330,9 +330,7 @@ def parse_and_resolve_filters(
         filter_strs: List of filter strings
         column_aliases: Map from dimension ref to alias
         cte_alias: Optional CTE alias to prefix column refs with
-        nodes: Optional ``ctx.nodes`` map. When provided, unresolved-ref errors
-            are escalated through ``_validate_column_on_node`` so callers get
-            actionable "Did you mean?" suggestions for typos.
+        nodes: Optional ``ctx.nodes`` map.
 
     Returns:
         Combined filter expression or None if no filters

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -78,6 +78,11 @@ def resolve_filter_references(
     "v3.date.month[order] >= 2024" where [order] is the role indicator.
     The SQL parser interprets [order] as an array subscript (ast.Subscript).
 
+    Any column reference that does not resolve to an entry in ``column_aliases``
+    raises ``DJInvalidInputException``. This is the last line of defense
+    against typos that would otherwise leak into the generated SQL and only
+    surface as engine-level errors at execution time.
+
     Args:
         filter_ast: The parsed filter expression (will be mutated!)
         column_aliases: Map from dimension ref (e.g., "v3.product.category") to alias (e.g., "category")
@@ -93,6 +98,16 @@ def resolve_filter_references(
         resolve_filter_references(filter_ast, aliases, "t2")
         # Now filter_ast contains "t2.category = 'Electronics'"
     """
+    # Track Column nodes that appear inside Subscript indexes — these are
+    # role markers (e.g., "order" in "dim.col[order]"), not real column refs,
+    # and must be excluded from the unresolved-ref check below.
+    role_marker_ids: set[int] = set()
+
+    # Track Column nodes inserted by the subscript pass below. Their names
+    # already point at the resolved alias (not a known column_aliases key),
+    # so the second-pass walk must skip them rather than re-resolve or flag.
+    already_resolved_ids: set[int] = set()
+
     # First pass: handle Subscript nodes that represent role-suffixed dimension refs.
     # The SQL parser interprets "dim.col[role]" as Subscript(Column("dim.col"), Column("role")).
     # We need to reconstruct the full dim ref with role and replace the entire Subscript.
@@ -107,6 +122,14 @@ def resolve_filter_references(
         role = extract_subscript_role(subscript)
         if not role:
             continue  # pragma: no cover
+
+        # Mark every Column under the index as a role marker so it isn't
+        # later flagged as an unresolved reference.
+        if isinstance(subscript.index, ast.Column):
+            role_marker_ids.add(id(subscript.index))
+        if hasattr(subscript.index, "find_all"):
+            for inner_col in subscript.index.find_all(ast.Column):
+                role_marker_ids.add(id(inner_col))
 
         # Look up with role first, then fall back to base ref without role
         dim_ref_with_role = f"{base_col_ref}[{role}]"
@@ -129,12 +152,25 @@ def resolve_filter_references(
                 name=ast.Name(col_name_for_replacement),
                 _table=ast.Table(ast.Name(cte_alias)) if cte_alias else None,
             )
+            already_resolved_ids.add(id(replacement))
             subscript.swap(replacement)
+        else:
+            raise DJInvalidInputException(
+                f"Filter references unknown dimension `{dim_ref_with_role}`. "
+                f"Make sure the dimension exists and is reachable from the "
+                f"requested metrics.",
+            )
 
     # Second pass: handle regular Column references (no subscript role syntax)
+    unresolved: list[str] = []
+
     def resolve_refs(node: ast.Expression) -> None:
         """Recursively resolve column references in the AST."""
-        if isinstance(node, ast.Column):
+        if (
+            isinstance(node, ast.Column)
+            and id(node) not in role_marker_ids
+            and id(node) not in already_resolved_ids
+        ):
             # Reconstruct the full reference from the column name
             # Column names may be namespaced (e.g., v3.product.category)
             full_ref = _extract_full_column_ref(node)
@@ -146,6 +182,8 @@ def resolve_filter_references(
                     node.name = ast.Name(col_alias, namespace=ast.Name(cte_alias))
                 else:
                     node.name = ast.Name(col_alias)
+            elif full_ref:
+                unresolved.append(full_ref)
 
         # Recursively process children
         if hasattr(node, "children"):  # pragma: no branch
@@ -154,6 +192,16 @@ def resolve_filter_references(
                     resolve_refs(child)
 
     resolve_refs(filter_ast)
+
+    if unresolved:
+        unique_refs = list(dict.fromkeys(unresolved))
+        joined = ", ".join(f"`{r}`" for r in unique_refs)
+        raise DJInvalidInputException(
+            f"Filter references unknown column(s): {joined}. "
+            f"Make sure each reference uses the `node.column` form and that "
+            f"the column exists on the referenced node.",
+        )
+
     return filter_ast
 
 

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -6,11 +6,19 @@ from __future__ import annotations
 
 from copy import deepcopy
 from functools import reduce
+from typing import TYPE_CHECKING
 
-from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.errors import (
+    DJError,
+    DJInvalidInputException,
+    ErrorCode,
+)
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.utils import SEPARATOR
+
+if TYPE_CHECKING:
+    from datajunction_server.database.node import Node
 
 
 def parse_filter(filter_str: str) -> ast.Expression:
@@ -63,10 +71,74 @@ def extract_subscript_role(subscript: ast.Subscript) -> str | None:
     return None  # pragma: no cover
 
 
+def _raise_for_unresolved_filter_refs(
+    refs: list[str],
+    nodes: dict[str, "Node"] | None,
+) -> None:
+    """
+    Raise a single DJInvalidInputException covering every unresolved filter ref.
+
+    When ``nodes`` is provided, each ref that decomposes into a known
+    ``node.column`` pair gets the rich "Column X does not exist on node Y
+    (Did you mean: ...?)" message from ``_format_column_validation_error``.
+    Refs that don't have a matching node fall back to a generic message.
+
+    All ref-level messages are joined with newlines so the user sees every
+    bad reference at once rather than fixing them one round-trip at a time.
+    """
+    # Local import to avoid the dimensions <-> filters cycle at import time.
+    from datajunction_server.construction.build_v3.dimensions import (
+        _format_column_validation_error,
+        parse_dimension_ref,
+    )
+
+    unique = list(dict.fromkeys(refs))
+    errors: list[DJError] = []
+    fallback_refs: list[str] = []
+
+    for ref in unique:
+        rich_message: str | None = None
+        if nodes:
+            try:
+                dim_ref = parse_dimension_ref(ref)
+            except DJInvalidInputException:
+                dim_ref = None
+            if dim_ref is not None:
+                node = nodes.get(dim_ref.node_name)
+                if node is not None:
+                    rich_message = _format_column_validation_error(
+                        node,
+                        dim_ref.column_name,
+                        ref,
+                    )
+        if rich_message is not None:
+            errors.append(
+                DJError(code=ErrorCode.INVALID_COLUMN_IN_FILTER, message=rich_message),
+            )
+        else:
+            fallback_refs.append(ref)
+
+    if fallback_refs:
+        joined = ", ".join(f"`{r}`" for r in fallback_refs)
+        errors.append(
+            DJError(
+                code=ErrorCode.INVALID_COLUMN_IN_FILTER,
+                message=(
+                    f"Filter references unknown column(s): {joined}. "
+                    f"Make sure each reference uses the `node.column` form and that "
+                    f"the column exists on the referenced node."
+                ),
+            ),
+        )
+
+    raise DJInvalidInputException(errors=errors)
+
+
 def resolve_filter_references(
     filter_ast: ast.Expression,
     column_aliases: dict[str, str],
     cte_alias: str | None = None,
+    nodes: dict[str, "Node"] | None = None,
 ) -> ast.Expression:
     """
     Resolve dimension/column references in a filter AST to their actual column aliases.
@@ -155,11 +227,7 @@ def resolve_filter_references(
             already_resolved_ids.add(id(replacement))
             subscript.swap(replacement)
         else:
-            raise DJInvalidInputException(
-                f"Filter references unknown dimension `{dim_ref_with_role}`. "
-                f"Make sure the dimension exists and is reachable from the "
-                f"requested metrics.",
-            )
+            _raise_for_unresolved_filter_refs([dim_ref_with_role], nodes)
 
     # Second pass: handle regular Column references (no subscript role syntax)
     unresolved: list[str] = []
@@ -194,13 +262,7 @@ def resolve_filter_references(
     resolve_refs(filter_ast)
 
     if unresolved:
-        unique_refs = list(dict.fromkeys(unresolved))
-        joined = ", ".join(f"`{r}`" for r in unique_refs)
-        raise DJInvalidInputException(
-            f"Filter references unknown column(s): {joined}. "
-            f"Make sure each reference uses the `node.column` form and that "
-            f"the column exists on the referenced node.",
-        )
+        _raise_for_unresolved_filter_refs(unresolved, nodes)
 
     return filter_ast
 
@@ -255,6 +317,7 @@ def parse_and_resolve_filters(
     filter_strs: list[str],
     column_aliases: dict[str, str],
     cte_alias: str | None = None,
+    nodes: dict[str, "Node"] | None = None,
 ) -> ast.Expression | None:
     """
     Parse filter strings and resolve references, returning combined WHERE clause.
@@ -266,6 +329,9 @@ def parse_and_resolve_filters(
         filter_strs: List of filter strings
         column_aliases: Map from dimension ref to alias
         cte_alias: Optional CTE alias to prefix column refs with
+        nodes: Optional ``ctx.nodes`` map. When provided, unresolved-ref errors
+            are escalated through ``_validate_column_on_node`` so callers get
+            actionable "Did you mean?" suggestions for typos.
 
     Returns:
         Combined filter expression or None if no filters
@@ -286,6 +352,7 @@ def parse_and_resolve_filters(
             deepcopy(filter_ast),  # Make a copy to avoid mutating cache
             column_aliases,
             cte_alias,
+            nodes=nodes,
         )
         parsed_filters.append(resolved)
 

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -607,6 +607,7 @@ def build_outer_where(
     main_alias: str,
     dim_aliases: dict[tuple[str, Optional[str]], str],
     parent_node: Node,
+    nodes: Optional[dict[str, Node]] = None,
 ) -> Optional[ast.Expression]:
     """Parse user filters and resolve column references for the outer WHERE clause.
 
@@ -617,6 +618,7 @@ def build_outer_where(
         filters,
         filter_column_aliases,
         cte_alias=None,
+        nodes=nodes,
     )
     if where_clause:  # pragma: no branch
         _add_table_prefixes_to_filter(
@@ -964,6 +966,7 @@ def build_select_ast(
             main_alias,
             dim_aliases,
             parent_node,
+            nodes=ctx.nodes,
         )
 
     # Build CTEs for all non-source nodes. Requested dimension filters and their

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -23,10 +23,6 @@ from datajunction_server.construction.build_v3.cte import (
     replace_dimension_refs_in_ast,
     replace_metric_refs_in_ast,
 )
-from datajunction_server.construction.build_v3.dimensions import (
-    _format_column_validation_error,
-    parse_dimension_ref,
-)
 from datajunction_server.construction.build_v3.filters import (
     combine_filters,
     get_filter_column_references,
@@ -51,7 +47,7 @@ from datajunction_server.construction.build_v3.types import (
     GrainGroupSQL,
     MetricExprInfo,
 )
-from datajunction_server.errors import DJError, DJInvalidInputException, ErrorCode
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.parsing import ast
@@ -2150,76 +2146,26 @@ def generate_metrics_sql(
 
     # Build HAVING clause from metric filters
     # Metric filters are applied after aggregation on computed metric values
-    # Use full aggregation expressions (not aliases) for SQL dialect portability
+    # Use full aggregation expressions (not aliases) for SQL dialect portability.
+    # Note: typo'd column refs in metric filters are caught upstream by
+    # ``add_dimensions_from_filters`` + ``resolve_dimensions`` — by the time
+    # we reach this block, every Column is either a known metric (replaced
+    # below) or a known dimension (passes through to engine-side resolution).
     having_clause: Optional[ast.Expression] = None
     if metric_filters_raw:
-        # Parse and resolve metric filters
-        # Replace metric references with their full aggregation expressions
         parsed_metric_filters = []
-        having_unknown: list[str] = []
         for f in metric_filters_raw:
             filter_ast = parse_filter(f)
 
             # Replace metric column references with their full aggregation expressions
-            # This ensures compatibility across all SQL dialects (some don't support aliases in HAVING)
-            # Use the AST's built-in replace() method for clean, robust replacement
+            # so HAVING is portable across dialects that don't support aliases there.
             for col in filter_ast.find_all(ast.Column):
                 full_name = get_column_full_name(col)
-                if not full_name:
-                    continue  # pragma: no cover
-                if full_name in metric_expr_asts:
-                    # Replace this column node with the metric's full expression
+                if full_name and full_name in metric_expr_asts:  # pragma: no branch
                     metric_expr = metric_expr_asts[full_name].expr_ast
                     filter_ast.replace(from_=col, to=metric_expr, copy=True)
-                elif full_name not in dimension_aliases:
-                    # Anything that is neither a known metric expression nor a
-                    # known dimension is a typo / stale ref — surface it now
-                    # rather than letting it leak into the HAVING clause.
-                    having_unknown.append(full_name)
 
             parsed_metric_filters.append(filter_ast)
-
-        if having_unknown:
-            unique = list(dict.fromkeys(having_unknown))
-            errors: list[DJError] = []
-            fallback_refs: list[str] = []
-            for ref in unique:
-                rich: str | None = None
-                try:
-                    parsed = parse_dimension_ref(ref)
-                except DJInvalidInputException:
-                    parsed = None
-                if parsed is not None:
-                    node = ctx.nodes.get(parsed.node_name)
-                    if node is not None:
-                        rich = _format_column_validation_error(
-                            node,
-                            parsed.column_name,
-                            ref,
-                        )
-                if rich is not None:
-                    errors.append(
-                        DJError(
-                            code=ErrorCode.INVALID_COLUMN_IN_FILTER,
-                            message=rich,
-                        ),
-                    )
-                else:
-                    fallback_refs.append(ref)
-
-            if fallback_refs:
-                joined = ", ".join(f"`{r}`" for r in fallback_refs)
-                errors.append(
-                    DJError(
-                        code=ErrorCode.INVALID_COLUMN_IN_FILTER,
-                        message=(
-                            f"Metric filter references unknown column(s): {joined}. "
-                            f"Use a metric or dimension that is part of the requested query."
-                        ),
-                    ),
-                )
-
-            raise DJInvalidInputException(errors=errors)
 
         if parsed_metric_filters:  # pragma: no branch
             having_clause = combine_filters(parsed_metric_filters)

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -23,6 +23,10 @@ from datajunction_server.construction.build_v3.cte import (
     replace_dimension_refs_in_ast,
     replace_metric_refs_in_ast,
 )
+from datajunction_server.construction.build_v3.dimensions import (
+    _format_column_validation_error,
+    parse_dimension_ref,
+)
 from datajunction_server.construction.build_v3.filters import (
     combine_filters,
     get_filter_column_references,
@@ -47,7 +51,7 @@ from datajunction_server.construction.build_v3.types import (
     GrainGroupSQL,
     MetricExprInfo,
 )
-from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.errors import DJError, DJInvalidInputException, ErrorCode
 from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.parsing import ast
@@ -2176,12 +2180,6 @@ def generate_metrics_sql(
             parsed_metric_filters.append(filter_ast)
 
         if having_unknown:
-            from datajunction_server.construction.build_v3.dimensions import (
-                _format_column_validation_error,
-                parse_dimension_ref,
-            )
-            from datajunction_server.errors import DJError, ErrorCode
-
             unique = list(dict.fromkeys(having_unknown))
             errors: list[DJError] = []
             fallback_refs: list[str] = []

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -2141,6 +2141,7 @@ def generate_metrics_sql(
                 applicable_dimension_filters,
                 dimension_aliases,
                 cte_alias=filter_cte,
+                nodes=ctx.nodes,
             )
 
     # Build HAVING clause from metric filters
@@ -2151,6 +2152,7 @@ def generate_metrics_sql(
         # Parse and resolve metric filters
         # Replace metric references with their full aggregation expressions
         parsed_metric_filters = []
+        having_unknown: list[str] = []
         for f in metric_filters_raw:
             filter_ast = parse_filter(f)
 
@@ -2159,12 +2161,67 @@ def generate_metrics_sql(
             # Use the AST's built-in replace() method for clean, robust replacement
             for col in filter_ast.find_all(ast.Column):
                 full_name = get_column_full_name(col)
-                if full_name and full_name in metric_expr_asts:  # pragma: no branch
+                if not full_name:
+                    continue  # pragma: no cover
+                if full_name in metric_expr_asts:
                     # Replace this column node with the metric's full expression
                     metric_expr = metric_expr_asts[full_name].expr_ast
                     filter_ast.replace(from_=col, to=metric_expr, copy=True)
+                elif full_name not in dimension_aliases:
+                    # Anything that is neither a known metric expression nor a
+                    # known dimension is a typo / stale ref — surface it now
+                    # rather than letting it leak into the HAVING clause.
+                    having_unknown.append(full_name)
 
             parsed_metric_filters.append(filter_ast)
+
+        if having_unknown:
+            from datajunction_server.construction.build_v3.dimensions import (
+                _format_column_validation_error,
+                parse_dimension_ref,
+            )
+            from datajunction_server.errors import DJError, ErrorCode
+
+            unique = list(dict.fromkeys(having_unknown))
+            errors: list[DJError] = []
+            fallback_refs: list[str] = []
+            for ref in unique:
+                rich: str | None = None
+                try:
+                    parsed = parse_dimension_ref(ref)
+                except DJInvalidInputException:
+                    parsed = None
+                if parsed is not None:
+                    node = ctx.nodes.get(parsed.node_name)
+                    if node is not None:
+                        rich = _format_column_validation_error(
+                            node,
+                            parsed.column_name,
+                            ref,
+                        )
+                if rich is not None:
+                    errors.append(
+                        DJError(
+                            code=ErrorCode.INVALID_COLUMN_IN_FILTER,
+                            message=rich,
+                        ),
+                    )
+                else:
+                    fallback_refs.append(ref)
+
+            if fallback_refs:
+                joined = ", ".join(f"`{r}`" for r in fallback_refs)
+                errors.append(
+                    DJError(
+                        code=ErrorCode.INVALID_COLUMN_IN_FILTER,
+                        message=(
+                            f"Metric filter references unknown column(s): {joined}. "
+                            f"Use a metric or dimension that is part of the requested query."
+                        ),
+                    ),
+                )
+
+            raise DJInvalidInputException(errors=errors)
 
         if parsed_metric_filters:  # pragma: no branch
             having_clause = combine_filters(parsed_metric_filters)

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -694,6 +694,45 @@ class TestFilterHelpers:
         ]
         assert exc_info.value.message == "\n".join(error_messages)
 
+    def test_resolve_filter_references_falls_back_when_ref_isnt_node_qualified(self):
+        """A bare unresolved column ref (no ``node.column`` form) cannot be
+        validated against any node, so the safety net falls back to the
+        generic message even when ``nodes`` is supplied. Covers the parse
+        failure branch in ``_raise_for_unresolved_filter_refs``.
+        """
+        filter_ast = parse_filter("bare_col = 'x'")
+        nodes = {
+            "v3.product": _make_node_with_columns(
+                "v3.product",
+                ["category", "price"],
+            ),
+        }
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, {}, nodes=nodes)
+        assert exc_info.value.message == (
+            "Filter references unknown column(s): `bare_col`. "
+            "Make sure each reference uses the `node.column` form and that "
+            "the column exists on the referenced node."
+        )
+
+    def test_resolve_filter_references_falls_back_when_node_not_loaded(self):
+        """A qualified ref whose node isn't in the supplied ``nodes`` dict
+        also falls back to the generic message — we can't construct the
+        rich "Did you mean?" without the node's column list. Covers the
+        ``node is None`` branch.
+        """
+        filter_ast = parse_filter("v3.unloaded_node.some_col = 'x'")
+        nodes = {
+            "v3.product": _make_node_with_columns("v3.product", ["category"]),
+        }
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, {}, nodes=nodes)
+        assert exc_info.value.message == (
+            "Filter references unknown column(s): `v3.unloaded_node.some_col`. "
+            "Make sure each reference uses the `node.column` form and that "
+            "the column exists on the referenced node."
+        )
+
 
 class TestAddTablePrefixesToFilter:
     """Tests for the _add_table_prefixes_to_filter helper in measures.py."""

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -562,32 +562,56 @@ class TestFilterHelpers:
         assert "order_details_0.country_home" in result_str
 
     def test_resolve_filter_references_unrecognized_subscript_index(self):
-        """Test that subscripts with unrecognized index types (not Column/Name/Lambda) are skipped.
+        """A subscript with a non-role index whose base column has no alias is rejected.
 
-        Covers the branch where subscript.index is neither ast.Column, ast.Name, nor
-        ast.Lambda (e.g., a numeric literal), so role stays None and the subscript
-        is left unchanged.
+        ``arr[0] = 'x'`` references unknown column ``arr``. The unresolved-ref
+        guard surfaces it as a DJInvalidInputException rather than letting the
+        broken reference reach the generated SQL.
         """
-        # arr[0] has a numeric index — not a role marker
         filter_ast = parse_filter("arr[0] = 'x'")
-        aliases = {}
-        result = resolve_filter_references(filter_ast, aliases)
-        # Subscript with unrecognized index is preserved as-is
-        assert result is not None
-        assert "[0]" in str(result)
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, {})
+        assert "arr" in str(exc_info.value)
 
     def test_resolve_filter_references_role_not_in_aliases(self):
-        """Test that a role-subscript whose role doesn't appear in aliases is left unchanged.
+        """A role-subscript whose role doesn't appear in aliases is rejected.
 
-        Covers the branch where role is successfully extracted (Column index) but
-        alias_to_use is None (neither the role-qualified ref nor the base ref is in aliases).
+        Previously the subscript was silently left unchanged, producing invalid
+        SQL like ``t1.year[order] >= 2024``. We now raise so the bad reference
+        is surfaced before SQL is built.
         """
         filter_ast = parse_filter("v3.date.year[order] >= 2024")
-        # Empty aliases — the role 'order' is extracted but maps to nothing
-        result = resolve_filter_references(filter_ast, {})
-        # Subscript is preserved because there's no alias to replace it with
-        assert result is not None
-        assert "[order]" in str(result)
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, {})
+        assert "v3.date.year[order]" in str(exc_info.value)
+
+    def test_resolve_filter_references_unknown_column_raises(self):
+        """An unknown qualified column ref is rejected by the safety net.
+
+        Regression guard for a real incident where a filter referenced
+        ``some.fact.dateint`` — a column that did not exist on that node.
+        DJ used to silently emit the bad column into the WHERE clause; now
+        it raises with the offending ref in the message.
+        """
+        filter_ast = parse_filter(
+            "arc.main.season_market.dateint BETWEEN 20260401 AND 20260429",
+        )
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, {})
+        assert "arc.main.season_market.dateint" in str(exc_info.value)
+
+    def test_resolve_filter_references_partial_resolution_raises(self):
+        """If one column resolves but another doesn't, the unresolved ref still raises."""
+        filter_ast = parse_filter(
+            "v3.product.category = 'X' AND v3.product.bogus = 'Y'",
+        )
+        aliases = {"v3.product.category": "category"}
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, aliases)
+        msg = str(exc_info.value)
+        assert "v3.product.bogus" in msg
+        # The valid ref shouldn't be flagged
+        assert "v3.product.category`" not in msg
 
 
 class TestAddTablePrefixesToFilter:

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -20,7 +20,6 @@ from datajunction_server.construction.build_v3.decomposition import (
     get_native_grain,
 )
 from datajunction_server.construction.build_v3.dimensions import (
-    _validate_column_on_node,
     parse_dimension_ref,
 )
 from datajunction_server.construction.build_v3.filters import (
@@ -118,96 +117,6 @@ def _make_node_with_columns(name: str, columns: list[str]) -> MagicMock:
     node.name = name
     node.current = rev
     return node
-
-
-class TestValidateColumnOnNode:
-    """Tests for the ``_validate_column_on_node`` helper.
-
-    The helper is the gate that prevents typo'd dimension columns from
-    being silently woven into generated SQL and only failing at engine runtime.
-    """
-
-    def test_existing_column_passes(self):
-        """A column that exists on the node validates without raising."""
-        node = _make_node_with_columns(
-            "arc.main.season_market_r",
-            ["market_code", "season_title_id"],
-        )
-        # Should not raise
-        _validate_column_on_node(
-            node,
-            "market_code",
-            "arc.main.season_market_r.market_code",
-        )
-
-    def test_missing_column_raises(self):
-        """A column that does not exist on the node raises with details.
-
-        Regression guard for the ``season_market_r.dateint`` incident — that
-        column wasn't on the node, but DJ used to compile the bad ref into
-        the WHERE clause anyway.
-        """
-        node = _make_node_with_columns(
-            "arc.main.season_market_r",
-            ["market_code", "season_title_id"],
-        )
-        with pytest.raises(DJInvalidInputException) as exc_info:
-            _validate_column_on_node(
-                node,
-                "dateint",
-                "arc.main.season_market_r.dateint",
-            )
-        assert exc_info.value.message == (
-            "Column `dateint` does not exist on node `arc.main.season_market_r` "
-            "(referenced as `arc.main.season_market_r.dateint`)."
-        )
-
-    def test_missing_column_includes_did_you_mean(self):
-        """Close-spelled columns are surfaced as suggestions in the error."""
-        node = _make_node_with_columns(
-            "v3.customer",
-            ["customer_id", "customer_name", "address"],
-        )
-        with pytest.raises(DJInvalidInputException) as exc_info:
-            _validate_column_on_node(
-                node,
-                "custmer_name",  # typo
-                "v3.customer.custmer_name",
-            )
-        assert exc_info.value.message == (
-            "Column `custmer_name` does not exist on node `v3.customer` "
-            "(referenced as `v3.customer.custmer_name`). "
-            "Did you mean: customer_name, customer_id?"
-        )
-
-    def test_no_suggestions_when_nothing_close(self):
-        """When no available column resembles the bad ref, the message has no
-        ``Did you mean`` suffix — we don't want to surface noise.
-        """
-        node = _make_node_with_columns(
-            "v3.customer",
-            ["customer_id", "address"],
-        )
-        with pytest.raises(DJInvalidInputException) as exc_info:
-            _validate_column_on_node(
-                node,
-                "completely_unrelated",
-                "v3.customer.completely_unrelated",
-            )
-        assert exc_info.value.message == (
-            "Column `completely_unrelated` does not exist on node `v3.customer` "
-            "(referenced as `v3.customer.completely_unrelated`)."
-        )
-
-    def test_node_without_columns_skips_validation(self):
-        """A node with no loaded columns is skipped — validation can't make a
-        determination without the schema, and forcing an error here would
-        regress legitimate paths where columns aren't loaded."""
-        node = MagicMock()
-        node.name = "v3.empty"
-        node.current = None
-        # Should not raise
-        _validate_column_on_node(node, "anything", "v3.empty.anything")
 
 
 class TestMakeColumnRef:
@@ -735,8 +644,8 @@ class TestFilterHelpers:
     def test_resolve_filter_references_unknown_column_with_nodes_uses_validate_helper(
         self,
     ):
-        """When ``nodes`` is plumbed in, the unresolved-ref message escalates to
-        ``_validate_column_on_node`` so the user gets the rich
+        """When ``nodes`` is plumbed in, the unresolved-ref message escalates
+        to ``_format_column_validation_error`` so the user gets the rich
         "Column X does not exist on node Y" error with suggestions.
         """
         filter_ast = parse_filter(

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -20,6 +20,7 @@ from datajunction_server.construction.build_v3.decomposition import (
     get_native_grain,
 )
 from datajunction_server.construction.build_v3.dimensions import (
+    _validate_column_on_node,
     parse_dimension_ref,
 )
 from datajunction_server.construction.build_v3.filters import (
@@ -102,6 +103,111 @@ class TestDimensionRefParsing:
         with an empty ``node_name`` that would silently match the wrong node."""
         with pytest.raises(DJInvalidInputException, match="not fully qualified"):
             parse_dimension_ref("status")
+
+
+def _make_node_with_columns(name: str, columns: list[str]) -> MagicMock:
+    """Build a Node mock whose ``current.columns`` exposes the given column names."""
+    mock_cols = []
+    for col_name in columns:
+        col = MagicMock()
+        col.name = col_name
+        mock_cols.append(col)
+    rev = MagicMock()
+    rev.columns = mock_cols
+    node = MagicMock()
+    node.name = name
+    node.current = rev
+    return node
+
+
+class TestValidateColumnOnNode:
+    """Tests for the ``_validate_column_on_node`` helper.
+
+    The helper is the gate that prevents typo'd dimension columns from
+    being silently woven into generated SQL and only failing at engine runtime.
+    """
+
+    def test_existing_column_passes(self):
+        """A column that exists on the node validates without raising."""
+        node = _make_node_with_columns(
+            "arc.main.season_market_r",
+            ["market_code", "season_title_id"],
+        )
+        # Should not raise
+        _validate_column_on_node(
+            node,
+            "market_code",
+            "arc.main.season_market_r.market_code",
+        )
+
+    def test_missing_column_raises(self):
+        """A column that does not exist on the node raises with details.
+
+        Regression guard for the ``season_market_r.dateint`` incident — that
+        column wasn't on the node, but DJ used to compile the bad ref into
+        the WHERE clause anyway.
+        """
+        node = _make_node_with_columns(
+            "arc.main.season_market_r",
+            ["market_code", "season_title_id"],
+        )
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            _validate_column_on_node(
+                node,
+                "dateint",
+                "arc.main.season_market_r.dateint",
+            )
+        assert exc_info.value.message == (
+            "Column `dateint` does not exist on node `arc.main.season_market_r` "
+            "(referenced as `arc.main.season_market_r.dateint`)."
+        )
+
+    def test_missing_column_includes_did_you_mean(self):
+        """Close-spelled columns are surfaced as suggestions in the error."""
+        node = _make_node_with_columns(
+            "v3.customer",
+            ["customer_id", "customer_name", "address"],
+        )
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            _validate_column_on_node(
+                node,
+                "custmer_name",  # typo
+                "v3.customer.custmer_name",
+            )
+        assert exc_info.value.message == (
+            "Column `custmer_name` does not exist on node `v3.customer` "
+            "(referenced as `v3.customer.custmer_name`). "
+            "Did you mean: customer_name, customer_id?"
+        )
+
+    def test_no_suggestions_when_nothing_close(self):
+        """When no available column resembles the bad ref, the message has no
+        ``Did you mean`` suffix — we don't want to surface noise.
+        """
+        node = _make_node_with_columns(
+            "v3.customer",
+            ["customer_id", "address"],
+        )
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            _validate_column_on_node(
+                node,
+                "completely_unrelated",
+                "v3.customer.completely_unrelated",
+            )
+        assert exc_info.value.message == (
+            "Column `completely_unrelated` does not exist on node `v3.customer` "
+            "(referenced as `v3.customer.completely_unrelated`)."
+        )
+
+    def test_node_without_columns_skips_validation(self):
+        """A node with no loaded columns is skipped — validation can't make a
+        determination without the schema, and forcing an error here would
+        regress legitimate paths where columns aren't loaded."""
+        node = MagicMock()
+        node.name = "v3.empty"
+        node.current = None
+        # Should not raise
+        _validate_column_on_node(node, "anything", "v3.empty.anything")
 
 
 class TestMakeColumnRef:
@@ -571,7 +677,11 @@ class TestFilterHelpers:
         filter_ast = parse_filter("arr[0] = 'x'")
         with pytest.raises(DJInvalidInputException) as exc_info:
             resolve_filter_references(filter_ast, {})
-        assert "arr" in str(exc_info.value)
+        assert exc_info.value.message == (
+            "Filter references unknown column(s): `arr`. "
+            "Make sure each reference uses the `node.column` form and that "
+            "the column exists on the referenced node."
+        )
 
     def test_resolve_filter_references_role_not_in_aliases(self):
         """A role-subscript whose role doesn't appear in aliases is rejected.
@@ -583,7 +693,11 @@ class TestFilterHelpers:
         filter_ast = parse_filter("v3.date.year[order] >= 2024")
         with pytest.raises(DJInvalidInputException) as exc_info:
             resolve_filter_references(filter_ast, {})
-        assert "v3.date.year[order]" in str(exc_info.value)
+        assert exc_info.value.message == (
+            "Filter references unknown column(s): `v3.date.year[order]`. "
+            "Make sure each reference uses the `node.column` form and that "
+            "the column exists on the referenced node."
+        )
 
     def test_resolve_filter_references_unknown_column_raises(self):
         """An unknown qualified column ref is rejected by the safety net.
@@ -598,7 +712,11 @@ class TestFilterHelpers:
         )
         with pytest.raises(DJInvalidInputException) as exc_info:
             resolve_filter_references(filter_ast, {})
-        assert "arc.main.season_market.dateint" in str(exc_info.value)
+        assert exc_info.value.message == (
+            "Filter references unknown column(s): `arc.main.season_market.dateint`. "
+            "Make sure each reference uses the `node.column` form and that "
+            "the column exists on the referenced node."
+        )
 
     def test_resolve_filter_references_partial_resolution_raises(self):
         """If one column resolves but another doesn't, the unresolved ref still raises."""
@@ -608,10 +726,64 @@ class TestFilterHelpers:
         aliases = {"v3.product.category": "category"}
         with pytest.raises(DJInvalidInputException) as exc_info:
             resolve_filter_references(filter_ast, aliases)
-        msg = str(exc_info.value)
-        assert "v3.product.bogus" in msg
-        # The valid ref shouldn't be flagged
-        assert "v3.product.category`" not in msg
+        assert exc_info.value.message == (
+            "Filter references unknown column(s): `v3.product.bogus`. "
+            "Make sure each reference uses the `node.column` form and that "
+            "the column exists on the referenced node."
+        )
+
+    def test_resolve_filter_references_unknown_column_with_nodes_uses_validate_helper(
+        self,
+    ):
+        """When ``nodes`` is plumbed in, the unresolved-ref message escalates to
+        ``_validate_column_on_node`` so the user gets the rich
+        "Column X does not exist on node Y" error with suggestions.
+        """
+        filter_ast = parse_filter(
+            "arc.main.season_market_r.dateint BETWEEN 20260401 AND 20260429",
+        )
+        nodes = {
+            "arc.main.season_market_r": _make_node_with_columns(
+                "arc.main.season_market_r",
+                ["market_code", "season_title_id"],
+            ),
+        }
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, {}, nodes=nodes)
+        assert exc_info.value.message == (
+            "Column `dateint` does not exist on node `arc.main.season_market_r` "
+            "(referenced as `arc.main.season_market_r.dateint`)."
+        )
+
+    def test_resolve_filter_references_batches_multiple_unknown_refs(self):
+        """Every unresolved ref shows up as its own DJError so the user can
+        fix them all at once instead of one round-trip per typo.
+        """
+        filter_ast = parse_filter(
+            "v3.product.bogus_a = 'X' AND v3.customer.bogus_b = 'Y' "
+            "AND v3.product.category = 'Z'",
+        )
+        aliases = {"v3.product.category": "category"}
+        nodes = {
+            "v3.product": _make_node_with_columns(
+                "v3.product",
+                ["category", "price"],
+            ),
+            "v3.customer": _make_node_with_columns(
+                "v3.customer",
+                ["customer_id", "name"],
+            ),
+        }
+        with pytest.raises(DJInvalidInputException) as exc_info:
+            resolve_filter_references(filter_ast, aliases, nodes=nodes)
+        error_messages = [e.message for e in exc_info.value.errors]
+        assert error_messages == [
+            "Column `bogus_a` does not exist on node `v3.product` "
+            "(referenced as `v3.product.bogus_a`).",
+            "Column `bogus_b` does not exist on node `v3.customer` "
+            "(referenced as `v3.customer.bogus_b`).",
+        ]
+        assert exc_info.value.message == "\n".join(error_messages)
 
 
 class TestAddTablePrefixesToFilter:

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -3506,10 +3506,11 @@ class TestMetricsSQLOrderByLimit:
         )
 
     @pytest.mark.asyncio
-    async def test_order_by_invalid_column_ignored(self, client_with_build_v3):
+    async def test_order_by_invalid_column_raises(self, client_with_build_v3):
         """
-        Test that invalid ORDER BY columns are ignored with a warning.
-        Valid columns should still work.
+        An ORDER BY referencing a name that's not in the result columns is
+        rejected with 422. Previously it was silently dropped, leaving the
+        user with unsorted results and no error to investigate.
         """
         response = await client_with_build_v3.get(
             "/sql/metrics/v3/",
@@ -3520,36 +3521,18 @@ class TestMetricsSQLOrderByLimit:
             },
         )
 
-        assert response.status_code == 200, response.json()
-        result = response.json()
-
-        # The invalid column should be skipped, valid one should work
-        assert_sql_equal(
-            result["sql"],
-            """
-            WITH
-            v3_order_details AS (
-                SELECT o.status, oi.quantity * oi.unit_price AS line_total
-                FROM default.v3.orders o
-                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-            ),
-            order_details_0 AS (
-                SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
-                FROM v3_order_details t1
-                GROUP BY t1.status
-            )
-            SELECT order_details_0.status AS status,
-                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
-            FROM order_details_0
-            GROUP BY order_details_0.status
-            ORDER BY total_revenue ASC
-            """,
-        )
+        assert response.status_code == 422, response.json()
+        message = response.json()["message"]
+        assert "v3.nonexistent_column" in message
+        # The valid name should also be surfaced as a hint
+        assert "v3.total_revenue" in message
 
     @pytest.mark.asyncio
-    async def test_order_by_all_invalid_columns(self, client_with_build_v3):
+    async def test_order_by_all_invalid_columns_raises(self, client_with_build_v3):
         """
-        Test that when all ORDER BY columns are invalid, no ORDER BY is added.
+        When every ORDER BY ref is unknown, the request is still rejected —
+        the prior behavior of silently dropping ORDER BY entirely produced
+        unsorted output that looked successful.
         """
         response = await client_with_build_v3.get(
             "/sql/metrics/v3/",
@@ -3560,30 +3543,8 @@ class TestMetricsSQLOrderByLimit:
             },
         )
 
-        assert response.status_code == 200, response.json()
-        result = response.json()
-
-        # No ORDER BY should be in the SQL since all columns were invalid
-        assert_sql_equal(
-            result["sql"],
-            """
-            WITH
-            v3_order_details AS (
-                SELECT o.status, oi.quantity * oi.unit_price AS line_total
-                FROM default.v3.orders o
-                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-            ),
-            order_details_0 AS (
-                SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
-                FROM v3_order_details t1
-                GROUP BY t1.status
-            )
-            SELECT order_details_0.status AS status,
-                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
-            FROM order_details_0
-            GROUP BY order_details_0.status
-            """,
-        )
+        assert response.status_code == 422, response.json()
+        assert "v3.nonexistent_column" in response.json()["message"]
 
 
 class TestFilterOnlyDimensions:

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -3521,11 +3521,24 @@ class TestMetricsSQLOrderByLimit:
             },
         )
 
-        assert response.status_code == 422, response.json()
-        message = response.json()["message"]
-        assert "v3.nonexistent_column" in message
-        # The valid name should also be surfaced as a hint
-        assert "v3.total_revenue" in message
+        expected_message = (
+            "ORDER BY references unknown column `v3.nonexistent_column`. "
+            "Use one of the requested metric or dimension names: "
+            "`v3.order_details.status`, `v3.total_revenue`."
+        )
+        assert response.status_code == 422
+        assert response.json() == {
+            "message": expected_message,
+            "errors": [
+                {
+                    "code": 208,
+                    "message": expected_message,
+                    "debug": None,
+                    "context": "",
+                },
+            ],
+            "warnings": [],
+        }
 
     @pytest.mark.asyncio
     async def test_order_by_all_invalid_columns_raises(self, client_with_build_v3):
@@ -3543,8 +3556,24 @@ class TestMetricsSQLOrderByLimit:
             },
         )
 
-        assert response.status_code == 422, response.json()
-        assert "v3.nonexistent_column" in response.json()["message"]
+        expected_message = (
+            "ORDER BY references unknown column `v3.nonexistent_column`. "
+            "Use one of the requested metric or dimension names: "
+            "`v3.order_details.status`, `v3.total_revenue`."
+        )
+        assert response.status_code == 422
+        assert response.json() == {
+            "message": expected_message,
+            "errors": [
+                {
+                    "code": 208,
+                    "message": expected_message,
+                    "debug": None,
+                    "context": "",
+                },
+            ],
+            "warnings": [],
+        }
 
 
 class TestFilterOnlyDimensions:

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -3575,6 +3575,44 @@ class TestMetricsSQLOrderByLimit:
             "warnings": [],
         }
 
+    @pytest.mark.asyncio
+    async def test_order_by_multiple_invalid_columns_batches_errors(
+        self,
+        client_with_build_v3,
+    ):
+        """Multiple invalid ORDER BY refs are surfaced as separate DJError
+        entries instead of being collapsed into a single message — so the
+        user can fix every typo in one shot.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "orderby": ["v3.bogus_a DESC", "v3.bogus_b ASC"],
+            },
+        )
+
+        msg_a = (
+            "ORDER BY references unknown column `v3.bogus_a`. "
+            "Use one of the requested metric or dimension names: "
+            "`v3.order_details.status`, `v3.total_revenue`."
+        )
+        msg_b = (
+            "ORDER BY references unknown column `v3.bogus_b`. "
+            "Use one of the requested metric or dimension names: "
+            "`v3.order_details.status`, `v3.total_revenue`."
+        )
+        assert response.status_code == 422
+        assert response.json() == {
+            "message": f"{msg_a}\n{msg_b}",
+            "errors": [
+                {"code": 208, "message": msg_a, "debug": None, "context": ""},
+                {"code": 208, "message": msg_b, "debug": None, "context": ""},
+            ],
+            "warnings": [],
+        }
+
 
 class TestFilterOnlyDimensions:
     """Tests for filter-only dimensions (dimensions in WHERE but not in GROUP BY)."""

--- a/datajunction-server/tests/construction/build_v3/node_query_test.py
+++ b/datajunction-server/tests/construction/build_v3/node_query_test.py
@@ -1290,3 +1290,50 @@ async def test_sql_for_cube_node_dispatches_to_metrics_sql(
     assert via_metrics_v3.status_code == 200, via_metrics_v3.json()
 
     assert_sql_equal(via_node.json()["sql"], via_metrics_v3.json()["sql"])
+
+
+@pytest.mark.asyncio
+async def test_sql_with_filter_on_nonexistent_column_on_local_node(
+    client_with_roads: AsyncClient,
+):
+    """
+    A filter that references a column that does not exist on the starting
+    node is rejected with a 422 and an actionable message — not silently
+    compiled into bad SQL that only fails at engine runtime.
+
+    Regression guard for the season_market.dateint incident.
+    """
+    response = await client_with_roads.get(
+        "/sql/default.repair_orders_fact/",
+        params={
+            "filters": ["default.repair_orders_fact.bogus_col > 100"],
+            "limit": 5,
+        },
+    )
+    assert response.status_code == 422, response.json()
+    message = response.json()["message"]
+    assert "bogus_col" in message
+    assert "default.repair_orders_fact" in message
+
+
+@pytest.mark.asyncio
+async def test_sql_with_filter_on_nonexistent_column_on_joined_dim(
+    client_with_roads: AsyncClient,
+):
+    """
+    A filter referencing a non-existent column on a *joined* dimension node
+    is also rejected. The join path is reachable, but the column itself is
+    unknown — that's the case where DJ used to emit ``tN.bogus_col`` and
+    only fail in the warehouse.
+    """
+    response = await client_with_roads.get(
+        "/sql/default.repair_orders_fact/",
+        params={
+            "filters": ["default.hard_hat.not_a_real_column = 'CA'"],
+            "limit": 3,
+        },
+    )
+    assert response.status_code == 422, response.json()
+    message = response.json()["message"]
+    assert "not_a_real_column" in message
+    assert "default.hard_hat" in message

--- a/datajunction-server/tests/construction/build_v3/node_query_test.py
+++ b/datajunction-server/tests/construction/build_v3/node_query_test.py
@@ -1182,8 +1182,37 @@ async def test_sql_orderby_unknown_column_raises(
             "limit": 2,
         },
     )
-    assert response.status_code == 422, response.json()
-    assert "default.nonexistent.column" in response.json()["message"]
+    expected_message = (
+        "ORDER BY references unknown column `default.nonexistent.column`. "
+        "Use one of the requested metric or dimension names: "
+        "`default.repair_orders_fact.discount`, "
+        "`default.repair_orders_fact.dispatch_delay`, "
+        "`default.repair_orders_fact.dispatched_date`, "
+        "`default.repair_orders_fact.dispatcher_id`, "
+        "`default.repair_orders_fact.hard_hat_id`, "
+        "`default.repair_orders_fact.municipality_id`, "
+        "`default.repair_orders_fact.order_date`, "
+        "`default.repair_orders_fact.price`, "
+        "`default.repair_orders_fact.quantity`, "
+        "`default.repair_orders_fact.repair_order_id`, "
+        "`default.repair_orders_fact.repair_type_id`, "
+        "`default.repair_orders_fact.required_date`, "
+        "`default.repair_orders_fact.time_to_dispatch`, "
+        "`default.repair_orders_fact.total_repair_cost`."
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "message": expected_message,
+        "errors": [
+            {
+                "code": 208,
+                "message": expected_message,
+                "debug": None,
+                "context": "",
+            },
+        ],
+        "warnings": [],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1283,10 +1312,23 @@ async def test_sql_with_filter_on_nonexistent_column_on_local_node(
             "limit": 5,
         },
     )
-    assert response.status_code == 422, response.json()
-    message = response.json()["message"]
-    assert "bogus_col" in message
-    assert "default.repair_orders_fact" in message
+    expected_message = (
+        "Column `bogus_col` does not exist on node `default.repair_orders_fact` "
+        "(referenced as `default.repair_orders_fact.bogus_col`)."
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "message": expected_message,
+        "errors": [
+            {
+                "code": 206,
+                "message": expected_message,
+                "debug": None,
+                "context": "",
+            },
+        ],
+        "warnings": [],
+    }
 
 
 @pytest.mark.asyncio
@@ -1306,7 +1348,20 @@ async def test_sql_with_filter_on_nonexistent_column_on_joined_dim(
             "limit": 3,
         },
     )
-    assert response.status_code == 422, response.json()
-    message = response.json()["message"]
-    assert "not_a_real_column" in message
-    assert "default.hard_hat" in message
+    expected_message = (
+        "Column `not_a_real_column` does not exist on node `default.hard_hat` "
+        "(referenced as `default.hard_hat.not_a_real_column`)."
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "message": expected_message,
+        "errors": [
+            {
+                "code": 206,
+                "message": expected_message,
+                "debug": None,
+                "context": "",
+            },
+        ],
+        "warnings": [],
+    }

--- a/datajunction-server/tests/construction/build_v3/node_query_test.py
+++ b/datajunction-server/tests/construction/build_v3/node_query_test.py
@@ -1167,13 +1167,13 @@ async def test_sql_with_orderby_on_dim_column(
 
 
 @pytest.mark.asyncio
-async def test_sql_orderby_unknown_column_is_skipped(
+async def test_sql_orderby_unknown_column_raises(
     client_with_roads: AsyncClient,
 ):
     """
-    ORDER BY references that don't resolve to any output column are dropped
-    with a warning rather than raising — same behavior as
-    ``apply_orderby_limit`` in the metrics path.
+    ORDER BY references that don't resolve to any output column are now
+    rejected with 422 instead of being silently dropped. Silently dropping
+    them previously produced unsorted output that looked successful.
     """
     response = await client_with_roads.get(
         "/sql/default.repair_orders_fact/",
@@ -1182,35 +1182,8 @@ async def test_sql_orderby_unknown_column_is_skipped(
             "limit": 2,
         },
     )
-    assert response.status_code == 200, response.json()
-
-    # No dims, no filters, no resolved orderby → simple Phase 1 shape +
-    # LIMIT only. The unknown ``default.nonexistent.column`` was silently
-    # skipped by ``apply_orderby_limit`` — same as the metrics path does.
-    assert_sql_equal(
-        response.json()["sql"],
-        """
-        SELECT
-          repair_orders.repair_order_id,
-          repair_orders.municipality_id,
-          repair_orders.hard_hat_id,
-          repair_orders.dispatcher_id,
-          repair_orders.order_date,
-          repair_orders.dispatched_date,
-          repair_orders.required_date,
-          repair_order_details.discount,
-          repair_order_details.price,
-          repair_order_details.quantity,
-          repair_order_details.repair_type_id,
-          repair_order_details.price * repair_order_details.quantity AS total_repair_cost,
-          repair_orders.dispatched_date - repair_orders.order_date AS time_to_dispatch,
-          repair_orders.dispatched_date - repair_orders.required_date AS dispatch_delay
-        FROM default.roads.repair_orders repair_orders
-        JOIN default.roads.repair_order_details repair_order_details
-          ON repair_orders.repair_order_id = repair_order_details.repair_order_id
-        LIMIT 2
-        """,
-    )
+    assert response.status_code == 422, response.json()
+    assert "default.nonexistent.column" in response.json()["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Catch invalid column references in SQL generation requests instead of letting them leak into the generated SQL. Previously an invalid column like `node.bogus_col` in a filter, dimension, or order by clause was silently woven into the `WHERE`/`SELECT`/`ORDER BY` and only failed at engine runtime. Users would get an opaque warehouse error instead of an actionable DJ error.

This PR adds validation at every entry point so that DJ rejects the request up front with a 422 and a `"Did you mean ...?"` suggestion.

All four paths populate `DJException.errors` with one `DJError` per bad reference (with appropriate `ErrorCode`: `INVALID_COLUMN`, `INVALID_COLUMN_IN_FILTER`, `INVALID_ORDER_BY`). The user sees every error in a single round-trip.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
