### PR TITLE
Remove deleted files as a part of the git sync path

### DIFF
--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -132,6 +132,8 @@ class SyncNamespaceResult(BaseModel):
 
     namespace: str
     files_synced: int
+    files_deleted: int = 0
+    deleted_paths: List[str] = []
     commit_sha: Optional[str] = None  # None if no changes detected
     commit_url: Optional[str] = None  # None if no changes detected
     results: List[SyncResult]
@@ -450,10 +452,9 @@ async def sync_namespace_to_git(
         git_path,
     )
 
-    if not files:
-        raise DJInvalidInputException(
-            message=f"Namespace '{namespace}' has no nodes to sync.",
-        )
+    # Note: we don't raise on `not files` here — the namespace may have had all
+    # of its nodes deactivated, in which case we still want to push the
+    # corresponding deletions to git below.
 
     # Filter out unchanged files (semantic comparison), unless force=True
     files_to_commit: List[dict] = []
@@ -488,28 +489,42 @@ async def sync_namespace_to_git(
             namespace,
         )
 
+    # Detect orphan files: YAML files in the existing git tree that no longer
+    # correspond to any active node in this namespace (e.g., because the node
+    # was deactivated). The git branch is assumed to belong wholly to this
+    # namespace, so any orphan under git_path is safe to delete.
+    expected_paths = {file_info["path"] for file_info in files}
+    paths_to_delete = sorted(
+        path
+        for path in existing_files_map
+        if path not in expected_paths and Path(path).name != "dj.yaml"
+    )
+
     results: List[SyncResult] = []
+
+    # If nothing changed and no orphans need deleting, return without even
+    # instantiating GitHubService (which has auth-config requirements).
+    if not files_to_commit and not paths_to_delete:
+        _logger.info(
+            "No changes detected for namespace '%s' - skipping commit",
+            namespace,
+        )
+        return SyncNamespaceResult(
+            namespace=namespace,
+            files_synced=0,
+            files_deleted=0,
+            deleted_paths=[],
+            commit_sha=None,
+            commit_url=None,
+            results=[],
+        )
 
     try:
         github = GitHubService()
 
-        # If no files have changed, return early without making a commit
-        if not files_to_commit:
-            _logger.info(
-                "No changes detected for namespace '%s' - skipping commit",
-                namespace,
-            )
-            return SyncNamespaceResult(
-                namespace=namespace,
-                files_synced=0,
-                commit_sha=None,
-                commit_url=None,
-                results=[],
-            )
-
         commit_message = request.commit_message or f"Sync {namespace}"
 
-        # Batch commit all files in a single commit
+        # Batch commit all files (and deletions) in a single commit
         commit_result = await github.commit_files(
             repo_path=github_repo_path,
             files=[
@@ -520,6 +535,7 @@ async def sync_namespace_to_git(
             co_author_name=current_user.username,
             co_author_email=current_user.email
             or f"{current_user.username}@users.noreply",
+            deletions=paths_to_delete or None,
         )
 
         commit_sha = commit_result["sha"]
@@ -538,15 +554,18 @@ async def sync_namespace_to_git(
             )
 
         _logger.info(
-            "Synced namespace '%s' to git: %d files in single commit (sha: %s)",
+            "Synced namespace '%s' to git: %d files, %d deletions in single commit (sha: %s)",
             namespace,
             len(results),
+            len(paths_to_delete),
             commit_sha[:8] if commit_sha else "none",
         )
 
         return SyncNamespaceResult(
             namespace=namespace,
             files_synced=len(results),
+            files_deleted=len(paths_to_delete),
+            deleted_paths=paths_to_delete,
             commit_sha=commit_sha,
             commit_url=commit_url,
             results=results,

--- a/datajunction-server/datajunction_server/internal/git/github_service.py
+++ b/datajunction-server/datajunction_server/internal/git/github_service.py
@@ -378,8 +378,9 @@ class GitHubService:
         branch: str,
         co_author_name: Optional[str] = None,
         co_author_email: Optional[str] = None,
+        deletions: Optional[list[str]] = None,
     ) -> dict:
-        """Commit multiple files in a single commit using Git Data API.
+        """Commit multiple files (and/or deletions) in a single commit using Git Data API.
 
         This is more efficient than commit_file() when updating multiple files,
         as it creates only one commit instead of one per file.
@@ -395,22 +396,26 @@ class GitHubService:
             branch: Target branch
             co_author_name: Name of user to add as co-author
             co_author_email: Email of user to add as co-author
+            deletions: Optional list of file paths to remove from the tree.
 
         Returns:
             Commit result with 'sha' and 'html_url'
         """
-        if not files:
+        deletions = deletions or []
+        if not files and not deletions:
             raise GitHubServiceError(
                 message="No files to commit",
                 http_status_code=400,
             )
 
         _logger.info(
-            "Batch committing %d files to %s branch '%s': %s",
+            "Batch committing %d files (%d deletions) to %s branch '%s': %s del=%s",
             len(files),
+            len(deletions),
             repo_path,
             branch,
             [f["path"] for f in files],
+            deletions,
         )
 
         async with httpx.AsyncClient() as client:
@@ -433,7 +438,7 @@ class GitHubService:
             base_tree_sha = commit_resp.json()["tree"]["sha"]
 
             # 3. Build tree entries with inline content (no separate blob creation needed)
-            tree_entries = [
+            tree_entries: list[dict] = [
                 {
                     "path": file_info["path"],
                     "mode": "100644",  # Regular file
@@ -442,6 +447,16 @@ class GitHubService:
                 }
                 for file_info in files
             ]
+            # Deletions: a tree entry with sha=None removes the path from base_tree
+            for del_path in deletions:
+                tree_entries.append(
+                    {
+                        "path": del_path,
+                        "mode": "100644",
+                        "type": "blob",
+                        "sha": None,
+                    },
+                )
 
             # 4. Create a new tree with all the files
             tree_resp = await client.post(
@@ -490,6 +505,7 @@ class GitHubService:
                 "sha": new_commit["sha"],
                 "html_url": new_commit["html_url"],
                 "files_committed": len(files),
+                "files_deleted": len(deletions),
             }
 
     async def create_pull_request(

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -2133,6 +2133,163 @@ columns:
             assert not mock_github.commit_files.called
 
     @pytest.mark.asyncio
+    async def test_sync_namespace_deletes_orphan_yamls(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """A YAML in the git tree with no matching active node is deleted in the sync commit.
+
+        Simulates: user deactivates a node in a branch, then clicks "Sync to Git" —
+        the orphan YAML for the deactivated node must be removed from the branch.
+        """
+        client = client_with_service_setup
+
+        await client.post("/namespaces/orphan_test")
+        await client.patch(
+            "/namespaces/orphan_test/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+            },
+        )
+
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "orphan_test.kept_source",
+                "description": "Kept source",
+                "catalog": "default",
+                "schema_": "public",
+                "table": "kept",
+                "columns": [{"name": "id", "type": "int"}],
+            },
+        )
+
+        # YAML for "kept_source" plus an orphan for a node that no longer exists.
+        # dj.yaml should be preserved (filtered out of orphan candidates).
+        orphan_yaml = (
+            "name: ${prefix}removed_node\n"
+            "node_type: source\n"
+            "catalog: default\n"
+            "schema: public\n"
+            "table: removed\n"
+            "columns:\n"
+            "  - name: id\n"
+            "    type: int\n"
+        )
+        kept_yaml = (
+            "name: ${prefix}kept_source\n"
+            "node_type: source\n"
+            "catalog: default\n"
+            "schema: public\n"
+            "table: kept\n"
+            "columns:\n"
+            "  - name: id\n"
+            "    type: int\n"
+        )
+
+        with (
+            patch(
+                "datajunction_server.internal.git.yaml_export.GitHubService",
+            ) as mock_fetch_github_class,
+            patch(
+                "datajunction_server.api.git_sync.GitHubService",
+            ) as mock_commit_github_class,
+        ):
+            mock_github = MagicMock()
+            mock_github.download_archive = AsyncMock(
+                return_value=create_mock_tarball(
+                    {
+                        "kept_source.yaml": kept_yaml,
+                        "removed_node.yaml": orphan_yaml,
+                        "dj.yaml": "name: dj-project\n",
+                    },
+                ),
+            )
+            mock_github.commit_files = AsyncMock(
+                return_value={
+                    "sha": "del-commit-1",
+                    "html_url": "https://github.com/myorg/myrepo/commit/del-commit-1",
+                },
+            )
+            mock_fetch_github_class.return_value = mock_github
+            mock_commit_github_class.return_value = mock_github
+
+            response = await client.post(
+                "/namespaces/orphan_test/sync-to-git",
+                json={},
+            )
+
+            assert response.status_code == HTTPStatus.OK
+            data = response.json()
+            assert data["files_deleted"] == 1
+            assert data["deleted_paths"] == ["removed_node.yaml"]
+            assert data["commit_sha"] == "del-commit-1"
+
+            assert mock_github.commit_files.called
+            call_kwargs = mock_github.commit_files.call_args.kwargs
+            assert call_kwargs["deletions"] == ["removed_node.yaml"]
+
+    @pytest.mark.asyncio
+    async def test_sync_namespace_only_deletions(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """When the namespace has no remaining nodes but orphan YAMLs exist, the sync
+        still commits the deletions (rather than erroring with "no nodes to sync")."""
+        client = client_with_service_setup
+
+        await client.post("/namespaces/only_del")
+        await client.patch(
+            "/namespaces/only_del/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+            },
+        )
+
+        with (
+            patch(
+                "datajunction_server.internal.git.yaml_export.GitHubService",
+            ) as mock_fetch_github_class,
+            patch(
+                "datajunction_server.api.git_sync.GitHubService",
+            ) as mock_commit_github_class,
+        ):
+            mock_github = MagicMock()
+            mock_github.download_archive = AsyncMock(
+                return_value=create_mock_tarball(
+                    {
+                        "gone.yaml": "name: ${prefix}gone\n",
+                    },
+                ),
+            )
+            mock_github.commit_files = AsyncMock(
+                return_value={
+                    "sha": "del-only-1",
+                    "html_url": "https://github.com/myorg/myrepo/commit/del-only-1",
+                },
+            )
+            mock_fetch_github_class.return_value = mock_github
+            mock_commit_github_class.return_value = mock_github
+
+            response = await client.post(
+                "/namespaces/only_del/sync-to-git",
+                json={},
+            )
+
+            assert response.status_code == HTTPStatus.OK
+            data = response.json()
+            assert data["files_synced"] == 0
+            assert data["files_deleted"] == 1
+            assert data["deleted_paths"] == ["gone.yaml"]
+            assert data["commit_sha"] == "del-only-1"
+
+            call_kwargs = mock_github.commit_files.call_args.kwargs
+            assert call_kwargs["files"] == []
+            assert call_kwargs["deletions"] == ["gone.yaml"]
+
+    @pytest.mark.asyncio
     async def test_sync_node_file_doesnt_exist_yet(
         self,
         client_with_roads: AsyncClient,
@@ -2351,7 +2508,7 @@ dimensions:
         self,
         client_with_service_setup: AsyncClient,
     ):
-        """Test syncing an empty namespace."""
+        """Syncing an empty namespace with an empty git tree is a no-op."""
         await client_with_service_setup.post("/namespaces/empty_sync_ns")
         await client_with_service_setup.patch(
             "/namespaces/empty_sync_ns/git",
@@ -2361,15 +2518,24 @@ dimensions:
             },
         )
 
-        response = await client_with_service_setup.post(
-            "/namespaces/empty_sync_ns/sync-to-git",
-            json={},
-        )
-        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-        assert (
-            response.json()["message"]
-            == "Namespace 'empty_sync_ns' has no nodes to sync."
-        )
+        with patch(
+            "datajunction_server.internal.git.yaml_export.GitHubService",
+        ) as mock_fetch_github_class:
+            mock_github = MagicMock()
+            mock_github.download_archive = AsyncMock(
+                return_value=create_mock_tarball({}),
+            )
+            mock_fetch_github_class.return_value = mock_github
+
+            response = await client_with_service_setup.post(
+                "/namespaces/empty_sync_ns/sync-to-git",
+                json={},
+            )
+            assert response.status_code == HTTPStatus.OK
+            data = response.json()
+            assert data["files_synced"] == 0
+            assert data["files_deleted"] == 0
+            assert data["commit_sha"] is None
 
     @pytest.mark.asyncio
     async def test_sync_namespace_no_git_config(

--- a/datajunction-server/tests/internal/git/test_github_service.py
+++ b/datajunction-server/tests/internal/git/test_github_service.py
@@ -759,6 +759,116 @@ class TestCommitFiles:
             assert result["files_committed"] == 2
 
     @pytest.mark.asyncio
+    async def test_commit_files_with_deletions(self, github_service):
+        """Should include deletion tree entries (sha=None) in the new tree."""
+        ref_response = MagicMock()
+        ref_response.is_success = True
+        ref_response.json.return_value = {"object": {"sha": "current-commit-sha"}}
+
+        commit_response = MagicMock()
+        commit_response.is_success = True
+        commit_response.json.return_value = {"tree": {"sha": "base-tree-sha"}}
+
+        tree_response = MagicMock()
+        tree_response.is_success = True
+        tree_response.json.return_value = {"sha": "new-tree-sha"}
+
+        new_commit_response = MagicMock()
+        new_commit_response.is_success = True
+        new_commit_response.json.return_value = {
+            "sha": "new-commit-sha",
+            "html_url": "https://github.com/owner/repo/commit/new-commit-sha",
+        }
+
+        update_ref_response = MagicMock()
+        update_ref_response.is_success = True
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = mock_client.return_value.__aenter__.return_value
+            mock_instance.get = AsyncMock(
+                side_effect=[ref_response, commit_response],
+            )
+            mock_instance.post = AsyncMock(
+                side_effect=[tree_response, new_commit_response],
+            )
+            mock_instance.patch = AsyncMock(return_value=update_ref_response)
+
+            result = await github_service.commit_files(
+                repo_path="owner/repo",
+                files=[{"path": "kept.yaml", "content": "content"}],
+                message="Sync with deletion",
+                branch="main",
+                deletions=["gone.yaml", "also_gone.yaml"],
+            )
+
+            assert result["sha"] == "new-commit-sha"
+            assert result["files_committed"] == 1
+            assert result["files_deleted"] == 2
+
+            # Verify the tree payload contains deletion entries with sha=None
+            tree_call = mock_instance.post.call_args_list[0]
+            tree_payload = tree_call.kwargs["json"]
+            tree_entries = tree_payload["tree"]
+            assert {
+                "path": "gone.yaml",
+                "mode": "100644",
+                "type": "blob",
+                "sha": None,
+            } in tree_entries
+            assert {
+                "path": "also_gone.yaml",
+                "mode": "100644",
+                "type": "blob",
+                "sha": None,
+            } in tree_entries
+
+    @pytest.mark.asyncio
+    async def test_commit_files_only_deletions(self, github_service):
+        """Should commit when only deletions are provided (no file updates)."""
+        ref_response = MagicMock()
+        ref_response.is_success = True
+        ref_response.json.return_value = {"object": {"sha": "sha-a"}}
+
+        commit_response = MagicMock()
+        commit_response.is_success = True
+        commit_response.json.return_value = {"tree": {"sha": "sha-b"}}
+
+        tree_response = MagicMock()
+        tree_response.is_success = True
+        tree_response.json.return_value = {"sha": "sha-c"}
+
+        new_commit_response = MagicMock()
+        new_commit_response.is_success = True
+        new_commit_response.json.return_value = {
+            "sha": "sha-d",
+            "html_url": "https://...",
+        }
+
+        update_ref_response = MagicMock()
+        update_ref_response.is_success = True
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = mock_client.return_value.__aenter__.return_value
+            mock_instance.get = AsyncMock(
+                side_effect=[ref_response, commit_response],
+            )
+            mock_instance.post = AsyncMock(
+                side_effect=[tree_response, new_commit_response],
+            )
+            mock_instance.patch = AsyncMock(return_value=update_ref_response)
+
+            result = await github_service.commit_files(
+                repo_path="owner/repo",
+                files=[],
+                message="Deletions only",
+                branch="main",
+                deletions=["gone.yaml"],
+            )
+
+            assert result["files_committed"] == 0
+            assert result["files_deleted"] == 1
+
+    @pytest.mark.asyncio
     async def test_commit_files_empty_list(self, github_service):
         """Should raise error when no files provided."""
         with pytest.raises(GitHubServiceError) as exc_info:

--- a/datajunction-ui/src/app/components/git/SyncToGitModal.jsx
+++ b/datajunction-ui/src/app/components/git/SyncToGitModal.jsx
@@ -84,7 +84,13 @@ export function SyncToGitModal({
               </span>
               <h4 style={{ margin: '0 0 8px 0' }}>
                 Synced {result.files_synced} file
-                {result.files_synced !== 1 ? 's' : ''}!
+                {result.files_synced !== 1 ? 's' : ''}
+                {result.files_deleted > 0
+                  ? `, deleted ${result.files_deleted} file${
+                      result.files_deleted !== 1 ? 's' : ''
+                    }`
+                  : ''}
+                !
               </h4>
             </div>
 


### PR DESCRIPTION
### Summary

With this PR, deactivating nodes and then clicking "Sync to Git" now actually removes the stale YAMLs from the branch, rather than leaving orphans behind or 422-ing on empty namespaces.

The changes include:
  - `sync_namespace_to_git` now detects orphan YAMLs in the existing git tree (paths under git_path that don't correspond to any active node in the namespace (e.g. deactivated nodes), and includes them as deletions in the same commit. dj.yaml is filtered out so it's never deleted.
  - Removes the early 422 "namespace has no nodes to sync" error so a namespace whose nodes were all deactivated can still push the resulting deletions.
  - `GitHubService.commit_files` accepts a deletions list, which are added to the tree as entries, which removes the path from the base tree in a single Git Data API commit.
  - In the UI the success message includes a `deleted N file(s)` log when deletions occurred.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
