### PR TITLE
Reactivate soft-deleted auto-registered sources on deploy

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -718,7 +718,7 @@ class Node(Base):
             selectinload(Node.tags),
         ]
         statement = statement.options(*options)
-        if not include_inactive:  # pragma: no cover
+        if not include_inactive:
             statement = statement.where(is_(Node.deactivated_at, None))
         result = await session.execute(statement)
         nodes = result.unique().scalars().all()

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1183,6 +1183,9 @@ class DeploymentOrchestrator:
                 # to `to_deploy` lets the deploy flow create a new revision
                 # against the existing node row (no INSERT into `node` —
                 # only `noderevision` — so the unique key on `node` is safe).
+                # `spec_by_name` is keyed by the same names that produced
+                # `auto_source_names`, so every existing_node.name is
+                # guaranteed to be in it; no defensive `in` check needed.
                 reactivated_specs: list[SourceSpec] = []
                 for existing_node in existing_auto_sources:
                     if existing_node.deactivated_at is not None:
@@ -1191,8 +1194,7 @@ class DeploymentOrchestrator:
                             existing_node.name,
                         )
                         existing_node.deactivated_at = None
-                        if existing_node.name in spec_by_name:
-                            reactivated_specs.append(spec_by_name[existing_node.name])
+                        reactivated_specs.append(spec_by_name[existing_node.name])
 
                 # Only include sources that don't already exist as nodes
                 sources_to_create = [

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1157,45 +1157,71 @@ class DeploymentOrchestrator:
                     len(auto_registered_sources),
                 )
 
-                # Check which auto-registered sources actually need to be created
+                # Check which auto-registered sources actually need to be
+                # created. `include_inactive=True` so soft-deleted matches
+                # surface here — the (name, namespace) unique constraint
+                # spans them, and INSERT-ing on top would crash. Reactivate
+                # any deactivated matches and route them through the deploy
+                # update path so the fresh column schema gets applied.
                 auto_source_names = [
                     src.rendered_name for src in auto_registered_sources
                 ]
                 existing_auto_sources = await Node.get_by_names(
                     self.session,
                     auto_source_names,
+                    include_inactive=True,
                 )
                 existing_auto_source_names = {
                     node.name for node in existing_auto_sources
                 }
+                spec_by_name = {
+                    src.rendered_name: src for src in auto_registered_sources
+                }
 
-                # Only include sources that don't already exist
+                # Reactivate any soft-deleted matches. We hold the freshly
+                # introspected columns in `spec_by_name`, so adding the spec
+                # to `to_deploy` lets the deploy flow create a new revision
+                # against the existing node row (no INSERT into `node` —
+                # only `noderevision` — so the unique key on `node` is safe).
+                reactivated_specs: list[SourceSpec] = []
+                for existing_node in existing_auto_sources:
+                    if existing_node.deactivated_at is not None:
+                        logger.info(
+                            "Restoring previously-deactivated auto-registered source %s",
+                            existing_node.name,
+                        )
+                        existing_node.deactivated_at = None
+                        if existing_node.name in spec_by_name:
+                            reactivated_specs.append(spec_by_name[existing_node.name])
+
+                # Only include sources that don't already exist as nodes
                 sources_to_create = [
                     src
                     for src in auto_registered_sources
                     if src.rendered_name not in existing_auto_source_names
                 ]
 
-                if sources_to_create:
+                new_specs = sources_to_create + reactivated_specs
+                if new_specs:
                     logger.info(
-                        "Adding %d new auto-registered sources to deployment spec (skipping %d that already exist)",
+                        "Adding %d auto-registered source(s) to deployment "
+                        "spec (%d new, %d reactivated); skipping %d that "
+                        "are already active",
+                        len(new_specs),
                         len(sources_to_create),
-                        len(auto_registered_sources) - len(sources_to_create),
+                        len(reactivated_specs),
+                        len(auto_registered_sources) - len(new_specs),
                     )
-                    # Prepend auto-registered sources so they're created first
-                    self.deployment_spec.nodes = (
-                        sources_to_create + self.deployment_spec.nodes
-                    )
-
-                    # Rebuild the deployment plan with the new sources included
+                    # Prepend so sources are created/refreshed first.
+                    self.deployment_spec.nodes = new_specs + self.deployment_spec.nodes
                     logger.info(
                         "Rebuilding deployment plan with auto-registered sources",
                     )
-                    to_deploy = sources_to_create + to_deploy
-                else:
-                    sources_to_create = []
+                    to_deploy = new_specs + to_deploy
 
-                # Add existing auto-registered sources to existing_specs so they can be found during link validation
+                # Add existing auto-registered sources to existing_specs so
+                # link validation finds them and the deploy plan routes
+                # them through update instead of create.
                 for existing_node in existing_auto_sources:
                     if existing_node.name not in existing_specs:  # pragma: no branch
                         existing_specs[

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -1945,6 +1945,124 @@ async def test_create_deployment_plan_all_auto_sources_already_exist(
 
 
 @pytest.mark.asyncio
+async def test_create_deployment_plan_reactivates_deactivated_auto_source(
+    session,
+    current_user: User,
+):
+    """A previously-deactivated auto-registered source must be reactivated
+    instead of crashing on the (name, namespace) unique constraint.
+
+    Before this fix, the existence check filtered out soft-deleted nodes,
+    so the deploy tried to INSERT a row that already existed and Postgres
+    rejected with a UniqueViolation.
+    """
+    from datetime import datetime, timezone
+
+    session.add(NodeNamespace(namespace="test"))
+    catalog = Catalog(name="ext_cat2")
+    session.add(catalog)
+    await session.commit()
+
+    # Existing soft-deleted source node
+    deactivated_source = Node(
+        name="ext_cat2.s.t",
+        type="source",
+        current_version="v1.0",
+        created_by_id=current_user.id,
+        deactivated_at=datetime.now(timezone.utc),
+    )
+    session.add(deactivated_source)
+    deactivated_rev = NodeRevision(
+        name="ext_cat2.s.t",
+        type="source",
+        node=deactivated_source,
+        version="v1.0",
+        created_by_id=current_user.id,
+        schema_="s",
+        table="t",
+        catalog_id=catalog.id,
+    )
+    session.add(deactivated_rev)
+    await session.commit()
+
+    deployment_spec = DeploymentSpec(
+        namespace="test",
+        nodes=[TransformSpec(name="my_transform", query="SELECT 1")],
+        auto_register_sources=True,
+    )
+    context = MagicMock(autospec=DeploymentContext)
+    context.current_user = current_user
+    orchestrator = DeploymentOrchestrator(
+        deployment_id="test-deployment-reactivate",
+        deployment_spec=deployment_spec,
+        session=session,
+        context=context,
+    )
+
+    auto_source = SourceSpec(
+        name="ext_cat2.s.t",
+        catalog="ext_cat2",
+        schema="s",
+        table="t",
+        columns=[],
+    )
+    auto_source.namespace = None  # rendered_name matches the DB node
+
+    with patch.object(
+        orchestrator,
+        "check_external_deps",
+        side_effect=[(set(), [auto_source], []), (set(), [], [])],
+    ):
+        plan, _ = await orchestrator._create_deployment_plan()
+
+    # The soft-deleted node was found, reactivated, and added to
+    # existing_specs so downstream link/dep validation finds it.
+    assert "ext_cat2.s.t" in plan.existing_specs
+    await session.refresh(deactivated_source)
+    assert deactivated_source.deactivated_at is None, (
+        "Soft-deleted auto-registered source should be reactivated on deploy"
+    )
+
+
+@pytest.mark.asyncio
+async def test_node_get_by_names_include_inactive(
+    session,
+    current_user: User,
+):
+    """Node.get_by_names returns deactivated nodes only when include_inactive=True.
+    Guards the (previously uncovered) inactive filter so a future regression
+    in this contract would surface immediately."""
+    from datetime import datetime, timezone
+
+    session.add(NodeNamespace(namespace="test_inactive"))
+    catalog = Catalog(name="inactive_test_cat")
+    session.add(catalog)
+    await session.commit()
+
+    node = Node(
+        name="test_inactive.deactivated_node",
+        type="source",
+        current_version="v1.0",
+        created_by_id=current_user.id,
+        deactivated_at=datetime.now(timezone.utc),
+    )
+    session.add(node)
+    await session.commit()
+
+    # Default: deactivated node is filtered out
+    found_active = await Node.get_by_names(session, ["test_inactive.deactivated_node"])
+    assert found_active == []
+
+    # Explicit include_inactive=True: deactivated node is returned
+    found_all = await Node.get_by_names(
+        session,
+        ["test_inactive.deactivated_node"],
+        include_inactive=True,
+    )
+    assert [n.name for n in found_all] == ["test_inactive.deactivated_node"]
+
+
+@pytest.mark.asyncio
 async def test_validate_single_cube_with_invalid_metric(
     orchestrator,
 ):


### PR DESCRIPTION
### Summary

The deployment orchestrator's auto-register path checked for existing sources but did not include deactivated source nodes. The (name, namespace) unique constraint on node includes these deactivated rows, so when an auto-registered source name matched a soft-deleted node, the check missed it and the orchestrator would add it to the bulk `INSERT`, causing Postgres to reject it with a `UniqueViolation` error. 

The fix here is that we need to include inactive nodes in the search so soft-deleted matches also surface. For these  deactivated matches, we clear `deactivated_at` and add the freshly-introspected source spec to the deployment. The deploy update path then creates a new node revision against the existing node, avoiding the unique key error.

### Test Plan

Added `test_create_deployment_plan_reactivates_deactivated_auto_source` to cover this case.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
