### PR TITLE
Set correct system engine

### DIFF
--- a/datajunction-server/datajunction_server/api/system.py
+++ b/datajunction-server/datajunction_server/api/system.py
@@ -95,6 +95,7 @@ async def get_data_for_system_metric(
             filters=filters,
             orderby=orderby,
             limit=limit,
+            engine_name=settings.seed_setup.system_engine_name,
         ),
     )
     # The /system/data endpoint executes the SQL directly against the DJ


### PR DESCRIPTION
### Summary

This change makes sure that `/system/data` builds with explicit postgres dialect before it hits the DB.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
