### PR TITLE
v3 SQL: Fix set op column pruning

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1497,7 +1497,7 @@ def collect_node_ctes(
         if needed_columns_by_node:  # pragma: no branch
             needed_cols = needed_columns_by_node.get(node.name)
 
-        if needed_cols:  # pragma: no branch
+        if needed_cols and not _cte_has_set_operation(query_ast):  # pragma: no branch
             query_ast = filter_cte_projection(query_ast, needed_cols)
 
         # Inject filters into this CTE's WHERE clause from two sources:

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -58,14 +58,6 @@ async def client_with_union_transform(client_with_build_v3: AsyncClient):
 class TestSetOperationTransforms:
     """Transforms whose body is a UNION/INTERSECT/EXCEPT."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Column pruning applies to only the first arm of a UNION ALL, "
-        "emitting arms with mismatched column counts (arm 1 pruned, arm 2 "
-        "intact) — invalid SQL.  The correct behavior is to skip pruning "
-        "entirely for set-op transform bodies so both arms preserve their "
-        "original projection.  Pinned here so the fix flips it to pass.",
-    )
     @pytest.mark.asyncio
     async def test_union_all_transform_metric_generates_sql(
         self,
@@ -108,13 +100,6 @@ class TestSetOperationTransforms:
             """,
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Same set-op column-pruning bug as above.  The filter-pushdown "
-        "refusal for set-op CTEs is correct (filter stays on outer query "
-        "only), but the CTE body still has mismatched arm column counts. "
-        "Flip to passing when the pruner skips set-op bodies.",
-    )
     @pytest.mark.asyncio
     async def test_union_transform_filter_stays_on_outer_query(
         self,
@@ -149,7 +134,6 @@ class TestSetOperationTransforms:
             orders_unified_0 AS (
               SELECT t1.status, t1.order_id
               FROM v3_orders_unified t1
-              WHERE t1.status = 'completed'
               GROUP BY t1.status, t1.order_id
             )
             SELECT orders_unified_0.status AS status,


### PR DESCRIPTION
### Summary

When building measures SQL, we prune a transform's SELECT list to only include columns needed downstream, but if the query has a set operation like `UNION ALL` in its output structure, we should not do this pruning, as it can break the set operation unless we also prune the other side of the set op.

This makes a deliberate choice *not* to do the most optimal solution (also prune the other side of the set op) to reduce complexity and potential chances of breaking the user's query.

### Test Plan

Two pre-written xfail tests in `set_operations_test.py` were already pinned for this exact bug; removed the xfail decorators and corrected one over-specified expected SQL (filter goes on the outer SELECT, not the intermediate CTE).

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
