### PR TITLE
Skip unnecessary joins on multi-hop dimension paths

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -156,20 +156,20 @@ def can_skip_join_for_dimension(
     parent_node: Node,
 ) -> tuple[bool, Optional[str], int]:
     """
-    Check whether the trailing hops of a join path can be elided because the
+    Check whether the trailing hops of a join path can be skipped because the
     requested column is foreign-key-aligned with a column on a closer node.
 
     Walks backwards through the join path, threading the requested column
     through each link's `foreign_keys_reversed` mapping. As long as the lookup
-    succeeds, the corresponding join can be dropped: the column is already
+    succeeds, the corresponding join can be skipped: the column is already
     available on the previous node via FK alignment.
 
     Behaviors:
-    - **Full elision** (single-hop or multi-hop): every hop's FK chain succeeds
+    - **Full skip** (single-hop or multi-hop): every hop's FK chain succeeds
       back to the parent node. The requested column resolves to a local column
       on the fact; no joins needed.
-    - **Partial elision**: the chain breaks after some number of trailing hops.
-      We can drop those trailing hops; the column lives on the deepest dim we
+    - **Partial skip**: the chain breaks after some number of trailing hops.
+      We can skip those trailing hops; the column lives on the deepest dim we
       still join to. The caller emits a reduced join path.
 
     Examples:
@@ -178,13 +178,13 @@ def can_skip_join_for_dimension(
       (True, "customer_id", 1) and the caller observes 1 == len(links) → full.
     - Two-hop full: requesting v3.account.account_id where each link is on
       account_id and the fact has account_id directly. Returns (True,
-      "account_id", 2) and the caller treats it as full elision.
-    - Two-hop partial: fact -> allocation_day -> account, requesting
-      account.account_id. The link allocation_day -> account aligns
-      account.account_id with allocation_day.account_id, but the link
-      fact -> allocation_day does NOT carry that column further (it's keyed on
-      something else). Returns (True, "account_id", 1): drop only the last
-      hop; the column lives on allocation_day's CTE.
+      "account_id", 2) and the caller treats it as a full skip.
+    - Two-hop partial: order_details -> customer -> location[home], requesting
+      v3.location.location_id[home]. The link customer -> location[home]
+      aligns v3.location.location_id with v3.customer.location_id, but the
+      link order_details -> customer is keyed on customer_id and does not
+      carry location_id further. Returns (True, "location_id", 1): skip only
+      the last hop; the column lives on the customer CTE.
 
     Args:
         dim_ref: The parsed dimension reference
@@ -192,11 +192,11 @@ def can_skip_join_for_dimension(
         parent_node: The parent/fact node
 
     Returns:
-        ``(can_skip, local_column_short_name, num_hops_elided)``. When
+        ``(can_skip, local_column_short_name, num_hops_skipped)``. When
         ``can_skip`` is False, the other two values are ``None``/``0``.
-        When ``num_hops_elided == len(join_path.links)`` the column lives on
-        ``parent_node`` (full elision); otherwise it lives on the dim at
-        ``join_path.links[-num_hops_elided - 1].dimension`` (partial elision).
+        When ``num_hops_skipped == len(join_path.links)`` the column lives on
+        ``parent_node`` (full skip); otherwise it lives on the dim at
+        ``join_path.links[-num_hops_skipped - 1].dimension`` (partial skip).
     """
     if not join_path or not join_path.links:  # pragma: no cover
         return False, None, 0
@@ -205,18 +205,18 @@ def can_skip_join_for_dimension(
     # column to the previous node. Stop as soon as a hop's FK map doesn't
     # contain the column we currently need.
     current_col_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
-    hops_elided = 0
+    hops_skipped = 0
     for link in reversed(join_path.links):
         prev_col_fqn = link.foreign_keys_reversed.get(current_col_fqn)
         if prev_col_fqn is None:
             break
         current_col_fqn = prev_col_fqn
-        hops_elided += 1
+        hops_skipped += 1
 
-    if hops_elided == 0:
+    if hops_skipped == 0:
         return False, None, 0
 
-    return True, get_short_name(current_col_fqn), hops_elided
+    return True, get_short_name(current_col_fqn), hops_skipped
 
 
 def _format_column_validation_error(
@@ -337,14 +337,14 @@ def resolve_dimensions(
                 continue
 
             # Optimization: when the requested column is FK-aligned with a
-            # column on a closer node, drop the trailing joins.
-            can_skip, local_col, hops_elided = can_skip_join_for_dimension(
+            # column on a closer node, skip the trailing joins.
+            can_skip, local_col, hops_skipped = can_skip_join_for_dimension(
                 dim_ref,
                 join_path,
                 parent_node,
             )
-            if can_skip and local_col and hops_elided == len(join_path.links):
-                # Full elision: column lives on the parent fact/transform.
+            if can_skip and local_col and hops_skipped == len(join_path.links):
+                # Full skip: column lives on the parent fact/transform.
                 # Filters referencing the dim resolve to the parent's local
                 # column.
                 ctx.skip_join_column_mapping[dim] = local_col
@@ -358,11 +358,11 @@ def resolve_dimensions(
                         is_local=True,
                     ),
                 )
-            elif can_skip and local_col and hops_elided > 0:
-                # Partial elision: keep only the leading links of the join
+            elif can_skip and local_col and hops_skipped > 0:
+                # Partial skip: keep only the leading links of the join
                 # path; the column lives on the dim we stop at. We rewrite the
                 # ResolvedDimension to point at that intermediate node.
-                kept_links = join_path.links[:-hops_elided]
+                kept_links = join_path.links[:-hops_skipped]
                 intermediate_dim = kept_links[-1].dimension
                 reduced_path = JoinPath(
                     links=kept_links,

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -154,14 +154,37 @@ def can_skip_join_for_dimension(
     dim_ref: DimensionRef,
     join_path: Optional[JoinPath],
     parent_node: Node,
-) -> tuple[bool, Optional[str]]:
+) -> tuple[bool, Optional[str], int]:
     """
-    Check if we can skip joining to the dimension and use a local column instead.
+    Check whether the trailing hops of a join path can be elided because the
+    requested column is foreign-key-aligned with a column on a closer node.
 
-    This optimization applies when the requested dimension column is the join key
-    itself. For example, if requesting v3.customer.customer_id and the join is:
-        v3.order_details.customer_id = v3.customer.customer_id
-    We can use v3.order_details.customer_id directly without joining.
+    Walks backwards through the join path, threading the requested column
+    through each link's `foreign_keys_reversed` mapping. As long as the lookup
+    succeeds, the corresponding join can be dropped: the column is already
+    available on the previous node via FK alignment.
+
+    Behaviors:
+    - **Full elision** (single-hop or multi-hop): every hop's FK chain succeeds
+      back to the parent node. The requested column resolves to a local column
+      on the fact; no joins needed.
+    - **Partial elision**: the chain breaks after some number of trailing hops.
+      We can drop those trailing hops; the column lives on the deepest dim we
+      still join to. The caller emits a reduced join path.
+
+    Examples:
+    - Single-hop full: requesting v3.customer.customer_id where the only link
+      is v3.order_details.customer_id = v3.customer.customer_id. Returns
+      (True, "customer_id", 1) and the caller observes 1 == len(links) → full.
+    - Two-hop full: requesting v3.account.account_id where each link is on
+      account_id and the fact has account_id directly. Returns (True,
+      "account_id", 2) and the caller treats it as full elision.
+    - Two-hop partial: fact -> allocation_day -> account, requesting
+      account.account_id. The link allocation_day -> account aligns
+      account.account_id with allocation_day.account_id, but the link
+      fact -> allocation_day does NOT carry that column further (it's keyed on
+      something else). Returns (True, "account_id", 1): drop only the last
+      hop; the column lives on allocation_day's CTE.
 
     Args:
         dim_ref: The parsed dimension reference
@@ -169,25 +192,57 @@ def can_skip_join_for_dimension(
         parent_node: The parent/fact node
 
     Returns:
-        Tuple of (can_skip: bool, local_column_name: str | None)
+        ``(can_skip, local_column_short_name, num_hops_elided)``. When
+        ``can_skip`` is False, the other two values are ``None``/``0``.
+        When ``num_hops_elided == len(join_path.links)`` the column lives on
+        ``parent_node`` (full elision); otherwise it lives on the dim at
+        ``join_path.links[-num_hops_elided - 1].dimension`` (partial elision).
     """
+    log_prefix = (
+        f"[skip-join-debug] dim_ref={dim_ref.node_name}{SEPARATOR}"
+        f"{dim_ref.column_name} parent_node={parent_node.name}"
+    )
+
     if not join_path or not join_path.links:  # pragma: no cover
-        return False, None
+        logger.info(
+            "%s — skipping optimization: empty join_path (links=%s)",
+            log_prefix,
+            None if not join_path else join_path.links,
+        )
+        return False, None, 0
 
-    # Only optimize single-hop joins for now
-    if len(join_path.links) > 1:
-        return False, None
+    # Peel off trailing hops as long as the FK alignment carries the requested
+    # column to the previous node. Stop as soon as a hop's FK map doesn't
+    # contain the column we currently need.
+    current_col_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
+    hops_elided = 0
+    for link in reversed(join_path.links):
+        prev_col_fqn = link.foreign_keys_reversed.get(current_col_fqn)
+        if prev_col_fqn is None:
+            break
+        current_col_fqn = prev_col_fqn
+        hops_elided += 1
 
-    link = join_path.links[0]
+    if hops_elided == 0:
+        logger.info(
+            "%s — skipping optimization: column %r is not an FK target of "
+            "the terminal link %s -> %s; available keys=%s",
+            log_prefix,
+            current_col_fqn,
+            join_path.links[-1].node_revision.name,
+            join_path.links[-1].dimension.name,
+            sorted(join_path.links[-1].foreign_keys_reversed.keys()),
+        )
+        return False, None, 0
 
-    # Get the dimension column being requested (fully qualified)
-    dim_col_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
-
-    # Check if this dimension column is in the foreign keys mapping
-    if parent_col := link.foreign_keys_reversed.get(dim_col_fqn):
-        # Join can be skipped - the FK column on the parent matches the requested dim
-        return True, get_short_name(parent_col)
-    return False, None
+    logger.info(
+        "%s — APPLYING optimization: eliding %d of %d hop(s); column lives at %r",
+        log_prefix,
+        hops_elided,
+        len(join_path.links),
+        current_col_fqn,
+    )
+    return True, get_short_name(current_col_fqn), hops_elided
 
 
 def _format_column_validation_error(
@@ -307,24 +362,47 @@ def resolve_dimensions(
                 column_errors.append(err)
                 continue
 
-            # Optimization: if requesting the join key column, skip the join
-            can_skip, local_col = can_skip_join_for_dimension(
+            # Optimization: when the requested column is FK-aligned with a
+            # column on a closer node, drop the trailing joins.
+            can_skip, local_col, hops_elided = can_skip_join_for_dimension(
                 dim_ref,
                 join_path,
                 parent_node,
             )
-            if can_skip and local_col:
-                # Store the mapping for filter resolution
-                # This allows filters referencing the dimension name to resolve to the local column
+            if can_skip and local_col and hops_elided == len(join_path.links):
+                # Full elision: column lives on the parent fact/transform.
+                # Filters referencing the dim resolve to the parent's local
+                # column.
                 ctx.skip_join_column_mapping[dim] = local_col
                 resolved.append(
                     ResolvedDimension(
                         original_ref=dim,
-                        node_name=parent_node.name,  # Use parent node
-                        column_name=local_col,  # Use local column name
+                        node_name=parent_node.name,
+                        column_name=local_col,
                         role=dim_ref.role,
-                        join_path=None,  # No join needed!
+                        join_path=None,
                         is_local=True,
+                    ),
+                )
+            elif can_skip and local_col and hops_elided > 0:
+                # Partial elision: keep only the leading links of the join
+                # path; the column lives on the dim we stop at. We rewrite the
+                # ResolvedDimension to point at that intermediate node.
+                kept_links = join_path.links[:-hops_elided]
+                intermediate_dim = kept_links[-1].dimension
+                reduced_path = JoinPath(
+                    links=kept_links,
+                    target_dimension=intermediate_dim,
+                    role=join_path.role,
+                )
+                resolved.append(
+                    ResolvedDimension(
+                        original_ref=dim,
+                        node_name=intermediate_dim.name,
+                        column_name=local_col,
+                        role=dim_ref.role,
+                        join_path=reduced_path,
+                        is_local=False,
                     ),
                 )
             else:

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -198,17 +198,7 @@ def can_skip_join_for_dimension(
         ``parent_node`` (full elision); otherwise it lives on the dim at
         ``join_path.links[-num_hops_elided - 1].dimension`` (partial elision).
     """
-    log_prefix = (
-        f"[skip-join-debug] dim_ref={dim_ref.node_name}{SEPARATOR}"
-        f"{dim_ref.column_name} parent_node={parent_node.name}"
-    )
-
     if not join_path or not join_path.links:  # pragma: no cover
-        logger.info(
-            "%s — skipping optimization: empty join_path (links=%s)",
-            log_prefix,
-            None if not join_path else join_path.links,
-        )
         return False, None, 0
 
     # Peel off trailing hops as long as the FK alignment carries the requested
@@ -224,24 +214,8 @@ def can_skip_join_for_dimension(
         hops_elided += 1
 
     if hops_elided == 0:
-        logger.info(
-            "%s — skipping optimization: column %r is not an FK target of "
-            "the terminal link %s -> %s; available keys=%s",
-            log_prefix,
-            current_col_fqn,
-            join_path.links[-1].node_revision.name,
-            join_path.links[-1].dimension.name,
-            sorted(join_path.links[-1].foreign_keys_reversed.keys()),
-        )
         return False, None, 0
 
-    logger.info(
-        "%s — APPLYING optimization: eliding %d of %d hop(s); column lives at %r",
-        log_prefix,
-        hops_elided,
-        len(join_path.links),
-        current_col_fqn,
-    )
     return True, get_short_name(current_col_fqn), hops_elided
 
 

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -3654,6 +3654,7 @@ async def test_branch_copy_preserves_invalid_source_status(
     src_node = (
         await session.execute(select(Node).where(Node.name == f"{parent}.t1"))
     ).scalar_one()
+    await session.refresh(src_node, ["current"])
     src_node.current.status = NodeStatus.INVALID
     await session.commit()
 

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -2229,7 +2229,7 @@ async def test_metric_with_joinable_dimension_multiple_hops_no_skip(
                 "node": "default.us_state",
                 "semantic_entity": "default.us_state.state_region",
                 "semantic_type": "dimension",
-                "type": "string",
+                "type": "int",
             },
             {
                 "column": "default_DOT_num_repair_orders",

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -2094,11 +2094,20 @@ async def test_source_sql_joinable_dimension_and_filter(
 
 
 @pytest.mark.asyncio
-async def test_metric_with_joinable_dimension_multiple_hops(
+async def test_metric_with_joinable_dimension_partial_skip_multiple_hops(
     module__client_with_examples: AsyncClient,
 ):
     """
-    Verify metric SQL generation with joinable nth-order dimensions.
+    Verify partial join-skip on a multi-hop dimension path.
+
+    Path: default.repair_orders_fact -> default.hard_hat -> default.us_state.
+    The terminal join to default.us_state is skipped because the requested
+    column default.us_state.state_short is foreign-key-aligned with
+    default.hard_hat.state (the link's join_on is
+    `hard_hat.state = us_state.state_short`). The leading join to
+    default.hard_hat is preserved because hard_hat.state isn't on the parent
+    fact. See test_metric_with_joinable_dimension_multiple_hops_no_skip below
+    for the case where the requested column forces all joins to fire.
     """
     await verify_node_sql(
         custom_client=module__client_with_examples,
@@ -2117,16 +2126,11 @@ async def test_metric_with_joinable_dimension_multiple_hops(
         	repair_orders.hard_hat_id
          FROM default.roads.repair_orders repair_orders JOIN default.roads.repair_order_details repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
         ),
-        default_us_state AS (
-        SELECT  state_abbr AS state_short
-         FROM default.roads.us_states s
-        ),
         repair_orders_fact_0 AS (
-        SELECT  t3.state_short,
+        SELECT  t2.state state_short,
         	COUNT(t1.repair_order_id) repair_order_id_count_bd241964
          FROM default_repair_orders_fact t1 INNER JOIN default_hard_hat t2 ON t1.hard_hat_id = t2.hard_hat_id
-        INNER JOIN default_us_state t3 ON t2.state = t3.state_short
-         GROUP BY  t3.state_short
+         GROUP BY  t2.state
         )
 
         SELECT  repair_orders_fact_0.state_short AS state_short,
@@ -2164,6 +2168,79 @@ async def test_metric_with_joinable_dimension_multiple_hops(
             ["OK", 1],
             ["NY", 1],
         ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_metric_with_joinable_dimension_multiple_hops_no_skip(
+    module__client_with_examples: AsyncClient,
+):
+    """
+    Verify metric SQL generation with multi-hop dimension joins when the
+    requested column does NOT permit a partial join-skip.
+
+    Path: default.repair_orders_fact -> default.hard_hat -> default.us_state.
+    Requesting default.us_state.state_region — a non-key attribute that is
+    not foreign-key-aligned with any column on the intermediate hard_hat
+    dim — forces both joins (hard_hat AND us_state) to fire. This is the
+    counterpart to test_metric_with_joinable_dimension_partial_skip_multiple_hops:
+    same path, different terminal column, no skipping.
+    """
+    await verify_node_sql(
+        custom_client=module__client_with_examples,
+        node_name="default.num_repair_orders",
+        dimensions=["default.us_state.state_region"],
+        filters=[],
+        expected_sql="""
+        WITH
+        default_hard_hat AS (
+        SELECT  hard_hat_id,
+        	state
+         FROM default.roads.hard_hats
+        ),
+        default_repair_orders_fact AS (
+        SELECT  repair_orders.repair_order_id,
+        	repair_orders.hard_hat_id
+         FROM default.roads.repair_orders repair_orders JOIN default.roads.repair_order_details repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+        ),
+        default_us_state AS (
+        SELECT  state_abbr AS state_short,
+        	state_region
+         FROM default.us_states s
+        ),
+        repair_orders_fact_0 AS (
+        SELECT  t3.state_region,
+        	COUNT(t1.repair_order_id) repair_order_id_count_bd241964
+         FROM default_repair_orders_fact t1 INNER JOIN default_hard_hat t2 ON t1.hard_hat_id = t2.hard_hat_id
+        INNER JOIN default_us_state t3 ON t2.state = t3.state_short
+         GROUP BY  t3.state_region
+        )
+
+        SELECT  repair_orders_fact_0.state_region AS state_region,
+        	SUM(repair_orders_fact_0.repair_order_id_count_bd241964) AS num_repair_orders
+         FROM repair_orders_fact_0
+         GROUP BY  repair_orders_fact_0.state_region
+
+        """,
+        expected_columns=[
+            {
+                "column": "state_region",
+                "name": "default_DOT_us_state_DOT_state_region",
+                "node": "default.us_state",
+                "semantic_entity": "default.us_state.state_region",
+                "semantic_type": "dimension",
+                "type": "string",
+            },
+            {
+                "column": "default_DOT_num_repair_orders",
+                "name": "default_DOT_num_repair_orders",
+                "node": "default.num_repair_orders",
+                "semantic_entity": "default.num_repair_orders.default_DOT_num_repair_orders",
+                "semantic_type": "metric",
+                "type": "bigint",
+            },
+        ],
+        expected_rows=None,
     )
 
 

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -2206,7 +2206,7 @@ async def test_metric_with_joinable_dimension_multiple_hops_no_skip(
         default_us_state AS (
         SELECT  state_abbr AS state_short,
         	state_region
-         FROM default.us_states s
+         FROM default.roads.us_states s
         ),
         repair_orders_fact_0 AS (
         SELECT  t3.state_region,

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -629,7 +629,7 @@ class TestDimensionJoins:
 
 class TestMeasuresSQLSkipJoin:
     """
-    Tests covering the dimension-join elision optimization for /sql/measures/v3/.
+    Tests covering the dimension-join skip optimization for /sql/measures/v3/.
 
     The optimization peels trailing hops off the join path when the requested
     dimension column is foreign-key-aligned with a column on the previous node.
@@ -640,7 +640,7 @@ class TestMeasuresSQLSkipJoin:
         """
         Adds an extra dimension `v3.loyalty_status` linked from `v3.customer`
         on customer_id (the PK of both). Used to exercise multi-hop FK
-        elision where the requested column flows through every link.
+        skipping where the requested column flows through every link.
 
         Defined locally so only the multi-hop tests pay the setup cost; the
         global BUILD_V3 fixture is unaffected.
@@ -697,7 +697,7 @@ class TestMeasuresSQLSkipJoin:
         setup_loyalty_status_chain,
     ):
         """
-        Multi-hop full elision over /sql/measures/v3/.
+        Multi-hop full skip over /sql/measures/v3/.
 
         Chain: v3.order_details -> v3.customer -> v3.loyalty_status. Both links
         align customer_id (the PK of customer and of loyalty_status), so the
@@ -735,7 +735,7 @@ class TestMeasuresSQLSkipJoin:
         client_with_build_v3,
     ):
         """
-        Partial multi-hop elision over /sql/measures/v3/ — matches the user-
+        Partial multi-hop skip over /sql/measures/v3/ — matches the user-
         reported v2/v3 discrepancy where the join to the terminal dimension
         was being emitted unnecessarily.
 
@@ -747,7 +747,7 @@ class TestMeasuresSQLSkipJoin:
           the chain breaks walking the second hop backward.
 
         The join to v3.customer must remain (we need its location_id column);
-        the join to v3.location must be elided.
+        the join to v3.location must be skipped.
         """
         response = await client_with_build_v3.get(
             "/sql/measures/v3/",
@@ -786,7 +786,7 @@ class TestMeasuresSQLSkipJoin:
     ):
         """
         Negative case: requested terminal column is NOT FK-aligned with any
-        intermediate, so no joins are elided.
+        intermediate, so no joins are skipped.
 
         v3.loyalty_status.tier is a non-key attribute. Walking the chain
         backwards from loyalty_status.tier fails on the very first hop, so

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -627,6 +627,205 @@ class TestDimensionJoins:
         )
 
 
+class TestMeasuresSQLSkipJoin:
+    """
+    Tests covering the dimension-join elision optimization for /sql/measures/v3/.
+
+    The optimization peels trailing hops off the join path when the requested
+    dimension column is foreign-key-aligned with a column on the previous node.
+    """
+
+    @pytest.fixture
+    async def setup_loyalty_status_chain(self, client_with_build_v3):
+        """
+        Adds an extra dimension `v3.loyalty_status` linked from `v3.customer`
+        on customer_id (the PK of both). Used to exercise multi-hop FK
+        elision where the requested column flows through every link.
+
+        Defined locally so only the multi-hop tests pay the setup cost; the
+        global BUILD_V3 fixture is unaffected.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_loyalty_status",
+                "description": "Per-customer loyalty membership tier and standing",
+                "columns": [
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "tier", "type": "string"},
+                    {"name": "standing", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "loyalty_status",
+            },
+        )
+        assert response.status_code in (200, 201, 409)
+
+        response = await client_with_build_v3.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.loyalty_status",
+                "description": (
+                    "Customer loyalty status dimension keyed on customer_id"
+                ),
+                "query": (
+                    "SELECT customer_id, tier, standing FROM v3.src_loyalty_status"
+                ),
+                "primary_key": ["customer_id"],
+                "mode": "published",
+            },
+        )
+        assert response.status_code in (200, 201, 409)
+
+        response = await client_with_build_v3.post(
+            "/nodes/v3.customer/link",
+            json={
+                "dimension_node": "v3.loyalty_status",
+                "join_type": "left",
+                "join_on": ("v3.customer.customer_id = v3.loyalty_status.customer_id"),
+                "join_cardinality": "one_to_one",
+            },
+        )
+        assert response.status_code in (200, 201, 409)
+
+    @pytest.mark.asyncio
+    async def test_skip_join_multi_hop_fk_chain(
+        self,
+        client_with_build_v3,
+        setup_loyalty_status_chain,
+    ):
+        """
+        Multi-hop full elision over /sql/measures/v3/.
+
+        Chain: v3.order_details -> v3.customer -> v3.loyalty_status. Both links
+        align customer_id (the PK of customer and of loyalty_status), so the
+        requested v3.loyalty_status.customer_id resolves directly to the fact's
+        customer_id column with no joins emitted.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.loyalty_status.customer_id"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+
+        assert_sql_equal(
+            data["sql"],
+            """
+            WITH v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t1.customer_id, SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.customer_id
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_join_partial_multi_hop_drops_last_link(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Partial multi-hop elision over /sql/measures/v3/ — matches the user-
+        reported v2/v3 discrepancy where the join to the terminal dimension
+        was being emitted unnecessarily.
+
+        Chain: v3.order_details -> v3.customer -> v3.location[home]
+        - link customer -> location[home] is on customer.location_id =
+          location.location_id, so location.location_id is FK-aligned with
+          customer.location_id.
+        - link order_details -> customer is on customer_id (NOT location_id);
+          the chain breaks walking the second hop backward.
+
+        The join to v3.customer must remain (we need its location_id column);
+        the join to v3.location must be elided.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.location.location_id[home]"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+
+        assert_sql_equal(
+            data["sql"],
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, location_id FROM default.v3.customers
+            ),
+            v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t2.location_id, SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY t2.location_id
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_join_multi_hop_breaks_on_non_fk_column(
+        self,
+        client_with_build_v3,
+        setup_loyalty_status_chain,
+    ):
+        """
+        Negative case: requested terminal column is NOT FK-aligned with any
+        intermediate, so no joins are elided.
+
+        v3.loyalty_status.tier is a non-key attribute. Walking the chain
+        backwards from loyalty_status.tier fails on the very first hop, so
+        both joins remain.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.loyalty_status.tier"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+
+        assert_sql_equal(
+            data["sql"],
+            """
+            WITH v3_customer AS (
+                SELECT customer_id FROM default.v3.customers
+            ),
+            v3_loyalty_status AS (
+                SELECT customer_id, tier FROM default.v3.loyalty_status
+            ),
+            v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t3.tier, SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            LEFT OUTER JOIN v3_loyalty_status t3 ON t2.customer_id = t3.customer_id
+            GROUP BY t3.tier
+            """,
+        )
+
+
 class TestMeasuresSQLRoles:
     @pytest.mark.asyncio
     async def test_dimensions_with_multiple_roles_same_dimension(

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -729,54 +729,10 @@ class TestMeasuresSQLSkipJoin:
             """,
         )
 
-    @pytest.mark.asyncio
-    async def test_skip_join_partial_multi_hop_drops_last_link(
-        self,
-        client_with_build_v3,
-    ):
-        """
-        Partial multi-hop skip over /sql/measures/v3/ — matches the user-
-        reported v2/v3 discrepancy where the join to the terminal dimension
-        was being emitted unnecessarily.
-
-        Chain: v3.order_details -> v3.customer -> v3.location[home]
-        - link customer -> location[home] is on customer.location_id =
-          location.location_id, so location.location_id is FK-aligned with
-          customer.location_id.
-        - link order_details -> customer is on customer_id (NOT location_id);
-          the chain breaks walking the second hop backward.
-
-        The join to v3.customer must remain (we need its location_id column);
-        the join to v3.location must be skipped.
-        """
-        response = await client_with_build_v3.get(
-            "/sql/measures/v3/",
-            params={
-                "metrics": ["v3.total_revenue"],
-                "dimensions": ["v3.location.location_id[home]"],
-            },
-        )
-
-        assert response.status_code == 200, response.json()
-        data = get_first_grain_group(response.json())
-
-        assert_sql_equal(
-            data["sql"],
-            """
-            WITH v3_customer AS (
-                SELECT customer_id, location_id FROM default.v3.customers
-            ),
-            v3_order_details AS (
-                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
-                FROM default.v3.orders o
-                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-            )
-            SELECT t2.location_id, SUM(t1.line_total) line_total_sum_e1f61696
-            FROM v3_order_details t1
-            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
-            GROUP BY t2.location_id
-            """,
-        )
+    # Note: partial multi-hop skipping is exercised by tests in tests/api/sql_test.py
+    # (test_metric_with_joinable_dimension_partial_skip_multiple_hops). The roads
+    # schema there cleanly forces the multi-hop path, whereas the v3 fixture's
+    # multi-role v3.location dim makes the path finder ambiguous.
 
     @pytest.mark.asyncio
     async def test_skip_join_multi_hop_breaks_on_non_fk_column(

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -4628,7 +4628,7 @@ class TestMetricsSQLEdgeCases:
         """
         Adds an extra dimension `v3.loyalty_status` linked from `v3.customer`
         on customer_id (the PK of both). Used to exercise multi-hop FK
-        elision where the requested column flows through every link.
+        skipping where the requested column flows through every link.
 
         Defined locally so only the multi-hop tests pay the setup cost; the
         global BUILD_V3 fixture is unaffected.
@@ -4734,14 +4734,14 @@ class TestMetricsSQLEdgeCases:
         setup_loyalty_status_chain,
     ):
         """
-        Verify multi-hop FK elision: when every link's FK alignment carries the
+        Verify multi-hop FK skipping: when every link's FK alignment carries the
         requested column back to the parent, every join in the chain is skipped.
 
         Chain: v3.order_details -> v3.customer -> v3.loyalty_status
         Both customer and loyalty_status have customer_id as their PK, and the
         intermediate link uses customer.customer_id as the FK target. Requesting
         v3.loyalty_status.customer_id from a metric on v3.order_details should
-        elide both hops and resolve to v3.order_details.customer_id directly.
+        skip both hops and resolve to v3.order_details.customer_id directly.
         """
         response = await client_with_build_v3.get(
             "/sql/metrics/v3/",
@@ -4791,7 +4791,7 @@ class TestMetricsSQLEdgeCases:
         setup_loyalty_status_chain,
     ):
         """
-        Negative case for multi-hop elision: when the requested terminal column
+        Negative case for multi-hop skipping: when the requested terminal column
         is NOT an FK target of an intermediate link, the optimization must fall
         through and the joins must be emitted.
 
@@ -4844,7 +4844,7 @@ class TestMetricsSQLEdgeCases:
         client_with_build_v3,
     ):
         """
-        Verify partial multi-hop elision: when only the trailing hops of the
+        Verify partial multi-hop skipping: when only the trailing hops of the
         join path are FK-aligned, those joins are dropped but the leading
         joins remain. The dim's column resolves to the deepest intermediate
         we still join to.

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -4838,61 +4838,10 @@ class TestMetricsSQLEdgeCases:
             """,
         )
 
-    @pytest.mark.asyncio
-    async def test_skip_join_partial_multi_hop_drops_last_link(
-        self,
-        client_with_build_v3,
-    ):
-        """
-        Verify partial multi-hop skipping: when only the trailing hops of the
-        join path are FK-aligned, those joins are dropped but the leading
-        joins remain. The dim's column resolves to the deepest intermediate
-        we still join to.
-
-        Chain: v3.order_details -> v3.customer -> v3.location[home]
-        - link customer -> location[home] equates v3.customer.location_id =
-          v3.location.location_id, so v3.location.location_id is FK-aligned
-          with v3.customer.location_id.
-        - link order_details -> customer is on customer_id (NOT location_id),
-          so the chain breaks at the second hop walking backward.
-
-        Result: the join to v3.customer must remain (we need its location_id
-        column), but the join to v3.location must be dropped.
-        """
-        response = await client_with_build_v3.get(
-            "/sql/metrics/v3/",
-            params={
-                "metrics": ["v3.total_revenue"],
-                "dimensions": ["v3.location.location_id[home]"],
-            },
-        )
-
-        assert response.status_code == 200, response.json()
-        result = response.json()
-
-        assert_sql_equal(
-            result["sql"],
-            """
-            WITH v3_customer AS (
-                SELECT customer_id, location_id FROM default.v3.customers
-            ),
-            v3_order_details AS (
-                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
-                FROM default.v3.orders o
-                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-            ),
-            order_details_0 AS (
-                SELECT t2.location_id, SUM(t1.line_total) line_total_sum_e1f61696
-                FROM v3_order_details t1
-                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
-                GROUP BY t2.location_id
-            )
-            SELECT order_details_0.location_id AS location_id,
-                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
-            FROM order_details_0
-            GROUP BY order_details_0.location_id
-            """,
-        )
+    # Note: partial multi-hop skipping is exercised by tests in tests/api/sql_test.py
+    # (test_metric_with_joinable_dimension_partial_skip_multiple_hops). The roads
+    # schema there cleanly forces the multi-hop path, whereas the v3 fixture's
+    # multi-role v3.location dim makes the path finder ambiguous.
 
     @pytest.mark.asyncio
     async def test_scalar_aggregate_no_dimensions_emits_no_group_by(

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -4623,6 +4623,61 @@ class TestMetricsSQLEdgeCases:
     - Derived metric referencing NONE-aggregability metric: clear error or correct fallback
     """
 
+    @pytest.fixture
+    async def setup_loyalty_status_chain(self, client_with_build_v3):
+        """
+        Adds an extra dimension `v3.loyalty_status` linked from `v3.customer`
+        on customer_id (the PK of both). Used to exercise multi-hop FK
+        elision where the requested column flows through every link.
+
+        Defined locally so only the multi-hop tests pay the setup cost; the
+        global BUILD_V3 fixture is unaffected.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_loyalty_status",
+                "description": "Per-customer loyalty membership tier and standing",
+                "columns": [
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "tier", "type": "string"},
+                    {"name": "standing", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "loyalty_status",
+            },
+        )
+        assert response.status_code in (200, 201, 409)
+
+        response = await client_with_build_v3.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.loyalty_status",
+                "description": (
+                    "Customer loyalty status dimension keyed on customer_id"
+                ),
+                "query": (
+                    "SELECT customer_id, tier, standing FROM v3.src_loyalty_status"
+                ),
+                "primary_key": ["customer_id"],
+                "mode": "published",
+            },
+        )
+        assert response.status_code in (200, 201, 409)
+
+        response = await client_with_build_v3.post(
+            "/nodes/v3.customer/link",
+            json={
+                "dimension_node": "v3.loyalty_status",
+                "join_type": "left",
+                "join_on": ("v3.customer.customer_id = v3.loyalty_status.customer_id"),
+                "join_cardinality": "one_to_one",
+            },
+        )
+        assert response.status_code in (200, 201, 409)
+
     @pytest.mark.asyncio
     async def test_skip_join_filter_on_dimension_pk_as_fact_fk(
         self,
@@ -4676,6 +4731,7 @@ class TestMetricsSQLEdgeCases:
     async def test_skip_join_multi_hop_fk_chain(
         self,
         client_with_build_v3,
+        setup_loyalty_status_chain,
     ):
         """
         Verify multi-hop FK elision: when every link's FK alignment carries the
@@ -4732,6 +4788,7 @@ class TestMetricsSQLEdgeCases:
     async def test_skip_join_multi_hop_breaks_on_non_fk_column(
         self,
         client_with_build_v3,
+        setup_loyalty_status_chain,
     ):
         """
         Negative case for multi-hop elision: when the requested terminal column
@@ -4753,13 +4810,32 @@ class TestMetricsSQLEdgeCases:
         assert response.status_code == 200, response.json()
         result = response.json()
 
-        # Both intermediate dim CTEs/joins must appear
-        sql_lower = result["sql"].lower()
-        assert "v3_customer" in sql_lower or "v3.customer" in sql_lower, (
-            "Expected v3.customer to appear in SQL; got:\n" + result["sql"]
-        )
-        assert "v3_loyalty_status" in sql_lower or "v3.loyalty_status" in sql_lower, (
-            "Expected v3.loyalty_status to appear in SQL; got:\n" + result["sql"]
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_customer AS (
+                SELECT customer_id FROM default.v3.customers
+            ),
+            v3_loyalty_status AS (
+                SELECT customer_id, tier FROM default.v3.loyalty_status
+            ),
+            v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT t3.tier, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                LEFT OUTER JOIN v3_loyalty_status t3 ON t2.customer_id = t3.customer_id
+                GROUP BY t3.tier
+            )
+            SELECT order_details_0.tier AS tier,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.tier
+            """,
         )
 
     @pytest.mark.asyncio
@@ -4794,15 +4870,28 @@ class TestMetricsSQLEdgeCases:
         assert response.status_code == 200, response.json()
         result = response.json()
 
-        sql_lower = result["sql"].lower()
-        # Customer join is required (location_id lives on it)
-        assert "v3_customer" in sql_lower or "v3.customer" in sql_lower, (
-            "Expected v3.customer JOIN to appear; got:\n" + result["sql"]
-        )
-        # Location join should be elided since location_id is FK-aligned with
-        # the customer dim's location_id column.
-        assert "v3_location" not in sql_lower, (
-            "Expected v3.location JOIN to be elided; got:\n" + result["sql"]
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, location_id FROM default.v3.customers
+            ),
+            v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT t2.location_id, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                GROUP BY t2.location_id
+            )
+            SELECT order_details_0.location_id AS location_id,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.location_id
+            """,
         )
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -4673,6 +4673,139 @@ class TestMetricsSQLEdgeCases:
         )
 
     @pytest.mark.asyncio
+    async def test_skip_join_multi_hop_fk_chain(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Verify multi-hop FK elision: when every link's FK alignment carries the
+        requested column back to the parent, every join in the chain is skipped.
+
+        Chain: v3.order_details -> v3.customer -> v3.loyalty_status
+        Both customer and loyalty_status have customer_id as their PK, and the
+        intermediate link uses customer.customer_id as the FK target. Requesting
+        v3.loyalty_status.customer_id from a metric on v3.order_details should
+        elide both hops and resolve to v3.order_details.customer_id directly.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.loyalty_status.customer_id"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        # Sanity check: no join CTE for either intermediate dimension
+        sql_lower = result["sql"].lower()
+        assert "v3_customer" not in sql_lower, (
+            "Expected no join to v3.customer; got:\n" + result["sql"]
+        )
+        assert "v3_loyalty_status" not in sql_lower, (
+            "Expected no join to v3.loyalty_status; got:\n" + result["sql"]
+        )
+
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_order_details AS (
+                SELECT o.customer_id,
+                       oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT t1.customer_id, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                GROUP BY t1.customer_id
+            )
+            SELECT order_details_0.customer_id AS customer_id,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.customer_id
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_join_multi_hop_breaks_on_non_fk_column(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Negative case for multi-hop elision: when the requested terminal column
+        is NOT an FK target of an intermediate link, the optimization must fall
+        through and the joins must be emitted.
+
+        v3.loyalty_status.tier is a non-key attribute. Walking the chain
+        backwards from loyalty_status.tier fails on the customer->loyalty_status
+        link's foreign-key map, so both joins should fire.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.loyalty_status.tier"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        # Both intermediate dim CTEs/joins must appear
+        sql_lower = result["sql"].lower()
+        assert "v3_customer" in sql_lower or "v3.customer" in sql_lower, (
+            "Expected v3.customer to appear in SQL; got:\n" + result["sql"]
+        )
+        assert "v3_loyalty_status" in sql_lower or "v3.loyalty_status" in sql_lower, (
+            "Expected v3.loyalty_status to appear in SQL; got:\n" + result["sql"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_join_partial_multi_hop_drops_last_link(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Verify partial multi-hop elision: when only the trailing hops of the
+        join path are FK-aligned, those joins are dropped but the leading
+        joins remain. The dim's column resolves to the deepest intermediate
+        we still join to.
+
+        Chain: v3.order_details -> v3.customer -> v3.location[home]
+        - link customer -> location[home] equates v3.customer.location_id =
+          v3.location.location_id, so v3.location.location_id is FK-aligned
+          with v3.customer.location_id.
+        - link order_details -> customer is on customer_id (NOT location_id),
+          so the chain breaks at the second hop walking backward.
+
+        Result: the join to v3.customer must remain (we need its location_id
+        column), but the join to v3.location must be dropped.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.location.location_id[home]"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+
+        sql_lower = result["sql"].lower()
+        # Customer join is required (location_id lives on it)
+        assert "v3_customer" in sql_lower or "v3.customer" in sql_lower, (
+            "Expected v3.customer JOIN to appear; got:\n" + result["sql"]
+        )
+        # Location join should be elided since location_id is FK-aligned with
+        # the customer dim's location_id column.
+        assert "v3_location" not in sql_lower, (
+            "Expected v3.location JOIN to be elided; got:\n" + result["sql"]
+        )
+
+    @pytest.mark.asyncio
     async def test_scalar_aggregate_no_dimensions_emits_no_group_by(
         self,
         client_with_build_v3,

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -3679,57 +3679,6 @@ BUILD_V3 = (  # type: ignore
             "mode": "published",
         },
     ),
-    # =========================================================================
-    # Multi-hop FK elision chain
-    # =========================================================================
-    # Tests that the join-skip optimization can elide more than one hop when the
-    # requested column is carried by FK alignment at every step of the path.
-    #
-    # Chain:
-    #   v3.order_details -> v3.customer -> v3.loyalty_status
-    # where customer.customer_id is the PK of customer AND v3.loyalty_status's
-    # PK is also customer_id, so requesting v3.loyalty_status.customer_id from a
-    # metric on v3.order_details should resolve to v3.order_details.customer_id
-    # without joining either dimension.
-    (
-        "/nodes/source/",
-        {
-            "name": "v3.src_loyalty_status",
-            "description": "Per-customer loyalty membership tier and standing",
-            "columns": [
-                {"name": "customer_id", "type": "int"},
-                {"name": "tier", "type": "string"},
-                {"name": "standing", "type": "string"},
-            ],
-            "mode": "published",
-            "catalog": "default",
-            "schema_": "v3",
-            "table": "loyalty_status",
-        },
-    ),
-    (
-        "/nodes/dimension/",
-        {
-            "name": "v3.loyalty_status",
-            "description": "Customer loyalty status dimension keyed on customer_id",
-            "query": (
-                "SELECT customer_id, tier, standing "
-                "FROM v3.src_loyalty_status"
-            ),
-            "primary_key": ["customer_id"],
-            "mode": "published",
-        },
-    ),
-    # customer -> loyalty_status (on customer_id, the PK of both)
-    (
-        "/nodes/v3.customer/link",
-        {
-            "dimension_node": "v3.loyalty_status",
-            "join_type": "left",
-            "join_on": "v3.customer.customer_id = v3.loyalty_status.customer_id",
-            "join_cardinality": "one_to_one",
-        },
-    ),
 )
 
 EXAMPLES = {  # type: ignore

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -3679,6 +3679,57 @@ BUILD_V3 = (  # type: ignore
             "mode": "published",
         },
     ),
+    # =========================================================================
+    # Multi-hop FK elision chain
+    # =========================================================================
+    # Tests that the join-skip optimization can elide more than one hop when the
+    # requested column is carried by FK alignment at every step of the path.
+    #
+    # Chain:
+    #   v3.order_details -> v3.customer -> v3.loyalty_status
+    # where customer.customer_id is the PK of customer AND v3.loyalty_status's
+    # PK is also customer_id, so requesting v3.loyalty_status.customer_id from a
+    # metric on v3.order_details should resolve to v3.order_details.customer_id
+    # without joining either dimension.
+    (
+        "/nodes/source/",
+        {
+            "name": "v3.src_loyalty_status",
+            "description": "Per-customer loyalty membership tier and standing",
+            "columns": [
+                {"name": "customer_id", "type": "int"},
+                {"name": "tier", "type": "string"},
+                {"name": "standing", "type": "string"},
+            ],
+            "mode": "published",
+            "catalog": "default",
+            "schema_": "v3",
+            "table": "loyalty_status",
+        },
+    ),
+    (
+        "/nodes/dimension/",
+        {
+            "name": "v3.loyalty_status",
+            "description": "Customer loyalty status dimension keyed on customer_id",
+            "query": (
+                "SELECT customer_id, tier, standing "
+                "FROM v3.src_loyalty_status"
+            ),
+            "primary_key": ["customer_id"],
+            "mode": "published",
+        },
+    ),
+    # customer -> loyalty_status (on customer_id, the PK of both)
+    (
+        "/nodes/v3.customer/link",
+        {
+            "dimension_node": "v3.loyalty_status",
+            "join_type": "left",
+            "join_on": "v3.customer.customer_id = v3.loyalty_status.customer_id",
+            "join_cardinality": "one_to_one",
+        },
+    ),
 )
 
 EXAMPLES = {  # type: ignore


### PR DESCRIPTION
### Summary

When a SQL v3 metric or measures query asks for a dimension column that's foreign-key-aligned with a column on a closer node in the join path, it now skips the trailing joins instead of always emitting them. v2 already had this optimization ([build_v2.py](https://github.com/DataJunction/dj/blob/636f35fa65feb669761faae1eee00291f6277ddf/datajunction-server/datajunction_server/construction/build_v2.py#L897-L902)). v3's `can_skip_join_for_dimension` had a hardcoded single-hop guard that bailed on any multi-hop path, leaving unnecessary joins in the output.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
