### PR TITLE
Deleting a node should return 404 (not 500) for unknown nodes

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3069,7 +3069,7 @@ async def deactivate_node(
     """
     Deactivates a node and propagates to all downstreams.
     """
-    node = await Node.get_by_name(session, name)
+    node = await Node.get_by_name(session, name, raise_if_not_exists=True)
 
     # Mark node as missing parent and update downstream nodes
     # For deactivation, we keep parent relationships intact so upstream queries can still find them

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -714,6 +714,29 @@ class TestNodeCRUD:
         ]
 
     @pytest.mark.asyncio
+    async def test_deleting_nonexistent_node_returns_404(
+        self,
+        client_with_basic: AsyncClient,
+    ):
+        """
+        DELETE on an unknown node must return 404, not 500. Previously
+        `deactivate_node` looked the node up without `raise_if_not_exists` and
+        then dereferenced `None` on `node.deactivated_at`, producing an
+        AttributeError 500.
+        """
+        response = await client_with_basic.delete("/nodes/basic.does_not_exist/")
+        assert response.status_code == 404
+        assert response.json()["message"] == (
+            "A node with name `basic.does_not_exist` does not exist."
+        )
+
+        # And the same on a node that was already deleted.
+        response = await client_with_basic.delete("/nodes/basic.source.users/")
+        assert response.status_code == 200
+        response = await client_with_basic.delete("/nodes/basic.source.users/")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
     async def test_deleting_source_upstream_from_metric(
         self,
         client: AsyncClient,


### PR DESCRIPTION
### Summary

Calling `DELETE /nodes/{name}` should not 500 on unknown nodes. This endpoint looked the node up via `Node.get_by_name(session, name)` without `raise_if_not_exists=True`, so an unknown or already-deleted node came back as None. The function then tried to deactivate the node by setting `deactivated_at` on the object, which produced `AttributeError: 'NoneType' object has no attribute 'deactivated_at'`, causing the endpoint to return a 500 to the caller.

### Test Plan

`test_deleting_nonexistent_node_returns_404` covers two cases:
  1. Delete on a name that never existed results in a 404 with the expected message.
  2. Delete on a name that was already deleted (second delete of the same node) also results in a 404.

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
