### PR TITLE
Preserve and rewrite dim-node column refs in v3 measures SQL

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -92,6 +92,50 @@ def _rewrite_col_refs(expr: Any, table_alias: str) -> None:
             _rewrite_col_refs(child, table_alias)
 
 
+def _rewrite_dim_namespace_refs(
+    expr: Any,
+    dim_node_to_alias: dict[str, str],
+) -> None:
+    """Rewrite columns whose namespace matches a joined dim node to use the dim's table alias.
+
+    A metric expression may contain a fully-qualified column like
+    ``v3.customer.tier`` referring to a column on a dimension node that the
+    parent fact joins to. The renderer would emit that namespace literally
+    (``v3.customer.tier``) — wrong, since the joined CTE is aliased as e.g.
+    ``t2``. Replace the namespace with the dim's table alias.
+    """
+    if isinstance(expr, ast.Column):
+        if expr.name and expr.name.namespace and expr.name.namespace.name:
+            ns = expr.name.namespace.identifier(quotes=False)
+            if ns in dim_node_to_alias:
+                expr.name = ast.Name(
+                    expr.name.name,
+                    namespace=ast.Name(dim_node_to_alias[ns]),
+                )
+    for child in expr.children if hasattr(expr, "children") else []:
+        if child:  # pragma: no branch
+            _rewrite_dim_namespace_refs(child, dim_node_to_alias)
+
+
+def _collect_dim_cols_from_metric_exprs(
+    metric_expressions: list[tuple[str, ast.Expression]],
+    dim_node_names: set[str],
+) -> dict[str, set[str]]:
+    """Find columns in metric expressions whose namespace matches a known dim node.
+
+    Returns a map of dim node name -> set of column short names referenced.
+    Used to ensure those columns are preserved in the dim's CTE projection.
+    """
+    result: dict[str, set[str]] = {}
+    for _, expr in metric_expressions:
+        for col in expr.find_all(ast.Column):
+            if col.name and col.name.namespace and col.name.namespace.name:
+                ns = col.name.namespace.identifier(quotes=False)
+                if ns in dim_node_names:
+                    result.setdefault(ns, set()).add(col.name.name)
+    return result
+
+
 # Mapping from type string to ColumnType instance
 # Used to convert stored type strings back to type objects for function inference
 _TYPE_STRING_MAP: dict[str, ct.ColumnType] = {
@@ -517,6 +561,21 @@ def collect_cte_nodes_and_needed_columns(
                         else:  # pragma: no cover
                             needed_columns_by_node[left_node_name] = left_join_cols
 
+    # Metric expressions may reference columns from a joined dim node directly
+    # (e.g. ``v3.customer.tier`` inside SUM(...)). Those columns must remain in
+    # the dim's CTE projection; otherwise filter_cte_projection drops them and
+    # the outer query references a non-existent column.
+    cte_node_names = {n.name for n in nodes_for_ctes}
+    metric_dim_cols = _collect_dim_cols_from_metric_exprs(
+        metric_expressions,
+        cte_node_names,
+    )
+    for dim_name, cols in metric_dim_cols.items():
+        if dim_name in needed_columns_by_node:
+            needed_columns_by_node[dim_name].update(cols)
+        else:  # pragma: no cover
+            needed_columns_by_node[dim_name] = set(cols)
+
     return nodes_for_ctes, needed_columns_by_node
 
 
@@ -668,12 +727,17 @@ def _build_metric_col_expr(
     expr: ast.Expression,
     clean_alias: str,
     main_alias: str,
+    dim_node_to_alias: dict[str, str] | None = None,
 ) -> ast.Alias:
     """Rewrite column references in a metric expression and wrap with an alias.
 
-    Adds the ``main_alias`` table qualifier to every unqualified column in
-    ``expr`` (mutates in place), then returns an ``ast.Alias`` node.
+    Mutates ``expr`` in place: columns whose namespace matches a joined dim
+    node are rewritten to use the dim's table alias, then any remaining
+    unqualified columns get the ``main_alias`` qualifier. Returns an
+    ``ast.Alias`` node.
     """
+    if dim_node_to_alias:
+        _rewrite_dim_namespace_refs(expr, dim_node_to_alias)
     _rewrite_col_refs(expr, main_alias)
     return ast.Alias(
         alias=ast.Name(clean_alias),
@@ -900,10 +964,31 @@ def build_select_ast(
             projection.append(ast.Alias(child=gc_expr, alias=ast.Name(gc_alias)))
             grain_col_refs.append(ast.Column(name=ast.Name(gc_alias)))
 
+    # Collect all nodes that need CTEs and the minimal columns each must project.
+    # Run this BEFORE rewriting metric-expression namespaces — the scan for
+    # dim-namespaced refs in metric_expressions reads the original namespace
+    # (e.g. ``v3.customer.tier``), which would otherwise be replaced below.
+    nodes_for_ctes, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
+        ctx,
+        parent_node,
+        resolved_dimensions,
+        grain_col_specs,
+        metric_expressions,
+    )
+
+    # Flat mapping from dim node name -> table alias, preferring the role-less
+    # entry when the same dim is joined via multiple roles.
+    dim_node_to_alias: dict[str, str] = {}
+    for (dim_node_name, role), alias in dim_aliases.items():
+        if dim_node_name not in dim_node_to_alias or not role:
+            dim_node_to_alias[dim_node_name] = alias
+
     # Add metric expressions
     for alias_name, expr in metric_expressions:
         clean_alias = ctx.alias_registry.register(alias_name)
-        projection.append(_build_metric_col_expr(expr, clean_alias, main_alias))
+        projection.append(
+            _build_metric_col_expr(expr, clean_alias, main_alias, dim_node_to_alias),
+        )
 
     group_by = _build_group_by(
         resolved_dimensions,
@@ -912,15 +997,6 @@ def build_select_ast(
         grain_col_specs,
         projected_dim_col_names,
         ctx.filter_dimensions,
-    )
-
-    # Collect all nodes that need CTEs and the minimal columns each must project
-    nodes_for_ctes, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
-        ctx,
-        parent_node,
-        resolved_dimensions,
-        grain_col_specs,
-        metric_expressions,
     )
 
     temporal_filter_ast, injected_cte_filters = _build_temporal_pushdown(

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -92,48 +92,37 @@ def _rewrite_col_refs(expr: Any, table_alias: str) -> None:
             _rewrite_col_refs(child, table_alias)
 
 
-def _rewrite_dim_namespace_refs(
-    expr: Any,
+def _resolve_dim_namespace_refs(
+    metric_expressions: list[tuple[str, ast.Expression]],
     dim_node_to_alias: dict[str, str],
-) -> None:
-    """Rewrite columns whose namespace matches a joined dim node to use the dim's table alias.
+) -> dict[str, set[str]]:
+    """Resolve dim-namespaced column refs in metric expressions.
 
     A metric expression may contain a fully-qualified column like
     ``v3.customer.tier`` referring to a column on a dimension node that the
-    parent fact joins to. The renderer would emit that namespace literally
-    (``v3.customer.tier``) — wrong, since the joined CTE is aliased as e.g.
-    ``t2``. Replace the namespace with the dim's table alias.
+    parent fact joins to. In one walk per expression, this function:
+
+    1. Rewrites the namespace from the dim node name to the dim's joined
+       table alias (so the renderer emits ``t2.tier`` instead of the literal
+       node name, which is not a valid table reference).
+    2. Returns ``{dim_node_name: {col, ...}}`` so the caller can keep those
+       columns in the dim's CTE projection (otherwise filter_cte_projection
+       drops them as unused).
     """
-    if isinstance(expr, ast.Column):
-        if expr.name and expr.name.namespace and expr.name.namespace.name:
-            ns = expr.name.namespace.identifier(quotes=False)
-            if ns in dim_node_to_alias:
-                expr.name = ast.Name(
-                    expr.name.name,
-                    namespace=ast.Name(dim_node_to_alias[ns]),
-                )
-    for child in expr.children if hasattr(expr, "children") else []:
-        if child:  # pragma: no branch
-            _rewrite_dim_namespace_refs(child, dim_node_to_alias)
-
-
-def _collect_dim_cols_from_metric_exprs(
-    metric_expressions: list[tuple[str, ast.Expression]],
-    dim_node_names: set[str],
-) -> dict[str, set[str]]:
-    """Find columns in metric expressions whose namespace matches a known dim node.
-
-    Returns a map of dim node name -> set of column short names referenced.
-    Used to ensure those columns are preserved in the dim's CTE projection.
-    """
-    result: dict[str, set[str]] = {}
+    dim_cols: dict[str, set[str]] = {}
     for _, expr in metric_expressions:
         for col in expr.find_all(ast.Column):
-            if col.name and col.name.namespace and col.name.namespace.name:
-                ns = col.name.namespace.identifier(quotes=False)
-                if ns in dim_node_names:
-                    result.setdefault(ns, set()).add(col.name.name)
-    return result
+            if not (col.name and col.name.namespace and col.name.namespace.name):
+                continue
+            ns = col.name.namespace.identifier(quotes=False)
+            if ns not in dim_node_to_alias:
+                continue
+            dim_cols.setdefault(ns, set()).add(col.name.name)
+            col.name = ast.Name(
+                col.name.name,
+                namespace=ast.Name(dim_node_to_alias[ns]),
+            )
+    return dim_cols
 
 
 # Mapping from type string to ColumnType instance
@@ -561,21 +550,6 @@ def collect_cte_nodes_and_needed_columns(
                         else:  # pragma: no cover
                             needed_columns_by_node[left_node_name] = left_join_cols
 
-    # Metric expressions may reference columns from a joined dim node directly
-    # (e.g. ``v3.customer.tier`` inside SUM(...)). Those columns must remain in
-    # the dim's CTE projection; otherwise filter_cte_projection drops them and
-    # the outer query references a non-existent column.
-    cte_node_names = {n.name for n in nodes_for_ctes}
-    metric_dim_cols = _collect_dim_cols_from_metric_exprs(
-        metric_expressions,
-        cte_node_names,
-    )
-    for dim_name, cols in metric_dim_cols.items():
-        if dim_name in needed_columns_by_node:
-            needed_columns_by_node[dim_name].update(cols)
-        else:  # pragma: no cover
-            needed_columns_by_node[dim_name] = set(cols)
-
     return nodes_for_ctes, needed_columns_by_node
 
 
@@ -727,17 +701,12 @@ def _build_metric_col_expr(
     expr: ast.Expression,
     clean_alias: str,
     main_alias: str,
-    dim_node_to_alias: dict[str, str] | None = None,
 ) -> ast.Alias:
     """Rewrite column references in a metric expression and wrap with an alias.
 
-    Mutates ``expr`` in place: columns whose namespace matches a joined dim
-    node are rewritten to use the dim's table alias, then any remaining
-    unqualified columns get the ``main_alias`` qualifier. Returns an
-    ``ast.Alias`` node.
+    Adds the ``main_alias`` table qualifier to every unqualified column in
+    ``expr`` (mutates in place), then returns an ``ast.Alias`` node.
     """
-    if dim_node_to_alias:
-        _rewrite_dim_namespace_refs(expr, dim_node_to_alias)
     _rewrite_col_refs(expr, main_alias)
     return ast.Alias(
         alias=ast.Name(clean_alias),
@@ -964,31 +933,20 @@ def build_select_ast(
             projection.append(ast.Alias(child=gc_expr, alias=ast.Name(gc_alias)))
             grain_col_refs.append(ast.Column(name=ast.Name(gc_alias)))
 
-    # Collect all nodes that need CTEs and the minimal columns each must project.
-    # Run this BEFORE rewriting metric-expression namespaces — the scan for
-    # dim-namespaced refs in metric_expressions reads the original namespace
-    # (e.g. ``v3.customer.tier``), which would otherwise be replaced below.
-    nodes_for_ctes, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
-        ctx,
-        parent_node,
-        resolved_dimensions,
-        grain_col_specs,
-        metric_expressions,
-    )
-
-    # Flat mapping from dim node name -> table alias, preferring the role-less
-    # entry when the same dim is joined via multiple roles.
+    # Resolve dim-namespaced refs in metric expressions (e.g. ``v3.customer.tier``)
+    # to the dim's joined table alias, and remember which columns each dim
+    # CTE must keep. Done up-front so the rewrite is visible to both the
+    # projection loop below and CTE pruning.
     dim_node_to_alias: dict[str, str] = {}
     for (dim_node_name, role), alias in dim_aliases.items():
         if dim_node_name not in dim_node_to_alias or not role:
             dim_node_to_alias[dim_node_name] = alias
+    metric_dim_cols = _resolve_dim_namespace_refs(metric_expressions, dim_node_to_alias)
 
     # Add metric expressions
     for alias_name, expr in metric_expressions:
         clean_alias = ctx.alias_registry.register(alias_name)
-        projection.append(
-            _build_metric_col_expr(expr, clean_alias, main_alias, dim_node_to_alias),
-        )
+        projection.append(_build_metric_col_expr(expr, clean_alias, main_alias))
 
     group_by = _build_group_by(
         resolved_dimensions,
@@ -998,6 +956,17 @@ def build_select_ast(
         projected_dim_col_names,
         ctx.filter_dimensions,
     )
+
+    # Collect all nodes that need CTEs and the minimal columns each must project.
+    nodes_for_ctes, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
+        ctx,
+        parent_node,
+        resolved_dimensions,
+        grain_col_specs,
+        metric_expressions,
+    )
+    for dim_name, cols in metric_dim_cols.items():
+        needed_columns_by_node.setdefault(dim_name, set()).update(cols)
 
     temporal_filter_ast, injected_cte_filters = _build_temporal_pushdown(
         ctx,

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -29,6 +29,7 @@ from datajunction_server.construction.build_v3.filters import (
 )
 from datajunction_server.construction.build_v3.measures import (
     _add_table_prefixes_to_filter,
+    _resolve_dim_namespace_refs,
     collect_cte_nodes_and_needed_columns,
 )
 from datajunction_server.construction.build_v3.types import (
@@ -809,6 +810,65 @@ class TestAddTablePrefixesToFilter:
         )
         # Unknown column should be prefixed with main_alias
         assert "t1.status" in str(filter_ast)
+
+
+class TestResolveDimNamespaceRefs:
+    """Tests for ``_resolve_dim_namespace_refs`` — rewrites dim-namespaced
+    column refs to use the dim's joined table alias and returns the columns
+    that must be preserved in each dim's CTE projection."""
+
+    @staticmethod
+    def _expr(sql: str) -> ast.Expression:
+        return parse(f"SELECT {sql}").select.projection[0]
+
+    def test_rewrites_known_dim_and_collects_col(self):
+        expr = self._expr("v3.customer.tier")
+        cols = _resolve_dim_namespace_refs(
+            [("alias", expr)],
+            {"v3.customer": "t2"},
+        )
+        assert str(expr) == "t2.tier"
+        assert cols == {"v3.customer": {"tier"}}
+
+    def test_skips_unknown_namespace(self):
+        """Namespaces that don't match a joined dim are left unchanged and
+        not recorded."""
+        expr = self._expr("v3.fact.amount + v3.customer.threshold")
+        cols = _resolve_dim_namespace_refs(
+            [("alias", expr)],
+            {"v3.customer": "t2"},
+        )
+        rendered = str(expr)
+        assert "v3.fact.amount" in rendered
+        assert "t2.threshold" in rendered
+        assert cols == {"v3.customer": {"threshold"}}
+
+    def test_skips_bare_columns(self):
+        """Bare columns have no namespace, so they're not touched here —
+        the main-alias rewrite runs separately."""
+        expr = self._expr("SUM(amount)")
+        cols = _resolve_dim_namespace_refs(
+            [("alias", expr)],
+            {"v3.customer": "t2"},
+        )
+        assert str(expr) == "SUM(amount)"
+        assert cols == {}
+
+    def test_walks_nested_expression(self):
+        """The walk reaches into function args / CASE branches."""
+        expr = self._expr(
+            "SUM(CASE WHEN amount >= v3.customer.threshold "
+            "THEN v3.customer.tier ELSE 'x' END)",
+        )
+        cols = _resolve_dim_namespace_refs(
+            [("alias", expr)],
+            {"v3.customer": "t2"},
+        )
+        rendered = str(expr)
+        assert "v3.customer." not in rendered
+        assert "t2.threshold" in rendered
+        assert "t2.tier" in rendered
+        assert cols == {"v3.customer": {"threshold", "tier"}}
 
 
 class TestBuildComponentExpression:

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -1,5 +1,6 @@
 """Tests for build_v3 helper functions."""
 
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -819,7 +820,7 @@ class TestResolveDimNamespaceRefs:
 
     @staticmethod
     def _expr(sql: str) -> ast.Expression:
-        return parse(f"SELECT {sql}").select.projection[0]
+        return cast(ast.Expression, parse(f"SELECT {sql}").select.projection[0])
 
     def test_rewrites_known_dim_and_collects_col(self):
         expr = self._expr("v3.customer.tier")

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -4865,11 +4865,37 @@ class TestMetricExprReferencesDimColumn:
         assert resp.status_code == 200, resp.text
         metrics_sql = resp.json()["sql"]
 
-        # The dim node name must NOT appear as a literal column reference
-        # anywhere in the rendered SQL.
-        assert "mx.customer.threshold" not in metrics_sql, metrics_sql
-        # And the threshold column must be preserved in the dim CTE.
-        assert "threshold" in metrics_sql
+        assert_sql_equal(
+            metrics_sql,
+            """
+            WITH
+            mx_customer AS (
+                SELECT customer_id, tier, threshold
+                FROM default.mx.src_customer
+            ),
+            mx_fact AS (
+                SELECT customer_id, amount
+                FROM default.mx.src_fact
+            ),
+            fact_0 AS (
+                SELECT
+                    t2.tier,
+                    SUM(CASE WHEN t1.amount >= t2.threshold
+                        THEN t1.amount ELSE 0 END)
+                        amount_mx_DOT_customer_DOT_threshold_amount_sum_HASH
+                FROM mx_fact t1
+                LEFT OUTER JOIN mx_customer t2 ON t1.customer_id = t2.customer_id
+                GROUP BY t2.tier
+            )
+            SELECT
+                fact_0.tier AS tier,
+                SUM(fact_0.amount_mx_DOT_customer_DOT_threshold_amount_sum_HASH)
+                    AS qualifying_amount
+            FROM fact_0
+            GROUP BY fact_0.tier
+            """,
+            normalize_aliases=True,
+        )
 
 
 class TestSparkJoinHints:

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -4716,6 +4716,162 @@ class TestDimReferencingDimViaAlias:
         )
 
 
+class TestMetricExprReferencesDimColumn:
+    """
+    A metric expression may reference a column from a joined dimension node
+    using fully-qualified ``<dim_node>.<column>`` notation. The generated SQL
+    must:
+
+    1. Preserve that column in the dim's CTE projection (otherwise
+       filter_cte_projection drops it as unused).
+    2. Rewrite the namespace from the dim node name to the dim's joined table
+       alias (otherwise the renderer emits the literal node name, which is
+       not a valid table reference).
+    """
+
+    @pytest.mark.asyncio
+    async def test_dim_column_in_metric_expression(self, client_with_service_setup):
+        resp = await client_with_service_setup.post("/namespaces/mx/")
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client_with_service_setup.post(
+            "/nodes/source/",
+            json={
+                "name": "mx.src_fact",
+                "catalog": "default",
+                "schema_": "mx",
+                "table": "src_fact",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client_with_service_setup.post(
+            "/nodes/source/",
+            json={
+                "name": "mx.src_customer",
+                "catalog": "default",
+                "schema_": "mx",
+                "table": "src_customer",
+                "columns": [
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "tier", "type": "string"},
+                    {"name": "threshold", "type": "double"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client_with_service_setup.post(
+            "/nodes/dimension/",
+            json={
+                "name": "mx.customer",
+                "mode": "published",
+                "primary_key": ["customer_id"],
+                "query": ("SELECT customer_id, tier, threshold FROM mx.src_customer"),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client_with_service_setup.post(
+            "/nodes/transform/",
+            json={
+                "name": "mx.fact",
+                "mode": "published",
+                "query": ("SELECT id, customer_id, amount FROM mx.src_fact"),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # Metric expression directly references mx.customer.threshold — a
+        # column on the joined dim node.
+        resp = await client_with_service_setup.post(
+            "/nodes/metric/",
+            json={
+                "name": "mx.qualifying_amount",
+                "mode": "published",
+                "query": (
+                    "SELECT SUM(CASE WHEN amount >= mx.customer.threshold "
+                    "THEN amount ELSE 0 END) FROM mx.fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client_with_service_setup.post(
+            "/nodes/mx.fact/link",
+            json={
+                "dimension_node": "mx.customer",
+                "join_type": "left",
+                "join_on": "mx.fact.customer_id = mx.customer.customer_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client_with_service_setup.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["mx.qualifying_amount"],
+                "dimensions": ["mx.customer.tier"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        sql = resp.json()["grain_groups"][0]["sql"]
+
+        # mx_customer CTE must project ``threshold`` (referenced by the
+        # metric expression) in addition to ``tier`` (the requested dim) and
+        # ``customer_id`` (the join key). The metric expression's
+        # ``mx.customer.threshold`` must be rewritten to ``t2.threshold``.
+        assert_sql_equal(
+            sql,
+            """
+            WITH mx_customer AS (
+                SELECT customer_id, tier, threshold
+                FROM default.mx.src_customer
+            ),
+            mx_fact AS (
+                SELECT customer_id, amount
+                FROM default.mx.src_fact
+            )
+            SELECT
+                t2.tier,
+                SUM(CASE WHEN t1.amount >= t2.threshold
+                    THEN t1.amount ELSE 0 END)
+                    amount_mx_DOT_customer_DOT_threshold_amount_sum_HASH
+            FROM mx_fact t1
+            LEFT OUTER JOIN mx_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY t2.tier
+            """,
+            normalize_aliases=True,
+        )
+
+        # /sql/metrics/v3 wraps the measures grain group and re-aggregates
+        # to produce the final metric. The same dim-namespace fix must apply:
+        # the inner grain-group CTE must reference ``t2.threshold`` (not
+        # ``mx.customer.threshold``) and ``mx_customer`` must still project
+        # ``threshold``.
+        resp = await client_with_service_setup.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["mx.qualifying_amount"],
+                "dimensions": ["mx.customer.tier"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        metrics_sql = resp.json()["sql"]
+
+        # The dim node name must NOT appear as a literal column reference
+        # anywhere in the rendered SQL.
+        assert "mx.customer.threshold" not in metrics_sql, metrics_sql
+        # And the threshold column must be preserved in the dim CTE.
+        assert "threshold" in metrics_sql
+
+
 class TestSparkJoinHints:
     """
     Tests for Spark SQL join hints emitted via spark_hints on DimensionLink.


### PR DESCRIPTION
### Summary

When a metric expression references a column on a joined dimension node via fully-qualified `<dim_node>.<column>` notation (e.g. `SUM(CASE WHEN amount >= mx.customer.threshold THEN ... END))`, the v3 measures SQL generator produced broken output:
- The dim's CTE projection dropped the column (`filter_cte_projection` only kept join keys + the requested dim attribute).
- The outer SELECT emitted the literal node name (`mx.customer.threshold`) instead of the joined alias (`t2.threshold`).

This affected both `/sql/measures/v3` and `/sql/metrics/v3`, since the latter wraps the former.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
