### PR TITLE
Add missing validation checks for linking dimensions

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -50,7 +50,6 @@ from datajunction_server.database.user import User
 from datajunction_server.database.measure import FrozenMeasure
 from datajunction_server.sql.decompose import MetricComponentExtractor
 from datajunction_server.errors import (
-    DJActionNotAllowedException,
     DJDoesNotExistException,
     DJError,
     DJException,
@@ -2626,8 +2625,17 @@ async def upsert_simple_dimension_link(
         raise DJInvalidInputException(f"Node {node.name} is not of type dimension!")  # type: ignore
     primary_key_columns = dimension_node.current.primary_key()  # type: ignore
     if len(primary_key_columns) > 1:
-        raise DJActionNotAllowedException(  # pragma: no cover
-            "Cannot use this endpoint to link a dimension with a compound primary key.",
+        raise DJInvalidInputException(
+            f"Dimension {dimension} has a compound primary key "
+            f"({', '.join(c.name for c in primary_key_columns)}); a single-column "
+            "FK link cannot join it correctly. Use the complex dimension link "
+            "endpoint with an explicit multi-column join expression.",
+        )
+    if not primary_key_columns and not dimension_column:
+        raise DJInvalidInputException(
+            f"Dimension {dimension} has no primary key defined. Either set a "
+            "primary key attribute on the dimension's column, or provide an "
+            "explicit `dimension_column` to join on.",
         )
 
     target_column = await get_column(session, node.current, column)  # type: ignore
@@ -2648,12 +2656,11 @@ async def upsert_simple_dimension_link(
                 " These column types are incompatible and the dimension cannot be linked",
             )
 
+    join_column = dimension_column or primary_key_columns[0].name  # type: ignore
     link_input = JoinLinkInput(
         dimension_node=dimension,
         join_type=JoinType.LEFT,
-        join_on=(
-            f"{name}.{column} = {dimension_node.name}.{primary_key_columns[0].name}"  # type: ignore
-        ),
+        join_on=(f"{name}.{column} = {dimension_node.name}.{join_column}"),  # type: ignore
     )
     return await upsert_complex_dimension_link(
         session,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -4710,6 +4710,139 @@ class TestValidateNodes:
         )
 
     @pytest.mark.asyncio
+    async def test_link_dimension_compound_pk_rejected(
+        self,
+        client_example_loader,
+    ):
+        """
+        Linking a dimension that has a compound primary key via the simple
+        column-level endpoint must fail with a clear error rather than
+        producing a one-column join (which would silently fan out) or
+        crashing with IndexError.
+        """
+        custom_client = await client_example_loader(["ACCOUNT_REVENUE"])
+        response = await custom_client.post(
+            "/nodes/dimension/",
+            json={
+                "description": "Compound-PK payment type dim",
+                "query": (
+                    "SELECT id, payment_type_name, payment_type_classification "
+                    "FROM default.payment_type_table"
+                ),
+                "mode": "published",
+                "name": "default.payment_type_compound",
+                "primary_key": ["id", "payment_type_name"],
+            },
+        )
+        assert response.status_code in (200, 201), response.json()
+
+        response = await custom_client.post(
+            "/nodes/default.revenue/columns/payment_type/"
+            "?dimension=default.payment_type_compound",
+        )
+        assert response.status_code == 422
+        assert "compound primary key" in response.json()["message"]
+
+        # Supplying dimension_column doesn't bypass the check — a single-column
+        # join still can't correctly link a compound-PK dimension.
+        response = await custom_client.post(
+            "/nodes/default.revenue/columns/payment_type/"
+            "?dimension=default.payment_type_compound&dimension_column=id",
+        )
+        assert response.status_code == 422
+        assert "compound primary key" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_link_dimension_no_pk_requires_dimension_column(
+        self,
+        client_example_loader,
+    ):
+        """
+        A dimension with no primary key attribute set can't be auto-joined.
+        Without `dimension_column` we should return a clean 422 — not crash
+        with IndexError. With an explicit `dimension_column` the link should
+        succeed and use that column on the dimension side of the join.
+        """
+        custom_client = await client_example_loader(["ACCOUNT_REVENUE"])
+        response = await custom_client.post(
+            "/nodes/dimension/",
+            json={
+                "description": "Payment type dim, PK attribute cleared below",
+                "query": (
+                    "SELECT id, payment_type_name, payment_type_classification "
+                    "FROM default.payment_type_table"
+                ),
+                "mode": "published",
+                "name": "default.payment_type_no_pk",
+                "primary_key": ["id"],
+            },
+        )
+        assert response.status_code in (200, 201), response.json()
+
+        # Server requires a PK at create time, so create with one then clear
+        # the primary_key attribute to simulate a dim with no PK attribute set.
+        response = await custom_client.post(
+            "/nodes/default.payment_type_no_pk/columns/id/attributes/",
+            json=[],
+        )
+        assert response.status_code in (200, 201), response.json()
+
+        response = await custom_client.post(
+            "/nodes/default.revenue/columns/payment_type/"
+            "?dimension=default.payment_type_no_pk",
+        )
+        assert response.status_code == 422
+        assert "no primary key" in response.json()["message"]
+
+        response = await custom_client.post(
+            "/nodes/default.revenue/columns/payment_type/"
+            "?dimension=default.payment_type_no_pk&dimension_column=id",
+        )
+        assert response.status_code in (200, 201), response.json()
+
+        node = (await custom_client.get("/nodes/default.revenue")).json()
+        link = next(
+            link
+            for link in node["dimension_links"]
+            if link["dimension"]["name"] == "default.payment_type_no_pk"
+        )
+        assert link["join_sql"] == (
+            "default.revenue.payment_type = default.payment_type_no_pk.id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_link_dimension_uses_provided_dimension_column(
+        self,
+        client_example_loader,
+    ):
+        """
+        When the caller supplies `dimension_column` on a dim that also has a
+        primary key, the join must be built against the supplied column —
+        not the primary key (which was silently the case before).
+        """
+        custom_client = await client_example_loader(["ACCOUNT_REVENUE"])
+        # default.payment_type's PK is `id`. We override with payment_type_name
+        # (compatible type) and verify the join_sql reflects the override.
+        # `default.revenue.payment_type` is int, so first widen its type by
+        # picking a compatible column on the revenue side: `account_type` (string).
+        response = await custom_client.post(
+            "/nodes/default.revenue/columns/account_type/"
+            "?dimension=default.payment_type"
+            "&dimension_column=payment_type_name",
+        )
+        assert response.status_code in (200, 201), response.json()
+
+        node = (await custom_client.get("/nodes/default.revenue")).json()
+        link = next(
+            link
+            for link in node["dimension_links"]
+            if link["dimension"]["name"] == "default.payment_type"
+        )
+        assert link["join_sql"] == (
+            "default.revenue.account_type = default.payment_type.payment_type_name"
+        )
+
+    @pytest.mark.asyncio
     async def test_update_node_with_dimension_links(
         self,
         client_with_roads: AsyncClient,

--- a/datajunction-ui/src/app/pages/NodePage/ManageDimensionLinksDialog.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/ManageDimensionLinksDialog.jsx
@@ -75,7 +75,18 @@ export default function ManageDimensionLinksDialog({
         djClient.unlinkDimension(node.name, column.name, dim),
       );
 
-      await Promise.all([...addPromises, ...removePromises]);
+      const results = await Promise.all([...addPromises, ...removePromises]);
+      const failures = results.filter(
+        r => !(r.status === 200 || r.status === 201),
+      );
+      if (failures.length > 0) {
+        const message =
+          failures[0].json?.message ||
+          failures[0].json?.detail ||
+          'Failed to update FK links';
+        setStatus({ failure: message });
+        return;
+      }
 
       setStatus({ success: 'FK links updated successfully!' });
       setTimeout(() => {

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/ManageDimensionLinksDialog.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/ManageDimensionLinksDialog.test.jsx
@@ -6,8 +6,36 @@ import {
   screen,
   act,
 } from '@testing-library/react';
+import { useFormikContext } from 'formik';
 import ManageDimensionLinksDialog from '../ManageDimensionLinksDialog';
 import DJClientContext from '../../../providers/djclient';
+
+// Stub FormikSelect with a plain multi-select so tests can drive the field
+// without wrestling react-select's pointer-event quirks.
+vi.mock('../../AddEditNodePage/FormikSelect', () => ({
+  FormikSelect: ({ selectOptions, formikFieldName }) => {
+    const { values, setFieldValue } = useFormikContext();
+    return (
+      <select
+        data-testid={`mock-select-${formikFieldName}`}
+        multiple
+        value={values[formikFieldName] || []}
+        onChange={e =>
+          setFieldValue(
+            formikFieldName,
+            Array.from(e.target.selectedOptions, opt => opt.value),
+          )
+        }
+      >
+        {selectOptions.map(opt => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    );
+  },
+}));
 
 // Mock window.location.reload
 delete window.location;
@@ -364,6 +392,81 @@ describe('<ManageDimensionLinksDialog />', () => {
       const requiredErrors = getAllByText('Required');
       expect(requiredErrors.length).toBeGreaterThan(0);
     });
+  });
+
+  it('shows success message when FK link save succeeds', async () => {
+    mockDjClient.DataJunctionAPI.linkDimension.mockResolvedValue({
+      status: 201,
+      json: { message: 'ok' },
+    });
+
+    const { getByLabelText, getByText, getByTestId } = render(
+      <DJClientContext.Provider value={mockDjClient}>
+        <ManageDimensionLinksDialog {...defaultProps} />
+      </DJClientContext.Provider>,
+    );
+
+    fireEvent.click(getByLabelText('ManageDimensionLinksToggle'));
+
+    await waitFor(() => {
+      expect(getByTestId('mock-select-fkDimensions')).toBeInTheDocument();
+    });
+
+    const select = getByTestId('mock-select-fkDimensions');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'default.dim1' } });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByText('Save'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('success')).toHaveTextContent(
+        'FK links updated successfully!',
+      );
+    });
+    expect(mockDjClient.DataJunctionAPI.linkDimension).toHaveBeenCalledWith(
+      'default.node1',
+      'test_column',
+      'default.dim1',
+    );
+  });
+
+  it('surfaces server error message when FK link save fails', async () => {
+    mockDjClient.DataJunctionAPI.linkDimension.mockResolvedValue({
+      status: 422,
+      json: {
+        message:
+          'Dimension default.dim1 has a compound primary key (a, b); a single-column FK link cannot join it correctly.',
+      },
+    });
+
+    const { getByLabelText, getByText, getByTestId, queryByTestId } = render(
+      <DJClientContext.Provider value={mockDjClient}>
+        <ManageDimensionLinksDialog {...defaultProps} />
+      </DJClientContext.Provider>,
+    );
+
+    fireEvent.click(getByLabelText('ManageDimensionLinksToggle'));
+
+    await waitFor(() => {
+      expect(getByTestId('mock-select-fkDimensions')).toBeInTheDocument();
+    });
+
+    const select = getByTestId('mock-select-fkDimensions');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'default.dim1' } });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByText('Save'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('failure')).toHaveTextContent('compound primary key');
+    });
+    expect(queryByTestId('success')).not.toBeInTheDocument();
   });
 
   it('closes modal when clicking backdrop', async () => {


### PR DESCRIPTION
### Summary

This PR has three related fixes around linking a dimension to another node via the simple `POST /nodes/{name}/columns/{col}?dimension=...` endpoint:
1. This endpoint shouldn't crash when the dimension has no PK attribute. `upsert_simple_dimension_link` called `primary_key_columns[0].name`, so if the dimension node had no primary key columns set (technically disallowed, but maybe there is some edge case that allows this to happen), this raised `IndexError` and the API returned 500. With this fix, we now return a clean 422 with a message telling the caller to set a PK or pass an explicit `dimension_column`.
2. This endpoint should use the caller's `dimension_column` in the join if one was provided. The endpoint accepts a `dimension_column` query param and validates it, but then it builds a `join_on` against the dimension's primary key anyway and produces the wrong join. With this fix, `join_on` always uses `dimension_column` when supplied.
3. For any compound-PK dimension nodes, we should raise with a 422 instead of 500 to indicate that it cannot be correctly joined via a single column. This change switches to `DJInvalidInputException` (422) with a message naming both PK columns.

In the UI, we should surface backend errors in the dimension links dialog box.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
