### PR TITLE
Inline node badges + hover tooltip in the SQL editor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,10 @@ jobs:
         working-directory: ./datajunction-ui
     strategy:
       matrix:
-        node-version: [19.x]
+        # 22.x for require()-ing ESM modules (needed by jsdom 25 →
+        # cssstyle → @asamuzakjp/css-color, which is ESM-only). Older
+        # versions fail with ERR_REQUIRE_ESM.
+        node-version: [22.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/datajunction-ui/.nvmrc
+++ b/datajunction-ui/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+22

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -122,7 +122,11 @@
     "strip-ansi": "^6.0.1",
     "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
     "wrap-ansi": "^7.0.0",
-    "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+    "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.39.11",
+    "@codemirror/language": "^6.11.0",
+    "@lezer/highlight": "^1.2.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "4.60.4",

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -30,6 +30,8 @@
   "homepage": "https://github.com/DataJunction/dj#readme",
   "dependencies": {
     "@codemirror/lang-sql": "^6.4.0",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.39.11",
     "@reduxjs/toolkit": "1.8.5",
     "@uiw/codemirror-extensions-basic-setup": "4.21.12",
     "@uiw/codemirror-extensions-langs": "4.21.12",

--- a/datajunction-ui/package.json
+++ b/datajunction-ui/package.json
@@ -105,7 +105,7 @@
     ]
   },
   "engines": {
-    "node": ">=18.x"
+    "node": ">=22.x"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -237,12 +237,16 @@ export default function NamespaceHeader({
     );
   };
 
-  // Button style helpers
+  // Button style helpers. React warns if a rerender swaps `border` shorthand
+  // for `borderColor` longhand on the same element, so we keep all three
+  // border properties in longhand form here.
   const buttonStyle = {
     height: '28px',
     padding: '0 10px',
     fontSize: '12px',
-    border: '1px solid #e2e8f0',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: '#e2e8f0',
     borderRadius: '4px',
     backgroundColor: '#ffffff',
     color: '#475569',

--- a/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
@@ -7,15 +7,43 @@ import { ErrorMessage, Field, useFormikContext } from 'formik';
 import CodeMirror from '@uiw/react-codemirror';
 import { langs } from '@uiw/codemirror-extensions-langs';
 import { extractCatalogTables } from './catalogTables';
+import {
+  djNodeBadges,
+  djNodeHoverTooltip,
+  refreshBadges,
+} from './djNodeBadges';
+import { djEditorExtensions } from './djEditorTheme';
 
 export const NodeQueryField = ({ djClient, value }) => {
   const [schema, setSchema] = React.useState([]);
   const formik = useFormikContext();
   const sqlExt = langs.sql({ schema: schema });
   const autoRegisterTimer = React.useRef(null);
+  const validateTimer = React.useRef(null);
   const registeredTables = React.useRef(new Set());
   // useRef so the onChange closure always sees the latest catalog list
   const knownCatalogsRef = React.useRef([]);
+
+  // Per-`catalog.schema.table` registration status, surfaced as badges in
+  // the editor. Mirrored into a ref so the CodeMirror extension (built once,
+  // memoized below) can read the latest value without rebuilding.
+  const [tableStatus, setTableStatus] = React.useState({});
+  const tableStatusRef = React.useRef(tableStatus);
+  React.useEffect(() => {
+    tableStatusRef.current = tableStatus;
+  }, [tableStatus]);
+  const editorViewRef = React.useRef(null);
+  const setStatus = React.useCallback((key, status) => {
+    // Update the ref synchronously so the ViewPlugin's getStatus() closure
+    // sees the new value on the redraw we're about to dispatch.
+    // setTableStatus only schedules the React rerender (next tick) which is
+    // too late for the dispatch below.
+    tableStatusRef.current = { ...tableStatusRef.current, [key]: status };
+    setTableStatus(tableStatusRef.current);
+    if (editorViewRef.current) {
+      editorViewRef.current.dispatch({ effects: refreshBadges.of(null) });
+    }
+  }, []);
 
   React.useEffect(() => {
     if (typeof djClient.catalogs !== 'function') return;
@@ -71,6 +99,70 @@ export const NodeQueryField = ({ djClient, value }) => {
         600,
       );
     }
+
+    // Validate the in-progress query against DJ to discover which 2-part
+    // refs (`namespace.name`) resolve to real nodes vs. are missing.
+    clearTimeout(validateTimer.current);
+    validateTimer.current = setTimeout(() => validateRefs(value), 700);
+  };
+
+  const validateRefs = async sql => {
+    if (typeof djClient.validateNode !== 'function') return;
+    const fv = formik.values || {};
+    if (!fv.type) return; // need a node type to validate
+    let response;
+    try {
+      response = await djClient.validateNode(
+        fv.type,
+        fv.name || '__draft__',
+        fv.display_name || 'Draft',
+        fv.description || '',
+        sql,
+      );
+    } catch {
+      return; // best-effort; ignore network failures
+    }
+    const json = response?.json || {};
+    const deps = json.dependencies || [];
+    const missing = json.missing_parents || [];
+    // Update the ref synchronously in one shot before dispatching, so the
+    // ViewPlugin only redraws once even though we set many keys.
+    const next = { ...tableStatusRef.current };
+    for (const dep of deps) {
+      // `dependencies` is a list of full node objects ({name, type, status, ...}).
+      // Use `type` to color the chip per node kind (source/dimension/…) and
+      // `status` to flag nodes that resolve but are themselves unhealthy
+      // (e.g. broken upstream, drifted columns). We also keep the whole
+      // object around so the hover popover can show description / version
+      // / mode without re-fetching.
+      const name = typeof dep === 'string' ? dep : dep?.name;
+      if (!name) continue;
+      const nodeType = typeof dep === 'object' ? dep.type : undefined;
+      const nodeStatus = typeof dep === 'object' ? dep.status : undefined;
+      const kind = nodeStatus && nodeStatus !== 'valid' ? 'warning' : 'valid';
+      next[name] = {
+        kind,
+        refType: nodeType || 'node',
+        node: typeof dep === 'object' ? dep : undefined,
+        message:
+          kind === 'warning' ? `Node \`${name}\` is ${nodeStatus}` : undefined,
+      };
+    }
+    for (const m of missing) {
+      // `missing_parents` is a list of bare name strings.
+      const name = typeof m === 'string' ? m : m?.name;
+      if (!name) continue;
+      next[name] = {
+        kind: 'invalid',
+        refType: 'node',
+        message: `Node \`${name}\` not found`,
+      };
+    }
+    tableStatusRef.current = next;
+    setTableStatus(next);
+    if (editorViewRef.current) {
+      editorViewRef.current.dispatch({ effects: refreshBadges.of(null) });
+    }
   };
 
   const autoRegisterCatalogTables = async sql => {
@@ -81,9 +173,11 @@ export const NodeQueryField = ({ djClient, value }) => {
       // If autocomplete already saw this node, DJ knows about it — skip silently
       if (schema[key] !== undefined) {
         registeredTables.current.add(key);
+        setStatus(key, { kind: 'valid' });
         continue;
       }
       registeredTables.current.add(key);
+      setStatus(key, { kind: 'registering' });
 
       let response;
       try {
@@ -93,8 +187,12 @@ export const NodeQueryField = ({ djClient, value }) => {
           table,
           '',
         );
-      } catch {
+      } catch (err) {
         registeredTables.current.delete(key);
+        setStatus(key, {
+          kind: 'invalid',
+          message: err?.message || 'Failed to register table',
+        });
         continue;
       }
       const { status, json } = response;
@@ -106,12 +204,37 @@ export const NodeQueryField = ({ djClient, value }) => {
           schema[table] = columns;
         }
         setSchema(schema);
-      } else if (status !== 409) {
-        // 409 = already exists (silent); other errors: allow retry on next edit
+        setStatus(key, { kind: 'valid' });
+      } else if (status === 409) {
+        // 409 = already exists; treat as valid.
+        setStatus(key, { kind: 'valid' });
+      } else {
         registeredTables.current.delete(key);
+        setStatus(key, {
+          kind: 'invalid',
+          message: json?.message || `Registration failed (HTTP ${status})`,
+        });
       }
     }
   };
+
+  const badgeExt = React.useMemo(
+    () =>
+      djNodeBadges({
+        getStatus: key => tableStatusRef.current[key],
+        getKnownCatalogs: () => knownCatalogsRef.current,
+      }),
+    [],
+  );
+
+  const hoverExt = React.useMemo(
+    () =>
+      djNodeHoverTooltip({
+        getStatus: key => tableStatusRef.current[key],
+        getKnownCatalogs: () => knownCatalogsRef.current,
+      }),
+    [],
+  );
 
   return (
     <div className="QueryInput NodeCreationInput">
@@ -133,7 +256,13 @@ export const NodeQueryField = ({ djClient, value }) => {
             sqlExt.language.data.of({
               autocomplete: initialAutocomplete,
             }),
+            ...djEditorExtensions,
+            badgeExt,
+            hoverExt,
           ]}
+          onCreateEditor={view => {
+            editorViewRef.current = view;
+          }}
           value={value}
           placeholder={
             'SELECT\n\tprimary_key,\n\tmeasure1,\n\tmeasure2,\n\tforeign_key_for_dimension1,\n\tforeign_key_for_dimension2\nFROM source.source_node\nWHERE ...'
@@ -147,7 +276,7 @@ export const NodeQueryField = ({ djClient, value }) => {
           style={{
             margin: '0 0 23px 0',
             flex: 1,
-            fontSize: '150%',
+            fontSize: '110%',
             textAlign: 'left',
           }}
           onChange={(value, viewUpdate) => {

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/djNodeBadges.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/djNodeBadges.test.jsx
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for djNodeBadges. We test the pure DOM renderer (no CodeMirror)
+ * directly. The full ViewPlugin + hoverTooltip integration is exercised
+ * implicitly via NodeQueryField.test.jsx — here we just lock in the shape of
+ * the popover content for each status / node combo.
+ */
+import { renderTooltipDom, refAtPos } from '../djNodeBadges';
+
+describe('renderTooltipDom', () => {
+  const sourceNode = {
+    name: 'prodhive.dse.playback_f',
+    type: 'source',
+    status: 'valid',
+    version: 'v1.0',
+    mode: 'published',
+    description: 'Playback fact table.',
+    catalog: { name: 'prodhive' },
+    columns: [
+      { name: 'account_id', type: 'bigint' },
+      {
+        name: 'session_meta',
+        type: 'struct<a int,b int>\nstruct<c int>',
+      },
+      {
+        name: 'profile_id',
+        type: 'bigint',
+        dimension: { name: 'common.dimensions.profile' },
+      },
+    ],
+  };
+
+  const validStatus = {
+    kind: 'valid',
+    refType: 'source',
+    node: sourceNode,
+  };
+
+  it('renders the header with type pill and qualified name', () => {
+    const dom = renderTooltipDom(validStatus, sourceNode.name);
+    const pill = dom.querySelector('.dj-node-tooltip__header .dj-node-chip');
+    expect(pill.textContent).toBe('source');
+    expect(pill.className).toContain('dj-node-chip--source');
+    expect(dom.querySelector('.dj-node-tooltip__name').textContent).toBe(
+      'prodhive.dse.playback_f',
+    );
+  });
+
+  it('renders the metadata grid (status / version / mode / column count)', () => {
+    const dom = renderTooltipDom(validStatus, sourceNode.name);
+    const cells = dom.querySelectorAll('.dj-node-tooltip__cell');
+    const map = {};
+    cells.forEach(cell => {
+      const label = cell.querySelector('.dj-node-tooltip__label').textContent;
+      const value = cell.querySelector('.dj-node-tooltip__value').textContent;
+      map[label] = value;
+    });
+    expect(map).toEqual({
+      Status: 'valid',
+      Version: 'v1.0',
+      Mode: 'published',
+      Columns: '3',
+    });
+  });
+
+  it('renders the description', () => {
+    const dom = renderTooltipDom(validStatus, sourceNode.name);
+    expect(dom.querySelector('.dj-node-tooltip__description').textContent).toBe(
+      'Playback fact table.',
+    );
+  });
+
+  it('truncates descriptions over 280 chars', () => {
+    const long = 'x'.repeat(500);
+    const status = {
+      ...validStatus,
+      node: { ...sourceNode, description: long },
+    };
+    const dom = renderTooltipDom(status, sourceNode.name);
+    const text = dom.querySelector('.dj-node-tooltip__description').textContent;
+    expect(text.length).toBe(278); // 277 + ellipsis
+    expect(text.endsWith('…')).toBe(true);
+  });
+
+  it('renders the scrollable column list with name + type', () => {
+    const dom = renderTooltipDom(validStatus, sourceNode.name);
+    const rows = dom.querySelectorAll('.dj-node-tooltip__col-row');
+    expect(rows).toHaveLength(3);
+    const first = rows[0];
+    expect(first.querySelector('.dj-node-tooltip__col-name').textContent).toBe(
+      'account_id',
+    );
+    expect(first.querySelector('.dj-node-tooltip__col-type').textContent).toBe(
+      'bigint',
+    );
+  });
+
+  it('clamps multi-line struct types to one line, with full text on title', () => {
+    const dom = renderTooltipDom(validStatus, sourceNode.name);
+    const rows = dom.querySelectorAll('.dj-node-tooltip__col-row');
+    const structType = rows[1].querySelector('.dj-node-tooltip__col-type');
+    expect(structType.textContent).toBe('struct<a int,b int>');
+    expect(structType.getAttribute('title')).toBe(
+      'struct<a int,b int>\nstruct<c int>',
+    );
+  });
+
+  it('tags columns that link to a dimension', () => {
+    const dom = renderTooltipDom(validStatus, sourceNode.name);
+    const rows = dom.querySelectorAll('.dj-node-tooltip__col-row');
+    expect(rows[0].querySelector('.dj-node-tooltip__col-tag')).toBeNull();
+    expect(rows[1].querySelector('.dj-node-tooltip__col-tag')).toBeNull();
+    const tag = rows[2].querySelector('.dj-node-tooltip__col-tag');
+    expect(tag).not.toBeNull();
+    expect(tag.textContent).toBe('dim');
+    expect(tag.getAttribute('title')).toBe(
+      'Links to common.dimensions.profile',
+    );
+  });
+
+  it('renders the Open node footer link', () => {
+    const dom = renderTooltipDom(validStatus, sourceNode.name);
+    const link = dom.querySelector('.dj-node-tooltip__footer a');
+    expect(link.textContent).toBe('Open node →');
+    expect(link.getAttribute('href')).toBe('/nodes/prodhive.dse.playback_f');
+    expect(link.getAttribute('target')).toBe('_blank');
+  });
+
+  it('collapses to a "Not found" note for invalid status', () => {
+    const dom = renderTooltipDom(
+      { kind: 'invalid', refType: 'node', message: 'gone' },
+      'foo.bar',
+    );
+    expect(dom.querySelector('.dj-node-tooltip__note').textContent).toBe(
+      'Not found in DJ.',
+    );
+    expect(dom.querySelector('.dj-node-tooltip__grid')).toBeNull();
+    expect(dom.querySelector('.dj-node-tooltip__columns')).toBeNull();
+    expect(dom.querySelector('.dj-node-tooltip__footer')).toBeNull();
+  });
+
+  it('collapses to a "Registering…" note for registering status', () => {
+    const dom = renderTooltipDom(
+      { kind: 'registering', refType: 'source' },
+      'prodhive.x.y',
+    );
+    expect(dom.querySelector('.dj-node-tooltip__note').textContent).toBe(
+      'Registering…',
+    );
+    expect(dom.querySelector('.dj-node-tooltip__grid')).toBeNull();
+  });
+
+  it('falls back to the refKey when the node object has no name', () => {
+    const dom = renderTooltipDom(
+      { kind: 'valid', refType: 'source', node: {} },
+      'unregistered.table.ref',
+    );
+    expect(dom.querySelector('.dj-node-tooltip__name').textContent).toBe(
+      'unregistered.table.ref',
+    );
+    // No node name → no footer link.
+    expect(dom.querySelector('.dj-node-tooltip__footer')).toBeNull();
+  });
+
+  it('skips the description block when the node has none', () => {
+    const node = { ...sourceNode, description: undefined };
+    const dom = renderTooltipDom({ ...validStatus, node }, sourceNode.name);
+    expect(dom.querySelector('.dj-node-tooltip__description')).toBeNull();
+  });
+
+  it('skips the column list when there are no columns', () => {
+    const node = { ...sourceNode, columns: [] };
+    const dom = renderTooltipDom({ ...validStatus, node }, sourceNode.name);
+    expect(dom.querySelector('.dj-node-tooltip__columns')).toBeNull();
+  });
+});
+
+describe('refAtPos', () => {
+  // refAtPos walks the doc line containing `pos`. We fake an EditorView that
+  // exposes just the bits the helper actually touches.
+  const fakeView = text => ({
+    state: {
+      doc: {
+        lineAt: pos => {
+          // Single-line doc, line.from = 0, line.text = whole text.
+          if (pos < 0 || pos > text.length) {
+            throw new Error('out of range');
+          }
+          return { from: 0, text };
+        },
+      },
+    },
+  });
+
+  it('returns the dotted ref under the cursor position', () => {
+    const view = fakeView('SELECT * FROM prodhive.dse.playback_f WHERE 1=1');
+    const hit = refAtPos(view, 20); // somewhere inside `prodhive.dse.playback_f`
+    expect(hit).toEqual({
+      key: 'prodhive.dse.playback_f',
+      from: 14,
+      to: 37,
+    });
+  });
+
+  it('returns null when the position is not inside any dotted ref', () => {
+    const view = fakeView('SELECT * FROM prodhive.dse.playback_f WHERE 1=1');
+    expect(refAtPos(view, 0)).toBeNull(); // on SELECT
+    expect(refAtPos(view, 9)).toBeNull(); // on FROM
+  });
+
+  it('strips backticks from the returned key', () => {
+    const view = fakeView('FROM `prodhive`.`dse`.`playback_f`');
+    const hit = refAtPos(view, 10);
+    expect(hit.key).toBe('prodhive.dse.playback_f');
+  });
+
+  it('matches 2-part refs (namespace.name)', () => {
+    const view = fakeView('JOIN common.dimensions.account ON x = y');
+    const hit = refAtPos(view, 8);
+    expect(hit.key).toBe('common.dimensions.account');
+  });
+});

--- a/datajunction-ui/src/app/pages/AddEditNodePage/djEditorTheme.js
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/djEditorTheme.js
@@ -1,0 +1,123 @@
+/**
+ * CodeMirror 6 theme tuned to share a palette with the rest of the DJ UI
+ * (especially the `.node_type__*` pills and the `.dj-node-chip--*` chips
+ * rendered inline by djNodeBadges). The goal: syntax colors and chip
+ * colors come from the same family, so chips read as theme-native rather
+ * than as foreign decoration.
+ */
+import { EditorView } from '@codemirror/view';
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+
+// Palette — kept in one place so it stays in sync with node-creation.scss.
+const palette = {
+  bg: '#fbfbfd',
+  surface: '#f6f6f9',
+  gutter: '#9aa2b1',
+  selection: '#dbe2ec',
+  caret: '#3b3f46',
+  text: '#27303d',
+  muted: '#8b94a5',
+  keyword: '#6b3aa0', // matches cube/dimension violet family
+  string: '#0e7c5a', // forest green
+  number: '#a96621', // warm amber (same as dimension chip)
+  operator: '#475569',
+  functionName: '#0063b4', // transform blue
+  punctuation: '#5c6573',
+  comment: '#9ca3af',
+};
+
+export const djEditorTheme = EditorView.theme(
+  {
+    '&': {
+      color: palette.text,
+      backgroundColor: palette.bg,
+      fontSize: '13px',
+    },
+    '.cm-content': {
+      caretColor: palette.caret,
+      fontFamily:
+        '"JetBrains Mono", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+    },
+    '.cm-cursor, .cm-dropCursor': { borderLeftColor: palette.caret },
+    '&.cm-focused .cm-selectionBackground, ::selection, .cm-selectionBackground':
+      {
+        backgroundColor: palette.selection,
+      },
+    '.cm-activeLine': {
+      backgroundColor: 'rgba(99, 102, 241, 0.05)',
+    },
+    '.cm-gutters': {
+      backgroundColor: palette.surface,
+      color: palette.gutter,
+      border: 'none',
+    },
+    '.cm-activeLineGutter': {
+      backgroundColor: 'rgba(99, 102, 241, 0.08)',
+      color: palette.text,
+    },
+    '.cm-lineNumbers .cm-gutterElement': {
+      padding: '0 8px 0 6px',
+    },
+    '.cm-foldGutter .cm-gutterElement': {
+      color: palette.muted,
+    },
+    '.cm-tooltip': {
+      background: '#ffffff',
+      border: '1px solid #e2e8f0',
+      borderRadius: '6px',
+      boxShadow: '0 4px 12px rgba(15, 23, 42, 0.06)',
+    },
+    '.cm-tooltip-autocomplete > ul > li[aria-selected]': {
+      background: '#eef2ff',
+      color: palette.text,
+    },
+    '.cm-matchingBracket, .cm-nonmatchingBracket': {
+      backgroundColor: '#fef3c7',
+      outline: 'none',
+    },
+    '.cm-panels': {
+      backgroundColor: palette.surface,
+      color: palette.text,
+    },
+  },
+  { dark: false },
+);
+
+const highlight = HighlightStyle.define([
+  {
+    tag: [t.keyword, t.modifier, t.controlKeyword, t.operatorKeyword],
+    color: palette.keyword,
+    fontWeight: '500',
+  },
+  { tag: [t.string, t.special(t.string)], color: palette.string },
+  { tag: [t.number, t.bool, t.null], color: palette.number },
+  {
+    tag: [t.function(t.variableName), t.function(t.propertyName)],
+    color: palette.functionName,
+  },
+  {
+    tag: [t.operator, t.compareOperator, t.arithmeticOperator, t.logicOperator],
+    color: palette.operator,
+  },
+  {
+    tag: [t.punctuation, t.paren, t.brace, t.bracket, t.separator],
+    color: palette.punctuation,
+  },
+  {
+    tag: [t.variableName, t.propertyName, t.attributeName],
+    color: palette.text,
+  },
+  { tag: [t.typeName, t.className], color: palette.functionName },
+  {
+    tag: [t.comment, t.lineComment, t.blockComment],
+    color: palette.comment,
+    fontStyle: 'italic',
+  },
+  { tag: t.invalid, color: '#cc2222' },
+]);
+
+export const djEditorExtensions = [
+  djEditorTheme,
+  syntaxHighlighting(highlight),
+];

--- a/datajunction-ui/src/app/pages/AddEditNodePage/djNodeBadges.js
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/djNodeBadges.js
@@ -1,0 +1,309 @@
+/**
+ * CodeMirror 6 extension that styles DJ node references in the SQL editor
+ * as inline chips with a status indicator.
+ *
+ * Catalog-qualified tables (`catalog.schema.table`, where `catalog` is in
+ * the known-catalogs list) get wrapped in a chip whose color + trailing icon
+ * reflect the auto-register flow:
+ *
+ *   ⟳  registering   ✓  valid (registered or already known)   ✗  invalid
+ *
+ * The extension is purely a display layer — it reads status from a
+ * caller-provided `getStatus(key)` and never writes data itself. The host
+ * component (NodeQueryField) drives the registration flow and dispatches
+ * `refreshBadges` whenever status changes so decorations rebuild even when
+ * the doc itself hasn't changed.
+ */
+import { ViewPlugin, Decoration, hoverTooltip } from '@codemirror/view';
+import { StateEffect } from '@codemirror/state';
+
+// Match dotted identifiers of any length (2+ segments). Greedy `+` keeps
+// `a.b.c.d` as a single match instead of splitting into `a.b` + `.c.d`.
+// Each segment is `[a-zA-Z_]\w*`, optionally backtick-quoted.
+const DOTTED_REF_RE =
+  /`?[a-zA-Z_][a-zA-Z0-9_]*`?(?:\.`?[a-zA-Z_][a-zA-Z0-9_]*`?)+/g;
+
+function unbacktick(s) {
+  return s.replace(/`/g, '');
+}
+
+export const refreshBadges = StateEffect.define();
+
+function classForStatus(statusKind) {
+  switch (statusKind) {
+    case 'registering':
+      return 'dj-node-chip--registering';
+    case 'valid':
+      return 'dj-node-chip--valid';
+    case 'warning':
+      return 'dj-node-chip--warning';
+    case 'invalid':
+      return 'dj-node-chip--invalid';
+    default:
+      return 'dj-node-chip--unknown';
+  }
+}
+
+function buildDecorations(view, getStatus, getKnownCatalogs) {
+  const known = new Set((getKnownCatalogs() || []).map(c => c.toLowerCase()));
+  const doc = view.state.doc;
+  const ranges = [];
+
+  for (const { from, to } of view.visibleRanges) {
+    const slice = doc.sliceString(from, to);
+    DOTTED_REF_RE.lastIndex = 0;
+    let m;
+    while ((m = DOTTED_REF_RE.exec(slice)) !== null) {
+      const whole = m[0];
+      const key = unbacktick(whole);
+      const status = getStatus(key);
+      const segments = key.split('.');
+
+      let refType;
+      if (status?.refType) {
+        // validateNode told us what this is; honor that.
+        refType = status.refType;
+      } else if (
+        segments.length === 3 &&
+        known.has(segments[0].toLowerCase())
+      ) {
+        // 3-part with a known catalog: candidate source registration.
+        refType = 'source';
+      } else {
+        // No status entry and not a catalog-qualified table — skip.
+        // This avoids false positives on `alias.column` patterns.
+        continue;
+      }
+
+      const cls = `dj-node-chip dj-node-chip--${refType} ${classForStatus(
+        status?.kind,
+      )}`;
+      const start = from + m.index;
+      const end = start + whole.length;
+      ranges.push({
+        from: start,
+        to: end,
+        deco: Decoration.mark({
+          class: cls,
+          attributes: status?.message ? { title: status.message } : undefined,
+        }),
+      });
+    }
+  }
+
+  ranges.sort((a, b) => a.from - b.from || a.to - b.to);
+  return Decoration.set(ranges.map(r => r.deco.range(r.from, r.to)));
+}
+
+/**
+ * Factory. Returns a CodeMirror extension that decorates DJ node refs.
+ *
+ *   getStatus(key)       — returns { kind, message? } | undefined for `catalog.schema.table`
+ *   getKnownCatalogs()   — returns string[] (lowercase catalog names)
+ *
+ * Both are read on every rebuild, so pass ref-backed closures and update
+ * the ref synchronously before dispatching `refreshBadges` — otherwise the
+ * extension reads pre-update state.
+ */
+export function djNodeBadges({ getStatus, getKnownCatalogs }) {
+  return ViewPlugin.fromClass(
+    class {
+      constructor(view) {
+        this.decorations = buildDecorations(view, getStatus, getKnownCatalogs);
+      }
+      update(update) {
+        const refreshed = update.transactions.some(tr =>
+          tr.effects.some(e => e.is(refreshBadges)),
+        );
+        if (update.docChanged || update.viewportChanged || refreshed) {
+          this.decorations = buildDecorations(
+            update.view,
+            getStatus,
+            getKnownCatalogs,
+          );
+        }
+      }
+    },
+    { decorations: v => v.decorations },
+  );
+}
+
+/**
+ * Find the dotted ref under a given document position. Returns
+ * `{ key, from, to }` if the position falls inside a 2+-segment dotted
+ * identifier, else null. Used by the hover tooltip to identify which chip
+ * the cursor is on.
+ */
+export function refAtPos(view, pos) {
+  const line = view.state.doc.lineAt(pos);
+  DOTTED_REF_RE.lastIndex = 0;
+  let m;
+  while ((m = DOTTED_REF_RE.exec(line.text)) !== null) {
+    const start = line.from + m.index;
+    const end = start + m[0].length;
+    if (pos >= start && pos <= end) {
+      return { key: unbacktick(m[0]), from: start, to: end };
+    }
+  }
+  return null;
+}
+
+export function renderTooltipDom(status, refKey) {
+  const wrap = document.createElement('div');
+  wrap.className = 'dj-node-tooltip';
+
+  const node = status.node || {};
+
+  // Header — type pill + qualified name.
+  const header = document.createElement('div');
+  header.className = 'dj-node-tooltip__header';
+
+  const pill = document.createElement('span');
+  pill.className = `dj-node-chip dj-node-chip--${status.refType || 'node'}`;
+  pill.textContent = status.refType || 'node';
+  header.appendChild(pill);
+
+  const name = document.createElement('span');
+  name.className = 'dj-node-tooltip__name';
+  name.textContent = node.name || refKey;
+  header.appendChild(name);
+
+  wrap.appendChild(header);
+
+  // Special-case transient + error states — no metadata grid, just one line.
+  if (status.kind === 'invalid') {
+    const note = document.createElement('div');
+    note.className = 'dj-node-tooltip__note';
+    note.textContent = 'Not found in DJ.';
+    wrap.appendChild(note);
+    return wrap;
+  }
+  if (status.kind === 'registering') {
+    const note = document.createElement('div');
+    note.className = 'dj-node-tooltip__note';
+    note.textContent = 'Registering…';
+    wrap.appendChild(note);
+    return wrap;
+  }
+
+  // Metadata grid (2 columns of label/value pairs).
+  const grid = document.createElement('div');
+  grid.className = 'dj-node-tooltip__grid';
+  const addCell = (label, value) => {
+    if (value == null || value === '') return;
+    const cell = document.createElement('div');
+    cell.className = 'dj-node-tooltip__cell';
+    const l = document.createElement('span');
+    l.className = 'dj-node-tooltip__label';
+    l.textContent = label;
+    const v = document.createElement('span');
+    v.className = 'dj-node-tooltip__value';
+    v.textContent = value;
+    cell.appendChild(l);
+    cell.appendChild(v);
+    grid.appendChild(cell);
+  };
+  if (node.status) addCell('Status', node.status);
+  if (node.version) addCell('Version', node.version);
+  if (node.mode) addCell('Mode', node.mode);
+  if (Array.isArray(node.columns)) {
+    addCell('Columns', String(node.columns.length));
+  }
+  if (grid.childElementCount > 0) wrap.appendChild(grid);
+
+  // Description (truncated if long).
+  if (node.description) {
+    const d = document.createElement('div');
+    d.className = 'dj-node-tooltip__description';
+    const text = node.description;
+    d.textContent = text.length > 280 ? text.slice(0, 277) + '…' : text;
+    wrap.appendChild(d);
+  }
+
+  // Column list — scrollable. The point of the popover for someone writing
+  // SQL is to see what's available to SELECT without leaving the editor.
+  if (Array.isArray(node.columns) && node.columns.length > 0) {
+    const list = document.createElement('div');
+    list.className = 'dj-node-tooltip__columns';
+    for (const col of node.columns) {
+      const row = document.createElement('div');
+      row.className = 'dj-node-tooltip__col-row';
+
+      const n = document.createElement('span');
+      n.className = 'dj-node-tooltip__col-name';
+      n.textContent = col.name;
+      row.appendChild(n);
+
+      // Mark columns that link to a dimension — useful signal for cube/SQL work.
+      if (col.dimension || col.dimension_column) {
+        const tag = document.createElement('span');
+        tag.className = 'dj-node-tooltip__col-tag';
+        tag.textContent = 'dim';
+        tag.title = col.dimension?.name
+          ? `Links to ${col.dimension.name}`
+          : 'Linked dimension';
+        row.appendChild(tag);
+      }
+
+      const t = document.createElement('span');
+      t.className = 'dj-node-tooltip__col-type';
+      // Struct/array types can be enormous (multi-line) — keep it on one line
+      // and let CSS clamp; full info is on the node page.
+      t.textContent = (col.type || '').split('\n')[0];
+      t.title = col.type || '';
+      row.appendChild(t);
+
+      list.appendChild(row);
+    }
+    wrap.appendChild(list);
+  }
+
+  // Footer link.
+  if (node.name) {
+    const foot = document.createElement('div');
+    foot.className = 'dj-node-tooltip__footer';
+    const link = document.createElement('a');
+    link.href = `/nodes/${encodeURIComponent(node.name)}`;
+    link.target = '_blank';
+    link.rel = 'noreferrer noopener';
+    link.textContent = 'Open node →';
+    foot.appendChild(link);
+    wrap.appendChild(foot);
+  }
+
+  return wrap;
+}
+
+/**
+ * Hover tooltip extension. Pairs with djNodeBadges so the same
+ * `getStatus` source of truth drives the popover content.
+ */
+export function djNodeHoverTooltip({ getStatus, getKnownCatalogs }) {
+  return hoverTooltip(
+    (view, pos) => {
+      const hit = refAtPos(view, pos);
+      if (!hit) return null;
+      const status = getStatus(hit.key);
+      if (!status) {
+        // No status entry; only show tooltip for catalog-qualified refs that
+        // would render as a chip — otherwise we'd pop up on every `t.column`.
+        const known = new Set(
+          (getKnownCatalogs() || []).map(c => c.toLowerCase()),
+        );
+        const segments = hit.key.split('.');
+        if (segments.length !== 3 || !known.has(segments[0].toLowerCase())) {
+          return null;
+        }
+      }
+      return {
+        pos: hit.from,
+        end: hit.to,
+        above: true,
+        create: () => ({
+          dom: renderTooltipDom(status || { refType: 'source' }, hit.key),
+        }),
+      };
+    },
+    { hoverTime: 150 },
+  );
+}

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/DimensionsSelect.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/DimensionsSelect.jsx
@@ -69,8 +69,13 @@ export const DimensionsSelect = React.memo(function DimensionsSelect({
   useEffect(() => {
     const fetchData = async () => {
       let cubeDimensions = undefined;
-      if (cube) {
-        cubeDimensions = cube?.current.cubeDimensions.map(cubeDim => {
+      // `cube` may be the bare cube object or a ref-like { current: ... }.
+      // Either shape can also arrive partially populated while data is in
+      // flight, so guard before touching `.cubeDimensions` to avoid the
+      // Suspense boundary surfacing a TypeError to the user.
+      const cubeData = cube?.current ?? cube;
+      if (cubeData?.cubeDimensions) {
+        cubeDimensions = cubeData.cubeDimensions.map(cubeDim => {
           return {
             value: cubeDim.name,
             label:
@@ -108,8 +113,11 @@ export const DimensionsSelect = React.memo(function DimensionsSelect({
 
         setDimensionsByHop(byHop);
 
-        // Set the selected cube dimensions if an existing cube is being edited
-        if (cube) {
+        // Set the selected cube dimensions if an existing cube is being edited.
+        // Only run when we actually have the cube's dimensions in hand — the
+        // outer guard leaves `cubeDimensions` undefined when the cube data
+        // hasn't loaded yet.
+        if (cube && cubeDimensions) {
           const currentSelectedDimensionsByGroup = {};
           Object.values(groupedByNodePath).forEach(dimensionsInGroup => {
             const groupKey =

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/MetricsSelect.jsx
@@ -3,7 +3,11 @@
  * Uses async search to efficiently handle large numbers of metrics.
  * Results are grouped by namespace for easier navigation.
  */
-import AsyncSelect, { components } from 'react-select/async';
+import AsyncSelect from 'react-select/async';
+// `components` is exported from the main `react-select` entry, not from
+// `react-select/async`. CRA's webpack was lenient about this; Vite's
+// stricter ESM resolution rejects the named import on the subpath.
+import { components } from 'react-select';
 import React, { useContext, useEffect, useState, useCallback } from 'react';
 import DJClientContext from '../../providers/djclient';
 

--- a/datajunction-ui/src/styles/node-creation.scss
+++ b/datajunction-ui/src/styles/node-creation.scss
@@ -296,3 +296,225 @@ form {
   background: #f5efff;
   padding: 5px;
 }
+
+/* Chips applied by djNodeBadges (CodeMirror extension) to catalog-qualified
+ * table references in the SQL editor. The mark decoration wraps the matched
+ * text directly (e.g. `prodhive.dse.playback_f`) — same visual vocabulary
+ * as the .node_type__* pills used in the node graph and elsewhere so users
+ * see the same colored chip in both places. */
+.dj-node-chip {
+  border-radius: 4px !important;
+  padding: 0 5px !important;
+  margin: 0 1px;
+  border: none;
+  /* Slightly tighter than the surrounding monospace so the chip doesn't
+   * crowd adjacent tokens — it should feel inline, not stacked on top. */
+  font-size: 0.95em;
+}
+
+/* Per-node-type palette — soft tints derived from the .node_type__* hex in
+ * styles/index.css, lightened so they sit inside the editor surface
+ * (`#fbfbfd` from djEditorTheme) without looking like loud stickers. */
+.dj-node-chip--source {
+  background: #d6f6e8 !important;
+  color: #008a55 !important;
+}
+.dj-node-chip--dimension {
+  background: #fbeacc !important;
+  color: #8f5418 !important;
+}
+.dj-node-chip--metric {
+  background: #f8dde2 !important;
+  color: #8c1f33 !important;
+}
+.dj-node-chip--transform {
+  background: #d4ecff !important;
+  color: #0058a3 !important;
+}
+.dj-node-chip--cube {
+  background: #ead0fb !important;
+  color: #4f0671 !important;
+}
+.dj-node-chip--node {
+  background: #ececec !important;
+  color: #4b5563 !important;
+}
+
+/* Status indicators — IDE-style. Healthy nodes have no extra signal; the
+ * chip color alone says "DJ recognizes this". Problem states reuse the
+ * convention every engineer already knows from VS Code / IntelliJ:
+ *   amber wavy underline = "exists but something is off"
+ *   red wavy underline   = "this doesn't exist"
+ * Registering shows a brief opacity pulse instead — it's a transient state,
+ * not an error, so it shouldn't look like one. */
+.dj-node-chip--registering {
+  animation: dj-node-chip-pulse 1.2s ease-in-out infinite;
+}
+
+.dj-node-chip--warning {
+  text-decoration: underline wavy #b97f00 !important;
+  text-decoration-thickness: 1px !important;
+  text-underline-offset: 2px;
+}
+
+.dj-node-chip--invalid {
+  text-decoration: underline wavy #cc2222 !important;
+  text-decoration-thickness: 1px !important;
+  text-underline-offset: 2px;
+}
+
+@keyframes dj-node-chip-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Hover tooltip rendered by djNodeHoverTooltip when the user hovers a chip.
+ * The outer .cm-tooltip wrapper is themed by djEditorTheme; this styles the
+ * inner content. Layout: header → metadata grid → description → scrollable
+ * column list → footer link. */
+.dj-node-tooltip {
+  font-family: 'Lato', sans-serif;
+  font-size: 12px;
+  color: #27303d;
+  width: 340px;
+}
+
+.dj-node-tooltip > * + * {
+  border-top: 1px solid #eef0f3;
+}
+.dj-node-tooltip > *:first-child,
+.dj-node-tooltip > *:last-child {
+  border: none;
+}
+
+.dj-node-tooltip__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+}
+.dj-node-tooltip__header .dj-node-chip {
+  font-size: 11px !important;
+  text-transform: lowercase;
+}
+.dj-node-tooltip__name {
+  font-family: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+  word-break: break-all;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.dj-node-tooltip__note {
+  padding: 8px 10px;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.dj-node-tooltip__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 12px;
+  padding: 8px 10px;
+}
+.dj-node-tooltip__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.dj-node-tooltip__label {
+  color: #6b7280;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  line-height: 1.2;
+}
+.dj-node-tooltip__value {
+  color: #1f2937;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.dj-node-tooltip__description {
+  padding: 8px 10px;
+  color: #4b5563;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.dj-node-tooltip__columns {
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 6px 0;
+  /* Thin custom scrollbar — minimal, doesn't fight the popover surface. */
+  scrollbar-width: thin;
+  scrollbar-color: #d1d5db transparent;
+}
+.dj-node-tooltip__columns::-webkit-scrollbar {
+  width: 6px;
+}
+.dj-node-tooltip__columns::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+  border-radius: 3px;
+}
+.dj-node-tooltip__col-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 2px 10px;
+  font-family: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 11px;
+}
+.dj-node-tooltip__col-row:hover {
+  background: #f4f6f9;
+}
+.dj-node-tooltip__col-name {
+  color: #1f2937;
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dj-node-tooltip__col-tag {
+  font-family: 'Lato', sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: #ead0fb;
+  color: #4f0671;
+  padding: 0 4px;
+  border-radius: 3px;
+  align-self: center;
+  flex: 0 0 auto;
+}
+.dj-node-tooltip__col-type {
+  color: #6b7280;
+  flex: 0 0 auto;
+  max-width: 40%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dj-node-tooltip__footer {
+  padding: 6px 10px;
+  text-align: right;
+}
+.dj-node-tooltip__footer a {
+  color: #2563eb;
+  font-weight: 500;
+  text-decoration: none;
+  font-size: 11px;
+}
+.dj-node-tooltip__footer a:hover {
+  text-decoration: underline;
+}

--- a/datajunction-ui/vite.config.ts
+++ b/datajunction-ui/vite.config.ts
@@ -42,6 +42,10 @@ export default defineConfig(({ mode }) => {
         utils: path.resolve(__dirname, 'src/utils'),
         mocks: path.resolve(__dirname, 'src/mocks'),
       },
+      // CodeMirror's instanceof checks break when @codemirror/state or
+      // @codemirror/view get loaded twice (once via @uiw/react-codemirror's
+      // pre-bundle, once via our direct import). Dedupe forces a single copy.
+      dedupe: ['@codemirror/state', '@codemirror/view'],
     },
     server: {
       host: '0.0.0.0',

--- a/datajunction-ui/vite.config.ts
+++ b/datajunction-ui/vite.config.ts
@@ -45,7 +45,12 @@ export default defineConfig(({ mode }) => {
       // CodeMirror's instanceof checks break when @codemirror/state or
       // @codemirror/view get loaded twice (once via @uiw/react-codemirror's
       // pre-bundle, once via our direct import). Dedupe forces a single copy.
-      dedupe: ['@codemirror/state', '@codemirror/view'],
+      dedupe: [
+        '@codemirror/state',
+        '@codemirror/view',
+        '@codemirror/language',
+        '@lezer/highlight',
+      ],
     },
     server: {
       host: '0.0.0.0',

--- a/datajunction-ui/vitest.config.ts
+++ b/datajunction-ui/vitest.config.ts
@@ -21,16 +21,17 @@ export default defineConfig(({ mode }) => {
         utils: path.resolve(__dirname, 'src/utils'),
         mocks: path.resolve(__dirname, 'src/mocks'),
       },
-      // Match vite.config.ts — without this, vitest can load
-      // @codemirror/state twice (once for @uiw/react-codemirror's
-      // pre-bundle, once for our direct import), breaking the
-      // `instanceof Extension` checks the extension array does.
       dedupe: [
         '@codemirror/state',
         '@codemirror/view',
         '@codemirror/language',
         '@lezer/highlight',
       ],
+      // Force ESM resolution. Without this Vitest can pull @uiw/* in
+      // through its `main` (CJS) field, which loads @codemirror/state's
+      // CJS build — while our direct imports load the ESM build, giving
+      // two module instances and breaking `instanceof Extension`.
+      conditions: ['module', 'browser', 'import', 'default'],
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('test'),
@@ -42,18 +43,13 @@ export default defineConfig(({ mode }) => {
       setupFiles: ['./src/setupTests.ts'],
       css: true,
       isolate: true,
-      // CodeMirror packages do `instanceof Extension` checks; under Vitest
-      // they can be loaded twice (once by @uiw/react-codemirror's pre-bundle
-      // and once by our own direct import), so the check fails. Inlining
-      // these forces a single instance in the test's module graph.
+      // CodeMirror packages do `instanceof Extension` checks; vitest can
+      // otherwise load them twice (once via @uiw's CJS bundle, once via
+      // our direct ESM import). Inline + dedupe + ESM conditions together
+      // pin a single module instance.
       server: {
         deps: {
-          inline: [
-            /@codemirror\//,
-            /@lezer\//,
-            /@uiw\/(react-)?codemirror/,
-            /codemirror/,
-          ],
+          inline: [/^@codemirror\//, /^@lezer\//, /^@uiw\//, /^codemirror$/],
         },
       },
       // Each test file gets a fresh module graph + mock registry. Without

--- a/datajunction-ui/vitest.config.ts
+++ b/datajunction-ui/vitest.config.ts
@@ -25,7 +25,12 @@ export default defineConfig(({ mode }) => {
       // @codemirror/state twice (once for @uiw/react-codemirror's
       // pre-bundle, once for our direct import), breaking the
       // `instanceof Extension` checks the extension array does.
-      dedupe: ['@codemirror/state', '@codemirror/view'],
+      dedupe: [
+        '@codemirror/state',
+        '@codemirror/view',
+        '@codemirror/language',
+        '@lezer/highlight',
+      ],
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('test'),
@@ -37,6 +42,20 @@ export default defineConfig(({ mode }) => {
       setupFiles: ['./src/setupTests.ts'],
       css: true,
       isolate: true,
+      // CodeMirror packages do `instanceof Extension` checks; under Vitest
+      // they can be loaded twice (once by @uiw/react-codemirror's pre-bundle
+      // and once by our own direct import), so the check fails. Inlining
+      // these forces a single instance in the test's module graph.
+      server: {
+        deps: {
+          inline: [
+            /@codemirror\//,
+            /@lezer\//,
+            /@uiw\/(react-)?codemirror/,
+            /codemirror/,
+          ],
+        },
+      },
       // Each test file gets a fresh module graph + mock registry. Without
       // this, App.test imports NodePage indirectly and primes the lazy
       // module cache, defeating NodePage.test's `vi.mock('cronstrue', ...)`.

--- a/datajunction-ui/vitest.config.ts
+++ b/datajunction-ui/vitest.config.ts
@@ -21,6 +21,11 @@ export default defineConfig(({ mode }) => {
         utils: path.resolve(__dirname, 'src/utils'),
         mocks: path.resolve(__dirname, 'src/mocks'),
       },
+      // Match vite.config.ts — without this, vitest can load
+      // @codemirror/state twice (once for @uiw/react-codemirror's
+      // pre-bundle, once for our direct import), breaking the
+      // `instanceof Extension` checks the extension array does.
+      dedupe: ['@codemirror/state', '@codemirror/view'],
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('test'),

--- a/datajunction-ui/yarn.lock
+++ b/datajunction-ui/yarn.lock
@@ -1464,14 +1464,14 @@
     "@codemirror/language" "^6.0.0"
     "@codemirror/legacy-modes" "^6.4.0"
 
-"@codemirror/language@^6.0.0", "@codemirror/language@^6.3.0", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0", "@codemirror/language@^6.8.0":
-  version "6.11.3"
-  resolved "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz"
-  integrity sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.11.0", "@codemirror/language@^6.3.0", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0", "@codemirror/language@^6.8.0":
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.12.3.tgz#0b220182973a4c19850b29f7dd82aec1bbae3d7e"
+  integrity sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.23.0"
-    "@lezer/common" "^1.1.0"
+    "@lezer/common" "^1.5.0"
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
     style-mod "^4.0.0"
@@ -1501,14 +1501,7 @@
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
-"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.1", "@codemirror/state@^6.4.0", "@codemirror/state@^6.5.0":
-  version "6.5.2"
-  resolved "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz"
-  integrity sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==
-  dependencies:
-    "@marijn/find-cluster-break" "^1.0.0"
-
-"@codemirror/state@^6.5.2", "@codemirror/state@^6.6.0":
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.1", "@codemirror/state@^6.4.0", "@codemirror/state@^6.5.2", "@codemirror/state@^6.6.0":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.6.0.tgz#b88dbdc14aea4ace3c6d67bb77fe28bb84e4394e"
   integrity sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==
@@ -1525,17 +1518,7 @@
     "@codemirror/view" "^6.0.0"
     "@lezer/highlight" "^1.0.0"
 
-"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0":
-  version "6.39.11"
-  resolved "https://registry.npmjs.org/@codemirror/view/-/view-6.39.11.tgz"
-  integrity sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==
-  dependencies:
-    "@codemirror/state" "^6.5.0"
-    crelt "^1.0.6"
-    style-mod "^4.1.0"
-    w3c-keyname "^2.2.4"
-
-"@codemirror/view@^6.39.11":
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0", "@codemirror/view@^6.39.11":
   version "6.43.0"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.43.0.tgz#a577da65f1d5d8f7cbf08e14849284c12f38365a"
   integrity sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==
@@ -2045,7 +2028,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.2.1", "@lezer/common@^1.3.0":
+"@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.2.1", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@lezer/common/-/common-1.4.0.tgz"
   integrity sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg==

--- a/datajunction-ui/yarn.lock
+++ b/datajunction-ui/yarn.lock
@@ -1508,6 +1508,13 @@
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 
+"@codemirror/state@^6.5.2", "@codemirror/state@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.6.0.tgz#b88dbdc14aea4ace3c6d67bb77fe28bb84e4394e"
+  integrity sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
 "@codemirror/theme-one-dark@^6.0.0":
   version "6.1.3"
   resolved "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz"
@@ -1524,6 +1531,16 @@
   integrity sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==
   dependencies:
     "@codemirror/state" "^6.5.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
+"@codemirror/view@^6.39.11":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.43.0.tgz#a577da65f1d5d8f7cbf08e14849284c12f38365a"
+  integrity sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==
+  dependencies:
+    "@codemirror/state" "^6.6.0"
     crelt "^1.0.6"
     style-mod "^4.1.0"
     w3c-keyname "^2.2.4"


### PR DESCRIPTION
### Summary

When you write SQL in the node-creation page, references to DJ nodes are now visually distinguished, color-coded by type, and hoverable with a details tooltip.

#### What you see

- A node reference gets wrapped in a colored chip that matches the existing node type palette (source = green, dimension = orange, metric = pink, transform = blue, cube = purple). Same vocabulary as the type pills in the node graph view.
- Hovering a chip pops up an inline info card showing the node's status, version, mode, column count, description, and a scrollable list of columns with their types. Columns linked to a dimension get a small "dim" tag. A footer link opens the full node page.
- Problem states use IDE-style indicators: amber wavy underline when the resolved node is unhealthy (status != valid), red wavy underline when the reference doesn't resolve at all (missing parent). The chip also pulses while a source table is being auto-registered.

#### How it works

- Added `djNodeBadges.js`, which is a CodeMirror 6 ViewPlugin that walks the document on every change/viewport update, finds dotted identifiers via regex, and emits Decoration.mark ranges with classes per node type + state. Companion hoverTooltip extension renders a DOM popover under the cursor using the same status source-of-truth.
- `djEditorTheme.js` is a custom theme that retunes the editor's syntax colors to the same palette family as the chips, so chips read as theme-native instead of stickers on top.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
