### PR TITLE
Fix binary op base cases

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -311,7 +311,12 @@ def combine_filters(filters: list[ast.Expression]) -> ast.Expression | None:
     if len(filters) == 1:
         return filters[0]
 
-    return reduce(lambda a, b: ast.BinaryOp.And(a, b), filters)
+    def _and(a: ast.Expression, b: ast.Expression) -> ast.Expression:
+        result = ast.BinaryOp.And(a, b)
+        assert result is not None  # noqa: S101  # two non-None args guarantee non-None result
+        return result
+
+    return reduce(_and, filters)
 
 
 def parse_and_resolve_filters(

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1339,18 +1339,22 @@ def build_select_ast(
     for tgt_name, exprs in ctx.upstream_pushdown_filters.items():
         if not exprs:
             continue  # pragma: no cover
-        combined = exprs[0]
+        combined: ast.Expression = exprs[0]
         for extra in exprs[1:]:
-            combined = ast.BinaryOp.And(combined, extra)
+            anded = ast.BinaryOp.And(combined, extra)
+            assert anded is not None  # noqa: S101  # both args non-None
+            combined = anded
         # Temporal pushdown landing on the same node as an upstream-link
         # pushdown is a rare overlap (typically temporal targets a
         # date-spine source, while upstream-link pushdowns target a
         # transform that references a different source).
         if tgt_name in injected_cte_filters:  # pragma: no cover
-            injected_cte_filters[tgt_name] = ast.BinaryOp.And(
+            merged = ast.BinaryOp.And(
                 injected_cte_filters[tgt_name],
                 combined,
             )
+            assert merged is not None  # noqa: S101  # both args non-None
+            injected_cte_filters[tgt_name] = merged
         else:
             injected_cte_filters[tgt_name] = combined
 

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -511,4 +511,6 @@ def _build_join_criteria(
     if len(conditions) == 1:
         return conditions[0]
 
-    return ast.BinaryOp.And(*conditions)
+    combined = ast.BinaryOp.And(*conditions)
+    assert combined is not None  # noqa: S101  # conditions is non-empty here
+    return combined

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -1929,14 +1929,17 @@ class BinaryOp(Operation):
     @classmethod
     def And(
         cls,
-        left: Expression,
+        left: Optional[Expression] = None,
         right: Optional[Expression] = None,
         *rest: Expression,
-    ) -> Union["BinaryOp", Expression]:
+    ) -> Optional[Union["BinaryOp", Expression]]:
         """
-        Create a BinaryOp of kind BinaryOpKind.Eq rolling up all expressions
+        Create a BinaryOp of kind BinaryOpKind.And rolling up all expressions.
+        Tolerates 0/1 args so that callers may safely `.And(*conditions)` an empty list.
         """
-        if right is None:  # pragma: no cover
+        if left is None:
+            return None
+        if right is None:
             return left
         return reduce(
             lambda left, right: BinaryOp(

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1416,3 +1416,47 @@ def test_struct_column_name_two_level():
     assert col.struct_column_name == "struct_col"
     assert col.struct_subscript == "field_leaf"
     assert str(col) == "tbl.struct_col.field_leaf"
+
+
+def test_binaryop_and_with_no_args_returns_none():
+    """
+    `BinaryOp.And(*[])` (i.e. spreading an empty filter list) must not raise.
+    Callers should be able to safely no-op when there are no conditions.
+    """
+    assert ast.BinaryOp.And() is None
+
+
+def test_binaryop_and_with_single_arg_returns_it_unchanged():
+    """
+    A single condition collapses to itself (no AND wrapping).
+    """
+    col = ast.Column(name=ast.Name("x"))
+    assert ast.BinaryOp.And(col) is col
+
+
+def test_binaryop_and_chains_multiple_conditions():
+    """
+    Multiple conditions roll up into nested BinaryOp(AND, ...) expressions.
+    """
+    a = ast.Column(name=ast.Name("a"))
+    b = ast.Column(name=ast.Name("b"))
+    c = ast.Column(name=ast.Name("c"))
+    result = ast.BinaryOp.And(a, b, c)
+    assert isinstance(result, ast.BinaryOp)
+    assert result.op == ast.BinaryOpKind.And
+    # Right-most is c, left side is (a AND b)
+    assert result.right is c
+    assert isinstance(result.left, ast.BinaryOp)
+    assert result.left.left is a
+    assert result.left.right is b
+
+
+def test_binaryop_and_with_empty_spread_does_not_raise():
+    """
+    Regression test for production crash: BinaryOp.And() missing required arg 'left'.
+    Triggered when a caller unpacks an empty filter list, e.g.
+        ast.BinaryOp.And(*conditions)  # conditions == []
+    """
+    conditions = []
+    # Should not raise TypeError
+    assert ast.BinaryOp.And(*conditions) is None


### PR DESCRIPTION
### Summary

Fixes a latent contract bug in `ast.BinaryOp.And` and tightens up the few call sites that were already working around it with extra branching.

After this fix, `BinaryOp.And(...)` can now handle 0/1/N arguments:
  - `And()` (no args) returns None
  - `And(x)` returns `x`
  - `And(x, y, …)` returns a folded `BinaryOp`

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
