### PR TITLE
Serialize concurrent registration of same source to prevent race condition

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import cast
 
-from sqlalchemy import func, or_, select, inspect as sa_inspect
+from sqlalchemy import func, or_, select, text, inspect as sa_inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload, defer, load_only, noload
 
@@ -1166,6 +1166,23 @@ class DeploymentOrchestrator:
                 auto_source_names = [
                     src.rendered_name for src in auto_registered_sources
                 ]
+
+                # Acquire a transaction-scoped advisory lock per source name
+                # to serialize concurrent auto-register flows for the same
+                # source. Without this, two deployments referencing the same
+                # missing source race: each one's include_inactive lookup
+                # misses the other's not-yet-committed write, both queue an
+                # INSERT, and they collide on `unique_node_namespace_name`.
+                # Sort the names so multiple sources are acquired in
+                # deterministic order, preventing deadlocks across
+                # transactions that reference overlapping sets of sources.
+                # Locks auto-release at COMMIT/ROLLBACK.
+                for source_name in sorted(auto_source_names):
+                    await self.session.execute(
+                        text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
+                        {"key": f"dj:autoreg:{source_name}"},
+                    )
+
                 existing_auto_sources = await Node.get_by_names(
                     self.session,
                     auto_source_names,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2025,6 +2025,82 @@ async def test_create_deployment_plan_reactivates_deactivated_auto_source(
 
 
 @pytest.mark.asyncio
+async def test_create_deployment_plan_acquires_advisory_lock_for_autoreg(
+    session,
+    current_user: User,
+):
+    """Auto-register acquires a per-source advisory lock before the
+    include_inactive existence check, serializing concurrent deployments
+    that reference the same missing source.
+
+    Without the lock, two concurrent transactions both miss each other's
+    not-yet-committed write and queue duplicate INSERTs that collide on
+    `unique_node_namespace_name`.
+    """
+    session.add(NodeNamespace(namespace="test_lock"))
+    catalog = Catalog(name="lock_cat")
+    session.add(catalog)
+    await session.commit()
+
+    deployment_spec = DeploymentSpec(
+        namespace="test_lock",
+        nodes=[TransformSpec(name="my_transform", query="SELECT 1")],
+        auto_register_sources=True,
+    )
+    context = MagicMock(autospec=DeploymentContext)
+    context.current_user = current_user
+    orchestrator = DeploymentOrchestrator(
+        deployment_id="test-deployment-lock",
+        deployment_spec=deployment_spec,
+        session=session,
+        context=context,
+    )
+
+    # Two missing sources to verify per-source locks and sorted order.
+    src_b = SourceSpec(
+        name="lock_cat.s.b",
+        catalog="lock_cat",
+        schema="s",
+        table="b",
+        columns=[],
+    )
+    src_b.namespace = None
+    src_a = SourceSpec(
+        name="lock_cat.s.a",
+        catalog="lock_cat",
+        schema="s",
+        table="a",
+        columns=[],
+    )
+    src_a.namespace = None
+
+    # Spy on session.execute to capture advisory-lock calls.
+    real_execute = session.execute
+    lock_calls: list[str] = []
+
+    async def spy_execute(stmt, params=None, *args, **kwargs):
+        sql_str = str(stmt).lower()
+        if "pg_advisory_xact_lock" in sql_str and params and "key" in params:
+            lock_calls.append(params["key"])
+        return await real_execute(stmt, params, *args, **kwargs)
+
+    with patch.object(session, "execute", side_effect=spy_execute):
+        with patch.object(
+            orchestrator,
+            "check_external_deps",
+            # Pass sources in NON-sorted order to verify they get sorted.
+            side_effect=[(set(), [src_b, src_a], []), (set(), [], [])],
+        ):
+            await orchestrator._create_deployment_plan()
+
+    # Both source names had their lock acquired, in sorted order.
+    assert lock_calls == [
+        "dj:autoreg:lock_cat.s.a",
+        "dj:autoreg:lock_cat.s.b",
+    ], f"Expected sorted lock acquisition; got {lock_calls}"
+
+
+@pytest.mark.asyncio
 async def test_node_get_by_names_include_inactive(
     session,
     current_user: User,


### PR DESCRIPTION
### Summary

When two deployments concurrently reference the same external source that needs to be auto-registered, both transactions' node lookups miss each other's not-yet-committed writes. Each one queues an `INSERT` into the node table, and the second to flush dies with:
```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "unique_node_namespace_name"
```

The previous fix (#2181) handled the soft-deleted-source case within a single transaction, but didn't address the concurrent-transaction case. This change acquires a per-source `pg_advisory_xact_lock` keyed by source name right before the existence check. Concurrent transactions targeting the same source serialize on the lock. Different sources don't block each other.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
