### PR TITLE
Stop alerting on GraphQL client errors

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -143,21 +143,34 @@ class GraphQLErrorReporter(SchemaExtension):
             operation = str(path[0]) if path else "unknown"
             original = getattr(error, "original_error", None)
             error_type = type(original).__name__ if original else "GraphQLError"
-            logger.error(
-                "[GQL] status=error operation=%s operation_name=%s error_type=%s path=%s message=%s",
-                operation,
-                operation_name,
-                error_type,
-                path,
-                error.message,
-                exc_info=original,
-            )
+            # Parse/validation errors fail before execution: no path, no
+            # underlying Python exception. They are client mistakes (typo'd
+            # field, malformed query), not server faults — log at WARNING and
+            # tag them so Radar can filter them out of error budgets.
+            is_client_error = original is None and path is None
+            if is_client_error:
+                logger.warning(
+                    "[GQL] status=client_error operation_name=%s message=%s",
+                    operation_name,
+                    error.message,
+                )
+            else:
+                logger.error(
+                    "[GQL] status=error operation=%s operation_name=%s error_type=%s path=%s message=%s",
+                    operation,
+                    operation_name,
+                    error_type,
+                    path,
+                    error.message,
+                    exc_info=original,
+                )
             get_metrics_provider().counter(
                 "dj.graphql.errors",
                 tags={
                     "operation": operation,
                     "operation_name": operation_name,
                     "error_type": error_type,
+                    "severity": "client_error" if is_client_error else "server_error",
                 },
             )
 

--- a/datajunction-server/tests/api/graphql/test_main.py
+++ b/datajunction-server/tests/api/graphql/test_main.py
@@ -93,6 +93,7 @@ def test_error_reporter_python_exception(spy_metrics):
                 "operation": "findNodes",
                 "operation_name": "LoadDashboard",
                 "error_type": "ValueError",
+                "severity": "server_error",
             },
         ),
     ]
@@ -101,9 +102,11 @@ def test_error_reporter_python_exception(spy_metrics):
     assert kwargs["exc_info"] is original
 
 
-def test_error_reporter_programmatic_error(spy_metrics):
-    """A spec-side error with no path / no original / no operation name tags as anonymous."""
-    error = GraphQLError("validation failed")
+def test_error_reporter_client_validation_error(spy_metrics):
+    """Parse/validation errors (no path, no original) are client errors — WARNING, not ERROR."""
+    error = GraphQLError(
+        "Cannot query field 'createdAt' on type 'NodeRevision'. Did you mean 'updatedAt'?",
+    )
 
     with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
         _run_on_operation([error])
@@ -116,6 +119,30 @@ def test_error_reporter_programmatic_error(spy_metrics):
                 "operation": "unknown",
                 "operation_name": "anonymous",
                 "error_type": "GraphQLError",
+                "severity": "client_error",
+            },
+        ),
+    ]
+    mock_logger.error.assert_not_called()
+    mock_logger.warning.assert_called_once()
+
+
+def test_error_reporter_programmatic_error_with_path(spy_metrics):
+    """A spec-side error attached to a resolver path is still a server error."""
+    error = GraphQLError("something went wrong", path=["findNodes"])
+
+    with patch("datajunction_server.api.graphql.main.logger") as mock_logger:
+        _run_on_operation([error])
+
+    assert spy_metrics.counters == [
+        (
+            "dj.graphql.errors",
+            1,
+            {
+                "operation": "findNodes",
+                "operation_name": "anonymous",
+                "error_type": "GraphQLError",
+                "severity": "server_error",
             },
         ),
     ]


### PR DESCRIPTION
### Summary

GraphQL parse and validation errors (e.g. `Cannot query field 'createdAt' on type 'NodeRevision'`) are caused by malformed client queries, not server faults. However, today they log at `ERROR` and increment `dj.graphql.errors` with no distinguishing tag, which trips alerts on user typos.

With this PR, we detect client errors by the combination of "no execution path" and "no original_error", which only happen during the parse/validation phase, before any resolver runs. Client errors now log at `WARNING` with just the message and operation name. The `dj.graphql.errors` counter also includes a severity tag (`client_error` or `server_error`) so that dashboards can split the two without losing visibility.

Server-side errors should keep the existing `ERROR`-level logging with `exc_info`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
