### PR TITLE
Pipe through lookback window for legacy druid cube materialization

### DIFF
--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -481,5 +481,6 @@ async def build_cube_materialization(
         dimensions=current_revision.cube_node_dimensions,
         measures_materializations=measures_materializations,
         combiners=combiners,
+        lookback_window=upsert_input.lookback_window if incremental else None,
     )
     return config

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -156,6 +156,7 @@ class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
                 strategy=materialization.strategy,
                 schedule=materialization.schedule,
                 job=materialization.job,
+                lookback_window=cube_config.lookback_window,
                 measures_materializations=cube_config.measures_materializations,
                 combiners=cube_config.combiners,
             ),

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -414,6 +414,9 @@ class DruidCubeConfig(BaseModel):
     # possible for metrics at different levels.
     combiners: list[CombineMaterialization]
 
+    # Lookback window, only relevant if materialization strategy is INCREMENTAL_TIME
+    lookback_window: Optional[str] = "1 DAY"
+
 
 class DruidCubeMaterializationInput(BaseModel):
     """

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -795,7 +795,7 @@ async def test_druid_cube_incremental(
             "job": "druid_cube",
             "strategy": "incremental_time",
             "schedule": "@daily",
-            "lookback_window": "1 DAY",
+            "lookback_window": "7 DAY",
         },
     )
     assert response.status_code in (200, 201)
@@ -810,6 +810,7 @@ async def test_druid_cube_incremental(
         == "druid_cube__incremental_time__default.repair_orders_fact.order_date"
     )
     assert mat.job == "DruidCubeMaterializationJob"
+    assert mat.lookback_window == "7 DAY"
     assert mat.cube == NodeNameVersion(
         name="default.repairs_cube__default_incremental",
         version="v1.0",

--- a/datajunction-server/tests/models/cube_materialization_test.py
+++ b/datajunction-server/tests/models/cube_materialization_test.py
@@ -1,15 +1,22 @@
 """Tests for cube materialization models."""
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.materialization.jobs.cube_materialization import (
+    DruidCubeMaterializationJob,
+)
 from datajunction_server.models.cube_materialization import (
+    DruidCubeConfig,
+    DruidCubeMaterializationInput,
     DruidCubeV3Config,
     MeasuresMaterialization,
     PreAggTableInfo,
 )
+from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.node_type import NodeNameVersion
 from datajunction_server.models.partition import Granularity
 from datajunction_server.models.decompose import (
@@ -18,6 +25,37 @@ from datajunction_server.models.decompose import (
     MetricComponent,
 )
 from datajunction_server.models.query import ColumnMetadata
+
+
+def test_druid_cube_materialization_job_passes_lookback_window():
+    """
+    The legacy Druid cube scheduler should preserve the configured lookback
+    window when it hands off to the query service.
+    """
+    cube_config = DruidCubeConfig(
+        cube=NodeNameVersion(name="default.repairs_cube", version="v1.0"),
+        dimensions=[],
+        metrics=[],
+        measures_materializations=[],
+        combiners=[],
+        lookback_window="7 DAY",
+    )
+    materialization = SimpleNamespace(
+        name="druid_cube__incremental_time__default.repair_orders_fact.order_date",
+        config=cube_config.model_dump(),
+        strategy=MaterializationStrategy.INCREMENTAL_TIME,
+        schedule="@daily",
+        job="DruidCubeMaterializationJob",
+    )
+    query_service_client = Mock()
+
+    DruidCubeMaterializationJob().schedule(materialization, query_service_client)
+
+    materialization_input = query_service_client.materialize_cube.call_args.kwargs[
+        "materialization_input"
+    ]
+    assert isinstance(materialization_input, DruidCubeMaterializationInput)
+    assert materialization_input.lookback_window == "7 DAY"
 
 
 class TestDruidCubeV3ConfigDruidCubeConfigCompatibility:


### PR DESCRIPTION
### Summary
Pass the configured cube `lookback_window` through the legacy Druid cube materialization flow.

## Changes

  - Store `lookback_window` on DruidCubeConfig
  - Preserve incremental cube lookback when building materialization config
  - Pass the value into DruidCubeMaterializationInput
  - Add regression coverage for the API flow and scheduler handoff

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

