### PR TITLE
Mixed-decomposable metrics produce correct measures SQL

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/decomposition.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/decomposition.py
@@ -528,6 +528,14 @@ def _merge_parent_grain_groups(groups: list[GrainGroup]) -> GrainGroup:
             # Track original aggregability for each component
             component_aggregabilities[component.name] = gg.aggregability
 
+    # Carry over non-decomposable metrics from every contributing group.
+    # Without this, merging a NONE group into a FULL/LIMITED neighbor
+    # silently drops the non-decomposable metric expressions and the
+    # response loses those metrics entirely.
+    all_non_decomposable: list[DecomposedMetricInfo] = []
+    for gg in groups:
+        all_non_decomposable.extend(gg.non_decomposable_metrics)
+
     # Compute finest grain (union of all grain columns)
     finest_grain_set: set[str] = set()
     merged_grain_col_aliases: dict[str, str] = {}
@@ -552,4 +560,5 @@ def _merge_parent_grain_groups(groups: list[GrainGroup]) -> GrainGroup:
         is_merged=True,
         component_aggregabilities=component_aggregabilities,
         grain_col_aliases=merged_grain_col_aliases,
+        non_decomposable_metrics=all_non_decomposable,
     )

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1901,6 +1901,20 @@ def build_grain_group_sql(
     # Handle non-decomposable metrics (like MAX_BY)
     # Extract column references from the metric expression and pass them through
     non_decomposable_columns: list[tuple[str, ast.Expression]] = []
+
+    # In the merged-with-non-decomposable case, components emit raw column
+    # refs (because downstream applies the aggregation after the join).  If a
+    # non-decomposable expression references one of those same columns
+    # (e.g. ``MAX_BY(product_id, line_total)`` shares ``line_total`` with a
+    # ``SUM(line_total)`` component), projecting it again here produces a
+    # duplicate column in the SELECT — track which column names the
+    # components already cover and skip them.
+    component_col_names: set[str] = set()
+    for _, expr in component_expressions:
+        for c in expr.find_all(ast.Column):
+            if c.name:  # pragma: no branch
+                component_col_names.add(c.name.name)
+
     for decomposed in grain_group.non_decomposable_metrics:
         metrics_covered.add(decomposed.metric_node.name)
 
@@ -1908,7 +1922,11 @@ def build_grain_group_sql(
         # These are the columns needed for the aggregation function
         for col in decomposed.derived_ast.find_all(ast.Column):
             col_name = col.name.name if col.name else None
-            if col_name and col_name not in seen_components:  # pragma: no branch
+            if (
+                col_name
+                and col_name not in seen_components
+                and col_name not in component_col_names
+            ):  # pragma: no branch
                 seen_components.add(col_name)
                 col_ast = make_column_ref(col_name)
                 non_decomposable_columns.append((col_name, col_ast))
@@ -1949,6 +1967,15 @@ def build_grain_group_sql(
     else:
         # Normal case: combine component expressions with non-decomposable columns
         all_metric_expressions = component_expressions + non_decomposable_columns
+        # When a merged grain group has non-decomposable metrics, the
+        # worst-case aggregability is NONE and components carry raw column
+        # refs (not pre-aggregations).  A GROUP BY here would be redundant
+        # — every projected column is part of the full grain — and the
+        # real aggregation happens downstream after the join.
+        skip_agg = bool(
+            grain_group.non_decomposable_metrics
+            and grain_group.aggregability == Aggregability.NONE,
+        )
         query_ast, scanned_sources = build_select_ast(
             ctx,
             metric_expressions=all_metric_expressions,
@@ -1957,6 +1984,7 @@ def build_grain_group_sql(
             grain_columns=effective_grain_columns,
             grain_col_aliases=grain_group.grain_col_aliases or None,
             filters=ctx.dimension_filters,  # Use dimension_filters only (not metric_filters)
+            skip_aggregation=skip_agg,
         )
 
     # Build column metadata

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -1054,8 +1054,11 @@ class MetricComponentExtractor:
         """Decompose an aggregation function using the registry."""
         decomposition = get_decomposition(dj_function)
 
-        if decomposition is None:
-            # Not decomposable (e.g., MAX_BY, MIN_BY)
+        if decomposition is None:  # pragma: no cover
+            # Defensive: ``_extract_base`` filters non-decomposable
+            # aggregations out before calling here, so this branch is
+            # unreachable in practice.  Kept so direct callers (if any)
+            # still get a sensible None return.
             return None
 
         # Build components from decomposition

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -959,6 +959,15 @@ class MetricComponentExtractor:
         """
         Extract components from a base metric by decomposing aggregations.
 
+        If any aggregation in the metric is non-decomposable (e.g. ``MIN_BY``,
+        ``MAX_BY``), the whole metric is treated as non-decomposable — we
+        return an empty components list and leave the AST untouched.  A
+        mixed metric (some decomposable, some not) can't be safely
+        pre-aggregated: the components that *did* decompose would lose
+        track of columns referenced inside the non-decomposable functions,
+        and the resulting measures table wouldn't contain everything the
+        metric expression needs.
+
         Returns:
             Tuple of (components, modified_query_ast)
         """
@@ -968,18 +977,27 @@ class MetricComponentExtractor:
         if query_ast.select.from_:  # pragma: no branch
             query_ast = self._normalize_aliases(query_ast)
 
+            agg_funcs: list[tuple[ast.Function, type]] = []
             for func in query_ast.find_all(ast.Function):
                 dj_function = func.function()
                 if dj_function and dj_function.is_aggregation:
-                    result = self._decompose(func, dj_function, query_ast)
-                    if result:
-                        # Apply combiner to AST
-                        func.parent.replace(from_=func, to=result.combiner)  # type: ignore
-                        # Collect unique components
-                        for comp in sorted(result.components, key=lambda m: m.name):
-                            if comp.name not in components_tracker:
-                                components_tracker.add(comp.name)
-                                components.append(comp)
+                    agg_funcs.append((func, dj_function))
+
+            # If any aggregation is non-decomposable, abort decomposition
+            # entirely — the metric is non-decomposable as a whole.
+            if any(get_decomposition(dj_fn) is None for _, dj_fn in agg_funcs):
+                return [], query_ast
+
+            for func, dj_function in agg_funcs:
+                result = self._decompose(func, dj_function, query_ast)
+                if result:  # pragma: no branch
+                    # Apply combiner to AST
+                    func.parent.replace(from_=func, to=result.combiner)  # type: ignore
+                    # Collect unique components
+                    for comp in sorted(result.components, key=lambda m: m.name):
+                        if comp.name not in components_tracker:
+                            components_tracker.add(comp.name)
+                            components.append(comp)
 
         return components, query_ast
 

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -83,7 +83,7 @@ async def test_list_all_namespaces(
         {"namespace": "different.basic.transform", "num_nodes": 1},
         {"namespace": "foo.bar", "num_nodes": 26},
         {"namespace": "hll", "num_nodes": 4},
-        {"namespace": "v3", "num_nodes": 46},
+        {"namespace": "v3", "num_nodes": 47},
     ]
 
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -353,6 +353,7 @@ async def test_get_nodes_with_details(client_with_examples: AsyncClient):
         "v3.aov_growth_index",
         "v3.efficiency_ratio",
         "v3.wow_aov_change",
+        "v3.first_product_when_any_quantity",
     }
 
 

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -3684,6 +3684,131 @@ class TestNonDecomposableMetrics:
             """,
         )
 
+    @pytest.mark.asyncio
+    async def test_mixed_decomposable_metric_is_non_decomposable(
+        self,
+        session,
+        client_with_build_v3,
+    ):
+        """
+        A metric mixing decomposable (MAX) and non-decomposable (MIN_BY)
+        aggregations must be treated as non-decomposable as a whole.
+
+        Pre-aggregating the MAX side alone would silently drop columns
+        referenced only inside MIN_BY (here ``product_id`` and
+        ``order_date``) from the CTE projection — and downstream consumers
+        that compute the metric expression against the measures table
+        would fail with missing-column errors.
+
+        Expected behavior: the metric is routed through the
+        non-decomposable pass-through path at native grain
+        (``order_id`` + ``line_number``), with raw rows projecting every
+        column the metric expression references.
+        """
+        result = await build_measures_sql(
+            session=session,
+            metrics=["v3.first_product_when_any_quantity"],
+            dimensions=["v3.order_details.status"],
+        )
+
+        assert len(result.grain_groups) == 1
+        gg = result.grain_groups[0]
+        # No pre-aggregation possible because MIN_BY is non-decomposable.
+        assert gg.aggregability.value == "none"
+        # Native grain of v3.order_details (the order_details PK columns).
+        assert set(gg.grain) == {"order_id", "line_number"}
+
+        # Pass-through SQL: every column referenced by the metric expression
+        # (`quantity`, `product_id`, `order_date`) plus grain + requested
+        # dimension (`status`) is in the projection, with no GROUP BY.
+        assert_sql_equal(
+            gg.sql,
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.line_number,
+                o.order_date,
+                o.status,
+                oi.product_id,
+                oi.quantity
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT
+              t1.status,
+              t1.order_id,
+              t1.line_number,
+              t1.quantity,
+              t1.product_id,
+              t1.order_date
+            FROM v3_order_details t1
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_decomposable_metric_merged_with_non_decomposable(
+        self,
+        session,
+        client_with_build_v3,
+    ):
+        """
+        FULL + NONE metrics on the same parent must merge into a single
+        grain group at the worst-case (NONE) aggregability, carrying both
+        the decomposable components and the non-decomposable metrics
+        through to the response.
+
+        Without proper merging, ``_merge_parent_grain_groups`` would
+        forget to carry over ``non_decomposable_metrics`` and silently
+        drop the non-decomposable metric from the output.
+
+        The emitted CTE must:
+        1. Include both metrics in ``metrics`` (no silent drop).
+        2. Project every column referenced by the non-decomposable
+           expression (here ``product_id``, ``line_total``) alongside
+           the decomposable component's source column (``line_total``).
+        3. Emit no GROUP BY on the outer SELECT — the merged grain is
+           NONE, so the downstream consumer applies aggregations after
+           the join.
+        """
+        result = await build_measures_sql(
+            session=session,
+            metrics=["v3.total_revenue", "v3.top_product_by_revenue"],
+            dimensions=["v3.order_details.status"],
+        )
+
+        # Both metrics merged into one grain group at NONE.
+        assert len(result.grain_groups) == 1
+        gg = result.grain_groups[0]
+        assert gg.aggregability.value == "none"
+        assert set(gg.metrics) == {
+            "v3.total_revenue",
+            "v3.top_product_by_revenue",
+        }
+
+        assert_sql_equal(
+            gg.sql,
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.line_number,
+                o.status,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT
+              t1.status,
+              t1.line_number,
+              t1.order_id,
+              t1.line_total AS line_total,
+              t1.product_id AS product_id
+            FROM v3_order_details t1
+            """,
+        )
+
 
 class TestCombinedMeasuresSQLEndpoint:
     """Tests for the /sql/measures/v3/combined endpoint."""

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -3803,8 +3803,8 @@ class TestNonDecomposableMetrics:
               t1.status,
               t1.line_number,
               t1.order_id,
-              t1.line_total AS line_total,
-              t1.product_id AS product_id
+              t1.line_total line_total,
+              t1.product_id product_id
             FROM v3_order_details t1
             """,
         )

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -1818,6 +1818,123 @@ class TestNonDecomposableMetrics:
         )
 
     @pytest.mark.asyncio
+    async def test_mixed_decomposable_metric_is_non_decomposable(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        Mixed decomposable + non-decomposable metric via /sql/metrics/v3.
+
+        ``v3.first_product_when_any_quantity`` mixes ``MAX(quantity)`` with
+        ``MIN_BY(product_id, order_date)``.  The whole metric is forced
+        non-decomposable, the measures CTE passes raw rows through at
+        native grain with every referenced column projected, and the
+        final SELECT applies the original metric expression verbatim
+        over those rows.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.first_product_when_any_quantity"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.line_number,
+                o.order_date,
+                o.status,
+                oi.product_id,
+                oi.quantity
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+              SELECT
+                t1.status,
+                t1.order_id,
+                t1.line_number,
+                t1.quantity,
+                t1.product_id,
+                t1.order_date
+              FROM v3_order_details t1
+            )
+            SELECT
+              order_details_0.status AS status,
+              IF(
+                MAX(order_details_0.quantity) IS NOT NULL,
+                MIN_BY(order_details_0.product_id, order_details_0.order_date),
+                NULL
+              ) AS first_product_when_any_quantity
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_decomposable_metric_combined_with_non_decomposable(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        FULL + NONE metrics on the same parent via /sql/metrics/v3.
+
+        Requests ``v3.total_revenue`` (SUM/FULL) and
+        ``v3.top_product_by_revenue`` (MAX_BY/NONE).  The merged grain
+        group passes raw rows through (no GROUP BY at the measures CTE),
+        and the final metrics SELECT applies SUM and MAX_BY downstream.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": [
+                    "v3.total_revenue",
+                    "v3.top_product_by_revenue",
+                ],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH v3_order_details AS (
+              SELECT
+                o.order_id,
+                oi.line_number,
+                o.status,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+              SELECT
+                t1.status,
+                t1.line_number,
+                t1.order_id,
+                t1.line_total line_total,
+                t1.product_id product_id
+              FROM v3_order_details t1
+            )
+            SELECT
+              order_details_0.status AS status,
+              SUM(order_details_0.line_total) AS total_revenue,
+              MAX_BY(order_details_0.product_id, order_details_0.line_total)
+                AS top_product_by_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_trailing_wow_metrics(self, client_with_build_v3):
         """
         Test trailing/rolling week-over-week metrics.

--- a/datajunction-server/tests/examples.py
+++ b/datajunction-server/tests/examples.py
@@ -3484,6 +3484,29 @@ BUILD_V3 = (  # type: ignore
             "mode": "published",
         },
     ),
+    # Mixed decomposable + non-decomposable aggregations — the whole metric
+    # must be treated as non-decomposable since MIN_BY can't be
+    # pre-aggregated alongside MAX.
+    (
+        "/nodes/metric/",
+        {
+            "name": "v3.first_product_when_any_quantity",
+            "description": (
+                "Product id of the earliest line with a quantity, only if any "
+                "line had a quantity at all.  Mixes MAX (decomposable) with "
+                "MIN_BY (non-decomposable) so the metric is non-decomposable "
+                "overall."
+            ),
+            "query": (
+                "SELECT IF("
+                "MAX(quantity) IS NOT NULL, "
+                "MIN_BY(product_id, order_date), "
+                "NULL"
+                ") FROM v3.order_details"
+            ),
+            "mode": "published",
+        },
+    ),
     # Conditional Aggregation (SUM with CASE WHEN)
     (
         "/nodes/metric/",

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -901,6 +901,47 @@ async def test_min_by(session: AsyncSession, create_metric):
 
 
 @pytest.mark.asyncio
+async def test_mixed_decomposable_and_non_decomposable_aggs(
+    session: AsyncSession,
+    create_metric,
+):
+    """
+    A metric mixing decomposable (MAX) and non-decomposable (MIN_BY)
+    aggregations is treated as non-decomposable as a whole.
+
+    Otherwise the MAX would produce a component while MIN_BY would not,
+    leaving the metric's column-dependency set incomplete:
+    column-pruning on the parent CTE would drop columns referenced only
+    inside MIN_BY (e.g. ``recovery_user_retry``, ``period_recovery_utc_ms``),
+    and the downstream measures table would be missing them.
+
+    Expected behavior: empty components list, derived AST preserved verbatim,
+    so the consumer routes the metric through the non-decomposable
+    pass-through path at native grain.
+    """
+    metric_rev = await create_metric(
+        "SELECT IF("
+        "MAX(recovered_cnt) IS NOT NULL, "
+        "MIN_BY(recovery_user_retry, period_recovery_utc_ms), "
+        "NULL"
+        ") FROM parent_node",
+    )
+    extractor = MetricComponentExtractor(metric_rev.id)
+    measures, derived_sql = await extractor.extract(session)
+    assert measures == []
+    # The query is preserved verbatim — MAX is NOT replaced with a combiner,
+    # since the whole metric is non-decomposable.
+    assert_sql_equal(
+        str(derived_sql),
+        "SELECT IF("
+        "MAX(recovered_cnt) IS NOT NULL, "
+        "MIN_BY(recovery_user_retry, period_recovery_utc_ms), "
+        "NULL"
+        ") FROM parent_node",
+    )
+
+
+@pytest.mark.asyncio
 async def test_approx_count_distinct(session: AsyncSession, create_metric):
     """
     Test decomposition for an approximate count distinct metric.


### PR DESCRIPTION
### Summary

When a metric mixes a decomposable aggregation (e.g., `MAX`, `SUM`, `COUNT` etc) with a non-decomposable one (e.g., `MIN_BY`, `MAX_BY`) in the same expression, `/sql/measures/v3` generates the wrong measures SQL.

If any aggregation in a metric is non-decomposable, we treat the whole metric as non-decomposable and pass the raw rows through the measures CTE. Previously we tried to pre-aggregate the decomposable parts and silently dropped columns that only appeared inside the non-decomposable function, breaking downstream consumers.

Three changes:
1. Carry non-decomposable metrics through grain-group merging. `_merge_parent_grain_groups` was forgetting `non_decomposable_metrics` when merging buckets, so the non-decomposable metric would disappear from the response.
2. Skip the outer `GROUP BY` when the merged grain is NONE. Since aggregations happen downstream for non-decomposable metrics, the `GROUP BY` at the measures level was redundant.
3. Dedupe column projections -- if a column is referenced both by a component (e.g. `SUM(line_total)`) and inside a non-decomposable function (e.g. `MAX_BY(product_id, line_total)`), only project it once.

### Test Plan

- Unit test that a metric mixing `MAX` with `MIN_BY` decomposes to empty components and an untouched AST.
- End-to-end test that the same mixed metric produces a pass-through measures SQL with every referenced column in the projection and no `GROUP BY`.
- End-to-end test combining a `SUM` metric with a `MAX_BY` metric on the same parent.

### Deployment Plan

<!-- Any special instructions around deployment? -->
