### PR TITLE
Fix `ColumnTypeDecorator` returning strings for unparseable types + dedup exception logging

### DIFF
--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -199,7 +199,11 @@ def configure_app(app: FastAPI) -> None:
         (rather than re-raising) prevents Starlette / uvicorn from emitting
         their own duplicate log entry on the way out.
         """
-        _logger.exception(
+        # Use error() not exception() — exc_info=True causes the Sentry
+        # logging integration to fire a second issue on top of the one
+        # OTel's ExceptionHandlerMiddleware already created via
+        # span.record_exception(exc) before this handler ran.
+        _logger.error(
             "Unhandled %s in %s %s",
             type(exc).__name__,
             request.method,

--- a/datajunction-server/datajunction_server/models/column.py
+++ b/datajunction-server/datajunction_server/models/column.py
@@ -81,8 +81,15 @@ class ColumnTypeDecorator(TypeDecorator):
             return value
         try:
             return _parse_column_type(value)
-        except Exception:  # pragma: no cover
-            return value  # pragma: no cover
+        except Exception:
+            # Stored type isn't antlr-parseable (e.g. legacy rows with
+            # type='unknown'). Returning the raw string breaks downstream
+            # callers that expect a ColumnType (e.g. is_compatible(),
+            # arithmetic op type resolution). Fall back to UnknownType so
+            # the contract holds.
+            from datajunction_server.sql.parsing.types import UnknownType
+
+            return UnknownType()
 
 
 class ColumnAttributeInput(BaseModel):

--- a/datajunction-server/tests/api/main_test.py
+++ b/datajunction-server/tests/api/main_test.py
@@ -25,7 +25,7 @@ def _install_unhandled_handler(app: FastAPI) -> None:
         request: Request,
         exc: Exception,
     ) -> JSONResponse:
-        logging.getLogger("datajunction_server.api.main").exception(
+        logging.getLogger("datajunction_server.api.main").error(
             "Unhandled %s in %s %s",
             type(exc).__name__,
             request.method,

--- a/datajunction-server/tests/models/column_test.py
+++ b/datajunction-server/tests/models/column_test.py
@@ -1,0 +1,41 @@
+"""
+Tests for ``datajunction_server.models.column`` decorators.
+"""
+
+from datajunction_server.models.column import ColumnTypeDecorator
+from datajunction_server.sql.parsing.types import (
+    ColumnType,
+    IntegerType,
+    UnknownType,
+)
+
+
+class TestColumnTypeDecorator:
+    """ColumnTypeDecorator must always return a ColumnType instance —
+    callers (binop type resolution, is_compatible, etc.) assume it. Returning
+    a bare string for unparseable values breaks them with cryptic
+    AttributeErrors at request time."""
+
+    def test_process_result_value_parses_known_type(self):
+        result = ColumnTypeDecorator().process_result_value("int", dialect=None)
+        assert isinstance(result, ColumnType)
+        assert isinstance(result, IntegerType)
+
+    def test_process_result_value_returns_none_for_falsy(self):
+        # Falsy values (None, "") pass through unchanged so the column reads
+        # as missing rather than being silently coerced to UnknownType.
+        assert ColumnTypeDecorator().process_result_value(None, dialect=None) is None
+        assert ColumnTypeDecorator().process_result_value("", dialect=None) == ""
+
+    def test_process_result_value_unparseable_falls_back_to_unknown_type(self):
+        # Legacy rows with type='unknown' (or anything else antlr can't parse)
+        # used to leak the raw string through, causing AttributeError at the
+        # binop type-resolution site. They must round-trip as UnknownType.
+        result = ColumnTypeDecorator().process_result_value(
+            "unknown",
+            dialect=None,
+        )
+        assert isinstance(result, ColumnType)
+        assert isinstance(result, UnknownType)
+        # Ensure it still satisfies the contract used by binop type resolution.
+        assert result.is_compatible(UnknownType()) is True


### PR DESCRIPTION
### Summary

Two bugfixes:

(1) `ColumnTypeDecorator`'s `process_result_value` fell back to returning the raw string when `_parse_column_type` raised. Any downstream code that called `.is_compatible()` or used the value in type resolution would crash with `AttributeError: 'str' object has no attribute 'is_compatible'` because it was assuming it would receiving a `ColumnType`. The fix returns `UnknownType()` instead, preserving the ColumnType contract.

(2) The unhandled exception handler used `_logger.exception(..., exc_info=True)`, which caused the Sentry logging integration to fire a second exception event on top of the one OTel's `ExceptionHandlerMiddleware` already created. Switched to `_logger.error(...)` so that only one event fires per unhandled exception.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
