### PR TITLE
Handle deletion of namespaces during `dj push`

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -279,9 +279,12 @@ class DeploymentPlan:
     existing_specs: dict[str, NodeSpec]
     node_graph: dict[str, list[str]]
     external_deps: set[str]
+    to_delete_namespaces: list[str] = field(default_factory=list)
 
     def is_empty(self) -> bool:
-        return not self.to_deploy and not self.to_delete
+        return (
+            not self.to_deploy and not self.to_delete and not self.to_delete_namespaces
+        )
 
     @property
     def linked_dimension_nodes(self) -> set[str]:
@@ -742,6 +745,35 @@ class DeploymentOrchestrator:
 
         return all_namespaces
 
+    async def _find_namespaces_to_delete(self) -> list[str]:
+        """
+        Identify child namespaces of the deployment namespace that no longer
+        appear in the local spec (folder structure) and should be pruned.
+
+        The root deployment namespace itself is never returned — ``dj push``
+        syncs *contents* of the namespace, not the namespace itself.
+        """
+        deployment_namespace = self.deployment_spec.namespace
+        desired = await self._find_namespaces_to_create()
+        existing = (
+            (
+                await self.session.execute(
+                    select(NodeNamespace.namespace).where(
+                        NodeNamespace.namespace.like(f"{deployment_namespace}.%"),
+                    ),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Deepest-first so children are removed before their parents (the
+        # parent_namespace FK is ON DELETE RESTRICT).
+        return sorted(
+            (ns for ns in existing if ns not in desired),
+            key=lambda ns: (ns.count(SEPARATOR), ns),
+            reverse=True,
+        )
+
     async def _setup_namespaces(self) -> list[NodeNamespace]:
         namespace_start = time.perf_counter()
         to_create = await self._find_namespaces_to_create()
@@ -1061,6 +1093,10 @@ class DeploymentOrchestrator:
                 f"{len(to_deploy)} deploy, {len(to_skip)} skip, {len(to_delete)} delete",
             )
 
+        with self._timer.phase("  plan: diff namespaces") as p:
+            to_delete_namespaces = await self._find_namespaces_to_delete()
+            p.append(f"{len(to_delete_namespaces)} namespaces")
+
         # Add skipped nodes to results - flag nodes that are still invalid
         for node_spec in to_skip:
             existing_node = self.registry.nodes.get(node_spec.rendered_name)
@@ -1195,6 +1231,7 @@ class DeploymentOrchestrator:
                 existing_specs=existing_specs,
                 node_graph=node_graph,
                 external_deps=external_deps,
+                to_delete_namespaces=to_delete_namespaces,
             ),
             pre_results,
         )
@@ -1274,6 +1311,18 @@ class DeploymentOrchestrator:
                 delete_results = await self._delete_nodes(plan.to_delete)
                 p.append(f"{len(delete_results)} deleted")
             self.deployed_results.extend(delete_results)
+            await self._update_deployment_status()
+
+        # Prune child namespaces that no longer appear in the local spec.
+        # Runs after node deletion so namespaces are empty by the time we
+        # try to remove them.
+        if plan.to_delete_namespaces:
+            with timer.phase("delete namespaces") as p:
+                ns_results = await self._delete_namespaces(
+                    plan.to_delete_namespaces,
+                )
+                p.append(f"{len(ns_results)} namespaces")
+            self.deployed_results.extend(ns_results)
             await self._update_deployment_status()
 
         return downstream
@@ -2600,6 +2649,76 @@ class DeploymentOrchestrator:
                 operation=DeploymentResult.Operation.DELETE,
                 message=str(exc),
             )
+
+    async def _delete_namespaces(
+        self,
+        namespaces: list[str],
+    ) -> list[DeploymentResult]:
+        """
+        Hard-delete child ``NodeNamespace`` rows that are no longer referenced
+        by the local spec. ``namespaces`` must be sorted deepest-first so the
+        ``parent_namespace`` self-FK (ON DELETE RESTRICT) doesn't trip.
+
+        Skips any namespace that still has nodes — that means a node delete
+        was blocked earlier (e.g. external references). Per-result FAILED
+        entries surface the reason to the caller.
+        """
+        results: list[DeploymentResult] = []
+        for ns in namespaces:
+            remaining_nodes = (
+                await self.session.execute(
+                    select(func.count())
+                    .select_from(Node)
+                    .where(Node.namespace == ns)
+                    .where(Node.deactivated_at.is_(None)),
+                )
+            ).scalar() or 0
+            if remaining_nodes:
+                results.append(
+                    DeploymentResult(
+                        name=ns,
+                        deploy_type=DeploymentResult.Type.NAMESPACE,
+                        status=DeploymentResult.Status.FAILED,
+                        operation=DeploymentResult.Operation.DELETE,
+                        message=(
+                            f"Cannot delete namespace '{ns}' — {remaining_nodes} "
+                            "node(s) remain (likely blocked by external references)."
+                        ),
+                    ),
+                )
+                continue
+
+            ns_row = await get_node_namespace(
+                session=self.session,
+                namespace=ns,
+                raise_if_not_exists=False,
+            )
+            if not ns_row:  # pragma: no cover
+                continue
+            try:
+                await self.session.delete(ns_row)
+                await self.session.flush()
+                results.append(
+                    DeploymentResult(
+                        name=ns,
+                        deploy_type=DeploymentResult.Type.NAMESPACE,
+                        status=DeploymentResult.Status.SUCCESS,
+                        operation=DeploymentResult.Operation.DELETE,
+                        message=f"Namespace {ns} has been removed.",
+                    ),
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.exception(exc)
+                results.append(
+                    DeploymentResult(
+                        name=ns,
+                        deploy_type=DeploymentResult.Type.NAMESPACE,
+                        status=DeploymentResult.Status.FAILED,
+                        operation=DeploymentResult.Operation.DELETE,
+                        message=str(exc),
+                    ),
+                )
+        return results
 
     def filter_nodes_to_deploy(
         self,

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -781,6 +781,7 @@ class DeploymentResult(BaseModel):
         NODE = "node"
         LINK = "link"
         TAG = "tag"
+        NAMESPACE = "namespace"
         GENERAL = "general"
 
     name: str

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2330,7 +2330,12 @@ class TestDeployments:
             client,
             DeploymentSpec(namespace=namespace, nodes=[]),
         )
-        assert data["results"][-1] == {
+        deletes = {
+            (r["deploy_type"], r["name"]): r
+            for r in data["results"]
+            if r["operation"] == "delete"
+        }
+        assert deletes[("node", "node_update.default.hard_hats")] == {
             "deploy_type": "node",
             "message": "Node node_update.default.hard_hats has been removed.",
             "name": "node_update.default.hard_hats",
@@ -2338,6 +2343,76 @@ class TestDeployments:
             "changed_fields": [],
             "status": "success",
         }
+        # The child namespace is no longer referenced by any local node —
+        # dj push syncs the namespace with the folder, so it should be
+        # pruned. The deployment root namespace itself is preserved.
+        assert deletes[("namespace", "node_update.default")] == {
+            "deploy_type": "namespace",
+            "message": "Namespace node_update.default has been removed.",
+            "name": "node_update.default",
+            "operation": "delete",
+            "changed_fields": [],
+            "status": "success",
+        }
+        assert ("namespace", "node_update") not in deletes
+
+    @pytest.mark.asyncio
+    async def test_deploy_prunes_nested_namespaces(
+        self,
+        client,
+    ):
+        """
+        dj push should sync the namespace with the spec contents: when a
+        whole sub-namespace's nodes disappear from the spec, the matching
+        ``NodeNamespace`` rows are pruned too (deepest-first), but the
+        deployment root namespace itself is preserved.
+        """
+        namespace = "ns_sync"
+
+        def src(name: str) -> SourceSpec:
+            return SourceSpec(
+                name=name,
+                catalog="default",
+                schema="roads",
+                table=name.rsplit(".", 1)[-1],
+                columns=[ColumnSpec(name="id", type="int")],
+            )
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace=namespace,
+                nodes=[src("a.deep.x"), src("b.y")],
+            ),
+        )
+        assert data["status"] == "success"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace=namespace,
+                nodes=[src("a.deep.x")],
+            ),
+        )
+        deletes = {
+            (r["deploy_type"], r["name"])
+            for r in data["results"]
+            if r["operation"] == "delete" and r["status"] == "success"
+        }
+        assert ("node", "ns_sync.b.y") in deletes
+        assert ("namespace", "ns_sync.b") in deletes
+        # Surviving branch and the deployment root are preserved.
+        assert ("namespace", "ns_sync.a") not in deletes
+        assert ("namespace", "ns_sync.a.deep") not in deletes
+        assert ("namespace", "ns_sync") not in deletes
+
+        # Verify on the server: ns_sync.b is gone, the rest remain.
+        resp = await client.get("/namespaces/")
+        all_namespaces = {n["namespace"] for n in resp.json()}
+        assert "ns_sync" in all_namespaces
+        assert "ns_sync.a" in all_namespaces
+        assert "ns_sync.a.deep" in all_namespaces
+        assert "ns_sync.b" not in all_namespaces
 
     @pytest.mark.asyncio
     async def test_deploy_tags(

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2415,6 +2415,100 @@ class TestDeployments:
         assert "ns_sync.b" not in all_namespaces
 
     @pytest.mark.asyncio
+    async def test_deploy_namespace_prune_blocked_by_external_ref(
+        self,
+        client,
+    ):
+        """
+        When a node delete is blocked because it's referenced by a node
+        outside the deployment, the surrounding namespace can't be pruned
+        either — surface that as a FAILED namespace result instead of
+        silently dropping the row or letting the FK trip.
+        """
+        source = SourceSpec(
+            name="drop.metric_b",
+            catalog="default",
+            schema="roads",
+            table="metric_b",
+            columns=[ColumnSpec(name="id", type="int")],
+        )
+
+        await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace="blocked_sync",
+                nodes=[
+                    SourceSpec(
+                        name="keep.metric_a",
+                        catalog="default",
+                        schema="roads",
+                        table="metric_a",
+                        columns=[ColumnSpec(name="id", type="int")],
+                    ),
+                    source,
+                ],
+            ),
+        )
+
+        # Outside deployment that depends on blocked_sync.drop.metric_b —
+        # establishes the NodeRelationship that blocks deletion later.
+        await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace="outside_ns",
+                nodes=[
+                    TransformSpec(
+                        name="consumer",
+                        description="External consumer of blocked_sync.drop.metric_b",
+                        query="SELECT id FROM blocked_sync.drop.metric_b",
+                        dimension_links=[],
+                        owners=["dj"],
+                    ),
+                ],
+            ),
+        )
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace="blocked_sync",
+                nodes=[
+                    SourceSpec(
+                        name="keep.metric_a",
+                        catalog="default",
+                        schema="roads",
+                        table="metric_a",
+                        columns=[ColumnSpec(name="id", type="int")],
+                    ),
+                ],
+            ),
+        )
+
+        node_delete = next(
+            r
+            for r in data["results"]
+            if r["deploy_type"] == "node"
+            and r["name"] == "blocked_sync.drop.metric_b"
+            and r["operation"] == "delete"
+        )
+        assert node_delete["status"] == "failed"
+        assert "outside_ns.consumer" in node_delete["message"]
+
+        ns_delete = next(
+            r
+            for r in data["results"]
+            if r["deploy_type"] == "namespace" and r["name"] == "blocked_sync.drop"
+        )
+        assert ns_delete["status"] == "failed"
+        assert ns_delete["operation"] == "delete"
+        assert "1 node(s) remain" in ns_delete["message"]
+
+        # Namespace row is still present on the server.
+        resp = await client.get("/namespaces/")
+        all_namespaces = {n["namespace"] for n in resp.json()}
+        assert "blocked_sync.drop" in all_namespaces
+
+    @pytest.mark.asyncio
     async def test_deploy_tags(
         self,
         session,


### PR DESCRIPTION
### Summary

`dj push ./nodes --namespace <ns>` was supposed to sync the server-side namespace with the contents of the folder, but child namespaces were never pruned. If you deleted a sub-folder locally, the nodes inside it got removed but the empty namespace lingered on the server, breaking the "this folder is the source of truth" mental model during deployments.

This PR adds server-side namespace pruning in the deployment orchestrator. During plan creation, we diff the existing child namespaces under the deployment root against the desired set (built from local nodes' rendered names). Anything in the diff gets removed after node deletion, deepest-first. These changes are dry-run aware, so that calls to `POST /deployments/impact` also surface upcoming namespace deletions in its results.
 
This also adds a new result type: `DeploymentResult.Type.NAMESPACE` so that namespace operations show up distinctly in the deployment report alongside node / link / tag.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
