### PR TITLE
Add ClientDisconnect exception handler

### DIFF
--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -15,6 +15,8 @@ from fastapi.responses import JSONResponse
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import ClientDisconnect
+from starlette.responses import Response
 
 from datajunction_server.instrumentation.middleware import DJInstrumentationMiddleware
 
@@ -146,6 +148,20 @@ def configure_app(app: FastAPI) -> None:
     from datajunction_server.mcp.transport import mount_mcp
 
     mount_mcp(app)
+
+    @app.exception_handler(ClientDisconnect)
+    async def client_disconnect_handler(
+        request: Request,
+        exc: ClientDisconnect,
+    ) -> Response:
+        # Client closed the connection before we finished reading the body.
+        # Not a server fault — log at WARNING so it doesn't page.
+        _logger.warning(
+            "Client disconnected before request body was read: %s %s",
+            request.method,
+            request.url.path,
+        )
+        return Response(status_code=HTTPStatus.NO_CONTENT)
 
     @app.exception_handler(DJException)
     async def dj_exception_handler(

--- a/datajunction-server/tests/api/main_test.py
+++ b/datajunction-server/tests/api/main_test.py
@@ -3,11 +3,14 @@ Tests for FastAPI app wiring in `datajunction_server.api.main`.
 """
 
 import logging
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from httpx import ASGITransport, AsyncClient
+from starlette.requests import ClientDisconnect
 
 from datajunction_server.errors import DJException
 
@@ -129,3 +132,25 @@ async def test_dj_exception_handler_still_wins_over_generic(caplog):
     body = response.json()
     # DJException's to_dict produces a structured "message" field.
     assert body.get("message") == "bad input"
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_handler_logs_warning() -> None:
+    """``ClientDisconnect`` is logged at WARNING and returns 204 instead of
+    bubbling up as a 500 server error.
+    """
+    from datajunction_server.api.main import app
+
+    handler = app.exception_handlers[ClientDisconnect]
+
+    request = MagicMock()
+    request.method = "POST"
+    request.url.path = "/graphql"
+
+    with patch("datajunction_server.api.main._logger") as mock_logger:
+        response = await handler(request, ClientDisconnect())
+
+    assert response.status_code == HTTPStatus.NO_CONTENT
+    mock_logger.warning.assert_called_once()
+    mock_logger.error.assert_not_called()
+    mock_logger.exception.assert_not_called()


### PR DESCRIPTION
### Summary

This downgrades `ClientDisconnect` exceptions to the `WARNING` level rather than letting the exception bubble up as a server error.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
