### PR TITLE
UI relative `DJ_URL` issue

### DIFF
--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -13,6 +13,19 @@ const DJ_GQL = process.env.REACT_APP_DJ_GQL
 // Export the base URL for components that need direct access
 export const getDJUrl = () => DJ_URL;
 
+// Build a URL we can mutate (searchParams, etc.) that works whether
+// DJ_URL is absolute (e.g. ``http://localhost:8000``) or relative (e.g.
+// ``/dj-api``). Plain ``new URL(rel)`` throws "Invalid URL" on a relative
+// path; passing ``window.location.origin`` as the base makes both shapes
+// work and ``url.pathname`` keeps the original relative prefix.
+const _djURL = path => {
+  const base =
+    typeof window !== 'undefined' && window.location
+      ? window.location.origin
+      : 'http://localhost';
+  return new URL(`${DJ_URL}${path}`, base);
+};
+
 const QUERY_END_STATES = ['FINISHED', 'CANCELED', 'FAILED'];
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -844,9 +857,7 @@ export const DataJunctionAPI = {
     table,
     sourceNodeNamespace = undefined,
   ) {
-    const url = new URL(
-      `${DJ_URL}/register/table/${catalog}/${schema}/${table}`,
-    );
+    const url = _djURL(`/register/table/${catalog}/${schema}/${table}`);
     if (sourceNodeNamespace !== undefined) {
       url.searchParams.set('source_node_namespace', sourceNodeNamespace);
     }
@@ -1791,9 +1802,7 @@ export const DataJunctionAPI = {
     dimensionColumn,
     role = null,
   ) {
-    const url = new URL(
-      `${DJ_URL}/nodes/${nodeName}/columns/${nodeColumn}/link`,
-    );
+    const url = _djURL(`/nodes/${nodeName}/columns/${nodeColumn}/link`);
     url.searchParams.append('dimension_node', dimensionNode);
     url.searchParams.append('dimension_column', dimensionColumn);
     if (role) {
@@ -2193,7 +2202,7 @@ export const DataJunctionAPI = {
 
   // DELETE /notifications/unsubscribe
   unsubscribeFromNotifications: async function ({ entity_type, entity_name }) {
-    const url = new URL(`${DJ_URL}/notifications/unsubscribe`);
+    const url = _djURL(`/notifications/unsubscribe`);
     url.searchParams.append('entity_type', entity_type);
     url.searchParams.append('entity_name', entity_name);
 

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -13,11 +13,7 @@ const DJ_GQL = process.env.REACT_APP_DJ_GQL
 // Export the base URL for components that need direct access
 export const getDJUrl = () => DJ_URL;
 
-// Build a URL we can mutate (searchParams, etc.) that works whether
-// DJ_URL is absolute (e.g. ``http://localhost:8000``) or relative (e.g.
-// ``/dj-api``). Plain ``new URL(rel)`` throws "Invalid URL" on a relative
-// path; passing ``window.location.origin`` as the base makes both shapes
-// work and ``url.pathname`` keeps the original relative prefix.
+// URL builder that works with either an absolute or relative DJ_URL.
 const _djURL = path => {
   const base =
     typeof window !== 'undefined' && window.location

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -3441,3 +3441,64 @@ describe('DataJunctionAPI', () => {
     expect(result.message).toBe('PR already exists');
   });
 });
+
+// Regression tests for the new URL() bug when DJ_URL is relative.
+// In prod, REACT_APP_DJ_URL is often a relative path (e.g. ``/dj-api``).
+// Plain ``new URL('/dj-api/...')`` throws ``TypeError: Failed to construct
+// 'URL'`` because URL requires an absolute spec when no base is given.
+// The three call sites that built URLs to mutate search params used to
+// crash client-side in prod, masquerading as server validation errors
+// (e.g. tables auto-flagged "invalid" in the SQL editor).
+describe('DataJunctionAPI with relative DJ_URL', () => {
+  const RELATIVE_DJ_URL = '/dj-api';
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    vi.resetModules();
+    process.env.REACT_APP_DJ_URL = RELATIVE_DJ_URL;
+  });
+
+  afterEach(() => {
+    // Restore so the main suite's absolute-URL assumption holds if reused.
+    process.env.REACT_APP_DJ_URL = 'http://localhost:8000';
+  });
+
+  it('registerTable does not throw on relative DJ_URL', async () => {
+    const { DataJunctionAPI: API } = await import('../DJService');
+    fetch.mockResponseOnce(JSON.stringify({}));
+    await API.registerTable('default', 'xyz', 'abc');
+    expect(fetch).toHaveBeenCalled();
+    const calledUrl = fetch.mock.calls[0][0];
+    expect(calledUrl).toContain('/dj-api/register/table/default/xyz/abc');
+  });
+
+  it('addReferenceDimensionLink does not throw on relative DJ_URL', async () => {
+    const { DataJunctionAPI: API } = await import('../DJService');
+    fetch.mockResponseOnce(JSON.stringify({}));
+    await API.addReferenceDimensionLink(
+      'default.node1',
+      'col1',
+      'default.dim1',
+      'dim_col',
+    );
+    expect(fetch).toHaveBeenCalled();
+    const calledUrl = fetch.mock.calls[0][0];
+    expect(calledUrl).toContain('/dj-api/nodes/default.node1/columns/col1/link');
+    expect(calledUrl).toContain('dimension_node=default.dim1');
+    expect(calledUrl).toContain('dimension_column=dim_col');
+  });
+
+  it('unsubscribeFromNotifications does not throw on relative DJ_URL', async () => {
+    const { DataJunctionAPI: API } = await import('../DJService');
+    fetch.mockResponseOnce(JSON.stringify({}));
+    await API.unsubscribeFromNotifications({
+      entity_type: 'node',
+      entity_name: 'default.node1',
+    });
+    expect(fetch).toHaveBeenCalled();
+    const calledUrl = fetch.mock.calls[0][0];
+    expect(calledUrl).toContain('/dj-api/notifications/unsubscribe');
+    expect(calledUrl).toContain('entity_type=node');
+    expect(calledUrl).toContain('entity_name=default.node1');
+  });
+});

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -3483,7 +3483,9 @@ describe('DataJunctionAPI with relative DJ_URL', () => {
     );
     expect(fetch).toHaveBeenCalled();
     const calledUrl = fetch.mock.calls[0][0];
-    expect(calledUrl).toContain('/dj-api/nodes/default.node1/columns/col1/link');
+    expect(calledUrl).toContain(
+      '/dj-api/nodes/default.node1/columns/col1/link',
+    );
     expect(calledUrl).toContain('dimension_node=default.dim1');
     expect(calledUrl).toContain('dimension_column=dim_col');
   });


### PR DESCRIPTION
### Summary

`DJService.js` had three call sites using `new URL(${DJ_URL}...`) to build mutable URL objects. When `REACT_APP_DJ_URL` is a relative path (e.g. `/dj-api`), `new URL('/dj-api/...')` throws `TypeError: Failed to construct 'URL': Invalid URL`, because URL requires an absolute spec without a base. This has always worked locally because the dev fallback is http://localhost:8000.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
