### PR TITLE
Tagging a non-existent node should 404

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1063,7 +1063,11 @@ async def tags_node(
     access_checker.add_request_by_node_name(name, ResourceAction.WRITE)
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
 
-    node = await Node.get_by_name(session=session, name=name)
+    node = await Node.get_by_name(
+        session=session,
+        name=name,
+        raise_if_not_exists=True,
+    )
     existing_tags = {tag.name for tag in node.tags}  # type: ignore
     if not tag_names:
         tag_names = []  # pragma: no cover

--- a/datajunction-server/tests/api/tags_test.py
+++ b/datajunction-server/tests/api/tags_test.py
@@ -271,6 +271,15 @@ class TestTags:
         assert response.status_code == 201
         await self.create_another_tag(client_with_dbt)
 
+        # Tagging a nonexistent node should 404 cleanly (not AttributeError)
+        response = await client_with_dbt.post(
+            "/nodes/default.does_not_exist/tags/?tag_names=sales_report",
+        )
+        assert response.status_code == 404
+        assert response.json()["message"] == (
+            "A node with name `default.does_not_exist` does not exist."
+        )
+
         # Trying tag a node with a nonexistent tag should fail
         response = await client_with_dbt.post(
             "/nodes/default.items_sold_count/tags?tag_names=random_tag",


### PR DESCRIPTION
### Summary

When someone tries to tag a non-existent node, we should raise a 404, not 500. The root cause is that `tags_node` calls `Node.get_by_name(...)` without `raise_if_not_exists=True`. For a nonexistent node it returns None, and the next line references `node.tags`, which leads to an `AttributeError: 'NoneType' object has no attribute 'tags'`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
