### PR TITLE
Add support for DATE_TRUNC

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -1721,6 +1721,36 @@ def infer_type(
     return ct.DateType()
 
 
+class DateTrunc(Function):
+    """
+    date_trunc(unit, expr) - Truncates a date/timestamp to the specified unit.
+    """
+
+
+@DateTrunc.register  # type: ignore
+def infer_type(
+    unit: ct.StringType,
+    expr: ct.TimestampType,
+) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
+@DateTrunc.register  # type: ignore
+def infer_type(
+    unit: ct.StringType,
+    expr: ct.DateType,
+) -> ct.DateType:
+    return ct.DateType()
+
+
+@DateTrunc.register  # type: ignore
+def infer_type(
+    unit: ct.StringType,
+    expr: ct.StringType,
+) -> ct.TimestampType:
+    return ct.TimestampType()
+
+
 class Day(Function):
     """
     Returns the day of the month for a specified date.

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -3482,6 +3482,33 @@ async def test_date_add(session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_date_trunc(session: AsyncSession):
+    """
+    Test `date_trunc`
+    """
+    query = parse("SELECT date_trunc('day', CURRENT_TIMESTAMP())")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+    query = parse("SELECT date_trunc('month', CURRENT_DATE())")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.DateType()  # type: ignore
+
+    query = parse("SELECT date_trunc('year', '2020-01-01')")
+    exc = DJException()
+    ctx = ast.CompileContext(session=session, exception=exc)
+    await query.compile(ctx)
+    assert not exc.errors
+    assert query.select.projection[0].type == ct.TimestampType()  # type: ignore
+
+
+@pytest.mark.asyncio
 async def test_replace(session: AsyncSession):
     """
     Test `replace`


### PR DESCRIPTION
### Summary

We were missing support for `DATE_TRUNC` (see https://spark.apache.org/docs/latest/api/sql/index.html#date_trunc), so this PR adds support for it.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
