### PR TITLE
Fix `UniqueViolation` in concurrent dimension-link mutations

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2886,8 +2886,36 @@ async def create_new_revision_for_dimension_link_update(
     """
     Create a new revision for the node to capture the dimension link changes in a new version
     """
-    new_revision = copy_existing_node_revision(node.current, current_user)
-    new_revision.version = str(Version.parse(node.current_version).next_minor_version())
+    # Lock the node row and re-read current_version atomically to prevent two concurrent
+    # requests from computing the same next version and hitting uq_noderevision_version.
+    fresh_version = (
+        await session.execute(
+            select(Node.current_version).where(Node.id == node.id).with_for_update(),
+        )
+    ).scalar_one()
+
+    # Load the NodeRevision at the locked version with all sub-relationships needed by
+    # copy_existing_node_revision. This handles the case where another concurrent request
+    # already bumped current_version between when we originally loaded `node` and now.
+    current_revision = (
+        (
+            await session.execute(
+                select(NodeRevision)
+                .where(
+                    NodeRevision.node_id == node.id,
+                    NodeRevision.version == fresh_version,
+                )
+                .options(*NodeRevision.default_load_options()),
+            )
+        )
+        .unique()
+        .scalar_one()
+    )
+
+    node.current_version = fresh_version
+
+    new_revision = copy_existing_node_revision(current_revision, current_user)
+    new_revision.version = str(Version.parse(fresh_version).next_minor_version())
     node.current_version = new_revision.version
     new_revision.node = node
 

--- a/datajunction-server/tests/internal/nodes/update_nodes_test.py
+++ b/datajunction-server/tests/internal/nodes/update_nodes_test.py
@@ -1,13 +1,16 @@
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from datajunction_server.database.node import Node, NodeType, NodeRevision, Column
 from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.database.history import History
 from datajunction_server.errors import DJDoesNotExistException
 from datajunction_server.api.helpers import get_save_history
-from datajunction_server.internal.nodes import update_owners
+from datajunction_server.internal.nodes import (
+    create_new_revision_for_dimension_link_update,
+    update_owners,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import datajunction_server.sql.parsing.types as ct
@@ -207,3 +210,82 @@ async def test_update_node_owners_invalid_user(
             current_user=user,
             save_history=(await get_save_history(notify=lambda event: None)),
         )
+
+
+@pytest.mark.asyncio
+async def test_create_new_revision_stale_version_is_refreshed(
+    session: AsyncSession,
+    user: User,
+):
+    """
+    Regression test for a UniqueViolation on uq_noderevision_version caused by concurrent
+    dimension-link mutations. Two concurrent requests could both read the same current_version
+    and each try to INSERT a NodeRevision with the same (version, node_id).
+
+    The fix adds a SELECT FOR UPDATE on the node row followed by session.refresh inside
+    create_new_revision_for_dimension_link_update. This test simulates the stale-cache scenario:
+    - The session has node.current_version = "v1.0" cached in memory.
+    - A separate transaction already bumped node.current_version to "v1.1" in the DB and
+      inserted the corresponding NodeRevision (simulating a concurrent request winning the race).
+    - Without the refresh, our call would try to INSERT version "v1.1" again → UniqueViolation.
+    - With the refresh, it reads the updated DB value "v1.1" and correctly writes "v1.2".
+    """
+    node = Node(
+        name="basic.race_condition_test",
+        type=NodeType.TRANSFORM,
+        current_version="v1.0",
+        display_name="Race Condition Test Node",
+        created_by_id=user.id,
+    )
+    node_revision = NodeRevision(
+        node=node,
+        name=node.name,
+        type=node.type,
+        version="v1.0",
+        query="SELECT user_id FROM users",
+        columns=[Column(name="user_id", type=ct.IntegerType())],
+        created_by_id=user.id,
+    )
+    session.add_all([node, node_revision])
+    await session.commit()
+    await session.refresh(node)
+    assert node.current_version == "v1.0"
+
+    # Simulate the concurrent request winning: insert NodeRevision v1.1 and update
+    # node.current_version in the DB, bypassing the ORM cache so `node` still reads
+    # current_version as "v1.0" until the FOR UPDATE + refresh in our fix.
+    concurrent_revision = NodeRevision(
+        node_id=node.id,
+        name=node.name,
+        type=node.type,
+        version="v1.1",
+        query="SELECT user_id FROM users",
+        columns=[],
+        created_by_id=user.id,
+    )
+    session.add(concurrent_revision)
+    await session.flush()
+    # Use synchronize_session=False so SQLAlchemy does NOT update the in-memory ORM object,
+    # simulating the stale-cache state a session would have after a concurrent request in
+    # another session committed the same bump.
+    await session.execute(
+        update(Node)
+        .where(Node.id == node.id)
+        .values(current_version="v1.1")
+        .execution_options(synchronize_session=False),
+    )
+    await session.flush()
+
+    # The ORM-cached value is still stale — the node object shows "v1.0"
+    assert node.current_version == "v1.0"
+
+    # create_new_revision_for_dimension_link_update should read the DB value via
+    # SELECT FOR UPDATE + refresh, compute v1.2, and succeed without UniqueViolation.
+    new_revision = await create_new_revision_for_dimension_link_update(
+        session,
+        node,
+        user,
+    )
+
+    assert new_revision.version == "v1.2"
+    assert node.current_version == "v1.2"


### PR DESCRIPTION
### Summary

Concurrent `DELETE /nodes/{node}/link/` (or `POST /nodes/{node}/link/`) requests on the same node would intermittently fail with:
```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "uq_noderevision_version"
DETAIL: Key (version, node_id)=(v18.3, 163965) already exists.
```

This is because `create_new_revision_for_dimension_link_update` read `node.current_version` from the ORM session cache to compute the next version. Under concurrency, two requests would both read a version, say v18.2, both compute v18.3, and the second `INSERT INTO noderevision` would hit the unique constraint.

The fix is to replace the stale ORM cache read with an atomic lock-and-read by using `SELECT node.current_version ... FOR UPDATE` to acquire a row-level lock on the node row. A second concurrent request blocks here until the first commits. Then we reload the current node revision at the locked version with all sub-relationships so `copy_existing_node_revision` uses the latest state.

The lock is taken on a simple scalar-only query (no joins), avoiding the PostgreSQL `FOR UPDATE cannot be applied to the nullable side of an outer join` limitation.

### Test Plan

Added `test_create_new_revision_stale_version_is_refreshed` to simulate the race condition.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
