### PR TITLE
Add remove partition column endpoint

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1693,6 +1693,56 @@ async def set_column_partition(
     return column
 
 
+@router.delete(
+    "/nodes/{node_name}/columns/{column_name}/partition",
+    response_model=ColumnOutput,
+    name="Remove Partition From Node Column",
+)
+async def remove_column_partition(
+    node_name: str,
+    column_name: str,
+    *,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    save_history: Callable = Depends(get_save_history),
+    access_checker: AccessChecker = Depends(get_access_checker),
+) -> ColumnOutput:
+    """
+    Remove the partition configuration from a node column.
+    """
+    access_checker.add_request_by_node_name(node_name, ResourceAction.WRITE)
+    await access_checker.check(on_denied=AccessDenialMode.RAISE)
+
+    node = await Node.get_by_name(
+        session,
+        node_name,
+        options=[
+            joinedload(Node.current).options(
+                *NodeRevision.default_load_options(),
+                joinedload(NodeRevision.cube_elements),
+            ),
+        ],
+    )
+    column = get_node_column(node, column_name)  # type: ignore
+    if column.partition:
+        await session.delete(column.partition)
+        column.partition = None
+        session.add(column)
+        await save_history(
+            event=History(
+                entity_type=EntityType.PARTITION,
+                node=node_name,
+                activity_type=ActivityType.DELETE,
+                details={"column": column_name},
+                user=current_user.username,
+            ),
+            session=session,
+        )
+        await session.commit()
+        await session.refresh(column)
+    return column
+
+
 @router.post(
     "/nodes/{node_name}/copy",
     response_model=DAGNodeOutput,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -6185,6 +6185,65 @@ async def test_set_column_partition(client_with_roads: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_remove_column_partition(client_with_roads: AsyncClient):
+    """
+    Test removing partition configuration from a node column.
+    """
+    # Set a temporal partition on hire_date
+    response = await client_with_roads.post(
+        "/nodes/default.hard_hat/columns/hire_date/partition",
+        json={
+            "type_": "temporal",
+            "granularity": "day",
+            "format": "yyyyMMdd",
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["partition"] == {
+        "expression": None,
+        "format": "yyyyMMdd",
+        "type_": "temporal",
+        "granularity": "day",
+    }
+
+    # Remove the partition
+    response = await client_with_roads.delete(
+        "/nodes/default.hard_hat/columns/hire_date/partition",
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "hire_date"
+    assert body["partition"] is None
+
+    # Removing again is a no-op (idempotent)
+    response = await client_with_roads.delete(
+        "/nodes/default.hard_hat/columns/hire_date/partition",
+    )
+    assert response.status_code == 200
+    assert response.json()["partition"] is None
+
+    # Removing partition from a column that never had one is also a no-op
+    response = await client_with_roads.delete(
+        "/nodes/default.hard_hat/columns/state/partition",
+    )
+    assert response.status_code == 200
+    assert response.json()["partition"] is None
+
+    # Delete event is recorded in history
+    response = await client_with_roads.get(
+        "/history/?node=default.hard_hat",
+    )
+    assert response.status_code == 200
+    partition_deletes = [
+        event
+        for event in response.json()
+        if event["entity_type"] == "partition" and event["activity_type"] == "delete"
+    ]
+    assert len(partition_deletes) >= 1
+    assert partition_deletes[0]["details"] == {"column": "hire_date"}
+
+
+@pytest.mark.asyncio
 async def test_delete_recreate_for_all_nodes(client_with_roads: AsyncClient):
     """
     Test deleting and recreating for all node types


### PR DESCRIPTION
### Summary

This adds an API endpoint to remove a column's partition configuration. Until now the only partition endpoint was `POST .../partition`, and there was no way to clear a partition once set. The UI's "Remove partition" button was POSTing `type_=''` and silently 422'ing against enum validation, so partition removal has effectively been a no-op since the feature was introduced.

The new endpoint is `DELETE /nodes/{name}/columns/{col}/partition`. It looks up the node and column, and if the column has a partition config, it deletes the Partition row, nulls column.partition, and writes a partition delete history event.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
