### PR TITLE
Expose column description on the GraphQL Column type

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/scalars/column.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/column.py
@@ -68,6 +68,7 @@ class Column:
 
     name: str
     display_name: Optional[str]
+    description: Optional[str]
     type: str
     attributes: List[Attribute] = strawberry.field(default_factory=list)
     dimension: Optional[NodeName]

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -196,6 +196,7 @@ class NodeRevision:
             Column(  # type: ignore
                 name=col.name,
                 display_name=col.display_name,
+                description=col.description,
                 type=col.type,
                 attributes=col.attributes,
                 dimension=(

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -54,6 +54,7 @@ type Collection {
 type Column {
   name: String!
   displayName: String
+  description: String
   type: String!
   attributes: [Attribute!]!
   dimension: NodeName


### PR DESCRIPTION
### Summary

Adds the existing column-level description field (already on the DB model and the REST API) to the GraphQL `Column` scalar, so clients querying nodes through GraphQL can see per-column descriptions without falling back to REST.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
