### PR TITLE
Add a null check for node before calling `temporal_partition_columns`

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -228,6 +228,11 @@ async def cube_materialization_info(
     To request metrics from the materialized cube, use the metrics' measures metadata.
     """
     node = await Node.get_cube_by_name(session, name)
+    if not node or not node.current:
+        raise DJNodeNotFound(
+            message=f"Cube node `{name}` does not exist.",
+            http_status_code=404,
+        )
     temporal_partitions = node.current.temporal_partition_columns()  # type: ignore
     if len(temporal_partitions) != 1:
         raise DJInvalidInputException(

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -3882,7 +3882,10 @@ async def test_cube_materialization_info_nonexistent_cube(
         "/cubes/default.nonexistent_cube/materialization",
     )
     assert response.status_code == 404
-    assert response.json()["message"] == "Cube node `default.nonexistent_cube` does not exist."
+    assert (
+        response.json()["message"]
+        == "Cube node `default.nonexistent_cube` does not exist."
+    )
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -3871,6 +3871,21 @@ async def test_cube_materialization_metadata(
 
 
 @pytest.mark.asyncio
+async def test_cube_materialization_info_nonexistent_cube(
+    client_with_repairs_cube: AsyncClient,
+):
+    """
+    Requesting materialization info for a cube that does not exist should return 404,
+    not a 500 AttributeError on node.current.
+    """
+    response = await client_with_repairs_cube.get(
+        "/cubes/default.nonexistent_cube/materialization",
+    )
+    assert response.status_code == 404
+    assert response.json()["message"] == "Cube node `default.nonexistent_cube` does not exist."
+
+
+@pytest.mark.asyncio
 async def test_get_all_cubes(
     client_with_repairs_cube: AsyncClient,
 ):


### PR DESCRIPTION
### Summary

This avoids a spurious 500 and instead raises a 404 if the node doesn't exist

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
