### PR TITLE
v3 SQL: walk every source-table reference when pushing dim filters

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1165,6 +1165,7 @@ def _resolve_pushdown_filters_for_cte(
         return [], set()
 
     target_select = cast(ast.Select, cte_query.select)
+    alias_to_table = _build_source_alias_map(cte_query)
     results: list[tuple[ast.Select, ast.Expression]] = []
     consumed: set[str] = set()
     for filter_str in pushdown_filters:
@@ -1178,7 +1179,125 @@ def _resolve_pushdown_filters_for_cte(
             continue
         results.append((target_select, rewritten))
         consumed.add(filter_str)
+
+        # Additionally walk every other reference to the same physical
+        # source tables inside the CTE body and inject a retargeted
+        # copy of the filter at each one's enclosing Select.  This
+        # matches the upstream-pushdown path's ``_resolve_pushdown_targets``
+        # behavior so that the direct-link path is just as thorough:
+        # a transform whose source body references the same fact table
+        # twice (e.g. once at top level, once inside a LEFT JOIN's
+        # nested subquery) gets the filter applied to BOTH references,
+        # not just the top-level alias.
+        for primary_alias in _qualifier_aliases(rewritten):
+            physical_table = alias_to_table.get(primary_alias)
+            if not physical_table:
+                continue
+            for ref_alias, enclosing_select in _find_table_refs(
+                cte_query,
+                physical_table,
+            ):
+                if ref_alias == primary_alias and enclosing_select is target_select:
+                    continue  # already covered by the primary injection
+                cloned = _retarget_filter_qualifier(
+                    rewritten,
+                    primary_alias,
+                    ref_alias,
+                )
+                results.append((enclosing_select, cloned))
     return results, consumed
+
+
+def _build_source_alias_map(cte_query: ast.Query) -> dict[str, str]:
+    """Walk every ``ast.Table`` in the CTE body and build an
+    ``alias → physical_table_name`` map.
+
+    For aliased refs (``Table AS a``) the key is the alias name.  For bare
+    refs (no alias) the key is the table's short name — matching how the
+    SQL parser surfaces them when looking up column qualifications.
+
+    Multiple Table refs sharing the same alias is rare and the last-write
+    wins here.  Callers use this map only to look up the physical table a
+    qualified column reference belongs to, so collisions only matter when
+    the same alias is reused for two different tables in distinct
+    subqueries — a pathological shape DJ doesn't optimize for.
+    """
+    result: dict[str, str] = {}
+    for tbl in cte_query.find_all(ast.Table):
+        try:
+            tbl_name = tbl.name.identifier(quotes=False)
+        except Exception:  # pragma: no cover
+            continue
+        alias = tbl.alias.name if tbl.alias else tbl_name.split(SEPARATOR)[-1]
+        result[alias] = tbl_name
+    return result
+
+
+def _find_table_refs(
+    cte_query: ast.Query,
+    physical_table_name: str,
+) -> list[tuple[str, ast.Select]]:
+    """Find every ``ast.Table`` reference to ``physical_table_name`` in
+    the CTE body and return ``(alias, enclosing_select)`` per match.
+
+    Used by :func:`_resolve_pushdown_filters_for_cte` to inject a filter
+    not just at the CTE's top-level Select but also at every nested
+    subquery that scans the same physical source table.
+    """
+    results: list[tuple[str, ast.Select]] = []
+    for tbl in cte_query.find_all(ast.Table):
+        try:
+            tbl_name = tbl.name.identifier(quotes=False)
+        except Exception:  # pragma: no cover
+            continue
+        if tbl_name != physical_table_name:
+            continue
+        alias = tbl.alias.name if tbl.alias else tbl_name.split(SEPARATOR)[-1]
+        enclosing: Optional[ast.Select] = None
+        cur = getattr(tbl, "parent", None)
+        while cur is not None:
+            if isinstance(cur, ast.Select):
+                enclosing = cur
+                break
+            cur = getattr(cur, "parent", None)
+        if enclosing is not None:  # pragma: no branch
+            results.append((alias, enclosing))
+    return results
+
+
+def _qualifier_aliases(filter_ast: ast.Expression) -> set[str]:
+    """Return the set of distinct qualifier aliases used in ``filter_ast``.
+
+    A column like ``a.snapshot_utc_date`` contributes ``"a"`` to the set;
+    bare column references contribute nothing.
+    """
+    result: set[str] = set()
+    for col in filter_ast.find_all(ast.Column):
+        if col.name and col.name.namespace:
+            result.add(col.name.namespace.name)
+    return result
+
+
+def _retarget_filter_qualifier(
+    filter_ast: ast.Expression,
+    old_alias: str,
+    new_alias: str,
+) -> ast.Expression:
+    """Deepcopy ``filter_ast`` and rewrite every column qualified by
+    ``old_alias`` to be qualified by ``new_alias`` instead.
+
+    Used to clone a primary-Select-targeted filter for injection at a
+    sibling reference to the same physical source table.  The cloned
+    filter uses the sibling's alias so column references resolve in the
+    sibling's scope.
+    """
+    cloned = deepcopy(filter_ast)
+    for col in cloned.find_all(ast.Column):
+        if col.name is None or not col.name.namespace:
+            continue
+        if col.name.namespace.name == old_alias:
+            col.name = ast.Name(col.name.name, namespace=ast.Name(new_alias))
+    return cloned
 
 
 def _cte_has_set_operation(cte_query: ast.Query) -> bool:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1235,7 +1235,7 @@ def _find_table_refs(
         alias = tbl.alias.name if tbl.alias else tbl_name.split(SEPARATOR)[-1]
         enclosing: Optional[ast.Select] = None
         cur = getattr(tbl, "parent", None)
-        while cur is not None:
+        while cur is not None:  # pragma: no branch
             if isinstance(cur, ast.Select):
                 enclosing = cur
                 break

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1142,11 +1142,15 @@ def _resolve_pushdown_filters_for_cte(
     using the CTE's internal table-qualified column names and returned, paired
     with the Select node it should be injected into.
 
-    For set-operation CTEs (UNION / INTERSECT / EXCEPT), the rewrite is done
-    independently per arm — each arm's projection may resolve the same output
-    column differently, and pushing only into the first arm would produce
-    semantically wrong SQL.  The push is atomic per filter: if any arm can't
-    accept the rewrite, the filter is skipped for the whole CTE.
+    Set-operation CTEs (UNION / INTERSECT / EXCEPT): the filter is injected
+    into the **primary** Select only — i.e. the first arm of the union
+    chain.  Subsequent arms (reachable via ``set_op.right``) are left
+    untouched.  Matches v2's behavior: transform authors often use
+    asymmetric UNION arms where the secondary arm acts as an unfiltered
+    backstop, and uniformly pushing into every arm would override that
+    intent.  Pushing into the primary arm is still useful — it's where
+    DJ's projection inspection sees the CTE's output schema, and Spark
+    can partition-prune through it just as well as a wrapper subquery.
 
     Returns ``(injections, consumed)`` where ``injections`` is the list of
     ``(target_select, rewritten_filter)`` pairs to inject and ``consumed``
@@ -1160,26 +1164,20 @@ def _resolve_pushdown_filters_for_cte(
     if not node_output_cols:  # pragma: no cover
         return [], set()
 
-    arms = _setop_arms(cte_query)
+    target_select = cast(ast.Select, cte_query.select)
     results: list[tuple[ast.Select, ast.Expression]] = []
     consumed: set[str] = set()
     for filter_str in pushdown_filters:
-        per_arm: list[tuple[ast.Select, ast.Expression]] = []
-        all_ok = True
-        for arm in arms:
-            rewritten = _rewrite_filter_for_select(
-                filter_str,
-                filter_column_aliases,
-                node_output_cols,
-                arm,
-            )
-            if rewritten is None:
-                all_ok = False
-                break
-            per_arm.append((arm, rewritten))
-        if all_ok:
-            results.extend(per_arm)
-            consumed.add(filter_str)
+        rewritten = _rewrite_filter_for_select(
+            filter_str,
+            filter_column_aliases,
+            node_output_cols,
+            target_select,
+        )
+        if rewritten is None:
+            continue
+        results.append((target_select, rewritten))
+        consumed.add(filter_str)
     return results, consumed
 
 
@@ -1213,19 +1211,89 @@ def _resolve_pushdown_form(
     output_col: str,
     cte_output_cols: set[str],
     projection_map: dict[str, str | None],
+    null_producing_aliases: set[str] | None = None,
 ) -> str | None:
     """Determine the WHERE-safe form for a filter column in a specific CTE.
 
     Returns the WHERE-safe reference as a string (qualified or bare), or
-    ``None`` when the filter cannot be safely pushed into this CTE — either
-    because the column isn't exposed at all, or because the projection is a
-    non-column expression that can't be inlined into WHERE.
+    ``None`` when the filter cannot be safely pushed into this CTE.  Three
+    cases decline pushdown:
+
+    1. The column isn't exposed at all.
+    2. The projection is a non-column expression that can't be inlined.
+    3. The underlying table is on the null-producing side of an OUTER join
+       inside the CTE body — pushing a NULL-rejecting predicate to WHERE
+       would silently convert the OUTER join to an INNER (drop rows that
+       the OUTER was supposed to preserve).  These filters belong in the
+       join's ON clause, not its WHERE; callers either need to handle
+       that themselves or leave the filter at outer scope.
     """
     if output_col not in cte_output_cols:
         return None
     if output_col in projection_map:
-        return projection_map[output_col]  # may be None: unsafe projection
+        underlying = projection_map[output_col]
+        if underlying is None:
+            return None  # non-column projection
+        if null_producing_aliases and "." in underlying:
+            prefix = underlying.split(".", 1)[0]
+            if prefix in null_producing_aliases:
+                return None  # would defeat the OUTER join
+        return underlying
     return output_col  # pruned from CTE SELECT; falls through to bare name
+
+
+def _null_producing_aliases(select: ast.Select) -> set[str]:
+    """Return the set of table aliases that sit on the null-producing side
+    of any OUTER join in this Select's FROM clause.
+
+    Rules per join type:
+    - ``LEFT OUTER``: the right side may be NULL → its alias is null-producing.
+    - ``RIGHT OUTER``: everything to its left may be NULL → all preceding
+      aliases in the same relation are null-producing.
+    - ``FULL OUTER``: both sides may be NULL.
+    - ``INNER`` / ``CROSS``: no nulls introduced.
+
+    The walk is per relation in ``select.from_.relations``; aliases from
+    different relations don't interact.
+    """
+    null_producing: set[str] = set()
+    if not select.from_:
+        return null_producing
+
+    def _extract_alias(expr: object) -> str | None:
+        # Aliased table reference: SQL parser wraps it in an Alias node.
+        if isinstance(expr, ast.Alias):
+            alias = getattr(expr, "alias", None)
+            if alias is not None and hasattr(alias, "name"):
+                return alias.name
+        # Bare Table with no alias: use the unqualified table name.
+        if isinstance(expr, ast.Table):
+            name = expr.name
+            if name is not None and hasattr(name, "name"):
+                return name.name
+        return None
+
+    for relation in select.from_.relations:
+        left_aliases: set[str] = set()
+        primary_alias = _extract_alias(relation.primary)
+        if primary_alias:
+            left_aliases.add(primary_alias)
+        for join in relation.extensions:
+            right_alias = _extract_alias(join.right)
+            jt = (join.join_type or "").upper().strip()
+            if jt in ("LEFT", "LEFT OUTER"):
+                if right_alias:
+                    null_producing.add(right_alias)
+            elif jt in ("RIGHT", "RIGHT OUTER"):
+                null_producing.update(left_aliases)
+            elif jt in ("FULL", "FULL OUTER"):
+                null_producing.update(left_aliases)
+                if right_alias:
+                    null_producing.add(right_alias)
+            # INNER / CROSS / (no join_type): no nulls introduced
+            if right_alias:
+                left_aliases.add(right_alias)
+    return null_producing
 
 
 def _rewrite_filter_for_cte(
@@ -1281,6 +1349,7 @@ def _rewrite_filter_for_select(
     safely pushed into this Select.
     """
     projection_map = _build_select_projection_map(cte_select)
+    null_producing = _null_producing_aliases(cte_select)
     filter_ast = parse_filter(filter_str)
 
     # First pass: plan the rewrites by walking the AST.  Role-qualified refs
@@ -1321,7 +1390,12 @@ def _rewrite_filter_for_select(
         ) or filter_column_aliases.get(base)
         if output_col is None:
             continue  # pragma: no cover
-        form = _resolve_pushdown_form(output_col, cte_output_cols, projection_map)
+        form = _resolve_pushdown_form(
+            output_col,
+            cte_output_cols,
+            projection_map,
+            null_producing,
+        )
         if form is None:
             return None
         replacement = _column_from_qualified(form)
@@ -1341,7 +1415,12 @@ def _rewrite_filter_for_select(
         if not full_name or full_name not in filter_column_aliases:
             continue
         output_col = filter_column_aliases[full_name]
-        form = _resolve_pushdown_form(output_col, cte_output_cols, projection_map)
+        form = _resolve_pushdown_form(
+            output_col,
+            cte_output_cols,
+            projection_map,
+            null_producing,
+        )
         if form is None:
             return None
         column_rewrites.append((col, _column_from_qualified(form)))

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1108,26 +1108,6 @@ def _inject_filter_into_where(
     inject_filter_into_select(cast(ast.Select, query_ast.select), filter_expr)
 
 
-def _setop_arms(cte_query: ast.Query) -> list[ast.Select]:
-    """Return every Select arm in a (possibly chained) set-operation CTE body.
-
-    A non-set-op CTE returns a single-element list containing its Select.
-    A UNION/INTERSECT/EXCEPT chain returns each arm in order — the first arm
-    is ``cte_query.select`` and subsequent arms hang off ``set_op.right``.
-    """
-    arms: list[ast.Select] = []
-    cur: Optional[ast.Select] = (
-        cte_query.select if isinstance(cte_query.select, ast.Select) else None
-    )
-    while cur is not None:
-        arms.append(cur)
-        nxt = cur.set_op.right if cur.set_op else None
-        # ``set_op.right`` is typed as SelectExpression which may also be a
-        # parenthesised subquery; in practice DJ always emits a Select here.
-        cur = nxt if isinstance(nxt, ast.Select) else None
-    return arms
-
-
 def _resolve_pushdown_filters_for_cte(
     node: "Node",
     cte_query: ast.Query,

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1171,7 +1171,7 @@ def _resolve_pushdown_filters_for_cte(
         # not just the top-level alias.
         for primary_alias in _qualifier_aliases(rewritten):
             physical_table = alias_to_table.get(primary_alias)
-            if not physical_table:
+            if not physical_table:  # pragma: no cover
                 continue
             for ref_alias, enclosing_select in _find_table_refs(
                 cte_query,
@@ -1273,9 +1273,9 @@ def _retarget_filter_qualifier(
     """
     cloned = deepcopy(filter_ast)
     for col in cloned.find_all(ast.Column):
-        if col.name is None or not col.name.namespace:
+        if col.name is None or not col.name.namespace:  # pragma: no cover
             continue
-        if col.name.namespace.name == old_alias:
+        if col.name.namespace.name == old_alias:  # pragma: no branch
             col.name = ast.Name(col.name.name, namespace=ast.Name(new_alias))
     return cloned
 
@@ -1310,89 +1310,28 @@ def _resolve_pushdown_form(
     output_col: str,
     cte_output_cols: set[str],
     projection_map: dict[str, str | None],
-    null_producing_aliases: set[str] | None = None,
 ) -> str | None:
     """Determine the WHERE-safe form for a filter column in a specific CTE.
 
     Returns the WHERE-safe reference as a string (qualified or bare), or
-    ``None`` when the filter cannot be safely pushed into this CTE.  Three
-    cases decline pushdown:
+    ``None`` when the filter cannot be safely pushed into this CTE — either
+    because the column isn't exposed at all, or because the projection is a
+    non-column expression that can't be inlined into WHERE.
 
-    1. The column isn't exposed at all.
-    2. The projection is a non-column expression that can't be inlined.
-    3. The underlying table is on the null-producing side of an OUTER join
-       inside the CTE body — pushing a NULL-rejecting predicate to WHERE
-       would silently convert the OUTER join to an INNER (drop rows that
-       the OUTER was supposed to preserve).  These filters belong in the
-       join's ON clause, not its WHERE; callers either need to handle
-       that themselves or leave the filter at outer scope.
+    Null-producing-side safety: the caller injects the rewritten filter
+    via :func:`inject_filter_into_select`, which routes parent-only atoms
+    through :func:`_try_push_filter_into_outer_join_side`.  That function
+    walks the join chain and wraps the inner relation when a predicate
+    would otherwise NULL-reject preserved rows, so it's safe for
+    ``_resolve_pushdown_form`` to allow pushdown even when the underlying
+    column sits on a null-producing side — the downstream injector will
+    do the right thing.
     """
     if output_col not in cte_output_cols:
         return None
     if output_col in projection_map:
-        underlying = projection_map[output_col]
-        if underlying is None:
-            return None  # non-column projection
-        if null_producing_aliases and "." in underlying:
-            prefix = underlying.split(".", 1)[0]
-            if prefix in null_producing_aliases:
-                return None  # would defeat the OUTER join
-        return underlying
+        return projection_map[output_col]  # may be None: unsafe projection
     return output_col  # pruned from CTE SELECT; falls through to bare name
-
-
-def _null_producing_aliases(select: ast.Select) -> set[str]:
-    """Return the set of table aliases that sit on the null-producing side
-    of any OUTER join in this Select's FROM clause.
-
-    Rules per join type:
-    - ``LEFT OUTER``: the right side may be NULL → its alias is null-producing.
-    - ``RIGHT OUTER``: everything to its left may be NULL → all preceding
-      aliases in the same relation are null-producing.
-    - ``FULL OUTER``: both sides may be NULL.
-    - ``INNER`` / ``CROSS``: no nulls introduced.
-
-    The walk is per relation in ``select.from_.relations``; aliases from
-    different relations don't interact.
-    """
-    null_producing: set[str] = set()
-    if not select.from_:
-        return null_producing
-
-    def _extract_alias(expr: object) -> str | None:
-        # Aliased table reference: SQL parser wraps it in an Alias node.
-        if isinstance(expr, ast.Alias):
-            alias = getattr(expr, "alias", None)
-            if alias is not None and hasattr(alias, "name"):
-                return alias.name
-        # Bare Table with no alias: use the unqualified table name.
-        if isinstance(expr, ast.Table):
-            name = expr.name
-            if name is not None and hasattr(name, "name"):
-                return name.name
-        return None
-
-    for relation in select.from_.relations:
-        left_aliases: set[str] = set()
-        primary_alias = _extract_alias(relation.primary)
-        if primary_alias:
-            left_aliases.add(primary_alias)
-        for join in relation.extensions:
-            right_alias = _extract_alias(join.right)
-            jt = (join.join_type or "").upper().strip()
-            if jt in ("LEFT", "LEFT OUTER"):
-                if right_alias:
-                    null_producing.add(right_alias)
-            elif jt in ("RIGHT", "RIGHT OUTER"):
-                null_producing.update(left_aliases)
-            elif jt in ("FULL", "FULL OUTER"):
-                null_producing.update(left_aliases)
-                if right_alias:
-                    null_producing.add(right_alias)
-            # INNER / CROSS / (no join_type): no nulls introduced
-            if right_alias:
-                left_aliases.add(right_alias)
-    return null_producing
 
 
 def _rewrite_filter_for_cte(
@@ -1404,9 +1343,9 @@ def _rewrite_filter_for_cte(
     """Rewrite a dimension filter for injection into a specific CTE.
 
     For non-set-op CTEs, delegates to :func:`_rewrite_filter_for_select`
-    against the single Select arm.  Set-op CTEs are not handled here —
-    callers that need per-arm rewrites use :func:`_setop_arms` and call
-    :func:`_rewrite_filter_for_select` per arm.
+    against the single Select arm.  Returns ``None`` for set-op CTE
+    bodies — callers (e.g. :func:`_resolve_pushdown_filters_for_cte`)
+    handle set-op CTEs by pushing into the primary arm only.
     """
     if _cte_has_set_operation(cte_query):
         return None
@@ -1448,7 +1387,6 @@ def _rewrite_filter_for_select(
     safely pushed into this Select.
     """
     projection_map = _build_select_projection_map(cte_select)
-    null_producing = _null_producing_aliases(cte_select)
     filter_ast = parse_filter(filter_str)
 
     # First pass: plan the rewrites by walking the AST.  Role-qualified refs
@@ -1493,7 +1431,6 @@ def _rewrite_filter_for_select(
             output_col,
             cte_output_cols,
             projection_map,
-            null_producing,
         )
         if form is None:
             return None
@@ -1518,7 +1455,6 @@ def _rewrite_filter_for_select(
             output_col,
             cte_output_cols,
             projection_map,
-            null_producing,
         )
         if form is None:
             return None

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -8760,3 +8760,124 @@ class TestParentCteFilterLanding:
             """,
             normalize_aliases=True,
         )
+
+    @pytest.mark.asyncio
+    async def test_filter_pushes_into_nested_subquery_self_reference(
+        self,
+        client_with_build_v3,
+    ):
+        """Transform body references the same source table twice: once
+        at the top-level FROM (alias ``a``) and once inside a nested
+        subquery on the LEFT-joined side (alias ``a2``).  A filter on
+        a column owned by that source must land at BOTH references —
+        not just the top-level one — so Spark partition pruning fires
+        at both scans (and the inner subquery doesn't full-scan).
+
+        Mirrors the XP-style transform pattern where an inner subquery
+        joins ``allocation_core_d a2`` for account-FK lookup.  The
+        direct dim-link pushdown path used to inject only at the
+        top-level alias; the inner ``a2`` reference would scan
+        unfiltered.  This test pins down the v2-parity fix.
+        """
+        client = client_with_build_v3
+
+        # Source: a fact-shaped table with a partition-eligible date column.
+        src = await _setup_events_source(
+            client,
+            "nested_self_ref",
+            "events_nested_self_ref",
+        )
+
+        # Side fact: subscription-style table the transform LEFT-joins
+        # via a nested subquery that references the primary source again.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_subs_lifecycle",
+                "description": "subscription lifecycle (side fact)",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "lifecycle_id", "type": "int"},
+                    {"name": "signup_ts_ms", "type": "bigint"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "subs_lifecycle",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Transform with the XP-shape: top-level FROM references the
+        # source once (a), inner subquery references it again (a2).
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.events_with_nested_self",
+                "query": (
+                    "SELECT a.account_id, a.event_date, a.value, "
+                    "       s.lifecycle_id "
+                    f"FROM {src} AS a "
+                    "LEFT JOIN ("
+                    "  SELECT rev.account_id, rev.lifecycle_id "
+                    "  FROM v3.src_subs_lifecycle AS rev "
+                    f"  JOIN {src} AS a2 ON a2.account_id = rev.account_id "
+                    "  WHERE rev.signup_ts_ms > 0 "
+                    ") AS s ON a.account_id = s.account_id"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.events_with_nested_self_count",
+                "query": "SELECT COUNT(*) FROM v3.events_with_nested_self",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.events_with_nested_self_count"],
+                "dimensions": ["v3.events_with_nested_self.account_id"],
+                "filters": [
+                    "v3.events_with_nested_self.event_date = 20260101",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # The filter ``event_date = 20260101`` is pushed into BOTH:
+        #   - the top-level CTE WHERE (qualified to ``a``), and
+        #   - the inner subquery's WHERE (qualified to ``a2``),
+        # because both ``a`` and ``a2`` reference the same source table
+        # ``events_nested_self_ref``.  Without the per-Table-reference
+        # walk, only the top-level injection would happen and the inner
+        # scan would run unfiltered.
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_events_with_nested_self AS (
+              SELECT a.account_id, a.event_date
+              FROM default.v3.events_nested_self_ref AS a
+              LEFT JOIN (
+                SELECT rev.account_id, rev.lifecycle_id
+                FROM default.v3.subs_lifecycle AS rev
+                JOIN default.v3.events_nested_self_ref AS a2
+                  ON a2.account_id = rev.account_id
+                WHERE rev.signup_ts_ms > 0 AND a2.event_date = 20260101
+              ) AS s ON a.account_id = s.account_id
+              WHERE a.event_date = 20260101
+            )
+            SELECT t1.account_id, COUNT(*) count_HASH
+            FROM v3_events_with_nested_self t1
+            GROUP BY t1.account_id
+            """,
+            normalize_aliases=True,
+        )

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -8458,16 +8458,16 @@ class TestParentCteFilterLanding:
         )
         assert response.status_code == 200, response.json()
         sql = get_first_grain_group(response.json())["sql"]
-        # Parent CTE body is a UNION ALL.  Shape B (per-arm pushdown)
-        # injects ``event_date >= 20260101`` into each arm's WHERE so
-        # the planner can prune at the source scan; that filter is
-        # marked consumed and drops out of the outer WHERE.  The
-        # ``branch = 'a'`` predicate is NOT pushed per-arm because each
-        # arm projects ``branch`` as a literal (``'a' AS branch``,
-        # ``'b' AS branch``) — pushing a literal-alias predicate into
-        # WHERE would be unsafe.  Since that filter wasn't consumed,
-        # the outer SELECT keeps it.  Regression guarantee: no filter
-        # is silently dropped.
+        # Parent CTE body is a UNION ALL.  DJ pushes the pushable
+        # filter into the PRIMARY arm only (matches v2 behavior).
+        # Subsequent UNION'd arms are left untouched so the author's
+        # asymmetric-arm semantics (e.g. one arm acting as an
+        # unfiltered backstop) survive intact.  The
+        # ``event_date >= 20260101`` filter pushes into arm 1 and is
+        # marked consumed → dropped from outer WHERE.  The
+        # ``branch = 'a'`` filter can't push (arm 1 projects
+        # ``branch`` as the literal ``'a'``, a non-column projection
+        # that's unsafe to inline) so it stays at outer WHERE.
         assert_sql_equal(
             sql,
             """
@@ -8479,7 +8479,6 @@ class TestParentCteFilterLanding:
                 UNION ALL
                 SELECT account_id, event_date, value, 'b' AS branch
                 FROM default.v3.events_setop
-                WHERE event_date >= 20260101
             )
             SELECT t1.branch, SUM(t1.value) value_sum_HASH
             FROM v3_events_union t1
@@ -8607,6 +8606,157 @@ class TestParentCteFilterLanding:
             RIGHT OUTER JOIN v3_right_spine_dim t2
                 ON t1.account_id = t2.account_id
             GROUP BY t2.spine_id
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_on_left_joined_side_inside_source_body_skips_pushdown(
+        self,
+        client_with_build_v3,
+    ):
+        """Regression for the XP-style LEFT JOIN bug.
+
+        A transform's source body LEFT-joins a side fact to a primary.
+        A filter on a column from the side fact (the null-producing side
+        of the LEFT JOIN inside the source) must NOT be pushed into the
+        CTE's WHERE — that would NULL-reject primary rows whose side
+        fact has no match and silently turn the LEFT JOIN into an INNER.
+
+        With the null-producing-side check in ``_resolve_pushdown_form``,
+        DJ declines the pushdown for such columns and the filter falls
+        through to the outer scope where it's safe.
+        """
+        client = client_with_build_v3
+
+        # Side fact — the null-producing side under the LEFT JOIN inside
+        # the source body.  Exposes a ``measure_date`` column.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_side_measurements",
+                "description": "side measurements",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "measure_date", "type": "int"},
+                    {"name": "measure_value", "type": "double"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "side_measurements",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Primary fact source — preserved through the LEFT JOIN inside
+        # the transform's source body.
+        primary_src = await _setup_events_source(
+            client,
+            "left_join_primary",
+            "events_left_join_primary",
+        )
+
+        # Transform whose source body LEFT-joins side measurements to
+        # the primary events.  The LEFT-joined columns end up in the
+        # CTE's projection — the bug was that DJ pushed filters on them
+        # straight into the CTE's WHERE.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.events_with_side",
+                "query": (
+                    "SELECT e.account_id, e.event_date, e.value, "
+                    "       s.measure_date, s.measure_value "
+                    f"FROM {primary_src} AS e "
+                    "LEFT JOIN v3.src_side_measurements AS s "
+                    "  ON e.account_id = s.account_id"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        # Dim link so DJ knows about ``measure_date`` as a filterable dim.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_measure_date_dim",
+                "description": "measure date dim",
+                "columns": [{"name": "dateint", "type": "int"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "measure_dates",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.measure_date_dim",
+                "description": "Measure date dim",
+                "query": "SELECT dateint FROM v3.src_measure_date_dim",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/v3.events_with_side/link",
+            json={
+                "dimension_node": "v3.measure_date_dim",
+                "join_type": "inner",
+                "join_on": "v3.events_with_side.measure_date = v3.measure_date_dim.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.events_with_side_count",
+                "query": "SELECT COUNT(*) FROM v3.events_with_side",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.events_with_side_count"],
+                "dimensions": ["v3.events_with_side.account_id"],
+                "filters": ["v3.measure_date_dim.dateint = 20260101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+
+        # DJ wraps the LEFT-joined inner side (``side_measurements``)
+        # with an inline subquery that pre-applies the filter, then the
+        # outer LEFT JOIN preserves primary rows that have no matching
+        # filtered side row.  The filter does NOT sit at the CTE's
+        # top-level WHERE (which would defeat the LEFT JOIN by
+        # NULL-rejecting unmatched primary rows).  This is the
+        # ``_try_push_filter_into_outer_join_side`` safety mechanism
+        # in action — see ``cte.py:1021``.
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_events_with_side AS (
+              SELECT e.account_id, s.measure_date
+              FROM default.v3.events_left_join_primary AS e
+              LEFT JOIN (
+                SELECT *
+                FROM default.v3.side_measurements AS s
+                WHERE s.measure_date = 20260101
+              ) s ON e.account_id = s.account_id
+            )
+            SELECT t1.account_id, COUNT(*) count_HASH
+            FROM v3_events_with_side t1
+            GROUP BY t1.account_id
             """,
             normalize_aliases=True,
         )

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -101,17 +101,19 @@ class TestSetOperationTransforms:
         )
 
     @pytest.mark.asyncio
-    async def test_union_transform_filter_pushed_into_each_arm(
+    async def test_union_transform_filter_pushed_into_primary_arm_only(
         self,
         client_with_union_transform,
     ):
-        """Filter on a column of a UNION-ALL transform is pushed into each
-        arm's WHERE (Shape B per-arm pushdown).  Each arm's original
-        predicate is preserved and the new filter is ANDed alongside it.
-        The filter also continues to land at the metrics-layer outer
-        WHERE — the per-arm pushdown narrows the scan early, and the
-        outer copy is the standard dim-filter narrowing on the
-        aggregation CTE.
+        """Filter on a column of a UNION-ALL transform is pushed into the
+        PRIMARY arm only (matches v2 behavior).  Subsequent UNION'd arms
+        are left untouched so the author's asymmetric-arm semantics
+        survive intact — e.g. a secondary arm acting as a deliberately
+        unfiltered backstop.  The filter is consumed by the primary
+        arm push, so the metrics-layer outer WHERE still gets a copy
+        for narrowing the aggregation CTE's output (the
+        consumption-aware drop only fires for measures-layer outer
+        WHERE, not for metrics-layer).
         """
         response = await client_with_union_transform.get(
             "/sql/metrics/v3/",
@@ -133,7 +135,7 @@ class TestSetOperationTransforms:
               UNION ALL
               SELECT order_id, customer_id, order_date, status
               FROM default.v3.orders
-              WHERE status = 'shipped' AND status = 'completed'
+              WHERE status = 'shipped'
             ),
             orders_unified_0 AS (
               SELECT t1.status, t1.order_id


### PR DESCRIPTION
### Summary

Direct dim-link pushdown in v3 only injects the filter into the primary select of a transform's source body. When the same source table is referenced multiple times (e.g., a pattern where the inner subquery rejoins the source for an FK lookup), the secondary reference is left unfiltered.

There are two pushdown paths in v3:
- Indirect path (`dimensions.py`'s `_register_pushdown_into_upstream`): runs when the filter resolves via an upstream link rather than a direct one. Uses `_resolve_pushdown_targets`, which searches through the entire parsed source body and injects into every reference's enclosing select.
- Direct path (`cte.py`'s `_resolve_pushdown_filters_for_cte`): runs when the parent transform has a direct dim link. Only looks at the CTE's primary select projection and injects into its where clause. Doesn't walk nested subqueries.

Counter-intuitively, adding a direct dim link to a transform makes pushdown less thorough because it short-circuits the upstream path that does the full walk. Modelers see the regression appear when they add what they think is a more-specific link.

The fix is to extend the direct path in `cte.py` to do the same `find_all(ast.Table)` walk that the indirect path does. After the primary-select rewrite succeeds.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
