### PR TITLE
v3 measures: filter-only dim resolution via upstream lineage

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1037,22 +1037,21 @@ def _try_push_filter_into_outer_join_side(
         target = _classify_outer_join_target(relation, namespaces)
         if target is None:
             continue
-        # If the target is already an outer-join-safety wrap from a previous
-        # call, AND the new atom into its inner WHERE rather than nesting
-        # another wrap layer.  The inner FROM preserves the original alias,
-        # so column refs qualified by that alias resolve correctly inside.
-        if isinstance(target, ast.Query) and getattr(
-            target,
-            "_outer_join_filter_wrap",
-            False,
+        # If the target is already a Query (whether from a previous
+        # outer-join-safety wrap or from projection pruning / a user-written
+        # subquery), AND the new atom into its inner WHERE rather than
+        # nesting another wrap layer.  The inner FROM preserves the original
+        # alias, so column refs qualified by that alias resolve correctly
+        # inside.
+        if isinstance(target, ast.Query) and isinstance(
+            target.select,
+            ast.Select,
         ):
             inner_select = cast(ast.Select, target.select)
-            # The wrap was created with a non-None WHERE; the cast keeps mypy
-            # happy without a runtime branch.
-            existing_where = cast(ast.Expression, inner_select.where)
-            inner_select.where = ast.BinaryOp.And(
-                existing_where,
-                deepcopy(filter_expr),
+            inner_select.where = (
+                ast.BinaryOp.And(inner_select.where, deepcopy(filter_expr))
+                if inner_select.where is not None
+                else deepcopy(filter_expr)
             )
             return True
         wrapped = _wrap_relation_side_with_filter(target, filter_expr)

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import difflib
 from http import HTTPStatus
 import logging
-from typing import Optional, cast
+from typing import Callable, Optional, cast
 
 from datajunction_server.construction.build_v3.utils import (
     get_short_name,
@@ -246,198 +246,54 @@ def _format_column_validation_error(
     )
 
 
-def _local_col_for_dim_via_metadata(
-    node: Node,
-    dim_node_name: str,
-    dim_col_name: str,
-) -> Optional[str]:
-    """
-    Return the local column on `node` that semantically equals
-    `dim_node_name.dim_col_name`, using only declared metadata
-    (column-level annotations + direct dim links). Returns None if neither
-    layer applies — caller may then fall back to AST tracing.
-    """
-    if not node.current:
-        return None  # pragma: no cover
-    for col in node.current.columns:
-        if col.dimension is None or col.dimension.name != dim_node_name:
-            continue
-        if (col.dimension_column or col.name) == dim_col_name:
-            return col.name
-    target_fqn = f"{dim_node_name}{SEPARATOR}{dim_col_name}"
-    for link in node.current.dimension_links:
-        if link.dimension.name != dim_node_name:
-            continue
-        fk_fqn = link.foreign_keys_reversed.get(target_fqn)
-        if fk_fqn is not None:
-            return get_short_name(fk_fqn)
-    return None
-
-
-def _trace_dim_col_through_query(
-    ctx: BuildContext,
-    node: Node,
-    dim_node_name: str,
-    dim_col_name: str,
-    depth: int = 0,
-) -> Optional[str]:
-    """
-    Walk `node`'s parsed query AST to find a projection whose value traces
-    back to a FROM source's column that semantically corresponds to
-    `dim_node_name.dim_col_name`. Returns the projection's output alias.
-
-    Handles renames through a SELECT chain: e.g., if `cs_contact_f` has a
-    dim link mapping `fact_utc_date` to the dim col, and `data_finalized`'s
-    query projects `cs.fact_utc_date AS alloc_utc_date FROM cs_contact_f cs`,
-    this returns `alloc_utc_date`.
-
-    Recurses through subqueries and intermediate transforms (capped at depth
-    5 to bound runtime on pathological lineages).
-    """
-    if depth >= 5 or not node.current or not node.current.query:
-        return None
-    try:
-        query_ast = ctx.get_parsed_query(node)
-    except Exception:  # pragma: no cover
-        return None
-
-    select = query_ast.select if hasattr(query_ast, "select") else query_ast
-    if not isinstance(select, ast.Select) or select.from_ is None:
-        return None  # pragma: no cover
-
-    # Map FROM source aliases -> local col name on the source that satisfies
-    # the dim semantics. Aliases are lowercased for case-insensitive matching.
-    alias_to_local: dict[str, str] = {}
-    for tbl in select.from_.find_all(ast.Table):
-        try:
-            src_name = tbl.name.identifier(quotes=False)
-        except Exception:  # pragma: no cover
-            src_name = str(tbl.name)
-        src_alias = (
-            tbl.alias.name.lower()
-            if tbl.alias
-            else src_name.split(SEPARATOR)[-1].lower()
-        )
-        src_node = ctx.nodes.get(src_name)
-        if src_node is None:
-            continue
-        local = _local_col_for_dim_via_metadata(
-            src_node,
-            dim_node_name,
-            dim_col_name,
-        )
-        if local is None:
-            local = _trace_dim_col_through_query(
-                ctx,
-                src_node,
-                dim_node_name,
-                dim_col_name,
-                depth + 1,
-            )
-        if local is not None:
-            alias_to_local[src_alias] = local
-
-    if not alias_to_local:
-        return None
-
-    # Walk projections; find one whose expression references an
-    # (alias, col) pair we resolved above.
-    for proj in select.projection:
-        out_name: Optional[str] = None
-        if isinstance(proj, ast.Aliasable) and proj.alias is not None:
-            out_name = proj.alias.name
-        elif isinstance(proj, ast.Column):
-            out_name = proj.name.name
-
-        if out_name is None:
-            continue  # pragma: no cover
-
-        for col_ref in proj.find_all(ast.Column):
-            qualifier = col_ref.name.namespace
-            qual_name = (
-                qualifier.identifier(quotes=False).lower()
-                if qualifier is not None
-                else None
-            )
-            if qual_name is None:
-                continue
-            col_short = col_ref.name.name
-            if qual_name in alias_to_local and alias_to_local[qual_name] == col_short:
-                return out_name
-    return None
-
-
-def _find_transform_referencing_node(
-    ctx: BuildContext,
-    target_node_name: str,
-) -> Optional[tuple[Node, str]]:
-    """
-    Find a transform/dimension node in ``ctx.nodes`` whose query has a direct
-    Table reference to ``target_node_name``. Return (the transform node, the
-    alias used). When no alias is present in the SQL, the table's short name
-    is used (matching how aliases work for unaliased FROM tables).
-
-    Used to push a dim-link FK filter into the immediate CTE that selects
-    from the linked upstream node.
-    """
-    for node_name, node in ctx.nodes.items():
-        if node_name == target_node_name:
-            continue
-        if node.type == NodeType.SOURCE:
-            continue
-        if not node.current or not node.current.query:
-            continue
-        try:
-            query_ast = ctx.get_parsed_query(node)
-        except Exception:  # pragma: no cover
-            continue
-        select = query_ast.select if hasattr(query_ast, "select") else None
-        if select is None or select.from_ is None:
-            continue  # pragma: no cover
-        for tbl in select.from_.find_all(ast.Table):
-            try:
-                tbl_name = tbl.name.identifier(quotes=False)
-            except Exception:  # pragma: no cover
-                continue
-            if tbl_name == target_node_name:
-                alias = (
-                    tbl.alias.name
-                    if tbl.alias
-                    else target_node_name.split(SEPARATOR)[-1]
-                )
-                return node, alias
-    return None
-
-
-def _register_upstream_pushdown(
+def _resolve_filter_only_dim(
     ctx: BuildContext,
     parent_node: Node,
     dim_ref: DimensionRef,
     original_ref: str,
-) -> bool:
+) -> Optional[str]:
     """
-    Identify upstreams of ``parent_node`` whose dim links to
-    ``dim_ref.node_name`` carry the requested column, then push each
-    user filter referencing this dim into the appropriate CTE.
+    Resolve a filter-only dim ref via the parent's upstream lineage in a
+    single BFS walk over ``ctx.parent_map``. Returns one of:
 
-    For a linked source (no CTE of its own), the filter is injected into a
-    transform that directly references the source, rewritten to use the
-    source's alias. For a linked transform, the filter is injected into that
-    transform's CTE on its local FK column.
+    - A column name on ``parent_node`` if the dim is resolvable there:
+      either via a column-level ``dimension``/``dimension_column`` annotation
+      on the parent, or via an upstream's FK link whose FK column survives
+      unchanged on the parent's projection. Caller treats this as a
+      full-skip (no join, filter lands on the parent CTE).
 
-    Returns True if at least one filter was registered; consumed filter
-    strings are added to ``ctx.pushdown_consumed_filters`` so the outer WHERE
-    builder can skip them.
+    - ``None`` if no local match. In that case, when at least one upstream's
+      dim link aligns the requested column to an FK column, this function
+      also *registers* a pushdown filter into the deepest reachable CTE
+      (the linked transform, or the immediate transform child of a linked
+      source) and marks the originating filter string consumed in
+      ``ctx.pushdown_consumed_filters``. Caller emits no
+      ``ResolvedDimension`` for the dim and skips the unreachable-dim
+      error.
+
+    Performance notes:
+    - One BFS over the parent_map. No AST traversal of unrelated nodes.
+    - Parsed queries are only inspected for nodes we actually need to
+      inject into (linked transform, or a direct child of a linked source).
+      ``ctx.get_parsed_query`` is cached.
     """
-    from datajunction_server.construction.build_v3.filters import parse_filter
-    from datajunction_server.construction.build_v3.cte import get_column_full_name
-
+    if not parent_node.current or not parent_node.current.columns:
+        return None  # pragma: no cover
+    parent_cols = {col.name for col in parent_node.current.columns}
     target_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
 
-    # Walk upstream lineage; collect (linked_node, fk_col_short).
+    # Cheap parent-side check: column annotation pointing at this dim col.
+    for col in parent_node.current.columns:
+        if col.dimension is None or col.dimension.name != dim_ref.node_name:
+            continue
+        if (col.dimension_column or col.name) == dim_ref.column_name:
+            return col.name
+
+    # Single BFS up parent_map; track both passthrough hits and pushdown
+    # candidates. Each upstream node is visited at most once.
     visited: set[str] = {parent_node.name}
     queue: list[str] = list(ctx.parent_map.get(parent_node.name, []))
-    candidates: list[tuple[Node, str]] = []
+    pushdown_candidates: list[tuple[Node, str]] = []  # (linked_node, fk_col)
     while queue:
         up_name = queue.pop(0)
         if up_name in visited:
@@ -451,15 +307,45 @@ def _register_upstream_pushdown(
                 fk_fqn = link.foreign_keys_reversed.get(target_fqn)
                 if fk_fqn is None:
                     continue
-                candidates.append((up_node, get_short_name(fk_fqn)))
+                fk_col = get_short_name(fk_fqn)
+                if fk_col in parent_cols:
+                    # Upstream FK passthrough: filter resolves on the
+                    # parent directly. No pushdown needed.
+                    return fk_col
+                pushdown_candidates.append((up_node, fk_col))
         queue.extend(ctx.parent_map.get(up_name, []))
 
-    if not candidates:
-        return False
+    if pushdown_candidates and _register_pushdown_into_upstream(
+        ctx,
+        original_ref,
+        pushdown_candidates,
+    ):
+        ctx.pushdown_resolved_dims.add(original_ref)
+    return None
 
-    # Find the filter strings that reference this dim ref.
-    matching_filters: list[str] = []
+
+def _register_pushdown_into_upstream(
+    ctx: BuildContext,
+    original_ref: str,
+    candidates: list[tuple[Node, str]],
+) -> bool:
+    """
+    Push each user filter referencing ``original_ref`` into the deepest
+    reachable CTE for every (linked_node, fk_col) candidate. Consumed
+    filter strings are recorded in ``ctx.pushdown_consumed_filters``.
+
+    For a linked SOURCE (no CTE of its own), the target CTE is the
+    immediate child transform that selects from it; the FK column is
+    aliased using that child's alias for the source. For a linked
+    transform, the filter goes into that transform's own CTE on the bare
+    FK column.
+    """
+    from datajunction_server.construction.build_v3.filters import parse_filter
+    from datajunction_server.construction.build_v3.cte import get_column_full_name
+
+    # Find filter strings that reference this dim ref. Parse each once.
     base_ref = original_ref.split("[")[0]
+    matching: list[str] = []
     for filter_str in ctx.dimension_filters:
         if filter_str in ctx.pushdown_consumed_filters:
             continue
@@ -470,147 +356,128 @@ def _register_upstream_pushdown(
         for col in f_ast.find_all(ast.Column):
             full = get_column_full_name(col)
             if full and full.split("[")[0] == base_ref:
-                matching_filters.append(filter_str)
+                matching.append(filter_str)
                 break
-
-    if not matching_filters:
+    if not matching:
         return False  # pragma: no cover
 
-    registered_any = False
-    for filter_str in matching_filters:
+    # Build a children-of map lazily, only for sources we actually need.
+    children_cache: dict[str, list[str]] = {}
+
+    def children_of(node_name: str) -> list[str]:
+        cached = children_cache.get(node_name)
+        if cached is not None:
+            return cached
+        result = [
+            child for child, parents in ctx.parent_map.items() if node_name in parents
+        ]
+        children_cache[node_name] = result
+        return result
+
+    for filter_str in matching:
+        consumed = False
         for linked_node, fk_col in candidates:
-            # Determine the (target_node, col_qualifier) for injection.
-            if linked_node.type == NodeType.SOURCE:
-                found = _find_transform_referencing_node(ctx, linked_node.name)
-                if found is None:
-                    continue  # pragma: no cover
-                target_node, alias = found
-                qualifier = alias
-            else:
-                target_node = linked_node
-                qualifier = None  # inject unaliased; CTE renders its own scope
-
-            # Build a rewritten copy of the filter AST.
-            try:
-                rewritten = parse_filter(filter_str)
-            except Exception:  # pragma: no cover
-                continue
-            for col in list(rewritten.find_all(ast.Column)):
-                full = get_column_full_name(col)
-                if full is None or full.split("[")[0] != base_ref:
-                    continue
-                new_name = (
-                    ast.Name(fk_col, namespace=ast.Name(qualifier))
-                    if qualifier
-                    else ast.Name(fk_col)
-                )
-                new_col = ast.Column(name=new_name)
-                if col.parent is not None:
-                    col.parent.replace(col, new_col, copy=False)
-
-            ctx.upstream_pushdown_filters.setdefault(target_node.name, []).append(
+            target_name, qualifier = _resolve_pushdown_target(
+                ctx,
+                linked_node,
+                fk_col,
+                children_of,
+            )
+            if target_name is None:
+                continue  # pragma: no cover
+            rewritten = _rewrite_filter_col_refs(
+                filter_str,
+                base_ref,
+                fk_col,
+                qualifier,
+            )
+            if rewritten is None:
+                continue  # pragma: no cover
+            ctx.upstream_pushdown_filters.setdefault(target_name, []).append(
                 rewritten,
             )
-            registered_any = True
-        if registered_any:
+            consumed = True
+        if consumed:
             ctx.pushdown_consumed_filters.add(filter_str)
-    return registered_any
+    return bool(ctx.pushdown_consumed_filters)
 
 
-def _find_filter_only_local_col(
+def _resolve_pushdown_target(
     ctx: BuildContext,
-    parent_node: Node,
-    dim_ref: DimensionRef,
-) -> Optional[str]:
+    linked_node: Node,
+    fk_col: str,
+    children_of: Callable[[str], list[str]],
+) -> tuple[Optional[str], Optional[str]]:
     """
-    Resolve a filter-only dim ref by walking the parent's upstream lineage for
-    a dimension link to the requested dim node. If an upstream link's FK
-    mapping aligns the requested column with a column that's also present on
-    the parent's projection, return that local column name — the filter can be
-    pushed down to the parent CTE without any join.
+    Return ``(target_cte_name, qualifier)`` for filter injection.
 
-    This is the v3 equivalent of the v2 behavior where ``filter_only=True``
-    dimensions (declared via FK mappings on any upstream link) are filterable
-    on a fact without requiring a join from the fact directly.
+    Transform with the link → inject into its own CTE, no qualifier.
+    Source with the link → inject into a child transform's CTE, qualified
+    with the alias that child uses for the source.
     """
-    if not parent_node.current or not parent_node.current.columns:
-        return None  # pragma: no cover
-    parent_cols = {col.name for col in parent_node.current.columns}
-    target_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
-
-    # Layer 1: direct metadata (annotation or own dim link) on the parent.
-    local = _local_col_for_dim_via_metadata(
-        parent_node,
-        dim_ref.node_name,
-        dim_ref.column_name,
-    )
-    if local is not None:
-        logger.info(
-            "[BuildV3] filter-only layer-1 (parent metadata): %s -> parent.%s",
-            target_fqn,
-            local,
-        )
-        return local
-
-    # Layer 2: walk upstream lineage for any dim link to the target dim,
-    # collect candidate FK cols. If any candidate FK col happens to flow up
-    # to the parent's projection unchanged, use it directly.
-    visited: set[str] = {parent_node.name}
-    queue: list[str] = list(ctx.parent_map.get(parent_node.name, []))
-    candidate_upstreams: list[tuple[str, str]] = []  # (up_name, fk_col)
-    while queue:
-        up_name = queue.pop(0)
-        if up_name in visited:
+    if linked_node.type != NodeType.SOURCE:
+        return linked_node.name, None
+    for child_name in children_of(linked_node.name):
+        child = ctx.nodes.get(child_name)
+        if (
+            child is None
+            or child.type == NodeType.SOURCE
+            or not child.current
+            or not child.current.query
+        ):
             continue  # pragma: no cover
-        visited.add(up_name)
-        up_node = ctx.nodes.get(up_name)
-        if up_node and up_node.current:
-            for link in up_node.current.dimension_links:
-                if link.dimension.name != dim_ref.node_name:
-                    continue
-                fk_fqn = link.foreign_keys_reversed.get(target_fqn)
-                if fk_fqn is None:
-                    continue
-                local_col = get_short_name(fk_fqn)
-                candidate_upstreams.append((up_name, local_col))
-                if local_col in parent_cols:
-                    logger.info(
-                        "[BuildV3] filter-only layer-2 (upstream FK passthrough): "
-                        "%s -> parent.%s (via upstream %s)",
-                        target_fqn,
-                        local_col,
-                        up_name,
-                    )
-                    return local_col
-        queue.extend(ctx.parent_map.get(up_name, []))
+        try:
+            child_query = ctx.get_parsed_query(child)
+        except Exception:  # pragma: no cover
+            continue
+        select = child_query.select if hasattr(child_query, "select") else None
+        if select is None or select.from_ is None:
+            continue  # pragma: no cover
+        for tbl in select.from_.find_all(ast.Table):
+            try:
+                tbl_name = tbl.name.identifier(quotes=False)
+            except Exception:  # pragma: no cover
+                continue
+            if tbl_name == linked_node.name:
+                alias = (
+                    tbl.alias.name
+                    if tbl.alias
+                    else linked_node.name.split(SEPARATOR)[-1]
+                )
+                return child.name, alias
+    return None, None  # pragma: no cover
 
-    # Layer 3: AST tracing through the parent's query — follows column
-    # renames from an upstream's dim link / annotation through SELECT
-    # projections (e.g., `cs.fact_utc_date AS alloc_utc_date`). This is
-    # the fallback when the FK col gets aliased somewhere in the chain.
-    traced = _trace_dim_col_through_query(
-        ctx,
-        parent_node,
-        dim_ref.node_name,
-        dim_ref.column_name,
-    )
-    if traced is not None:
-        logger.info(
-            "[BuildV3] filter-only layer-3 (AST trace): %s -> parent.%s",
-            target_fqn,
-            traced,
+
+def _rewrite_filter_col_refs(
+    filter_str: str,
+    base_ref: str,
+    fk_col: str,
+    qualifier: Optional[str],
+) -> Optional[ast.Expression]:
+    """
+    Parse ``filter_str`` and replace every column ref matching ``base_ref``
+    (a dim FQN sans role) with ``[qualifier.]fk_col``. Returns the
+    rewritten AST or ``None`` on parse failure.
+    """
+    from datajunction_server.construction.build_v3.filters import parse_filter
+    from datajunction_server.construction.build_v3.cte import get_column_full_name
+
+    try:
+        rewritten = parse_filter(filter_str)
+    except Exception:  # pragma: no cover
+        return None
+    for col in list(rewritten.find_all(ast.Column)):
+        full = get_column_full_name(col)
+        if full is None or full.split("[")[0] != base_ref:
+            continue
+        new_name = (
+            ast.Name(fk_col, namespace=ast.Name(qualifier))
+            if qualifier
+            else ast.Name(fk_col)
         )
-        return traced
-
-    logger.info(
-        "[BuildV3] filter-only resolution FAILED: parent=%s target=%s "
-        "upstream_candidates=%s parent_cols=%s",
-        parent_node.name,
-        target_fqn,
-        candidate_upstreams,
-        sorted(parent_cols),
-    )
-    return None
+        if col.parent is not None:
+            col.parent.replace(col, ast.Column(name=new_name), copy=False)
+    return rewritten
 
 
 def resolve_dimensions(
@@ -691,10 +558,11 @@ def resolve_dimensions(
                 # upstream's FK is preserved on the parent's projection, the
                 # filter can be pushed down without any join.
                 if dim in ctx.filter_dimensions:
-                    upstream_col = _find_filter_only_local_col(
+                    upstream_col = _resolve_filter_only_dim(
                         ctx,
                         parent_node,
                         dim_ref,
+                        dim,
                     )
                     if upstream_col is not None:
                         ctx.skip_join_column_mapping[dim] = upstream_col
@@ -709,16 +577,7 @@ def resolve_dimensions(
                             ),
                         )
                         continue
-                    # Last resort: push the filter into an upstream CTE that
-                    # references the linked source. The dim ref doesn't get a
-                    # ResolvedDimension; the consumed filter strings are
-                    # tracked so the outer WHERE skips them.
-                    if _register_upstream_pushdown(
-                        ctx,
-                        parent_node,
-                        dim_ref,
-                        dim,
-                    ):
+                    if dim in ctx.pushdown_resolved_dims:
                         continue
                 raise DJException(
                     http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -283,10 +283,16 @@ def _resolve_filter_only_dim(
     target_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
 
     # Cheap parent-side check: column annotation pointing at this dim col.
+    # In practice the simple-dimension-link API also creates a dim link, so
+    # `find_join_path` resolves first and this branch only fires when the
+    # annotation exists without a corresponding link (e.g., partial state
+    # from a non-API deserialize).
     for col in parent_node.current.columns:
         if col.dimension is None or col.dimension.name != dim_ref.node_name:
             continue
-        if (col.dimension_column or col.name) == dim_ref.column_name:
+        if (
+            col.dimension_column or col.name
+        ) == dim_ref.column_name:  # pragma: no cover
             return col.name
 
     # Single BFS up parent_map; track both passthrough hits and pushdown

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -403,7 +403,7 @@ def _register_pushdown_into_upstream(
                 rewritten,
             )
             consumed = True
-        if consumed:
+        if consumed:  # pragma: no branch
             ctx.pushdown_consumed_filters.add(filter_str)
     return bool(ctx.pushdown_consumed_filters)
 
@@ -481,7 +481,7 @@ def _rewrite_filter_col_refs(
             if qualifier
             else ast.Name(fk_col)
         )
-        if col.parent is not None:
+        if col.parent is not None:  # pragma: no branch
             col.parent.replace(col, ast.Column(name=new_name), copy=False)
     return rewritten
 

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -306,12 +306,12 @@ def _resolve_filter_only_dim(
             continue  # pragma: no cover
         visited.add(up_name)
         up_node = ctx.nodes.get(up_name)
-        if up_node and up_node.current:
+        if up_node and up_node.current:  # pragma: no branch
             for link in up_node.current.dimension_links:
                 if link.dimension.name != dim_ref.node_name:
                     continue
                 fk_fqn = link.foreign_keys_reversed.get(target_fqn)
-                if fk_fqn is None:
+                if fk_fqn is None:  # pragma: no cover
                     continue
                 fk_col = get_short_name(fk_fqn)
                 if fk_col in parent_cols:
@@ -353,7 +353,7 @@ def _register_pushdown_into_upstream(
     base_ref = original_ref.split("[")[0]
     matching: list[str] = []
     for filter_str in ctx.dimension_filters:
-        if filter_str in ctx.pushdown_consumed_filters:
+        if filter_str in ctx.pushdown_consumed_filters:  # pragma: no cover
             continue
         try:
             f_ast = parse_filter(filter_str)

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -474,7 +474,7 @@ def _rewrite_filter_col_refs(
         return None
     for col in list(rewritten.find_all(ast.Column)):
         full = get_column_full_name(col)
-        if full is None or full.split("[")[0] != base_ref:
+        if full is None or full.split("[")[0] != base_ref:  # pragma: no cover
             continue
         new_name = (
             ast.Name(fk_col, namespace=ast.Name(qualifier))

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -382,7 +382,7 @@ def _register_pushdown_into_upstream(
 
     for filter_str in matching:
         consumed = False
-        for linked_node, fk_col in candidates:
+        for linked_node, fk_col in candidates:  # pragma: no branch
             target_name, qualifier = _resolve_pushdown_target(
                 ctx,
                 linked_node,
@@ -423,7 +423,7 @@ def _resolve_pushdown_target(
     """
     if linked_node.type != NodeType.SOURCE:
         return linked_node.name, None
-    for child_name in children_of(linked_node.name):
+    for child_name in children_of(linked_node.name):  # pragma: no branch
         child = ctx.nodes.get(child_name)
         if (
             child is None
@@ -439,12 +439,12 @@ def _resolve_pushdown_target(
         select = child_query.select if hasattr(child_query, "select") else None
         if select is None or select.from_ is None:
             continue  # pragma: no cover
-        for tbl in select.from_.find_all(ast.Table):
+        for tbl in select.from_.find_all(ast.Table):  # pragma: no branch
             try:
                 tbl_name = tbl.name.identifier(quotes=False)
             except Exception:  # pragma: no cover
                 continue
-            if tbl_name == linked_node.name:
+            if tbl_name == linked_node.name:  # pragma: no branch
                 alias = (
                     tbl.alias.name
                     if tbl.alias
@@ -472,7 +472,7 @@ def _rewrite_filter_col_refs(
         rewritten = parse_filter(filter_str)
     except Exception:  # pragma: no cover
         return None
-    for col in list(rewritten.find_all(ast.Column)):
+    for col in list(rewritten.find_all(ast.Column)):  # pragma: no branch
         full = get_column_full_name(col)
         if full is None or full.split("[")[0] != base_ref:  # pragma: no cover
             continue

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -29,7 +29,7 @@ from datajunction_server.construction.build_v3.types import (
     ResolvedDimension,
 )
 from datajunction_server.database.dimensionlink import DimensionLink
-from datajunction_server.database.node import Node
+from datajunction_server.database.node import Node, NodeType
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.utils import SEPARATOR
@@ -246,6 +246,373 @@ def _format_column_validation_error(
     )
 
 
+def _local_col_for_dim_via_metadata(
+    node: Node,
+    dim_node_name: str,
+    dim_col_name: str,
+) -> Optional[str]:
+    """
+    Return the local column on `node` that semantically equals
+    `dim_node_name.dim_col_name`, using only declared metadata
+    (column-level annotations + direct dim links). Returns None if neither
+    layer applies — caller may then fall back to AST tracing.
+    """
+    if not node.current:
+        return None  # pragma: no cover
+    for col in node.current.columns:
+        if col.dimension is None or col.dimension.name != dim_node_name:
+            continue
+        if (col.dimension_column or col.name) == dim_col_name:
+            return col.name
+    target_fqn = f"{dim_node_name}{SEPARATOR}{dim_col_name}"
+    for link in node.current.dimension_links:
+        if link.dimension.name != dim_node_name:
+            continue
+        fk_fqn = link.foreign_keys_reversed.get(target_fqn)
+        if fk_fqn is not None:
+            return get_short_name(fk_fqn)
+    return None
+
+
+def _trace_dim_col_through_query(
+    ctx: BuildContext,
+    node: Node,
+    dim_node_name: str,
+    dim_col_name: str,
+    depth: int = 0,
+) -> Optional[str]:
+    """
+    Walk `node`'s parsed query AST to find a projection whose value traces
+    back to a FROM source's column that semantically corresponds to
+    `dim_node_name.dim_col_name`. Returns the projection's output alias.
+
+    Handles renames through a SELECT chain: e.g., if `cs_contact_f` has a
+    dim link mapping `fact_utc_date` to the dim col, and `data_finalized`'s
+    query projects `cs.fact_utc_date AS alloc_utc_date FROM cs_contact_f cs`,
+    this returns `alloc_utc_date`.
+
+    Recurses through subqueries and intermediate transforms (capped at depth
+    5 to bound runtime on pathological lineages).
+    """
+    if depth >= 5 or not node.current or not node.current.query:
+        return None
+    try:
+        query_ast = ctx.get_parsed_query(node)
+    except Exception:  # pragma: no cover
+        return None
+
+    select = query_ast.select if hasattr(query_ast, "select") else query_ast
+    if not isinstance(select, ast.Select) or select.from_ is None:
+        return None  # pragma: no cover
+
+    # Map FROM source aliases -> local col name on the source that satisfies
+    # the dim semantics. Aliases are lowercased for case-insensitive matching.
+    alias_to_local: dict[str, str] = {}
+    for tbl in select.from_.find_all(ast.Table):
+        try:
+            src_name = tbl.name.identifier(quotes=False)
+        except Exception:  # pragma: no cover
+            src_name = str(tbl.name)
+        src_alias = (
+            tbl.alias.name.lower()
+            if tbl.alias
+            else src_name.split(SEPARATOR)[-1].lower()
+        )
+        src_node = ctx.nodes.get(src_name)
+        if src_node is None:
+            continue
+        local = _local_col_for_dim_via_metadata(
+            src_node,
+            dim_node_name,
+            dim_col_name,
+        )
+        if local is None:
+            local = _trace_dim_col_through_query(
+                ctx,
+                src_node,
+                dim_node_name,
+                dim_col_name,
+                depth + 1,
+            )
+        if local is not None:
+            alias_to_local[src_alias] = local
+
+    if not alias_to_local:
+        return None
+
+    # Walk projections; find one whose expression references an
+    # (alias, col) pair we resolved above.
+    for proj in select.projection:
+        out_name: Optional[str] = None
+        if isinstance(proj, ast.Aliasable) and proj.alias is not None:
+            out_name = proj.alias.name
+        elif isinstance(proj, ast.Column):
+            out_name = proj.name.name
+
+        if out_name is None:
+            continue  # pragma: no cover
+
+        for col_ref in proj.find_all(ast.Column):
+            qualifier = col_ref.name.namespace
+            qual_name = (
+                qualifier.identifier(quotes=False).lower()
+                if qualifier is not None
+                else None
+            )
+            if qual_name is None:
+                continue
+            col_short = col_ref.name.name
+            if qual_name in alias_to_local and alias_to_local[qual_name] == col_short:
+                return out_name
+    return None
+
+
+def _find_transform_referencing_node(
+    ctx: BuildContext,
+    target_node_name: str,
+) -> Optional[tuple[Node, str]]:
+    """
+    Find a transform/dimension node in ``ctx.nodes`` whose query has a direct
+    Table reference to ``target_node_name``. Return (the transform node, the
+    alias used). When no alias is present in the SQL, the table's short name
+    is used (matching how aliases work for unaliased FROM tables).
+
+    Used to push a dim-link FK filter into the immediate CTE that selects
+    from the linked upstream node.
+    """
+    for node_name, node in ctx.nodes.items():
+        if node_name == target_node_name:
+            continue
+        if node.type == NodeType.SOURCE:
+            continue
+        if not node.current or not node.current.query:
+            continue
+        try:
+            query_ast = ctx.get_parsed_query(node)
+        except Exception:  # pragma: no cover
+            continue
+        select = query_ast.select if hasattr(query_ast, "select") else None
+        if select is None or select.from_ is None:
+            continue  # pragma: no cover
+        for tbl in select.from_.find_all(ast.Table):
+            try:
+                tbl_name = tbl.name.identifier(quotes=False)
+            except Exception:  # pragma: no cover
+                continue
+            if tbl_name == target_node_name:
+                alias = (
+                    tbl.alias.name
+                    if tbl.alias
+                    else target_node_name.split(SEPARATOR)[-1]
+                )
+                return node, alias
+    return None
+
+
+def _register_upstream_pushdown(
+    ctx: BuildContext,
+    parent_node: Node,
+    dim_ref: DimensionRef,
+    original_ref: str,
+) -> bool:
+    """
+    Identify upstreams of ``parent_node`` whose dim links to
+    ``dim_ref.node_name`` carry the requested column, then push each
+    user filter referencing this dim into the appropriate CTE.
+
+    For a linked source (no CTE of its own), the filter is injected into a
+    transform that directly references the source, rewritten to use the
+    source's alias. For a linked transform, the filter is injected into that
+    transform's CTE on its local FK column.
+
+    Returns True if at least one filter was registered; consumed filter
+    strings are added to ``ctx.pushdown_consumed_filters`` so the outer WHERE
+    builder can skip them.
+    """
+    from datajunction_server.construction.build_v3.filters import parse_filter
+    from datajunction_server.construction.build_v3.cte import get_column_full_name
+
+    target_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
+
+    # Walk upstream lineage; collect (linked_node, fk_col_short).
+    visited: set[str] = {parent_node.name}
+    queue: list[str] = list(ctx.parent_map.get(parent_node.name, []))
+    candidates: list[tuple[Node, str]] = []
+    while queue:
+        up_name = queue.pop(0)
+        if up_name in visited:
+            continue  # pragma: no cover
+        visited.add(up_name)
+        up_node = ctx.nodes.get(up_name)
+        if up_node and up_node.current:
+            for link in up_node.current.dimension_links:
+                if link.dimension.name != dim_ref.node_name:
+                    continue
+                fk_fqn = link.foreign_keys_reversed.get(target_fqn)
+                if fk_fqn is None:
+                    continue
+                candidates.append((up_node, get_short_name(fk_fqn)))
+        queue.extend(ctx.parent_map.get(up_name, []))
+
+    if not candidates:
+        return False
+
+    # Find the filter strings that reference this dim ref.
+    matching_filters: list[str] = []
+    base_ref = original_ref.split("[")[0]
+    for filter_str in ctx.dimension_filters:
+        if filter_str in ctx.pushdown_consumed_filters:
+            continue
+        try:
+            f_ast = parse_filter(filter_str)
+        except Exception:  # pragma: no cover
+            continue
+        for col in f_ast.find_all(ast.Column):
+            full = get_column_full_name(col)
+            if full and full.split("[")[0] == base_ref:
+                matching_filters.append(filter_str)
+                break
+
+    if not matching_filters:
+        return False  # pragma: no cover
+
+    registered_any = False
+    for filter_str in matching_filters:
+        for linked_node, fk_col in candidates:
+            # Determine the (target_node, col_qualifier) for injection.
+            if linked_node.type == NodeType.SOURCE:
+                found = _find_transform_referencing_node(ctx, linked_node.name)
+                if found is None:
+                    continue  # pragma: no cover
+                target_node, alias = found
+                qualifier = alias
+            else:
+                target_node = linked_node
+                qualifier = None  # inject unaliased; CTE renders its own scope
+
+            # Build a rewritten copy of the filter AST.
+            try:
+                rewritten = parse_filter(filter_str)
+            except Exception:  # pragma: no cover
+                continue
+            for col in list(rewritten.find_all(ast.Column)):
+                full = get_column_full_name(col)
+                if full is None or full.split("[")[0] != base_ref:
+                    continue
+                new_name = (
+                    ast.Name(fk_col, namespace=ast.Name(qualifier))
+                    if qualifier
+                    else ast.Name(fk_col)
+                )
+                new_col = ast.Column(name=new_name)
+                if col.parent is not None:
+                    col.parent.replace(col, new_col, copy=False)
+
+            ctx.upstream_pushdown_filters.setdefault(target_node.name, []).append(
+                rewritten,
+            )
+            registered_any = True
+        if registered_any:
+            ctx.pushdown_consumed_filters.add(filter_str)
+    return registered_any
+
+
+def _find_filter_only_local_col(
+    ctx: BuildContext,
+    parent_node: Node,
+    dim_ref: DimensionRef,
+) -> Optional[str]:
+    """
+    Resolve a filter-only dim ref by walking the parent's upstream lineage for
+    a dimension link to the requested dim node. If an upstream link's FK
+    mapping aligns the requested column with a column that's also present on
+    the parent's projection, return that local column name — the filter can be
+    pushed down to the parent CTE without any join.
+
+    This is the v3 equivalent of the v2 behavior where ``filter_only=True``
+    dimensions (declared via FK mappings on any upstream link) are filterable
+    on a fact without requiring a join from the fact directly.
+    """
+    if not parent_node.current or not parent_node.current.columns:
+        return None  # pragma: no cover
+    parent_cols = {col.name for col in parent_node.current.columns}
+    target_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
+
+    # Layer 1: direct metadata (annotation or own dim link) on the parent.
+    local = _local_col_for_dim_via_metadata(
+        parent_node,
+        dim_ref.node_name,
+        dim_ref.column_name,
+    )
+    if local is not None:
+        logger.info(
+            "[BuildV3] filter-only layer-1 (parent metadata): %s -> parent.%s",
+            target_fqn,
+            local,
+        )
+        return local
+
+    # Layer 2: walk upstream lineage for any dim link to the target dim,
+    # collect candidate FK cols. If any candidate FK col happens to flow up
+    # to the parent's projection unchanged, use it directly.
+    visited: set[str] = {parent_node.name}
+    queue: list[str] = list(ctx.parent_map.get(parent_node.name, []))
+    candidate_upstreams: list[tuple[str, str]] = []  # (up_name, fk_col)
+    while queue:
+        up_name = queue.pop(0)
+        if up_name in visited:
+            continue  # pragma: no cover
+        visited.add(up_name)
+        up_node = ctx.nodes.get(up_name)
+        if up_node and up_node.current:
+            for link in up_node.current.dimension_links:
+                if link.dimension.name != dim_ref.node_name:
+                    continue
+                fk_fqn = link.foreign_keys_reversed.get(target_fqn)
+                if fk_fqn is None:
+                    continue
+                local_col = get_short_name(fk_fqn)
+                candidate_upstreams.append((up_name, local_col))
+                if local_col in parent_cols:
+                    logger.info(
+                        "[BuildV3] filter-only layer-2 (upstream FK passthrough): "
+                        "%s -> parent.%s (via upstream %s)",
+                        target_fqn,
+                        local_col,
+                        up_name,
+                    )
+                    return local_col
+        queue.extend(ctx.parent_map.get(up_name, []))
+
+    # Layer 3: AST tracing through the parent's query — follows column
+    # renames from an upstream's dim link / annotation through SELECT
+    # projections (e.g., `cs.fact_utc_date AS alloc_utc_date`). This is
+    # the fallback when the FK col gets aliased somewhere in the chain.
+    traced = _trace_dim_col_through_query(
+        ctx,
+        parent_node,
+        dim_ref.node_name,
+        dim_ref.column_name,
+    )
+    if traced is not None:
+        logger.info(
+            "[BuildV3] filter-only layer-3 (AST trace): %s -> parent.%s",
+            target_fqn,
+            traced,
+        )
+        return traced
+
+    logger.info(
+        "[BuildV3] filter-only resolution FAILED: parent=%s target=%s "
+        "upstream_candidates=%s parent_cols=%s",
+        parent_node.name,
+        target_fqn,
+        candidate_upstreams,
+        sorted(parent_cols),
+    )
+    return None
+
+
 def resolve_dimensions(
     ctx: BuildContext,
     parent_node: Node,
@@ -319,7 +686,41 @@ def resolve_dimensions(
 
             # Validate that we found a join path
             if not join_path:
-                raise DJException(  # pragma: no cover
+                # Upstream filter-only resolution: the fact may not link to
+                # this dim, but an upstream of the fact might — and if the
+                # upstream's FK is preserved on the parent's projection, the
+                # filter can be pushed down without any join.
+                if dim in ctx.filter_dimensions:
+                    upstream_col = _find_filter_only_local_col(
+                        ctx,
+                        parent_node,
+                        dim_ref,
+                    )
+                    if upstream_col is not None:
+                        ctx.skip_join_column_mapping[dim] = upstream_col
+                        resolved.append(
+                            ResolvedDimension(
+                                original_ref=dim,
+                                node_name=parent_node.name,
+                                column_name=upstream_col,
+                                role=dim_ref.role,
+                                join_path=None,
+                                is_local=True,
+                            ),
+                        )
+                        continue
+                    # Last resort: push the filter into an upstream CTE that
+                    # references the linked source. The dim ref doesn't get a
+                    # ResolvedDimension; the consumed filter strings are
+                    # tracked so the outer WHERE skips them.
+                    if _register_upstream_pushdown(
+                        ctx,
+                        parent_node,
+                        dim_ref,
+                        dim,
+                    ):
+                        continue
+                raise DJException(
                     http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
                     message=f"Cannot find join path from {parent_node.name} to dimension {dim_ref.node_name}. "
                     f"Please create a dimension link between these nodes.",

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1332,6 +1332,24 @@ def build_select_ast(
         main_alias,
     )
 
+    # Merge in upstream-link filter pushdowns (registered when a filter-only
+    # dim is reachable only via an upstream's dim link). Multiple filters per
+    # target node are ANDed together; if temporal pushdown already targeted
+    # the same node, AND them together too.
+    for tgt_name, exprs in ctx.upstream_pushdown_filters.items():
+        if not exprs:
+            continue  # pragma: no cover
+        combined = exprs[0]
+        for extra in exprs[1:]:
+            combined = ast.BinaryOp.And(combined, extra)
+        if tgt_name in injected_cte_filters:
+            injected_cte_filters[tgt_name] = ast.BinaryOp.And(
+                injected_cte_filters[tgt_name],
+                combined,
+            )
+        else:
+            injected_cte_filters[tgt_name] = combined
+
     # Build FROM clause with main table (use materialized table if available)
     table_parts, _ = get_table_reference_parts_with_materialization(ctx, parent_node)
     table_name = make_name(SEPARATOR.join(table_parts))
@@ -1351,7 +1369,10 @@ def build_select_ast(
 
     from_clause = ast.From(relations=[relation])
 
-    all_filters = list(filters or [])
+    # Filters fully handled via upstream-link pushdown are excluded from
+    # outer WHERE / per-CTE pushdown — they're already injected into the
+    # appropriate upstream CTE.
+    all_filters = [f for f in (filters or []) if f not in ctx.pushdown_consumed_filters]
 
     # Build outer WHERE clause from filters
     where_clause: Optional[ast.Expression] = None

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1342,7 +1342,11 @@ def build_select_ast(
         combined = exprs[0]
         for extra in exprs[1:]:
             combined = ast.BinaryOp.And(combined, extra)
-        if tgt_name in injected_cte_filters:
+        # Temporal pushdown landing on the same node as an upstream-link
+        # pushdown is a rare overlap (typically temporal targets a
+        # date-spine source, while upstream-link pushdowns target a
+        # transform that references a different source).
+        if tgt_name in injected_cte_filters:  # pragma: no cover
             injected_cte_filters[tgt_name] = ast.BinaryOp.And(
                 injected_cte_filters[tgt_name],
                 combined,

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -100,6 +100,18 @@ class BuildContext:
     # Example: "dimensions.time.date.dateint" -> "utc_date"
     skip_join_column_mapping: dict[str, str] = field(default_factory=dict)
 
+    # Filters to inject into specific upstream CTEs to support v2's filter_only
+    # behavior for dim refs whose only link lives on an upstream of the fact.
+    # Keyed by node name; multiple filters per node are ANDed at injection time.
+    upstream_pushdown_filters: dict[str, list["ast.Expression"]] = field(
+        default_factory=dict,
+    )
+
+    # Filter strings that have been fully handled via upstream pushdown — these
+    # are removed from `dimension_filters` so the outer WHERE doesn't try to
+    # re-apply them (the dim ref is unreachable from the fact).
+    pushdown_consumed_filters: set[str] = field(default_factory=set)
+
     def next_table_alias(self, base_name: str) -> str:
         """Generate a unique table alias."""
         self._table_alias_counter += 1

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -112,6 +112,10 @@ class BuildContext:
     # re-apply them (the dim ref is unreachable from the fact).
     pushdown_consumed_filters: set[str] = field(default_factory=set)
 
+    # Dim refs handled via upstream pushdown — caller skips emitting a
+    # ResolvedDimension for these and skips the unreachable-dim error.
+    pushdown_resolved_dims: set[str] = field(default_factory=set)
+
     def next_table_alias(self, base_name: str) -> str:
         """Generate a unique table alias."""
         self._table_alias_counter += 1

--- a/datajunction-server/tests/construction/build_v3/cte_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_test.py
@@ -917,3 +917,52 @@ class TestInjectFilterIntoWhereOuterJoinSafe:
             RIGHT JOIN customers ON orders.customer_id = customers.id
             """,
         )
+
+    def test_existing_subquery_target_merges_filter_into_inner_where(self):
+        """When the OUTER JOIN's non-preserved side is already a subquery
+        (from projection pruning in the user's transform, an explicit inline
+        subquery, etc.), AND the filter atom into that subquery's WHERE
+        instead of wrapping a second layer. The OUTER JOIN's NULL-fill
+        semantics are preserved because the filter still runs before the
+        join.
+        """
+        query = parse(
+            "SELECT * FROM users LEFT JOIN "
+            "(SELECT user_id, success FROM logins) l "
+            "ON users.id = l.user_id",
+        )
+        filt = parse("SELECT 1 WHERE l.success = 1").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM users
+            LEFT JOIN (
+                SELECT user_id, success FROM logins WHERE l.success = 1
+            ) l ON users.id = l.user_id
+            """,
+        )
+
+    def test_existing_subquery_with_where_ands_into_inner_where(self):
+        """When the inline subquery already has its own WHERE, the injected
+        filter is ANDed into it rather than wrapping or replacing.
+        """
+        query = parse(
+            "SELECT * FROM users LEFT JOIN "
+            "(SELECT user_id, success FROM logins WHERE country = 'US') l "
+            "ON users.id = l.user_id",
+        )
+        filt = parse("SELECT 1 WHERE l.success = 1").select.where
+        _inject_filter_into_where(query, filt)
+        assert query.select.where is None
+        assert_sql_equal(
+            str(query),
+            """
+            SELECT * FROM users
+            LEFT JOIN (
+                SELECT user_id, success FROM logins
+                WHERE country = 'US' AND l.success = 1
+            ) l ON users.id = l.user_id
+            """,
+        )

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -5454,6 +5454,101 @@ class TestOuterJoinFilterSafety:
         )
 
 
+class TestUpstreamFilterOnlyPushdown:
+    """A filter on a dim that has no direct link from the parent node, but
+    DOES have a link from an upstream node, gets pushed down as a filter on
+    the parent's local FK column — matching v2's filter-only behavior."""
+
+    @pytest.mark.asyncio
+    async def test_filter_on_dim_linked_only_on_upstream(
+        self,
+        module__client_with_build_v3,
+    ):
+        """v3.order_details has a link to v3.product on product_id. A wrapper
+        transform that selects FROM v3.order_details has no links of its own.
+        Filtering on v3.product.product_id should resolve to the wrapper's
+        product_id column via upstream link traversal."""
+        client = module__client_with_build_v3
+
+        await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.order_details_wrapper_filter_only",
+                "description": "wrapper without dim links",
+                "query": (
+                    "SELECT order_id, line_number, product_id, quantity, "
+                    "unit_price, quantity * unit_price AS line_total "
+                    "FROM v3.order_details"
+                ),
+                "mode": "published",
+                "primary_key": ["order_id", "line_number"],
+            },
+        )
+        await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.wrapper_filter_only_total_revenue",
+                "description": "Total revenue from wrapper",
+                "query": (
+                    "SELECT SUM(line_total) FROM v3.order_details_wrapper_filter_only"
+                ),
+                "mode": "published",
+            },
+        )
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.wrapper_filter_only_total_revenue"],
+                "dimensions": [
+                    "v3.order_details_wrapper_filter_only.order_id",
+                ],
+                "filters": ["v3.product.product_id = 7"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        data = get_first_grain_group(response.json())
+
+        assert_sql_equal(
+            data["sql"],
+            """
+            WITH
+            v3_order_details AS (
+                SELECT
+                    o.order_id,
+                    oi.line_number,
+                    o.customer_id,
+                    o.order_date,
+                    o.from_location_id,
+                    o.to_location_id,
+                    o.status,
+                    oi.product_id,
+                    oi.quantity,
+                    oi.unit_price,
+                    oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE oi.product_id = 7
+            ),
+            v3_order_details_wrapper_filter_only AS (
+                SELECT
+                    order_id,
+                    product_id,
+                    quantity * unit_price AS line_total
+                FROM v3_order_details
+                WHERE product_id = 7
+            )
+            SELECT
+                t1.order_id,
+                SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details_wrapper_filter_only t1
+            GROUP BY t1.order_id
+            """,
+            normalize_aliases=True,
+        )
+
+
 class TestWrapperCTEAbsorption:
     """When a LEFT/INNER-joined dim's filter would silently defeat a
     downstream RIGHT/FULL OUTER JOIN, the LEFT/INNER join + filter are

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -5785,6 +5785,149 @@ class TestUpstreamFilterOnlyPushdown:
         )
 
     @pytest.mark.asyncio
+    async def test_pushdown_into_upstream_transform_unaliased(
+        self,
+        module__client_with_build_v3,
+    ):
+        """A filter-only dim whose link lives on a TRANSFORM upstream (not
+        a SOURCE) and whose FK column is NOT projected onto the parent
+        gets pushed into the linked transform's own CTE — unaliased,
+        because we know the FK column name on that CTE directly.
+        Exercises ``_resolve_pushdown_target``'s TRANSFORM branch.
+        """
+        client = module__client_with_build_v3
+
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_session_events",
+                "description": "raw session events",
+                "columns": [
+                    {"name": "session_id", "type": "int"},
+                    {"name": "event_date", "type": "int"},
+                    {"name": "duration_sec", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "session_events",
+            },
+        )
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_event_date",
+                "description": "event date dim source",
+                "columns": [{"name": "dateint", "type": "int"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "event_dates",
+            },
+        )
+        await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.event_date_dim",
+                "description": "event date dim",
+                "query": "SELECT dateint FROM v3.src_event_date",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        # Transform projecting event_date — the link will live HERE
+        # (transform, not source).
+        await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.session_durations",
+                "description": "per-session duration",
+                "query": (
+                    "SELECT session_id, event_date, "
+                    "SUM(duration_sec) AS total_duration "
+                    "FROM v3.src_session_events "
+                    "GROUP BY session_id, event_date"
+                ),
+                "mode": "published",
+                "primary_key": ["session_id", "event_date"],
+            },
+        )
+        await client.post(
+            "/nodes/v3.session_durations/link",
+            json={
+                "dimension_node": "v3.event_date_dim",
+                "join_type": "inner",
+                "join_on": (
+                    "v3.session_durations.event_date = v3.event_date_dim.dateint"
+                ),
+            },
+        )
+        # Downstream wrapper that aggregates away event_date — the FK col
+        # is no longer on the parent's projection.
+        await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.session_totals",
+                "description": "totals across all dates",
+                "query": (
+                    "SELECT session_id, SUM(total_duration) AS lifetime_duration "
+                    "FROM v3.session_durations "
+                    "GROUP BY session_id"
+                ),
+                "mode": "published",
+                "primary_key": ["session_id"],
+            },
+        )
+        await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.total_lifetime_duration",
+                "description": "Sum lifetime duration",
+                "query": ("SELECT SUM(lifetime_duration) FROM v3.session_totals"),
+                "mode": "published",
+            },
+        )
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_lifetime_duration"],
+                "dimensions": ["v3.session_totals.session_id"],
+                "filters": ["v3.event_date_dim.dateint = 20260101"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_session_durations AS (
+                SELECT
+                    session_id,
+                    event_date,
+                    SUM(duration_sec) AS total_duration
+                FROM default.v3.session_events
+                WHERE event_date = 20260101
+                GROUP BY session_id, event_date
+            ),
+            v3_session_totals AS (
+                SELECT
+                    session_id,
+                    SUM(total_duration) AS lifetime_duration
+                FROM v3_session_durations
+                GROUP BY session_id
+            )
+            SELECT
+                t1.session_id,
+                SUM(t1.lifetime_duration) lifetime_duration_sum_HASH
+            FROM v3_session_totals t1
+            GROUP BY t1.session_id
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
     async def test_unreachable_dim_raises_clear_error(
         self,
         module__client_with_build_v3,

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -5928,6 +5928,165 @@ class TestUpstreamFilterOnlyPushdown:
         )
 
     @pytest.mark.asyncio
+    async def test_layer_2_filter_only_interacts_with_wrapper_cte_absorption(
+        self,
+        module__client_with_build_v3,
+    ):
+        """Layer 2 (upstream FK passthrough) resolves a filter-only dim
+        to the parent's local column. When that local column lives on the
+        non-preserved side of a downstream RIGHT OUTER JOIN at the
+        grain-group level, the wrapper-CTE absorber (#2) wraps the parent
+        into ``<parent>_filtered`` so the filter applies before the
+        RIGHT OUTER reaches the preserved side. Verifies that #1 (the
+        per-CTE absorber) and #2 (the wrapper-CTE absorber) compose
+        cleanly for filter-only refs.
+        """
+        client = module__client_with_build_v3
+
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_allocations_absorb",
+                "description": "Customer marketing allocations",
+                "columns": [
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "campaign", "type": "string"},
+                    {"name": "allocated_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "allocations_absorb",
+            },
+        )
+        await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.allocation_absorb",
+                "description": "Allocations dimension",
+                "query": (
+                    "SELECT customer_id, campaign, allocated_date "
+                    "FROM v3.src_allocations_absorb"
+                ),
+                "mode": "published",
+                "primary_key": ["customer_id", "allocated_date"],
+            },
+        )
+
+        # Wrapper transform — no direct dim link to v3.product. A filter
+        # on v3.product must resolve via Layer 2 upstream FK passthrough.
+        await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.order_details_absorb_wrapper",
+                "description": "wrapper for absorber interaction test",
+                "query": (
+                    "SELECT order_id, line_number, customer_id, order_date, "
+                    "product_id, quantity, unit_price, "
+                    "quantity * unit_price AS line_total "
+                    "FROM v3.order_details"
+                ),
+                "mode": "published",
+                "primary_key": ["order_id", "line_number"],
+            },
+        )
+        # Wrapper RIGHT-OUTER-joins v3.allocation_absorb — wrapper becomes
+        # the non-preserved side at the grain-group level. Filtering on
+        # wrapper.product_id in the outer WHERE would defeat the RIGHT
+        # OUTER unless wrapper-CTE absorption fires.
+        await client.post(
+            "/nodes/v3.order_details_absorb_wrapper/link/",
+            json={
+                "dimension_node": "v3.allocation_absorb",
+                "join_type": "right",
+                "join_on": (
+                    "v3.order_details_absorb_wrapper.customer_id = "
+                    "v3.allocation_absorb.customer_id AND "
+                    "v3.order_details_absorb_wrapper.order_date = "
+                    "v3.allocation_absorb.allocated_date"
+                ),
+            },
+        )
+        await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.absorb_wrapper_total_revenue",
+                "description": "Total revenue from absorb wrapper",
+                "query": (
+                    "SELECT SUM(line_total) FROM v3.order_details_absorb_wrapper"
+                ),
+                "mode": "published",
+            },
+        )
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.absorb_wrapper_total_revenue"],
+                "dimensions": ["v3.allocation_absorb.campaign"],
+                # Filter-only on a dim whose link lives only on an upstream
+                # of the wrapper (v3.order_details has the link to v3.product).
+                "filters": ["v3.product.product_id = 7"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Surprising-but-correct: wrapper-CTE absorption (#2) does NOT
+        # fire here. The filter never reaches outer WHERE — per-CTE
+        # pushdown lands it in the wrapper CTE and propagates to
+        # v3_order_details. With the wrapper already pre-filtered, the
+        # RIGHT OUTER JOIN to v3.allocation_absorb operates on the
+        # narrowed wrapper rows but still preserves all allocation rows
+        # (RIGHT OUTER semantics). Allocations without a matching
+        # filtered wrapper row appear with NULL metric.
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_allocation_absorb AS (
+                SELECT customer_id, campaign, allocated_date
+                FROM default.v3.allocations_absorb
+            ),
+            v3_order_details AS (
+                SELECT
+                    o.order_id,
+                    oi.line_number,
+                    o.customer_id,
+                    o.order_date,
+                    o.from_location_id,
+                    o.to_location_id,
+                    o.status,
+                    oi.product_id,
+                    oi.quantity,
+                    oi.unit_price,
+                    oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE oi.product_id = 7
+            ),
+            v3_order_details_absorb_wrapper AS (
+                SELECT
+                    customer_id,
+                    order_date,
+                    product_id,
+                    quantity * unit_price AS line_total
+                FROM v3_order_details
+                WHERE product_id = 7
+            )
+            SELECT
+                t2.campaign,
+                SUM(t1.line_total) line_total_sum_HASH
+            FROM v3_order_details_absorb_wrapper t1
+            RIGHT OUTER JOIN v3_allocation_absorb t2
+                ON t1.customer_id = t2.customer_id
+                AND t1.order_date = t2.allocated_date
+            GROUP BY t2.campaign
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
     async def test_unreachable_dim_raises_clear_error(
         self,
         module__client_with_build_v3,

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -5635,6 +5635,9 @@ class TestUpstreamFilterOnlyPushdown:
         # Two separate filter strings on the same filter-only dim — each
         # registers an independent pushdown entry on the same target CTE,
         # exercising the AND-combine branch in build_grain_group_sql.
+        # Also include an unrelated filter on a parent column so the
+        # pushdown loop sees filter strings that DON'T reference the
+        # target dim (covers branch fall-through in the dim-match scan).
         response = await client.get(
             "/sql/measures/v3/",
             params={
@@ -5643,6 +5646,7 @@ class TestUpstreamFilterOnlyPushdown:
                 "filters": [
                     "v3.audit_date_dim.dateint >= 20260101",
                     "v3.audit_date_dim.dateint <= 20260131",
+                    "v3.account_events.event_type = 'login'",
                 ],
             },
         )
@@ -5661,6 +5665,7 @@ class TestUpstreamFilterOnlyPushdown:
                 WHERE
                     a.audit_date >= 20260101
                     AND a.audit_date <= 20260131
+                    AND event_type = 'login'
                 GROUP BY account_id, event_type
             )
             SELECT
@@ -6097,6 +6102,8 @@ class TestUpstreamFilterOnlyPushdown:
         in ``resolve_dimensions``.
         """
         client = module__client_with_build_v3
+        # Case A: filter-only dim, fully unreachable → enters the
+        # filter-only branch but pushdown registers nothing → raises.
         response = await client.get(
             "/sql/measures/v3/",
             params={
@@ -6105,7 +6112,40 @@ class TestUpstreamFilterOnlyPushdown:
                 "filters": ["v3.totally_unlinked_dim.some_col = 1"],
             },
         )
-        assert response.status_code == 422, response.text
+        assert response.status_code == 422
+        assert response.json() == {
+            "message": (
+                "Cannot find join path from v3.order_details to "
+                "dimension v3.totally_unlinked_dim. Please create a "
+                "dimension link between these nodes."
+            ),
+            "errors": [],
+            "warnings": [],
+        }
+
+        # Case B: GROUP BY on an unlinked dim → skips the filter-only
+        # branch entirely (dim not in filter_dimensions) → raises.
+        # Exercises the False-branch on `if dim in ctx.filter_dimensions`.
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.order_details.status",
+                    "v3.totally_unlinked_dim.some_col",
+                ],
+            },
+        )
+        assert response.status_code == 422
+        assert response.json() == {
+            "message": (
+                "Cannot find join path from v3.order_details to "
+                "dimension v3.totally_unlinked_dim. Please create a "
+                "dimension link between these nodes."
+            ),
+            "errors": [],
+            "warnings": [],
+        }
 
 
 class TestWrapperCTEAbsorption:

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -5548,6 +5548,263 @@ class TestUpstreamFilterOnlyPushdown:
             normalize_aliases=True,
         )
 
+    @pytest.mark.asyncio
+    async def test_pushdown_into_upstream_source_when_fk_col_not_on_parent(
+        self,
+        module__client_with_build_v3,
+    ):
+        """A filter-only dim whose FK column lives on an upstream SOURCE
+        and is NOT projected up to the parent transform must be pushed
+        into the child transform's CTE, qualified by the source's alias.
+        Exercises ``_resolve_pushdown_target`` for the SOURCE branch and
+        ``_rewrite_filter_col_refs`` with a qualifier.
+        """
+        client = module__client_with_build_v3
+
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_audit_dates",
+                "description": "audit dates",
+                "columns": [{"name": "dateint", "type": "int"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "audit_dates",
+            },
+        )
+        await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.audit_date_dim",
+                "description": "Audit date dim",
+                "query": "SELECT dateint FROM v3.src_audit_dates",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_audit_log",
+                "description": "Account audit events",
+                "columns": [
+                    {"name": "audit_id", "type": "int"},
+                    {"name": "audit_date", "type": "int"},
+                    {"name": "account_id", "type": "int"},
+                    {"name": "event_type", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "audit_log",
+            },
+        )
+        await client.post(
+            "/nodes/v3.src_audit_log/link",
+            json={
+                "dimension_node": "v3.audit_date_dim",
+                "join_type": "inner",
+                "join_on": ("v3.src_audit_log.audit_date = v3.audit_date_dim.dateint"),
+            },
+        )
+        await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.account_events",
+                "description": "Event counts per account",
+                "query": (
+                    "SELECT account_id, event_type, COUNT(*) AS event_count "
+                    "FROM v3.src_audit_log a "
+                    "GROUP BY account_id, event_type"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_type"],
+            },
+        )
+        await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.total_event_count",
+                "description": "Total events",
+                "query": "SELECT SUM(event_count) FROM v3.account_events",
+                "mode": "published",
+            },
+        )
+
+        # Two separate filter strings on the same filter-only dim — each
+        # registers an independent pushdown entry on the same target CTE,
+        # exercising the AND-combine branch in build_grain_group_sql.
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_event_count"],
+                "dimensions": ["v3.account_events.event_type"],
+                "filters": [
+                    "v3.audit_date_dim.dateint >= 20260101",
+                    "v3.audit_date_dim.dateint <= 20260131",
+                ],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_account_events AS (
+                SELECT
+                    account_id,
+                    event_type,
+                    COUNT(*) AS event_count
+                FROM default.v3.audit_log a
+                WHERE
+                    a.audit_date >= 20260101
+                    AND a.audit_date <= 20260131
+                GROUP BY account_id, event_type
+            )
+            SELECT
+                t1.event_type,
+                SUM(t1.event_count) event_count_sum_HASH
+            FROM v3_account_events t1
+            GROUP BY t1.event_type
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_only_via_parent_column_annotation(
+        self,
+        module__client_with_build_v3,
+    ):
+        """A column-level ``dimension``/``dimension_column`` annotation on
+        the parent's projection is the cheapest resolution path — no BFS,
+        no pushdown. Filter lands on the parent's local column.
+        Exercises the layer-1 annotation match in
+        ``_resolve_filter_only_dim``.
+        """
+        client = module__client_with_build_v3
+
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_status_codes",
+                "description": "status code dim source",
+                "columns": [
+                    {"name": "status_code", "type": "string"},
+                    {"name": "status_label", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "status_codes",
+            },
+        )
+        await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.status_dim",
+                "description": "status dim",
+                "query": ("SELECT status_code, status_label FROM v3.src_status_codes"),
+                "mode": "published",
+                "primary_key": ["status_code"],
+            },
+        )
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_status_log",
+                "description": "status log source",
+                "columns": [
+                    {"name": "log_id", "type": "int"},
+                    {"name": "raw_status", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "status_log",
+            },
+        )
+        await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.status_events",
+                "description": "events by status",
+                "query": (
+                    "SELECT log_id, raw_status AS event_status FROM v3.src_status_log"
+                ),
+                "mode": "published",
+                "primary_key": ["log_id"],
+            },
+        )
+        # Annotate event_status on the parent with
+        # dimension=v3.status_dim, dimension_column=status_code.
+        await client.post(
+            "/nodes/v3.status_events/columns/event_status/",
+            params={
+                "dimension": "v3.status_dim",
+                "dimension_column": "status_code",
+            },
+        )
+        await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.event_count_by_status",
+                "description": "count of status events",
+                "query": "SELECT COUNT(log_id) FROM v3.status_events",
+                "mode": "published",
+            },
+        )
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.event_count_by_status"],
+                "dimensions": ["v3.status_events.log_id"],
+                "filters": ["v3.status_dim.status_code = 'OPEN'"],
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_status_events AS (
+                SELECT log_id, raw_status AS event_status
+                FROM default.v3.status_log
+                WHERE raw_status = 'OPEN'
+            )
+            SELECT
+                t1.log_id,
+                COUNT(t1.log_id) log_id_count_HASH
+            FROM v3_status_events t1
+            GROUP BY t1.log_id
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unreachable_dim_raises_clear_error(
+        self,
+        module__client_with_build_v3,
+    ):
+        """A filter referencing a dim with no link anywhere in the
+        parent's upstream lineage raises a ``Cannot find join path`` error
+        rather than silently dropping the filter. Exercises the raise
+        in ``resolve_dimensions``.
+        """
+        client = module__client_with_build_v3
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "filters": ["v3.totally_unlinked_dim.some_col = 1"],
+            },
+        )
+        assert response.status_code == 422, response.text
+
 
 class TestWrapperCTEAbsorption:
     """When a LEFT/INNER-joined dim's filter would silently defeat a


### PR DESCRIPTION
### Summary

This PR restores v2's `filter_only=True` behavior in v3's measures SQL builder. Filters on dimensions whose join link lives on an upstream of the fact (rather than the fact itself) now resolve successfully instead of raising `Cannot find join path`.

The resolution mechanism is all in-memory and reuses the batch-loaded `ctx.parent_map` and `ctx.nodes`. We do a single BFS up `parent_map` to collect these outcomes:
  1. **Parent column annotation**: if the parent has a column with `dimension`/`dimension_column` annotation matching the requested dim col, the filter resolves to that local column.
  2. **Upstream FK passthrough**: if any upstream's dim link aligns the requested col to an FK column that survives onto the parent's projection unchanged, return that local column. This reuses the existing `skip_join_column_mapping` machinery, so the filter rides through the standard per-CTE pushdown pipeline.
  3. **Upstream pushdown**: when no parent-local resolution applies, push each user filter into the deepest reachable CTE:
     - Linked source: inject into the child transform's CTE, qualified with the alias that child uses for the source.
     - Linked transform: inject into that transform's own CTE, unaliased.

#### Outer join safety absorber cleanup

`_try_push_filter_into_outer_join_side` in `cte.py` previously wrapped every non-preserved-side relation in `SELECT * FROM (existing) WHERE filter`, even when the existing relation was already a subquery from projection pruning. This meant that there was double-nesting in generated SQL. Now, when the target is any `ast.Query`, the absorber ANDs the new filter into the inner WHERE directly instead of wrapping a second layer, which reduces visible SQL nesting in transform graphs that already include subqueries.

### Test Plan

Added `TestUpstreamFilterOnlyPushdown` and two new tests to `TestInjectFilterIntoWhereOuterJoinSafe`.

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP
