### PR TITLE
Speed up hard delete namespace from 54s to 620ms

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_05_14_0000-6d7e8f9a0b1c_add_missing_fk_indexes.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_05_14_0000-6d7e8f9a0b1c_add_missing_fk_indexes.py
@@ -1,0 +1,95 @@
+"""add missing FK indexes for fast cascade deletes
+
+Revision ID: 6d7e8f9a0b1c
+Revises: 5a8b4c2d1e0f
+Create Date: 2026-05-14 00:00:00.000000+00:00
+
+Postgres does not auto-index the referencing side of a foreign key. When the
+referenced row is deleted (with ON DELETE CASCADE or RESTRICT), Postgres must
+locate matching child rows — without an index that's a sequential scan per
+parent row. A 555-node hard-delete was spending ~55s here. Adding these
+indexes turns those scans into fast index lookups.
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+from alembic import op
+
+revision = "6d7e8f9a0b1c"
+down_revision = "5a8b4c2d1e0f"
+branch_labels = None
+depends_on = None
+
+
+# (table_name, index_name, [columns]) — one row per missing FK index.
+FK_INDEXES = [
+    # node.id referencers
+    ("noderevision", "ix_noderevision_node_id", ["node_id"]),
+    ("column", "ix_column_dimension_id", ["dimension_id"]),
+    ("collectionnodes", "ix_collectionnodes_node_id", ["node_id"]),
+    ("tagnoderelationship", "ix_tagnoderelationship_node_id", ["node_id"]),
+    # noderevision.id referencers
+    ("materialization", "ix_materialization_node_revision_id", ["node_revision_id"]),
+    (
+        "node_revision_frozen_measures",
+        "ix_node_revision_frozen_measures_node_revision_id",
+        ["node_revision_id"],
+    ),
+    ("pre_aggregation", "ix_pre_aggregation_node_revision_id", ["node_revision_id"]),
+    ("nodeavailabilitystate", "ix_nodeavailabilitystate_node_id", ["node_id"]),
+    (
+        "metric_required_dimensions",
+        "ix_metric_required_dimensions_metric_id",
+        ["metric_id"],
+    ),
+    (
+        "nodemissingparents",
+        "ix_nodemissingparents_referencing_node_id",
+        ["referencing_node_id"],
+    ),
+    (
+        "frozen_measures",
+        "ix_frozen_measures_upstream_revision_id",
+        ["upstream_revision_id"],
+    ),
+    # column.id referencers
+    ("partition", "ix_partition_column_id", ["column_id"]),
+    ("columnattribute", "ix_columnattribute_column_id", ["column_id"]),
+    ("cube", "ix_cube_cube_element_id", ["cube_element_id"]),
+    (
+        "metric_required_dimensions",
+        "ix_metric_required_dimensions_bound_dimension_id",
+        ["bound_dimension_id"],
+    ),
+    ("tablecolumns", "ix_tablecolumns_column_id", ["column_id"]),
+    # extra node.id referencer
+    (
+        "hierarchy_levels",
+        "ix_hierarchy_levels_dimension_node_id",
+        ["dimension_node_id"],
+    ),
+    # frozen_measures.id referencers (huge win — 7.7s in cascade triggers)
+    (
+        "node_revision_frozen_measures",
+        "ix_node_revision_frozen_measures_frozen_measure_id",
+        ["frozen_measure_id"],
+    ),
+    # partition.id referencers
+    ("column", "ix_column_partition_id", ["partition_id"]),
+]
+
+
+def upgrade():
+    # Use raw SQL with IF NOT EXISTS so the migration is idempotent — some
+    # of these indexes may have been created out-of-band on existing
+    # environments.
+    for table, name, cols in FK_INDEXES:
+        cols_sql = ", ".join(f'"{c}"' for c in cols)
+        op.execute(
+            f'CREATE INDEX IF NOT EXISTS {name} ON "{table}" ({cols_sql})',
+        )
+
+
+def downgrade():
+    for _table, name, _cols in reversed(FK_INDEXES):
+        op.execute(f"DROP INDEX IF EXISTS {name}")

--- a/datajunction-server/datajunction_server/database/attributetype.py
+++ b/datajunction-server/datajunction_server/database/attributetype.py
@@ -87,7 +87,10 @@ class ColumnAttribute(Base):
     """
 
     __tablename__ = "columnattribute"
-    __table_args__ = (UniqueConstraint("attribute_type_id", "column_id"),)
+    __table_args__ = (
+        UniqueConstraint("attribute_type_id", "column_id"),
+        sa.Index("ix_columnattribute_column_id", "column_id"),
+    )
 
     id: Mapped[int] = mapped_column(
         sa.BigInteger().with_variant(sa.Integer, "sqlite"),

--- a/datajunction-server/datajunction_server/database/availabilitystate.py
+++ b/datajunction-server/datajunction_server/database/availabilitystate.py
@@ -5,7 +5,7 @@ from functools import partial
 from typing import Any, Dict, List, Optional
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, DateTime, ForeignKey
+from sqlalchemy import JSON, DateTime, ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column
 
 from datajunction_server.database.base import Base
@@ -95,6 +95,7 @@ class NodeAvailabilityState(Base):
     """
 
     __tablename__ = "nodeavailabilitystate"
+    __table_args__ = (Index("ix_nodeavailabilitystate_node_id", "node_id"),)
 
     availability_id: Mapped[int] = mapped_column(
         ForeignKey(

--- a/datajunction-server/datajunction_server/database/collection.py
+++ b/datajunction-server/datajunction_server/database/collection.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from functools import partial
 from typing import List, Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, select
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -77,6 +77,7 @@ class CollectionNodes(Base):  # type: ignore
     """
 
     __tablename__ = "collectionnodes"
+    __table_args__ = (Index("ix_collectionnodes_node_id", "node_id"),)
 
     collection_id: Mapped[int] = mapped_column(
         ForeignKey("collection.id", name="fk_collectionnodes_collection_id_collection"),

--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from sqlalchemy import BigInteger, ForeignKey, Integer, String
+from sqlalchemy import BigInteger, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.attributetype import ColumnAttribute
@@ -27,6 +27,10 @@ class Column(Base):  # type: ignore
     """
 
     __tablename__ = "column"
+    __table_args__ = (
+        Index("ix_column_dimension_id", "dimension_id"),
+        Index("ix_column_partition_id", "partition_id"),
+    )
 
     id: Mapped[int] = mapped_column(
         BigInteger().with_variant(Integer, "sqlite"),

--- a/datajunction-server/datajunction_server/database/database.py
+++ b/datajunction-server/datajunction_server/database/database.py
@@ -5,7 +5,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
-from sqlalchemy import JSON, BigInteger, DateTime, ForeignKey, Integer, String
+from sqlalchemy import JSON, BigInteger, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy_utils import UUIDType
 
@@ -118,6 +118,7 @@ class TableColumns(Base):
     """
 
     __tablename__ = "tablecolumns"
+    __table_args__ = (Index("ix_tablecolumns_column_id", "column_id"),)
 
     table_id: Mapped[int] = mapped_column(
         ForeignKey("table.id", name="fk_tablecolumns_table_id_table"),

--- a/datajunction-server/datajunction_server/database/hierarchy.py
+++ b/datajunction-server/datajunction_server/database/hierarchy.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     BigInteger,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     JSON,
@@ -294,7 +295,10 @@ class HierarchyLevel(Base):  # type: ignore
     """
 
     __tablename__ = "hierarchy_levels"
-    __table_args__ = (UniqueConstraint("hierarchy_id", "name"),)
+    __table_args__ = (
+        UniqueConstraint("hierarchy_id", "name"),
+        Index("ix_hierarchy_levels_dimension_node_id", "dimension_node_id"),
+    )
 
     id: Mapped[int] = mapped_column(BigInteger(), primary_key=True)
 

--- a/datajunction-server/datajunction_server/database/materialization.py
+++ b/datajunction-server/datajunction_server/database/materialization.py
@@ -43,6 +43,7 @@ class Materialization(Base):
             "node_revision_id",
             name="name_node_revision_uniq",
         ),
+        sa.Index("ix_materialization_node_revision_id", "node_revision_id"),
     )
 
     id: Mapped[int] = mapped_column(

--- a/datajunction-server/datajunction_server/database/measure.py
+++ b/datajunction-server/datajunction_server/database/measure.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     BigInteger,
     Enum,
     ForeignKey,
+    Index,
     Integer,
     String,
     JSON,
@@ -84,6 +85,9 @@ class FrozenMeasure(Base):
     """
 
     __tablename__ = "frozen_measures"
+    __table_args__ = (
+        Index("ix_frozen_measures_upstream_revision_id", "upstream_revision_id"),
+    )
 
     id: Mapped[int] = mapped_column(BigInteger(), primary_key=True)
 
@@ -217,6 +221,16 @@ class NodeRevisionFrozenMeasure(Base):
     """
 
     __tablename__ = "node_revision_frozen_measures"
+    __table_args__ = (
+        Index(
+            "ix_node_revision_frozen_measures_node_revision_id",
+            "node_revision_id",
+        ),
+        Index(
+            "ix_node_revision_frozen_measures_frozen_measure_id",
+            "frozen_measure_id",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(BigInteger(), primary_key=True)
     node_revision_id: Mapped[int] = mapped_column(

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -1278,6 +1278,7 @@ class NodeRevision(
     __tablename__ = "noderevision"
     __table_args__ = (
         UniqueConstraint("version", "node_id"),
+        Index("ix_noderevision_node_id", "node_id"),
         Index(
             "ix_noderevision_display_name",
             "display_name",

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -214,7 +214,10 @@ class CubeRelationship(Base):
     """
 
     __tablename__ = "cube"
-    __table_args__ = (Index("idx_cube_cube_id", "cube_id"),)
+    __table_args__ = (
+        Index("idx_cube_cube_id", "cube_id"),
+        Index("ix_cube_cube_element_id", "cube_element_id"),
+    )
 
     cube_id: Mapped[int] = mapped_column(
         ForeignKey(
@@ -242,6 +245,13 @@ class BoundDimensionsRelationship(Base):
     """
 
     __tablename__ = "metric_required_dimensions"
+    __table_args__ = (
+        Index("ix_metric_required_dimensions_metric_id", "metric_id"),
+        Index(
+            "ix_metric_required_dimensions_bound_dimension_id",
+            "bound_dimension_id",
+        ),
+    )
 
     metric_id: Mapped[int] = mapped_column(
         ForeignKey(
@@ -286,6 +296,9 @@ class NodeMissingParents(Base):
     """
 
     __tablename__ = "nodemissingparents"
+    __table_args__ = (
+        Index("ix_nodemissingparents_referencing_node_id", "referencing_node_id"),
+    )
 
     missing_parent_id: Mapped[int] = mapped_column(
         ForeignKey(

--- a/datajunction-server/datajunction_server/database/partition.py
+++ b/datajunction-server/datajunction_server/database/partition.py
@@ -3,7 +3,7 @@
 import re
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import BigInteger, Enum, ForeignKey, Integer
+from sqlalchemy import BigInteger, Enum, ForeignKey, Index, Integer
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from datajunction_server.database.base import Base
@@ -32,6 +32,7 @@ class Partition(Base):  # type: ignore
     """
 
     __tablename__ = "partition"
+    __table_args__ = (Index("ix_partition_column_id", "column_id"),)
 
     id: Mapped[int] = mapped_column(
         BigInteger().with_variant(Integer, "sqlite"),

--- a/datajunction-server/datajunction_server/database/tag.py
+++ b/datajunction-server/datajunction_server/database/tag.py
@@ -182,6 +182,7 @@ class TagNodeRelationship(Base):
     """
 
     __tablename__ = "tagnoderelationship"
+    __table_args__ = (Index("ix_tagnoderelationship_node_id", "node_id"),)
 
     tag_id: Mapped[int] = mapped_column(
         ForeignKey(

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -23,12 +23,7 @@ from datajunction_server.api.helpers import get_node_namespace
 from datajunction_server.database.deployment import Deployment
 from datajunction_server.database.history import History
 from datajunction_server.database.namespace import NodeNamespace
-from datajunction_server.database.dimensionlink import DimensionLink
-from datajunction_server.database.node import (
-    Column,
-    Node,
-    NodeRevision,
-)
+from datajunction_server.database.node import Column, Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJActionNotAllowedException,
@@ -471,40 +466,59 @@ async def hard_delete_namespace(
             impacted_downstreams[child_name] = [node_id_to_name[pid] for pid in ordered]
 
     if dimension_ids:
-        column_links_q = (
-            select(Column.dimension_id, Node.name)
-            .select_from(Column)
-            .join(NodeRevision, NodeRevision.id == Column.node_revision_id)
-            .join(
-                Node,
-                (Node.id == NodeRevision.node_id)
-                & (Node.current_version == NodeRevision.version),
-            )
-            .where(Column.dimension_id.in_(dimension_ids))
-            .where(~Node.id.in_(node_ids))
-            .distinct()
+        # Walk the dimension graph upstream: any dimension D' whose current
+        # revision has a column or dimension link pointing at a deleted
+        # dimension D (transitively) means consumers of D' lose a path that
+        # leads to D. We propagate the original deleted-dim attribution
+        # through the recursive expansion, then find non-deleted consumers
+        # of any dimension in the expanded set.
+        link_rows = await session.execute(
+            text(
+                """
+                WITH RECURSIVE
+                edges(node_revision_id, dimension_id) AS (
+                    SELECT node_revision_id, dimension_id
+                    FROM "column"
+                    WHERE dimension_id IS NOT NULL
+                  UNION ALL
+                    SELECT node_revision_id, dimension_id
+                    FROM dimensionlink
+                ),
+                dim_graph(deleted_dim_id, reachable_dim_id) AS (
+                    SELECT id, id FROM node WHERE id IN :deleted_dim_ids
+                  UNION
+                    SELECT dg.deleted_dim_id, n.id
+                    FROM dim_graph dg
+                    JOIN edges e ON e.dimension_id = dg.reachable_dim_id
+                    JOIN noderevision nr ON nr.id = e.node_revision_id
+                    JOIN node n
+                      ON n.id = nr.node_id
+                     AND n.current_version = nr.version
+                    WHERE n.type = 'DIMENSION'
+                      AND n.deactivated_at IS NULL
+                )
+                SELECT DISTINCT dg.deleted_dim_id, consumer.name
+                FROM dim_graph dg
+                JOIN edges e ON e.dimension_id = dg.reachable_dim_id
+                JOIN noderevision nr ON nr.id = e.node_revision_id
+                JOIN node consumer
+                  ON consumer.id = nr.node_id
+                 AND consumer.current_version = nr.version
+                WHERE consumer.deactivated_at IS NULL
+                  AND consumer.id NOT IN :deleted_node_ids
+                """,
+            ).bindparams(
+                bindparam("deleted_dim_ids", expanding=True),
+                bindparam("deleted_node_ids", expanding=True),
+            ),
+            {"deleted_dim_ids": dimension_ids, "deleted_node_ids": node_ids},
         )
-        dim_links_q = (
-            select(DimensionLink.dimension_id, Node.name)
-            .select_from(DimensionLink)
-            .join(NodeRevision, NodeRevision.id == DimensionLink.node_revision_id)
-            .join(
-                Node,
-                (Node.id == NodeRevision.node_id)
-                & (Node.current_version == NodeRevision.version),
-            )
-            .where(DimensionLink.dimension_id.in_(dimension_ids))
-            .where(~Node.id.in_(node_ids))
-            .distinct()
-        )
-        seen_link_pairs: set = set()
-        for query in (column_links_q, dim_links_q):
-            for dim_id, consumer_name in (await session.execute(query)).all():
-                pair = (consumer_name, dim_id)
-                if pair in seen_link_pairs:
-                    continue
-                seen_link_pairs.add(pair)
-                impacted_links[consumer_name].append(node_id_to_name[dim_id])
+        link_pairs: Dict[str, List[int]] = defaultdict(list)
+        for dim_id, consumer_name in link_rows.all():
+            link_pairs[consumer_name].append(dim_id)
+        for consumer_name, dim_ids in link_pairs.items():
+            ordered = sorted(set(dim_ids), key=lambda d: node_id_to_name[d])
+            impacted_links[consumer_name] = [node_id_to_name[d] for d in ordered]
 
     # Stage history events on the session without committing — the whole
     # hard-delete operation (history + node deletes + namespace deletes)

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, List, Optional, Tuple, cast
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import Comment, CommentedMap, CommentedSeq
-from sqlalchemy import delete, func, or_, select
+from sqlalchemy import bindparam, delete, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from yamlfix import fix_code
@@ -23,7 +23,12 @@ from datajunction_server.api.helpers import get_node_namespace
 from datajunction_server.database.deployment import Deployment
 from datajunction_server.database.history import History
 from datajunction_server.database.namespace import NodeNamespace
-from datajunction_server.database.node import Column, Node, NodeRevision
+from datajunction_server.database.dimensionlink import DimensionLink
+from datajunction_server.database.node import (
+    Column,
+    Node,
+    NodeRevision,
+)
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJActionNotAllowedException,
@@ -48,11 +53,7 @@ from datajunction_server.models.namespace import (
 )
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
-from datajunction_server.sql.dag import (
-    get_downstream_nodes,
-    get_nodes_with_common_dimensions,
-    topological_sort,
-)
+from datajunction_server.sql.dag import topological_sort
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import SEPARATOR
 
@@ -390,22 +391,22 @@ async def hard_delete_namespace(
     """
     Hard delete a node namespace.
     """
-    node_names = (
-        (
-            await session.execute(
-                select(Node.name)
-                .where(
-                    or_(
-                        Node.namespace.like(f"{namespace}.%"),
-                        Node.namespace == namespace,
-                    ),
-                )
-                .order_by(Node.name),
+    node_rows = (
+        await session.execute(
+            select(Node.id, Node.name, Node.type)
+            .where(
+                or_(
+                    Node.namespace.like(f"{namespace}.%"),
+                    Node.namespace == namespace,
+                ),
             )
+            .order_by(Node.name),
         )
-        .scalars()
-        .all()
-    )
+    ).all()
+    node_names = [row.name for row in node_rows]
+    node_ids = [row.id for row in node_rows]
+    node_id_to_name = {row.id: row.name for row in node_rows}
+    dimension_ids = [row.id for row in node_rows if row.type == NodeType.DIMENSION]
 
     if not cascade and node_names:
         raise DJActionNotAllowedException(
@@ -421,58 +422,126 @@ async def hard_delete_namespace(
         for node_name in node_names
     }
 
-    # Track downstream nodes affected by deletions
-    impacted_downstreams = defaultdict(list)
-    impacted_links = defaultdict(list)
-    nodes = await Node.get_by_names(session, node_names)
-    for node in nodes:
-        # Downstream links
-        if node.type == NodeType.DIMENSION:
-            for downstream_link in await get_nodes_with_common_dimensions(
-                session,
-                [node],
-            ):
-                if downstream_link.name not in node_names:
-                    impacted_links[downstream_link.name].append(node.name)
+    # Track downstream nodes affected by deletions. Instead of calling
+    # get_downstream_nodes / get_nodes_with_common_dimensions per deleted node
+    # (which is O(N) BFS traversals for N nodes), compute direct edges in two
+    # bulk queries:
+    #   1. NodeRelationship rows where parent is deleted and child is not.
+    #   2. Column.dimension_id / DimensionLink.dimension_id rows pointing at
+    #      a deleted dimension from a non-deleted consumer.
+    impacted_downstreams: Dict[str, List[str]] = defaultdict(list)
+    impacted_links: Dict[str, List[str]] = defaultdict(list)
 
-        # Downstream query references
-        for downstream_node in await get_downstream_nodes(
-            session=session,
-            node_name=node.name,
-        ):
-            if downstream_node.name not in node_names:
-                impacted_downstreams[downstream_node.name].append(node.name)
+    if node_ids:
+        # Transitive downstream attribution: a downstream node D is "caused
+        # by" every deleted ancestor X for which there is a path X -> ... -> D
+        # in the noderelationship graph. We compute this with one recursive
+        # CTE seeded at the deleted nodes, propagating each deleted ancestor
+        # label down through current revisions.
+        downstream_rows = await session.execute(
+            text(
+                """
+                WITH RECURSIVE descendants(deleted_id, current_id) AS (
+                    SELECT id, id FROM node WHERE id IN :deleted_ids
+                  UNION
+                    SELECT d.deleted_id, n.id
+                    FROM descendants d
+                    JOIN noderelationship rel ON rel.parent_id = d.current_id
+                    JOIN noderevision nr ON nr.id = rel.child_id
+                    JOIN node n
+                      ON n.id = nr.node_id
+                     AND n.current_version = nr.version
+                    WHERE n.deactivated_at IS NULL
+                )
+                SELECT DISTINCT d.deleted_id, n.name
+                FROM descendants d
+                JOIN node n ON n.id = d.current_id
+                WHERE d.current_id NOT IN :deleted_ids
+                """,
+            ).bindparams(bindparam("deleted_ids", expanding=True)),
+            {"deleted_ids": node_ids},
+        )
+        # Preserve attribution ordering by deleted-node sort order (node_names
+        # is already sorted), so tests can assert on the caused_by list.
+        downstream_pairs: Dict[str, List[int]] = defaultdict(list)
+        for parent_id, child_name in downstream_rows.all():
+            downstream_pairs[child_name].append(parent_id)
+        for child_name, parent_ids in downstream_pairs.items():
+            ordered = sorted(parent_ids, key=lambda pid: node_id_to_name[pid])
+            impacted_downstreams[child_name] = [node_id_to_name[pid] for pid in ordered]
 
-    # Save history and update impacts for downstream nodes
+    if dimension_ids:
+        column_links_q = (
+            select(Column.dimension_id, Node.name)
+            .select_from(Column)
+            .join(NodeRevision, NodeRevision.id == Column.node_revision_id)
+            .join(
+                Node,
+                (Node.id == NodeRevision.node_id)
+                & (Node.current_version == NodeRevision.version),
+            )
+            .where(Column.dimension_id.in_(dimension_ids))
+            .where(~Node.id.in_(node_ids))
+            .distinct()
+        )
+        dim_links_q = (
+            select(DimensionLink.dimension_id, Node.name)
+            .select_from(DimensionLink)
+            .join(NodeRevision, NodeRevision.id == DimensionLink.node_revision_id)
+            .join(
+                Node,
+                (Node.id == NodeRevision.node_id)
+                & (Node.current_version == NodeRevision.version),
+            )
+            .where(DimensionLink.dimension_id.in_(dimension_ids))
+            .where(~Node.id.in_(node_ids))
+            .distinct()
+        )
+        seen_link_pairs: set = set()
+        for query in (column_links_q, dim_links_q):
+            for dim_id, consumer_name in (await session.execute(query)).all():
+                pair = (consumer_name, dim_id)
+                if pair in seen_link_pairs:
+                    continue
+                seen_link_pairs.add(pair)
+                impacted_links[consumer_name].append(node_id_to_name[dim_id])
+
+    # Stage history events on the session without committing — the whole
+    # hard-delete operation (history + node deletes + namespace deletes)
+    # commits atomically at the end. ``save_history`` commits per-event, so
+    # we ``session.add`` directly here. Notifications are intentionally
+    # skipped on bulk hard-delete (the notifier is a per-event side effect
+    # that isn't useful at this scale).
     for impacted_node, causes in impacted_downstreams.items():
-        await save_history(
-            event=History(
+        session.add(
+            History(
                 entity_type=EntityType.DEPENDENCY,
                 entity_name=impacted_node,
                 activity_type=ActivityType.DELETE,
                 user=current_user.username,
                 details={"caused_by": causes},
             ),
-            session=session,
         )
 
     for impacted_node, causes in impacted_links.items():
-        await save_history(
-            event=History(
+        session.add(
+            History(
                 entity_type=EntityType.DEPENDENCY,
                 entity_name=impacted_node,
                 activity_type=ActivityType.DELETE,
                 user=current_user.username,
                 details={"caused_by": causes},
             ),
-            session=session,
         )
 
-    # Delete the nodes
-    await session.execute(delete(Node).where(Node.name.in_(node_names)))
-    await session.commit()
+    # Delete the nodes — FK CASCADE handles all child tables. Fast as long
+    # as every cascade-target FK column is indexed; otherwise Postgres
+    # seq-scans each child table per row deleted (catastrophic). See the
+    # add_missing_fk_indexes migration.
+    await session.execute(delete(Node).where(Node.id.in_(node_ids)))
 
-    # Delete namespaces and record impact
+    # Delete namespaces in the same transaction so the whole operation is
+    # atomic.
     namespaces = await list_namespaces_in_hierarchy(session, namespace)
     deleted_namespaces = [ns.namespace for ns in namespaces]
     for _namespace in namespaces:
@@ -481,6 +550,7 @@ async def hard_delete_namespace(
             "status": "hard deleted",
         }
         await session.delete(_namespace)
+
     await session.commit()
 
     return HardDeleteResponse(


### PR DESCRIPTION
### Summary

#### Problem

Hard-deleting a 555-node namespace took ~54 seconds. `EXPLAIN ANALYZE` showed the time was almost entirely in FK constraint triggers firing during the cascade. Postgres doesn't auto-index the referencing side of a foreign key, so when a parent row is deleted it sequentially scans every child table to find rows to cascade or validate. With ~30k rows cascading across ~15 child tables, it becomes very slow. 

####  Fixes

1. New database migration to add 19 missing FK indexes covering every referencer that lacked one. Uses `CREATE INDEX IF NOT EXISTS` so it's idempotent across environments where some indexes may already exist out-of-band. Also added a matching `Index(...)` declaration on the `NodeRevision` db model so that future autogen doesn't drift.
2. Replaced per-node impact computation with bulk queries. The old code called `get_downstream_nodes` and `get_nodes_with_common_dimensions` once per deleted node, which results in N-BFS traversals. This change switches it to one recursive CTE for transitive downstream attribution, plus two direct dimension-link queries.
3. Made the operation atomic. Previously `save_history` committed per-event, then nodes committed, then namespaces committed, which can cause the operation to terminate in a half-finished state. Now history events are staged via `session.add()` and the whole operation commits once at the end. If the delete fails partway, nothing changed.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
