### PR TITLE
Cascade read-only status across the namespace hierarchy

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -93,31 +93,52 @@ async def check_namespace_not_git_only(
     namespace: str,
 ) -> None:
     """
-    Check that a namespace is not git-managed. If it is, raise an error.
-    Used to prevent direct node mutations (create/update/delete) on git-managed namespaces.
+    Check that a namespace (or any of its ancestors) is not git-managed.
 
-    Blocks mutations when:
-    - The namespace has git_only=True (explicitly locked branch namespace), OR
-    - The namespace is a git root (has github_repo_path set directly)
+    The check cascades up the dotted namespace hierarchy so that locking
+    ``foo.main`` also locks ``foo.main.metrics``, ``foo.main.dimensions``,
+    etc. Without that, a flagged parent is trivially bypassable by mutating
+    in a child namespace.
 
-    Branch namespaces (children of a git root) are intentionally allowed — edits
-    there are valid and get synced back to the git repo.
+    Blocks mutations when any ancestor (or the namespace itself):
+    - Has ``git_only=True`` (explicitly locked), OR
+    - Is a git root (``github_repo_path`` set and ``git_branch`` null).
+
+    Branch namespaces (children of a git root with a non-null ``git_branch``)
+    are intentionally allowed — edits there are valid and get synced back to
+    the git repo, so they don't trip this check.
+
+    Implementation: namespace names contain their parent path (``a.b.c``),
+    so we materialize every prefix and fire a single ``IN`` query. One round
+    trip regardless of hierarchy depth.
     """
-    node_namespace = await get_node_namespace(
-        session,
-        namespace,
-        raise_if_not_exists=False,
-    )
-    is_git_root = (
-        node_namespace is not None
-        and node_namespace.github_repo_path is not None
-        and node_namespace.git_branch is None
-    )
-    if node_namespace and (node_namespace.git_only or is_git_root):
-        raise DJInvalidInputException(
-            message=f"Namespace '{namespace}' is git-managed. "
-            "Node changes must be deployed from git via the /deployments API.",
+    parts = namespace.split(".")
+    candidates = [".".join(parts[: i + 1]) for i in range(len(parts))]
+    statement = select(NodeNamespace).where(NodeNamespace.namespace.in_(candidates))
+    matches = {ns.namespace: ns for ns in (await session.execute(statement)).scalars()}
+
+    # Walk deepest-first so the most specific locked ancestor (the one the
+    # user can most usefully act on) wins the error message. ``is_git_root``
+    # only applies to the namespace itself — its branch children are
+    # intentionally editable — so don't propagate that flag up the chain.
+    for candidate in reversed(candidates):
+        ns = matches.get(candidate)
+        if ns is None:
+            continue
+        is_self = ns.namespace == namespace
+        is_git_root = (
+            is_self and ns.github_repo_path is not None and ns.git_branch is None
         )
+        if ns.git_only or is_git_root:
+            scope_msg = (
+                f"'{namespace}'"
+                if is_self
+                else f"'{namespace}' (locked via ancestor '{ns.namespace}')"
+            )
+            raise DJInvalidInputException(
+                message=f"Namespace {scope_msg} is git-managed. "
+                "Node changes must be deployed from git via the /deployments API.",
+            )
 
 
 async def get_node_by_name(

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -114,17 +114,21 @@ async def check_namespace_not_git_only(
     """
     parts = namespace.split(".")
     candidates = [".".join(parts[: i + 1]) for i in range(len(parts))]
-    statement = select(NodeNamespace).where(NodeNamespace.namespace.in_(candidates))
-    matches = {ns.namespace: ns for ns in (await session.execute(statement)).scalars()}
+    matches = (
+        (
+            await session.execute(
+                select(NodeNamespace).where(NodeNamespace.namespace.in_(candidates)),
+            )
+        )
+        .scalars()
+        .all()
+    )
 
     # Walk deepest-first so the most specific locked ancestor (the one the
     # user can most usefully act on) wins the error message. ``is_git_root``
     # only applies to the namespace itself — its branch children are
     # intentionally editable — so don't propagate that flag up the chain.
-    for candidate in reversed(candidates):
-        ns = matches.get(candidate)
-        if ns is None:
-            continue
+    for ns in sorted(matches, key=lambda n: len(n.namespace), reverse=True):
         is_self = ns.namespace == namespace
         is_git_root = (
             is_self and ns.github_repo_path is not None and ns.git_branch is None

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -683,31 +683,21 @@ async def get_namespace_git_config(
 
     node_namespace = await get_node_namespace(session, namespace)
 
-    # Resolve the effective git config (including inherited values). Use the
-    # rich resolver so we also get a cascaded ``git_only`` — a lock on any
-    # ancestor (typically the default-branch namespace like ``ads.main``)
-    # must propagate down to its subnamespaces (``ads.main.metrics`` etc.)
-    # or the UI's read-only badge / edit-button gating fires off the wrong
-    # value.
-    git_info = await get_git_info_for_namespace(session, namespace)
-    if git_info:
-        return NamespaceGitConfig(
-            github_repo_path=git_info["repo"],
-            git_path=git_info["path"],
-            git_branch=git_info["branch"],
-            default_branch=node_namespace.default_branch,
-            parent_namespace=node_namespace.parent_namespace,
-            git_only=git_info["git_only"],
-            branch_namespace=git_info["branch_namespace"],
-        )
-
+    # Resolve the effective git config (including inherited values). The
+    # rich resolver also cascades ``git_only`` — a lock on any ancestor
+    # must propagate down to its subnamespaces or the UI's read-only badge
+    # / edit-button gating fires off the wrong value. When no git context
+    # is found (no git root in the ancestor chain), git_info is None and
+    # we fall back to this namespace's own ``git_only`` flag.
+    git_info = await get_git_info_for_namespace(session, namespace) or {}
     return NamespaceGitConfig(
-        github_repo_path=None,
-        git_path=None,
-        git_branch=None,
+        github_repo_path=git_info.get("repo"),
+        git_path=git_info.get("path"),
+        git_branch=git_info.get("branch"),
         default_branch=node_namespace.default_branch,
         parent_namespace=node_namespace.parent_namespace,
-        git_only=node_namespace.git_only,
+        git_only=git_info.get("git_only", node_namespace.git_only),
+        branch_namespace=git_info.get("branch_namespace"),
     )
 
 

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -683,17 +683,28 @@ async def get_namespace_git_config(
 
     node_namespace = await get_node_namespace(session, namespace)
 
-    # Resolve the effective git config (including inherited values)
-    resolved_repo, resolved_path, resolved_branch = await resolve_git_config(
-        session,
-        namespace,
-    )
+    # Resolve the effective git config (including inherited values). Use the
+    # rich resolver so we also get a cascaded ``git_only`` — a lock on any
+    # ancestor (typically the default-branch namespace like ``ads.main``)
+    # must propagate down to its subnamespaces (``ads.main.metrics`` etc.)
+    # or the UI's read-only badge / edit-button gating fires off the wrong
+    # value.
+    git_info = await get_git_info_for_namespace(session, namespace)
+    if git_info:
+        return NamespaceGitConfig(
+            github_repo_path=git_info["repo"],
+            git_path=git_info["path"],
+            git_branch=git_info["branch"],
+            default_branch=node_namespace.default_branch,
+            parent_namespace=node_namespace.parent_namespace,
+            git_only=git_info["git_only"],
+            branch_namespace=git_info["branch_namespace"],
+        )
 
     return NamespaceGitConfig(
-        # Return resolved values (effective configuration)
-        github_repo_path=resolved_repo,
-        git_path=resolved_path,
-        git_branch=resolved_branch,
+        github_repo_path=None,
+        git_path=None,
+        git_branch=None,
         default_branch=node_namespace.default_branch,
         parent_namespace=node_namespace.parent_namespace,
         git_only=node_namespace.git_only,

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -270,6 +270,14 @@ def resolve_git_info_from_map(
 
     branch = branch_ns.git_branch if branch_ns else None
     default_branch = config_ns.default_branch
+    # Effective git_only cascades: any ancestor (or the namespace itself)
+    # with git_only=True locks all descendants. Without this the UI would
+    # treat a child namespace as editable when its parent is locked,
+    # while the backend's check_namespace_not_git_only correctly rejects
+    # the mutation — desynced UX.
+    effective_git_only = any(
+        ns_map[n].git_only for n in ancestor_names if ns_map.get(n)
+    )
     return {
         "repo": config_ns.github_repo_path,
         "branch": branch,
@@ -280,7 +288,15 @@ def resolve_git_info_from_map(
             or (default_branch is not None and branch == default_branch)
         ),
         "parent_namespace": branch_ns.parent_namespace if branch_ns else None,
-        "git_only": config_ns.git_only,
+        "git_only": effective_git_only,
+        # Name of the branch namespace this lookup resolves through. Equals
+        # ``namespace`` when called against the branch itself, or the
+        # ancestor branch namespace when called against a descendant. The UI
+        # uses this to show branch-scoped controls (Git Settings, Sync to
+        # Git, Create PR) on every page under the branch, while still being
+        # able to distinguish "this IS the branch" from "this is INSIDE the
+        # branch."
+        "branch_namespace": branch_ns.namespace if branch_ns else None,
     }
 
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -676,6 +676,11 @@ class NamespaceGitConfig(BaseModel):
     default_branch: str | None = None  # Default branch for git roots (e.g., "main")
     parent_namespace: str | None = None  # Links branch namespaces to parent
     git_only: bool | None = None  # If True, UI edits blocked; must edit via git
+    # Name of the branch namespace this namespace lives under (equals the
+    # namespace itself when it IS the branch). Lets the UI show branch
+    # controls (Git Settings / Sync to Git / Create PR) on subnamespaces
+    # too, scoped to the branch.
+    branch_namespace: str | None = None
 
 
 class DeploymentSpec(BaseModel):

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -318,6 +318,7 @@ class TestNamespaceGitConfig:
             "github_repo_path": "myorg/monorepo",
             "parent_namespace": None,
             "default_branch": None,
+            "branch_namespace": None,
         }
 
     @pytest.mark.asyncio
@@ -354,6 +355,7 @@ class TestNamespaceGitConfig:
             "github_repo_path": "myorg/repo",
             "parent_namespace": None,
             "default_branch": None,
+            "branch_namespace": None,
         }
 
 

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -131,6 +131,7 @@ def test_deployment_spec():
             "github_repo_path": "some/repo",
             "parent_namespace": None,
             "default_branch": None,
+            "branch_namespace": None,
         },
         "namespace": "test_deployment",
         "nodes": [

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -75,30 +75,49 @@ export default function NamespaceHeader({
             onGitConfigLoaded(config);
           }
 
-          // If this is a branch namespace, fetch parent's git config, branches, and check for existing PR
-          if (config?.parent_namespace) {
-            try {
-              const parentConfig = await djClient.getNamespaceGitConfig(
-                config.parent_namespace,
-              );
-              setParentGitConfig(parentConfig);
-            } catch (e) {
-              console.error('Failed to fetch parent git config:', e);
+          // If this namespace is inside a branch (or IS the branch), fetch
+          // parent/branches/PR. ``branch_namespace`` is set both when this
+          // namespace IS the branch and when it's a descendant of one, so
+          // subnamespaces get the same data.
+          if (config?.branch_namespace) {
+            // The branch namespace itself carries the parent_namespace FK to
+            // the git root. If this is a subnamespace, fetch the branch's
+            // config to get that FK; otherwise the current config already
+            // has it.
+            const branchConfig =
+              config.branch_namespace === namespace
+                ? config
+                : await djClient
+                    .getNamespaceGitConfig(config.branch_namespace)
+                    .catch(() => null);
+            const gitRootNs = branchConfig?.parent_namespace;
+
+            if (gitRootNs) {
+              try {
+                const parentConfig = await djClient.getNamespaceGitConfig(
+                  gitRootNs,
+                );
+                setParentGitConfig(parentConfig);
+              } catch (e) {
+                console.error('Failed to fetch parent git config:', e);
+              }
+
+              try {
+                const branchList = await djClient.getNamespaceBranches(
+                  gitRootNs,
+                );
+                setBranches(branchList || []);
+              } catch (e) {
+                console.error('Failed to fetch branches:', e);
+              }
             }
 
-            try {
-              const branchList = await djClient.getNamespaceBranches(
-                config.parent_namespace,
-              );
-              setBranches(branchList || []);
-            } catch (e) {
-              console.error('Failed to fetch branches:', e);
-            }
-
-            // Check for existing PR
+            // Check for existing PR scoped to the branch, not the current
+            // (sub)namespace — a branch has at most one PR regardless of
+            // which subnamespace page the user is on.
             setPrLoading(true);
             try {
-              const pr = await djClient.getPullRequest(namespace);
+              const pr = await djClient.getPullRequest(config.branch_namespace);
               setExistingPR(pr);
             } catch (e) {
               // No PR or error - that's fine
@@ -146,7 +165,15 @@ export default function NamespaceHeader({
   const hasGitConfig =
     gitConfig?.github_repo_path ||
     (gitConfig?.parent_namespace && gitConfig?.git_branch);
-  const isBranchNamespace = !!gitConfig?.parent_namespace;
+  // ``branch_namespace`` is the branch this namespace belongs to (equals the
+  // namespace when called against the branch itself, the ancestor branch when
+  // called against a descendant). isBranchNamespace = "this IS the branch"
+  // (used for the breadcrumb branch switcher); isInBranch = "this lives under
+  // a branch" (used to show branch-scoped git controls on subnamespaces too).
+  const isBranchNamespace =
+    !!gitConfig?.branch_namespace && gitConfig.branch_namespace === namespace;
+  const isInBranch = !!gitConfig?.branch_namespace;
+  const branchScopeNamespace = gitConfig?.branch_namespace || namespace;
   const isGitRoot = gitConfig?.github_repo_path && !gitConfig?.parent_namespace;
   const canCreateBranches = isGitRoot && gitConfig?.default_branch;
 
@@ -170,20 +197,26 @@ export default function NamespaceHeader({
   };
 
   const handleSyncToGit = async commitMessage => {
-    return await djClient.syncNamespaceToGit(namespace, commitMessage);
+    // Sync/PR operations always target the whole branch namespace, even
+    // when invoked from a subnamespace page.
+    return await djClient.syncNamespaceToGit(
+      gitConfig?.branch_namespace || namespace,
+      commitMessage,
+    );
   };
 
   const handleCreatePR = async (title, body, onProgress) => {
+    const targetNs = gitConfig?.branch_namespace || namespace;
     // First sync changes to git using PR title as commit message
     if (onProgress) onProgress('syncing');
-    const syncResult = await djClient.syncNamespaceToGit(namespace, title);
+    const syncResult = await djClient.syncNamespaceToGit(targetNs, title);
     if (syncResult?._error) {
       return syncResult;
     }
 
     // Then create the PR
     if (onProgress) onProgress('creating');
-    const result = await djClient.createPullRequest(namespace, title, body);
+    const result = await djClient.createPullRequest(targetNs, title, body);
     if (result && !result._error) {
       setExistingPR(result);
     }
@@ -827,8 +860,11 @@ export default function NamespaceHeader({
 
         {/* Right side: git actions + children */}
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          {/* Git controls for non-branch namespaces */}
-          {namespace && !isBranchNamespace && !gitConfigLoading && (
+          {/* Git controls for namespaces not inside a branch (git roots,
+              orphan namespaces). Subnamespaces under a branch fall through
+              to the branch-scoped block below so we don't render two sets
+              of buttons. */}
+          {namespace && !isInBranch && !gitConfigLoading && (
             <>
               <button
                 style={buttonStyle}
@@ -878,8 +914,8 @@ export default function NamespaceHeader({
             </>
           )}
 
-          {/* Git controls for branch namespaces */}
-          {isBranchNamespace && hasGitConfig && (
+          {/* Git controls for branch namespaces (and subnamespaces under them) */}
+          {isInBranch && hasGitConfig && (
             <>
               <button
                 style={buttonStyle}
@@ -1063,7 +1099,7 @@ export default function NamespaceHeader({
           isOpen={showSyncToGit}
           onClose={() => setShowSyncToGit(false)}
           onSync={handleSyncToGit}
-          namespace={namespace}
+          namespace={branchScopeNamespace}
           gitBranch={gitConfig?.git_branch}
           repoPath={gitConfig?.github_repo_path}
         />
@@ -1072,7 +1108,7 @@ export default function NamespaceHeader({
           isOpen={showCreatePR}
           onClose={() => setShowCreatePR(false)}
           onCreate={handleCreatePR}
-          namespace={namespace}
+          namespace={branchScopeNamespace}
           gitBranch={gitConfig?.git_branch}
           parentBranch={
             parentGitConfig?.git_branch || parentGitConfig?.default_branch

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -196,27 +196,33 @@ export default function NamespaceHeader({
     return await djClient.createBranch(namespace, branchName);
   };
 
+  // Sync/PR operations always target the whole branch namespace, even
+  // when invoked from a subnamespace page.
   const handleSyncToGit = async commitMessage => {
-    // Sync/PR operations always target the whole branch namespace, even
-    // when invoked from a subnamespace page.
     return await djClient.syncNamespaceToGit(
-      gitConfig?.branch_namespace || namespace,
+      branchScopeNamespace,
       commitMessage,
     );
   };
 
   const handleCreatePR = async (title, body, onProgress) => {
-    const targetNs = gitConfig?.branch_namespace || namespace;
     // First sync changes to git using PR title as commit message
     if (onProgress) onProgress('syncing');
-    const syncResult = await djClient.syncNamespaceToGit(targetNs, title);
+    const syncResult = await djClient.syncNamespaceToGit(
+      branchScopeNamespace,
+      title,
+    );
     if (syncResult?._error) {
       return syncResult;
     }
 
     // Then create the PR
     if (onProgress) onProgress('creating');
-    const result = await djClient.createPullRequest(targetNs, title, body);
+    const result = await djClient.createPullRequest(
+      branchScopeNamespace,
+      title,
+      body,
+    );
     if (result && !result._error) {
       setExistingPR(result);
     }

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -76,19 +76,18 @@ export default function NamespaceHeader({
           }
 
           // If this namespace is inside a branch (or IS the branch), fetch
-          // parent/branches/PR. ``branch_namespace`` is set both when this
-          // namespace IS the branch and when it's a descendant of one, so
-          // subnamespaces get the same data.
-          if (config?.branch_namespace) {
+          // parent/branches/PR.
+          const branchNs = config?.branch_namespace;
+          if (branchNs) {
             // The branch namespace itself carries the parent_namespace FK to
             // the git root. If this is a subnamespace, fetch the branch's
             // config to get that FK; otherwise the current config already
             // has it.
             const branchConfig =
-              config.branch_namespace === namespace
+              branchNs === namespace
                 ? config
                 : await djClient
-                    .getNamespaceGitConfig(config.branch_namespace)
+                    .getNamespaceGitConfig(branchNs)
                     .catch(() => null);
             const gitRootNs = branchConfig?.parent_namespace;
 
@@ -117,7 +116,7 @@ export default function NamespaceHeader({
             // which subnamespace page the user is on.
             setPrLoading(true);
             try {
-              const pr = await djClient.getPullRequest(config.branch_namespace);
+              const pr = await djClient.getPullRequest(branchNs);
               setExistingPR(pr);
             } catch (e) {
               // No PR or error - that's fine
@@ -167,13 +166,14 @@ export default function NamespaceHeader({
     (gitConfig?.parent_namespace && gitConfig?.git_branch);
   // ``branch_namespace`` is the branch this namespace belongs to (equals the
   // namespace when called against the branch itself, the ancestor branch when
-  // called against a descendant). isBranchNamespace = "this IS the branch"
-  // (used for the breadcrumb branch switcher); isInBranch = "this lives under
-  // a branch" (used to show branch-scoped git controls on subnamespaces too).
-  const isBranchNamespace =
-    !!gitConfig?.branch_namespace && gitConfig.branch_namespace === namespace;
-  const isInBranch = !!gitConfig?.branch_namespace;
-  const branchScopeNamespace = gitConfig?.branch_namespace || namespace;
+  // called against a descendant).
+  // isBranchNamespace = "this IS the branch" (used for the breadcrumb branch
+  // switcher); isInBranch = "this lives under a branch" (used to show
+  // branch-scoped git controls on subnamespaces too).
+  const branchNamespace = gitConfig?.branch_namespace || null;
+  const isBranchNamespace = branchNamespace === namespace;
+  const isInBranch = !!branchNamespace;
+  const branchScopeNamespace = branchNamespace || namespace;
   const isGitRoot = gitConfig?.github_repo_path && !gitConfig?.parent_namespace;
   const canCreateBranches = isGitRoot && gitConfig?.default_branch;
 

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -590,6 +590,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',
@@ -672,6 +673,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',
@@ -830,6 +832,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',
@@ -893,6 +896,7 @@ describe('<NamespaceHeader />', () => {
         git_path: 'nodes/',
         git_only: false,
         parent_namespace: 'test.main',
+        branch_namespace: 'test.feature',
       }),
       getPullRequest: jest.fn().mockResolvedValue({
         pr_number: 42,
@@ -932,6 +936,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',
@@ -1019,6 +1024,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',
@@ -1087,6 +1093,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',
@@ -1142,6 +1149,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockRejectedValueOnce(new Error('Parent not found')),
       getPullRequest: jest.fn().mockResolvedValue(null),
@@ -1184,6 +1192,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',
@@ -1339,6 +1348,7 @@ describe('<NamespaceHeader />', () => {
           git_path: 'nodes/',
           git_only: false,
           parent_namespace: 'test.main',
+          branch_namespace: 'test.feature',
         })
         .mockResolvedValueOnce({
           github_repo_path: 'test/repo',

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -9,7 +9,7 @@ import PartitionColumnPopover from './PartitionColumnPopover';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
 
-export default function NodeColumnTab({ node, djClient }) {
+export default function NodeColumnTab({ node, djClient, readOnly = false }) {
   const [attributes, setAttributes] = useState([]);
   const [dimensions, setDimensions] = useState([]);
   const [columns, setColumns] = useState([]);
@@ -182,14 +182,16 @@ export default function NodeColumnTab({ node, djClient }) {
               aria-hidden="false"
             >
               {col.description || ''}
-              <EditColumnDescriptionPopover
-                column={col}
-                node={node}
-                onSubmit={async () => {
-                  const res = await djClient.node(node.name);
-                  setColumns(res.columns);
-                }}
-              />
+              {!readOnly && (
+                <EditColumnDescriptionPopover
+                  column={col}
+                  node={node}
+                  onSubmit={async () => {
+                    const res = await djClient.node(node.name);
+                    setColumns(res.columns);
+                  }}
+                />
+              )}
             </span>
           </td>
           <td>
@@ -246,18 +248,20 @@ export default function NodeColumnTab({ node, djClient }) {
                     </a>
                   </span>
                 )}
-                <ManageDimensionLinksDialog
-                  column={col}
-                  node={node}
-                  dimensions={dimensions}
-                  fkLinks={fkLinksForColumn}
-                  referenceLink={referenceLink}
-                  onSubmit={async () => {
-                    const res = await djClient.node(node.name);
-                    setLinks(res.dimension_links);
-                    setColumns(res.columns);
-                  }}
-                />
+                {!readOnly && (
+                  <ManageDimensionLinksDialog
+                    column={col}
+                    node={node}
+                    dimensions={dimensions}
+                    fkLinks={fkLinksForColumn}
+                    referenceLink={referenceLink}
+                    onSubmit={async () => {
+                      const res = await djClient.node(node.name);
+                      setLinks(res.dimension_links);
+                      setColumns(res.columns);
+                    }}
+                  />
+                )}
               </div>
             </td>
           ) : (
@@ -266,29 +270,33 @@ export default function NodeColumnTab({ node, djClient }) {
           {node.type !== 'cube' ? (
             <td>
               {showColumnAttributes(col)}
-              <EditColumnPopover
-                column={col}
-                node={node}
-                options={attributes}
-                onSubmit={async () => {
-                  const res = await djClient.node(node.name);
-                  setColumns(res.columns);
-                }}
-              />
+              {!readOnly && (
+                <EditColumnPopover
+                  column={col}
+                  node={node}
+                  options={attributes}
+                  onSubmit={async () => {
+                    const res = await djClient.node(node.name);
+                    setColumns(res.columns);
+                  }}
+                />
+              )}
             </td>
           ) : (
             ''
           )}
           <td>
             {showColumnPartition(col)}
-            <PartitionColumnPopover
-              column={col}
-              node={node}
-              onSubmit={async () => {
-                const res = await djClient.node(node.name);
-                setColumns(res.columns);
-              }}
-            />
+            {!readOnly && (
+              <PartitionColumnPopover
+                column={col}
+                node={node}
+                onSubmit={async () => {
+                  const res = await djClient.node(node.name);
+                  setColumns(res.columns);
+                }}
+              />
+            )}
           </td>
         </tr>
       );

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -16,7 +16,11 @@ const cronstrue = require('cronstrue');
  * For non-cube nodes, the parent component (index.jsx) renders
  * NodePreAggregationsTab instead.
  */
-export default function NodeMaterializationTab({ node, djClient }) {
+export default function NodeMaterializationTab({
+  node,
+  djClient,
+  readOnly = false,
+}) {
   const [rawMaterializations, setRawMaterializations] = useState([]);
   const [selectedRevisionTab, setSelectedRevisionTab] = useState(null);
   const [showInactive, setShowInactive] = useState(false);
@@ -179,7 +183,7 @@ export default function NodeMaterializationTab({ node, djClient }) {
                 Show Inactive
               </label>
             )}
-            {node && <AddMaterializationPopover node={node} />}
+            {node && !readOnly && <AddMaterializationPopover node={node} />}
           </div>
         </div>
       );
@@ -282,6 +286,7 @@ export default function NodeMaterializationTab({ node, djClient }) {
             Show Inactive
           </label>
           {node &&
+            !readOnly &&
             (hasLatestVersionMaterialization ? (
               <button
                 className="edit_button"
@@ -322,11 +327,13 @@ export default function NodeMaterializationTab({ node, djClient }) {
                 .join(' ')}
             </div>
             <div className="td">
-              <NodeMaterializationDelete
-                nodeName={node.name}
-                materializationName={materialization.name}
-                nodeVersion={selectedRevisionTab}
-              />
+              {!readOnly && (
+                <NodeMaterializationDelete
+                  nodeName={node.name}
+                  materializationName={materialization.name}
+                  nodeVersion={selectedRevisionTab}
+                />
+              )}
             </div>
             <div className="td">
               <span className={`badge cron`}>{materialization.schedule}</span>
@@ -397,13 +404,15 @@ export default function NodeMaterializationTab({ node, djClient }) {
                   </summary>
                   {materialization.strategy === 'incremental_time' ? (
                     <ul>
-                      <li>
-                        <AddBackfillPopover
-                          node={node}
-                          materialization={materialization}
-                          onSubmit={fetchData}
-                        />
-                      </li>
+                      {!readOnly && (
+                        <li>
+                          <AddBackfillPopover
+                            node={node}
+                            materialization={materialization}
+                            onSubmit={fetchData}
+                          />
+                        </li>
+                      )}
                       {materialization.backfills.map(backfill => (
                         <li className="backfill">
                           <div className="partitionLink">

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -136,7 +136,13 @@ export function NodePage() {
       tabToDisplay = node ? <NodeInfoTab node={node} /> : '';
       break;
     case 'columns':
-      tabToDisplay = <NodeColumnTab node={node} djClient={djClient} />;
+      tabToDisplay = (
+        <NodeColumnTab
+          node={node}
+          djClient={djClient}
+          readOnly={!!gitConfig?.git_only}
+        />
+      );
       break;
     case 'data-flow':
       tabToDisplay = <NodeDataFlowTab djNode={node} />;
@@ -152,7 +158,11 @@ export function NodePage() {
       // Other nodes (transform, metric, dimension) use pre-aggregations tab
       tabToDisplay =
         node?.type === 'cube' ? (
-          <NodeMaterializationTab node={node} djClient={djClient} />
+          <NodeMaterializationTab
+            node={node}
+            djClient={djClient}
+            readOnly={!!gitConfig?.git_only}
+          />
         ) : (
           <NodePreAggregationsTab node={node} />
         );
@@ -253,6 +263,42 @@ export function NodePage() {
                   >
                     {node?.type}
                   </span>
+                  {gitConfigLoaded && isGitOnly && (
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        marginLeft: '4px',
+                        color: '#92400e',
+                        verticalAlign: 'middle',
+                        cursor: 'help',
+                      }}
+                      aria-label="ReadOnly"
+                      title="Read-only — edits must go through git."
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <rect
+                          x="3"
+                          y="11"
+                          width="18"
+                          height="11"
+                          rx="2"
+                          ry="2"
+                        />
+                        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                      </svg>
+                    </span>
+                  )}
                 </span>
               </h3>
               <NodeButtons />


### PR DESCRIPTION
### Summary

#### Backend 

When a namespace is marked `git_only=True` (typically the default-branch namespace), the lock now applies to every descendant, both at the API boundary (mutations are rejected) and in the UI (read-only badge shown, edit buttons hidden). Previously the flag was checked only on the immediate namespace, so a flagged parent like `foo.main` was trivially bypassable by mutating in foo.main.metrics.

#### UI changes

- Read-only badge on subnamespaces. When a branch namespace (typically `<repo>.main`) is locked, the "Read-only" badge in the breadcrumb now appears on every subnamespace under it (e.g., `<repo>.main.metrics` `<repo>.main.cubes` etc), not just on the branch namespace itself.
- Nodes under a locked subnamespace now show a small lock icon next to the node-type badge.
- On read-only nodes, the page-level Edit button is gone, and so are the per-row edit affordances inside the Columns and Materializations tabs (edit description, edit attributes, manage dimension links, edit partition, add/delete materialization, add backfill, rebuild).
- Git Settings / Sync to Git / Create PR show on every page under an editable branch. Previously you could only do these actions from the branch namespace itself. Now they're available from any subnamespace page under that branch, and they always target the whole branch.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
