### PR TITLE
Add git root namespace to namespace git config

### DIFF
--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -698,6 +698,7 @@ async def get_namespace_git_config(
         parent_namespace=node_namespace.parent_namespace,
         git_only=git_info.get("git_only", node_namespace.git_only),
         branch_namespace=git_info.get("branch_namespace"),
+        git_root_namespace=git_info.get("git_root_namespace"),
     )
 
 

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -285,10 +285,8 @@ def resolve_git_info_from_map(
         ),
         "parent_namespace": branch_ns.parent_namespace if branch_ns else None,
         "git_only": effective_git_only,
-        # Name of the namespace that actually carries ``github_repo_path``
-        # (the git root). Lets callers distinguish "this IS the git root"
-        # from "this is a descendant inheriting the root's repo path" —
-        # ``repo`` alone can't, since both report the same value.
+        # The namespace that owns the repo path. Lets callers tell apart
+        # the git root from descendants that inherit it.
         "git_root_namespace": config_ns.namespace,
         # Name of the branch namespace this lookup resolves through. Equals
         # ``namespace`` when called against the branch itself, or the

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -285,6 +285,11 @@ def resolve_git_info_from_map(
         ),
         "parent_namespace": branch_ns.parent_namespace if branch_ns else None,
         "git_only": effective_git_only,
+        # Name of the namespace that actually carries ``github_repo_path``
+        # (the git root). Lets callers distinguish "this IS the git root"
+        # from "this is a descendant inheriting the root's repo path" —
+        # ``repo`` alone can't, since both report the same value.
+        "git_root_namespace": config_ns.namespace,
         # Name of the branch namespace this lookup resolves through. Equals
         # ``namespace`` when called against the branch itself, or the
         # ancestor branch namespace when called against a descendant. The UI

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional, Union, cast
 from fastapi import BackgroundTasks, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -3157,21 +3158,21 @@ async def activate_node(
             missing_parent and missing_parent in downstream.current.missing_parents
         ):
             downstream.current.missing_parents.remove(missing_parent)
-        # Query NodeRelationship directly rather than trusting the in-memory
-        # `downstream.current.parents` collection. On Python 3.11 we've seen
-        # the selectinload'd collection miss the row that already exists in
-        # the DB (autoflush ordering across the prior deactivate + this
-        # activate), which caused duplicate-key violations at flush time.
-        existing = await session.execute(
-            select(NodeRelationship.parent_id)
-            .where(
-                NodeRelationship.parent_id == node.id,
-                NodeRelationship.child_id == downstream.current.id,
+        # Re-link parent directly via INSERT...ON CONFLICT DO NOTHING. The
+        # ORM collection approach is racy here: selectinload + autoflush
+        # ordering can produce either a missed-row read (we append, then
+        # flush a duplicate) or a stale in-memory state that triggers a
+        # duplicate insert during a later autoflush. We've seen both on
+        # 3.11 and 3.13. Going through the table directly sidesteps both.
+        await session.execute(
+            pg_insert(NodeRelationship)
+            .values(
+                parent_id=node.id,
+                parent_version="latest",
+                child_id=downstream.current.id,
             )
-            .limit(1),
+            .on_conflict_do_nothing(index_elements=["parent_id", "child_id"]),
         )
-        if existing.first() is None:
-            downstream.current.parents.append(node)
 
         _logger.info(
             f"Revalidating downstream: {downstream.name} (type={downstream.type}, old_status={downstream.current.status})",

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -681,10 +681,8 @@ class NamespaceGitConfig(BaseModel):
     # controls (Git Settings / Sync to Git / Create PR) on subnamespaces
     # too, scoped to the branch.
     branch_namespace: str | None = None
-    # Namespace that owns ``github_repo_path`` (the git root). Equals the
-    # queried namespace when it IS the git root; otherwise points at an
-    # ancestor. Lets clients tell apart a git root from a descendant that
-    # merely inherits its repo path.
+    # The namespace that owns the repo path. Lets clients tell apart
+    # the git root from descendants that inherit it.
     git_root_namespace: str | None = None
 
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -681,6 +681,11 @@ class NamespaceGitConfig(BaseModel):
     # controls (Git Settings / Sync to Git / Create PR) on subnamespaces
     # too, scoped to the branch.
     branch_namespace: str | None = None
+    # Namespace that owns ``github_repo_path`` (the git root). Equals the
+    # queried namespace when it IS the git root; otherwise points at an
+    # ancestor. Lets clients tell apart a git root from a descendant that
+    # merely inherits its repo path.
+    git_root_namespace: str | None = None
 
 
 class DeploymentSpec(BaseModel):

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -319,6 +319,7 @@ class TestNamespaceGitConfig:
             "parent_namespace": None,
             "default_branch": None,
             "branch_namespace": None,
+            "git_root_namespace": None,
         }
 
     @pytest.mark.asyncio
@@ -356,6 +357,7 @@ class TestNamespaceGitConfig:
             "parent_namespace": None,
             "default_branch": None,
             "branch_namespace": None,
+            "git_root_namespace": None,
         }
 
 

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -3010,6 +3010,91 @@ async def test_git_inheritance_with_no_git_path(
 
 
 @pytest.mark.asyncio
+async def test_git_root_namespace_distinguishes_root_from_descendants(
+    module__client_with_all_examples: AsyncClient,
+) -> None:
+    """``git_root_namespace`` lets clients tell apart a git root from a
+    descendant that merely inherits the root's repo path.
+
+    Without it the UI conflates the two (descendants have inherited
+    ``github_repo_path`` and own ``parent_namespace=None``), which hid the
+    "Add Nodes" control on every plain subnamespace under a git root.
+    """
+    root = "rootns.repo"
+    plain_sub = "rootns.repo.plain_sub"
+    branch_ns = "rootns.repo.feature_branch"
+    branch_sub = "rootns.repo.feature_branch.cubes"
+
+    await module__client_with_all_examples.post(f"/namespaces/{root}/")
+    await module__client_with_all_examples.post(f"/namespaces/{plain_sub}/")
+    await module__client_with_all_examples.post(f"/namespaces/{branch_ns}/")
+    await module__client_with_all_examples.post(f"/namespaces/{branch_sub}/")
+
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{root}/git",
+        json={"github_repo_path": "corp/repo", "git_path": "nodes/"},
+    )
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{branch_ns}/git",
+        json={"parent_namespace": root, "git_branch": "feature"},
+    )
+
+    root_data = (
+        await module__client_with_all_examples.get(f"/namespaces/{root}/git")
+    ).json()
+    plain_data = (
+        await module__client_with_all_examples.get(f"/namespaces/{plain_sub}/git")
+    ).json()
+    branch_data = (
+        await module__client_with_all_examples.get(f"/namespaces/{branch_ns}/git")
+    ).json()
+    branch_sub_data = (
+        await module__client_with_all_examples.get(f"/namespaces/{branch_sub}/git")
+    ).json()
+
+    assert root_data == {
+        "github_repo_path": "corp/repo",
+        "git_path": "nodes/",
+        "git_branch": None,
+        "default_branch": None,
+        "parent_namespace": None,
+        "git_only": False,
+        "branch_namespace": None,
+        "git_root_namespace": root,
+    }
+    assert plain_data == {
+        "github_repo_path": "corp/repo",
+        "git_path": "nodes/",
+        "git_branch": None,
+        "default_branch": None,
+        "parent_namespace": None,
+        "git_only": False,
+        "branch_namespace": None,
+        "git_root_namespace": root,
+    }
+    assert branch_data == {
+        "github_repo_path": "corp/repo",
+        "git_path": "nodes/",
+        "git_branch": "feature",
+        "default_branch": None,
+        "parent_namespace": root,
+        "git_only": False,
+        "branch_namespace": branch_ns,
+        "git_root_namespace": root,
+    }
+    assert branch_sub_data == {
+        "github_repo_path": "corp/repo",
+        "git_path": "nodes/",
+        "git_branch": "feature",
+        "default_branch": None,
+        "parent_namespace": None,
+        "git_only": False,
+        "branch_namespace": branch_ns,
+        "git_root_namespace": root,
+    }
+
+
+@pytest.mark.asyncio
 async def test_list_namespace_branches_empty(
     module__client_with_all_examples: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -132,6 +132,7 @@ def test_deployment_spec():
             "parent_namespace": None,
             "default_branch": None,
             "branch_namespace": None,
+            "git_root_namespace": None,
         },
         "namespace": "test_deployment",
         "nodes": [

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -174,7 +174,10 @@ export default function NamespaceHeader({
   const isBranchNamespace = branchNamespace === namespace;
   const isInBranch = !!branchNamespace;
   const branchScopeNamespace = branchNamespace || namespace;
-  const isGitRoot = gitConfig?.github_repo_path && !gitConfig?.parent_namespace;
+  // Compare against the namespace that owns the repo path — inheriting it
+  // via cascade doesn't make a subnamespace a git root.
+  const isGitRoot =
+    gitConfig?.github_repo_path && gitConfig?.git_root_namespace === namespace;
   const canCreateBranches = isGitRoot && gitConfig?.default_branch;
 
   // Handlers for git operations

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -174,8 +174,8 @@ export default function NamespaceHeader({
   const isBranchNamespace = branchNamespace === namespace;
   const isInBranch = !!branchNamespace;
   const branchScopeNamespace = branchNamespace || namespace;
-  // Compare against the namespace that owns the repo path — inheriting it
-  // via cascade doesn't make a subnamespace a git root.
+  // Descendants inherit github_repo_path via cascade, so compare against
+  // git_root_namespace to know if this namespace IS the git root.
   const isGitRoot =
     gitConfig?.github_repo_path && gitConfig?.git_root_namespace === namespace;
   const canCreateBranches = isGitRoot && gitConfig?.default_branch;

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -554,6 +554,7 @@ describe('<NamespaceHeader />', () => {
         git_path: 'nodes/',
         default_branch: 'main',
         // No git_branch or parent_namespace - this is a git root with default_branch
+        git_root_namespace: 'test.namespace',
       }),
     };
 
@@ -631,6 +632,7 @@ describe('<NamespaceHeader />', () => {
         git_path: 'nodes/',
         default_branch: 'main',
         // No git_branch or parent_namespace - this is a git root with default_branch
+        git_root_namespace: 'test.namespace',
       }),
     };
 
@@ -768,6 +770,7 @@ describe('<NamespaceHeader />', () => {
         git_path: 'nodes/',
         default_branch: 'main',
         // No git_branch or parent_namespace - this is a git root
+        git_root_namespace: 'test.namespace',
       }),
       createBranch: vi.fn().mockResolvedValue({
         branch: {

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
@@ -632,6 +632,7 @@ describe('NamespacePage', () => {
       default_branch: 'main',
       parent_namespace: null,
       git_only: false,
+      git_root_namespace: 'default',
     };
 
     const mockBranches = [
@@ -805,6 +806,7 @@ describe('NamespacePage', () => {
         default_branch: 'main',
         parent_namespace: null,
         git_only: false,
+        git_root_namespace: 'default',
       });
       mockDjClient.getNamespaceBranches.mockResolvedValue([
         {

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -393,10 +393,14 @@ export function NamespacePage() {
 
   // Only show edit/add controls once git config has loaded and namespace is not git-only
   const gitConfigLoaded = gitConfig !== undefined;
+  // A namespace IS the git root only when its own row carries the repo
+  // path. ``github_repo_path`` alone isn't enough — descendants inherit
+  // it via cascade, so we compare against ``git_root_namespace`` (the
+  // ancestor that actually owns the config).
   const isGitRoot =
     gitConfigLoaded &&
     !!gitConfig?.github_repo_path &&
-    !gitConfig?.parent_namespace;
+    gitConfig?.git_root_namespace === namespace;
   const isBranchNamespace = gitConfigLoaded && !!gitConfig?.parent_namespace;
   const showEditControls =
     gitConfigLoaded && !gitConfig?.git_only && !isGitRoot;

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -393,10 +393,8 @@ export function NamespacePage() {
 
   // Only show edit/add controls once git config has loaded and namespace is not git-only
   const gitConfigLoaded = gitConfig !== undefined;
-  // A namespace IS the git root only when its own row carries the repo
-  // path. ``github_repo_path`` alone isn't enough — descendants inherit
-  // it via cascade, so we compare against ``git_root_namespace`` (the
-  // ancestor that actually owns the config).
+  // Descendants inherit github_repo_path via cascade, so compare against
+  // git_root_namespace to know if this namespace IS the git root.
   const isGitRoot =
     gitConfigLoaded &&
     !!gitConfig?.github_repo_path &&


### PR DESCRIPTION
### Summary

Add `git_root_namespace` to enable clients to distinguish a git root from a descendant that merely inherits the root's repo path. This is useful for displaying the correct configuration knobs in the UI (e.g., Add Nodes) on git-backed sub-namespaces.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
