### PR TITLE
Tolerate higher-order function lambdas that don't reference all parameters

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3274,8 +3274,13 @@ class MapFilter(Function):
             for col in func.expr.find_all(ast.Column)
             if col.alias_or_name.name in identifiers
         }
-        lambda_arg_cols[0].add_type(expr.type.key.type)
-        lambda_arg_cols[1].add_type(expr.type.value.type)
+        # The lambda body may legally reference only one (or neither) of the
+        # two parameters; only annotate types for the slots that actually
+        # appear as column references inside the body.
+        if 0 in lambda_arg_cols:
+            lambda_arg_cols[0].add_type(expr.type.key.type)
+        if 1 in lambda_arg_cols:
+            lambda_arg_cols[1].add_type(expr.type.value.type)
 
 
 @MapFilter.register  # type: ignore

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1987,12 +1987,16 @@ class Exists(Function):
                 message="The function `exists` takes a lambda function that takes at "
                 "most one argument.",
             )
-        lambda_arg_col = [
+        # The lambda body may legally not reference its parameter at all
+        # (e.g., `x -> true`); only annotate the type if a matching column
+        # actually appears.
+        matches = [
             col
             for col in func.expr.find_all(ast.Column)
             if col.alias_or_name.name == func.identifiers[0].name
-        ][0]
-        lambda_arg_col.add_type(expr.type.element.type)
+        ]
+        if matches:
+            matches[0].add_type(expr.type.element.type)
 
 
 @Exists.register  # type: ignore
@@ -2290,12 +2294,16 @@ class Forall(Function):
                 message="The function `forall` takes a lambda function that takes at "
                 "most one argument.",
             )
-        lambda_arg_col = [
+        # The lambda body may legally not reference its parameter at all
+        # (e.g., `x -> true`); only annotate the type if a matching column
+        # actually appears.
+        matches = [
             col
             for col in func.expr.find_all(ast.Column)
             if col.alias_or_name.name == func.identifiers[0].name
-        ][0]
-        lambda_arg_col.add_type(expr.type.element.type)
+        ]
+        if matches:
+            matches[0].add_type(expr.type.element.type)
 
 
 @Forall.register  # type: ignore

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -1593,6 +1593,33 @@ async def test_exists_func(session: AsyncSession):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lambda_expr",
+    [
+        # The lambda parameter `x` is never referenced inside the body.
+        # Previously crashed with IndexError because the list comprehension
+        # matching `x` against body columns returned [] and was then [0]-indexed.
+        "x -> true",
+        # Constant non-true predicate, still no reference to `x`.
+        "x -> 1 = 1",
+    ],
+)
+async def test_exists_lambda_unreferenced_param(
+    session: AsyncSession,
+    lambda_expr: str,
+):
+    """`exists`'s lambda may legally have a body that doesn't reference its
+    single parameter; compile_lambda must tolerate this rather than crash
+    on `[match_list][0]` when no body columns match the param name.
+    """
+    query = parse(f"SELECT exists(array(1, 2, 3), {lambda_expr})")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
+
+
+@pytest.mark.asyncio
 async def test_explode_outer_func(session: AsyncSession):
     """
     Test the `explode_outer` function
@@ -1786,6 +1813,31 @@ async def test_forall_func(session: AsyncSession):
     # assert not exc.errors
     assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
     assert query.select.projection[1].type == ct.BooleanType()  # type: ignore
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lambda_expr",
+    [
+        # Lambda parameter `x` never referenced — previously raised IndexError.
+        "x -> true",
+        # Constant non-true predicate, still no reference to `x`.
+        "x -> 1 = 1",
+    ],
+)
+async def test_forall_lambda_unreferenced_param(
+    session: AsyncSession,
+    lambda_expr: str,
+):
+    """`forall`'s lambda may legally have a body that doesn't reference its
+    single parameter; compile_lambda must tolerate this rather than crash
+    on `[match_list][0]` when no body columns match the param name.
+    """
+    query = parse(f"SELECT forall(array(1, 2, 3), {lambda_expr})")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert query.select.projection[0].type == ct.BooleanType()  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2700,6 +2700,43 @@ async def test_map_filter_func(session: AsyncSession):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lambda_expr",
+    [
+        # Only `v` is referenced in the body — `k` (position 0) never appears
+        # as a column inside the lambda. Previously raised KeyError: 0.
+        "(k, v) -> v > 0",
+        # Only `k` is referenced — `v` (position 1) never appears as a column.
+        # Previously raised KeyError: 1.
+        "(k, v) -> length(k) > 3",
+        # Neither lambda parameter is referenced; constant predicate is a
+        # legal Spark expression, must not crash compile_lambda.
+        "(k, v) -> true",
+    ],
+)
+async def test_map_filter_lambda_unreferenced_params(
+    session: AsyncSession,
+    lambda_expr: str,
+):
+    """`map_filter`'s lambda may reference only one (or neither) of its two
+    parameters; compile_lambda must tolerate the unreferenced slot rather
+    than KeyError on the integer index into `lambda_arg_cols`. The result
+    type still comes from the input map's `MapType` regardless of which
+    params the body uses.
+    """
+    query = parse(
+        f"SELECT map_filter(map('a', 1, 'bb', 2, 'ccc', 3), {lambda_expr})",
+    )
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert query.select.projection[0].type == ct.MapType(  # type: ignore
+        key_type=ct.StringType(),
+        value_type=ct.IntegerType(),
+    )
+
+
+@pytest.mark.asyncio
 async def test_map_from_arrays_func(session: AsyncSession):
     """
     Test the `map_from_arrays` function


### PR DESCRIPTION
### Summary

All of these are legal Spark expressions:
```sql
  map_filter(m, (k, v) -> v > 0)          -- only v referenced
  map_filter(m, (k, v) -> length(k) > 3)  -- only k referenced
  map_filter(m, (k, v) -> true)           -- neither referenced
  exists(arr, x -> true)                  -- x unreferenced
  forall(arr, x -> 1 = 1)                 -- x unreferenced
```
but each crashed DJ validation with a stack trace into `compile_lambda` and surfaced as a 500 on `/nodes/validate`. This was because each one used a different positional-access pattern that assumed every parameter would appear as a column in the body:
  - `MapFilter.compile_lambda` did `lambda_arg_cols[0] / [1]` against a dict keyed only by referenced params, resulting in a `KeyError: 0` or `KeyError: 1`.
  - `Exists.compile_lambda` and `Forall.compile_lambda` did tried to pick the first out of a list filtered to referenced columns, resulting in an `IndexError: list index out of range`.

The fix is to guard the positional access with an existence check.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
