### PR TITLE
Preserve node status on branch creation + enable deploy of invalid cubes

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2209,7 +2209,7 @@ class DeploymentOrchestrator:
 
         return NodeValidationResult(
             spec=cube_spec,
-            status=NodeStatus.VALID,
+            status=cube_spec._source_status or NodeStatus.VALID,
             inferred_columns=cube_spec.rendered_columns,
             errors=[],
             dependencies=[],
@@ -2861,7 +2861,7 @@ class DeploymentOrchestrator:
                 validation_results = [
                     NodeValidationResult(
                         spec=spec,
-                        status=NodeStatus.VALID,
+                        status=spec._source_status or NodeStatus.VALID,
                         inferred_columns=spec.columns or [],
                         errors=[],
                         dependencies=node_graph.get(spec.rendered_name, []),

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -1469,8 +1469,16 @@ def _node_spec_to_yaml_dict(node_spec, include_all_columns=False) -> dict:
             if "attributes" in col and isinstance(col["attributes"], list):
                 col["attributes"] = sorted(col["attributes"])
 
-    # Remove empty lists/dicts for cleaner YAML
-    data = {k: v for k, v in data.items() if v or v == 0 or v is False}
+    # Remove empty lists/dicts for cleaner YAML — but keep fields the spec
+    # model marks required, otherwise the YAML won't round-trip through
+    # pydantic. ``CubeSpec.metrics`` is required (no default), so dropping
+    # ``metrics: []`` here breaks redeploys with "Field required".
+    required_keys: set[str] = set()
+    if data.get("node_type") == "cube":
+        required_keys = {"metrics", "dimensions"}
+    data = {
+        k: v for k, v in data.items() if v or v == 0 or v is False or k in required_keys
+    }
 
     # Clean up multiline strings by stripping trailing whitespace from each line
     # Use LiteralScalarString to force literal block style (|) for multiline queries

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -1027,8 +1027,10 @@ async def get_node_specs_for_export(
     )
     node_specs = [await node.to_spec(session) for node in nodes]
 
-    # Pre-populate upstream dependency names from DB parent relationships.
-    # This avoids re-parsing SQL during the copy fast-path.
+    # Pre-populate fields the copy fast-path needs but can't recompute:
+    # - ``_upstream_names`` from DB parents (avoids re-parsing SQL)
+    # - ``_source_status`` so a branch copy preserves VALID/INVALID instead
+    #   of unconditionally being marked VALID.
     for node, spec in zip(nodes, node_specs):
         if node.current and node.current.parents:
             spec._upstream_names = [
@@ -1036,10 +1038,10 @@ async def get_node_specs_for_export(
             ]
         else:
             spec._upstream_names = []
-        # Carry the source node's status through the copy fast-path so branch
-        # copies preserve VALID/INVALID instead of unconditionally going VALID.
-        if node.current:
-            spec._source_status = node.current.status
+        # node.current is always populated here — node.to_spec(session) above
+        # would have failed otherwise — but the access is paired with the
+        # spec write to keep the precondition local.
+        spec._source_status = node.current.status
 
     # Build set of node suffixes in this namespace (for cube reference matching)
     # e.g., for "demo.feature_x.reports.revenue" with namespace "demo.feature_x",

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -1036,6 +1036,10 @@ async def get_node_specs_for_export(
             ]
         else:
             spec._upstream_names = []
+        # Carry the source node's status through the copy fast-path so branch
+        # copies preserve VALID/INVALID instead of unconditionally going VALID.
+        if node.current:
+            spec._source_status = node.current.status
 
     # Build set of node suffixes in this namespace (for cube reference matching)
     # e.g., for "demo.feature_x.reports.revenue" with namespace "demo.feature_x",

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -1469,16 +1469,8 @@ def _node_spec_to_yaml_dict(node_spec, include_all_columns=False) -> dict:
             if "attributes" in col and isinstance(col["attributes"], list):
                 col["attributes"] = sorted(col["attributes"])
 
-    # Remove empty lists/dicts for cleaner YAML — but keep fields the spec
-    # model marks required, otherwise the YAML won't round-trip through
-    # pydantic. ``CubeSpec.metrics`` is required (no default), so dropping
-    # ``metrics: []`` here breaks redeploys with "Field required".
-    required_keys: set[str] = set()
-    if data.get("node_type") == "cube":
-        required_keys = {"metrics", "dimensions"}
-    data = {
-        k: v for k, v in data.items() if v or v == 0 or v is False or k in required_keys
-    }
+    # Remove empty lists/dicts for cleaner YAML
+    data = {k: v for k, v in data.items() if v or v == 0 or v is False}
 
     # Clean up multiline strings by stripping trailing whitespace from each line
     # Use LiteralScalarString to force literal block style (|) for multiline queries

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -24,6 +24,7 @@ from datajunction_server.models.node import (
     MetricDirection,
     MetricUnit,
     NodeMode,
+    NodeStatus,
     NodeType,
 )
 from datajunction_server.utils import SEPARATOR
@@ -244,6 +245,10 @@ class NodeSpec(BaseModel):
     # Populated during export from source node DB parents to avoid re-parsing SQL
     # during the copy fast-path. None means "not populated; fall back to SQL parsing".
     _upstream_names: list[str] | None = PrivateAttr(default=None)
+    # Internal: source node status carried through the copy fast-path so a branch
+    # copy preserves VALID/INVALID instead of unconditionally marking nodes VALID.
+    # None means "not populated; fall back to NodeStatus.VALID".
+    _source_status: NodeStatus | None = PrivateAttr(default=None)
 
     model_config = ConfigDict(truncate_errors=False)
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -485,8 +485,12 @@ class CubeSpec(NodeSpec):
     """
 
     node_type: Literal[NodeType.CUBE] = NodeType.CUBE
-    metrics: list[str]
-    dimensions: list[str] = Field(default_factory=dict)
+    # Both default to empty so a malformed cube spec (e.g., one whose metrics
+    # were dropped during YAML round-trip, or a cube authored with zero
+    # metrics) still parses. Downstream validation flags the cube as INVALID
+    # rather than failing the whole deployment at pydantic-parse time.
+    metrics: list[str] = Field(default_factory=list)
+    dimensions: list[str] = Field(default_factory=list)
     filters: list[str] | None = None
     columns: list[ColumnSpec] | None = None
 

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -3601,6 +3601,96 @@ class TestCopyNodesToNamespace:
 
 
 @pytest.mark.asyncio
+async def test_branch_copy_preserves_invalid_source_status(
+    session,
+    client_with_service_setup: AsyncClient,
+):
+    """Branch creation copies INVALID source-node status into the branch.
+
+    Before the fix, the copy fast-path unconditionally set status=VALID, so
+    an INVALID source node would silently become VALID in the branch. This
+    test marks a transform as INVALID at the DB layer, branches the parent
+    namespace, and asserts the branched copy stays INVALID.
+    """
+    from sqlalchemy import select
+
+    from datajunction_server.database.node import Node
+    from datajunction_server.models.node import NodeStatus
+
+    client = client_with_service_setup
+    parent = "status_copy.main"
+    branch_full = "status_copy.feature_copy"
+
+    # Set up parent namespace with git config and one transform.
+    await client.post(f"/namespaces/{parent}")
+    await client.patch(
+        f"/namespaces/{parent}/git",
+        json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+    )
+    response = await client.post(
+        "/nodes/source/",
+        json={
+            "name": f"{parent}.src",
+            "catalog": "default",
+            "schema_": "test",
+            "table": "src",
+            "columns": [{"name": "id", "type": "int"}],
+        },
+    )
+    assert response.status_code <= HTTPStatus.CREATED
+    response = await client.post(
+        "/nodes/transform/",
+        json={
+            "name": f"{parent}.t1",
+            "query": f"SELECT id FROM {parent}.src",
+        },
+    )
+    assert response.status_code <= HTTPStatus.CREATED
+
+    # Mark the transform as INVALID directly. Going through the API to
+    # reliably produce an INVALID node is fragile (validators tend to
+    # reject), and the orchestrator's bulk-validate fast path is what we're
+    # really testing.
+    src_node = (
+        await session.execute(select(Node).where(Node.name == f"{parent}.t1"))
+    ).scalar_one()
+    src_node.current.status = NodeStatus.INVALID
+    await session.commit()
+
+    # Branch creation triggers copy_nodes_to_namespace -> bulk fast path.
+    with patch(
+        "datajunction_server.api.branches.GitHubService",
+    ) as mock_github_class:
+        mock_github = MagicMock()
+        mock_github.create_branch = AsyncMock(
+            return_value={
+                "ref": "refs/heads/feature-copy",
+                "object": {"sha": "abc123"},
+            },
+        )
+        mock_github_class.return_value = mock_github
+        response = await client.post(
+            f"/namespaces/{parent}/branches",
+            json={"branch_name": "feature-copy"},
+        )
+    assert response.status_code == HTTPStatus.CREATED, response.json()
+
+    # The copied transform must keep INVALID status.
+    copied = (
+        await session.execute(select(Node).where(Node.name == f"{branch_full}.t1"))
+    ).scalar_one()
+    await session.refresh(copied, ["current"])
+    assert copied.current.status == NodeStatus.INVALID
+
+    # Sanity-check the source node is still untouched.
+    src_after = (
+        await session.execute(select(Node).where(Node.name == f"{parent}.src"))
+    ).scalar_one()
+    await session.refresh(src_after, ["current"])
+    assert src_after.current.status == NodeStatus.VALID
+
+
+@pytest.mark.asyncio
 async def test_branch_copy_validates_all_specs_match(
     session,
     client_with_service_setup: AsyncClient,

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -431,6 +431,21 @@ def test_deployment_spec_propagates_namespace_to_links():
     )
 
 
+def test_cube_spec_metrics_and_dimensions_default_empty():
+    """A CubeSpec missing metrics/dimensions parses with empty defaults.
+
+    Both fields used to be required (and ``dimensions`` had a buggy
+    ``default_factory=dict``), so a YAML round-trip that dropped empty lists
+    would fail to re-parse. Now both default to ``[]`` so the deployment
+    proceeds and downstream cube validation can flag the cube as INVALID.
+    """
+    from datajunction_server.models.deployment import CubeSpec
+
+    cube = CubeSpec(namespace="test", name="empty_cube")
+    assert cube.metrics == []
+    assert cube.dimensions == []
+
+
 def test_cube_spec_eq_non_cube_spec():
     """CubeSpec.__eq__ returns False when compared to a non-CubeSpec."""
     from datajunction_server.models.deployment import CubeSpec


### PR DESCRIPTION
### Summary

**Branch copy fast-path preserves original node status**

Prior to this, we were unconditionally setting a valid status on all copied nodes during the creation of a new branch namespace, so an invalid entity silently became valid in the branch. With this fix, we always mirror the status on all fast-path call sites.

**CubeSpec accepts empty metrics/dimensions**

Metrics were required on a cube, so when the export YAML round-trip dropped empty lists, redeploys failed with `Field required`. Both now default to `[]` so an empty-metrics cube parses, deploys, and gets flagged invalid by downstream cube validation rather than failing at pydantic-parse time.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
