### PR TITLE
v3 SQL: dim-link-aware filter pushdown into inner subquery scopes

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1212,7 +1212,7 @@ def _resolve_pushdown_filters_for_cte(
         if not isinstance(inner, ast.Select) or inner.set_op is None:
             continue
         cursor: Optional[ast.Select] = inner
-        while cursor is not None:
+        while cursor is not None:  # pragma: no branch
             wrapped_setop_arms.add(id(cursor))
             if cursor.set_op is None or not isinstance(
                 cursor.set_op.right,
@@ -1312,12 +1312,12 @@ def _select_has_table_in_from(sel: ast.Select) -> bool:
     """
     if sel.from_ is None:  # pragma: no cover
         return False
-    for relation in sel.from_.relations:
+    for relation in sel.from_.relations:  # pragma: no branch
         sides = [relation.primary, *(j.right for j in relation.extensions)]
-        for expr in sides:
+        for expr in sides:  # pragma: no branch
             if isinstance(expr, ast.Table):
                 return True
-    return False
+    return False  # pragma: no cover
 
 
 def _qualifier_aliases(filter_ast: ast.Expression) -> set[str]:
@@ -1565,7 +1565,7 @@ def _populate_scope_column_aliases(
             or cte_name_to_node.get(tbl_name)
             or physical_to_node.get(tbl_name)
         )
-        if target_node and target_node.current:
+        if target_node and target_node.current:  # pragma: no branch
             from datajunction_server.construction.build_v3.utils import get_short_name
 
             # Dim-link-derived entries — for each dim the node
@@ -1595,7 +1595,7 @@ def _populate_scope_column_aliases(
             if target_node.type == NodeType.DIMENSION and target_node.current.columns:
                 for col in target_node.current.columns:
                     dim_pk_fqn = f"{target_node.name}{SEPARATOR}{col.name}"
-                    if dim_pk_fqn not in col_alias:
+                    if dim_pk_fqn not in col_alias:  # pragma: no branch
                         col_alias[dim_pk_fqn] = (alias_name, col.name)
     elif isinstance(expr, ast.Query):
         alias_obj = getattr(expr, "alias", None)
@@ -1607,7 +1607,7 @@ def _populate_scope_column_aliases(
             return
         for proj in inner_sel.projection:
             output_name = _projection_output_name(proj)
-            if output_name and output_name not in col_alias:
+            if output_name and output_name not in col_alias:  # pragma: no branch
                 col_alias[output_name] = (alias_name, output_name)
 
 
@@ -1615,7 +1615,7 @@ def _projection_output_name(proj: object) -> Optional[str]:
     """Extract the output column name of a projection element."""
     alias = getattr(proj, "alias", None)
     if alias is not None and hasattr(alias, "name"):
-        return alias.name
+        return alias.name  # pragma: no cover
     if isinstance(proj, ast.Column) and proj.name:  # pragma: no cover
         return proj.name.name
     return None  # pragma: no cover

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1605,22 +1605,37 @@ def _populate_scope_column_aliases(
             or physical_to_node.get(tbl_name)
         )
         if target_node and target_node.current:
-            if target_node.current.columns:
-                for col in target_node.current.columns:
-                    if col.name not in col_alias:
-                        col_alias[col.name] = (alias_name, col.name)
-            # Register dim-link-aware entries so filters that target
-            # a specific dim ref resolve to *this* table's alias,
-            # even when a sibling table in the same scope exposes
-            # the same bare column name.
             from datajunction_server.construction.build_v3.utils import get_short_name
 
+            # Dim-link-derived entries — for each dim the node
+            # explicitly links to, register a ``dim_pk_fqn → (alias,
+            # fk_col)`` entry.  This is the ONLY route column-aware
+            # retargeting uses to push filters into this scope; a
+            # bare-col fallback was tried but caused over-aggressive
+            # pushdown into tables that incidentally share a column
+            # name with the filter's dim but aren't actually linked
+            # to it (e.g. pushing ``alloc_utc_date BETWEEN ...`` into
+            # retention_revenue_d whose ``alloc_utc_date`` column
+            # isn't linked to the ``allocation_date`` dim — v2
+            # doesn't push there either).
             for link in target_node.current.dimension_links or []:
                 for dim_pk_fqn, fk_fqn in (link.foreign_keys_reversed or {}).items():
                     if not fk_fqn:  # pragma: no cover
                         continue
                     if dim_pk_fqn not in col_alias:  # pragma: no branch
                         col_alias[dim_pk_fqn] = (alias_name, get_short_name(fk_fqn))
+            # If the target IS itself a dimension node, register
+            # entries for its own primary-key columns pointing at
+            # this alias — without this, filters on the dim's own
+            # PK (e.g. ``observation_window.observation_window IN
+            # ('1-35')`` against the obs_window dim) wouldn't
+            # resolve since dim nodes don't have dim_links of
+            # their own.
+            if target_node.type == NodeType.DIMENSION and target_node.current.columns:
+                for col in target_node.current.columns:
+                    dim_pk_fqn = f"{target_node.name}{SEPARATOR}{col.name}"
+                    if dim_pk_fqn not in col_alias:
+                        col_alias[dim_pk_fqn] = (alias_name, col.name)
     elif isinstance(expr, ast.Query):
         alias_obj = getattr(expr, "alias", None)
         if alias_obj is None or not hasattr(alias_obj, "name"):  # pragma: no cover
@@ -1653,24 +1668,23 @@ def _rewrite_filter_for_scope(
     """Parse a filter fresh and qualify each dim-ref column using the
     scope's resolver map.
 
-    The resolver map keys may be either a fully-qualified dim ref
-    (e.g. ``common.dimensions.xp.allocation_snapshot_date.dateint``)
-    or a bare column name (e.g. ``snapshot_utc_date``).  Each value
-    is ``(alias, emit_col_name)`` — the alias to qualify the column
-    with, and the column name to emit (often the same as the bare
-    key, but the dim-ref form's emit_col_name is the FK column of
-    the linked table, which may differ from the dim PK column name).
+    The resolver map keys are fully-qualified dim refs (e.g.
+    ``common.dimensions.xp.allocation_snapshot_date.dateint``)
+    populated from each FROM-side node's ``dimension_links``.  Each
+    value is ``(alias, emit_col_name)`` — the alias to qualify the
+    column with, and the FK column on the linked table.
 
-    Lookup precedence per filter column:
+    Filter columns whose dim ref isn't present in the map are
+    silently skipped (the filter as a whole still pushes if other
+    columns resolve).  Bare-column fallback is intentionally not
+    used: if a node doesn't have an explicit dim_link to the
+    filter's dim, pushing the filter there could be semantically
+    wrong (e.g. incidentally matching ``alloc_utc_date`` on a
+    retention table whose date semantics differ from the
+    allocation source).
 
-    1. **Dim-ref FQN** (e.g. ``common.dimensions.xp.A.B``) — preferred,
-       since dim_links provide unambiguous routing even when sibling
-       tables in the scope share the same bare column name.
-    2. **Bare column** (resolved via ``filter_column_aliases``) —
-       fallback for columns not covered by an explicit dim link.
-
-    Returns ``None`` when any column is unresolvable in this scope —
-    atomic per filter to mirror the primary-rewrite behavior.
+    Returns ``None`` when no column resolves — atomic per filter
+    to mirror the primary-rewrite behavior.
     """
     if not column_to_alias:
         return None
@@ -1682,12 +1696,7 @@ def _rewrite_filter_for_scope(
             continue
         resolution = column_to_alias.get(full)
         if resolution is None:
-            bare_col = filter_column_aliases.get(full)
-            if bare_col is None:
-                continue
-            resolution = column_to_alias.get(bare_col)
-            if resolution is None:
-                return None
+            continue
         target_alias, emit_col = resolution
         new_name = ast.Name(emit_col, namespace=ast.Name(target_alias))
         rewrites.append((col, ast.Column(name=new_name)))

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1162,6 +1162,26 @@ def _resolve_pushdown_filters_for_cte(
     results: list[tuple[ast.Select, ast.Expression]] = []
     consumed: set[str] = set()
 
+    # Alias-substitution map: ``{alias → physical_table}`` derived
+    # from every Table in the CTE body.  Used together with the
+    # column-aware retargeting below — when the primary rewrite at
+    # target_select uses alias X for physical table P, sibling
+    # Table refs to P elsewhere in the CTE body get a retargeted
+    # copy of the rewrite with their own alias.  This disambiguates
+    # cases where multiple FROM-side tables in an inner scope expose
+    # the same bare column name (e.g. ``rev.snapshot_utc_date`` vs
+    # ``a2.snapshot_utc_date`` when both rev and a2 carry the
+    # column); column-aware retargeting alone has no way to prefer
+    # the table that's the same physical source as the primary.
+    alias_to_phys: dict[str, str] = {}
+    for tbl in cte_query.find_all(ast.Table):
+        try:
+            tbl_name = tbl.name.identifier(quotes=False)
+        except Exception:  # pragma: no cover
+            continue
+        alias_tag = tbl.alias.name if tbl.alias else tbl_name.split(SEPARATOR)[-1]
+        alias_to_phys.setdefault(alias_tag, tbl_name)
+
     # Pre-compute a column->alias map for every distinct Select scope
     # inside the CTE body.  Each scope's map says: "for a bare column
     # name X, which alias provides it in this scope's FROM tree?"
@@ -1173,6 +1193,33 @@ def _resolve_pushdown_filters_for_cte(
     scope_column_aliases = (
         _build_all_scope_column_alias_maps(cte_query, ctx) if ctx else {}
     )
+
+    # Identify "wrapped UNION arms" — arms of a set-op chain that
+    # lives inside a derived-table boundary (an ast.Query nested
+    # somewhere under target_select), NOT the CTE body's own
+    # top-level set-op chain.  When a wrapped UNION sits inside a
+    # derived table, the enclosing Select's WHERE already
+    # constrains the UNION's output — pushing the same predicate
+    # into each arm is redundant and diverges from v2.  Arms of
+    # the CTE body's OWN top-level UNION (e.g. the CTE is
+    # ``(SELECT ...) UNION ALL (SELECT ...)`` directly) still get
+    # pushdown, since there's no outer WHERE to handle them.
+    wrapped_setop_arms: set[int] = set()
+    for query_node in cte_query.find_all(ast.Query):
+        if query_node is cte_query:
+            continue
+        inner = query_node.select
+        if not isinstance(inner, ast.Select) or inner.set_op is None:
+            continue
+        cursor: Optional[ast.Select] = inner
+        while cursor is not None:
+            wrapped_setop_arms.add(id(cursor))
+            if cursor.set_op is None or not isinstance(
+                cursor.set_op.right,
+                ast.Select,
+            ):
+                break
+            cursor = cursor.set_op.right
 
     for filter_str in pushdown_filters:
         rewritten = _rewrite_filter_for_select(
@@ -1186,19 +1233,61 @@ def _resolve_pushdown_filters_for_cte(
         results.append((target_select, rewritten))
         consumed.add(filter_str)
 
-        # Column-aware retargeting: walk every other distinct Select
-        # scope inside the body.  For each, try to rebuild the filter
-        # using that scope's column->alias map so each column gets
-        # qualified by whichever alias in that scope actually exposes
-        # it (Table aliases via ctx.nodes, subquery aliases via the
-        # subquery's projection output names).  Inject if all of the
-        # filter's columns are resolvable in the scope.  Matches v2's
-        # source-wrapping pattern where every reference to a source
-        # table got the same set of partition-eligible predicates,
-        # while keeping cross-scope qualifier safety (different ``a``
-        # aliases in different subqueries don't get conflated).
+        # First pass — alias-substitution by physical table.  For
+        # every alias used in the primary rewrite, find sibling
+        # Table references to the same physical source and inject a
+        # retargeted copy at each enclosing Select.  Preferred over
+        # column-aware retargeting because it unambiguously routes
+        # the filter to the same physical source the primary
+        # rewrite came from, even when sibling tables in the scope
+        # share the bare column name.
+        alias_subst_scopes: set[int] = set()
+        for primary_alias in _qualifier_aliases(rewritten):
+            physical = alias_to_phys.get(primary_alias)
+            if not physical:  # pragma: no cover
+                continue
+            for ref_alias, enclosing_select in _find_table_refs(
+                cte_query,
+                physical,
+            ):
+                if ref_alias == primary_alias and enclosing_select is target_select:
+                    continue
+                cloned = _retarget_filter_qualifier(
+                    rewritten,
+                    primary_alias,
+                    ref_alias,
+                )
+                results.append((enclosing_select, cloned))
+                alias_subst_scopes.add(id(enclosing_select))
+
+        # Second pass — column-aware retargeting.  Walk every other
+        # Select scope inside the body and rebuild the filter using
+        # that scope's resolver map.  Handles cases the
+        # alias-substitution pass can't reach (CROSS-joined dim
+        # subqueries with different physical sources, source-table
+        # references that share columns with the primary).
+        #
+        # Skipped at scopes whose direct FROM contains ONLY
+        # subquery aliases and no Tables — at such scopes the
+        # only candidate aliases are the OUTER alias of inner
+        # subqueries, and pushing a filter qualified by one of
+        # those triggers the existing
+        # ``_try_push_filter_into_outer_join_side`` outer-join
+        # safety wrap, which ANDs the filter into the inner
+        # subquery's WHERE without retargeting — producing a
+        # qualifier that's invalid inside the subquery
+        # (e.g. ``numerator.utc_date`` referenced inside the
+        # body of a subquery the OUTER calls ``numerator``).
+        # Also skipped at scopes already handled by
+        # alias-substitution to avoid duplicate injections.
         for inner_select, col_to_alias in scope_column_aliases.items():
             if inner_select is target_select:
+                continue
+            if id(inner_select) in alias_subst_scopes:
+                continue
+            if id(inner_select) in wrapped_setop_arms:
+                continue
+            if not _select_has_table_in_from(inner_select):
                 continue
             inner_rewrite = _rewrite_filter_for_scope(
                 filter_str,
@@ -1207,8 +1296,137 @@ def _resolve_pushdown_filters_for_cte(
             )
             if inner_rewrite is None:
                 continue
+            # Conservative asymmetric-arm protection: if the
+            # scope's existing WHERE already references any of the
+            # filter's columns, skip the push.  Mirrors what an
+            # author signals by writing e.g. ``WHERE status =
+            # 'shipped'`` in one UNION arm — a different
+            # ``status = 'completed'`` user filter pushed there
+            # would AND to an always-false predicate and zero out
+            # the arm.  Cases where the existing reference is
+            # actually compatible (``WHERE status IS NOT NULL``)
+            # are penalized by this heuristic, but the conservative
+            # call avoids silently breaking author intent.
+            if _select_where_references_any(inner_select, inner_rewrite):
+                continue
             results.append((inner_select, inner_rewrite))
     return results, consumed
+
+
+def _select_where_references_any(
+    sel: ast.Select,
+    filter_ast: ast.Expression,
+) -> bool:
+    """Return True iff ``sel.where`` references any bare column name
+    that also appears as a bare column in ``filter_ast``.
+
+    Used to avoid pushing a user filter into a secondary set-op arm
+    whose authored WHERE already constrains the same column —
+    the AND'd result would often be always-false and silently
+    zero out the arm.
+    """
+    if sel.where is None:
+        return False
+    filter_cols: set[str] = set()
+    for col in filter_ast.find_all(ast.Column):
+        if col.name:  # pragma: no branch
+            filter_cols.add(col.name.name)
+    if not filter_cols:  # pragma: no cover
+        return False
+    for col in sel.where.find_all(ast.Column):
+        if col.name and col.name.name in filter_cols:
+            return True
+    return False
+
+
+def _select_has_table_in_from(sel: ast.Select) -> bool:
+    """Return True iff the Select's direct FROM has at least one
+    ``ast.Table`` relation side.
+
+    A scope whose FROM contains only ``ast.Query`` derived-table
+    aliases (e.g. ``(SELECT ...) AS denominator LEFT JOIN (SELECT
+    ...) AS numerator``) shouldn't receive column-aware filter
+    injection — its only candidate aliases are the outer-level
+    aliases for those subqueries, which don't exist inside them.
+    """
+    if sel.from_ is None:  # pragma: no cover
+        return False
+    for relation in sel.from_.relations:
+        sides = [relation.primary, *(j.right for j in relation.extensions)]
+        for expr in sides:
+            if isinstance(expr, ast.Table):
+                return True
+    return False
+
+
+def _qualifier_aliases(filter_ast: ast.Expression) -> set[str]:
+    """Return the set of distinct qualifier aliases used in ``filter_ast``.
+
+    A column like ``a.snapshot_utc_date`` contributes ``"a"`` to the
+    set; bare column references contribute nothing.
+    """
+    result: set[str] = set()
+    for col in filter_ast.find_all(ast.Column):
+        if col.name and col.name.namespace:  # pragma: no branch
+            result.add(col.name.namespace.name)
+    return result
+
+
+def _retarget_filter_qualifier(
+    filter_ast: ast.Expression,
+    old_alias: str,
+    new_alias: str,
+) -> ast.Expression:
+    """Deepcopy ``filter_ast`` and rewrite every column qualified by
+    ``old_alias`` to be qualified by ``new_alias`` instead.
+
+    Used to clone a primary-Select-targeted filter for injection at
+    a sibling reference to the same physical source table.  The
+    cloned filter uses the sibling's alias so column references
+    resolve in the sibling's scope.
+    """
+    cloned = deepcopy(filter_ast)
+    for col in cloned.find_all(ast.Column):
+        if col.name is None or not col.name.namespace:  # pragma: no cover
+            continue
+        if col.name.namespace.name == old_alias:  # pragma: no branch
+            col.name = ast.Name(col.name.name, namespace=ast.Name(new_alias))
+    return cloned
+
+
+def _find_table_refs(
+    cte_query: ast.Query,
+    physical_table_name: str,
+) -> list[tuple[str, ast.Select]]:
+    """Find every ``ast.Table`` reference to ``physical_table_name``
+    in the CTE body and return ``(alias, enclosing_select)`` per
+    match.
+
+    Used by :func:`_resolve_pushdown_filters_for_cte` to inject a
+    retargeted copy of the primary filter at every nested
+    subquery / arm that scans the same physical source table.
+    Crosses set-op arms via ``find_all`` so secondary arms with the
+    same source as the primary arm also get the pushdown.
+    """
+    results: list[tuple[str, ast.Select]] = []
+    for tbl in cte_query.find_all(ast.Table):
+        try:
+            tbl_name = tbl.name.identifier(quotes=False)
+        except Exception:  # pragma: no cover
+            continue
+        if tbl_name != physical_table_name:
+            continue
+        alias_tag = tbl.alias.name if tbl.alias else tbl_name.split(SEPARATOR)[-1]
+        enclosing: Optional[ast.Select] = None
+        cur = getattr(tbl, "parent", None)
+        while cur is not None:  # pragma: no branch
+            if isinstance(cur, ast.Select):
+                enclosing = cur
+                break
+            cur = getattr(cur, "parent", None)
+        if enclosing is not None:  # pragma: no branch
+            results.append((alias_tag, enclosing))
+    return results
 
 
 def _build_local_dim_aliases(node: "Node") -> dict[str, str]:
@@ -1244,7 +1462,7 @@ def _build_local_dim_aliases(node: "Node") -> dict[str, str]:
 def _build_all_scope_column_alias_maps(
     cte_query: ast.Query,
     ctx: "BuildContext",
-) -> dict[ast.Select, dict[str, str]]:
+) -> dict[ast.Select, dict[str, tuple[str, str]]]:
     """For every distinct ``ast.Select`` scope reachable through the
     target Select's FROM subtree (subqueries inside JOINs, nested
     derived tables, etc.), build a ``{column_name → alias}`` map.
@@ -1261,9 +1479,14 @@ def _build_all_scope_column_alias_maps(
     For each FROM entry inside the walked subtree:
 
     - **``ast.Table``** with alias ``a`` (or table short-name if no
-      alias): look up its columns via ``ctx.nodes`` (handling both
-      direct node-name match and the dot-to-underscore CTE-name form
-      DJ emits in generated SQL).
+      alias): look up its columns via a three-step chain — direct
+      node-name match, then dot-to-underscore CTE-name form, then
+      materialized-physical-name match (handles
+      ``prodhive.dse.foo`` for a node named
+      ``source.prodhive.dse.foo``, or
+      ``prodhive.dj.dim__name__v5_0`` for a dim node).  Tables that
+      can't be resolved contribute nothing to the scope (safer than
+      guessing columns the Table may not actually have).
     - **Subquery** (``ast.Query`` aliased as ``s``): walk the
       subquery's projection for output column names.
 
@@ -1272,61 +1495,132 @@ def _build_all_scope_column_alias_maps(
     retargeting: each scope can qualify the same filter differently
     based on which alias actually exposes each column there.
     """
-    result: dict[ast.Select, dict[str, str]] = {}
+    result: dict[ast.Select, dict[str, tuple[str, str]]] = {}
     target_select = cte_query.select
     if not isinstance(target_select, ast.Select):  # pragma: no cover
         return result
 
     cte_name_to_node = {get_cte_name(n.name): n for n in ctx.nodes.values()}
 
-    # Collect target_select plus every Select inside its FROM subtree.
-    # find_all() over the FROM avoids crossing into set-op arms via
-    # target_select.set_op.right — those arms get the primary-arm-only
-    # policy from the existing logic.
-    selects: list[ast.Select] = [target_select]
-    if target_select.from_:
-        for inner in target_select.from_.find_all(ast.Select):
-            if isinstance(inner, ast.Select):  # pragma: no branch
-                selects.append(inner)
+    # Build a reverse lookup from a node's emitted physical table
+    # reference (``catalog.schema.table``) back to the node.  Lets us
+    # resolve Tables referenced by their materialized name (e.g.
+    # ``prodhive.dse.ab_nm_alloc_f`` for a source node named
+    # ``source.prodhive.dse.ab_nm_alloc_f``, or
+    # ``prodhive.dj.common__dimensions__xp__observation_window__v5_0``
+    # for the obs_window dim) instead of by node name or CTE form.
+    # Safely skips nodes whose materialization parts can't be derived.
+    physical_to_node: dict[str, "Node"] = {}
+    for n in ctx.nodes.values():
+        try:
+            parts, _ = get_table_reference_parts_with_materialization(ctx, n)
+        except Exception:  # pragma: no cover
+            continue
+        if parts:  # pragma: no branch
+            physical_to_node.setdefault(".".join(parts), n)
+
+    # Walk every Select in the CTE body — including secondary arms
+    # of set-op chains and their nested subqueries.  Each scope's
+    # column→alias map is built independently, so column-aware
+    # safety naturally prevents pushing into an arm whose tables
+    # don't expose the filter's columns.  Matches v2 behavior where
+    # filters land in every UNION arm whose source supports them.
+    selects: list[ast.Select] = []
+    for sel in cte_query.find_all(ast.Select):
+        if isinstance(sel, ast.Select):  # pragma: no branch
+            selects.append(sel)
 
     seen: set[int] = set()
     for sel in selects:
         if id(sel) in seen:
             continue
         seen.add(id(sel))
-        col_alias: dict[str, str] = {}
+        col_alias: dict[str, tuple[str, str]] = {}
         if not sel.from_:  # pragma: no cover
             result[sel] = col_alias
             continue
         for relation in sel.from_.relations:
             sides = [relation.primary, *(j.right for j in relation.extensions)]
             for expr in sides:
-                _populate_scope_column_aliases(expr, col_alias, ctx, cte_name_to_node)
+                _populate_scope_column_aliases(
+                    expr,
+                    col_alias,
+                    ctx,
+                    cte_name_to_node,
+                    physical_to_node,
+                )
         result[sel] = col_alias
     return result
 
 
 def _populate_scope_column_aliases(
     expr: object,
-    col_alias: dict[str, str],
+    col_alias: dict[str, tuple[str, str]],
     ctx: "BuildContext",
     cte_name_to_node: dict[str, "Node"],
+    physical_to_node: dict[str, "Node"],
 ) -> None:
     """Helper: add this FROM-side expression's columns to a scope's
-    column->alias map.  Handles Tables (via ctx.nodes lookup) and
-    subqueries (via projection walk)."""
+    resolver map.
+
+    The resolver map is ``{key → (alias, emit_col)}`` where the key
+    is either a bare column name (for direct-projection lookup) or a
+    fully-qualified dim-ref FQN (for dim-link-aware lookup).
+
+    Handles Tables (resolved via a node-name / CTE-name /
+    materialized-physical-name chain) and subqueries (via projection
+    walk).  For a resolved Table, the node's own ``dimension_links``
+    contribute dim-ref entries: each ``foreign_keys_reversed`` row
+    yields ``dim_pk_fqn → (alias, fk_col_short)``, so a filter on
+    that dim resolves to *this* table's alias even when a sibling
+    table in the same scope exposes the same bare column name.
+
+    First-write-wins on collisions — within a single scope, the
+    earliest-registered Table for a given dim ref or bare column
+    wins.  This matches the FROM-order convention DJ uses elsewhere.
+
+    For Tables, the chain tries three forms in order:
+
+    1. Direct node-name match (``ctx.nodes[tbl_name]``) — covers nodes
+       referenced by their canonical name.
+    2. CTE-name match (``cte_name_to_node[tbl_name]``) — covers nodes
+       referenced as ``a_b_c`` for ``a.b.c``.
+    3. Materialized-physical-name match
+       (``physical_to_node[tbl_name]``) — covers source/transform/dim
+       nodes referenced by their materialized
+       ``catalog.schema.table`` form.
+
+    When all three miss, the Table contributes nothing to the scope's
+    resolver map — safer than guessing.
+    """
     if isinstance(expr, ast.Table):
         try:
             tbl_name = expr.name.identifier(quotes=False)
         except Exception:  # pragma: no cover
             return
         alias_name = expr.alias.name if expr.alias else tbl_name.split(SEPARATOR)[-1]
-        # Try direct lookup, then reverse-CTE-name lookup.
-        target_node = ctx.nodes.get(tbl_name) or cte_name_to_node.get(tbl_name)
-        if target_node and target_node.current and target_node.current.columns:
-            for col in target_node.current.columns:
-                if col.name not in col_alias:
-                    col_alias[col.name] = alias_name
+        target_node = (
+            ctx.nodes.get(tbl_name)
+            or cte_name_to_node.get(tbl_name)
+            or physical_to_node.get(tbl_name)
+        )
+        if target_node and target_node.current:
+            if target_node.current.columns:
+                for col in target_node.current.columns:
+                    if col.name not in col_alias:
+                        col_alias[col.name] = (alias_name, col.name)
+            # Register dim-link-aware entries so filters that target
+            # a specific dim ref resolve to *this* table's alias,
+            # even when a sibling table in the same scope exposes
+            # the same bare column name.
+            from datajunction_server.construction.build_v3.utils import get_short_name
+
+            for link in target_node.current.dimension_links or []:
+                for dim_pk_fqn, fk_fqn in (link.foreign_keys_reversed or {}).items():
+                    if not fk_fqn:  # pragma: no cover
+                        continue
+                    if dim_pk_fqn not in col_alias:  # pragma: no branch
+                        col_alias[dim_pk_fqn] = (alias_name, get_short_name(fk_fqn))
     elif isinstance(expr, ast.Query):
         alias_obj = getattr(expr, "alias", None)
         if alias_obj is None or not hasattr(alias_obj, "name"):  # pragma: no cover
@@ -1338,7 +1632,7 @@ def _populate_scope_column_aliases(
         for proj in inner_sel.projection:
             output_name = _projection_output_name(proj)
             if output_name and output_name not in col_alias:
-                col_alias[output_name] = alias_name
+                col_alias[output_name] = (alias_name, output_name)
 
 
 def _projection_output_name(proj: object) -> Optional[str]:
@@ -1354,16 +1648,29 @@ def _projection_output_name(proj: object) -> Optional[str]:
 def _rewrite_filter_for_scope(
     filter_str: str,
     filter_column_aliases: dict[str, str],
-    column_to_alias: dict[str, str],
+    column_to_alias: dict[str, tuple[str, str]],
 ) -> Optional[ast.Expression]:
     """Parse a filter fresh and qualify each dim-ref column using the
-    scope's ``{column → alias}`` map.
+    scope's resolver map.
 
-    Returns the rewritten filter AST, or ``None`` when any of the
-    filter's dim refs can't be resolved in this scope's columns.
-    Atomic per filter: if a single column is unreachable in this scope,
-    the whole filter is skipped (mirrors the primary-rewrite behavior
-    that bails on a partial OR-predicate).
+    The resolver map keys may be either a fully-qualified dim ref
+    (e.g. ``common.dimensions.xp.allocation_snapshot_date.dateint``)
+    or a bare column name (e.g. ``snapshot_utc_date``).  Each value
+    is ``(alias, emit_col_name)`` — the alias to qualify the column
+    with, and the column name to emit (often the same as the bare
+    key, but the dim-ref form's emit_col_name is the FK column of
+    the linked table, which may differ from the dim PK column name).
+
+    Lookup precedence per filter column:
+
+    1. **Dim-ref FQN** (e.g. ``common.dimensions.xp.A.B``) — preferred,
+       since dim_links provide unambiguous routing even when sibling
+       tables in the scope share the same bare column name.
+    2. **Bare column** (resolved via ``filter_column_aliases``) —
+       fallback for columns not covered by an explicit dim link.
+
+    Returns ``None`` when any column is unresolvable in this scope —
+    atomic per filter to mirror the primary-rewrite behavior.
     """
     if not column_to_alias:
         return None
@@ -1371,13 +1678,18 @@ def _rewrite_filter_for_scope(
     rewrites: list[tuple[ast.Column, ast.Column]] = []
     for col in filter_ast.find_all(ast.Column):
         full = get_column_full_name(col)
-        if not full or full not in filter_column_aliases:
+        if not full:  # pragma: no cover
             continue
-        bare_col = filter_column_aliases[full]
-        target_alias = column_to_alias.get(bare_col)
-        if target_alias is None:
-            return None  # column not resolvable in this scope
-        new_name = ast.Name(bare_col, namespace=ast.Name(target_alias))
+        resolution = column_to_alias.get(full)
+        if resolution is None:
+            bare_col = filter_column_aliases.get(full)
+            if bare_col is None:
+                continue
+            resolution = column_to_alias.get(bare_col)
+            if resolution is None:
+                return None
+        target_alias, emit_col = resolution
+        new_name = ast.Name(emit_col, namespace=ast.Name(target_alias))
         rewrites.append((col, ast.Column(name=new_name)))
     if not rewrites:
         return None

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1113,6 +1113,7 @@ def _resolve_pushdown_filters_for_cte(
     cte_query: ast.Query,
     pushdown_filters: list[str],
     filter_column_aliases: dict[str, str],
+    ctx: Optional["BuildContext"] = None,
 ) -> tuple[list[tuple[ast.Select, ast.Expression]], set[str]]:
     """Determine which user filters can be pushed into this CTE.
 
@@ -1158,9 +1159,21 @@ def _resolve_pushdown_filters_for_cte(
     }
 
     target_select = cast(ast.Select, cte_query.select)
-    alias_to_table = _build_source_alias_map(cte_query)
     results: list[tuple[ast.Select, ast.Expression]] = []
     consumed: set[str] = set()
+
+    # Pre-compute a column->alias map for every distinct Select scope
+    # inside the CTE body.  Each scope's map says: "for a bare column
+    # name X, which alias provides it in this scope's FROM tree?"
+    # Used by the retargeting walk below to inject the filter at inner
+    # scopes (nested subqueries) with correct per-scope qualifiers —
+    # e.g. ``observation_window`` resolves to the CROSS-joined dim's
+    # alias while ``alloc_group_id`` resolves to the fact's alias, even
+    # though both share the same parent qualifier in the outer scope.
+    scope_column_aliases = (
+        _build_all_scope_column_alias_maps(cte_query, ctx) if ctx else {}
+    )
+
     for filter_str in pushdown_filters:
         rewritten = _rewrite_filter_for_select(
             filter_str,
@@ -1173,31 +1186,28 @@ def _resolve_pushdown_filters_for_cte(
         results.append((target_select, rewritten))
         consumed.add(filter_str)
 
-        # Additionally walk every other reference to the same physical
-        # source tables inside the CTE body and inject a retargeted
-        # copy of the filter at each one's enclosing Select.  This
-        # matches the upstream-pushdown path's ``_resolve_pushdown_targets``
-        # behavior so that the direct-link path is just as thorough:
-        # a transform whose source body references the same fact table
-        # twice (e.g. once at top level, once inside a LEFT JOIN's
-        # nested subquery) gets the filter applied to BOTH references,
-        # not just the top-level alias.
-        for primary_alias in _qualifier_aliases(rewritten):
-            physical_table = alias_to_table.get(primary_alias)
-            if not physical_table:  # pragma: no cover
+        # Column-aware retargeting: walk every other distinct Select
+        # scope inside the body.  For each, try to rebuild the filter
+        # using that scope's column->alias map so each column gets
+        # qualified by whichever alias in that scope actually exposes
+        # it (Table aliases via ctx.nodes, subquery aliases via the
+        # subquery's projection output names).  Inject if all of the
+        # filter's columns are resolvable in the scope.  Matches v2's
+        # source-wrapping pattern where every reference to a source
+        # table got the same set of partition-eligible predicates,
+        # while keeping cross-scope qualifier safety (different ``a``
+        # aliases in different subqueries don't get conflated).
+        for inner_select, col_to_alias in scope_column_aliases.items():
+            if inner_select is target_select:
                 continue
-            for ref_alias, enclosing_select in _find_table_refs(
-                cte_query,
-                physical_table,
-            ):
-                if ref_alias == primary_alias and enclosing_select is target_select:
-                    continue  # already covered by the primary injection
-                cloned = _retarget_filter_qualifier(
-                    rewritten,
-                    primary_alias,
-                    ref_alias,
-                )
-                results.append((enclosing_select, cloned))
+            inner_rewrite = _rewrite_filter_for_scope(
+                filter_str,
+                effective_aliases,
+                col_to_alias,
+            )
+            if inner_rewrite is None:
+                continue
+            results.append((inner_select, inner_rewrite))
     return results, consumed
 
 
@@ -1231,96 +1241,150 @@ def _build_local_dim_aliases(node: "Node") -> dict[str, str]:
     return result
 
 
-def _build_source_alias_map(cte_query: ast.Query) -> dict[str, str]:
-    """Walk every ``ast.Table`` in the CTE body and build an
-    ``alias → physical_table_name`` map.
-
-    For aliased refs (``Table AS a``) the key is the alias name.  For bare
-    refs (no alias) the key is the table's short name — matching how the
-    SQL parser surfaces them when looking up column qualifications.
-
-    Multiple Table refs sharing the same alias is rare and the last-write
-    wins here.  Callers use this map only to look up the physical table a
-    qualified column reference belongs to, so collisions only matter when
-    the same alias is reused for two different tables in distinct
-    subqueries — a pathological shape DJ doesn't optimize for.
-    """
-    result: dict[str, str] = {}
-    for tbl in cte_query.find_all(ast.Table):
-        try:
-            tbl_name = tbl.name.identifier(quotes=False)
-        except Exception:  # pragma: no cover
-            continue
-        alias = tbl.alias.name if tbl.alias else tbl_name.split(SEPARATOR)[-1]
-        result[alias] = tbl_name
-    return result
-
-
-def _find_table_refs(
+def _build_all_scope_column_alias_maps(
     cte_query: ast.Query,
-    physical_table_name: str,
-) -> list[tuple[str, ast.Select]]:
-    """Find every ``ast.Table`` reference to ``physical_table_name`` in
-    the CTE body and return ``(alias, enclosing_select)`` per match.
+    ctx: "BuildContext",
+) -> dict[ast.Select, dict[str, str]]:
+    """For every distinct ``ast.Select`` scope reachable through the
+    target Select's FROM subtree (subqueries inside JOINs, nested
+    derived tables, etc.), build a ``{column_name → alias}`` map.
 
-    Used by :func:`_resolve_pushdown_filters_for_cte` to inject a filter
-    not just at the CTE's top-level Select but also at every nested
-    subquery that scans the same physical source table.
+    Crucially, this only walks the **primary Select's FROM subtree**,
+    not chained UNION/INTERSECT/EXCEPT arms reached via ``set_op.right``.
+    Transform authors often use asymmetric set-op arms — one arm
+    deliberately filtered, another acting as an unfiltered backstop —
+    and we don't want column-aware retargeting to override that intent
+    by pushing the filter into every arm.  The primary arm gets the
+    full retargeting; secondary arms are left alone (matching v2 and
+    the existing primary-Select-only set-op pushdown policy).
+
+    For each FROM entry inside the walked subtree:
+
+    - **``ast.Table``** with alias ``a`` (or table short-name if no
+      alias): look up its columns via ``ctx.nodes`` (handling both
+      direct node-name match and the dot-to-underscore CTE-name form
+      DJ emits in generated SQL).
+    - **Subquery** (``ast.Query`` aliased as ``s``): walk the
+      subquery's projection for output column names.
+
+    First-write-wins on collisions.  Used by
+    :func:`_resolve_pushdown_filters_for_cte` for column-aware
+    retargeting: each scope can qualify the same filter differently
+    based on which alias actually exposes each column there.
     """
-    results: list[tuple[str, ast.Select]] = []
-    for tbl in cte_query.find_all(ast.Table):
-        try:
-            tbl_name = tbl.name.identifier(quotes=False)
-        except Exception:  # pragma: no cover
+    result: dict[ast.Select, dict[str, str]] = {}
+    target_select = cte_query.select
+    if not isinstance(target_select, ast.Select):  # pragma: no cover
+        return result
+
+    cte_name_to_node = {get_cte_name(n.name): n for n in ctx.nodes.values()}
+
+    # Collect target_select plus every Select inside its FROM subtree.
+    # find_all() over the FROM avoids crossing into set-op arms via
+    # target_select.set_op.right — those arms get the primary-arm-only
+    # policy from the existing logic.
+    selects: list[ast.Select] = [target_select]
+    if target_select.from_:
+        for inner in target_select.from_.find_all(ast.Select):
+            if isinstance(inner, ast.Select):  # pragma: no branch
+                selects.append(inner)
+
+    seen: set[int] = set()
+    for sel in selects:
+        if id(sel) in seen:
             continue
-        if tbl_name != physical_table_name:
+        seen.add(id(sel))
+        col_alias: dict[str, str] = {}
+        if not sel.from_:  # pragma: no cover
+            result[sel] = col_alias
             continue
-        alias = tbl.alias.name if tbl.alias else tbl_name.split(SEPARATOR)[-1]
-        enclosing: Optional[ast.Select] = None
-        cur = getattr(tbl, "parent", None)
-        while cur is not None:  # pragma: no branch
-            if isinstance(cur, ast.Select):
-                enclosing = cur
-                break
-            cur = getattr(cur, "parent", None)
-        if enclosing is not None:  # pragma: no branch
-            results.append((alias, enclosing))
-    return results
-
-
-def _qualifier_aliases(filter_ast: ast.Expression) -> set[str]:
-    """Return the set of distinct qualifier aliases used in ``filter_ast``.
-
-    A column like ``a.snapshot_utc_date`` contributes ``"a"`` to the set;
-    bare column references contribute nothing.
-    """
-    result: set[str] = set()
-    for col in filter_ast.find_all(ast.Column):
-        if col.name and col.name.namespace:
-            result.add(col.name.namespace.name)
+        for relation in sel.from_.relations:
+            sides = [relation.primary, *(j.right for j in relation.extensions)]
+            for expr in sides:
+                _populate_scope_column_aliases(expr, col_alias, ctx, cte_name_to_node)
+        result[sel] = col_alias
     return result
 
 
-def _retarget_filter_qualifier(
-    filter_ast: ast.Expression,
-    old_alias: str,
-    new_alias: str,
-) -> ast.Expression:
-    """Deepcopy ``filter_ast`` and rewrite every column qualified by
-    ``old_alias`` to be qualified by ``new_alias`` instead.
+def _populate_scope_column_aliases(
+    expr: object,
+    col_alias: dict[str, str],
+    ctx: "BuildContext",
+    cte_name_to_node: dict[str, "Node"],
+) -> None:
+    """Helper: add this FROM-side expression's columns to a scope's
+    column->alias map.  Handles Tables (via ctx.nodes lookup) and
+    subqueries (via projection walk)."""
+    if isinstance(expr, ast.Table):
+        try:
+            tbl_name = expr.name.identifier(quotes=False)
+        except Exception:  # pragma: no cover
+            return
+        alias_name = expr.alias.name if expr.alias else tbl_name.split(SEPARATOR)[-1]
+        # Try direct lookup, then reverse-CTE-name lookup.
+        target_node = ctx.nodes.get(tbl_name) or cte_name_to_node.get(tbl_name)
+        if target_node and target_node.current and target_node.current.columns:
+            for col in target_node.current.columns:
+                if col.name not in col_alias:
+                    col_alias[col.name] = alias_name
+    elif isinstance(expr, ast.Query):
+        alias_obj = getattr(expr, "alias", None)
+        if alias_obj is None or not hasattr(alias_obj, "name"):  # pragma: no cover
+            return
+        alias_name = alias_obj.name
+        inner_sel = expr.select
+        if not isinstance(inner_sel, ast.Select):  # pragma: no cover
+            return
+        for proj in inner_sel.projection:
+            output_name = _projection_output_name(proj)
+            if output_name and output_name not in col_alias:
+                col_alias[output_name] = alias_name
 
-    Used to clone a primary-Select-targeted filter for injection at a
-    sibling reference to the same physical source table.  The cloned
-    filter uses the sibling's alias so column references resolve in the
-    sibling's scope.
+
+def _projection_output_name(proj: object) -> Optional[str]:
+    """Extract the output column name of a projection element."""
+    alias = getattr(proj, "alias", None)
+    if alias is not None and hasattr(alias, "name"):
+        return alias.name
+    if isinstance(proj, ast.Column) and proj.name:
+        return proj.name.name
+    return None  # pragma: no cover
+
+
+def _rewrite_filter_for_scope(
+    filter_str: str,
+    filter_column_aliases: dict[str, str],
+    column_to_alias: dict[str, str],
+) -> Optional[ast.Expression]:
+    """Parse a filter fresh and qualify each dim-ref column using the
+    scope's ``{column → alias}`` map.
+
+    Returns the rewritten filter AST, or ``None`` when any of the
+    filter's dim refs can't be resolved in this scope's columns.
+    Atomic per filter: if a single column is unreachable in this scope,
+    the whole filter is skipped (mirrors the primary-rewrite behavior
+    that bails on a partial OR-predicate).
     """
-    cloned = deepcopy(filter_ast)
-    for col in cloned.find_all(ast.Column):
-        if col.name is None or not col.name.namespace:  # pragma: no cover
+    if not column_to_alias:
+        return None
+    filter_ast = parse_filter(filter_str)
+    rewrites: list[tuple[ast.Column, ast.Column]] = []
+    for col in filter_ast.find_all(ast.Column):
+        full = get_column_full_name(col)
+        if not full or full not in filter_column_aliases:
             continue
-        if col.name.namespace.name == old_alias:  # pragma: no branch
-            col.name = ast.Name(col.name.name, namespace=ast.Name(new_alias))
-    return cloned
+        bare_col = filter_column_aliases[full]
+        target_alias = column_to_alias.get(bare_col)
+        if target_alias is None:
+            return None  # column not resolvable in this scope
+        new_name = ast.Name(bare_col, namespace=ast.Name(target_alias))
+        rewrites.append((col, ast.Column(name=new_name)))
+    if not rewrites:
+        return None
+    for old_col, new_col in rewrites:
+        if old_col.parent is not None:  # pragma: no branch
+            old_col.parent.replace(old_col, new_col, copy=False)
+    return filter_ast
 
 
 def _cte_has_set_operation(cte_query: ast.Query) -> bool:
@@ -1744,6 +1808,7 @@ def collect_node_ctes(
                 query_ast,
                 pushdown.filters,
                 pushdown.column_aliases,
+                ctx,
             )
             for target_select, filter_ast in injections:
                 inject_filter_into_select(target_select, filter_ast)

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1287,7 +1287,7 @@ def _resolve_pushdown_filters_for_cte(
                 continue
             if id(inner_select) in wrapped_setop_arms:
                 continue
-            if not _select_has_table_in_from(inner_select):
+            if not _select_has_table_in_from(inner_select):  # pragma: no cover
                 continue
             inner_rewrite = _rewrite_filter_for_scope(
                 filter_str,
@@ -1296,47 +1296,8 @@ def _resolve_pushdown_filters_for_cte(
             )
             if inner_rewrite is None:
                 continue
-            # Conservative asymmetric-arm protection: if the
-            # scope's existing WHERE already references any of the
-            # filter's columns, skip the push.  Mirrors what an
-            # author signals by writing e.g. ``WHERE status =
-            # 'shipped'`` in one UNION arm — a different
-            # ``status = 'completed'`` user filter pushed there
-            # would AND to an always-false predicate and zero out
-            # the arm.  Cases where the existing reference is
-            # actually compatible (``WHERE status IS NOT NULL``)
-            # are penalized by this heuristic, but the conservative
-            # call avoids silently breaking author intent.
-            if _select_where_references_any(inner_select, inner_rewrite):
-                continue
             results.append((inner_select, inner_rewrite))
     return results, consumed
-
-
-def _select_where_references_any(
-    sel: ast.Select,
-    filter_ast: ast.Expression,
-) -> bool:
-    """Return True iff ``sel.where`` references any bare column name
-    that also appears as a bare column in ``filter_ast``.
-
-    Used to avoid pushing a user filter into a secondary set-op arm
-    whose authored WHERE already constrains the same column —
-    the AND'd result would often be always-false and silently
-    zero out the arm.
-    """
-    if sel.where is None:
-        return False
-    filter_cols: set[str] = set()
-    for col in filter_ast.find_all(ast.Column):
-        if col.name:  # pragma: no branch
-            filter_cols.add(col.name.name)
-    if not filter_cols:  # pragma: no cover
-        return False
-    for col in sel.where.find_all(ast.Column):
-        if col.name and col.name.name in filter_cols:
-            return True
-    return False
 
 
 def _select_has_table_in_from(sel: ast.Select) -> bool:
@@ -1532,7 +1493,7 @@ def _build_all_scope_column_alias_maps(
 
     seen: set[int] = set()
     for sel in selects:
-        if id(sel) in seen:
+        if id(sel) in seen:  # pragma: no cover
             continue
         seen.add(id(sel))
         col_alias: dict[str, tuple[str, str]] = {}
@@ -1655,7 +1616,7 @@ def _projection_output_name(proj: object) -> Optional[str]:
     alias = getattr(proj, "alias", None)
     if alias is not None and hasattr(alias, "name"):
         return alias.name
-    if isinstance(proj, ast.Column) and proj.name:
+    if isinstance(proj, ast.Column) and proj.name:  # pragma: no cover
         return proj.name.name
     return None  # pragma: no cover
 
@@ -1695,12 +1656,12 @@ def _rewrite_filter_for_scope(
         if not full:  # pragma: no cover
             continue
         resolution = column_to_alias.get(full)
-        if resolution is None:
+        if resolution is None:  # pragma: no cover
             continue
         target_alias, emit_col = resolution
         new_name = ast.Name(emit_col, namespace=ast.Name(target_alias))
         rewrites.append((col, ast.Column(name=new_name)))
-    if not rewrites:
+    if not rewrites:  # pragma: no cover
         return None
     for old_col, new_col in rewrites:
         if old_col.parent is not None:  # pragma: no branch

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -9305,7 +9305,9 @@ class TestParentCteFilterLanding:
             json={
                 "name": "v3.alloc_with_sibling",
                 "query": (
-                    "SELECT * FROM ("
+                    "SELECT s.account_id, s.snapshot_utc_date, "
+                    "       s.alloc_value, s.sibling_value "
+                    "FROM ("
                     "  SELECT a.account_id, a.snapshot_utc_date, "
                     "         a.alloc_value, sib.sibling_value "
                     "  FROM v3.src_sibling_two_cols sib "
@@ -9401,7 +9403,7 @@ class TestParentCteFilterLanding:
             "/nodes/transform/",
             json={
                 "name": "v3.star_proj_xform",
-                "query": "SELECT * FROM v3.src_star_proj",
+                "query": ("SELECT account_id, utc_date, val_a FROM v3.src_star_proj"),
                 "mode": "published",
                 "primary_key": ["account_id", "utc_date"],
             },

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -8459,11 +8459,16 @@ class TestParentCteFilterLanding:
         assert response.status_code == 200, response.json()
         sql = get_first_grain_group(response.json())["sql"]
         # Parent CTE body is a UNION ALL.  DJ pushes the
-        # ``event_date >= 20260101`` filter into BOTH arms via
-        # column-aware retargeting against each arm's FROM —
-        # safe here because the arms share the same source
-        # (events_setop) and neither arm has an existing WHERE
-        # that would conflict with the predicate.  The
+        # pushable ``event_date`` filter into the PRIMARY arm
+        # only — column-aware retargeting at the secondary arm
+        # only fires for filters whose dim is explicitly linked
+        # to the arm's source node (or whose target IS the dim
+        # itself), and ``events_setop`` is a plain source with
+        # no dim_link to the filter's date dim.  This
+        # conservative policy avoids the v2-divergent
+        # over-pushdown that bare-column matching would cause
+        # by incidentally firing on tables that don't actually
+        # have a dim_link to the filter's dim.  The
         # ``branch = 'a'`` filter can't push (arm 1 projects
         # ``branch`` as the literal ``'a'``, a non-column
         # projection that's unsafe to inline) so it stays at
@@ -8479,7 +8484,6 @@ class TestParentCteFilterLanding:
                 UNION ALL
                 SELECT account_id, event_date, value, 'b' AS branch
                 FROM default.v3.events_setop
-                WHERE events_setop.event_date >= 20260101
             )
             SELECT t1.branch, SUM(t1.value) value_sum_HASH
             FROM v3_events_union t1

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -8458,16 +8458,16 @@ class TestParentCteFilterLanding:
         )
         assert response.status_code == 200, response.json()
         sql = get_first_grain_group(response.json())["sql"]
-        # Parent CTE body is a UNION ALL.  DJ pushes the pushable
-        # filter into the PRIMARY arm only (matches v2 behavior).
-        # Subsequent UNION'd arms are left untouched so the author's
-        # asymmetric-arm semantics (e.g. one arm acting as an
-        # unfiltered backstop) survive intact.  The
-        # ``event_date >= 20260101`` filter pushes into arm 1 and is
-        # marked consumed → dropped from outer WHERE.  The
+        # Parent CTE body is a UNION ALL.  DJ pushes the
+        # ``event_date >= 20260101`` filter into BOTH arms via
+        # column-aware retargeting against each arm's FROM —
+        # safe here because the arms share the same source
+        # (events_setop) and neither arm has an existing WHERE
+        # that would conflict with the predicate.  The
         # ``branch = 'a'`` filter can't push (arm 1 projects
-        # ``branch`` as the literal ``'a'``, a non-column projection
-        # that's unsafe to inline) so it stays at outer WHERE.
+        # ``branch`` as the literal ``'a'``, a non-column
+        # projection that's unsafe to inline) so it stays at
+        # outer WHERE.
         assert_sql_equal(
             sql,
             """
@@ -8479,6 +8479,7 @@ class TestParentCteFilterLanding:
                 UNION ALL
                 SELECT account_id, event_date, value, 'b' AS branch
                 FROM default.v3.events_setop
+                WHERE events_setop.event_date >= 20260101
             )
             SELECT t1.branch, SUM(t1.value) value_sum_HASH
             FROM v3_events_union t1
@@ -9194,3 +9195,443 @@ class TestParentCteFilterLanding:
             f"where ``a`` references scope_inner_events (which has no "
             f"window_label):\n{sql}"
         )
+
+    @pytest.mark.asyncio
+    async def test_filter_disambiguates_joined_tables_via_dim_link(
+        self,
+        client_with_build_v3,
+    ):
+        """When an inner subquery's FROM has two Tables exposing the
+        same bare column, the filter must route to the Table whose
+        ``dimension_link`` references the filter's dim — not a
+        first-write-wins arbitrary pick.
+
+        Regression from a real Netflix XP query: an inner subquery
+        had ``subscription_lifecycle_cohort_d rev JOIN
+        allocation_core_d a2 ON ...`` where BOTH tables expose
+        ``snapshot_utc_date``.  The filter
+        ``allocation_snapshot_date.dateint = X`` is supposed to
+        constrain allocation_core_d (a2) since that's the linked
+        table; first-write-wins picked ``rev`` instead, sending
+        the predicate to the wrong table and changing result
+        semantics.  This test pins the dim-link-aware routing.
+        """
+        client = client_with_build_v3
+
+        # Allocation source — linked to the alloc-date dim.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_alloc_two_cols",
+                "description": "alloc",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "snapshot_utc_date", "type": "int"},
+                    {"name": "alloc_value", "type": "double"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "alloc_two_cols",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Sibling source — also exposes ``snapshot_utc_date`` but is
+        # NOT linked to the alloc-date dim.  This is the collision
+        # source: both this and v3.src_alloc_two_cols project a
+        # column named ``snapshot_utc_date``, so a naive bare-col
+        # lookup is ambiguous.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_sibling_two_cols",
+                "description": "sibling",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "snapshot_utc_date", "type": "int"},
+                    {"name": "sibling_value", "type": "double"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "sibling_two_cols",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Alloc-date dim, linked from v3.src_alloc_two_cols only.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_alloc_dim_dates",
+                "description": "alloc-date PK",
+                "columns": [{"name": "dateint", "type": "int"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "alloc_dim_dates",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.alloc_date_dim",
+                "query": "SELECT dateint FROM v3.src_alloc_dim_dates",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/v3.src_alloc_two_cols/link",
+            json={
+                "dimension_node": "v3.alloc_date_dim",
+                "join_type": "inner",
+                "join_on": (
+                    "v3.src_alloc_two_cols.snapshot_utc_date "
+                    "= v3.alloc_date_dim.dateint"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Transform: inner subquery JOINs both sources, exposing the
+        # collision.  Top-level wraps the join in a derived table so
+        # the filter routing happens at the inner Select's scope.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.alloc_with_sibling",
+                "query": (
+                    "SELECT * FROM ("
+                    "  SELECT a.account_id, a.snapshot_utc_date, "
+                    "         a.alloc_value, sib.sibling_value "
+                    "  FROM v3.src_sibling_two_cols sib "
+                    "  JOIN v3.src_alloc_two_cols a "
+                    "    ON a.account_id = sib.account_id"
+                    ") s"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "snapshot_utc_date"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.alloc_with_sibling_total",
+                "query": "SELECT SUM(alloc_value) FROM v3.alloc_with_sibling",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.alloc_with_sibling_total"],
+                "dimensions": ["v3.alloc_with_sibling.account_id"],
+                "filters": ["v3.alloc_date_dim.dateint = 20260520"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Filter routes to ``a`` (allocation table) via the dim
+        # link, NOT to ``sib`` (sibling table) — even though sib is
+        # processed first in the inner subquery's FROM and would
+        # otherwise win first-write-wins.
+        assert "a.snapshot_utc_date = 20260520" in sql, (
+            f"Filter not routed to allocation table via dim link:\n{sql}"
+        )
+        assert "sib.snapshot_utc_date = 20260520" not in sql, (
+            f"Filter mis-routed to sibling table that has no dim link:\n{sql}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_not_injected_at_subquery_only_from_scope(
+        self,
+        client_with_build_v3,
+    ):
+        """A Select whose direct FROM has ONLY subquery aliases (no
+        Tables) must not receive column-aware filter injection.
+
+        At such scopes the only candidate aliases are the OUTER's
+        aliases for inner subqueries.  Pushing a filter qualified
+        by one of those aliases triggers the existing outer-join
+        safety wrap, which ANDs the filter into the inner
+        subquery's WHERE *without* retargeting the qualifier —
+        producing a reference like ``numerator.utc_date`` inside
+        a body that doesn't have a ``numerator`` alias, which
+        fails at engine resolution.
+
+        Regression from a real XP search-session query where the
+        metric body was ``SELECT ... FROM (denom subq) AS
+        denominator LEFT JOIN (num subq) AS numerator USING (...)``
+        and column-aware retargeting at the outer Select picked
+        ``numerator`` (because the denominator subquery's
+        projection was ``SELECT *``, which doesn't register any
+        column→alias entry), then pushed the filter inside the
+        numerator subquery with a stale qualifier.
+        """
+        client = client_with_build_v3
+
+        # A Star-projecting transform — its projection is ``SELECT *``
+        # which contributes no column→alias entries when DJ walks
+        # it as a subquery side, so first-write-wins favors the
+        # OTHER side of the join.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_star_proj",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "utc_date", "type": "int"},
+                    {"name": "val_a", "type": "double"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "star_proj_tbl",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.star_proj_xform",
+                "query": "SELECT * FROM v3.src_star_proj",
+                "mode": "published",
+                "primary_key": ["account_id", "utc_date"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        # A LEFT-side fact for the join — has utc_date too.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_left_fact",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "utc_date", "type": "int"},
+                    {"name": "val_l", "type": "double"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "left_fact_tbl",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.left_fact_xform",
+                "query": ("SELECT account_id, utc_date, val_l FROM v3.src_left_fact"),
+                "mode": "published",
+                "primary_key": ["account_id", "utc_date"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        # Outer transform whose FROM is ``(subq) LEFT JOIN (subq)
+        # USING (...)``: both sides are subquery aliases, no
+        # direct Table.  Column-aware retargeting at this Select
+        # must be skipped.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.subq_only_join",
+                "query": (
+                    "SELECT l.account_id, l.utc_date, l.val_l, r.val_a "
+                    "FROM v3.left_fact_xform l "
+                    "LEFT JOIN v3.star_proj_xform r "
+                    "  ON l.account_id = r.account_id "
+                    " AND l.utc_date = r.utc_date"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "utc_date"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.subq_only_join_total",
+                "query": "SELECT SUM(val_l) FROM v3.subq_only_join",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.subq_only_join_total"],
+                "dimensions": ["v3.subq_only_join.account_id"],
+                "filters": ["v3.subq_only_join.utc_date = 20260520"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # The filter must NOT appear with the right-side subquery's
+        # alias (``r``) inside the star-projecting transform's CTE
+        # body — that's the scope where ``r`` doesn't exist and
+        # the SQL would fail at resolution.
+        star_cte_body = (
+            sql.split("v3_star_proj_xform AS (")[1].split("),")[0]
+            if "v3_star_proj_xform AS (" in sql
+            else ""
+        )
+        assert "r.utc_date" not in star_cte_body, (
+            f"Stale outer alias ``r`` injected inside the inner "
+            f"CTE body where it doesn't resolve:\n{sql}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_skips_arms_of_wrapped_union_inside_derived_table(
+        self,
+        client_with_build_v3,
+    ):
+        """A UNION ALL nested inside a derived table (whose outer
+        Select already constrains the union's output) must NOT
+        receive per-arm filter pushdown — the outer WHERE already
+        handles the constraint, and arm-level pushdown diverges
+        from v2.
+
+        Contrast with :meth:`test_filter_lands_when_parent_cte_is_setop`
+        where the CTE body IS the UNION (no wrapping derived
+        table); there the only place the filter can land is into
+        the arms, so it does.  The structural distinction is
+        whether the UNION is the top of ``cte_query.select`` (then
+        arms get pushdown) or nested inside a Query within
+        ``target_select.from_`` (then the outer WHERE owns the
+        constraint and arms are left alone).
+
+        Regression from a real XP ads-allocation query where
+        DJ_v3 was injecting per-arm WHEREs into a UNION wrapped
+        as ``(...) AS alloc CROSS JOIN dim WHERE ...`` even
+        though the outer WHERE already filtered the union output.
+        """
+        client = client_with_build_v3
+
+        # Two parallel sources that both feed a UNION inside the
+        # alloc transform.  Identical columns so the UNION
+        # type-checks.
+        for name, table in (
+            ("v3.src_alloc_p1", "alloc_p1"),
+            ("v3.src_alloc_p2", "alloc_p2"),
+        ):
+            resp = await client.post(
+                "/nodes/source/",
+                json={
+                    "name": name,
+                    "description": f"alloc partition {table}",
+                    "columns": [
+                        {"name": "account_id", "type": "int"},
+                        {"name": "test_id", "type": "int"},
+                        {"name": "snapshot_date", "type": "int"},
+                    ],
+                    "mode": "published",
+                    "catalog": "default",
+                    "schema_": "v3",
+                    "table": table,
+                },
+            )
+            assert resp.status_code in (200, 201), resp.json()
+
+        # A tiny spine dim CROSS-joined into the UNION wrap.
+        await _setup_window_dim(client)
+
+        # Alloc transform: UNION ALL of two sources wrapped in
+        # a derived table, then CROSS-joined to the obs_window
+        # spine.  The outer WHERE on the transform body is what
+        # constrains the union's output — arm-level pushdown is
+        # redundant.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.alloc_wrapped_union",
+                "query": (
+                    "SELECT alloc.account_id, alloc.test_id, "
+                    "       alloc.snapshot_date, w.window "
+                    "FROM ("
+                    "  SELECT account_id, test_id, snapshot_date "
+                    "    FROM v3.src_alloc_p1 "
+                    "  UNION ALL "
+                    "  SELECT account_id, test_id, snapshot_date "
+                    "    FROM v3.src_alloc_p2"
+                    ") AS alloc "
+                    "CROSS JOIN v3.obs_window_dim AS w"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "test_id", "window"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.alloc_wrapped_union_count",
+                "query": "SELECT COUNT(*) FROM v3.alloc_wrapped_union",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.alloc_wrapped_union_count"],
+                "dimensions": ["v3.alloc_wrapped_union.account_id"],
+                "filters": [
+                    "v3.alloc_wrapped_union.test_id = 42",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+
+        # Slice out the alloc CTE body for the per-arm check.
+        cte_marker = "v3_alloc_wrapped_union AS ("
+        if cte_marker in sql:
+            cte_body = sql.split(cte_marker, 1)[1]
+            # Stop at the next CTE boundary or the SELECT after
+            # the CTE list.  Conservatively take everything up to
+            # the first standalone ``),\n`` followed by a name and
+            # ``AS (`` — or fall back to the rest if no such
+            # boundary is found.
+            cte_body = cte_body.split("\n),\n", 1)[0]
+        else:  # pragma: no cover
+            cte_body = sql
+        # The two UNION-arm FROMs must NOT each have their own
+        # WHERE injected with the user filter — only the outer
+        # CTE-level WHERE should carry it.
+        p1_chunk = (
+            cte_body.split("FROM default.v3.alloc_p1", 1)[1].split("UNION", 1)[0]
+            if "FROM default.v3.alloc_p1" in cte_body
+            else ""
+        )
+        p2_chunk = (
+            cte_body.split("FROM default.v3.alloc_p2", 1)[1].split(") AS alloc", 1)[0]
+            if "FROM default.v3.alloc_p2" in cte_body
+            else ""
+        )
+        assert "test_id = 42" not in p1_chunk and "test_id IN (42)" not in p1_chunk, (
+            f"Per-arm pushdown leaked into the first UNION arm — "
+            f"the outer wrapping WHERE already constrains it:\n{sql}"
+        )
+        assert "test_id = 42" not in p2_chunk and "test_id IN (42)" not in p2_chunk, (
+            f"Per-arm pushdown leaked into the second UNION arm — "
+            f"the outer wrapping WHERE already constrains it:\n{sql}"
+        )
+        # The outer wrapping WHERE on the CTE body must still
+        # carry the filter — the constraint isn't dropped, just
+        # not duplicated into the arms.
+        assert (
+            "alloc.test_id = 42" in cte_body
+            or "test_id = 42" in cte_body
+            or "test_id IN (42)" in cte_body
+        ), f"Filter dropped from outer wrapping WHERE entirely:\n{sql}"

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -9074,3 +9074,123 @@ class TestParentCteFilterLanding:
             """,
             normalize_aliases=True,
         )
+
+    @pytest.mark.asyncio
+    async def test_subquery_alias_shadows_nested_table_alias(
+        self,
+        client_with_build_v3,
+    ):
+        """Scope-correct alias resolution.
+
+        Transform body uses ``(subquery) AS a`` as the outer FROM, while
+        a *different* inner subquery deeper down has ``some_source AS a``
+        (the same alias name, but it's an alias for a real Table this
+        time).  A filter on ``a.<col>`` at the outer scope must NOT
+        cause the retargeting walk to inject a clone into the inner
+        subquery — the two ``a`` aliases live in different scopes and
+        refer to different things.
+
+        Pre-fix, ``_build_source_alias_map`` walked
+        ``find_all(ast.Table)`` across the whole body and saw the inner
+        ``a → some_source`` mapping, then incorrectly retargeted the
+        outer filter into the inner subquery's WHERE — producing
+        ``a.some_col`` where ``a`` (in that scope) doesn't have
+        ``some_col``.
+        """
+        client = client_with_build_v3
+
+        # Inner-most source: the real Table that the deeper subquery
+        # aliases as ``a``.
+        src_inner = await _setup_events_source(
+            client,
+            "scope_inner",
+            "scope_inner_events",
+        )
+
+        # Mid-transform: aliases src_inner as ``a`` AND CROSS-joins a
+        # date dim to expose a ``window_label`` column.  This is the
+        # transform whose ``a`` (inner) collides with the outer
+        # transform's subquery alias.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_window_labels",
+                "description": "window labels",
+                "columns": [{"name": "window_label", "type": "string"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "window_labels",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.scope_mid_transform",
+                "query": (
+                    "SELECT a.account_id, a.event_date, a.value, w.window_label "
+                    f"FROM {src_inner} AS a "
+                    "CROSS JOIN v3.src_window_labels AS w"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date", "window_label"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        # Outer transform: aliases scope_mid_transform as ``a`` (a
+        # subquery alias, not a Table).  The outer body filters /
+        # projects from this ``a``.  Pre-fix, the retargeting walk
+        # incorrectly conflated the outer ``a`` (subquery) with the
+        # inner ``a`` (Table aliasing scope_inner_events).
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.scope_outer_transform",
+                "query": (
+                    "SELECT a.account_id, a.event_date, a.value, a.window_label "
+                    "FROM v3.scope_mid_transform AS a"
+                ),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date", "window_label"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.scope_outer_count",
+                "query": "SELECT COUNT(*) FROM v3.scope_outer_transform",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.scope_outer_count"],
+                "dimensions": ["v3.scope_outer_transform.account_id"],
+                "filters": [
+                    "v3.scope_outer_transform.window_label = 'demo'",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+
+        # The filter must NOT be injected inside the mid-transform's
+        # CTE body where ``a`` is an alias for ``scope_inner_events``
+        # — that table doesn't have ``window_label`` and the resulting
+        # SQL would fail at engine resolution.
+        assert "a.window_label = 'demo'" not in (
+            sql.split("v3_scope_mid_transform AS (")[1].split(")")[0]
+            if "v3_scope_mid_transform AS (" in sql
+            else ""
+        ), (
+            f"Filter incorrectly injected into mid-transform's CTE "
+            f"where ``a`` references scope_inner_events (which has no "
+            f"window_label):\n{sql}"
+        )


### PR DESCRIPTION
### Summary

This PR overhauls how `_resolve_pushdown_filters_for_cte` decides where to inject user-supplied dimension filters within a CTE body, closing several regressions in the original "walk every source-table reference" pass (#2166) and bringing v3's pushdown placement closer to v2's behavior.

For context, the filter pushdown in v3 had two known regressions as compared to v2:
  1. Spark OOMs when the same source table was referenced inside a nested subquery but only the top-level reference got the partition predicate.
  2. Column doesn't exist errors when an outer subquery alias collided with a deeper Table alias, causing the filter to be retargeted into the wrong scope.

Earlier attempts to fix these (the "walk every source-table reference" change) also went too far: they pushed filters into tables that incidentally shared a column name with the filter's dim but weren't actually linked to it, diverging from v2.

`_resolve_pushdown_filters_for_cte` now does two complementary passes:

1. Alias-substitution pass: For each alias used in the primary rewrite at `target_select`, find every sibling `ast.Table` ref to the same physical source elsewhere in the CTE body and inject a retargeted copy. Restores the v2 partition-prune-everywhere behavior for self-references.
2. Column-aware retargeting pass: For each `ast.Select` scope inside the CTE body (including secondary set-op arms), builds a resolver map from:
  - Dim-link entries: for each node referenced in the scope's `FROM`, register one entry per `foreign_keys_reversed` row from its dimension links. This is the only route by which filters get pushed at inner scopes.
  - Dim-self entries: when the scope's table is itself a dimension node, register its PK columns as self-pointing entries.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
