### PR TITLE
Fix decompose distinct

### DIFF
--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -1159,35 +1159,45 @@ class MetricComponentExtractor:
             for a in func.args:
                 columns.extend(a.find_all(ast.Column))
 
-        # Build component name from columns in the expression
-        if is_distinct:
-            # DISTINCT uses column names + "_distinct"
-            base_name = amenable_col_names(columns) + "_distinct"
-        elif columns:
-            # Normal case: column names + suffix
-            base_name = amenable_col_names(columns) + comp_def.suffix
-        else:
-            # No columns (e.g., COUNT(*)) - use suffix without leading underscore
-            base_name = comp_def.suffix.lstrip("_") or "count"
-
-        short_hash = self._short_hash(expression, query_ast)
-        component_name = f"{base_name}_{short_hash}"
-
-        # For LIMITED (COUNT DISTINCT) components, compute the SQL alias that
-        # measures.py should use for the grain column.  Simple column args get the
-        # bare column name, whereas complex expressions (like IF, CASE etc) get
-        # component_name, so the alias is a stable identifier derived from the same logic.
-        grain_alias: str | None = None
-        if is_distinct:
-            _arg = (
-                cast(ast.Expression, func.args[comp_def.arg_index])
-                if comp_def.arg_index is not None
-                else None
-            )
+        # For plain-column DISTINCT (e.g. ``COUNT(DISTINCT account_id)``),
+        # name the component after the bare column itself — there's no
+        # expression ambiguity to disambiguate.  This keeps
+        # ``component.name`` aligned with the column already projected
+        # as a grain alias by measures.py: ``derived_expression`` and
+        # the live measures SQL output reference the same identifier,
+        # so external consumers (XP/ABlaze) can evaluate the persisted
+        # expression directly against the materialized table.
+        #
+        # Complex DISTINCT (CASE/IF over a column) and non-DISTINCT
+        # components still get a ``<base>_<hash>`` name — those need
+        # the hash to distinguish different expressions that share a
+        # column-name prefix.
+        plain_distinct_col: str | None = None
+        if is_distinct and comp_def.arg_index is not None:
+            _arg = cast(ast.Expression, func.args[comp_def.arg_index])
             if isinstance(_arg, ast.Column):
-                grain_alias = _arg.name.name
+                plain_distinct_col = _arg.name.name
+
+        if plain_distinct_col is not None:
+            component_name = plain_distinct_col
+            grain_alias: str | None = plain_distinct_col
+        else:
+            # Build component name from columns in the expression
+            if is_distinct:
+                # DISTINCT uses column names + "_distinct"
+                base_name = amenable_col_names(columns) + "_distinct"
+            elif columns:
+                # Normal case: column names + suffix
+                base_name = amenable_col_names(columns) + comp_def.suffix
             else:
-                grain_alias = component_name
+                # No columns (e.g., COUNT(*)) - use suffix without leading underscore
+                base_name = comp_def.suffix.lstrip("_") or "count"
+
+            short_hash = self._short_hash(expression, query_ast)
+            component_name = f"{base_name}_{short_hash}"
+            # Complex DISTINCT: grain alias equals the component name
+            # so the projection alias stays a stable identifier.
+            grain_alias = component_name if is_distinct else None
 
         # Build accumulate expression with template expansion
         accumulate_expr = self._expand_template(comp_def.accumulate, func.args)

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -4945,8 +4945,8 @@ class TestCubeMaterializeV2SuccessPaths:
             metric_combiners = data["metric_combiners"]
             assert metric_combiners == {
                 "v3.total_revenue": "SUM(line_total_sum_e1f61696)",
-                "v3.order_count": "COUNT( DISTINCT order_id_distinct_f93d50ab)",
-                "v3.avg_order_value": "SAFE_DIVIDE(SUM(line_total_sum_e1f61696), NULLIF(COUNT( DISTINCT order_id_distinct_f93d50ab), 0))",
+                "v3.order_count": "COUNT( DISTINCT order_id)",
+                "v3.avg_order_value": "SAFE_DIVIDE(SUM(line_total_sum_e1f61696), NULLIF(COUNT( DISTINCT order_id), 0))",
                 # wow_revenue_change now has:
                 # - PARTITION BY injected (for querying the materialized cube)
                 # - Dimension refs replaced with column aliases (week_order instead of v3.date.week[order])

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -1202,14 +1202,11 @@ async def create_metric_distinct_single_column(client: AsyncClient):
             "expression": "hard_hat_id",
             "grain_alias": "hard_hat_id",
             "merge": None,
-            "name": "hard_hat_id_distinct_ac37a223",
+            "name": "hard_hat_id",
             "rule": {"level": ["hard_hat_id"], "type": "limited"},
         },
     ]
-    assert (
-        metric_data["derived_expression"]
-        == "COUNT( DISTINCT hard_hat_id_distinct_ac37a223)"
-    )
+    assert metric_data["derived_expression"] == "COUNT( DISTINCT hard_hat_id)"
     return metric_name
 
 
@@ -1311,7 +1308,7 @@ async def test_measures_sql_agg_distinct_metric(
       default_DOT_repair_orders_fact_built.default_DOT_dispatcher_DOT_company_name,
       COUNT(price) AS price_count_935e7117,
       SUM(price) AS price_sum_935e7117,
-      hard_hat_id AS hard_hat_id_distinct_ac37a223,
+      hard_hat_id AS hard_hat_id,
       IF(hard_hat_id = 1, 1, 0) AS hard_hat_id_distinct_0291ee39
     FROM default_DOT_repair_orders_fact_built
     GROUP BY
@@ -1691,17 +1688,14 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
                 "expression": "default.municipality_dim.contact_name",
                 "grain_alias": "contact_name",
                 "merge": None,
-                "name": "default_DOT_municipality_dim_DOT_contact_name_distinct_bc16351d",
+                "name": "contact_name",
                 "rule": {
                     "level": ["default.municipality_dim.contact_name"],
                     "type": "limited",
                 },
             },
         ]
-        assert (
-            data["derived_expression"]
-            == "COUNT( DISTINCT default_DOT_municipality_dim_DOT_contact_name_distinct_bc16351d)"
-        )
+        assert data["derived_expression"] == "COUNT( DISTINCT contact_name)"
         response = await module__client_with_roads.get(
             "/sql/measures/v2",
             params={
@@ -1752,7 +1746,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
         )
         SELECT
           default_DOT_repair_orders_fact_built.default_DOT_municipality_dim_DOT_contact_name,
-          default_DOT_municipality_dim_DOT_contact_name AS default_DOT_municipality_dim_DOT_contact_name_distinct_bc16351d
+          default_DOT_municipality_dim_DOT_contact_name AS contact_name
         FROM default_DOT_repair_orders_fact_built
         GROUP BY
           default_DOT_repair_orders_fact_built.default_DOT_municipality_dim_DOT_contact_name,

--- a/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
@@ -830,7 +830,7 @@ class TestBuildSqlFromCube:
             category,
             line_total_sum_e1f61696,
             quantity_sum_06b64d2e,
-            order_id_distinct_f93d50ab,
+            order_id,
             customer_id_hll_23002251,
             unit_price_count_55cff00f,
             unit_price_sum_55cff00f,
@@ -842,13 +842,13 @@ class TestBuildSqlFromCube:
           test_cube_all_order_metrics_0.category AS category,
           SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696) AS total_revenue,
           SUM(test_cube_all_order_metrics_0.quantity_sum_06b64d2e) AS total_quantity,
-          COUNT( DISTINCT test_cube_all_order_metrics_0.order_id_distinct_f93d50ab) AS order_count,
+          COUNT( DISTINCT test_cube_all_order_metrics_0.order_id) AS order_count,
           hll_sketch_estimate(hll_union_agg(test_cube_all_order_metrics_0.customer_id_hll_23002251)) AS customer_count,
           SUM(test_cube_all_order_metrics_0.unit_price_sum_55cff00f) / NULLIF(SUM(test_cube_all_order_metrics_0.unit_price_count_55cff00f), 0) AS avg_unit_price,
           MAX(test_cube_all_order_metrics_0.unit_price_max_55cff00f) AS max_unit_price,
           MIN(test_cube_all_order_metrics_0.unit_price_min_55cff00f) AS min_unit_price,
-          SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696) / NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id_distinct_f93d50ab), 0) AS avg_order_value,
-          SUM(test_cube_all_order_metrics_0.quantity_sum_06b64d2e) / NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id_distinct_f93d50ab), 0) AS avg_items_per_order,
+          SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696) / NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id), 0) AS avg_order_value,
+          SUM(test_cube_all_order_metrics_0.quantity_sum_06b64d2e) / NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id), 0) AS avg_items_per_order,
           SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696) / NULLIF(hll_sketch_estimate(hll_union_agg(test_cube_all_order_metrics_0.customer_id_hll_23002251)), 0) AS revenue_per_customer,
           (MAX(test_cube_all_order_metrics_0.unit_price_max_55cff00f) - MIN(test_cube_all_order_metrics_0.unit_price_min_55cff00f)) / NULLIF(SUM(test_cube_all_order_metrics_0.unit_price_sum_55cff00f) / NULLIF(SUM(test_cube_all_order_metrics_0.unit_price_count_55cff00f), 0), 0) * 100 AS price_spread_pct
         FROM test_cube_all_order_metrics_0
@@ -876,7 +876,7 @@ class TestBuildSqlFromCube:
             category,
             line_total_sum_e1f61696,
             quantity_sum_06b64d2e,
-            order_id_distinct_f93d50ab,
+            order_id,
             customer_id_hll_23002251,
             unit_price_count_55cff00f,
             unit_price_sum_55cff00f,
@@ -888,13 +888,13 @@ class TestBuildSqlFromCube:
           test_cube_all_order_metrics_0.category AS category,
           SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696) AS total_revenue,
           SUM(test_cube_all_order_metrics_0.quantity_sum_06b64d2e) AS total_quantity,
-          COUNT( DISTINCT test_cube_all_order_metrics_0.order_id_distinct_f93d50ab) AS order_count,
+          COUNT( DISTINCT test_cube_all_order_metrics_0.order_id) AS order_count,
           hll_sketch_estimate(ds_hll(test_cube_all_order_metrics_0.customer_id_hll_23002251)) AS customer_count,
           SAFE_DIVIDE(SUM(test_cube_all_order_metrics_0.unit_price_sum_55cff00f), NULLIF(SUM(test_cube_all_order_metrics_0.unit_price_count_55cff00f), 0)) AS avg_unit_price,
           MAX(test_cube_all_order_metrics_0.unit_price_max_55cff00f) AS max_unit_price,
           MIN(test_cube_all_order_metrics_0.unit_price_min_55cff00f) AS min_unit_price,
-          SAFE_DIVIDE(SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696), NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id_distinct_f93d50ab), 0)) AS avg_order_value,
-          SAFE_DIVIDE(SUM(test_cube_all_order_metrics_0.quantity_sum_06b64d2e), NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id_distinct_f93d50ab), 0)) AS avg_items_per_order,
+          SAFE_DIVIDE(SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696), NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id), 0)) AS avg_order_value,
+          SAFE_DIVIDE(SUM(test_cube_all_order_metrics_0.quantity_sum_06b64d2e), NULLIF(COUNT( DISTINCT test_cube_all_order_metrics_0.order_id), 0)) AS avg_items_per_order,
           SAFE_DIVIDE(SUM(test_cube_all_order_metrics_0.line_total_sum_e1f61696), NULLIF(hll_sketch_estimate(ds_hll(test_cube_all_order_metrics_0.customer_id_hll_23002251)), 0)) AS revenue_per_customer,
           SAFE_DIVIDE((MAX(test_cube_all_order_metrics_0.unit_price_max_55cff00f) - MIN(test_cube_all_order_metrics_0.unit_price_min_55cff00f)), NULLIF(SAFE_DIVIDE(SUM(test_cube_all_order_metrics_0.unit_price_sum_55cff00f), NULLIF(SUM(test_cube_all_order_metrics_0.unit_price_count_55cff00f), 0)), 0)) * 100 AS price_spread_pct
         FROM test_cube_all_order_metrics_0
@@ -1001,14 +1001,14 @@ class TestBuildSqlFromCube:
             week_order,
             category,
             line_total_sum_e1f61696,
-            order_id_distinct_f93d50ab
+            order_id
           FROM default.analytics.cube_window_metrics
         ),
         base_metrics AS (
           SELECT
             test_cube_window_metrics_0.week_order AS week_order,
             test_cube_window_metrics_0.category AS category,
-            COUNT( DISTINCT test_cube_window_metrics_0.order_id_distinct_f93d50ab) AS order_count,
+            COUNT( DISTINCT test_cube_window_metrics_0.order_id) AS order_count,
             SUM(test_cube_window_metrics_0.line_total_sum_e1f61696) AS total_revenue
           FROM test_cube_window_metrics_0
           GROUP BY  test_cube_window_metrics_0.week_order, test_cube_window_metrics_0.category

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -9806,3 +9806,160 @@ class TestParentCteFilterLanding:
             """,
             normalize_aliases=True,
         )
+
+
+class TestCountDistinctPlainColumnCoalesceJoin:
+    """Regression: ``COUNT(DISTINCT plain_col)`` measures SQL must stay
+    valid when the metric's parent transform is joined to a right-outer
+    dim that exposes the same column, producing a ``COALESCE(t1, t2)``
+    grain projection.
+
+    The previous fix path emitted an additional ``<bare> AS <hashed>``
+    projection referencing the raw left-side column.  That column was
+    not in ``GROUP BY COALESCE(t1, t2)`` and Spark rejected the SQL.
+
+    Under the decompose-level fix, plain-column DISTINCT uses the bare
+    column as the component identity, so the dim grain projection
+    (whatever expression it ends up being — bare, COALESCE, or CAST)
+    serves both roles.  No extra projection is emitted, the GROUP BY
+    naturally covers the grain expression, and the combiner
+    references the dim grain alias directly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_count_distinct_with_right_outer_dim_join(
+        self,
+        client_with_build_v3,
+    ):
+        client = client_with_build_v3
+        # Event source with account_id.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_coalesce_events",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "event_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "coalesce_events",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        # Account source acting as the dim source.
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_coalesce_accounts",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "country", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "coalesce_accounts",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        # Parent transform for the metric.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.coalesce_events_xform",
+                "query": ("SELECT account_id, event_date FROM v3.src_coalesce_events"),
+                "mode": "published",
+                "primary_key": ["account_id", "event_date"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        # Dimension exposing account_id + country.
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.coalesce_account_dim",
+                "query": ("SELECT account_id, country FROM v3.src_coalesce_accounts"),
+                "mode": "published",
+                "primary_key": ["account_id"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        # Right-outer link forces the dim side preserved, the
+        # transform side nullable, and the grain projection becomes
+        # ``COALESCE(t1.account_id, t2.account_id) AS account_id`` at
+        # measures-build time.
+        resp = await client.post(
+            "/nodes/v3.coalesce_events_xform/link/",
+            json={
+                "dimension_node": "v3.coalesce_account_dim",
+                "join_type": "right",
+                "join_on": (
+                    "v3.coalesce_events_xform.account_id = "
+                    "v3.coalesce_account_dim.account_id"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        # The metric: COUNT(DISTINCT account_id) on the events transform.
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.coalesce_distinct_accounts",
+                "query": (
+                    "SELECT COUNT(DISTINCT account_id) FROM v3.coalesce_events_xform"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        # Request the metric with the dim's country attribute as the
+        # grouping dimension — this forces the right-outer join at
+        # the measures-build layer and the COALESCE grain projection.
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.coalesce_distinct_accounts"],
+                "dimensions": ["v3.coalesce_account_dim.country"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        body = response.json()
+        gg = body["grain_groups"][0]
+
+        # Combiner references the bare grain alias — same column as the
+        # dim grain projection.  ``component.name`` is the bare column
+        # name under the decompose-level fix.
+        assert body["metric_formulas"][0]["combiner"] == ("COUNT( DISTINCT account_id)")
+
+        # Exactly one projection for the COUNT(DISTINCT) grain — no
+        # extra ``<bare> AS <hashed>`` column.  The grain projection
+        # uses COALESCE because of the right-outer join.
+        col_names = [c["name"] for c in gg["columns"]]
+        assert col_names.count("account_id") == 1
+        # No hashed-name column appears for the plain DISTINCT component.
+        assert not any(n.startswith("account_id_distinct_") for n in col_names), (
+            col_names
+        )
+
+        # Spot the COALESCE in the SQL — the grain projection
+        # absorbed the outer-join NULL semantics.
+        sql = gg["sql"]
+        assert "COALESCE" in sql, sql
+        # The raw ``t1.account_id`` reference is only inside the
+        # COALESCE — not as a standalone projection that would break
+        # GROUP BY validation.
+        assert "t1.account_id account_id_distinct" not in sql, sql
+
+        # Cross-check: the persisted derived_expression and the
+        # combiner both reference the bare column — so XP can
+        # evaluate the expression against the live SQL output.
+        metric_resp = await client.get(
+            "/metrics/v3.coalesce_distinct_accounts",
+        )
+        assert metric_resp.status_code == 200
+        assert metric_resp.json()["derived_expression"] == (
+            "COUNT( DISTINCT account_id)"
+        )

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -9915,14 +9915,20 @@ class TestCountDistinctPlainColumnCoalesceJoin:
         )
         assert resp.status_code == 201, resp.json()
 
-        # Request the metric with the dim's country attribute as the
-        # grouping dimension — this forces the right-outer join at
-        # the measures-build layer and the COALESCE grain projection.
+        # Request the metric with BOTH the dim's account_id and
+        # country — the dim's account_id is exposed on both sides of
+        # the right-outer join, forcing measures-build to emit
+        # ``COALESCE(t1.account_id, t2.account_id) AS account_id`` as
+        # the grain projection.  This is the milo-style shape that
+        # broke the previous extra-projection fix.
         response = await client.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.coalesce_distinct_accounts"],
-                "dimensions": ["v3.coalesce_account_dim.country"],
+                "dimensions": [
+                    "v3.coalesce_account_dim.account_id",
+                    "v3.coalesce_account_dim.country",
+                ],
             },
         )
         assert response.status_code == 200, response.json()

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -250,7 +250,7 @@ class TestMetricsSQLDerived:
             order_details_0_agg AS (
                 SELECT
                   category,
-                  COUNT(DISTINCT order_id) order_id_distinct_f93d50ab
+                  COUNT(DISTINCT order_id) order_id
                 FROM order_details_0
                 GROUP BY category
             ),
@@ -262,12 +262,12 @@ class TestMetricsSQLDerived:
             ),
             page_views_enriched_0_agg AS (
                 SELECT  category,
-                    COUNT( DISTINCT customer_id) customer_id_distinct_dd4be7a5
+                    COUNT( DISTINCT customer_id) customer_id
                 FROM page_views_enriched_0
                 GROUP BY  category
             )
             SELECT COALESCE(order_details_0_agg.category, page_views_enriched_0_agg.category) AS category,
-                   CAST(MAX(order_details_0_agg.order_id_distinct_f93d50ab) AS DOUBLE) / NULLIF(MAX(page_views_enriched_0_agg.customer_id_distinct_dd4be7a5), 0) AS conversion_rate
+                   CAST(MAX(order_details_0_agg.order_id) AS DOUBLE) / NULLIF(MAX(page_views_enriched_0_agg.customer_id), 0) AS conversion_rate
             FROM order_details_0_agg
             FULL OUTER JOIN page_views_enriched_0_agg ON order_details_0_agg.category = page_views_enriched_0_agg.category
             GROUP BY 1
@@ -1625,14 +1625,14 @@ class TestMetricsSQLCrossFact:
                 GROUP BY t2.category, t1.customer_id
             ),
             page_views_enriched_0_agg AS (
-                SELECT category, COUNT(DISTINCT customer_id) customer_id_distinct_dd4be7a5
+                SELECT category, COUNT(DISTINCT customer_id) customer_id
                 FROM page_views_enriched_0
                 GROUP BY category
             )
             SELECT
                 COALESCE(order_details_0.category, page_views_enriched_0_agg.category) AS category,
                 SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue,
-                MAX(page_views_enriched_0_agg.customer_id_distinct_dd4be7a5) AS visitor_count
+                MAX(page_views_enriched_0_agg.customer_id) AS visitor_count
             FROM order_details_0
             FULL OUTER JOIN page_views_enriched_0_agg
                 ON order_details_0.category = page_views_enriched_0_agg.category

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -668,16 +668,27 @@ async def test_count_distinct_complex_expression_keeps_hashed_name(
         "FROM parent_node",
     )
     extractor = MetricComponentExtractor(metric_rev.id)
-    measures, _ = await extractor.extract(session)
-    assert len(measures) == 1
-    comp = measures[0]
-    # Hash suffix preserved on complex DISTINCT.
-    assert comp.name.startswith("is_active_user_id_distinct_")
-    assert comp.name != "user_id"
-    assert comp.grain_alias == comp.name
-    assert comp.aggregation is None
-    assert comp.merge is None
-    assert comp.rule.type == Aggregability.LIMITED
+    measures, derived_sql = await extractor.extract(session)
+    expression = (
+        "CASE \n        WHEN is_active THEN user_id\n        ELSE NULL\n    END"
+    )
+    assert measures == [
+        MetricComponent(
+            name="is_active_user_id_distinct_62ecf94a",
+            expression=expression,
+            aggregation=None,
+            merge=None,
+            rule=AggregationRule(
+                type=Aggregability.LIMITED,
+                level=[expression],
+            ),
+            grain_alias="is_active_user_id_distinct_62ecf94a",
+        ),
+    ]
+    assert_sql_equal(
+        str(derived_sql),
+        "SELECT COUNT( DISTINCT is_active_user_id_distinct_62ecf94a) FROM parent_node",
+    )
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -609,6 +609,13 @@ async def test_count(session: AsyncSession, create_metric):
 async def test_count_distinct_rate(session: AsyncSession, create_metric):
     """
     Test decomposition for a metric that uses count distinct.
+
+    Plain-column ``COUNT(DISTINCT col)`` keeps ``col`` as ``component.name``
+    (no hash) — there's no expression ambiguity to disambiguate, and the
+    bare name matches the column already projected as the grain alias in
+    measures SQL.  ``derived_expression`` then references the same column
+    that the live SQL output exposes, so external evaluators can resolve
+    it directly.
     """
     metric_rev = await create_metric(
         "SELECT COUNT(DISTINCT user_id) / COUNT(action) FROM parent_node",
@@ -617,7 +624,7 @@ async def test_count_distinct_rate(session: AsyncSession, create_metric):
     measures, derived_sql = await extractor.extract(session)
     expected_measures = [
         MetricComponent(
-            name="user_id_distinct_7f092f23",
+            name="user_id",
             expression="user_id",
             aggregation=None,
             merge=None,
@@ -638,9 +645,39 @@ async def test_count_distinct_rate(session: AsyncSession, create_metric):
     assert measures == expected_measures
     assert_sql_equal(
         str(derived_sql),
-        "SELECT COUNT( DISTINCT user_id_distinct_7f092f23) / "
+        "SELECT COUNT( DISTINCT user_id) / "
         "NULLIF(SUM(action_count_50d753fd), 0) FROM parent_node",
     )
+
+
+@pytest.mark.asyncio
+async def test_count_distinct_complex_expression_keeps_hashed_name(
+    session: AsyncSession,
+    create_metric,
+):
+    """
+    ``COUNT(DISTINCT <expression>)`` over a non-Column argument keeps
+    the hashed ``<base>_distinct_<hash>`` component name — the hash
+    disambiguates different expressions that share a column-name
+    prefix, and there's no bare column to alias the projection under.
+    ``grain_alias`` equals ``component.name`` in this case so the
+    projection alias is the same stable identifier.
+    """
+    metric_rev = await create_metric(
+        "SELECT COUNT(DISTINCT CASE WHEN is_active THEN user_id ELSE NULL END) "
+        "FROM parent_node",
+    )
+    extractor = MetricComponentExtractor(metric_rev.id)
+    measures, _ = await extractor.extract(session)
+    assert len(measures) == 1
+    comp = measures[0]
+    # Hash suffix preserved on complex DISTINCT.
+    assert comp.name.startswith("is_active_user_id_distinct_")
+    assert comp.name != "user_id"
+    assert comp.grain_alias == comp.name
+    assert comp.aggregation is None
+    assert comp.merge is None
+    assert comp.rule.type == Aggregability.LIMITED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

For `COUNT(DISTINCT plain_col)` metrics, the metric component name was `<col>_distinct_<hash>` and the persisted derived expression referenced that hashed name. But the live measures SQL output projected the column under its bare grain alias (`<col>`). External consumers reading derived expression and the measures output would not be able to find the column.

PR #1931 introduced a `grain_alias` field set to the bare column name for plain-column DISTINCT, and routed the measures SQL projection at `grain_alias`. That fixed v3-internal queries (rewrite layers translated `component.name` to `grain_alias`) but left the derived expression unchanged.

The fix is to change decomposition: when the DISTINCT argument is a plain column, set the component name to the bare column name instead of `{base_name}_{short_hash}`. Complex DISTINCT (eg `CASE WHEN ... THEN col END`) keeps the hashed name. Non-DISTINCT components are untouched.

With this change, every layer agrees on a single name for plain `DISTINCT`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
