### PR TITLE
Tolerate duplicate `MissingParent` rows on deactivate/restore

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2995,18 +2995,23 @@ async def mark_node_as_missing_parent(
     Returns:
         A tuple of (MissingParent object, list of downstream nodes)
     """
-    # Get or create MissingParent for this node
+    # `missingparent.name` has no unique constraint, so duplicates can
+    # exist. Reuse the first match; orphans get cleaned up later.
     missing_parent_result = await session.execute(
         select(MissingParent).where(MissingParent.name == node_name),
     )
-    missing_parent = missing_parent_result.scalar_one_or_none()
-    if not missing_parent:
+    existing_missing_parents = list(missing_parent_result.scalars().all())
+    if existing_missing_parents:
+        missing_parent = existing_missing_parents[0]
+        _logger.info(
+            f"MissingParent already exists for: {node_name} "
+            f"({len(existing_missing_parents)} row(s); using id={missing_parent.id})",
+        )
+    else:
         _logger.info(f"Creating MissingParent for node: {node_name}")
         missing_parent = MissingParent(name=node_name)
         session.add(missing_parent)
         await session.flush()  # Get the id
-    else:
-        _logger.info(f"MissingParent already exists for: {node_name}")
 
     # Find all downstream nodes and update them
     downstreams = await get_downstream_nodes(session, node_name)
@@ -3137,13 +3142,14 @@ async def activate_node(
         )
     node.deactivated_at = None  # type: ignore
 
-    # Get the MissingParent entry for this node (if it exists)
-    missing_parent_result = await session.execute(
+    # `missingparent.name` is non-unique, so duplicates can exist; clean
+    # up every match below.
+    missing_parents_result = await session.execute(
         select(MissingParent).where(MissingParent.name == name),
     )
-    missing_parent = missing_parent_result.scalar_one_or_none()
+    missing_parents = list(missing_parents_result.scalars().all())
     _logger.info(
-        f"Activating node {name}, missing_parent found: {missing_parent is not None}",
+        f"Activating node {name}, found {len(missing_parents)} MissingParent row(s)",
     )
 
     # Find downstream nodes that need revalidation
@@ -3174,11 +3180,13 @@ async def activate_node(
     for downstream in downstreams:
         _logger.info(f"Processing downstream: {downstream.name}")
 
-        # Remove from missing_parents and add back to parents
-        if (  # pragma: no branch
-            missing_parent and missing_parent in downstream.current.missing_parents
-        ):
-            downstream.current.missing_parents.remove(missing_parent)
+        # Remove from missing_parents and add back to parents. Iterate over
+        # all MissingParent rows with this name — different downstreams
+        # may be linked to different duplicates, so we clean up each
+        # downstream against the full set.
+        for missing_parent in missing_parents:
+            if missing_parent in downstream.current.missing_parents:
+                downstream.current.missing_parents.remove(missing_parent)
         # Re-link parent directly via INSERT...ON CONFLICT DO NOTHING. The
         # ORM collection approach is racy here: selectinload + autoflush
         # ordering can produce either a missed-row read (we append, then

--- a/datajunction-server/tests/internal/nodes/mark_missing_parent_test.py
+++ b/datajunction-server/tests/internal/nodes/mark_missing_parent_test.py
@@ -354,7 +354,78 @@ async def test_activate_node_when_parent_already_in_parents(
     assert parent_count == 1
 
 
-# Note: Line 2923 in nodes.py (if element.node_revision) is defensive code
-# that cannot be realistically tested because the database has a NOT NULL
-# constraint on node_revision_id in the column table. The check is there for
-# safety but shouldn't be reachable in practice.
+@pytest.mark.asyncio
+async def test_activate_node_with_duplicate_missing_parents(
+    session: AsyncSession,
+    user: User,
+    parent_node: Node,
+    child_node: Node,
+    query_service_client,
+    background_tasks,
+):
+    """
+    `MissingParent.name` has no unique constraint and several creation sites
+    insert unconditionally, so a long-missing parent name can accumulate
+    duplicate rows over time. `activate_node` must tolerate this — the
+    earlier `scalar_one_or_none()` raised `MultipleResultsFound` whenever
+    duplicates existed, blocking any restore of the affected node.
+    """
+    from sqlalchemy import insert, select
+    from datajunction_server.database.node import (
+        MissingParent,
+        NodeMissingParents,
+    )
+
+    save_history = mock_save_history
+
+    # Simulate an accumulated history: multiple MissingParent rows with the
+    # same name, attached to the child via NodeMissingParents.
+    extra_missing_parents = []
+    for _ in range(3):
+        mp = MissingParent(name=parent_node.name)
+        session.add(mp)
+        extra_missing_parents.append(mp)
+    await session.flush()
+    for mp in extra_missing_parents:
+        await session.execute(
+            insert(NodeMissingParents).values(
+                missing_parent_id=mp.id,
+                referencing_node_id=child_node.current.id,
+            ),
+        )
+    await session.commit()
+
+    # Deactivate so we can restore.
+    await deactivate_node(
+        session=session,
+        name=parent_node.name,
+        current_user=user,
+        save_history=save_history,
+        query_service_client=query_service_client,
+        background_tasks=background_tasks,
+    )
+
+    # Activate — previously raised MultipleResultsFound from scalar_one_or_none().
+    await activate_node(
+        session=session,
+        name=parent_node.name,
+        current_user=user,
+        save_history=save_history,
+    )
+
+    # All duplicates should be cleaned up by delete_orphaned_missing_parents.
+    remaining = (
+        (
+            await session.execute(
+                select(MissingParent).where(
+                    MissingParent.name == parent_node.name,
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == [], (
+        f"Expected all duplicate MissingParent rows to be cleaned up, "
+        f"found {len(remaining)} still present"
+    )

--- a/datajunction-server/tests/internal/nodes/mark_missing_parent_test.py
+++ b/datajunction-server/tests/internal/nodes/mark_missing_parent_test.py
@@ -360,8 +360,6 @@ async def test_activate_node_with_duplicate_missing_parents(
     user: User,
     parent_node: Node,
     child_node: Node,
-    query_service_client,
-    background_tasks,
 ):
     """
     `MissingParent.name` has no unique constraint and several creation sites
@@ -369,49 +367,38 @@ async def test_activate_node_with_duplicate_missing_parents(
     duplicate rows over time. `activate_node` must tolerate this — the
     earlier `scalar_one_or_none()` raised `MultipleResultsFound` whenever
     duplicates existed, blocking any restore of the affected node.
+
+    Setup attaches one duplicate to the child and leaves two unattached,
+    so the cleanup loop's inner check fires both True and False.
     """
-    from sqlalchemy import insert, select
-    from datajunction_server.database.node import (
-        MissingParent,
-        NodeMissingParents,
-    )
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+    from datajunction_server.database.node import MissingParent
 
     save_history = mock_save_history
 
-    # Simulate an accumulated history: multiple MissingParent rows with the
-    # same name. Only some are attached to this child via NodeMissingParents;
-    # the rest are duplicates created for other (now-gone) referencing
-    # nodes. The activate_node loop must tolerate both — its inner `if mp
-    # in downstream.missing_parents` exercises the False branch on the
-    # unattached duplicates.
-    extra_missing_parents = []
+    # Mark the parent deactivated so activate_node will proceed.
+    parent_node.deactivated_at = datetime.now(timezone.utc)
+    session.add(parent_node)
+
+    # Three duplicate MissingParent rows for the same name. Attach only
+    # the first to the child via the ORM relationship; the other two are
+    # leftover rows from other (now-gone) referencing nodes. (Attaching
+    # via the relationship — not a raw INSERT into NodeMissingParents —
+    # ensures SQLAlchemy tracks the join row so .remove() in activate_node
+    # emits the corresponding DELETE.)
+    mps = []
     for _ in range(3):
         mp = MissingParent(name=parent_node.name)
         session.add(mp)
-        extra_missing_parents.append(mp)
-    await session.flush()
-    # Attach the first two to the child; leave the third unattached so the
-    # cleanup loop hits the "not in this downstream" branch.
-    for mp in extra_missing_parents[:2]:
-        await session.execute(
-            insert(NodeMissingParents).values(
-                missing_parent_id=mp.id,
-                referencing_node_id=child_node.current.id,
-            ),
-        )
+        mps.append(mp)
+    child_node.current.missing_parents.append(mps[0])
     await session.commit()
 
-    # Deactivate so we can restore.
-    await deactivate_node(
-        session=session,
-        name=parent_node.name,
-        current_user=user,
-        save_history=save_history,
-        query_service_client=query_service_client,
-        background_tasks=background_tasks,
-    )
-
     # Activate — previously raised MultipleResultsFound from scalar_one_or_none().
+    # Inner loop iterates all 3 MPs against the child's [mp0]:
+    #   mp0 -> True (remove); mp1 -> False; mp2 -> False.
     await activate_node(
         session=session,
         name=parent_node.name,

--- a/datajunction-server/tests/internal/nodes/mark_missing_parent_test.py
+++ b/datajunction-server/tests/internal/nodes/mark_missing_parent_test.py
@@ -379,14 +379,20 @@ async def test_activate_node_with_duplicate_missing_parents(
     save_history = mock_save_history
 
     # Simulate an accumulated history: multiple MissingParent rows with the
-    # same name, attached to the child via NodeMissingParents.
+    # same name. Only some are attached to this child via NodeMissingParents;
+    # the rest are duplicates created for other (now-gone) referencing
+    # nodes. The activate_node loop must tolerate both — its inner `if mp
+    # in downstream.missing_parents` exercises the False branch on the
+    # unattached duplicates.
     extra_missing_parents = []
     for _ in range(3):
         mp = MissingParent(name=parent_node.name)
         session.add(mp)
         extra_missing_parents.append(mp)
     await session.flush()
-    for mp in extra_missing_parents:
+    # Attach the first two to the child; leave the third unattached so the
+    # cleanup loop hits the "not in this downstream" branch.
+    for mp in extra_missing_parents[:2]:
         await session.execute(
             insert(NodeMissingParents).values(
                 missing_parent_id=mp.id,


### PR DESCRIPTION
### Summary

The `missingparent` table tracks references to nodes that don't exist yet. However, its `name` column has no unique constraint, and several creation sites insert unconditionally, so over time, some missing-parent names will accumulate duplicate rows. Both `mark_node_as_missing_parent` and `activate_node` looked up these rows with `scalar_one_or_none()` (assuming that there would only be one row), which raises `MultipleResultsFound` whenever 2+ rows match. That caused any deactivate or restoration of an affected node to crash.

The fix is to not assume a single row and turn the two `scalar_one_or_none()` calls to `scalars().all()`.
  - For `mark_node_as_missing_parent`, we take the first existing match as the canonical row and then do an existing orphan cleanup pass.
  - For `activate_node`, we iterate over all matches when cleaning each downstream's `missing_parents` collection.

This PR doesn't address the underlying schema gap around `MissingParent.name` being non-unique. That would need a data-cleanup migration to dedupe existing rows before adding the unique constraint.

### Test Plan

Added one new regression test in `mark_missing_parent_test.py` that seeds multiple `MissingParent` rows for the same name, runs deactivate followed by restore, and asserts the duplicates are cleaned up by the end.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
