### PR TITLE
Support aliased relations + unimplemented grammar branches raise DJParseException 

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -311,8 +311,12 @@ class Visitor:
         func = self.registry.get(type(ctx), None)
         if func is None:
             line, col = ctx.start.line, ctx.start.column
-            raise TypeError(
-                f"{line}:{col} No visitor registered for type {type(ctx).__name__}",
+            # Unimplemented grammar branch — surface as a parse error so the
+            # validation layer (which already catches DJParseException) returns
+            # a clean 422 instead of crashing with a 500.
+            raise DJParseException(
+                f"{line}:{col} Unsupported SQL syntax "
+                f"({type(ctx).__name__.removesuffix('Context')})",
             )
         result = func(ctx)
 
@@ -901,6 +905,29 @@ def _(ctx: sbp.RelationContext):
     primary_relation = visit(ctx.relationPrimary())
     extensions = visit(ctx.relationExtension()) if ctx.relationExtension() else []
     return ast.Relation(primary_relation, extensions)
+
+
+@visit.register
+def _(ctx: sbp.AliasedRelationContext):
+    # Parenthesized relation, optionally aliased: `( relation ) [AS] alias`.
+    inner = visit(ctx.relation())
+    table_alias = ctx.tableAlias()
+    alias_ident, _cols = visit(table_alias) if table_alias else (None, [])
+    # Only single-primary, no-join parenthesizations can carry an alias today —
+    # ast.Relation has no alias field, so a multi-relation join group like
+    # `(a JOIN b) AS x` would need an AST extension. Surface that as a parse
+    # error rather than silently dropping the alias.
+    if inner.extensions:
+        line, col = ctx.start.line, ctx.start.column
+        raise DJParseException(
+            f"{line}:{col} Aliasing a parenthesized join group is not supported",
+        )
+    primary = inner.primary
+    if alias_ident and hasattr(primary, "set_alias"):
+        primary = primary.set_alias(alias_ident)
+        if table_alias.AS() and hasattr(primary, "set_as"):
+            primary = primary.set_as(True)
+    return primary
 
 
 @visit.register

--- a/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
+++ b/datajunction-server/tests/sql/parsing/backends/antlr4_test.py
@@ -246,3 +246,37 @@ def test_parse_dangling_join_raises_djparse_not_attribute_error():
     """
     with pytest.raises(DJParseException):
         parse(bad_sql)
+
+
+def test_aliased_relation_single_primary():
+    """`JOIN (t) alias` — parenthesized single relation with alias — must parse
+    and treat the inner table as if aliased directly. Previously raised
+    ``TypeError: No visitor registered for type AliasedRelationContext``."""
+    query_ast = parse(
+        "SELECT d.col FROM foo CROSS JOIN (bar) d",
+    )
+    rendered = str(query_ast)
+    assert "bar" in rendered
+    assert " d" in rendered or "AS d" in rendered
+
+
+def test_aliased_relation_join_group_rejected():
+    """`(a JOIN b) AS x` — aliasing a parenthesized join group — isn't yet
+    representable in the AST and must surface as a ``DJParseException`` rather
+    than crashing."""
+    with pytest.raises(DJParseException, match="join group"):
+        parse(
+            "SELECT * FROM (a CROSS JOIN b) AS x",
+        )
+
+
+def test_unsupported_grammar_branch_surfaces_djparse():
+    """An unknown/unimplemented grammar branch must raise ``DJParseException``,
+    not ``TypeError`` — otherwise the validator's parse-error catch misses it
+    and the request returns 500."""
+    # An empty grouping `()` in a relation position triggers an unhandled
+    # context. Whatever the exact shape, a parser visitor gap must be a parse
+    # error from the user's perspective.
+    bad_sql = "SELECT * FROM foo CROSS JOIN ()"
+    with pytest.raises(DJParseException):
+        parse(bad_sql)


### PR DESCRIPTION
### Summary

Changes in this PR include:
- Unimplemented ANTLR visitor branches now raise `DJParseException` instead of `TypeError`, so the validation layer's existing parse-error catch returns a 4xx instead of letting Starlette emit a 500.
- Adds an `AliasedRelationContext` visitor for the common case: a single parenthesized relation with an optional alias (`JOIN (t) [AS] alias`). The alias is pushed onto the inner primary so downstream compilation sees the same shape as `JOIN t AS alias`.
- The harder case is aliasing a multi-relation join group like `(a JOIN b) AS x`. This isn't representable today (because `ast.Relation` has no `alias` field) and now raises `DJParseException` rather than silently dropping the alias. This is left as a follow-up for when an AST change is justified.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
