### PR TITLE
Treat ANTLR parser errors during SQL parsing as client errors

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -250,6 +250,24 @@ def parse(sql: Optional[str]) -> ast.Query:
             return cast(ast.Query, parse_rule(sql, "singleStatement"))
         except SqlParsingError as exc:
             raise DJParseException(message=f"Error parsing SQL `{sql}`: {exc}") from exc
+        except DJParseException:
+            raise
+        except Exception as exc:
+            # ANTLR's default error strategy can recover from syntax errors
+            # without surfacing them (producing a partial tree with None
+            # children), which then crashes the visitor with e.g. an
+            # AttributeError. Treat any such failure as a client-facing
+            # parse error rather than a server error, but log it at
+            # WARNING so visitor bugs unrelated to malformed input remain
+            # visible.
+            logger.warning(
+                "Unexpected %s while parsing SQL (treating as parse error): %s",
+                type(exc).__name__,
+                exc,
+            )
+            raise DJParseException(
+                message=f"Error parsing SQL `{sql}`: {type(exc).__name__}: {exc}",
+            ) from exc
     finally:
         from datajunction_server.instrumentation.provider import get_metrics_provider  # noqa: PLC0415
 

--- a/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
+++ b/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
@@ -228,3 +228,21 @@ def test_antlr4_decimal_at_eof():
     # Decimal with scientific notation at EOF (normalized to 150.0)
     query_ast = parse("SELECT 1.5E2")
     assert "150.0" in str(query_ast)
+
+
+def test_parse_dangling_join_raises_djparse_not_attribute_error():
+    """Malformed SQL where ANTLR recovers without surfacing a syntax error
+    (e.g. a dangling ``LEFT JOIN`` with no table) used to crash the visitor
+    with ``AttributeError: 'NoneType' object has no attribute 'start'`` and
+    log as a server error. It must now surface as ``DJParseException`` so
+    the request returns 4xx instead.
+    """
+    bad_sql = """
+    SELECT a.x
+    FROM foo a
+      LEFT JOIN bar b ON a.id = b.id
+      LEFT JOIN
+      LEFT JOIN baz c ON a.id = c.id
+    """
+    with pytest.raises(DJParseException):
+        parse(bad_sql)


### PR DESCRIPTION
### Summary

In the ANTLR parser, only `SqlParsingError` was being reclassified to `DJParseException`. That covers cases where ANTLR's listener or bail strategy raises explicitly, but when the LL fallback path runs, ANTLR's default error strategy can silently recover from malformed SQL and hand back a parse tree with `None` children. The visitor then crashes with `AttributeError: 'NoneType' object has no attribute 'start'`, which surfaces as an inscrutable 500.

This PR adds a catch-all except after the existing `SqlParsingError` catch. It:
  - Re-raises as DJParseException so the API returns 4xx instead of 500.
  - Prefixes the message with the underlying exception type so the client sees something meaningful.
  - Logs at `WARNING` so that we keep it visible.

### Test Plan

Added a regression test using a dangling-`LEFT JOIN` pattern

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
