### PR TITLE
Raise an appropriate invalid input error for user SQL errors

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -526,8 +526,7 @@ async def create_node_revision(
         if node_revision.mode == NodeMode.DRAFT:
             node_revision.status = NodeStatus.INVALID
         else:
-            raise DJException(
-                http_status_code=HTTPStatus.BAD_REQUEST,
+            raise DJInvalidInputException(
                 errors=node_validator.errors,
             )
     else:
@@ -2055,8 +2054,7 @@ async def create_new_revision_from_existing(
             if new_mode == NodeMode.DRAFT:
                 new_revision.status = NodeStatus.INVALID
             else:
-                raise DJException(
-                    http_status_code=HTTPStatus.BAD_REQUEST,
+                raise DJInvalidInputException(
                     errors=node_validator.errors,
                 )
 

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -1511,7 +1511,7 @@ async def test_create_invalid_metric(module__client_with_roads: AsyncClient):
         },
     )
     data = response.json()
-    assert response.status_code == 400
+    assert response.status_code == 422
     assert (
         "Metric definition references missing columns: non_existent_column"
         in data["message"]

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1101,7 +1101,7 @@ class TestNodeCRUD:
                 "required_dimensions": ["testdld.messages.foo"],
             },
         )
-        assert response.status_code == 400
+        assert response.status_code == 422
         assert response.json() == {
             "message": "Node definition contains references to "
             "columns as required dimensions that are not on parent nodes.",
@@ -2603,7 +2603,7 @@ class TestNodeCRUD:
             json=create_invalid_transform_node_payload,
         )
         data = response.json()
-        assert response.status_code == 400
+        assert response.status_code == 422
         assert data["message"].startswith(
             "Node definition contains references to nodes that do not exist",
         )


### PR DESCRIPTION
### Summary

When the create/update node process found validation errors (e.g., missing columns, unresolvable types etc), the API endpoint just raised a generic `DJException`. This means that user SQL errors were logged at the exception level and surfaced as alert-worthy issues.
 
This PR swaps both raise sites to `DJInvalidInputException`, which is on the warning list and returns a 422 status, so future occurrences log as warnings instead.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
