### PR TITLE
Stop logging GQL parse errors as ERROR via strawberry's default logger

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -306,6 +306,20 @@ class Query:
     )
 
 
-schema = strawberry.Schema(query=Query, extensions=[GraphQLErrorReporter])
+class DJSchema(strawberry.Schema):
+    """
+    Suppress Strawberry's default ``process_errors`` so the only thing
+    logging GraphQL errors is ``GraphQLErrorReporter``. The default
+    implementation logs every error (including client-side parse and
+    validation failures) at ERROR via the ``strawberry.execution`` logger,
+    which double-logs and floods Radar with WARN-level user mistakes
+    re-promoted to ERROR.
+    """
+
+    def process_errors(self, errors, execution_context=None):
+        return
+
+
+schema = DJSchema(query=Query, extensions=[GraphQLErrorReporter])
 
 graphql_app = GraphQLRouter(schema, context_getter=get_context)

--- a/datajunction-server/tests/api/graphql/test_main.py
+++ b/datajunction-server/tests/api/graphql/test_main.py
@@ -205,6 +205,24 @@ async def test_resolve_silent_for_fast_resolvers():
     mock_logger.warning.assert_not_called()
 
 
+def test_dj_schema_suppresses_default_error_logger():
+    """
+    DJSchema.process_errors must be a no-op so the strawberry.execution
+    logger doesn't double-log every GraphQL error at ERROR level — that's
+    exactly what previously promoted client validation errors back to
+    ERROR in Radar even after the GraphQLErrorReporter WARNING fix.
+    """
+    import logging
+    from datajunction_server.api.graphql.main import schema
+
+    error = GraphQLError("Cannot query field 'foo' on type 'Node'.")
+
+    with patch.object(logging.getLogger("strawberry.execution"), "error") as mock_log:
+        schema.process_errors([error])
+
+    mock_log.assert_not_called()
+
+
 @pytest.mark.asyncio
 @patch("datajunction_server.api.graphql.main.create_node_by_name_loader")
 @patch("datajunction_server.api.graphql.main.get_settings")


### PR DESCRIPTION
### Summary

The previous fix (#2182) demoted client-side GraphQL parse/validation errors to `WARNING` in our `GraphQLErrorReporter` extension, but they kept showing up as `ERROR`. This is because Strawberry's `Schema.process_errors()` runs independently of our extension and logs every error via `logging.getLogger("strawberry.execution").error(...)`. Our extension just added a second log line at `WARNING`, but the original Strawberry error was still being emitted.

This change subclasses `strawberry.Schema` as `DJSchema` with a no-op process_errors, so the only thing logging GraphQL errors is GraphQLErrorReporter (which already applies the client-error vs server-error split). 

### Test Plan

Added a new unit test `test_dj_schema_suppresses_default_error_logger` which patches `logging.getLogger("strawberry.execution").error` and asserts `schema.process_errors([...])` does not invoke it.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
