### PR TITLE
Fix missing await on submit_query in MCP `get_metric_data` / `visualize_metrics`

### DIFF
--- a/datajunction-server/datajunction_server/mcp/tools.py
+++ b/datajunction-server/datajunction_server/mcp/tools.py
@@ -455,7 +455,7 @@ async def _execute_metrics_query(
         submitted_query=generated_sql.sql,
         async_=False,
     )
-    result = query_service_client.submit_query(query_create)
+    result = await query_service_client.submit_query(query_create)
     if result.results.root:
         result.results.root[0].columns = generated_sql.columns or []  # type: ignore
     return result, generated_sql

--- a/datajunction-server/tests/dj_mcp/test_tools.py
+++ b/datajunction-server/tests/dj_mcp/test_tools.py
@@ -1208,7 +1208,7 @@ async def test_execute_metrics_query_full_round_trip(
     submitted: list = []
 
     class _FakeQueryServiceClient:
-        def submit_query(self, query_create):
+        async def submit_query(self, query_create):
             submitted.append(query_create)
             return _stub_dataset([["a", 1]], ["dim", "amount"])
 
@@ -1293,7 +1293,7 @@ async def test_execute_metrics_query_empty_results_skips_column_inject(
         root: list = []
 
     class _FakeQueryServiceClient:
-        def submit_query(self, query_create):
+        async def submit_query(self, query_create):
             r = MagicMock()
             r.results = _EmptyResults()
             r.state = "FINISHED"


### PR DESCRIPTION
### Summary

The MCP's visualize metrics call was calling `query_service_client.submit_query(...)` without `await`, and then accessed `.results.root` on the coroutine, which crashed with: `'coroutine' object has no attribute 'results'`.

### Test Plan

Updated the two round-trip tests in `test_tools.py` to stub `submit_query` as `async def`, matching the real signature.

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
