### PR TITLE
Fix various add-edit node form bugs

### DIFF
--- a/datajunction-ui/src/app/pages/AddEditNodePage/MetricQueryField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/MetricQueryField.jsx
@@ -15,7 +15,12 @@ export const MetricQueryField = ({ djClient, value }) => {
   const [schema, setSchema] = React.useState({});
   const [availableMetrics, setAvailableMetrics] = React.useState([]);
   const formik = useFormikContext();
-  const sqlExt = langs.sql({ schema: schema });
+  const upstreamNode = formik.values['upstream_node'];
+  // Memoize the sql extension on schema so it only rebuilds when the schema
+  // actually changes. Without this, every parent render produces a new
+  // sqlExt reference and CodeMirror re-registers extensions — which closes
+  // any open autocomplete dropdown.
+  const sqlExt = React.useMemo(() => langs.sql({ schema }), [schema]);
 
   // Load available metrics for derived metric autocomplete
   React.useEffect(() => {
@@ -30,38 +35,39 @@ export const MetricQueryField = ({ djClient, value }) => {
     fetchMetrics();
   }, [djClient]);
 
-  const initialAutocomplete = async context => {
-    const newSchema = {};
-    const nodeName = formik.values['upstream_node'];
-
-    // If an upstream node is selected, load its columns for regular metrics
-    if (nodeName && nodeName.trim() !== '') {
-      try {
-        const nodeDetails = await djClient.node(nodeName);
-        if (nodeDetails && nodeDetails.columns) {
-          nodeDetails.columns.forEach(col => {
-            newSchema[col.name] = [];
+  // Build the autocomplete schema once when upstream node or metrics change.
+  // Doing this from inside an autocomplete source (per keystroke) caused a
+  // re-render mid-completion which dismissed the dropdown.
+  React.useEffect(() => {
+    let cancelled = false;
+    async function loadSchema() {
+      const next = {};
+      if (upstreamNode && upstreamNode.trim() !== '') {
+        try {
+          const nodeDetails = await djClient.node(upstreamNode);
+          nodeDetails?.columns?.forEach(col => {
+            next[col.name] = [];
           });
+        } catch (err) {
+          console.error('Failed to load upstream node columns:', err);
         }
-      } catch (err) {
-        console.error('Failed to load upstream node columns:', err);
       }
+      availableMetrics.forEach(metricName => {
+        next[metricName] = [];
+      });
+      if (!cancelled) setSchema(next);
     }
-
-    // Always include available metrics for derived metric expressions
-    availableMetrics.forEach(metricName => {
-      newSchema[metricName] = [];
-    });
-
-    setSchema(newSchema);
-  };
+    loadSchema();
+    return () => {
+      cancelled = true;
+    };
+  }, [djClient, upstreamNode, availableMetrics]);
 
   const updateFormik = val => {
     formik.setFieldValue('aggregate_expression', val);
   };
 
   // Determine the label and help text based on whether upstream is selected
-  const upstreamNode = formik.values['upstream_node'];
   const isDerivedMode = !upstreamNode || upstreamNode.trim() === '';
   const labelText = isDerivedMode
     ? 'Derived Metric Expression *'
@@ -91,12 +97,7 @@ export const MetricQueryField = ({ djClient, value }) => {
         <CodeMirror
           id={'aggregate_expression'}
           name={'aggregate_expression'}
-          extensions={[
-            sqlExt,
-            sqlExt.language.data.of({
-              autocomplete: initialAutocomplete,
-            }),
-          ]}
+          extensions={[sqlExt]}
           value={value}
           options={{
             theme: 'default',
@@ -107,7 +108,7 @@ export const MetricQueryField = ({ djClient, value }) => {
           style={{
             margin: '0 0 23px 0',
             flex: 1,
-            fontSize: '150%',
+            fontSize: '110%',
             textAlign: 'left',
           }}
           onChange={(value, viewUpdate) => {

--- a/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
@@ -15,9 +15,13 @@ import {
 import { djEditorExtensions } from './djEditorTheme';
 
 export const NodeQueryField = ({ djClient, value }) => {
-  const [schema, setSchema] = React.useState([]);
+  // Schema is `{ [nodeName]: string[] }` — passed to @codemirror/lang-sql so
+  // it can offer table + column autocompletion. Must be an OBJECT, not array,
+  // and every update must produce a new reference so React re-renders and
+  // langs.sql() rebuilds with the latest map.
+  const [schema, setSchema] = React.useState({});
   const formik = useFormikContext();
-  const sqlExt = langs.sql({ schema: schema });
+  const sqlExt = React.useMemo(() => langs.sql({ schema }), [schema]);
   const autoRegisterTimer = React.useRef(null);
   const validateTimer = React.useRef(null);
   const registeredTables = React.useRef(new Set());
@@ -64,11 +68,16 @@ export const NodeQueryField = ({ djClient, value }) => {
     // to save on unnecessary calls
     const word = context.matchBefore(/[\.\w]*/);
     const matches = await djClient.nodes(word.text);
-    matches.forEach(nodeName => {
-      if (schema[nodeName] === undefined) {
-        schema[nodeName] = [];
-        setSchema(schema);
+    setSchema(prev => {
+      const next = { ...prev };
+      let changed = false;
+      for (const nodeName of matches) {
+        if (next[nodeName] === undefined) {
+          next[nodeName] = [];
+          changed = true;
+        }
       }
+      return changed ? next : prev;
     });
   };
 
@@ -78,16 +87,14 @@ export const NodeQueryField = ({ djClient, value }) => {
 
   const updateAutocomplete = async (value, _) => {
     // If a particular node has been chosen, load the columns of that node into
-    // the autocomplete schema for column-level autocompletion
-    for (var nodeName in schema) {
-      if (
-        value.includes(nodeName) &&
-        (!schema.hasOwnProperty(nodeName) ||
-          (schema.hasOwnProperty(nodeName) && schema[nodeName].length === 0))
-      ) {
+    // the autocomplete schema for column-level autocompletion. Mutate via a
+    // functional setState so every update produces a new map reference and
+    // langs.sql sees the change.
+    for (const nodeName of Object.keys(schema)) {
+      if (value.includes(nodeName) && schema[nodeName].length === 0) {
         const nodeDetails = await djClient.node(nodeName);
-        schema[nodeName] = nodeDetails.columns.map(col => col.name);
-        setSchema(schema);
+        const cols = (nodeDetails?.columns || []).map(col => col.name);
+        setSchema(prev => ({ ...prev, [nodeName]: cols }));
       }
     }
 
@@ -199,11 +206,11 @@ export const NodeQueryField = ({ djClient, value }) => {
       if (status === 200 || status === 201) {
         const nodeName = json?.name || key;
         const columns = (json?.columns || []).map(col => col.name);
-        schema[nodeName] = columns;
-        if (table && table !== nodeName) {
-          schema[table] = columns;
-        }
-        setSchema(schema);
+        setSchema(prev => {
+          const next = { ...prev, [nodeName]: columns };
+          if (table && table !== nodeName) next[table] = columns;
+          return next;
+        });
         setStatus(key, { kind: 'valid' });
       } else if (status === 409) {
         // 409 = already exists; treat as valid.

--- a/datajunction-ui/src/app/pages/AddEditNodePage/OwnersField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/OwnersField.jsx
@@ -1,7 +1,7 @@
 /**
  * Owner select field
  */
-import { ErrorMessage } from 'formik';
+import { ErrorMessage, useField } from 'formik';
 import { useContext, useEffect, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
 import { useCurrentUser } from '../../providers/UserProvider';
@@ -10,6 +10,7 @@ import { FormikSelect } from './FormikSelect';
 export const OwnersField = ({ defaultValue }) => {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
   const { currentUser } = useCurrentUser();
+  const [, meta, helpers] = useField('owners');
 
   const [availableUsers, setAvailableUsers] = useState([]);
 
@@ -28,6 +29,22 @@ export const OwnersField = ({ defaultValue }) => {
     fetchData();
   }, [djClient]);
 
+  // Seed the Formik `owners` field — FormikSelect's `defaultValue` prop
+  // is ignored because the inner <Select> uses Formik's field state.
+  // - Edit mode: seed from `defaultValue` (option objects)
+  // - Add mode: seed with currentUser so creators don't have to set
+  //   themselves as an owner manually
+  // Only seed if the field is still empty (the user hasn't touched it).
+  useEffect(() => {
+    if (meta.value && meta.value.length > 0) return;
+    if (defaultValue && defaultValue.length > 0) {
+      helpers.setValue(defaultValue.map(d => d.value));
+    } else if (currentUser) {
+      helpers.setValue([currentUser.username]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultValue, currentUser]);
+
   return defaultValue || currentUser ? (
     <div className="NodeCreationInput">
       <ErrorMessage name="owners" component="span" />
@@ -35,11 +52,6 @@ export const OwnersField = ({ defaultValue }) => {
       <span data-testid="select-owner">
         <FormikSelect
           className=""
-          defaultValue={
-            defaultValue || [
-              { value: currentUser.username, label: currentUser.username },
-            ]
-          }
           selectOptions={availableUsers}
           formikFieldName="owners"
           placeholder="Select Owners"

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -59,7 +59,18 @@ export function AddEditNodePage({ extensions = {} }) {
 
   const validator = values => {
     const errors = {};
-    if (!values.name) {
+    // Display name drives the synthesized full name (`namespace.display_name`).
+    // Without it the full name collapses to `namespace.` — non-empty but
+    // useless. Validate the user-facing field instead of the derived one.
+    if (action === Action.Add && !values.display_name?.trim()) {
+      errors.display_name = 'Required';
+    }
+    if (
+      !values.name ||
+      values.name.endsWith('.') ||
+      values.name.startsWith('.') ||
+      values.name.includes('..')
+    ) {
       errors.name = 'Required';
     }
     if (values.type !== 'metric' && !values.query) {


### PR DESCRIPTION
### Summary

This fixes various add/edit node form bugs surfaced after the layout rework.
  - Owners auto-seed on create. `OwnersField` now seeds the Formik owners field with the current username once `currentUser` resolves, so creators don't have to set themselves as owner manually.
  - Validator rejects empty/trailing-dot names. The backend should also reject these (separate fix).
  - Re-enable auto-complete on schemas in `NodeQueryField`.
  - Ensure that in `MetricQueryField`, the autocomplete dropdown stays open.
  - Reduced metric expression font size to match other fields.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
