### PR TITLE
Filter pushdown into non-leading arms of `UNION ALL` bodies

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -347,7 +347,10 @@ def _register_pushdown_into_upstream(
     FK column.
     """
     from datajunction_server.construction.build_v3.filters import parse_filter
-    from datajunction_server.construction.build_v3.cte import get_column_full_name
+    from datajunction_server.construction.build_v3.cte import (
+        get_column_full_name,
+        inject_filter_into_select,
+    )
 
     # Find filter strings that reference this dim ref. Parse each once.
     base_ref = original_ref.split("[")[0]
@@ -383,14 +386,15 @@ def _register_pushdown_into_upstream(
     for filter_str in matching:
         consumed = False
         for linked_node, fk_col in candidates:  # pragma: no branch
-            target_name, qualifier = _resolve_pushdown_target(
+            target = _resolve_pushdown_target(
                 ctx,
                 linked_node,
                 fk_col,
                 children_of,
             )
-            if target_name is None:
+            if target is None:
                 continue  # pragma: no cover
+            target_name, qualifier, arm_select = target
             rewritten = _rewrite_filter_col_refs(
                 filter_str,
                 base_ref,
@@ -399,9 +403,17 @@ def _register_pushdown_into_upstream(
             )
             if rewritten is None:
                 continue  # pragma: no cover
-            ctx.upstream_pushdown_filters.setdefault(target_name, []).append(
-                rewritten,
-            )
+            if arm_select is not None:
+                # Source link case — bake the filter directly into the arm's
+                # WHERE in the cached AST.  For set-op bodies this targets
+                # the specific arm that references the source; for plain
+                # SELECTs the arm is the top-level select, equivalent to
+                # injecting at the CTE WHERE.
+                inject_filter_into_select(arm_select, rewritten)
+            else:
+                ctx.upstream_pushdown_filters.setdefault(target_name, []).append(
+                    rewritten,
+                )
             consumed = True
         if consumed:  # pragma: no branch
             ctx.pushdown_consumed_filters.add(filter_str)
@@ -413,16 +425,19 @@ def _resolve_pushdown_target(
     linked_node: Node,
     fk_col: str,
     children_of: Callable[[str], list[str]],
-) -> tuple[Optional[str], Optional[str]]:
+) -> Optional[tuple[str, Optional[str], Optional["ast.Select"]]]:
     """
-    Return ``(target_cte_name, qualifier)`` for filter injection.
+    Return ``(target_cte_name, qualifier, arm_select)`` or ``None``.
 
-    Transform with the link → inject into its own CTE, no qualifier.
-    Source with the link → inject into a child transform's CTE, qualified
-    with the alias that child uses for the source.
+    - Transform with the link: ``arm_select`` is ``None``; caller registers
+      the filter for normal top-level CTE injection.
+    - Source with the link: walk every arm of the child transform's body
+      (UNION/INTERSECT/EXCEPT or plain SELECT) and return the specific
+      arm whose FROM references the source.  Caller injects directly into
+      that arm's WHERE.
     """
     if linked_node.type != NodeType.SOURCE:
-        return linked_node.name, None
+        return linked_node.name, None, None
     for child_name in children_of(linked_node.name):  # pragma: no branch
         child = ctx.nodes.get(child_name)
         if (
@@ -436,22 +451,34 @@ def _resolve_pushdown_target(
             child_query = ctx.get_parsed_query(child)
         except Exception:  # pragma: no cover
             continue
-        select = child_query.select if hasattr(child_query, "select") else None
-        if select is None or select.from_ is None:
+        top_select = child_query.select
+        if not isinstance(top_select, ast.Select):
             continue  # pragma: no cover
-        for tbl in select.from_.find_all(ast.Table):  # pragma: no branch
-            try:
-                tbl_name = tbl.name.identifier(quotes=False)
-            except Exception:  # pragma: no cover
-                continue
-            if tbl_name == linked_node.name:  # pragma: no branch
-                alias = (
-                    tbl.alias.name
-                    if tbl.alias
-                    else linked_node.name.split(SEPARATOR)[-1]
-                )
-                return child.name, alias
-    return None, None  # pragma: no cover
+        # Walk every arm: leading SELECT, then each set_op.right recursively.
+        arms: list[ast.Select] = [top_select]
+        cur_set_op = top_select.set_op
+        while cur_set_op is not None:
+            right = cur_set_op.right
+            if not isinstance(right, ast.Select):
+                break  # pragma: no cover
+            arms.append(right)
+            cur_set_op = right.set_op
+        for arm in arms:
+            if arm.from_ is None:
+                continue  # pragma: no cover
+            for tbl in arm.from_.find_all(ast.Table):  # pragma: no branch
+                try:
+                    tbl_name = tbl.name.identifier(quotes=False)
+                except Exception:  # pragma: no cover
+                    continue
+                if tbl_name == linked_node.name:  # pragma: no branch
+                    alias = (
+                        tbl.alias.name
+                        if tbl.alias
+                        else linked_node.name.split(SEPARATOR)[-1]
+                    )
+                    return child.name, alias, arm
+    return None  # pragma: no cover
 
 
 def _rewrite_filter_col_refs(

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -404,11 +404,10 @@ def _register_pushdown_into_upstream(
             if rewritten is None:
                 continue  # pragma: no cover
             if arm_select is not None:
-                # Source link case — bake the filter directly into the arm's
-                # WHERE in the cached AST.  For set-op bodies this targets
-                # the specific arm that references the source; for plain
-                # SELECTs the arm is the top-level select, equivalent to
-                # injecting at the CTE WHERE.
+                # Source lives in a non-leading set-op arm — the normal CTE
+                # WHERE injection would target the leading arm and reference
+                # an alias that doesn't exist there.  Bake the filter
+                # directly into the matching arm's WHERE in the cached AST.
                 inject_filter_into_select(arm_select, rewritten)
             else:
                 ctx.upstream_pushdown_filters.setdefault(target_name, []).append(
@@ -429,12 +428,11 @@ def _resolve_pushdown_target(
     """
     Return ``(target_cte_name, qualifier, arm_select)`` or ``None``.
 
-    - Transform with the link: ``arm_select`` is ``None``; caller registers
-      the filter for normal top-level CTE injection.
-    - Source with the link: walk every arm of the child transform's body
-      (UNION/INTERSECT/EXCEPT or plain SELECT) and return the specific
-      arm whose FROM references the source.  Caller injects directly into
-      that arm's WHERE.
+    ``arm_select`` is set only when the source lives in a non-leading arm
+    of a UNION/INTERSECT/EXCEPT body — in that case the caller injects
+    directly into that arm's WHERE.  For plain SELECT bodies or set-op
+    leading arms, ``arm_select`` is ``None`` and the caller registers the
+    filter through the normal CTE WHERE injection path.
     """
     if linked_node.type != NodeType.SOURCE:
         return linked_node.name, None, None
@@ -463,7 +461,7 @@ def _resolve_pushdown_target(
                 break  # pragma: no cover
             arms.append(right)
             cur_set_op = right.set_op
-        for arm in arms:
+        for idx, arm in enumerate(arms):  # pragma: no branch
             if arm.from_ is None:
                 continue  # pragma: no cover
             for tbl in arm.from_.find_all(ast.Table):  # pragma: no branch
@@ -477,7 +475,14 @@ def _resolve_pushdown_target(
                         if tbl.alias
                         else linked_node.name.split(SEPARATOR)[-1]
                     )
-                    return child.name, alias, arm
+                    # arm_select is only returned for non-leading set-op
+                    # arms; the leading arm goes through the normal CTE
+                    # WHERE injection (which would target the same arm).
+                    return (
+                        child.name,
+                        alias,
+                        arm if idx > 0 else None,
+                    )
     return None  # pragma: no cover
 
 

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -13,7 +13,7 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
-from tests.construction.build_v3 import assert_sql_equal
+from tests.construction.build_v3 import assert_sql_equal, get_first_grain_group
 
 
 @pytest_asyncio.fixture
@@ -141,5 +141,134 @@ class TestSetOperationTransforms:
             FROM orders_unified_0
             WHERE orders_unified_0.status = 'completed'
             GROUP BY orders_unified_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_only_dim_link_on_one_arm_source_only(
+        self,
+        client_with_build_v3,
+    ):
+        """Partial-source pushdown into a UNION-ALL transform.
+
+        Two sources, ``v3.src_orders_us`` and ``v3.src_orders_eu``, both
+        carry an ``order_date`` column.  Only the US source has a
+        dimension link to ``v3.audit_date_dim``.  The transform UNION-ALLs
+        both.  A filter on the dim must be pushed into ONLY the arm
+        reading from the linked source — the other arm has no formal
+        binding to the dim and must stay untouched.
+        """
+        client = client_with_build_v3
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_audit_dates",
+                "description": "audit dates",
+                "columns": [{"name": "dateint", "type": "int"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "audit_dates",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.audit_date_dim",
+                "description": "Audit date dim",
+                "query": "SELECT dateint FROM v3.src_audit_dates",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        for name, table in (
+            ("v3.src_orders_us", "orders_us"),
+            ("v3.src_orders_eu", "orders_eu"),
+        ):
+            resp = await client.post(
+                "/nodes/source/",
+                json={
+                    "name": name,
+                    "description": f"Orders for {table}",
+                    "columns": [
+                        {"name": "order_id", "type": "int"},
+                        {"name": "order_date", "type": "int"},
+                        {"name": "status", "type": "string"},
+                    ],
+                    "mode": "published",
+                    "catalog": "default",
+                    "schema_": "v3",
+                    "table": table,
+                },
+            )
+            assert resp.status_code in (200, 201), resp.json()
+
+        # Only the US source carries the dim link.
+        resp = await client.post(
+            "/nodes/v3.src_orders_us/link",
+            json={
+                "dimension_node": "v3.audit_date_dim",
+                "join_type": "inner",
+                "join_on": "v3.src_orders_us.order_date = v3.audit_date_dim.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.orders_global",
+                "description": "Union of US and EU orders",
+                "query": """
+                    SELECT order_id, status FROM v3.src_orders_us
+                    UNION ALL
+                    SELECT order_id, status FROM v3.src_orders_eu
+                """,
+                "mode": "published",
+                "primary_key": ["order_id"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.global_order_count",
+                "query": "SELECT COUNT(DISTINCT order_id) FROM v3.orders_global",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.global_order_count"],
+                "dimensions": ["v3.orders_global.status"],
+                "filters": ["v3.audit_date_dim.dateint >= 20260101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # The filter lands in the US arm (linked to the dim) only;
+        # the EU arm stays untouched.
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_orders_global AS (
+                SELECT order_id, status
+                FROM default.v3.orders_us
+                WHERE src_orders_us.order_date >= 20260101
+                UNION ALL
+                SELECT order_id, status
+                FROM default.v3.orders_eu
+            )
+            SELECT t1.status, t1.order_id
+            FROM v3_orders_global t1
+            GROUP BY t1.status, t1.order_id
             """,
         )

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -223,10 +223,12 @@ class TestSetOperationTransforms:
             json={
                 "name": "v3.orders_global",
                 "description": "Union of US and EU orders",
+                # Linked source is in the SECOND (non-leading) arm so the
+                # pushdown goes through the direct-arm-WHERE-mutation path.
                 "query": """
-                    SELECT order_id, status FROM v3.src_orders_us
-                    UNION ALL
                     SELECT order_id, status FROM v3.src_orders_eu
+                    UNION ALL
+                    SELECT order_id, status FROM v3.src_orders_us
                 """,
                 "mode": "published",
                 "primary_key": ["order_id"],
@@ -255,17 +257,18 @@ class TestSetOperationTransforms:
         assert response.status_code == 200, response.json()
         sql = get_first_grain_group(response.json())["sql"]
         # The filter lands in the US arm (linked to the dim) only;
-        # the EU arm stays untouched.
+        # the EU arm stays untouched.  US is the non-leading arm, so this
+        # exercises the direct-arm-WHERE-mutation path.
         assert_sql_equal(
             sql,
             """
             WITH v3_orders_global AS (
                 SELECT order_id, status
-                FROM default.v3.orders_us
-                WHERE src_orders_us.order_date >= 20260101
+                FROM default.v3.orders_eu
                 UNION ALL
                 SELECT order_id, status
-                FROM default.v3.orders_eu
+                FROM default.v3.orders_us
+                WHERE src_orders_us.order_date >= 20260101
             )
             SELECT t1.status, t1.order_id
             FROM v3_orders_global t1


### PR DESCRIPTION
### Summary

#### Problem

When a transform's query is a `UNION ALL` (or other set op) and a filter-only dimension is reachable only via a source that appears in a non-leading arm, v3 SQL raises `Cannot find join path even` though a valid pushdown target exists. This is because the pushdown resolver (`_resolve_pushdown_target`) doesn't see the non-leading arms: it only looks at `select.from_` of the child transform's parsed query. But for a `UNION ALL` body, the from clause is just the leading arm's `FROM`. Every other arm lives under `select.set_op`, so any source referenced in the other arms were invisible.

#### Changes

1. `_resolve_pushdown_target` now walks every arm: the leading Select, then each `set_op.right` recursively. When it finds the linked source's table in arm N, it returns the matching arm's select only when non-leading arms need direct injection. For the leading arm (or any plain non-set-op transform), it preserves the existing flow.
2. `_register_pushdown_into_upstream` checks whether `arm_select` is set. If so, it bakes the rewritten filter directly into that specific arm's `WHERE` in the cached AST via `inject_filter_into_select`. This bypasses the usual `upstream_pushdown_filters` registration, which would otherwise land the filter on the leading arm's WHERE with the wrong alias.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
