### PR TITLE
Push partition-eligible filters into parent CTEs

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1108,40 +1108,79 @@ def _inject_filter_into_where(
     inject_filter_into_select(cast(ast.Select, query_ast.select), filter_expr)
 
 
+def _setop_arms(cte_query: ast.Query) -> list[ast.Select]:
+    """Return every Select arm in a (possibly chained) set-operation CTE body.
+
+    A non-set-op CTE returns a single-element list containing its Select.
+    A UNION/INTERSECT/EXCEPT chain returns each arm in order — the first arm
+    is ``cte_query.select`` and subsequent arms hang off ``set_op.right``.
+    """
+    arms: list[ast.Select] = []
+    cur: Optional[ast.Select] = (
+        cte_query.select if isinstance(cte_query.select, ast.Select) else None
+    )
+    while cur is not None:
+        arms.append(cur)
+        nxt = cur.set_op.right if cur.set_op else None
+        # ``set_op.right`` is typed as SelectExpression which may also be a
+        # parenthesised subquery; in practice DJ always emits a Select here.
+        cur = nxt if isinstance(nxt, ast.Select) else None
+    return arms
+
+
 def _resolve_pushdown_filters_for_cte(
     node: "Node",
     cte_query: ast.Query,
     pushdown_filters: list[str],
     filter_column_aliases: dict[str, str],
-) -> list[ast.Expression]:
-    """Determine which user filters can be pushed into this CTE and return them.
+) -> tuple[list[tuple[ast.Select, ast.Expression]], set[str]]:
+    """Determine which user filters can be pushed into this CTE.
 
     For each filter, extracts the dimension references, resolves them to bare
     column names via filter_column_aliases, and checks whether this CTE outputs
     those columns.  If all referenced columns are present, the filter is rewritten
-    using the CTE's internal table-qualified column names and returned.
+    using the CTE's internal table-qualified column names and returned, paired
+    with the Select node it should be injected into.
 
-    Returns a list of parsed filter AST expressions ready for injection.
+    For set-operation CTEs (UNION / INTERSECT / EXCEPT), the rewrite is done
+    independently per arm — each arm's projection may resolve the same output
+    column differently, and pushing only into the first arm would produce
+    semantically wrong SQL.  The push is atomic per filter: if any arm can't
+    accept the rewrite, the filter is skipped for the whole CTE.
+
+    Returns ``(injections, consumed)`` where ``injections`` is the list of
+    ``(target_select, rewritten_filter)`` pairs to inject and ``consumed``
+    is the set of original filter strings that were successfully pushed
+    into the CTE (so the caller can drop them from outer-level WHERE).
     """
     node_output_cols = (
         {col.name for col in (node.current.columns or [])} if node.current else set()
     )
 
     if not node_output_cols:  # pragma: no cover
-        return []
+        return [], set()
 
-    results: list[ast.Expression] = []
+    arms = _setop_arms(cte_query)
+    results: list[tuple[ast.Select, ast.Expression]] = []
+    consumed: set[str] = set()
     for filter_str in pushdown_filters:
-        rewritten = _rewrite_filter_for_cte(
-            filter_str,
-            filter_column_aliases,
-            node_output_cols,
-            cte_query,
-        )
-        if rewritten is None:
-            continue
-        results.append(rewritten)
-    return results
+        per_arm: list[tuple[ast.Select, ast.Expression]] = []
+        all_ok = True
+        for arm in arms:
+            rewritten = _rewrite_filter_for_select(
+                filter_str,
+                filter_column_aliases,
+                node_output_cols,
+                arm,
+            )
+            if rewritten is None:
+                all_ok = False
+                break
+            per_arm.append((arm, rewritten))
+        if all_ok:
+            results.extend(per_arm)
+            consumed.add(filter_str)
+    return results, consumed
 
 
 def _cte_has_set_operation(cte_query: ast.Query) -> bool:
@@ -1197,32 +1236,51 @@ def _rewrite_filter_for_cte(
 ) -> ast.Expression | None:
     """Rewrite a dimension filter for injection into a specific CTE.
 
-    Resolves each dimension reference (e.g., ``v3.product.category``) to the
-    form that's safe in the CTE's WHERE clause.  Three projection cases:
+    For non-set-op CTEs, delegates to :func:`_rewrite_filter_for_select`
+    against the single Select arm.  Set-op CTEs are not handled here —
+    callers that need per-arm rewrites use :func:`_setop_arms` and call
+    :func:`_rewrite_filter_for_select` per arm.
+    """
+    if _cte_has_set_operation(cte_query):
+        return None
+    return _rewrite_filter_for_select(
+        filter_str,
+        filter_column_aliases,
+        cte_output_cols,
+        cast(ast.Select, cte_query.select),
+    )
 
-    1. CTE projects the column as a simple (possibly aliased) column: replace
-       with the underlying qualified form (e.g., ``p.category``).  This is the
-       correctness-critical case — emitting a SELECT-list alias in WHERE is
-       rejected by Spark SQL and standard SQL.
-    2. CTE doesn't project the column at all (pruned): fall through to the
-       bare column name.  Safe because the CTE's underlying source exposes
-       the column, even if it's not selected into the outer query.
-    3. CTE projects the column via a non-column expression (e.g.
+
+def _rewrite_filter_for_select(
+    filter_str: str,
+    filter_column_aliases: dict[str, str],
+    cte_output_cols: set[str],
+    cte_select: ast.Select,
+) -> ast.Expression | None:
+    """Rewrite a dimension filter for injection into a specific Select.
+
+    Resolves each dimension reference (e.g., ``v3.product.category``) to the
+    form that's safe in the Select's WHERE clause.  Three projection cases:
+
+    1. Select projects the column as a simple (possibly aliased) column:
+       replace with the underlying qualified form (e.g., ``p.category``).
+       This is the correctness-critical case — emitting a SELECT-list alias
+       in WHERE is rejected by Spark SQL and standard SQL.
+    2. Select doesn't project the column at all (pruned): fall through to
+       the bare column name.  Safe because the Select's underlying source
+       still exposes the column, even if it's not selected.
+    3. Select projects the column via a non-column expression (e.g.
        ``SUM(x) AS y``): skip — inlining is unsafe.
 
     Multi-predicate handling: a single filter may reference several dim refs
     (``a.x = 1 OR b.y = 2``).  All matching refs are rewritten, but if ANY
-    ref's column isn't exposed by this CTE, the whole filter is skipped —
-    pushing a partial OR-predicate into the wrong CTE produces invalid SQL.
+    ref's column isn't exposed by this Select, the whole filter is skipped —
+    pushing a partial OR-predicate into the wrong scope produces invalid SQL.
 
     Returns the rewritten filter AST, or None when the filter can't be
-    safely pushed into this CTE.
+    safely pushed into this Select.
     """
-    # Set-operation CTEs can't be safely pushed into via the first arm alone.
-    if _cte_has_set_operation(cte_query):
-        return None
-
-    projection_map = _build_cte_projection_map(cte_query)
+    projection_map = _build_select_projection_map(cte_select)
     filter_ast = parse_filter(filter_str)
 
     # First pass: plan the rewrites by walking the AST.  Role-qualified refs
@@ -1303,19 +1361,32 @@ def _rewrite_filter_for_cte(
 def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str | None]:
     """Map a CTE's output column name to its underlying qualified reference.
 
+    Thin wrapper around :func:`_build_select_projection_map`; kept for
+    callers that already hold an ``ast.Query``.
+    """
+    if not cte_query.select:  # pragma: no cover
+        return {}
+    return _build_select_projection_map(cast(ast.Select, cte_query.select))
+
+
+def _build_select_projection_map(
+    cte_select: ast.Select,
+) -> dict[str, str | None]:
+    """Map a Select's projection output names to underlying qualified refs.
+
     Output name is the SELECT-list alias when present, else the bare column
     name.  Value is either:
 
     - A string — the form that's safe to reference in a WHERE clause pushed
-      into this CTE (a table-qualified column when qualified in the
+      into this Select (a table-qualified column when qualified in the
       projection, else the bare column name).
     - ``None`` — the projection is a non-column expression under an alias
-      (e.g., ``SUM(x) AS y``); pushdown should skip this CTE to avoid
-      inlining an expression that would be semantically wrong in WHERE.
+      (e.g., ``SUM(x) AS y``); pushdown should skip to avoid inlining an
+      expression that would be semantically wrong in WHERE.
 
-    Columns that the CTE doesn't project at all are absent from the map;
-    callers should treat that as "fall through to the bare name" since the
-    CTE's underlying source still exposes them.
+    Columns that aren't projected at all are absent from the map; callers
+    should treat that as "fall through to the bare name" since the Select's
+    underlying source still exposes them.
 
     Examples::
 
@@ -1329,9 +1400,7 @@ def _build_cte_projection_map(cte_query: ast.Query) -> dict[str, str | None]:
           becomes {"total": None}
     """
     result: dict[str, str | None] = {}
-    if not cte_query.select:  # pragma: no cover
-        return result
-    for expr in cte_query.select.projection:
+    for expr in cte_select.projection:
         inner = getattr(expr, "child", expr)
         alias = getattr(expr, "alias", None)
         # Unwrap CAST around a column — CAST(col AS T) is a transparent
@@ -1365,7 +1434,7 @@ def collect_node_ctes(
     needed_columns_by_node: Optional[dict[str, set[str]]] = None,
     injected_filters: Optional[dict[str, ast.Expression]] = None,
     pushdown: Optional[PushdownFilters] = None,
-) -> tuple[list[tuple[str, ast.Query]], list[str]]:
+) -> tuple[list[tuple[str, ast.Query]], list[str], dict[str, set[str]]]:
     """
     Collect CTEs for all non-source nodes, recursively expanding table references.
 
@@ -1389,14 +1458,19 @@ def collect_node_ctes(
             them on the outer query after an expensive join.
 
     Returns:
-        Tuple of (cte_list, scanned_sources):
+        Tuple of (cte_list, scanned_sources, consumed_by_node):
         - cte_list: List of (cte_name, query_ast) tuples in dependency order
         - scanned_sources: List of source node names encountered during traversal
+        - consumed_by_node: Map of node_name -> set of filter strings that were
+          successfully pushed into that node's CTE WHERE clause. Callers use
+          this to drop redundant copies from outer-level WHERE.
     """
     # Collect all node names that need CTEs (including transitive dependencies)
     all_node_names: set[str] = set()
     # Track source nodes encountered during traversal
     scanned_source_names: set[str] = set()
+    # Map of node_name -> filter strings successfully pushed into that CTE
+    consumed_by_node: dict[str, set[str]] = {}
     mat_check_time = 0.0
     parse_check_time = 0.0
     ref_extract_time = 0.0
@@ -1508,17 +1582,20 @@ def collect_node_ctes(
             _inject_filter_into_where(query_ast, injected_filters[node.name])
 
         if pushdown:
-            for filter_ast in _resolve_pushdown_filters_for_cte(
+            injections, consumed = _resolve_pushdown_filters_for_cte(
                 node,
                 query_ast,
                 pushdown.filters,
                 pushdown.column_aliases,
-            ):
-                _inject_filter_into_where(query_ast, filter_ast)
+            )
+            for target_select, filter_ast in injections:
+                inject_filter_into_select(target_select, filter_ast)
+            if consumed:
+                consumed_by_node[node.name] = consumed
 
         ctes.append((cte_name, query_ast))
 
-    return ctes, list(scanned_source_names)
+    return ctes, list(scanned_source_names), consumed_by_node
 
 
 def process_metric_combiner_expression(

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -674,22 +674,22 @@ def _apply_outer_where_atoms(
     select: ast.Select,
     where_clause: Optional[ast.Expression],
     main_alias: str,
-    parent_pushdown_active: bool = False,
+    parent_pushdown_active: bool = False,  # noqa: ARG001 (kept for back-compat)
 ) -> None:
     """Apply each AND atom of ``where_clause`` to ``select.where``.
 
-    Three categories of atoms:
+    Two categories of atoms:
 
-    - **Parent-alias atoms** (``main_alias.col`` only) when
-      ``parent_pushdown_active`` is True — DROPPED from outer WHERE.
-      The same predicate has already been pushed into the parent CTE's
-      WHERE, so the outer-level copy is redundant *and* unsafe (it
-      would defeat downstream RIGHT/FULL OUTER joins to dims).
-
-    - **Parent-alias atoms** when parent pushdown wasn't applied (e.g.
-      parent is materialized or has a set-op body that blocks
-      pushdown) — routed through :func:`inject_filter_into_select` as
-      the safety backstop.
+    - **Parent-alias atoms** (``main_alias.col`` only) — routed through
+      :func:`inject_filter_into_select`, which handles OUTER-join safety
+      (wrapping the inner relation when the predicate would otherwise
+      defeat a downstream RIGHT/FULL OUTER join).  Always applying these
+      at the outer SELECT is safe because the CTE-level pushdown can
+      silently fail when the parent CTE has an opaque body (set-op,
+      CROSS-joined dim columns from authored source SQL, etc.) — dropping
+      the outer copy in those cases loses the filter entirely.  Worst
+      case is a double-application of the same predicate, which is a
+      no-op for correctness.
 
     - **Dim-alias atoms** (and unqualified atoms) — ANDed into the outer
       WHERE.  These rely on the standard dim-filter narrowing
@@ -707,8 +707,6 @@ def _apply_outer_where_atoms(
     for atom in _split_and_atoms(where_clause):
         ns = _filter_namespaces(atom)
         is_parent_only = bool(ns) and ns.issubset({main_alias})
-        if is_parent_only and parent_pushdown_active:
-            continue
         if is_parent_only:
             inject_filter_into_select(select, atom)
         elif select.where:
@@ -1156,17 +1154,32 @@ def build_dimension_joins(
 ) -> tuple[dict[tuple[str, Optional[str]], str], list[ast.Join]]:
     """Build JOIN clauses for non-local dimensions.
 
-    Walks each resolved dimension's join path, deduplicating joins when two
-    dimensions share a common prefix (same dimension node + accumulated role).
+    Chains whose first link is a null-padding join (RIGHT / FULL OUTER) are
+    processed after chains whose first link is source-preserving (INNER /
+    LEFT / CROSS). This keeps each dim join's ON clause evaluating against
+    live source columns: an intervening RIGHT/FULL OUTER off the same source
+    won't run first and null-pad the columns a sibling chain depends on.
+    Chain locality is preserved — each chain still emits its links
+    contiguously.
 
     Returns:
         (dim_aliases, joins) where dim_aliases maps (node_name, accumulated_role)
         to the table alias used in the JOIN.
     """
+    from datajunction_server.models.dimensionlink import JoinType
+
+    def _chain_bucket(rdim: ResolvedDimension) -> int:
+        if rdim.is_local or not rdim.join_path or not rdim.join_path.links:
+            return 0
+        jt = rdim.join_path.links[0].join_type
+        return 1 if jt in (JoinType.RIGHT, JoinType.FULL) else 0
+
+    ordered_dimensions = sorted(resolved_dimensions, key=_chain_bucket)
+
     dim_aliases: dict[tuple[str, Optional[str]], str] = {}
     joins: list[ast.Join] = []
 
-    for resolved_dim in resolved_dimensions:
+    for resolved_dim in ordered_dimensions:
         if not resolved_dim.is_local and resolved_dim.join_path:
             current_left_alias = main_alias
             accumulated_role_parts: list[str] = []
@@ -1183,7 +1196,7 @@ def build_dimension_joins(
 
                 dim_key = (dim_node_name, accumulated_role)
 
-                if dim_key not in dim_aliases:  # pragma: no branch
+                if dim_key not in dim_aliases:
                     if accumulated_role:
                         alias_base = accumulated_role.replace("->", "_")
                     else:

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -674,22 +674,26 @@ def _apply_outer_where_atoms(
     select: ast.Select,
     where_clause: Optional[ast.Expression],
     main_alias: str,
-    parent_pushdown_active: bool = False,  # noqa: ARG001 (kept for back-compat)
+    parent_pushdown_active: bool = False,
 ) -> None:
     """Apply each AND atom of ``where_clause`` to ``select.where``.
 
-    Two categories of atoms:
+    Three categories of atoms:
 
-    - **Parent-alias atoms** (``main_alias.col`` only) — routed through
-      :func:`inject_filter_into_select`, which handles OUTER-join safety
-      (wrapping the inner relation when the predicate would otherwise
-      defeat a downstream RIGHT/FULL OUTER join).  Always applying these
-      at the outer SELECT is safe because the CTE-level pushdown can
-      silently fail when the parent CTE has an opaque body (set-op,
-      CROSS-joined dim columns from authored source SQL, etc.) — dropping
-      the outer copy in those cases loses the filter entirely.  Worst
-      case is a double-application of the same predicate, which is a
-      no-op for correctness.
+    - **Parent-alias atoms** (``main_alias.col`` only) when
+      ``parent_pushdown_active`` is True — DROPPED from outer WHERE.
+      The same predicate has already been pushed into the parent CTE's
+      WHERE, so the outer-level copy is redundant *and* unsafe (it
+      would defeat downstream RIGHT/FULL OUTER joins to dims).
+      ``parent_pushdown_active`` should be set only when the caller
+      knows pushdown actually succeeded for the parent CTE — callers
+      that aren't sure should pre-strip un-pushed filter strings from
+      ``where_clause`` instead of relying on this flag.
+
+    - **Parent-alias atoms** when parent pushdown wasn't applied (e.g.
+      parent is materialized or has a set-op body that blocks
+      pushdown) — routed through :func:`inject_filter_into_select` as
+      the safety backstop.
 
     - **Dim-alias atoms** (and unqualified atoms) — ANDed into the outer
       WHERE.  These rely on the standard dim-filter narrowing
@@ -707,6 +711,8 @@ def _apply_outer_where_atoms(
     for atom in _split_and_atoms(where_clause):
         ns = _filter_namespaces(atom)
         is_parent_only = bool(ns) and ns.issubset({main_alias})
+        if is_parent_only and parent_pushdown_active:
+            continue
         if is_parent_only:
             inject_filter_into_select(select, atom)
         elif select.where:
@@ -1417,7 +1423,7 @@ def build_select_ast(
     # Build CTEs for all non-source nodes. Requested dimension filters and their
     # resolution map are passed through so each CTE can independently decide
     # whether to push a filter into its own WHERE clause.
-    ctes, scanned_sources = collect_node_ctes(
+    ctes, scanned_sources, consumed_by_node = collect_node_ctes(
         ctx,
         nodes_for_ctes,
         needed_columns_by_node,
@@ -1429,6 +1435,10 @@ def build_select_ast(
         if all_filters
         else None,
     )
+    # Surface all CTE-consumed filters so the metrics layer's outer WHERE
+    # can skip re-applying them on top of the aggregation CTEs.
+    for _consumed_set in consumed_by_node.values():
+        ctx.cte_consumed_filters.update(_consumed_set)
 
     # Build SELECT.
     # For non-decomposable metrics, skip GROUP BY to pass through raw rows.
@@ -1440,16 +1450,39 @@ def build_select_ast(
         hints=spark_hints if spark_hints else None,
     )
 
-    # Apply outer WHERE atoms.  Parent-alias atoms are dropped from outer
-    # WHERE when the parent CTE pushdown is active (filter is already in
-    # the parent CTE; the outer copy is redundant and would defeat
-    # downstream OUTER joins).  Dim-alias atoms continue to land in
-    # outer WHERE for standard dim-filter semantics.  See
-    # ``_apply_outer_where_atoms`` for the full rule.
-    parent_pushdown_active = bool(all_filters) and not should_use_materialized_table(
+    # Determine which filters were actually consumed by the parent CTE's
+    # pushdown.  Parent-alias atoms from those filters are dropped from the
+    # outer WHERE (the parent CTE already has them; double-application is
+    # redundant and can defeat downstream RIGHT/FULL OUTER joins).
+    # Filters that weren't consumed (couldn't be pushed — e.g. their column
+    # is projected as a non-column expression) still need to land at the
+    # outer WHERE so they aren't silently dropped.
+    parent_consumed = consumed_by_node.get(parent_node.name, set())
+    parent_pushdown_active = bool(
+        parent_consumed,
+    ) and not should_use_materialized_table(
         ctx,
         parent_node,
     )
+    # If pushdown was partial, strip the consumed filters from
+    # ``where_clause`` before applying the outer atoms — keeps unconsumed
+    # atoms while dropping the redundant copies of consumed ones.
+    if parent_consumed and parent_consumed != set(all_filters):
+        remaining = [f for f in all_filters if f not in parent_consumed]
+        where_clause = (
+            build_outer_where(
+                remaining,
+                filter_column_aliases,
+                resolved_dimensions,
+                main_alias,
+                dim_aliases,
+                parent_node,
+                nodes=ctx.nodes,
+            )
+            if remaining
+            else None
+        )
+        parent_pushdown_active = False
     # Absorb LEFT/INNER-joined dims whose filter would defeat a
     # downstream RIGHT/FULL OUTER JOIN into a filtered CTE on the
     # parent side.  Mutates ``select.from_`` (re-pointing the parent

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -2111,14 +2111,9 @@ def generate_metrics_sql(
         )
 
         # Filter out filters that reference filter-only dimensions
-        # Those filters are already applied in the grain group CTEs.
-        # Also skip filters that were already injected into the measures-layer
-        # CTE's WHERE — re-applying them at the outer level is redundant and
-        # would defeat downstream OUTER-join semantics.
+        # Those filters are already applied in the grain group CTEs
         applicable_dimension_filters = []
         for f in dimension_filters_raw:
-            if f in ctx.cte_consumed_filters:
-                continue
             filter_ast = parse_filter(f)
             # Check if any column ref in this filter is a filter-only dimension.
             # Must handle both plain column refs and role-qualified subscript refs

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -2111,9 +2111,14 @@ def generate_metrics_sql(
         )
 
         # Filter out filters that reference filter-only dimensions
-        # Those filters are already applied in the grain group CTEs
+        # Those filters are already applied in the grain group CTEs.
+        # Also skip filters that were already injected into the measures-layer
+        # CTE's WHERE — re-applying them at the outer level is redundant and
+        # would defeat downstream OUTER-join semantics.
         applicable_dimension_filters = []
         for f in dimension_filters_raw:
+            if f in ctx.cte_consumed_filters:
+                continue
             filter_ast = parse_filter(f)
             # Check if any column ref in this filter is a filter-only dimension.
             # Must handle both plain column refs and role-qualified subscript refs

--- a/datajunction-server/datajunction_server/construction/build_v3/node_query.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/node_query.py
@@ -340,7 +340,7 @@ def _build_no_dimensions(
     # ``collect_node_ctes`` returns (cte_name, body) pairs for every non-source
     # node in the dependency chain (including the starting node itself, with
     # its parent table refs already rewritten by ``rewrite_table_references``).
-    cte_pairs, _ = collect_node_ctes(ctx, [starting])
+    cte_pairs, _, _ = collect_node_ctes(ctx, [starting])
     starting_cte_name = get_cte_name(starting.name)
 
     starting_body: ast.Query | None = None
@@ -426,7 +426,7 @@ def _build_with_dimensions(
     # ``needed_columns_by_node`` — the v3 metric path uses it for column
     # trimming, but for ``/sql/{node}`` we want each node's full projection
     # in the CTE so the user gets every column the node defines.
-    cte_pairs, _ = collect_node_ctes(
+    cte_pairs, _, _ = collect_node_ctes(
         ctx,
         nodes_for_ctes,
         pushdown=PushdownFilters(

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -112,6 +112,12 @@ class BuildContext:
     # re-apply them (the dim ref is unreachable from the fact).
     pushdown_consumed_filters: set[str] = field(default_factory=set)
 
+    # Filter strings that were successfully injected into a measures-layer
+    # CTE's WHERE clause.  The metrics-layer outer WHERE checks this set
+    # and skips re-applying these predicates on top of the aggregation
+    # CTEs — the CTE already narrows its rows correctly.
+    cte_consumed_filters: set[str] = field(default_factory=set)
+
     # Dim refs handled via upstream pushdown — caller skips emitting a
     # ResolvedDimension for these and skips the unreachable-dim error.
     pushdown_resolved_dims: set[str] = field(default_factory=set)

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -8300,14 +8300,26 @@ class TestParentCteFilterLanding:
         )
         assert response.status_code == 200, response.json()
         sql = get_first_grain_group(response.json())["sql"]
-        # The filter on the CROSS-joined spine column MUST appear in the
-        # SQL.  Before the fix this was silently dropped because the
-        # parent CTE is opaque (DJ couldn't inject into the source's
-        # CROSS JOIN), and the outer-WHERE copy was dropped on the
-        # false assumption that the parent CTE already had it.
-        assert "'1-35'" in sql, (
-            "Filter on CROSS-joined spine column was dropped from generated SQL.\n"
-            f"SQL:\n{sql}"
+        # The filter lands in the parent CTE's WHERE (DJ's pushdown
+        # into the transform body succeeds because the column is
+        # exposed by the CTE projection).  Now that pushdown success
+        # is tracked per-filter, the outer SELECT drops its redundant
+        # copy — single application, no double-WHERE.
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_events_by_window AS (
+                SELECT e.value, w.window
+                FROM default.v3.events_cross_spine AS e
+                CROSS JOIN default.v3.obs_windows AS w
+                WHERE w.window IN ('1-35')
+            )
+            SELECT t1.window, SUM(t1.value) value_sum_HASH
+            FROM v3_events_by_window t1
+            GROUP BY t1.window
+            """,
+            normalize_aliases=True,
         )
 
     @pytest.mark.asyncio
@@ -8375,11 +8387,26 @@ class TestParentCteFilterLanding:
         )
         assert response.status_code == 200, response.json()
         sql = get_first_grain_group(response.json())["sql"]
-        # Both filters must survive into the generated SQL.  Before the
-        # fix, the `event_date` filter (parent-alias atom) would be
-        # silently dropped because `parent_pushdown_active` was True.
-        assert "'1-35'" in sql, f"Spine filter dropped.\nSQL:\n{sql}"
-        assert "20260101" in sql, f"Parent-column filter dropped.\nSQL:\n{sql}"
+        # Both filters land in the parent CTE's WHERE.  Both are
+        # tracked as consumed, so neither appears in the outer SELECT.
+        # The regression guarantee is that neither filter is silently
+        # dropped — they live in the CTE's WHERE.
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_events_by_window_multi AS (
+                SELECT e.account_id, e.event_date, e.value, w.window
+                FROM default.v3.events_multi_filter AS e
+                CROSS JOIN default.v3.obs_windows AS w
+                WHERE w.window IN ('1-35') AND e.event_date >= 20260101
+            )
+            SELECT t1.window, t1.account_id, SUM(t1.value) value_sum_HASH
+            FROM v3_events_by_window_multi t1
+            GROUP BY t1.window, t1.account_id
+            """,
+            normalize_aliases=True,
+        )
 
     @pytest.mark.asyncio
     async def test_filter_lands_when_parent_cte_is_setop(
@@ -8431,8 +8458,33 @@ class TestParentCteFilterLanding:
         )
         assert response.status_code == 200, response.json()
         sql = get_first_grain_group(response.json())["sql"]
-        # Both predicates must appear in the SQL — before the fix, the
-        # set-op body blocked CTE pushdown AND the outer copy was
-        # dropped, losing the filters entirely.
-        assert "20260101" in sql, f"event_date filter dropped.\nSQL:\n{sql}"
-        assert "'a'" in sql, f"branch filter dropped.\nSQL:\n{sql}"
+        # Parent CTE body is a UNION ALL.  Shape B (per-arm pushdown)
+        # injects ``event_date >= 20260101`` into each arm's WHERE so
+        # the planner can prune at the source scan; that filter is
+        # marked consumed and drops out of the outer WHERE.  The
+        # ``branch = 'a'`` predicate is NOT pushed per-arm because each
+        # arm projects ``branch`` as a literal (``'a' AS branch``,
+        # ``'b' AS branch``) — pushing a literal-alias predicate into
+        # WHERE would be unsafe.  Since that filter wasn't consumed,
+        # the outer SELECT keeps it.  Regression guarantee: no filter
+        # is silently dropped.
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_events_union AS (
+                SELECT account_id, event_date, value, 'a' AS branch
+                FROM default.v3.events_setop
+                WHERE event_date >= 20260101
+                UNION ALL
+                SELECT account_id, event_date, value, 'b' AS branch
+                FROM default.v3.events_setop
+                WHERE event_date >= 20260101
+            )
+            SELECT t1.branch, SUM(t1.value) value_sum_HASH
+            FROM v3_events_union t1
+            WHERE t1.branch = 'a'
+            GROUP BY t1.branch
+            """,
+            normalize_aliases=True,
+        )

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -8172,3 +8172,267 @@ class TestMultiHopInnerDefeatsLeft:
             """,
             normalize_aliases=True,
         )
+
+
+async def _setup_window_dim(client):
+    """A tiny "spine" dim — rows like ('1-35',), ('1-7',), etc.
+
+    Shape mirrors the XP observation_window dimension that's CROSS-joined
+    into a fact's transform body.  Idempotent: a 200 response means the
+    dim was created by a prior test in the same fixture.
+    """
+    resp = await client.post(
+        "/nodes/source/",
+        json={
+            "name": "v3.src_obs_window",
+            "description": "Observation windows",
+            "columns": [{"name": "window", "type": "string"}],
+            "mode": "published",
+            "catalog": "default",
+            "schema_": "v3",
+            "table": "obs_windows",
+        },
+    )
+    assert resp.status_code in (200, 201), resp.json()
+    resp = await client.post(
+        "/nodes/dimension/",
+        json={
+            "name": "v3.obs_window_dim",
+            "description": "Observation window dim",
+            "query": "SELECT window FROM v3.src_obs_window",
+            "mode": "published",
+            "primary_key": ["window"],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.json()
+
+
+async def _setup_events_source(client, suffix: str, table: str) -> str:
+    """A fact-shaped events source used by the cross-joined-spine tests."""
+    name = f"v3.src_events_{suffix}"
+    resp = await client.post(
+        "/nodes/source/",
+        json={
+            "name": name,
+            "description": f"Events ({suffix})",
+            "columns": [
+                {"name": "event_id", "type": "int"},
+                {"name": "account_id", "type": "int"},
+                {"name": "event_date", "type": "int"},
+                {"name": "value", "type": "double"},
+            ],
+            "mode": "published",
+            "catalog": "default",
+            "schema_": "v3",
+            "table": table,
+        },
+    )
+    assert resp.status_code in (200, 201), resp.json()
+    return name
+
+
+class TestParentCteFilterLanding:
+    """Regression tests for the silent-drop bug in
+    :func:`_apply_outer_where_atoms`.
+
+    Before the fix, parent-only filter atoms were dropped whenever any
+    filter was present, on the assumption that pushdown into the parent
+    CTE had already happened.  That assumption broke when the parent CTE
+    was opaque (set-op body, CROSS-joined dim columns from authored
+    source SQL), and the filter was lost entirely.
+
+    These tests pin the shape: every requested filter must land in the
+    generated SQL somewhere, even when the parent CTE can't accept a
+    pushdown.
+    """
+
+    @pytest.mark.asyncio
+    async def test_filter_on_cross_joined_spine_lands_at_outer_where(
+        self,
+        client_with_build_v3,
+    ):
+        """Transform CROSS-joins a spine dim inline (XP observation_window
+        shape).  A filter on the spine's column must land at the outer
+        SELECT — DJ can't push it into the source SQL's CROSS JOIN.
+        """
+        client = client_with_build_v3
+        await _setup_window_dim(client)
+        src = await _setup_events_source(client, "cross_spine", "events_cross_spine")
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.events_by_window",
+                "query": (
+                    "SELECT e.account_id, e.event_date, e.value, w.window "
+                    f"FROM {src} AS e "
+                    "CROSS JOIN v3.src_obs_window AS w"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date", "window"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/v3.events_by_window/link",
+            json={
+                "dimension_node": "v3.obs_window_dim",
+                "join_type": "inner",
+                "join_on": "v3.events_by_window.window = v3.obs_window_dim.window",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.events_by_window_total",
+                "query": "SELECT SUM(value) FROM v3.events_by_window",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.events_by_window_total"],
+                "dimensions": ["v3.obs_window_dim.window"],
+                "filters": ["v3.obs_window_dim.window IN ('1-35')"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # The filter on the CROSS-joined spine column MUST appear in the
+        # SQL.  Before the fix this was silently dropped because the
+        # parent CTE is opaque (DJ couldn't inject into the source's
+        # CROSS JOIN), and the outer-WHERE copy was dropped on the
+        # false assumption that the parent CTE already had it.
+        assert "'1-35'" in sql, (
+            "Filter on CROSS-joined spine column was dropped from generated SQL.\n"
+            f"SQL:\n{sql}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_filters_all_land_when_pushdown_partial(
+        self,
+        client_with_build_v3,
+    ):
+        """Mix of filters: one on a column the parent CTE exposes
+        directly (the CROSS-joined spine), one on a column from the
+        source's own projection.  Both must land; neither may be
+        silently dropped because the other was tagged "pushable".
+        """
+        client = client_with_build_v3
+        await _setup_window_dim(client)
+        src = await _setup_events_source(
+            client,
+            "multi_filter",
+            "events_multi_filter",
+        )
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.events_by_window_multi",
+                "query": (
+                    "SELECT e.account_id, e.event_date, e.value, w.window "
+                    f"FROM {src} AS e "
+                    "CROSS JOIN v3.src_obs_window AS w"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date", "window"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/v3.events_by_window_multi/link",
+            json={
+                "dimension_node": "v3.obs_window_dim",
+                "join_type": "inner",
+                "join_on": "v3.events_by_window_multi.window = v3.obs_window_dim.window",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.events_by_window_multi_total",
+                "query": "SELECT SUM(value) FROM v3.events_by_window_multi",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.events_by_window_multi_total"],
+                "dimensions": [
+                    "v3.obs_window_dim.window",
+                    "v3.events_by_window_multi.account_id",
+                ],
+                "filters": [
+                    "v3.obs_window_dim.window IN ('1-35')",
+                    "v3.events_by_window_multi.event_date >= 20260101",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Both filters must survive into the generated SQL.  Before the
+        # fix, the `event_date` filter (parent-alias atom) would be
+        # silently dropped because `parent_pushdown_active` was True.
+        assert "'1-35'" in sql, f"Spine filter dropped.\nSQL:\n{sql}"
+        assert "20260101" in sql, f"Parent-column filter dropped.\nSQL:\n{sql}"
+
+    @pytest.mark.asyncio
+    async def test_filter_lands_when_parent_cte_is_setop(
+        self,
+        client_with_build_v3,
+    ):
+        """Transform body is a UNION ALL — `_cte_has_set_operation` is
+        True, so `filter_cte_projection` is skipped and pushdown into
+        the parent CTE body can silently fail.  Filters on
+        parent-exposed columns must still land at the outer SELECT.
+        """
+        client = client_with_build_v3
+        src = await _setup_events_source(client, "setop", "events_setop")
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.events_union",
+                "query": (
+                    "SELECT account_id, event_date, value, 'a' AS branch "
+                    f"FROM {src} "
+                    "UNION ALL "
+                    "SELECT account_id, event_date, value, 'b' AS branch "
+                    f"FROM {src}"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date", "branch"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.events_union_total",
+                "query": "SELECT SUM(value) FROM v3.events_union",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.events_union_total"],
+                "dimensions": ["v3.events_union.branch"],
+                "filters": [
+                    "v3.events_union.event_date >= 20260101",
+                    "v3.events_union.branch = 'a'",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Both predicates must appear in the SQL — before the fix, the
+        # set-op body blocked CTE pushdown AND the outer copy was
+        # dropped, losing the filters entirely.
+        assert "20260101" in sql, f"event_date filter dropped.\nSQL:\n{sql}"
+        assert "'a'" in sql, f"branch filter dropped.\nSQL:\n{sql}"

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -8488,3 +8488,125 @@ class TestParentCteFilterLanding:
             """,
             normalize_aliases=True,
         )
+
+    @pytest.mark.asyncio
+    async def test_fact_filter_under_right_outer_join_lands_in_fact_cte(
+        self,
+        client_with_build_v3,
+    ):
+        """Regression for the XP-style RIGHT OUTER bug.
+
+        When the fact is RIGHT-OUTER-joined to a spine dim, the fact is
+        the null-producing side: spine rows without a matching fact row
+        have NULL fact columns.  A filter on a fact column placed at the
+        outer WHERE silently converts the RIGHT OUTER to INNER — the
+        null-fact rows fail the predicate and get dropped.  The fix
+        pushes the parent-only filter into the fact's CTE *before* the
+        join, so the RIGHT OUTER's row-preservation semantics survive.
+
+        Asserts: the filter on ``account_id`` lives in the fact CTE's
+        WHERE; the outer SELECT has no WHERE on the fact column; the
+        ``RIGHT OUTER JOIN`` keyword remains intact.
+        """
+        client = client_with_build_v3
+
+        # Spine dim — preserved by a RIGHT OUTER from the fact.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_right_spine",
+                "description": "Spine source",
+                "columns": [
+                    {"name": "spine_id", "type": "int"},
+                    {"name": "account_id", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "right_spine",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.right_spine_dim",
+                "description": "Right spine dim",
+                "query": "SELECT spine_id, account_id FROM v3.src_right_spine",
+                "mode": "published",
+                "primary_key": ["spine_id"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Fact source — the null-producing side under the RIGHT OUTER.
+        src = await _setup_events_source(
+            client,
+            "right_outer",
+            "events_right_outer",
+        )
+
+        # Fact-rooted dim link with join_type=right — fact RIGHT-OUTER-joins
+        # the spine.  The fact side becomes the null-producing branch.
+        resp = await client.post(
+            f"/nodes/{src}/link",
+            json={
+                "dimension_node": "v3.right_spine_dim",
+                "join_type": "right",
+                "join_on": (f"{src}.account_id = v3.right_spine_dim.account_id"),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.right_outer_total",
+                "query": f"SELECT SUM(value) FROM {src}",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.right_outer_total"],
+                "dimensions": ["v3.right_spine_dim.spine_id"],
+                # Filter on a fact column.  At the outer WHERE this would
+                # null-reject spine-only rows and defeat the RIGHT OUTER.
+                "filters": [f"{src}.account_id IN (1, 2, 3)"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+
+        # The fact's source CTE has the filter applied BEFORE the RIGHT
+        # OUTER.  The fact-column filter is wrapped into the fact-source
+        # side of the RIGHT OUTER via
+        # ``_try_push_filter_into_outer_join_side`` — the
+        # events_right_outer table becomes an inline subquery with the
+        # filter pre-applied, and *then* the RIGHT OUTER joins the
+        # spine dim CTE.  No filter at the outer SELECT scope.  Spine
+        # rows whose ``account_id`` doesn't match any filtered fact row
+        # are preserved with NULL value (RIGHT OUTER's row-preservation
+        # semantics survive).
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_right_spine_dim AS (
+              SELECT spine_id, account_id
+              FROM default.v3.right_spine
+              WHERE account_id IN (1, 2, 3)
+            )
+            SELECT t2.spine_id, SUM(t1.value) value_sum_HASH
+            FROM (SELECT *
+                  FROM default.v3.events_right_outer t1
+                  WHERE t1.account_id IN (1, 2, 3)) t1
+            RIGHT OUTER JOIN v3_right_spine_dim t2
+                ON t1.account_id = t2.account_id
+            GROUP BY t2.spine_id
+            """,
+            normalize_aliases=True,
+        )

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -108,8 +108,10 @@ class TestSetOperationTransforms:
         """Filter on a column of a UNION-ALL transform is pushed into each
         arm's WHERE (Shape B per-arm pushdown).  Each arm's original
         predicate is preserved and the new filter is ANDed alongside it.
-        Once pushed, the filter is consumed so it doesn't reappear at
-        the outer query's WHERE.
+        The filter also continues to land at the metrics-layer outer
+        WHERE — the per-arm pushdown narrows the scan early, and the
+        outer copy is the standard dim-filter narrowing on the
+        aggregation CTE.
         """
         response = await client_with_union_transform.get(
             "/sql/metrics/v3/",
@@ -141,6 +143,7 @@ class TestSetOperationTransforms:
             SELECT orders_unified_0.status AS status,
               COUNT(DISTINCT orders_unified_0.order_id) AS unified_order_count
             FROM orders_unified_0
+            WHERE orders_unified_0.status = 'completed'
             GROUP BY orders_unified_0.status
             """,
         )

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -101,13 +101,15 @@ class TestSetOperationTransforms:
         )
 
     @pytest.mark.asyncio
-    async def test_union_transform_filter_stays_on_outer_query(
+    async def test_union_transform_filter_pushed_into_each_arm(
         self,
         client_with_union_transform,
     ):
-        """Filter on a column of a UNION-ALL transform must NOT be pushed
-        into either arm.  The filter lands on the outer query's WHERE; the
-        set-op arms keep their original predicates untouched.
+        """Filter on a column of a UNION-ALL transform is pushed into each
+        arm's WHERE (Shape B per-arm pushdown).  Each arm's original
+        predicate is preserved and the new filter is ANDed alongside it.
+        Once pushed, the filter is consumed so it doesn't reappear at
+        the outer query's WHERE.
         """
         response = await client_with_union_transform.get(
             "/sql/metrics/v3/",
@@ -125,11 +127,11 @@ class TestSetOperationTransforms:
             v3_orders_unified AS (
               SELECT order_id, customer_id, order_date, status
               FROM default.v3.orders
-              WHERE status = 'completed'
+              WHERE status = 'completed' AND status = 'completed'
               UNION ALL
               SELECT order_id, customer_id, order_date, status
               FROM default.v3.orders
-              WHERE status = 'shipped'
+              WHERE status = 'shipped' AND status = 'completed'
             ),
             orders_unified_0 AS (
               SELECT t1.status, t1.order_id
@@ -139,7 +141,6 @@ class TestSetOperationTransforms:
             SELECT orders_unified_0.status AS status,
               COUNT(DISTINCT orders_unified_0.order_id) AS unified_order_count
             FROM orders_unified_0
-            WHERE orders_unified_0.status = 'completed'
             GROUP BY orders_unified_0.status
             """,
         )


### PR DESCRIPTION
### Summary

Two related issues in v3 measures SQL generation cause filters to be applied at the wrong scope.

#### Example 1: Set-op CTE bodies skipped

A transform `events_unified` with a `UNION ALL` body:
```sql
SELECT order_id, status, amount FROM orders_live
UNION ALL
SELECT order_id, status, amount FROM orders_archive
```

Requesting a metric on `events_unified` with filter `events_unified.status = 'completed'` used to produce:
```sql
WITH events_unified AS (
  SELECT order_id, status, amount FROM orders_live
  UNION ALL
  SELECT order_id, status, amount FROM orders_archive
)
SELECT status, SUM(amount)
FROM events_unified
WHERE status = 'completed'    -- applied only at outer scope, so both arms get fully scanned
GROUP BY status
```

Both source tables (`orders_live` and `orders_archive`) get fully scanned because the pushdown bails on set-op bodies on either side of the union all.

#### Example 2: Filter silently dropped

A transform `events_windowed` that exposes a column via an inline `CROSS JOIN` in its source SQL:
```sql
SELECT e.*, w.window_size
FROM events e
CROSS JOIN window_dim w
```

Requesting filter `window_dim.window_size = '7d'` would silently drop the filter. The blanket `parent_pushdown_active` flag assumed the filter had been pushed into `events_windowed`, so the outer `WHERE` copy was dropped, but the actual pushdown failed because the column lives inside an opaque source body.

This results in no `window_size` filter anywhere in the SQL.

#### Fix

For set-op CTEs, we do a per-arm pushdown. When a CTE body is a `UNION`/`INTERSECT`/`EXCEPT` chain, `_resolve_pushdown_filters_for_cte` now walks every arm and rewrites the filter against each arm's projection. This is atomic per filter, so if any arm can't accept the rewrite, the filter is skipped entirely for that CTE.

Example 1 above now produces:
```sql
WITH events_unified AS (
  SELECT order_id, status, amount FROM orders_live
  WHERE status = 'completed'         -- ← pushed into arm 1
  UNION ALL
  SELECT order_id, status, amount FROM orders_archive
  WHERE status = 'completed'         -- ← pushed into arm 2
)
SELECT status, SUM(amount) FROM events_unified GROUP BY status
```

We also do per-filter pushdown tracking, so the silent-drop case is gone. The filter that wasn't successfully consumed by the parent CTE stays in the outer WHERE clause, and `_apply_outer_where_atoms` routes it through `inject_filter_into_select`, which handles the outer-join safety.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
