### PR TITLE
Unify branch delete with namespace deletion for speed

### DIFF
--- a/datajunction-server/datajunction_server/api/branches.py
+++ b/datajunction-server/datajunction_server/api/branches.py
@@ -10,15 +10,15 @@ import logging
 import time
 from datetime import datetime
 from http import HTTPStatus
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from fastapi import Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from datajunction_server.api.helpers import get_node_namespace
+from datajunction_server.api.helpers import get_node_namespace, get_save_history
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
@@ -35,6 +35,7 @@ from datajunction_server.internal.access.authorization import (
 from datajunction_server.internal.git.github_service import GitHubService
 from datajunction_server.internal.git.github_service import GitHubServiceError
 from datajunction_server.internal.namespaces import (
+    hard_delete_namespace,
     resolve_git_config,
     validate_sibling_relationship,
 )
@@ -595,6 +596,7 @@ async def delete_branch(
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
     access_checker: AccessChecker = Depends(get_access_checker),
+    save_history: Callable = Depends(get_save_history),
 ) -> JSONResponse:
     """
     Delete a branch namespace.
@@ -658,46 +660,14 @@ async def delete_branch(
                 _logger.warning("Failed to delete git branch: %s", e)
                 # Don't fail the request - the branch might already be deleted
 
-    # Delete all nodes in the branch namespace
-    from datajunction_server.database.node import Node
-
-    nodes_query = select(Node).where(
-        or_(
-            Node.namespace == branch_namespace,
-            Node.namespace.like(f"{branch_namespace}.%"),
-        ),
+    impact = await hard_delete_namespace(
+        session=session,
+        namespace=branch_namespace,
+        current_user=current_user,
+        save_history=save_history,
+        cascade=True,
     )
-    result = await session.execute(nodes_query)
-    nodes_to_delete = result.scalars().all()
-    nodes_deleted = len(nodes_to_delete)
-
-    for node in nodes_to_delete:
-        await session.delete(node)
-
-    # Delete child namespaces before the branch namespace itself to satisfy
-    # the self-referential FK constraint (fk_nodenamespace_parent).
-    # This covers sub-namespaces created during deployment (e.g., project.branch.metrics).
-    child_ns_query = select(NodeNamespace).where(
-        NodeNamespace.namespace.like(f"{branch_namespace}.%"),
-    )
-    child_result = await session.execute(child_ns_query)
-    for child_ns in child_result.scalars().all():
-        await session.delete(child_ns)
-
-    # Nullify parent_namespace on any remaining namespaces that reference this one
-    # (e.g., sibling branches created from this namespace as a git root). This
-    # handles the case where the referencing namespace name doesn't start with
-    # branch_namespace and so wasn't caught by the LIKE query above.
-    await session.execute(
-        update(NodeNamespace)
-        .where(NodeNamespace.parent_namespace == branch_namespace)
-        .values(parent_namespace=None),
-    )
-
-    # Delete the namespace record last
-    await session.delete(branch_ns)
-
-    await session.commit()
+    nodes_deleted = len(impact.deleted_nodes)
 
     _logger.info(
         "Deleted branch namespace '%s' (parent: '%s', nodes: %d, git_branch: %s)",

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, List, Optional, Tuple, cast
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import Comment, CommentedMap, CommentedSeq
-from sqlalchemy import bindparam, delete, func, or_, select, text
+from sqlalchemy import bindparam, delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from yamlfix import fix_code
@@ -558,6 +558,19 @@ async def hard_delete_namespace(
     # atomic.
     namespaces = await list_namespaces_in_hierarchy(session, namespace)
     deleted_namespaces = [ns.namespace for ns in namespaces]
+
+    # Nullify ``parent_namespace`` on any namespaces that reference one of
+    # the to-be-deleted namespaces — e.g., sibling branches whose name
+    # doesn't start with ``namespace`` but that point to it as parent.
+    # Without this the namespace delete trips the self-FK.
+    if deleted_namespaces:
+        await session.execute(
+            update(NodeNamespace)
+            .where(NodeNamespace.parent_namespace.in_(deleted_namespaces))
+            .where(~NodeNamespace.namespace.in_(deleted_namespaces))
+            .values(parent_namespace=None),
+        )
+
     for _namespace in namespaces:
         impacts[_namespace.namespace] = {
             "type": "namespace",

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -563,13 +563,12 @@ async def hard_delete_namespace(
     # the to-be-deleted namespaces — e.g., sibling branches whose name
     # doesn't start with ``namespace`` but that point to it as parent.
     # Without this the namespace delete trips the self-FK.
-    if deleted_namespaces:
-        await session.execute(
-            update(NodeNamespace)
-            .where(NodeNamespace.parent_namespace.in_(deleted_namespaces))
-            .where(~NodeNamespace.namespace.in_(deleted_namespaces))
-            .values(parent_namespace=None),
-        )
+    await session.execute(
+        update(NodeNamespace)
+        .where(NodeNamespace.parent_namespace.in_(deleted_namespaces))
+        .where(~NodeNamespace.namespace.in_(deleted_namespaces))
+        .values(parent_namespace=None),
+    )
 
     for _namespace in namespaces:
         impacts[_namespace.namespace] = {

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -3233,3 +3233,58 @@ async def test_delete_non_default_git_branch_namespace_allowed(
     )
     assert response.status_code == 200
     assert "deactivated" in response.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_namespace_with_sibling_parent_ref(
+    module__client_with_all_examples: AsyncClient,
+) -> None:
+    """
+    Hard deleting a namespace that is referenced as ``parent_namespace`` by
+    a sibling (whose own name doesn't start with the deleted namespace) must
+    nullify the dangling reference rather than tripping the self-referential
+    FK constraint.
+    """
+    root = "siblingref.root"
+    branch_a = "siblingref.feature_a"
+    branch_b = "siblingref.feature_b"
+
+    # Git root with default branch
+    await module__client_with_all_examples.post(f"/namespaces/{root}/")
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{root}/git",
+        json={"github_repo_path": "corp/siblingref", "default_branch": "main"},
+    )
+
+    # Two sibling branches that both point to feature_a as parent_namespace
+    # (simulates a branch created from another branch — feature_b's parent
+    # is feature_a, but feature_b's name is not a child of feature_a).
+    await module__client_with_all_examples.post(f"/namespaces/{branch_a}/")
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{branch_a}/git",
+        json={"parent_namespace": root, "git_branch": "feature-a"},
+    )
+    await module__client_with_all_examples.post(f"/namespaces/{branch_b}/")
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{branch_b}/git",
+        json={"parent_namespace": branch_a, "git_branch": "feature-b"},
+    )
+
+    # Hard delete feature_a — feature_b references it as parent.
+    response = await module__client_with_all_examples.delete(
+        f"/namespaces/{branch_a}/hard/?cascade=true",
+    )
+    assert response.status_code == 200
+    assert response.json()["impact"]["deleted_namespaces"] == [branch_a]
+
+    # feature_b survives with its parent_namespace nullified.
+    list_response = await module__client_with_all_examples.get("/namespaces/")
+    namespaces = {ns["namespace"]: ns for ns in list_response.json()}
+    assert branch_a not in namespaces
+    assert branch_b in namespaces
+
+    config_response = await module__client_with_all_examples.get(
+        f"/namespaces/{branch_b}/git",
+    )
+    assert config_response.status_code == 200
+    assert config_response.json()["parent_namespace"] is None


### PR DESCRIPTION
### Summary

Now that hard-deletion of namespaces has been significantly sped up (https://github.com/DataJunction/dj/pull/2123), we can unify that logic with the branch delete logic. Branch namespace deletes (`DELETE /namespaces/{ns}/branches/{branch}`) reimplemented the same node + namespace cleanup as `hard_delete_namespace`, but with a per-row ORM delete loop instead of a bulk `DELETE`. This switches it to just reuse the logic under `hard_delete_namespace` for consistency.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
