### PR TITLE
Fix filters after outer joins silently turning them into inner joins

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -937,13 +937,18 @@ def _classify_outer_join_target(
     relation: ast.Relation,
     filter_namespaces: set[str],
 ) -> Optional[ast.Expression]:
-    """Return the relation-side expression that should host a filter as a wrapped
+    """
+    Return the relation-side expression that should host a filter as a wrapped
     subquery, or ``None`` when WHERE injection is safe.
 
-    A filter applied in WHERE after an OUTER JOIN silently turns it into an
-    INNER JOIN whenever the filter touches a non-preserved side: the NULL
-    fill-in rows from the JOIN evaluate the predicate to NULL → false and get
-    dropped. This walks the relation's joins, tracks which side identifiers
+    This function walks the join chain and classifies each side, asking the
+    question: "Does this join introduce NULL-fill on either side?"
+    - LEFT OUTER: yes, on the right, so right side is non-preserved
+    - RIGHT OUTER: yes, on the left, so left side is non-preserved
+    - FULL OUTER: yes, on both sides, so both sides are non-preserved
+    - INNER JOIN: no, both sides are preserved
+
+    This walks the relation's joins, tracks which side identifiers
     are non-preserved, and returns the target expression to wrap when all of
     the filter's namespace references resolve to a single non-preserved side.
     """

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -5,7 +5,7 @@ CTE building and AST transformation utilities
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Optional
+from typing import Optional, cast
 
 from datajunction_server.construction.build_v3.filters import (
     extract_subscript_role,
@@ -904,18 +904,203 @@ def flatten_inner_ctes(
 # ---------------------------------------------------------------------------
 
 
+_OUTER_JOIN_KINDS_LEFT = {"LEFT", "LEFT OUTER"}
+_OUTER_JOIN_KINDS_RIGHT = {"RIGHT", "RIGHT OUTER"}
+_OUTER_JOIN_KINDS_FULL = {"FULL", "FULL OUTER", "OUTER"}
+
+
+def _get_relation_side_id(expr: ast.Expression) -> Optional[str]:
+    """Extract the alias or unqualified name used to qualify column refs to a side.
+
+    Returns ``None`` when the expression has no extractable identifier (e.g.
+    an unaliased subquery — defensive only; the v3 builder always emits
+    aliased relations).
+    """
+    alias = getattr(expr, "alias", None)
+    if alias is not None:
+        return alias.name
+    if isinstance(expr, ast.Table):
+        return expr.name.name
+    return None  # pragma: no cover
+
+
+def _filter_namespaces(filter_ast: ast.Expression) -> set[str]:
+    """Collect the namespace identifiers used to qualify columns in a filter."""
+    return {
+        col.name.namespace.name
+        for col in filter_ast.find_all(ast.Column)
+        if col.name.namespace is not None
+    }
+
+
+def _classify_outer_join_target(
+    relation: ast.Relation,
+    filter_namespaces: set[str],
+) -> Optional[ast.Expression]:
+    """Return the relation-side expression that should host a filter as a wrapped
+    subquery, or ``None`` when WHERE injection is safe.
+
+    A filter applied in WHERE after an OUTER JOIN silently turns it into an
+    INNER JOIN whenever the filter touches a non-preserved side: the NULL
+    fill-in rows from the JOIN evaluate the predicate to NULL → false and get
+    dropped. This walks the relation's joins, tracks which side identifiers
+    are non-preserved, and returns the target expression to wrap when all of
+    the filter's namespace references resolve to a single non-preserved side.
+    """
+    if not relation.extensions or not filter_namespaces:
+        return None
+
+    # ``_get_relation_side_id`` returns None only for unaliased subqueries the
+    # v3 builder never emits — branches guarding ``is not None`` are
+    # defensive only, hence the no-branch pragmas on this loop.
+    preserved: dict[str, ast.Expression] = {}
+    non_preserved: dict[str, ast.Expression] = {}
+    primary_id = _get_relation_side_id(relation.primary)
+    if primary_id is not None:  # pragma: no branch
+        preserved[primary_id] = relation.primary
+
+    for join in relation.extensions:
+        right_id = _get_relation_side_id(join.right)
+        kind = (join.join_type or "").upper().strip()
+
+        if kind in _OUTER_JOIN_KINDS_LEFT:
+            if right_id is not None:  # pragma: no branch
+                non_preserved[right_id] = join.right
+        elif kind in _OUTER_JOIN_KINDS_RIGHT:
+            non_preserved.update(preserved)
+            preserved = {}
+            if right_id is not None:  # pragma: no branch
+                preserved[right_id] = join.right
+        elif kind in _OUTER_JOIN_KINDS_FULL:
+            non_preserved.update(preserved)
+            if right_id is not None:  # pragma: no branch
+                non_preserved[right_id] = join.right
+        elif right_id is not None:  # pragma: no branch
+            preserved[right_id] = join.right
+
+    if not non_preserved or not filter_namespaces.issubset(non_preserved):
+        return None
+    targets = {non_preserved[ns] for ns in filter_namespaces}
+    return next(iter(targets)) if len(targets) == 1 else None
+
+
+def _wrap_relation_side_with_filter(
+    target_expr: ast.Expression,
+    filter_ast: ast.Expression,
+) -> ast.Query:
+    """Wrap a relation-side expression as ``(SELECT * FROM <expr> WHERE filter) <alias>``.
+
+    The original alias is preserved on the outer wrapping query so column refs
+    qualified by the original side identifier continue to resolve.
+    """
+    side_id = _get_relation_side_id(target_expr)
+    inner_select = ast.Select(
+        projection=[ast.Wildcard()],
+        from_=ast.From(relations=[ast.Relation(primary=deepcopy(target_expr))]),
+        where=deepcopy(filter_ast),
+    )
+    wrapped = ast.Query(select=inner_select)
+    wrapped.parenthesized = True
+    # Mark this Query as an outer-join-safety wrap so subsequent filters
+    # targeting the same side AND into its WHERE instead of nesting another
+    # layer.  Inside the wrap, the original alias is preserved on the inner
+    # FROM, so re-qualifying isn't necessary.
+    wrapped._outer_join_filter_wrap = True  # type: ignore[attr-defined]
+    if side_id is not None:  # pragma: no branch
+        wrapped.alias = ast.Name(side_id)
+        wrapped.as_ = False
+    return wrapped
+
+
+def _try_push_filter_into_outer_join_side(
+    select: ast.Select,
+    filter_expr: ast.Expression,
+) -> bool:
+    """Route a filter into the inner-side of an outer join when WHERE would be unsafe.
+
+    Returns True when the filter has been applied via inner-side wrapping
+    (caller must NOT also AND it into WHERE). Returns False when no outer-join
+    hazard applies, leaving the caller to fall back to standard WHERE injection.
+    """
+    if select.from_ is None:
+        return False
+    namespaces = _filter_namespaces(filter_expr)
+    if not namespaces:
+        return False
+
+    for relation in select.from_.relations:
+        target = _classify_outer_join_target(relation, namespaces)
+        if target is None:
+            continue
+        # If the target is already an outer-join-safety wrap from a previous
+        # call, AND the new atom into its inner WHERE rather than nesting
+        # another wrap layer.  The inner FROM preserves the original alias,
+        # so column refs qualified by that alias resolve correctly inside.
+        if isinstance(target, ast.Query) and getattr(
+            target,
+            "_outer_join_filter_wrap",
+            False,
+        ):
+            inner_select = cast(ast.Select, target.select)
+            # The wrap was created with a non-None WHERE; the cast keeps mypy
+            # happy without a runtime branch.
+            existing_where = cast(ast.Expression, inner_select.where)
+            inner_select.where = ast.BinaryOp.And(
+                existing_where,
+                deepcopy(filter_expr),
+            )
+            return True
+        wrapped = _wrap_relation_side_with_filter(target, filter_expr)
+        if relation.primary is target:
+            relation.primary = wrapped
+        else:
+            for join in relation.extensions:  # pragma: no branch
+                if join.right is target:  # pragma: no branch
+                    join.right = wrapped
+                    break
+        return True
+    return False
+
+
+def _split_and_atoms(expr: ast.Expression) -> list[ast.Expression]:
+    """Flatten an AND-tree into its leaf predicates."""
+    if (
+        isinstance(expr, ast.BinaryOp) and expr.op == ast.BinaryOpKind.And  # type: ignore[attr-defined]
+    ):
+        return _split_and_atoms(expr.left) + _split_and_atoms(expr.right)
+    return [expr]
+
+
+def inject_filter_into_select(
+    select: ast.Select,
+    filter_expr: ast.Expression,
+) -> None:
+    """AND a filter expression into a SELECT's WHERE clause, safely.
+
+    When the SELECT's FROM contains an OUTER JOIN whose non-preserved side
+    owns every column referenced by ``filter_expr``, the filter is instead
+    wrapped around that inner-side relation as a subquery — preventing the
+    WHERE from silently turning the OUTER JOIN into an INNER JOIN.
+
+    AND-trees are split so each atom is classified independently: a single
+    bundled WHERE may have some atoms safe for WHERE and others that need
+    inner-side wrapping.
+    """
+    for atom in _split_and_atoms(filter_expr):
+        if _try_push_filter_into_outer_join_side(select, atom):
+            continue
+        if select.where:
+            select.where = ast.BinaryOp.And(select.where, atom)
+        else:
+            select.where = atom
+
+
 def _inject_filter_into_where(
     query_ast: ast.Query,
     filter_expr: ast.Expression,
 ) -> None:
-    """AND a filter expression into a query's WHERE clause."""
-    if query_ast.select.where:
-        query_ast.select.where = ast.BinaryOp.And(
-            query_ast.select.where,
-            filter_expr,
-        )
-    else:
-        query_ast.select.where = filter_expr
+    """AND a filter into a Query's WHERE — wrapper around :func:`inject_filter_into_select`."""
+    inject_filter_into_select(cast(ast.Select, query_ast.select), filter_expr)
 
 
 def _resolve_pushdown_filters_for_cte(
@@ -1133,6 +1318,8 @@ def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str | None]:
           becomes {"order_date": "o.placed_on"}
         SELECT T.test_id
           becomes {"test_id": "T.test_id"}
+        SELECT CAST(x AS INT) AS x
+          becomes {"x": "x"}                   -- CAST is a transparent passthrough
         SELECT SUM(x) AS total
           becomes {"total": None}
     """
@@ -1142,6 +1329,17 @@ def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str | None]:
     for expr in cte_query.select.projection:
         inner = getattr(expr, "child", expr)
         alias = getattr(expr, "alias", None)
+        # Unwrap CAST around a column — CAST(col AS T) is a transparent
+        # passthrough for filter pushdown.  Equality, IN, and range
+        # comparisons against a literal of the cast target type are
+        # value-equivalent to the same comparison against the unwrapped
+        # column (modulo lossy casts, which are rare and generally
+        # intentional in the projection).  Recognising this lets filters
+        # land in CTEs whose projection wraps a column in CAST for type
+        # normalization (e.g. ``CAST(x AS INT) AS x`` from a LATERAL
+        # VIEW EXPLODE'd column).
+        if isinstance(inner, ast.Cast) and isinstance(inner.expression, ast.Column):
+            inner = inner.expression
         if isinstance(inner, ast.Column) and inner.name:
             bare = inner.name.name
             underlying = (

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -356,6 +356,7 @@ def resolve_dimensions(
                         role=dim_ref.role,
                         join_path=None,
                         is_local=True,
+                        pre_skip_join_path=join_path,
                     ),
                 )
             elif can_skip and local_col and hops_skipped > 0:

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 from datajunction_server.construction.build_v3.cte import (
     collect_node_ctes,
     extract_dimension_node,
+    inject_filter_into_select,
     strip_role_suffix,
 )
 from datajunction_server.construction.build_v3.decomposition import (
@@ -32,6 +33,7 @@ from datajunction_server.construction.build_v3.utils import (
     extract_columns_from_expression,
     extract_columns_referenced_from_node,
     get_column_type,
+    get_cte_name,
     get_short_name,
     make_column_ref,
     make_name,
@@ -39,6 +41,7 @@ from datajunction_server.construction.build_v3.utils import (
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.construction.build_v3.materialization import (
     get_table_reference_parts_with_materialization,
+    should_use_materialized_table,
 )
 from datajunction_server.construction.build_v3.types import (
     BuildContext,
@@ -558,15 +561,18 @@ def _build_temporal_pushdown(
     parent_node: Node,
     main_alias: str,
 ) -> tuple[Optional[ast.Expression], dict[str, ast.Expression]]:
-    """Build temporal filter and attempt to push it into the upstream date-spine CTE.
+    """Build temporal filter and push it into the most upstream applicable CTE.
 
-    If a temporal partition filter can be pushed into the upstream CTE that
-    drives the date spine, it is removed from the outer query (returns None
-    for the filter AST) and placed in the injected_cte_filters dict instead.
+    Tries the date-spine upstream first (so the filter applies before any
+    expensive join); falls back to the parent node's own CTE when no
+    upstream date-spine source can be located. The filter is never applied
+    to the outer query's WHERE — that would silently turn any OUTER JOIN
+    inside the parent body into an INNER JOIN by dropping NULL-fill rows.
 
     Returns:
         (temporal_filter_ast, injected_cte_filters) where temporal_filter_ast
-        is None if the filter was successfully pushed down.
+        is always None when the filter was successfully built (it is fully
+        delegated to a CTE injection).
     """
     temporal_filter_ast, fk_col_name = build_temporal_filter(
         ctx,
@@ -581,11 +587,11 @@ def _build_temporal_pushdown(
             parent_node,
             fk_col_name,
         )
-        if upstream_node:
-            unaliased_filter_ast, _ = build_temporal_filter(ctx, parent_node, None)
-            if unaliased_filter_ast:  # pragma: no branch
-                injected_cte_filters[upstream_node.name] = unaliased_filter_ast
-                temporal_filter_ast = None
+        target_node_name = upstream_node.name if upstream_node else parent_node.name
+        unaliased_filter_ast, _ = build_temporal_filter(ctx, parent_node, None)
+        if unaliased_filter_ast:  # pragma: no branch
+            injected_cte_filters[target_node_name] = unaliased_filter_ast
+            temporal_filter_ast = None
 
     return temporal_filter_ast, injected_cte_filters
 
@@ -664,16 +670,334 @@ def build_outer_where(
     return where_clause
 
 
+def _apply_outer_where_atoms(
+    select: ast.Select,
+    where_clause: Optional[ast.Expression],
+    main_alias: str,
+    parent_pushdown_active: bool = False,
+) -> None:
+    """Apply each AND atom of ``where_clause`` to ``select.where``.
+
+    Three categories of atoms:
+
+    - **Parent-alias atoms** (``main_alias.col`` only) when
+      ``parent_pushdown_active`` is True — DROPPED from outer WHERE.
+      The same predicate has already been pushed into the parent CTE's
+      WHERE, so the outer-level copy is redundant *and* unsafe (it
+      would defeat downstream RIGHT/FULL OUTER joins to dims).
+
+    - **Parent-alias atoms** when parent pushdown wasn't applied (e.g.
+      parent is materialized or has a set-op body that blocks
+      pushdown) — routed through :func:`inject_filter_into_select` as
+      the safety backstop.
+
+    - **Dim-alias atoms** (and unqualified atoms) — ANDed into the outer
+      WHERE.  These rely on the standard dim-filter narrowing
+      semantics.  Note: under a downstream RIGHT/FULL OUTER JOIN this
+      can silently defeat that join — the wrapper-CTE absorption step
+      runs earlier to handle the unsafe cases.
+    """
+    if where_clause is None:
+        return
+    from datajunction_server.construction.build_v3.cte import (
+        _filter_namespaces,
+        _split_and_atoms,
+    )
+
+    for atom in _split_and_atoms(where_clause):
+        ns = _filter_namespaces(atom)
+        is_parent_only = bool(ns) and ns.issubset({main_alias})
+        if is_parent_only and parent_pushdown_active:
+            continue
+        if is_parent_only:
+            inject_filter_into_select(select, atom)
+        elif select.where:
+            select.where = ast.BinaryOp.And(select.where, atom)
+        else:
+            select.where = atom
+
+
+def _col_table_name(col: ast.Column) -> Optional[str]:
+    """Return the table-qualifier short name for a column, or None.
+
+    Handles both qualification styles:
+    - ``_table`` (set by :func:`make_column_ref`) — projection / GROUP BY.
+    - ``name.namespace`` (set by ``_add_table_prefixes_to_filter``) —
+      filter atoms.
+    """
+    tbl = col._table
+    if tbl is not None:
+        tname = getattr(tbl, "name", None)
+        if tname is None:  # pragma: no cover
+            return None
+        return tname.name if hasattr(tname, "name") else str(tname)
+    if col.name and col.name.namespace:
+        ns = col.name.namespace
+        return ns.name if hasattr(ns, "name") else str(ns)
+    return None  # pragma: no cover
+
+
+def _set_col_table_alias(col: ast.Column, new_alias: str) -> None:
+    """Rewrite the table-qualifier on a column to ``new_alias``,
+    matching the qualification style already on the column.
+    """
+    if col._table is not None and getattr(col._table, "name", None) is not None:
+        col._table.name = ast.Name(new_alias)  # type: ignore[union-attr]
+    elif col.name and col.name.namespace:  # pragma: no branch
+        col.name = ast.Name(col.name.name, namespace=ast.Name(new_alias))
+
+
+def _absorb_filtered_joins_for_outer_safety(
+    select: ast.Select,
+    where_clause: Optional[ast.Expression],
+    main_alias: str,
+    dim_aliases: dict[tuple[str, Optional[str]], str],
+    parent_cte_name: str,
+    group_by: list[ast.Expression],
+) -> tuple[Optional[ast.Expression], Optional[tuple[str, ast.Query]]]:
+    """Absorb LEFT/INNER joins whose dim-alias filter would defeat a
+    downstream RIGHT/FULL OUTER JOIN into a subquery on the parent
+    side.
+
+    Why this is needed: applying a WHERE on a non-preserved-side dim
+    alias *after* a downstream OUTER JOIN preserving the dim side
+    drops the preserved null-fill rows.  The fix is to apply the dim
+    filter *before* the OUTER JOIN — by absorbing the LEFT/INNER join
+    plus its WHERE into a subquery that the OUTER JOIN's preserved
+    side reaches via a clean ``RIGHT/FULL OUTER JOIN <wrapper>``
+    pattern.
+
+    Builds a filtered CTE named ``<parent_cte_name>_filtered`` that
+    contains the parent + absorbed LEFT/INNER joins with the absorbed
+    WHERE applied inside.  The outer FROM is rewritten to read from
+    that CTE (still aliased as ``main_alias``).  Rewrites references
+    to absorbed aliases (in projection, GROUP BY, remaining join ONs,
+    remaining WHERE atoms) so they point at ``main_alias``.
+
+    Returns ``(updated_where_clause, new_cte_or_None)``.  The caller is
+    responsible for appending ``new_cte`` (if non-None) to the CTE
+    list attached to the final query.
+    """
+    if where_clause is None or not select.from_ or not select.from_.relations:
+        return where_clause, None
+
+    relation = select.from_.relations[0]
+    extensions = relation.extensions
+    if not extensions:
+        return where_clause, None
+
+    # Find the first RIGHT/FULL OUTER join — only then is absorption needed.
+    right_full_idx: Optional[int] = None
+    for i, jn in enumerate(extensions):
+        jt = (jn.join_type or "").upper().strip()
+        if "RIGHT" in jt or "FULL" in jt:
+            right_full_idx = i
+            break
+    if right_full_idx is None:
+        return where_clause, None
+
+    from datajunction_server.construction.build_v3.cte import (
+        _filter_namespaces,
+        _get_relation_side_id,
+        _split_and_atoms,
+    )
+
+    atoms = _split_and_atoms(where_clause)
+    atoms_by_alias: dict[str, list[ast.Expression]] = {}
+    other_atoms: list[ast.Expression] = []
+    for atom in atoms:
+        ns = _filter_namespaces(atom)
+        if len(ns) == 1 and main_alias not in ns:
+            atoms_by_alias.setdefault(next(iter(ns)), []).append(atom)
+        else:
+            other_atoms.append(atom)
+
+    # Scan EVERY LEFT/INNER join in the chain (not just those before the
+    # first RIGHT/FULL OUTER).  Once a RIGHT/FULL OUTER is in the chain,
+    # *any* LEFT/INNER-joined dim's filter in outer WHERE would silently
+    # null-drop preserved-side rows from the OUTER JOIN.  Consolidating all
+    # filtered fact-side LEFT/INNER joins into the wrapper CTE applies the
+    # filters before the OUTER JOIN can reach them.
+    to_absorb_idx: list[int] = []
+    absorbed_aliases: set[str] = set()
+    for i in range(len(extensions)):
+        jn = extensions[i]
+        jt = (jn.join_type or "").upper().strip()
+        if "RIGHT" in jt or "FULL" in jt:
+            continue
+        side_alias = _get_relation_side_id(jn.right)
+        if side_alias and side_alias in atoms_by_alias:
+            to_absorb_idx.append(i)
+            absorbed_aliases.add(side_alias)
+
+    if not absorbed_aliases:
+        return where_clause, None
+
+    absorbed_joins = [extensions[i] for i in to_absorb_idx]
+    kept_joins = [
+        extensions[i] for i in range(len(extensions)) if i not in to_absorb_idx
+    ]
+
+    # Collect absorbed-dim columns referenced outside the wrapper
+    # (projection, kept joins' ON clauses, other atoms) so the wrapper
+    # exposes them.
+    absorbed_cols: dict[str, set[str]] = {a: set() for a in absorbed_aliases}
+
+    def _collect(node: ast.Node) -> None:
+        for col in node.find_all(ast.Column):
+            tname_str = _col_table_name(col)
+            if tname_str is not None and tname_str in absorbed_aliases:
+                absorbed_cols[tname_str].add(col.name.name)
+
+    for proj_item in select.projection:
+        _collect(proj_item)
+    for kj in kept_joins:
+        if kj.criteria and kj.criteria.on:  # pragma: no branch
+            _collect(kj.criteria.on)
+    for atom in other_atoms:
+        _collect(atom)
+
+    # Build wrapper projection: parent.* + each absorbed col.
+    wrapper_proj: list[Any] = [
+        ast.Column(name=ast.Name("*"), _table=ast.Table(ast.Name(main_alias))),
+    ]
+    for alias in absorbed_aliases:
+        for col_name in sorted(absorbed_cols[alias]):
+            wrapper_proj.append(make_column_ref(col_name, alias))
+
+    # WHERE for wrapper = AND of all absorbed atoms.
+    absorbed_atoms: list[ast.Expression] = []
+    for alias in absorbed_aliases:
+        absorbed_atoms.extend(atoms_by_alias[alias])
+    wrapper_where: Optional[ast.Expression] = None
+    for atom in absorbed_atoms:
+        wrapper_where = (
+            atom if wrapper_where is None else ast.BinaryOp.And(wrapper_where, atom)
+        )
+
+    wrapper_select = ast.Select(
+        projection=wrapper_proj,
+        from_=ast.From(
+            relations=[
+                ast.Relation(primary=relation.primary, extensions=absorbed_joins),
+            ],
+        ),
+        where=wrapper_where,
+    )
+    wrapper_query = ast.Query(select=wrapper_select)
+    filtered_cte_name = f"{parent_cte_name}_filtered"
+
+    # Outer FROM now reads from the filtered CTE, still aliased as main_alias.
+    relation.primary = cast(
+        ast.Expression,
+        ast.Alias(
+            child=ast.Table(ast.Name(filtered_cte_name)),
+            alias=ast.Name(main_alias),
+        ),
+    )
+    relation.extensions = kept_joins
+
+    # Rewrite references to absorbed aliases → main_alias in everything
+    # outside the wrapper.
+    def _rewrite(node: ast.Node) -> None:
+        for col in node.find_all(ast.Column):
+            tname_str = _col_table_name(col)
+            if tname_str is not None and tname_str in absorbed_aliases:
+                _set_col_table_alias(col, main_alias)
+
+    for proj_item in select.projection:
+        _rewrite(proj_item)
+    for kj in kept_joins:
+        if kj.criteria and kj.criteria.on:  # pragma: no branch
+            _rewrite(kj.criteria.on)
+    for atom in other_atoms:
+        _rewrite(atom)
+    for gb_item in group_by:
+        _rewrite(gb_item)
+
+    # Remap dim_aliases so downstream lookups (e.g. _build_group_by)
+    # find main_alias instead of an absorbed dim alias.
+    for key in list(dim_aliases.keys()):
+        if dim_aliases[key] in absorbed_aliases:
+            dim_aliases[key] = main_alias
+
+    # Rebuild where_clause from remaining atoms:
+    # - Compound/cross-namespace atoms (already in ``other_atoms``).
+    # - Single-dim atoms whose alias was NOT absorbed (typically the
+    #   preserved RIGHT/FULL OUTER side, where outer-WHERE filtering
+    #   safely narrows the preserved row set).
+    remaining_atoms: list[ast.Expression] = list(other_atoms)
+    for alias, atoms_for_alias in atoms_by_alias.items():
+        if alias not in absorbed_aliases:
+            remaining_atoms.extend(atoms_for_alias)
+
+    new_where: Optional[ast.Expression] = None
+    for atom in remaining_atoms:
+        new_where = atom if new_where is None else ast.BinaryOp.And(new_where, atom)
+    return new_where, (filtered_cte_name, wrapper_query)
+
+
+def _coalesce_partner_for_full_skipped_fk(
+    resolved_dim: ResolvedDimension,
+    resolved_dimensions: list[ResolvedDimension],
+    dim_aliases: dict[tuple[str, Optional[str]], str],
+    parent_node_name: str,
+) -> Optional[ast.Column]:
+    """Find a joined dim whose first link is FK-aligned with the fact FK
+    column we just full-skip-resolved, and return a column reference to
+    that dim's equivalent column.
+
+    Two dims sharing the same fact FK both carry an equivalent value via
+    each link's ``foreign_keys_reversed``.  When the requested dim was
+    fully skipped (its own CTE isn't joined) but another joined dim
+    shares the FK, the joined dim's PK is the correct COALESCE partner
+    for the fact FK under any OUTER JOIN that preserves the dim side.
+
+    Returns ``None`` when no co-joined sibling carries the FK.
+    """
+    if resolved_dim.pre_skip_join_path is None:
+        return None
+
+    parent_fk_fqn = f"{parent_node_name}{SEPARATOR}{resolved_dim.column_name}"
+
+    for other in resolved_dimensions:
+        if other.original_ref == resolved_dim.original_ref:
+            continue
+        if not other.join_path or not other.join_path.links:  # pragma: no cover
+            continue
+        first_link = other.join_path.links[0]
+        # foreign_keys_reversed: {dim_pk_fqn -> fact_fk_fqn}
+        for dim_pk_fqn, fact_fk_fqn in first_link.foreign_keys_reversed.items():
+            if fact_fk_fqn != parent_fk_fqn:
+                continue
+            dim_short = dim_pk_fqn.rsplit(SEPARATOR, 1)[-1]
+            dim_node_name = first_link.dimension.name
+            role = first_link.role or ""
+            alias = dim_aliases.get(
+                (dim_node_name, role),
+            ) or dim_aliases.get((dim_node_name, None))
+            if alias is not None:  # pragma: no branch
+                return make_column_ref(dim_short, alias)
+    return None
+
+
 def build_dimension_col_expr(
     resolved_dim: ResolvedDimension,
     main_alias: str,
     dim_aliases: dict[tuple[str, Optional[str]], str],
     clean_alias: str,
+    ctx: Optional[BuildContext] = None,
+    resolved_dimensions: Optional[list[ResolvedDimension]] = None,
+    parent_node_name: Optional[str] = None,
 ) -> Any:
     """Build a SELECT expression for a single resolved dimension.
 
     Returns a column reference, optionally wrapped in COALESCE (when the
-    dimension link has a ``default_value``) and aliased.
+    dimension link has a ``default_value``, or when the FK column was
+    substituted for a dim PK via the full-skip optimization but the dim
+    CTE is still joined for other columns — in which case ``t1.fk`` may
+    be NULL under a downstream OUTER JOIN preserving the dim side, and
+    we COALESCE in the dim PK so the projected value matches the dim).
     """
     table_alias = get_dimension_table_alias(resolved_dim, main_alias, dim_aliases)
     col_ref = make_column_ref(resolved_dim.column_name, table_alias)
@@ -687,6 +1011,30 @@ def build_dimension_col_expr(
         coalesce_func = ast.Function(
             ast.Name("COALESCE"),
             args=[col_ref, ast.String(f"'{default_value}'")],
+        )
+        col_expr = coalesce_func.set_alias(ast.Name(clean_alias))
+        col_expr.set_as(True)
+        return col_expr
+
+    # Full-skip + co-joined-dim COALESCE.  When the original ref pointed
+    # at a non-local dim node but the FK was substituted in via the
+    # full-skip optimization, walk the original (pre-skip) join path to
+    # find any intermediate dim that's still joined, and COALESCE its
+    # FK-aligned column into the projection.  Under OUTER JOINs that
+    # preserve the dim side, ``t1.fk`` is NULL where unmatched and the
+    # co-joined dim's column has the value.
+    coalesce_extra: Optional[ast.Column] = None
+    if resolved_dimensions is not None and parent_node_name is not None:
+        coalesce_extra = _coalesce_partner_for_full_skipped_fk(
+            resolved_dim,
+            resolved_dimensions,
+            dim_aliases,
+            parent_node_name,
+        )
+    if coalesce_extra is not None:
+        coalesce_func = ast.Function(
+            ast.Name("COALESCE"),
+            args=[col_ref, coalesce_extra],
         )
         col_expr = coalesce_func.set_alias(ast.Name(clean_alias))
         col_expr.set_as(True)
@@ -721,12 +1069,18 @@ def _build_group_by(
     grain_col_specs: list[tuple[ast.Expression, str]],
     projected_dim_col_names: set[str],
     filter_dimensions: set[str],
+    parent_node_name: Optional[str] = None,
 ) -> list[ast.Expression]:
     """Build the GROUP BY clause from dimensions and grain columns.
 
     Dimensions marked as filter-only are excluded.  Grain columns that are
     simple identifiers already present as a dimension are also skipped to
     avoid duplicates.
+
+    When a dimension's projection is wrapped in COALESCE (full-skip with
+    a co-joined sibling dim — see :func:`build_dimension_col_expr`), the
+    GROUP BY expression mirrors the COALESCE so rows aren't bucketed by
+    the NULL-side alone.
     """
     group_by: list[ast.Expression] = []
 
@@ -734,7 +1088,24 @@ def _build_group_by(
         if resolved_dim.original_ref in filter_dimensions:
             continue
         table_alias = get_dimension_table_alias(resolved_dim, main_alias, dim_aliases)
-        group_by.append(make_column_ref(resolved_dim.column_name, table_alias))
+        col_ref = make_column_ref(resolved_dim.column_name, table_alias)
+        coalesce_extra: Optional[ast.Column] = None
+        if parent_node_name is not None:  # pragma: no branch
+            coalesce_extra = _coalesce_partner_for_full_skipped_fk(
+                resolved_dim,
+                resolved_dimensions,
+                dim_aliases,
+                parent_node_name,
+            )
+        if coalesce_extra is not None:
+            group_by.append(
+                ast.Function(
+                    ast.Name("COALESCE"),
+                    args=[col_ref, coalesce_extra],
+                ),
+            )
+        else:
+            group_by.append(col_ref)
 
     for gc_expr, gc_alias in grain_col_specs:
         if isinstance(gc_expr, ast.Column):
@@ -903,6 +1274,9 @@ def build_select_ast(
             main_alias,
             dim_aliases,
             clean_alias,
+            ctx=ctx,
+            resolved_dimensions=resolved_dimensions,
+            parent_node_name=parent_node.name,
         )
         projection.append(col_expr)
 
@@ -955,6 +1329,7 @@ def build_select_ast(
         grain_col_specs,
         projected_dim_col_names,
         ctx.filter_dimensions,
+        parent_node_name=parent_node.name,
     )
 
     # Collect all nodes that need CTEs and the minimal columns each must project.
@@ -1030,23 +1405,54 @@ def build_select_ast(
         else None,
     )
 
-    # Combine user filters with temporal filter
-    if temporal_filter_ast:
-        if where_clause:
-            where_clause = ast.BinaryOp.And(where_clause, temporal_filter_ast)
-        else:
-            where_clause = temporal_filter_ast
-
-    # Build SELECT
-    # For non-decomposable metrics, skip GROUP BY to pass through raw rows
+    # Build SELECT.
+    # For non-decomposable metrics, skip GROUP BY to pass through raw rows.
     effective_group_by = [] if skip_aggregation else (group_by if group_by else [])
     select = ast.Select(
         projection=projection,
         from_=from_clause,
-        where=where_clause,
         group_by=effective_group_by,
         hints=spark_hints if spark_hints else None,
     )
+
+    # Apply outer WHERE atoms.  Parent-alias atoms are dropped from outer
+    # WHERE when the parent CTE pushdown is active (filter is already in
+    # the parent CTE; the outer copy is redundant and would defeat
+    # downstream OUTER joins).  Dim-alias atoms continue to land in
+    # outer WHERE for standard dim-filter semantics.  See
+    # ``_apply_outer_where_atoms`` for the full rule.
+    parent_pushdown_active = bool(all_filters) and not should_use_materialized_table(
+        ctx,
+        parent_node,
+    )
+    # Absorb LEFT/INNER-joined dims whose filter would defeat a
+    # downstream RIGHT/FULL OUTER JOIN into a filtered CTE on the
+    # parent side.  Mutates ``select.from_`` (re-pointing the parent
+    # FROM at the new CTE), rewrites references to absorbed aliases,
+    # remaps ``dim_aliases``, and removes the absorbed atoms from
+    # ``where_clause``.  Returns a new CTE to append to the query.
+    where_clause, filtered_cte = _absorb_filtered_joins_for_outer_safety(
+        select=select,
+        where_clause=where_clause,
+        main_alias=main_alias,
+        dim_aliases=dim_aliases,
+        parent_cte_name=get_cte_name(parent_node.name),
+        group_by=effective_group_by,
+    )
+    if filtered_cte is not None:
+        ctes.append(filtered_cte)
+    _apply_outer_where_atoms(
+        select,
+        where_clause,
+        main_alias,
+        parent_pushdown_active=parent_pushdown_active,
+    )
+    if temporal_filter_ast is not None:  # pragma: no cover
+        # ``_build_temporal_pushdown`` always pushes the filter into a
+        # CTE and returns ``None``, so this branch is currently dead.
+        # Kept as a safety backstop in case the pushdown logic changes
+        # in the future.
+        inject_filter_into_select(select, temporal_filter_ast)
 
     # Build Query with CTEs
     query = ast.Query(select=select)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -747,6 +747,42 @@ def _set_col_table_alias(col: ast.Column, new_alias: str) -> None:
         col.name = ast.Name(col.name.name, namespace=ast.Name(new_alias))
 
 
+def _and_atoms(atoms: list[ast.Expression]) -> Optional[ast.Expression]:
+    """Fold a list of atoms into a left-associative AND, or ``None``
+    for an empty list."""
+    result: Optional[ast.Expression] = None
+    for atom in atoms:
+        result = atom if result is None else ast.BinaryOp.And(result, atom)
+    return result
+
+
+def _maybe_coalesce_with_sibling(
+    col_ref: ast.Column,
+    resolved_dim: ResolvedDimension,
+    resolved_dimensions: Optional[list[ResolvedDimension]],
+    dim_aliases: dict[tuple[str, Optional[str]], str],
+    parent_node_name: Optional[str],
+) -> ast.Expression:
+    """Return ``COALESCE(col_ref, sibling_col)`` when the dim was
+    full-skipped to a parent FK and another joined dim shares the same
+    FK alignment; otherwise return ``col_ref`` unchanged.
+
+    Used by both the projection and GROUP BY builders so they stay in
+    lockstep (the GROUP BY must mirror the projection's COALESCE).
+    """
+    if resolved_dimensions is None or parent_node_name is None:
+        return col_ref
+    partner = _coalesce_partner_for_full_skipped_fk(
+        resolved_dim,
+        resolved_dimensions,
+        dim_aliases,
+        parent_node_name,
+    )
+    if partner is None:
+        return col_ref
+    return ast.Function(ast.Name("COALESCE"), args=[col_ref, partner])
+
+
 def _absorb_filtered_joins_for_outer_safety(
     select: ast.Select,
     where_clause: Optional[ast.Expression],
@@ -786,16 +822,6 @@ def _absorb_filtered_joins_for_outer_safety(
     if not extensions:
         return where_clause, None
 
-    # Find the first RIGHT/FULL OUTER join — only then is absorption needed.
-    right_full_idx: Optional[int] = None
-    for i, jn in enumerate(extensions):
-        jt = (jn.join_type or "").upper().strip()
-        if "RIGHT" in jt or "FULL" in jt:
-            right_full_idx = i
-            break
-    if right_full_idx is None:
-        return where_clause, None
-
     from datajunction_server.construction.build_v3.cte import (
         _filter_namespaces,
         _get_relation_side_id,
@@ -812,50 +838,53 @@ def _absorb_filtered_joins_for_outer_safety(
         else:
             other_atoms.append(atom)
 
-    # Scan EVERY LEFT/INNER join in the chain (not just those before the
-    # first RIGHT/FULL OUTER).  Once a RIGHT/FULL OUTER is in the chain,
-    # *any* LEFT/INNER-joined dim's filter in outer WHERE would silently
-    # null-drop preserved-side rows from the OUTER JOIN.  Consolidating all
-    # filtered fact-side LEFT/INNER joins into the wrapper CTE applies the
-    # filters before the OUTER JOIN can reach them.
+    # Single pass over join chain: track whether any RIGHT/FULL OUTER is
+    # present (gate) and which LEFT/INNER joins have defeating filters
+    # (candidates).  Absorption only commits when both conditions hold —
+    # otherwise pure-LEFT-chain narrowing semantics are preserved.
+    has_right_full = False
     to_absorb_idx: list[int] = []
     absorbed_aliases: set[str] = set()
-    for i in range(len(extensions)):
-        jn = extensions[i]
+    for i, jn in enumerate(extensions):
         jt = (jn.join_type or "").upper().strip()
         if "RIGHT" in jt or "FULL" in jt:
+            has_right_full = True
             continue
         side_alias = _get_relation_side_id(jn.right)
         if side_alias and side_alias in atoms_by_alias:
             to_absorb_idx.append(i)
             absorbed_aliases.add(side_alias)
 
-    if not absorbed_aliases:
+    if not has_right_full or not absorbed_aliases:
         return where_clause, None
 
+    absorb_set = set(to_absorb_idx)
     absorbed_joins = [extensions[i] for i in to_absorb_idx]
-    kept_joins = [
-        extensions[i] for i in range(len(extensions)) if i not in to_absorb_idx
-    ]
+    kept_joins = [j for i, j in enumerate(extensions) if i not in absorb_set]
 
-    # Collect absorbed-dim columns referenced outside the wrapper
-    # (projection, kept joins' ON clauses, other atoms) so the wrapper
-    # exposes them.
+    # Single pass over outer-scope nodes: record column names referenced
+    # from absorbed aliases (for the wrapper projection) AND rewrite the
+    # alias qualifier in place to point at ``main_alias``.  The wrapper
+    # captures ``relation.primary`` and ``absorbed_joins`` by reference
+    # before we mutate them below, so doing both in one pass is safe.
     absorbed_cols: dict[str, set[str]] = {a: set() for a in absorbed_aliases}
 
-    def _collect(node: ast.Node) -> None:
+    def _process(node: ast.Node) -> None:
         for col in node.find_all(ast.Column):
             tname_str = _col_table_name(col)
             if tname_str is not None and tname_str in absorbed_aliases:
                 absorbed_cols[tname_str].add(col.name.name)
+                _set_col_table_alias(col, main_alias)
 
     for proj_item in select.projection:
-        _collect(proj_item)
+        _process(proj_item)
     for kj in kept_joins:
         if kj.criteria and kj.criteria.on:  # pragma: no branch
-            _collect(kj.criteria.on)
+            _process(kj.criteria.on)
     for atom in other_atoms:
-        _collect(atom)
+        _process(atom)
+    for gb_item in group_by:
+        _process(gb_item)
 
     # Build wrapper projection: parent.* + each absorbed col.
     wrapper_proj: list[Any] = [
@@ -865,15 +894,9 @@ def _absorb_filtered_joins_for_outer_safety(
         for col_name in sorted(absorbed_cols[alias]):
             wrapper_proj.append(make_column_ref(col_name, alias))
 
-    # WHERE for wrapper = AND of all absorbed atoms.
     absorbed_atoms: list[ast.Expression] = []
     for alias in absorbed_aliases:
         absorbed_atoms.extend(atoms_by_alias[alias])
-    wrapper_where: Optional[ast.Expression] = None
-    for atom in absorbed_atoms:
-        wrapper_where = (
-            atom if wrapper_where is None else ast.BinaryOp.And(wrapper_where, atom)
-        )
 
     wrapper_select = ast.Select(
         projection=wrapper_proj,
@@ -882,7 +905,7 @@ def _absorb_filtered_joins_for_outer_safety(
                 ast.Relation(primary=relation.primary, extensions=absorbed_joins),
             ],
         ),
-        where=wrapper_where,
+        where=_and_atoms(absorbed_atoms),
     )
     wrapper_query = ast.Query(select=wrapper_select)
     filtered_cte_name = f"{parent_cte_name}_filtered"
@@ -897,44 +920,20 @@ def _absorb_filtered_joins_for_outer_safety(
     )
     relation.extensions = kept_joins
 
-    # Rewrite references to absorbed aliases → main_alias in everything
-    # outside the wrapper.
-    def _rewrite(node: ast.Node) -> None:
-        for col in node.find_all(ast.Column):
-            tname_str = _col_table_name(col)
-            if tname_str is not None and tname_str in absorbed_aliases:
-                _set_col_table_alias(col, main_alias)
-
-    for proj_item in select.projection:
-        _rewrite(proj_item)
-    for kj in kept_joins:
-        if kj.criteria and kj.criteria.on:  # pragma: no branch
-            _rewrite(kj.criteria.on)
-    for atom in other_atoms:
-        _rewrite(atom)
-    for gb_item in group_by:
-        _rewrite(gb_item)
-
     # Remap dim_aliases so downstream lookups (e.g. _build_group_by)
     # find main_alias instead of an absorbed dim alias.
     for key in list(dim_aliases.keys()):
         if dim_aliases[key] in absorbed_aliases:
             dim_aliases[key] = main_alias
 
-    # Rebuild where_clause from remaining atoms:
-    # - Compound/cross-namespace atoms (already in ``other_atoms``).
-    # - Single-dim atoms whose alias was NOT absorbed (typically the
-    #   preserved RIGHT/FULL OUTER side, where outer-WHERE filtering
-    #   safely narrows the preserved row set).
+    # Remaining outer-WHERE atoms: compound/cross-namespace atoms +
+    # single-dim atoms whose alias wasn't absorbed (typically the
+    # preserved RIGHT/FULL OUTER side).
     remaining_atoms: list[ast.Expression] = list(other_atoms)
     for alias, atoms_for_alias in atoms_by_alias.items():
         if alias not in absorbed_aliases:
             remaining_atoms.extend(atoms_for_alias)
-
-    new_where: Optional[ast.Expression] = None
-    for atom in remaining_atoms:
-        new_where = atom if new_where is None else ast.BinaryOp.And(new_where, atom)
-    return new_where, (filtered_cte_name, wrapper_query)
+    return _and_atoms(remaining_atoms), (filtered_cte_name, wrapper_query)
 
 
 def _coalesce_partner_for_full_skipped_fk(
@@ -1016,29 +1015,21 @@ def build_dimension_col_expr(
         col_expr.set_as(True)
         return col_expr
 
-    # Full-skip + co-joined-dim COALESCE.  When the original ref pointed
-    # at a non-local dim node but the FK was substituted in via the
-    # full-skip optimization, walk the original (pre-skip) join path to
-    # find any intermediate dim that's still joined, and COALESCE its
-    # FK-aligned column into the projection.  Under OUTER JOINs that
-    # preserve the dim side, ``t1.fk`` is NULL where unmatched and the
-    # co-joined dim's column has the value.
-    coalesce_extra: Optional[ast.Column] = None
-    if resolved_dimensions is not None and parent_node_name is not None:
-        coalesce_extra = _coalesce_partner_for_full_skipped_fk(
-            resolved_dim,
-            resolved_dimensions,
-            dim_aliases,
-            parent_node_name,
-        )
-    if coalesce_extra is not None:
-        coalesce_func = ast.Function(
-            ast.Name("COALESCE"),
-            args=[col_ref, coalesce_extra],
-        )
-        col_expr = coalesce_func.set_alias(ast.Name(clean_alias))
-        col_expr.set_as(True)
-        return col_expr
+    # Full-skip + co-joined-dim COALESCE.  When the FK was substituted
+    # in via full-skip but a sibling dim shares the same alignment,
+    # wrap the projection so OUTER JOINs that preserve the sibling
+    # don't surface NULL where the sibling has the value.
+    expr = _maybe_coalesce_with_sibling(
+        col_ref,
+        resolved_dim,
+        resolved_dimensions,
+        dim_aliases,
+        parent_node_name,
+    )
+    if expr is not col_ref:
+        aliased = expr.set_alias(ast.Name(clean_alias))
+        aliased.set_as(True)
+        return aliased
 
     if clean_alias != resolved_dim.column_name:
         col_ref.alias = ast.Name(clean_alias)
@@ -1089,23 +1080,15 @@ def _build_group_by(
             continue
         table_alias = get_dimension_table_alias(resolved_dim, main_alias, dim_aliases)
         col_ref = make_column_ref(resolved_dim.column_name, table_alias)
-        coalesce_extra: Optional[ast.Column] = None
-        if parent_node_name is not None:  # pragma: no branch
-            coalesce_extra = _coalesce_partner_for_full_skipped_fk(
+        group_by.append(
+            _maybe_coalesce_with_sibling(
+                col_ref,
                 resolved_dim,
                 resolved_dimensions,
                 dim_aliases,
                 parent_node_name,
-            )
-        if coalesce_extra is not None:
-            group_by.append(
-                ast.Function(
-                    ast.Name("COALESCE"),
-                    args=[col_ref, coalesce_extra],
-                ),
-            )
-        else:
-            group_by.append(col_ref)
+            ),
+        )
 
     for gc_expr, gc_alias in grain_col_specs:
         if isinstance(gc_expr, ast.Column):

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -369,6 +369,13 @@ class ResolvedDimension:
         JoinPath
     ]  # Join path from fact to this dimension (None if local)
     is_local: bool  # True if dimension is on the fact table itself
+    # The full original join path before any full-skip optimization.  Used by
+    # the projection layer to find intermediate joined dims whose columns are
+    # FK-aligned with the requested column — those columns can be COALESCEd
+    # in so the projected value survives OUTER joins that null-fill the FK
+    # side.  ``None`` when no skipping occurred (the regular ``join_path`` is
+    # authoritative).
+    pre_skip_join_path: Optional[JoinPath] = None
 
 
 @dataclass

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -576,7 +576,7 @@ default_users AS (
   WHERE  registration_country = 'NZ'
 ),
 events_0 AS (
-  SELECT  t1.user_id user_id_user_windowed,
+  SELECT  COALESCE(t1.user_id, t2.user_id) AS user_id_user_windowed,
     t2.snapshot_date snapshot_date_user_windowed,
     t2.registration_country registration_country_user_windowed,
     SUM(t1.elapsed_secs) elapsed_secs_sum_88a2603f
@@ -585,7 +585,7 @@ events_0 AS (
     AND t1.event_start_date BETWEEN t2.snapshot_date
     AND CAST(DATE_ADD(CAST(t2.snapshot_date AS DATE), 10) AS INT)
   WHERE  t2.registration_country = 'NZ'
-  GROUP BY  t1.user_id, t2.snapshot_date, t2.registration_country
+  GROUP BY  COALESCE(t1.user_id, t2.user_id), t2.snapshot_date, t2.registration_country
 )
 SELECT  events_0.user_id_user_windowed AS user_id_user_windowed,
   events_0.snapshot_date_user_windowed AS snapshot_date_user_windowed,
@@ -619,14 +619,14 @@ GROUP BY  events_0.user_id_user_windowed,
       FROM default.examples.users
     ),
     events_0 AS (
-      SELECT  t1.user_id user_id_user_direct,
-        t1.event_start_date snapshot_date_user_direct,
+      SELECT  COALESCE(t1.user_id, t2.user_id) AS user_id_user_direct,
+        COALESCE(t1.event_start_date, t2.snapshot_date) AS snapshot_date_user_direct,
         t2.registration_country registration_country_user_direct,
         SUM(t1.elapsed_secs) elapsed_secs_sum_88a2603f
       FROM default_events t1
       LEFT OUTER JOIN default_users t2 ON t1.user_id = t2.user_id
         AND t1.event_start_date = t2.snapshot_date
-      GROUP BY  t1.user_id, t1.event_start_date, t2.registration_country
+      GROUP BY  COALESCE(t1.user_id, t2.user_id), COALESCE(t1.event_start_date, t2.snapshot_date), t2.registration_country
     )
     SELECT  events_0.user_id_user_direct AS user_id_user_direct,
       events_0.snapshot_date_user_direct AS snapshot_date_user_direct,
@@ -676,7 +676,7 @@ default_users AS (
 ),
 events_0 AS (
   SELECT  t3.name name_registration_country,
-    t1.event_start_date snapshot_date_user_direct,
+    COALESCE(t1.event_start_date, t2.snapshot_date) AS snapshot_date_user_direct,
     t2.registration_country registration_country_user_direct,
     SUM(t1.elapsed_secs) elapsed_secs_sum_88a2603f
   FROM default_events t1
@@ -684,7 +684,7 @@ events_0 AS (
     AND t1.event_start_date = t2.snapshot_date
   INNER JOIN default_countries t3 ON t2.registration_country = t3.country_code
   WHERE  t3.name = 'NZ'
-  GROUP BY  t3.name, t1.event_start_date, t2.registration_country
+  GROUP BY  t3.name, COALESCE(t1.event_start_date, t2.snapshot_date), t2.registration_country
 )
 SELECT  events_0.name_registration_country AS name_registration_country,
   events_0.snapshot_date_user_direct AS snapshot_date_user_direct,

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -1592,7 +1592,7 @@ async def test_metric_with_node_level_and_nth_order_filters(
         SELECT  t2.state,
         	COUNT(t1.repair_order_id) repair_order_id_count_bd241964
          FROM default_repair_orders_fact t1 INNER JOIN default_hard_hat t2 ON t1.hard_hat_id = t2.hard_hat_id
-         WHERE  t1.dispatcher_id = 1 OR t1.dispatcher_id IS NOT NULL AND t2.state = 'AZ'
+         WHERE  t2.state = 'AZ'
          GROUP BY  t2.state
         )
 
@@ -1690,7 +1690,7 @@ async def test_metric_with_nth_order_dimensions_filters(
          FROM default_repair_orders_fact t1 INNER JOIN default_hard_hat t2 ON t1.hard_hat_id = t2.hard_hat_id
         INNER JOIN default_dispatcher t3 ON t1.dispatcher_id = t3.dispatcher_id
         INNER JOIN default_municipality_dim t4 ON t1.municipality_id = t4.municipality_id
-         WHERE  t1.dispatcher_id = 1 AND t2.state != 'AZ' AND t3.phone = '4082021022' AND t1.order_date >= '2020-01-01'
+         WHERE  t2.state != 'AZ' AND t3.phone = '4082021022'
          GROUP BY  t2.city, t2.last_name, t3.company_name, t4.local_region
         )
 

--- a/datajunction-server/tests/construction/build_v3/combiners_test.py
+++ b/datajunction-server/tests/construction/build_v3/combiners_test.py
@@ -1692,7 +1692,6 @@ class TestCombinedMeasuresSQLEndpoint:
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.status = 'active'
             GROUP BY t1.status
             """,
         )

--- a/datajunction-server/tests/construction/build_v3/cte_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from datajunction_server.construction.build_v3.cte import (
     _build_cte_projection_map,
+    _inject_filter_into_where,
     _rewrite_filter_for_cte,
     get_column_full_name,
     inject_partition_by_into_windows,
@@ -12,6 +13,8 @@ from datajunction_server.construction.build_v3.cte import (
 )
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
+
+from . import assert_sql_equal
 
 
 class TestGetColumnFullName:
@@ -405,6 +408,45 @@ class TestBuildCteProjectionMap:
             "bare_col": "t.bare_col",
         }
 
+    def test_cast_around_column_is_passthrough(self):
+        """``CAST(col AS T) AS col`` maps the alias to the unwrapped column,
+        not None.  CAST is value-equivalent for equality/IN/range filters
+        against literals of the cast target type, so filters can safely
+        push into the CTE referring to the underlying column.
+
+        This covers the LATERAL-VIEW-EXPLODE'd column pattern where the
+        modeler CASTs the exploded value for type normalization
+        (``CAST(max_observation_end AS INT) AS max_observation_end``).
+        """
+        query = parse(
+            "SELECT CAST(max_observation_end AS INT) AS max_observation_end FROM t",
+        )
+        assert _build_cte_projection_map(query) == {
+            "max_observation_end": "max_observation_end",
+        }
+
+    def test_cast_around_qualified_column_preserves_qualifier(self):
+        """``CAST(t.col AS T) AS alias`` unwraps to ``t.col``, retaining the
+        table qualifier in the WHERE-safe form."""
+        query = parse(
+            "SELECT CAST(t.placed_on AS DATE) AS order_date FROM src t",
+        )
+        assert _build_cte_projection_map(query) == {
+            "order_date": "t.placed_on",
+        }
+
+    def test_cast_around_non_column_marks_unsafe(self):
+        """``CAST`` around a non-column expression (e.g.
+        ``CAST(SUM(x) AS BIGINT) AS total``) is still unsafe — only
+        column-arg CASTs are passthroughs.
+        """
+        query = parse(
+            "SELECT CAST(SUM(x) AS BIGINT) AS total FROM t",
+        )
+        assert _build_cte_projection_map(query) == {
+            "total": None,
+        }
+
 
 class TestRewriteFilterForCte:
     """Tests for _rewrite_filter_for_cte."""
@@ -607,3 +649,271 @@ class TestPushdownEdgeCases:
             cte_query=cte_query,
         )
         assert str(rewritten) == "o.placed_on > 0"
+
+
+def _normalize_sql(sql: str) -> str:
+    """Collapse whitespace for stable equality on emitted SQL."""
+    return " ".join(sql.split())
+
+
+class TestInjectFilterIntoWhereOuterJoinSafe:
+    """`_inject_filter_into_where` must not turn OUTER JOINs into INNER JOINs.
+
+    Filters whose columns resolve entirely to the non-preserved side of an
+    OUTER JOIN are wrapped around that inner-side relation as a subquery,
+    not ANDed into the surrounding WHERE.
+    """
+
+    def test_right_join_filter_on_left_wraps_left_side(self):
+        """`orders RIGHT JOIN customers` with filter on `orders.placed_on`
+        must wrap the orders relation, not WHERE the post-join row set.
+        """
+        query = parse(
+            "SELECT * FROM orders RIGHT JOIN customers "
+            "ON orders.customer_id = customers.id",
+        )
+        filt = parse("SELECT 1 WHERE orders.placed_on BETWEEN 1 AND 2").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM (
+                SELECT * FROM orders WHERE orders.placed_on BETWEEN 1 AND 2
+            ) orders
+            RIGHT JOIN customers ON orders.customer_id = customers.id
+            """,
+        )
+
+    def test_left_join_filter_on_right_wraps_right_side(self):
+        """`users LEFT JOIN logins` with filter on `logins.success` must wrap
+        the logins relation.
+        """
+        query = parse(
+            "SELECT * FROM users LEFT JOIN logins ON users.id = logins.user_id",
+        )
+        filt = parse("SELECT 1 WHERE logins.success = 1").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM users
+            LEFT JOIN (
+                SELECT * FROM logins WHERE logins.success = 1
+            ) logins ON users.id = logins.user_id
+            """,
+        )
+
+    def test_full_outer_join_filter_on_left_wraps_left_side(self):
+        """`stocks FULL OUTER JOIN sales` makes both sides non-preserved.
+        A filter on `stocks.sku` wraps the stocks relation.
+        """
+        query = parse(
+            "SELECT * FROM stocks FULL OUTER JOIN sales ON stocks.sku = sales.sku",
+        )
+        filt = parse("SELECT 1 WHERE stocks.sku > 0").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM (
+                SELECT * FROM stocks WHERE stocks.sku > 0
+            ) stocks
+            FULL OUTER JOIN sales ON stocks.sku = sales.sku
+            """,
+        )
+
+    def test_full_outer_join_filter_on_right_wraps_right_side(self):
+        """Symmetric case: filter on `sales.qty` wraps the sales relation."""
+        query = parse(
+            "SELECT * FROM stocks FULL OUTER JOIN sales ON stocks.sku = sales.sku",
+        )
+        filt = parse("SELECT 1 WHERE sales.qty > 0").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM stocks
+            FULL OUTER JOIN (
+                SELECT * FROM sales WHERE sales.qty > 0
+            ) sales ON stocks.sku = sales.sku
+            """,
+        )
+
+    def test_inner_join_filter_lands_in_where(self):
+        """INNER JOIN has no preserved/non-preserved asymmetry — WHERE is safe."""
+        query = parse(
+            "SELECT * FROM authors INNER JOIN books ON authors.id = books.author_id",
+        )
+        filt = parse("SELECT 1 WHERE authors.age > 0").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is not None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM authors
+            INNER JOIN books ON authors.id = books.author_id
+            WHERE authors.age > 0
+            """,
+        )
+
+    def test_filter_on_preserved_side_lands_in_where(self):
+        """Filter on the preserved side of a LEFT JOIN is safe in WHERE — it
+        just narrows the preserved row set, which is the user's intent.
+        """
+        query = parse(
+            "SELECT * FROM orders LEFT JOIN refunds ON orders.id = refunds.order_id",
+        )
+        filt = parse("SELECT 1 WHERE orders.region = 'US'").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is not None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM orders
+            LEFT JOIN refunds ON orders.id = refunds.order_id
+            WHERE orders.region = 'US'
+            """,
+        )
+
+    def test_filter_spanning_two_non_preserved_sides_falls_through_to_where(self):
+        """A filter that touches columns from two distinct non-preserved sides
+        can't be wrapped on a single relation — single-side wrapping wouldn't
+        preserve the cross-side semantics.  Falls through to WHERE.
+
+        ``a LEFT JOIN b LEFT JOIN c`` makes both ``b`` and ``c`` non-preserved
+        against a post-WHERE filter; a predicate touching ``b.x AND c.y``
+        spans both, so the classifier returns ``None`` and the filter lands
+        in WHERE — covering the ``len(targets) != 1`` branch.
+        """
+        query = parse(
+            "SELECT * FROM a LEFT JOIN b ON a.id = b.a_id LEFT JOIN c ON a.id = c.a_id",
+        )
+        # The AND-tree split routes each atom independently, so combine the
+        # cross-side references into one atom (a non-AND op) to exercise the
+        # multi-namespace classification path.
+        single_atom = parse(
+            "SELECT 1 WHERE COALESCE(b.x, 0) + COALESCE(c.y, 0) > 0",
+        ).select.where
+        _inject_filter_into_where(query, single_atom)
+        assert query.select.where is not None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM a
+            LEFT JOIN b ON a.id = b.a_id
+            LEFT JOIN c ON a.id = c.a_id
+            WHERE COALESCE(b.x, 0) + COALESCE(c.y, 0) > 0
+            """,
+        )
+
+    def test_filter_spanning_both_sides_splits_via_and_atoms(self):
+        """A top-level AND between a non-preserved-side atom and a
+        preserved-side atom splits via the AND-atom router: the
+        non-preserved atom wraps its side; the preserved atom lands in
+        the outer WHERE.  Together they replicate the original AND
+        semantics without defeating the OUTER JOIN.
+        """
+        query = parse(
+            "SELECT * FROM orders RIGHT JOIN customers "
+            "ON orders.customer_id = customers.id",
+        )
+        filt = parse(
+            "SELECT 1 WHERE orders.placed_on > 1 AND customers.tier = 'A'",
+        ).select.where
+        _inject_filter_into_where(query, filt)
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM (
+                SELECT * FROM orders WHERE orders.placed_on > 1
+            ) orders
+            RIGHT JOIN customers ON orders.customer_id = customers.id
+            WHERE customers.tier = 'A'
+            """,
+        )
+
+    def test_no_join_lands_in_where(self):
+        """Single-table FROM has nothing to wrap — WHERE is the only landing spot."""
+        query = parse("SELECT * FROM orders")
+        filt = parse("SELECT 1 WHERE orders.placed_on > 0").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is not None
+        assert_sql_equal(
+            str(query),
+            "SELECT * FROM orders WHERE orders.placed_on > 0",
+        )
+
+    def test_unqualified_filter_falls_through_to_where(self):
+        """Without a namespace on the column ref we can't determine which side
+        the filter belongs to; default to WHERE so behavior is unchanged from
+        the pre-fix code path.
+        """
+        query = parse(
+            "SELECT * FROM orders RIGHT JOIN customers "
+            "ON orders.customer_id = customers.id",
+        )
+        filt = parse("SELECT 1 WHERE placed_on > 0").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is not None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM orders
+            RIGHT JOIN customers ON orders.customer_id = customers.id
+            WHERE placed_on > 0
+            """,
+        )
+
+    def test_filter_existing_where_is_preserved(self):
+        """When wrapping happens the original WHERE on the outer query is
+        untouched (no double-application).
+        """
+        query = parse(
+            "SELECT * FROM orders RIGHT JOIN customers "
+            "ON orders.customer_id = customers.id "
+            "WHERE customers.tier = 'A'",
+        )
+        filt = parse("SELECT 1 WHERE orders.placed_on > 0").select.where
+        _inject_filter_into_where(query, filt)
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM (
+                SELECT * FROM orders WHERE orders.placed_on > 0
+            ) orders
+            RIGHT JOIN customers ON orders.customer_id = customers.id
+            WHERE customers.tier = 'A'
+            """,
+        )
+
+    def test_consecutive_filters_flatten_into_single_wrap(self):
+        """Two filters on the same non-preserved side flatten into a single
+        wrap — the second call detects the existing wrap and ANDs into its
+        WHERE rather than nesting another subquery layer.
+        """
+        query = parse(
+            "SELECT * FROM orders RIGHT JOIN customers "
+            "ON orders.customer_id = customers.id",
+        )
+        _inject_filter_into_where(
+            query,
+            parse("SELECT 1 WHERE orders.placed_on > 0").select.where,
+        )
+        _inject_filter_into_where(
+            query,
+            parse("SELECT 1 WHERE orders.region = 'US'").select.where,
+        )
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM (
+                SELECT * FROM orders
+                WHERE orders.placed_on > 0 AND orders.region = 'US'
+            ) orders
+            RIGHT JOIN customers ON orders.customer_id = customers.id
+            """,
+        )

--- a/datajunction-server/tests/construction/build_v3/djsql_test.py
+++ b/datajunction-server/tests/construction/build_v3/djsql_test.py
@@ -379,7 +379,6 @@ class TestDJSQLFilterOnlyDimensions:
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
-                WHERE t1.status = 'completed'
                 GROUP BY t1.status
             )
             SELECT order_details_0.status AS status,

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -51,7 +51,6 @@ class TestFilterPushdownToParentCTE:
               SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
             LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
-            WHERE t1.order_date >= 20240101
             GROUP BY t2.category
             """,
         )
@@ -146,7 +145,7 @@ class TestFilterPushdownMultiple:
               SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
             LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
-            WHERE t1.order_date >= 20240101 AND t2.category = 'Electronics'
+            WHERE t2.category = 'Electronics'
             GROUP BY t2.category
             """,
         )
@@ -193,7 +192,6 @@ class TestFilterPushdownMultiple:
               SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
             LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
-            WHERE t1.order_date >= 20240101 AND t1.status = 'completed'
             GROUP BY t2.category
             """,
         )
@@ -245,7 +243,6 @@ class TestFilterPushdownMultiRef:
               SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
             LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
-            WHERE t1.order_date >= 20240101 OR t1.status = 'completed'
             GROUP BY t2.category
             """,
         )
@@ -364,7 +361,6 @@ class TestFilterPushdownEdgeCases:
             SELECT t1.status,
               SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.status = 'completed'
             GROUP BY t1.status
             """,
         )

--- a/datajunction-server/tests/construction/build_v3/having_clause_test.py
+++ b/datajunction-server/tests/construction/build_v3/having_clause_test.py
@@ -439,7 +439,7 @@ class TestHavingClauseMixedFilters:
                 SUM(t1.line_total) line_total_sum_e1f61696
               FROM v3_order_details t1
               LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
-              WHERE  t2.category IN ('Electronics', 'Clothing') AND t1.status = 'completed'
+              WHERE  t2.category IN ('Electronics', 'Clothing')
               GROUP BY  t2.category, t1.status, t1.order_id
             )
             SELECT

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -6116,9 +6116,7 @@ class TestMultiHopInnerDefeatsLeft:
             json={
                 "dimension_node": "v3.product_lookup",
                 "join_type": "inner",
-                "join_on": (
-                    "v3.product.category = v3.product_lookup.category"
-                ),
+                "join_on": ("v3.product.category = v3.product_lookup.category"),
             },
         )
         assert r.status_code in (200, 201), r.text

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -6052,3 +6052,138 @@ class TestMeasuresMaterializedParentFilter:
             """,
             normalize_aliases=True,
         )
+
+
+class TestMultiHopInnerDefeatsLeft:
+    """Multi-hop dim chains can produce ``LEFT JOIN dim1 INNER JOIN dim2 ON
+    dim1.X = dim2.Y`` shapes when ``dim1`` is reached via a LEFT link from
+    the fact and ``dim1`` has its own INNER link to ``dim2``.
+
+    The downstream INNER's predicate references ``dim1`` (a non-preserved
+    alias).  For fact rows where ``dim1`` doesn't match, ``dim1.X`` is NULL
+    → the INNER predicate is NULL → the row is dropped.  This silently
+    converts the upstream LEFT JOIN into an effective INNER JOIN.
+
+    This is a real hazard in multi-hop dim graphs (common pattern: a
+    fact LEFT-links to a "main" dim, that dim INNER-links to a lookup
+    dim, and a user requests a column from the lookup).  The fix
+    requires the absorber or classifier to recognize that an INNER's
+    cross-dim predicate undoes upstream preservation.
+    """
+
+    @pytest.fixture
+    async def setup_multi_hop_chain(self, client_with_build_v3):
+        """Build a chain: ``v3.order_details`` LEFT-linked to ``v3.product``,
+        ``v3.product`` INNER-linked to a new ``v3.product_lookup`` dim.
+        Requesting a column from ``v3.product_lookup`` forces the chain.
+        """
+        # New lookup dim source + dim
+        r = await client_with_build_v3.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_product_lookup",
+                "columns": [
+                    {"name": "category", "type": "string"},
+                    {"name": "category_group", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "product_lookup",
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+        r = await client_with_build_v3.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.product_lookup",
+                "description": "Product category lookup",
+                "query": "SELECT category, category_group FROM v3.src_product_lookup",
+                "mode": "published",
+                "primary_key": ["category"],
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+        # v3.product INNER-links to v3.product_lookup on its `category`
+        # column.  The link's join_on is cross-dim:
+        #   v3.product.category = v3.product_lookup.category
+        # so when chained downstream of the LEFT link from order_details,
+        # the INNER's predicate references the LEFT-joined dim's column.
+        r = await client_with_build_v3.post(
+            "/nodes/v3.product/link/",
+            json={
+                "dimension_node": "v3.product_lookup",
+                "join_type": "inner",
+                "join_on": (
+                    "v3.product.category = v3.product_lookup.category"
+                ),
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+    @pytest.mark.asyncio
+    async def test_inner_link_downstream_of_left_defeats_left(
+        self,
+        client_with_build_v3,
+        setup_multi_hop_chain,
+    ):
+        """Demonstrates the bug: chain ``order_details LEFT product INNER
+        product_lookup`` generates SQL where the INNER's predicate
+        references the LEFT-joined ``product`` alias, silently dropping
+        fact rows that have no matching product.
+
+        Asserts the current (buggy) shape via ``assert_sql_equal``.
+        Marked ``xfail`` until the classifier propagates non-preserved
+        through cross-dim INNER predicates (or the absorber broadens
+        scope to consolidate multi-hop chains).
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product_lookup.category_group",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Current behavior (the documented bug): the chain emits
+        # ``... LEFT OUTER JOIN v3_product t2 ... INNER JOIN v3_product_lookup t3
+        # ON t2.category = t3.category``.  The INNER's predicate
+        # references the LEFT-joined ``t2`` alias — for fact rows where
+        # ``t2`` doesn't match, ``t2.category`` is NULL and the INNER
+        # silently drops them, defeating the upstream LEFT.
+        #
+        # A correctness fix would either flip the downstream INNER to
+        # LEFT or wrap the LEFT+INNER pair so the NULL fact rows from
+        # the LEFT JOIN survive.  Until then this asserts the buggy
+        # shape so the test fails the day the fix lands and we can
+        # update the expected output.
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+            ),
+            v3_product_lookup AS (
+                SELECT category, category_group
+                FROM default.v3.product_lookup
+            )
+            SELECT t3.category_group, SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            INNER JOIN v3_product_lookup t3 ON t2.category = t3.category
+            GROUP BY t3.category_group
+            """,
+            normalize_aliases=True,
+        )

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -2585,7 +2585,6 @@ class TestMeasuresSQLFilters:
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.status = 'completed'
             GROUP BY t1.status
             """,
         )
@@ -2661,7 +2660,7 @@ class TestMeasuresSQLFilters:
             SELECT t1.status, t2.category, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
             LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
-            WHERE t1.status = 'completed' AND t2.category = 'Electronics'
+            WHERE t2.category = 'Electronics'
             GROUP BY t1.status, t2.category
             """,
         )
@@ -2727,7 +2726,6 @@ class TestMeasuresSQLFilters:
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.status IN ('completed', 'pending')
             GROUP BY t1.status
             """,
         )
@@ -2875,7 +2873,9 @@ class TestTemporalFilters:
             include_temporal_filters=True,
         )
 
-        # Should have DJ_LOGICAL_TIMESTAMP in the SQL for exact partition match
+        # Should have DJ_LOGICAL_TIMESTAMP in the SQL for exact partition match.
+        # Pushed into the parent CTE's WHERE so it applies before any internal
+        # join, not after — protecting any OUTER JOIN inside parent body.
         assert_sql_equal(
             result.grain_groups[0].sql,
             """
@@ -2883,10 +2883,10 @@ class TestTemporalFilters:
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             )
             SELECT t1.order_date date_id, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY t1.order_date
             """,
         )
@@ -2913,7 +2913,7 @@ class TestTemporalFilters:
             lookback_window="3 DAY",
         )
 
-        # Should have BETWEEN for lookback window
+        # Should have BETWEEN for lookback window — pushed into parent CTE.
         assert_sql_equal(
             result.grain_groups[0].sql,
             """
@@ -2921,11 +2921,11 @@ class TestTemporalFilters:
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE order_date BETWEEN CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP) - INTERVAL '3' DAY, 'yyyyMMdd') AS INT)
+                                     AND CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             )
             SELECT t1.order_date date_id, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.order_date BETWEEN CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP) - INTERVAL '3' DAY, 'yyyyMMdd') AS INT)
-                                    AND CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY t1.order_date
             """,
         )
@@ -2985,8 +2985,11 @@ class TestTemporalFilters:
             include_temporal_filters=True,
         )
 
-        # Should have AND between temporal and user filters
-        # The filter on v3.date.date_id is rewritten to use the parent's FK column (order_date)
+        # Both user filter and temporal filter are pushed into the parent CTE's
+        # WHERE — combined via AND.  Temporal goes in first (via the
+        # injected_filters path), then the user filter is appended via the
+        # generic pushdown path; the user-filter form uses the FK alias
+        # (`o.order_date`) while the temporal form uses the bare column.
         assert_sql_equal(
             result.grain_groups[0].sql,
             """
@@ -2994,29 +2997,31 @@ class TestTemporalFilters:
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-                WHERE o.order_date > 20200101
+                WHERE order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
+                  AND o.order_date > 20200101
             )
             SELECT t1.order_date date_id, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.order_date > 20200101 AND t1.order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY t1.order_date
             """,
         )
 
     @pytest.mark.asyncio
-    async def test_temporal_filter_fallback_when_parent_reads_from_source(
+    async def test_temporal_filter_falls_back_to_parent_cte(
         self,
         session,
         client_with_build_v3,
         setup_temporal_partition,
     ):
         """
-        Regression: when the parent node's primary FROM table is a source node
-        (not a transform), find_upstream_temporal_source_node returns None and
-        the filter falls back to the outer grain-group WHERE.
+        When the parent node's primary FROM table is a source node (not a
+        transform), find_upstream_temporal_source_node returns None.  The
+        filter then falls back to the parent node's own CTE — never to the
+        outer grain-group WHERE, since that would silently turn an OUTER JOIN
+        inside the parent body into an INNER JOIN.
 
         v3.order_details reads directly from default.v3.orders (a source), so
-        no pushdown occurs and the WHERE lands on the outer query.
+        no upstream pushdown — the temporal predicate lands in the parent CTE.
         """
         result = await build_measures_sql(
             session=session,
@@ -3032,10 +3037,10 @@ class TestTemporalFilters:
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             )
             SELECT t1.order_date date_id, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY t1.order_date
             """,
         )
@@ -3119,7 +3124,7 @@ class TestCubeBasedTemporalFiltering:
         assert response.status_code == 200
         data = response.json()
 
-        # Should have temporal filter in the SQL
+        # Temporal filter pushed into the parent CTE's WHERE.
         assert_sql_equal(
             data["grain_groups"][0]["sql"],
             """
@@ -3127,12 +3132,12 @@ class TestCubeBasedTemporalFiltering:
                 SELECT o.order_date, oi.quantity, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             )
             SELECT t1.order_date date_id,
                    SUM(t1.line_total) line_total_sum_e1f61696,
                    SUM(t1.quantity) quantity_sum_06b64d2e
             FROM v3_order_details t1
-            WHERE t1.order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY t1.order_date
             """,
         )
@@ -3150,7 +3155,7 @@ class TestCubeBasedTemporalFiltering:
         assert response.status_code == 200
         data = response.json()
 
-        # Should have temporal filter in the SQL
+        # Temporal filter pushed into the parent CTE's WHERE.
         assert_sql_equal(
             data["grain_groups"][0]["sql"],
             """
@@ -3162,6 +3167,7 @@ class TestCubeBasedTemporalFiltering:
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              WHERE order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             )
             SELECT
               t1.order_date date_id,
@@ -3169,7 +3175,6 @@ class TestCubeBasedTemporalFiltering:
               SUM(t1.line_total) line_total_sum_e1f61696,
               SUM(t1.quantity) quantity_sum_06b64d2e
             FROM v3_order_details t1
-            WHERE  t1.order_date = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY  t1.order_date, t1.order_id
             """,
         )
@@ -3188,7 +3193,7 @@ class TestCubeBasedTemporalFiltering:
         assert response.status_code == 200
         data = response.json()
 
-        # Should have BETWEEN filter for lookback
+        # BETWEEN filter for lookback — pushed into parent CTE.
         assert_sql_equal(
             data["grain_groups"][0]["sql"],
             """
@@ -3196,12 +3201,12 @@ class TestCubeBasedTemporalFiltering:
                 SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE order_date BETWEEN CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP) - INTERVAL '7' DAY, 'yyyyMMdd') AS INT)
+                                     AND CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             )
             SELECT t1.order_date date_id,
                    SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.order_date BETWEEN CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP) - INTERVAL '7' DAY, 'yyyyMMdd') AS INT)
-                                    AND CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY t1.order_date
             """,
         )
@@ -3416,19 +3421,22 @@ class TestTemporalFilterPushdown:
         )
 
     @pytest.mark.asyncio
-    async def test_no_pushdown_when_upstream_lacks_fk_column(
+    async def test_no_upstream_pushdown_falls_back_to_parent_cte(
         self,
         session,
         client_with_build_v3,
     ):
         """
-        When the primary FROM of the parent node is a non-source transform that does NOT expose
-        the FK column (date_id), pushdown finds no match and returns None. The filter falls
-        back to the outer WHERE.
+        When the primary FROM of the parent node is a non-source transform that
+        does NOT expose the FK column (date_id), upstream pushdown finds no
+        match. The filter then falls back to the parent's own CTE — never to
+        the outer grain-group WHERE, which would be unsafe in the presence of
+        OUTER JOINs inside the parent body.
 
-        v3.order_details is a non-source transform but its columns don't include
-        date_id (only order_date), so find_upstream_temporal_source_node returns
-        None and the filter lands on the outer query instead.
+        v3.orders_by_date is a non-source transform but its columns don't
+        include date_id directly via the underlying source — so
+        find_upstream_temporal_source_node returns None and the filter lands
+        on the parent CTE.
         """
         # Transform that reads from v3.order_details (non-source, no date_id column)
         # but exposes date_id by aliasing order_date
@@ -3492,7 +3500,9 @@ class TestTemporalFilterPushdown:
         )
         sql = result.grain_groups[0].sql
 
-        # Filter must be on the outer WHERE (no upstream CTE to push into)
+        # Filter lands in the parent CTE (v3_orders_by_date), not the outer
+        # WHERE — outer WHERE would be unsafe if the parent body had any
+        # OUTER JOIN.
         assert_sql_equal(
             sql,
             """
@@ -3516,27 +3526,28 @@ class TestTemporalFilterPushdown:
                 order_date AS date_id,
                 COUNT(order_id) AS order_cnt
               FROM v3_order_details
+              WHERE date_id = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
               GROUP BY  order_date
             )
             SELECT
               t1.date_id,
               SUM(t1.order_cnt) order_cnt_sum_e668c538
             FROM v3_orders_by_date t1
-            WHERE  t1.date_id = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY  t1.date_id
             """,
         )
 
     @pytest.mark.asyncio
-    async def test_no_pushdown_when_parent_query_has_no_from(
+    async def test_parent_query_no_from_falls_back_to_parent_cte(
         self,
         session,
         client_with_build_v3,
     ):
         """
-        Line 854: when the parent node's query has no FROM clause,
+        When the parent node's query has no FROM clause,
         find_upstream_temporal_source_node returns None at the from_ check
-        and the filter falls back to the outer WHERE.
+        and the filter falls back to the parent's own CTE — not the outer
+        grain-group WHERE.
         """
         response = await client_with_build_v3.post(
             "/nodes/transform/",
@@ -3597,7 +3608,8 @@ class TestTemporalFilterPushdown:
             include_temporal_filters=True,
         )
         sql = result.grain_groups[0].sql
-        # Filter must land on outer WHERE (no FROM to push into)
+        # Filter lands in the parent CTE (no FROM means no inner-side hazard;
+        # AND-into-WHERE on the parent's own SELECT is safe).
         assert_sql_equal(
             sql,
             """
@@ -3605,12 +3617,12 @@ class TestTemporalFilterPushdown:
               SELECT
                 CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT) AS date_id,
                 1 AS cnt
+              WHERE date_id = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             )
             SELECT
               t1.date_id,
               SUM(t1.cnt) cnt_sum_293e7033
             FROM v3_constant_date t1
-            WHERE  t1.date_id = CAST(DATE_FORMAT(CAST(DJ_LOGICAL_TIMESTAMP() AS TIMESTAMP), 'yyyyMMdd') AS INT)
             GROUP BY  t1.date_id
             """,
         )
@@ -4231,7 +4243,6 @@ class TestFilterOnlyDimensions:
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1
-            WHERE t1.status = 'completed'
             GROUP BY t1.status
             """,
         )
@@ -5290,6 +5301,753 @@ class TestSparkJoinHints:
             )
             SELECT t1.status, SUM(t1.line_total) line_total_sum_HASH
             FROM v3_order_details t1
+            GROUP BY t1.status
+            """,
+            normalize_aliases=True,
+        )
+
+
+class TestOuterJoinFilterSafety:
+    """Filters must not silently turn OUTER JOINs into INNER JOINs.
+
+    The bug: when a parent transform's body contains an OUTER JOIN and a
+    filter resolves to the non-preserved side, applying the filter in WHERE
+    drops the NULL fill-in rows the OUTER JOIN was meant to preserve.
+
+    The fix: route such filters through the inner-side relation as a wrapping
+    subquery — both for filters pushed into the parent CTE itself, and for
+    parent-alias atoms that would otherwise land on the outer query's WHERE
+    after a build-time RIGHT/FULL OUTER JOIN to a dim.
+    """
+
+    @pytest.fixture
+    async def setup_right_outer_join_parent(self, client_with_build_v3):
+        """A transform whose body has ``orders RIGHT OUTER JOIN dates``.
+
+        ``orders o`` is the non-preserved (left) side; ``dates d`` is the
+        preserved (right) side.  Filters on ``o.*`` columns post-join would
+        eliminate dates rows that have no matching order — the failure mode
+        we want to verify the builder avoids.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.dates_with_orders",
+                "display_name": "Dates with Orders",
+                "description": "All dates, joined to orders that fall on them.",
+                "mode": "published",
+                "query": """
+                    SELECT
+                        d.date_id,
+                        o.order_id,
+                        o.customer_id,
+                        o.status,
+                        o.order_date
+                    FROM v3.src_orders o
+                    RIGHT OUTER JOIN v3.src_dates d ON o.order_date = d.date_id
+                """,
+                "columns": [
+                    {
+                        "name": "date_id",
+                        "type": "int",
+                        "attributes": [{"attribute_type": {"name": "primary_key"}}],
+                    },
+                    {"name": "order_id", "type": "int"},
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "status", "type": "string"},
+                    {"name": "order_date", "type": "int"},
+                ],
+            },
+        )
+        assert response.status_code in (200, 201), response.text
+
+        response = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.dates_with_orders_count",
+                "display_name": "Order Count via Dates",
+                "mode": "published",
+                "query": "SELECT COUNT(order_id) FROM v3.dates_with_orders",
+            },
+        )
+        assert response.status_code in (200, 201), response.text
+
+    @pytest.mark.asyncio
+    async def test_local_filter_on_non_preserved_side_wraps_inside_parent_cte(
+        self,
+        client_with_build_v3,
+        setup_right_outer_join_parent,
+    ):
+        """A filter on ``status`` (a column from the non-preserved ``o`` side)
+        must be applied INSIDE the orders subquery — before the RIGHT OUTER
+        JOIN — not in the CTE body's WHERE.  Verifies the inner-side wrapping
+        path inside ``_inject_filter_into_where``.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.dates_with_orders_count"],
+                "dimensions": ["v3.dates_with_orders.date_id"],
+                "filters": ["v3.dates_with_orders.status = 'completed'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_dates_with_orders AS (
+                SELECT
+                    d.date_id,
+                    o.order_id,
+                    o.status
+                FROM (SELECT * FROM default.v3.orders o WHERE o.status = 'completed') o
+                RIGHT OUTER JOIN default.v3.dates d ON o.order_date = d.date_id
+            )
+            SELECT
+                t1.date_id,
+                COUNT(t1.order_id) order_id_count_HASH
+            FROM v3_dates_with_orders t1
+            GROUP BY t1.date_id
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_on_preserved_side_lands_in_cte_where(
+        self,
+        client_with_build_v3,
+        setup_right_outer_join_parent,
+    ):
+        """A filter on ``date_id`` (the preserved ``d`` side) is safe as a
+        plain CTE WHERE — pushdown into the dates subquery is unnecessary.
+        Verifies the classifier doesn't over-trigger on preserved-side filters.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.dates_with_orders_count"],
+                "dimensions": ["v3.dates_with_orders.date_id"],
+                "filters": ["v3.dates_with_orders.date_id >= 20240101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_dates_with_orders AS (
+                SELECT
+                    d.date_id,
+                    o.order_id
+                FROM default.v3.orders o
+                RIGHT OUTER JOIN default.v3.dates d ON o.order_date = d.date_id
+                WHERE d.date_id >= 20240101
+            )
+            SELECT
+                t1.date_id,
+                COUNT(t1.order_id) order_id_count_HASH
+            FROM v3_dates_with_orders t1
+            GROUP BY t1.date_id
+            """,
+            normalize_aliases=True,
+        )
+
+
+class TestWrapperCTEAbsorption:
+    """When a LEFT/INNER-joined dim's filter would silently defeat a
+    downstream RIGHT/FULL OUTER JOIN, the LEFT/INNER join + filter are
+    absorbed into a ``<parent>_filtered`` CTE so the filter applies
+    *before* the OUTER JOIN reaches the preserved side.
+
+    Also covers the COALESCE projection/GROUP BY for full-skipped FKs
+    whose dim is fully skipped but a co-joined sibling dim carries the
+    same FK alignment.
+    """
+
+    @pytest.fixture
+    async def setup_right_outer_dim(self, client_with_build_v3):
+        """Add a ``v3.allocation`` dim RIGHT-OUTER-linked to
+        ``v3.order_details``.  The RIGHT-OUTER link is the trigger for
+        wrapper-CTE absorption when any LEFT-joined dim has a filter.
+        """
+        r = await client_with_build_v3.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_allocations",
+                "description": "Customer marketing allocations",
+                "columns": [
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "campaign", "type": "string"},
+                    {"name": "allocated_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "allocations",
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+        r = await client_with_build_v3.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.allocation",
+                "description": "Allocations dimension",
+                "query": (
+                    "SELECT customer_id, campaign, allocated_date "
+                    "FROM v3.src_allocations"
+                ),
+                "mode": "published",
+                "primary_key": ["customer_id", "allocated_date"],
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+        r = await client_with_build_v3.post(
+            "/nodes/v3.order_details/link/",
+            json={
+                "dimension_node": "v3.allocation",
+                "join_type": "right",
+                "join_on": (
+                    "v3.order_details.customer_id = v3.allocation.customer_id "
+                    "AND v3.order_details.order_date = v3.allocation.allocated_date"
+                ),
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+    @pytest.mark.asyncio
+    async def test_left_filter_before_right_join_absorbed_into_filtered_cte(
+        self,
+        client_with_build_v3,
+        setup_right_outer_dim,
+    ):
+        """LEFT-joined dim with filter + RIGHT-joined dim → absorbed
+        into ``v3_order_details_filtered`` CTE; outer WHERE empty."""
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.allocation.campaign",
+                ],
+                "filters": ["v3.product.category = 'Electronics'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_allocation AS (
+                SELECT customer_id, campaign, allocated_date
+                FROM default.v3.allocations
+            ),
+            v3_order_details AS (
+                SELECT
+                    o.customer_id,
+                    o.order_date,
+                    oi.product_id,
+                    oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+                WHERE category = 'Electronics'
+            ),
+            v3_order_details_filtered AS (
+                SELECT *, t2.category
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                WHERE t2.category = 'Electronics'
+            )
+            SELECT t1.category, t3.campaign,
+                SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details_filtered t1
+            RIGHT OUTER JOIN v3_allocation t3
+                ON t1.customer_id = t3.customer_id
+                AND t1.order_date = t3.allocated_date
+            GROUP BY t1.category, t3.campaign
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_right_join_no_absorption(
+        self,
+        client_with_build_v3,
+    ):
+        """No RIGHT/FULL OUTER → no wrapper CTE built."""
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.product.category = 'Electronics'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+                WHERE category = 'Electronics'
+            )
+            SELECT t2.category, SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            WHERE t2.category = 'Electronics'
+            GROUP BY t2.category
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unfiltered_left_join_not_absorbed(
+        self,
+        client_with_build_v3,
+        setup_right_outer_dim,
+    ):
+        """LEFT-joined dim without a filter is left alone."""
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.allocation.campaign",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_allocation AS (
+                SELECT customer_id, campaign, allocated_date
+                FROM default.v3.allocations
+            ),
+            v3_order_details AS (
+                SELECT
+                    o.customer_id,
+                    o.order_date,
+                    oi.product_id,
+                    oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+            )
+            SELECT t2.category, t3.campaign, SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            RIGHT OUTER JOIN v3_allocation t3
+                ON t1.customer_id = t3.customer_id
+                AND t1.order_date = t3.allocated_date
+            GROUP BY t2.category, t3.campaign
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_coalesce_for_full_skipped_fk_with_co_joined_sibling(
+        self,
+        client_with_build_v3,
+    ):
+        """When ``v3.customer.customer_id`` is full-skipped to
+        ``t1.customer_id`` and ``v3.customer`` is also joined for
+        another column (``name``), the projection becomes
+        ``COALESCE(t1.customer_id, t_customer.customer_id)`` and the
+        GROUP BY mirrors it.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.customer.customer_id",
+                    "v3.customer.name",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT
+                COALESCE(t1.customer_id, t2.customer_id) AS customer_id,
+                t2.name,
+                SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY COALESCE(t1.customer_id, t2.customer_id), t2.name
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.fixture
+    async def setup_full_outer_dim(self, client_with_build_v3):
+        """Same as ``setup_right_outer_dim`` but FULL OUTER instead of
+        RIGHT OUTER — exercises the FULL-OUTER-trigger branch of the
+        absorber."""
+        r = await client_with_build_v3.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_allocations_full",
+                "columns": [
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "campaign", "type": "string"},
+                    {"name": "allocated_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "allocations",
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+        r = await client_with_build_v3.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.allocation_full",
+                "query": (
+                    "SELECT customer_id, campaign, allocated_date "
+                    "FROM v3.src_allocations_full"
+                ),
+                "mode": "published",
+                "primary_key": ["customer_id", "allocated_date"],
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+        r = await client_with_build_v3.post(
+            "/nodes/v3.order_details/link/",
+            json={
+                "dimension_node": "v3.allocation_full",
+                "join_type": "full",
+                "join_on": (
+                    "v3.order_details.customer_id = v3.allocation_full.customer_id "
+                    "AND v3.order_details.order_date = v3.allocation_full.allocated_date"
+                ),
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+    @pytest.mark.asyncio
+    async def test_full_outer_also_triggers_absorption(
+        self,
+        client_with_build_v3,
+        setup_full_outer_dim,
+    ):
+        """A FULL OUTER JOIN preserves both sides — same defeat risk
+        as RIGHT OUTER, so absorption fires here too."""
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.allocation_full.campaign",
+                ],
+                "filters": ["v3.product.category = 'Electronics'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert "v3_order_details_filtered" in sql
+        assert "FULL OUTER JOIN v3_allocation_full" in sql
+
+    @pytest.mark.asyncio
+    async def test_compound_atom_not_absorbed(
+        self,
+        client_with_build_v3,
+        setup_right_outer_dim,
+    ):
+        """A compound atom referencing both the parent and an absorbed
+        dim alias stays in the outer WHERE — the absorber only picks
+        single-alias atoms."""
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.allocation.campaign",
+                ],
+                "filters": [
+                    "v3.order_details.order_id > v3.product.product_id",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # No wrapper CTE built — compound atom isn't a single-alias
+        # filter the absorber knows how to handle.
+        assert "v3_order_details_filtered" not in sql
+
+    @pytest.mark.asyncio
+    async def test_post_right_left_filter_also_absorbed(
+        self,
+        client_with_build_v3,
+        setup_right_outer_dim,
+    ):
+        """A filter on a LEFT-joined dim that's positioned *after* the
+        RIGHT/FULL OUTER also gets absorbed into the wrapper CTE.  The
+        absorber consolidates every filtered fact-side LEFT/INNER join
+        regardless of where it appears relative to the RIGHT JOIN, so
+        the wrapper applies the filter before the OUTER JOIN reaches
+        the preserved side — preventing the post-RIGHT LEFT JOIN from
+        being defeated by the outer WHERE.
+        """
+        # Make v3.product a post-RIGHT LEFT-joined dim by listing it
+        # AFTER the RIGHT-joined allocation dim.  DJ joins dims in
+        # request order, so this ordering produces:
+        #   member_download t1
+        #   RIGHT JOIN allocation t_a
+        #   LEFT JOIN product t_p           <- positioned AFTER the RIGHT
+        # With the broadened absorber, the filter on v3.product.category
+        # is still absorbed into v3_order_details_filtered.
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.allocation.campaign",
+                    "v3.product.category",
+                ],
+                "filters": ["v3.product.category = 'Electronics'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # The filtered product LEFT JOIN should be absorbed even though
+        # it sits after the RIGHT JOIN to allocation in request order.
+        assert "v3_order_details_filtered" in sql
+        # No outer WHERE on the absorbed dim alias — it's now inside
+        # the wrapper.  References to the dim's column should resolve
+        # through the wrapper's alias (t1), not a separate dim alias.
+        assert "WHERE t2.category" not in sql
+
+    @pytest.mark.asyncio
+    async def test_pre_and_post_right_filters_both_absorbed(
+        self,
+        client_with_build_v3,
+        setup_right_outer_dim,
+    ):
+        """Filters on two LEFT-joined dims — one before and one after
+        the RIGHT JOIN — both get absorbed into a single wrapper CTE.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",  # pre-RIGHT LEFT
+                    "v3.allocation.campaign",  # RIGHT
+                    "v3.customer.name",  # post-RIGHT LEFT
+                ],
+                "filters": [
+                    "v3.product.category = 'Electronics'",
+                    "v3.customer.name = 'Alice'",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Both filters are absorbed into one wrapper CTE.
+        assert "v3_order_details_filtered" in sql
+        # Both filter predicates should be applied inside the wrapper.
+        wrapper_section = sql.split("v3_order_details_filtered AS (")[1].split(
+            ")",
+            1,
+        )[0]
+        assert "category = 'Electronics'" in wrapper_section
+        assert "name = 'Alice'" in wrapper_section
+
+    @pytest.mark.asyncio
+    async def test_preserved_side_filter_remains_in_outer_where(
+        self,
+        client_with_build_v3,
+        setup_right_outer_dim,
+    ):
+        """A filter on the RIGHT/FULL OUTER preserved side stays in the
+        outer WHERE (not absorbed) — filtering a preserved side just
+        narrows it without defeating anything.  Together with a
+        LEFT-joined-dim filter (absorbed), this verifies the absorber
+        leaves preserved-side single-dim atoms alone instead of
+        silently dropping them.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.allocation.campaign",
+                ],
+                "filters": [
+                    "v3.product.category = 'Electronics'",
+                    "v3.allocation.campaign = 'spring'",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Product filter absorbed.
+        assert "v3_order_details_filtered" in sql
+        # Allocation (preserved RIGHT side) filter STAYS in outer WHERE
+        # — it wasn't silently dropped.
+        outer_section = sql.split("v3_order_details_filtered AS (")[1]
+        outer_section = outer_section.split(")")[-1]  # after the last )
+        assert "campaign" in outer_section
+
+    @pytest.mark.asyncio
+    async def test_compound_atom_alongside_absorbed_dim(
+        self,
+        client_with_build_v3,
+        setup_right_outer_dim,
+    ):
+        """A compound (cross-namespace) atom plus a single-dim atom on
+        a LEFT-joined dim: the single-dim atom is absorbed into the
+        wrapper CTE, and the compound atom rides through ``other_atoms``
+        — exercising the iteration over ``other_atoms`` in both the
+        column-collection and alias-rewrite loops.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.allocation.campaign",
+                ],
+                "filters": [
+                    "v3.product.category = 'Electronics'",
+                    # Cross-namespace compound: absorbed dim (product) vs
+                    # RIGHT-preserved dim (allocation).  Single non-AND
+                    # atom, so it lands in ``other_atoms`` and exercises
+                    # both the column-collection and alias-rewrite loops
+                    # over ``other_atoms``.
+                    "v3.product.category != v3.allocation.campaign",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_allocation AS (
+                SELECT customer_id, campaign, allocated_date
+                FROM default.v3.allocations
+            ),
+            v3_order_details AS (
+                SELECT
+                    o.customer_id,
+                    o.order_date,
+                    oi.product_id,
+                    oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+                SELECT product_id, category
+                FROM default.v3.products
+                WHERE category = 'Electronics'
+            ),
+            v3_order_details_filtered AS (
+                SELECT *, t2.category
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                WHERE t2.category = 'Electronics'
+            )
+            SELECT t1.category, t3.campaign,
+                SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details_filtered t1
+            RIGHT OUTER JOIN v3_allocation t3
+                ON t1.customer_id = t3.customer_id
+                AND t1.order_date = t3.allocated_date
+            WHERE t1.category != t3.campaign
+            GROUP BY t1.category, t3.campaign
+            """,
+            normalize_aliases=True,
+        )
+
+
+class TestMeasuresMaterializedParentFilter:
+    """Filters on a materialized parent's local columns are routed
+    through ``inject_filter_into_select`` instead of being dropped.
+
+    With materialization, no parent CTE is built, so the safety
+    backstop in ``_apply_outer_where_atoms`` must keep the filter
+    visible at the outer level.
+    """
+
+    @pytest.mark.asyncio
+    async def test_local_filter_on_materialized_parent_kept_in_outer(
+        self,
+        client_with_build_v3,
+    ):
+        """Add availability to ``v3.order_details`` so it's materialized,
+        then request a metric on it with a local-column filter.  The
+        filter must survive into the outer SQL (via the safety
+        backstop), even though no parent CTE exists to push it into.
+        """
+        response = await client_with_build_v3.post(
+            "/data/v3.order_details/availability/",
+            json={
+                "catalog": "analytics",
+                "schema_": "warehouse",
+                "table": "order_details_materialized_pa",
+                "valid_through_ts": 9999999999,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "filters": ["v3.order_details.status = 'completed'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            SELECT t1.status, SUM(t1.line_total) line_total_sum_HASH
+            FROM analytics.warehouse.order_details_materialized_pa t1
+            WHERE t1.status = 'completed'
             GROUP BY t1.status
             """,
             normalize_aliases=True,

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -990,7 +990,6 @@ class TestMetricsSQLDerived:
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
-                WHERE t1.status = 'completed'
                 GROUP BY t1.status
             )
             SELECT order_details_0.status AS status,
@@ -1030,7 +1029,6 @@ class TestMetricsSQLDerived:
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
-                WHERE t1.status IN ('active', 'completed')
                 GROUP BY t1.status
             )
             SELECT order_details_0.status AS status,
@@ -1070,7 +1068,6 @@ class TestMetricsSQLDerived:
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
-                WHERE t1.status != 'cancelled'
                 GROUP BY t1.status
             )
             SELECT order_details_0.status AS status,
@@ -1110,7 +1107,6 @@ class TestMetricsSQLDerived:
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
-                WHERE t1.status LIKE 'act%'
                 GROUP BY t1.status
             )
             SELECT order_details_0.status AS status,
@@ -1159,7 +1155,7 @@ class TestMetricsSQLDerived:
                 SELECT t1.status, t2.category, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
                 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
-                WHERE t1.status = 'active' AND t2.category = 'Electronics'
+                WHERE t2.category = 'Electronics'
                 GROUP BY t1.status, t2.category
             )
             SELECT order_details_0.status AS status,
@@ -2352,14 +2348,14 @@ class TestMetricsSQLNestedDerived:
             ),
             order_details_0 AS (
               SELECT
-                t1.order_date date_id_order,
+                COALESCE(t1.order_date, t3.date_id) AS date_id_order,
                 t2.category,
                 t3.week,
                 SUM(t1.line_total) line_total_sum_e1f61696
               FROM v3_order_details t1
               LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
               LEFT OUTER JOIN v3_date t3 ON t1.order_date = t3.date_id
-              GROUP BY t1.order_date, t2.category, t3.week
+              GROUP BY COALESCE(t1.order_date, t3.date_id), t2.category, t3.week
             ),
             base_metrics AS (
               SELECT
@@ -2444,7 +2440,7 @@ class TestMetricsSQLNestedDerived:
             ),
             order_details_0 AS (
               SELECT
-                t1.order_date date_id_order,
+                COALESCE(t1.order_date, t3.date_id) AS date_id_order,
                 t2.category,
                 t3.month,
                 t3.week,
@@ -2452,7 +2448,7 @@ class TestMetricsSQLNestedDerived:
               FROM v3_order_details t1
               LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
               LEFT OUTER JOIN v3_date t3 ON t1.order_date = t3.date_id
-              GROUP BY t1.order_date, t2.category, t3.month, t3.week
+              GROUP BY COALESCE(t1.order_date, t3.date_id), t2.category, t3.month, t3.week
             ),
             base_metrics AS (
               SELECT
@@ -2566,7 +2562,7 @@ class TestMetricsSQLNestedDerived:
             ),
             order_details_0 AS (
               SELECT
-                t1.order_date date_id_order,
+                COALESCE(t1.order_date, t3.date_id) AS date_id_order,
                 t2.category,
                 t3.week,
                 t1.order_id,
@@ -2574,7 +2570,7 @@ class TestMetricsSQLNestedDerived:
               FROM v3_order_details t1
               LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
               LEFT OUTER JOIN v3_date t3 ON t1.order_date = t3.date_id
-              GROUP BY t1.order_date, t2.category, t3.week, t1.order_id
+              GROUP BY COALESCE(t1.order_date, t3.date_id), t2.category, t3.week, t1.order_id
             ),
             base_metrics AS (
               SELECT
@@ -2905,22 +2901,22 @@ class TestMetricsSQLCrossFactWindow:
             FROM default.v3.page_views
             ),
             order_details_0 AS (
-            SELECT  t1.order_date date_id,
+            SELECT  COALESCE(t1.order_date, t3.date_id) AS date_id,
                 t2.category,
                 t3.week,
                 t1.order_id
             FROM v3_order_details t1 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
             LEFT OUTER JOIN v3_date t3 ON t1.order_date = t3.date_id
-            GROUP BY  t1.order_date, t2.category, t3.week, t1.order_id
+            GROUP BY  COALESCE(t1.order_date, t3.date_id), t2.category, t3.week, t1.order_id
             ),
             page_views_enriched_0 AS (
-            SELECT  t1.page_date date_id,
+            SELECT  COALESCE(t1.page_date, t3.date_id) AS date_id,
                 t2.category,
                 t3.week,
                 t1.customer_id
             FROM v3_page_views_enriched t1 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
             LEFT OUTER JOIN v3_date t3 ON t1.page_date = t3.date_id
-            GROUP BY  t1.page_date, t2.category, t3.week, t1.customer_id
+            GROUP BY  COALESCE(t1.page_date, t3.date_id), t2.category, t3.week, t1.customer_id
             ),
             base_metrics AS (
             SELECT  COALESCE(order_details_0.date_id, page_views_enriched_0.date_id) AS date_id,
@@ -3013,24 +3009,24 @@ class TestMetricsSQLCrossFactWindow:
             FROM default.v3.page_views
             ),
             order_details_0 AS (
-            SELECT  t1.order_date date_id,
+            SELECT  COALESCE(t1.order_date, t3.date_id) AS date_id,
                 t2.category,
                 t3.week,
                 t1.order_id,
                 SUM(t1.line_total) line_total_sum_e1f61696
             FROM v3_order_details t1 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
             LEFT OUTER JOIN v3_date t3 ON t1.order_date = t3.date_id
-            GROUP BY  t1.order_date, t2.category, t3.week, t1.order_id
+            GROUP BY  COALESCE(t1.order_date, t3.date_id), t2.category, t3.week, t1.order_id
             ),
             page_views_enriched_0 AS (
-            SELECT  t1.page_date date_id,
+            SELECT  COALESCE(t1.page_date, t3.date_id) AS date_id,
                 t2.category,
                 t3.week,
                 t1.session_id,
                 COUNT(t1.view_id) view_id_count_f41e2db4
             FROM v3_page_views_enriched t1 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
             LEFT OUTER JOIN v3_date t3 ON t1.page_date = t3.date_id
-            GROUP BY  t1.page_date, t2.category, t3.week, t1.session_id
+            GROUP BY  COALESCE(t1.page_date, t3.date_id), t2.category, t3.week, t1.session_id
             ),
             base_metrics AS (
             SELECT  COALESCE(order_details_0.date_id, page_views_enriched_0.date_id) AS date_id,
@@ -3128,22 +3124,22 @@ class TestMetricsSQLCrossFactWindow:
             FROM default.v3.page_views
             ),
             order_details_0 AS (
-            SELECT  t1.order_date date_id,
+            SELECT  COALESCE(t1.order_date, t3.date_id) AS date_id,
                 t2.category,
                 t3.week,
                 t1.order_id
             FROM v3_order_details t1 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
             LEFT OUTER JOIN v3_date t3 ON t1.order_date = t3.date_id
-            GROUP BY  t1.order_date, t2.category, t3.week, t1.order_id
+            GROUP BY  COALESCE(t1.order_date, t3.date_id), t2.category, t3.week, t1.order_id
             ),
             page_views_enriched_0 AS (
-            SELECT  t1.page_date date_id,
+            SELECT  COALESCE(t1.page_date, t3.date_id) AS date_id,
                 t2.category,
                 t3.week,
                 t1.customer_id
             FROM v3_page_views_enriched t1 LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
             LEFT OUTER JOIN v3_date t3 ON t1.page_date = t3.date_id
-            GROUP BY  t1.page_date, t2.category, t3.week, t1.customer_id
+            GROUP BY  COALESCE(t1.page_date, t3.date_id), t2.category, t3.week, t1.customer_id
             ),
             base_metrics AS (
             SELECT  COALESCE(order_details_0.date_id, page_views_enriched_0.date_id) AS date_id,
@@ -3648,7 +3644,6 @@ class TestFilterOnlyDimensions:
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
-                WHERE t1.status = 'completed'
                 GROUP BY t1.status
             )
             SELECT order_details_0.status AS status,
@@ -4717,7 +4712,6 @@ class TestMetricsSQLEdgeCases:
             order_details_0 AS (
                 SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
                 FROM v3_order_details t1
-                WHERE t1.customer_id = 42
                 GROUP BY t1.status
             )
             SELECT order_details_0.status AS status,


### PR DESCRIPTION
### Summary

When a v3 measures query joins to a dim via `RIGHT OUTER` / `FULL OUTER`, filters on adjacent left-joined dims land in the outer where after the outer join. This silently breaks the outer join's preservation semantics and preserved-side rows (the ones the outer join exists to keep) get dropped whenever the filter's column is NULL on them. This PR fixes that and consolidates the related filter-routing logic.

For queries that mix left join-with-filter and right/full outer, the result rows differ from before this PR: preserved-side rows from the outer join now survive when no matching fact row exists, matching the user's intent of right outer (preserve everything from the right). Queries that don't involve right/full are unaffected (pure-LEFT-chain filter narrowing semantics remain as today).

#### OUTER-JOIN-safe filter routing in CTE bodies

When a right or full outer join is present in the chain, every left/inner-joined dim that has a defeating filter is consolidated into a `<parent>_filtered` CTE that applies its filters before the outer join reaches it. The outer `FROM` then reads from the filtered CTE, and the outer join preserves correctly.

Absorbed-dim references (t2.client_name) are rewritten to the wrapper alias (t1.client_name) across projection, GROUP BY, kept-join ONs, and remaining WHERE atoms. The absorber handles both qualification styles DJ uses: _table-set (projection/GROUP BY) and name.namespace-set (filter atoms via _add_table_prefixes_to_filter).

#### Add `COALESCE` for outer join FKs

When the full-skip optimization substitutes a dim's PK with the fact's FK and a sibling dim shares the same FK alignment via its own link, the projection now emits `COALESCE(t1.foreign_key, t3.primary_key) AS final_key` and the `GROUP BY` mirrors the `COALESCE`. This preserves correct values under outer joins that null-fill the fact side.

#### Redundant outer-WHERE cleanup

The parent-alias atoms that are already pushed into the parent CTE (via the existing pushdown machinery) are no longer duplicated into the outer SELECT's WHERE. They were redundant and, under downstream OUTER JOINs, actively unsafe.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
