### PR TITLE
Fix MissingGreenlet error during branch creation when copying cubes

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -987,15 +987,21 @@ class DeploymentOrchestrator:
         external_dep_names = all_referenced - incoming_names
 
         if external_dep_names:
-            # Only catalog is needed from external deps: _create_node_revision uses it
-            # for catalog inference. Column type re-parsing is skipped for the copy
-            # fast-path (skip_type_reparsing=True in get_dependencies).
+            # Need: catalog (for catalog inference in _create_node_revision) and
+            # columns (with attributes) for the copy fast-path cube validation
+            # in _build_copy_cube_validation_data — that function is sync and
+            # would otherwise lazy-load columns, triggering MissingGreenlet.
             ext_nodes = await Node.get_by_names(
                 self.session,
                 list(external_dep_names),
                 options=[
                     selectinload(Node.current).options(
                         joinedload(NodeRevision.catalog),
+                        selectinload(NodeRevision.columns).options(
+                            joinedload(Column.attributes).joinedload(
+                                ColumnAttribute.attribute_type,
+                            ),
+                        ),
                     ),
                     selectinload(Node.tags),
                 ],


### PR DESCRIPTION
### Summary

Fixes a SQLAlchemy `MissingGreenlet` error that occurred when creating a branch from a namespace containing cubes whose metrics/dimensions were external dependencies (i.e., not part of the deployment spec itself).

The copy fast-path in `DeploymentOrchestrator._create_copy_fast_plan` loads external dependency nodes (the metrics/dimensions referenced by cubes being copied) via `Node.get_by_names`, but only eagerly loads `Node.current` and `NodeRevision.catalog`. A stale comment claimed "only catalog is needed from external deps".

That assumption was wrong because `_build_copy_cube_validation_data` (a synchronous method called during cube validation) iterates over `node.current.columns`. With the columns relationship not eager-loaded, this triggers a lazy DB load from sync code. Lazy loads on AsyncSession require an active greenlet context, which doesn't exist in sync stack frames, resulting in:
```
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here.
```

The fix is to extend the load options for the copy fast-path's external deps to include `NodeRevision.columns`, along with `Column.attributes` and `attribute_type`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
