### PR TITLE
Validate that no metrics when requesting sql raises 422

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -36,6 +36,7 @@ from datajunction_server.construction.build_v3.types import (
 from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.column import Column
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.database.partition import Partition
 from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.node_type import NodeType
@@ -255,6 +256,12 @@ async def resolve_dialect_and_engine_for_metrics(
                     catalog_name=avail_catalog_name,
                     cube=cube,
                 )
+
+    if not metrics:
+        raise DJInvalidInputException(
+            "At least one metric is required.",
+            http_status_code=422,
+        )
 
     # Fallback: use first metric's catalog's default engine
     node = await Node.get_by_name(

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -119,6 +119,19 @@ class TestMeasuresSQLEndpoint:
         assert response.status_code >= 400
 
     @pytest.mark.asyncio
+    async def test_metrics_v3_no_metrics_raises_422(self, client_with_build_v3):
+        """GET /sql/metrics/v3/ with no metrics must return 422, not a 500 IndexError."""
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": [],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert response.status_code == 422
+        assert "metric" in response.json()["message"].lower()
+
+    @pytest.mark.asyncio
     async def test_nonexistent_metric_raises_error(self, client_with_build_v3):
         """Test that nonexistent metric raises an error."""
         response = await client_with_build_v3.get(


### PR DESCRIPTION
### Summary

If a user calls `GET /sql/metrics/v3/` with empty metrics, it'll raise:
```
IndexError: list index out of range on metrics[0]
```

This fix adds a guard in `resolve_dialect_and_engine_for_metrics` to raise a 422 instead of the 500.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
