### PR TITLE
Fix aggregation check per function

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1398,6 +1398,8 @@ class CountMinSketch(Function):
     count_min_sketch(col, eps, confidence, seed) - Creates a Count-Min sketch of col.
     """
 
+    is_aggregation = True
+
 
 @CountMinSketch.register  # type: ignore
 def infer_type(
@@ -2503,6 +2505,8 @@ class HistogramNumeric(Function):
     defined by equally spaced width intervals.
     """
 
+    is_aggregation = True
+
 
 @HistogramNumeric.register  # type: ignore
 def infer_type(arg1: ct.ColumnType, arg2: ct.IntegerType) -> ct.ColumnType:
@@ -2753,6 +2757,8 @@ class Kurtosis(Function):
     """
     kurtosis(expr) - Returns the kurtosis of the values in a group.
     """
+
+    is_aggregation = True
 
 
 @Kurtosis.register  # type: ignore
@@ -3463,6 +3469,8 @@ class Mean(Function):
     mean(expr) - Returns the average of the values in the group.
     """
 
+    is_aggregation = True
+
 
 @Mean.register  # type: ignore
 def infer_type(arg: ct.ColumnType) -> ct.ColumnType:
@@ -3473,6 +3481,8 @@ class Median(Function):
     """
     median(expr) - Returns the median of the values in the group.
     """
+
+    is_aggregation = True
 
 
 @Median.register  # type: ignore
@@ -3574,6 +3584,8 @@ class Mode(Function):
     """
     mode(col) - Returns the most frequent value for the values within col.
     """
+
+    is_aggregation = True
 
 
 @Mode.register  # type: ignore

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -239,7 +239,7 @@ class Abs(Function):
     Returns the absolute value of the numeric or interval value.
     """
 
-    is_aggregation = True
+    is_aggregation = False
     dialects = [Dialect.SPARK, Dialect.DRUID]
 
 
@@ -3473,8 +3473,6 @@ class Median(Function):
     """
     median(expr) - Returns the median of the values in the group.
     """
-
-    is_aggregation = True
 
 
 @Median.register  # type: ignore

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -14,6 +14,7 @@ from datajunction_server.models.cube_materialization import (
     MetricComponent,
 )
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.sql import functions as dj_functions
 from datajunction_server.sql.decompose import (
     MetricComponentExtractor,
     safe_denominator,
@@ -2232,3 +2233,57 @@ async def test_user_authored_division_not_double_wrapped(
         str(derived_sql),
         "SELECT SUM(x_sum_b5c12ce5) / NULLIF(SUM(y_sum_898a9389), 0) FROM parent_node",
     )
+
+
+class TestFunctionAggregationClassification:
+    """
+    Locks in ``is_aggregation`` for functions that have been (or could be)
+    misclassified. Misclassifying a scalar function as an aggregation makes
+    every metric that uses it (e.g. ``SUM(ABS(x))``) silently extract with
+    empty ``measures`` because ``_extract_base`` early-returns when any
+    walked aggregation lacks a registered decomposition. The reverse
+    misclassification (real aggregation marked scalar) hides the function
+    from the extractor entirely, also producing empty measures.
+    """
+
+    def test_scalar_functions_not_marked_as_aggregation(self):
+        # ``ABS`` was previously is_aggregation=True; that single line broke
+        # ``SUM(ABS(...))``-style metrics across the codebase.
+        assert dj_functions.Abs.is_aggregation is False
+
+    def test_real_aggregations_marked_as_aggregation(self):
+        for cls in (
+            dj_functions.Mean,
+            dj_functions.Median,
+            dj_functions.Mode,
+            dj_functions.Kurtosis,
+            dj_functions.HistogramNumeric,
+            dj_functions.CountMinSketch,
+        ):
+            assert cls.is_aggregation is True, (
+                f"{cls.__name__} is a real aggregation but is_aggregation is False"
+            )
+
+
+@pytest.mark.asyncio
+async def test_sum_abs_decomposes(session: AsyncSession, create_metric):
+    """Regression test for the ABS-misclassification cascade: a metric
+    wrapping ``ABS`` inside ``SUM`` must decompose into a single SUM
+    component whose expression is the inner ``ABS(...)``. Previously
+    ``Abs.is_aggregation = True`` triggered the non-decomposable early
+    return in ``_extract_base``, producing empty measures.
+    """
+    metric_rev = await create_metric(
+        "SELECT SUM(ABS(amount - 100)) FROM parent_node",
+    )
+    extractor = MetricComponentExtractor(metric_rev.id)
+    measures, derived_sql = await extractor.extract(session)
+    assert len(measures) == 1
+    comp = measures[0]
+    assert comp.aggregation == "SUM"
+    assert comp.merge == "SUM"
+    assert comp.rule.type == Aggregability.FULL
+    # The component's expression is the ABS arg of the outer SUM.
+    assert "ABS" in comp.expression
+    # The combiner re-sums the per-row pre-aggregated component.
+    assert_sql_equal(str(derived_sql), f"SELECT SUM({comp.name}) FROM parent_node")

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -2236,19 +2236,9 @@ async def test_user_authored_division_not_double_wrapped(
 
 
 class TestFunctionAggregationClassification:
-    """
-    Locks in ``is_aggregation`` for functions that have been (or could be)
-    misclassified. Misclassifying a scalar function as an aggregation makes
-    every metric that uses it (e.g. ``SUM(ABS(x))``) silently extract with
-    empty ``measures`` because ``_extract_base`` early-returns when any
-    walked aggregation lacks a registered decomposition. The reverse
-    misclassification (real aggregation marked scalar) hides the function
-    from the extractor entirely, also producing empty measures.
-    """
+    """Lock in is_aggregation for previously-misclassified functions."""
 
     def test_scalar_functions_not_marked_as_aggregation(self):
-        # ``ABS`` was previously is_aggregation=True; that single line broke
-        # ``SUM(ABS(...))``-style metrics across the codebase.
         assert dj_functions.Abs.is_aggregation is False
 
     def test_real_aggregations_marked_as_aggregation(self):
@@ -2267,12 +2257,7 @@ class TestFunctionAggregationClassification:
 
 @pytest.mark.asyncio
 async def test_sum_abs_decomposes(session: AsyncSession, create_metric):
-    """Regression test for the ABS-misclassification cascade: a metric
-    wrapping ``ABS`` inside ``SUM`` must decompose into a single SUM
-    component whose expression is the inner ``ABS(...)``. Previously
-    ``Abs.is_aggregation = True`` triggered the non-decomposable early
-    return in ``_extract_base``, producing empty measures.
-    """
+    """SUM(ABS(x)) decomposes into one SUM component over ABS(x)."""
     metric_rev = await create_metric(
         "SELECT SUM(ABS(amount - 100)) FROM parent_node",
     )
@@ -2283,7 +2268,5 @@ async def test_sum_abs_decomposes(session: AsyncSession, create_metric):
     assert comp.aggregation == "SUM"
     assert comp.merge == "SUM"
     assert comp.rule.type == Aggregability.FULL
-    # The component's expression is the ABS arg of the outer SUM.
     assert "ABS" in comp.expression
-    # The combiner re-sums the per-row pre-aggregated component.
     assert_sql_equal(str(derived_sql), f"SELECT SUM({comp.name}) FROM parent_node")


### PR DESCRIPTION
### Summary

The `ABS` function's `is_aggregation` was set to true, which is wrong as `ABS` is a scalar function (one row in, one row out), not an aggregation.

That misclassification broke decomposition for every metric containing `ABS(...)`, as well as for other functions.


### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
