### PR TITLE
Role-qualified dimension usage for partition

### DIFF
--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -449,10 +449,18 @@ async def get_measures_query(
         parent_ast = rename_columns(parent_ast, parent_node.current, preaggregate)
 
         # Sort the selected columns into dimension vs measure columns and
-        # generate identifiers for them
+        # generate identifiers for them.
+        # The column identifier carries any role suffix
+        # (e.g. ``node.col[role]``) but ``dimensions_without_roles`` has
+        # the role stripped, so strip the column identifier the same way.
         for expr in parent_ast.select.projection:
             column_identifier = expr.alias_or_name.identifier(False)  # type: ignore
-            if from_amenable_name(column_identifier) in dimensions_without_roles:
+            identifier_path = from_amenable_name(column_identifier)
+            identifier_no_role = matcher.findall(identifier_path)[0][0]
+            if (
+                identifier_no_role in dimensions_without_roles
+                or identifier_path in dimensions
+            ):
                 dimensional_columns.append(expr)
                 expr.set_semantic_type(SemanticType.DIMENSION)  # type: ignore
             else:

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -141,7 +141,7 @@ class MeasuresMaterialization(BaseModel):
         ]
         # The cube column stores the role separately in ``dimension_column``
         # as ``[role]``. Reconstruct the role-qualified form to match the v3
-        # measures-query ``semantic_entity`` (e.g. ``default.date.dateint[asset_create_date]``).
+        # measures-query ``semantic_entity`` (e.g. ``node.col[role]``).
         partition_ref = (
             f"{temporal_partition.name}{temporal_partition.dimension_column or ''}"
         )

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -139,15 +139,29 @@ class MeasuresMaterialization(BaseModel):
             for component in metric_components
             if not component.aggregation
         ]
+        # The cube column stores the role separately in ``dimension_column``
+        # as ``[role]``. Reconstruct the role-qualified form to match the v3
+        # measures-query ``semantic_entity`` (e.g. ``default.date.dateint[asset_create_date]``).
+        partition_ref = (
+            f"{temporal_partition.name}{temporal_partition.dimension_column or ''}"
+        )
+        partition_matches = [
+            col.name
+            for col in measures_query.columns
+            if col.semantic_entity == partition_ref
+        ]
+        if not partition_matches:
+            raise DJInvalidInputException(
+                f"Could not find timestamp column for temporal partition "
+                f"`{partition_ref}` in measures query columns. "
+                f"Available semantic_entity values: "
+                f"{[c.semantic_entity for c in measures_query.columns]}",
+            )
         return MeasuresMaterialization(
             node=measures_query.node,
             grain=measures_query.grain,
             columns=measures_query.columns,
-            timestamp_column=[
-                col.name
-                for col in measures_query.columns
-                if col.semantic_entity == temporal_partition.name
-            ][0],
+            timestamp_column=partition_matches[0],
             timestamp_format=temporal_partition.partition.format,
             granularity=temporal_partition.partition.granularity,
             query=measures_query.sql,

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -340,10 +340,16 @@ class DruidMeasuresCubeConfig(DruidCubeConfigInput, GenericCubeConfig):
         # Use the user-defined temporal partition if it exists
         user_defined_temporal_partition = None
         user_defined_temporal_partition = user_defined_temporal_partitions[0]
+        # The cube column stores the role separately in ``dimension_column`` as
+        # ``[role]``. Reconstruct the role-qualified form to match the v3
+        # measures-query ``semantic_entity`` (e.g. ``default.date.dateint[asset_create_date]``).
+        partition_ref = user_defined_temporal_partition.name + (
+            user_defined_temporal_partition.dimension_column or ""
+        )
         timestamp_column = [
             col.name
             for col in self.columns  # type: ignore
-            if col.semantic_entity == user_defined_temporal_partition.name
+            if col.semantic_entity == partition_ref
         ][0]
 
         druid_datasource_name = (

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -342,7 +342,7 @@ class DruidMeasuresCubeConfig(DruidCubeConfigInput, GenericCubeConfig):
         user_defined_temporal_partition = user_defined_temporal_partitions[0]
         # The cube column stores the role separately in ``dimension_column`` as
         # ``[role]``. Reconstruct the role-qualified form to match the v3
-        # measures-query ``semantic_entity`` (e.g. ``default.date.dateint[asset_create_date]``).
+        # measures-query ``semantic_entity`` (e.g. ``node.col[role]``).
         partition_ref = user_defined_temporal_partition.name + (
             user_defined_temporal_partition.dimension_column or ""
         )

--- a/datajunction-server/tests/models/cube_materialization_test.py
+++ b/datajunction-server/tests/models/cube_materialization_test.py
@@ -1,11 +1,17 @@
 """Tests for cube materialization models."""
 
+from types import SimpleNamespace
+
 import pytest
 
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.cube_materialization import (
     DruidCubeV3Config,
+    MeasuresMaterialization,
     PreAggTableInfo,
 )
+from datajunction_server.models.node_type import NodeNameVersion
+from datajunction_server.models.partition import Granularity
 from datajunction_server.models.decompose import (
     AggregationRule,
     Aggregability,
@@ -198,3 +204,104 @@ class TestDruidCubeV3ConfigDruidCubeConfigCompatibility:
 
         assert config.urls == []
         assert config.workflow_urls == []
+
+
+class TestFromMeasuresQueryRoleResolution:
+    """``MeasuresMaterialization.from_measures_query`` must reconstruct the
+    role-qualified dimension reference from the cube column's ``name`` +
+    ``dimension_column`` so it can match the v3 measures query's
+    ``semantic_entity`` (which embeds the role).
+
+    Regression: cubes whose temporal partition uses a role-qualified dimension
+    raised ``IndexError`` because the comparison was a bare ``name`` equality.
+    """
+
+    @pytest.fixture
+    def measures_query(self):
+        """A v3-style measures query with a role-qualified date dimension."""
+        return SimpleNamespace(
+            node=NodeNameVersion(name="default.cube", version="v1.0"),
+            grain=["default_DOT_date_DOT_dateint_LBRACKET_asset_create_date_RBRACKET"],
+            columns=[
+                ColumnMetadata(
+                    name="dateint",
+                    type="int",
+                    semantic_entity="default.date.dateint[asset_create_date]",
+                    semantic_type="dimension",
+                ),
+                ColumnMetadata(
+                    name="amount_sum",
+                    type="double",
+                    semantic_entity="default.amount",
+                    semantic_type="metric",
+                ),
+            ],
+            metrics={
+                "default.total_amount": (
+                    [
+                        MetricComponent(
+                            name="amount_sum",
+                            expression="amount",
+                            aggregation="SUM",
+                            merge="SUM",
+                            rule=AggregationRule(type=Aggregability.FULL),
+                        ),
+                    ],
+                    "amount_sum",
+                ),
+            },
+            sql="SELECT 1",
+            spark_conf={},
+            upstream_tables=["default.facts"],
+        )
+
+    def test_role_qualified_partition_resolves(self, measures_query):
+        """Cube column with ``dimension_column='[asset_create_date]'`` must
+        match the role-qualified ``semantic_entity`` in the measures query."""
+        # Mimics a database Column for a role-qualified temporal partition.
+        # Cube columns store the role separately in ``dimension_column``.
+        temporal_partition = SimpleNamespace(
+            name="default.date.dateint",
+            dimension_column="[asset_create_date]",
+            partition=SimpleNamespace(format="yyyyMMdd", granularity=Granularity.DAY),
+        )
+
+        result = MeasuresMaterialization.from_measures_query(
+            measures_query,
+            temporal_partition,
+        )
+
+        assert result.timestamp_column == "dateint"
+        assert result.timestamp_format == "yyyyMMdd"
+        assert result.granularity == Granularity.DAY
+
+    def test_unqualified_partition_still_resolves(self, measures_query):
+        """A cube without a role on its temporal partition must still match."""
+        measures_query.columns[0].semantic_entity = "default.date.dateint"
+        temporal_partition = SimpleNamespace(
+            name="default.date.dateint",
+            dimension_column=None,
+            partition=SimpleNamespace(format="yyyyMMdd", granularity=Granularity.DAY),
+        )
+
+        result = MeasuresMaterialization.from_measures_query(
+            measures_query,
+            temporal_partition,
+        )
+
+        assert result.timestamp_column == "dateint"
+
+    def test_missing_partition_raises_clear_error(self, measures_query):
+        """If no measures column matches the partition, raise a clear error
+        instead of an opaque ``IndexError``."""
+        temporal_partition = SimpleNamespace(
+            name="default.unrelated.column",
+            dimension_column=None,
+            partition=SimpleNamespace(format="yyyyMMdd", granularity=Granularity.DAY),
+        )
+
+        with pytest.raises(DJInvalidInputException, match="Could not find timestamp"):
+            MeasuresMaterialization.from_measures_query(
+                measures_query,
+                temporal_partition,
+            )

--- a/datajunction-server/tests/models/cube_materialization_test.py
+++ b/datajunction-server/tests/models/cube_materialization_test.py
@@ -221,12 +221,12 @@ class TestFromMeasuresQueryRoleResolution:
         """A v3-style measures query with a role-qualified date dimension."""
         return SimpleNamespace(
             node=NodeNameVersion(name="default.cube", version="v1.0"),
-            grain=["default_DOT_date_DOT_dateint_LBRACKET_asset_create_date_RBRACKET"],
+            grain=["default_DOT_date_DOT_dateint_LBRACKET_reporting_date_RBRACKET"],
             columns=[
                 ColumnMetadata(
                     name="dateint",
                     type="int",
-                    semantic_entity="default.date.dateint[asset_create_date]",
+                    semantic_entity="default.date.dateint[reporting_date]",
                     semantic_type="dimension",
                 ),
                 ColumnMetadata(
@@ -256,13 +256,13 @@ class TestFromMeasuresQueryRoleResolution:
         )
 
     def test_role_qualified_partition_resolves(self, measures_query):
-        """Cube column with ``dimension_column='[asset_create_date]'`` must
+        """Cube column with ``dimension_column='[reporting_date]'`` must
         match the role-qualified ``semantic_entity`` in the measures query."""
         # Mimics a database Column for a role-qualified temporal partition.
         # Cube columns store the role separately in ``dimension_column``.
         temporal_partition = SimpleNamespace(
             name="default.date.dateint",
-            dimension_column="[asset_create_date]",
+            dimension_column="[reporting_date]",
             partition=SimpleNamespace(format="yyyyMMdd", granularity=Granularity.DAY),
         )
 


### PR DESCRIPTION
### Summary

Cube materialization (`POST /nodes/{cube}/materialization` with `job=druid_cube`) errored with `IndexError: list index out of range` when the cube's temporal partition was set on a role-qualified dimension (e.g. `node.col[role]`).

A cube column splits the role across two fields, but we weren't taking into account the role:
  - `column.name` contains the bare path: `node.col`
  - `column.dimension_column` contains the role: `[role]`

The fix is to reconstruct the role-qualified dimension attr from the cube column's two fields (`name + dimension_column`) and match against `semantic_entity` exactly. This preserves role, which is important if a cube ever carries two partitions on the same dimension under different roles.

This also replaces the opaque `IndexError` with a `DJInvalidInputException` that lists the available semantic entity values, so that future mismatches are debuggable.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
