### PR TITLE
Fix `Exception in ASGI application` spam from background tasks

### DIFF
--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -345,13 +345,19 @@ async def schedule_materialization_jobs_bg(
     """
     Schedule a materialization job in the background.
     """
-    async with session_context() as session:
-        await schedule_materialization_jobs(
-            session=session,
-            node_revision_id=node_revision_id,
-            materialization_names=materialization_names,
-            query_service_client=query_service_client,
-            request_headers=request_headers,
+    try:
+        async with session_context() as session:
+            await schedule_materialization_jobs(
+                session=session,
+                node_revision_id=node_revision_id,
+                materialization_names=materialization_names,
+                query_service_client=query_service_client,
+                request_headers=request_headers,
+            )
+    except Exception:
+        _logger.exception(
+            "Error scheduling materialization jobs for node revision %s",
+            node_revision_id,
         )
 
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -701,10 +701,17 @@ async def derive_frozen_measures(node_revision_id: int) -> list[FrozenMeasure]:
     on completion. The deployment path uses ``derive_frozen_measures_bulk``
     instead to batch DB work across all metrics in a single transaction.
     """
-    async with session_context() as session:
-        result = await _derive_frozen_measures_impl(node_revision_id, session)
-        await session.commit()
-        return result
+    try:
+        async with session_context() as session:
+            result = await _derive_frozen_measures_impl(node_revision_id, session)
+            await session.commit()
+            return result
+    except Exception:
+        _logger.exception(
+            "Error deriving frozen measures for node revision %s",
+            node_revision_id,
+        )
+        return []
 
 
 async def _derive_frozen_measures_impl(
@@ -1663,13 +1670,19 @@ async def propagate_update_downstream(
     """
     Background task to propagate the updated node's changes to all of its downstream children.
     """
-    async with session_context() as session:
-        await _propagate_update_downstream(
-            session=session,
-            node=node,
-            current_user=current_user,
-            save_history=save_history,
-            cache=cache,
+    try:
+        async with session_context() as session:
+            await _propagate_update_downstream(
+                session=session,
+                node=node,
+                current_user=current_user,
+                save_history=save_history,
+                cache=cache,
+            )
+    except Exception:
+        _logger.exception(
+            "Error propagating update of node %s downstream",
+            node.name,
         )
 
 
@@ -2160,25 +2173,33 @@ async def save_column_level_lineage(node_revision_id: int):
     """
     Saves the column-level lineage for a node revision
     """
-    async with session_context() as session:
-        statement = (
-            select(NodeRevision)
-            .where(NodeRevision.id == node_revision_id)
-            .options(
-                selectinload(NodeRevision.columns),
+    try:
+        async with session_context() as session:
+            statement = (
+                select(NodeRevision)
+                .where(NodeRevision.id == node_revision_id)
+                .options(
+                    selectinload(NodeRevision.columns),
+                )
             )
+            node_revision = (
+                (await session.execute(statement)).unique().scalar_one_or_none()
+            )
+            if node_revision:  # pragma: no cover
+                column_level_lineage = await get_column_level_lineage(
+                    session,
+                    node_revision,
+                )
+                node_revision.lineage = [
+                    lineage.model_dump() for lineage in column_level_lineage
+                ]
+                session.add(node_revision)
+                await session.commit()
+    except Exception:
+        _logger.exception(
+            "Error saving column-level lineage for node revision %s",
+            node_revision_id,
         )
-        node_revision = (await session.execute(statement)).unique().scalar_one_or_none()
-        if node_revision:  # pragma: no cover
-            column_level_lineage = await get_column_level_lineage(
-                session,
-                node_revision,
-            )
-            node_revision.lineage = [
-                lineage.model_dump() for lineage in column_level_lineage
-            ]
-            session.add(node_revision)
-            await session.commit()
 
 
 async def save_query_ast(  # pragma: no cover

--- a/datajunction-server/tests/internal/nodes/background_tasks_test.py
+++ b/datajunction-server/tests/internal/nodes/background_tasks_test.py
@@ -1,0 +1,115 @@
+"""
+Tests that background task entry points swallow exceptions rather than
+propagating them to Starlette's ServerErrorMiddleware (which would log the
+generic "Exception in ASGI application" instead of anything actionable).
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from datajunction_server.internal.nodes import (
+    derive_frozen_measures,
+    propagate_update_downstream,
+    save_column_level_lineage,
+)
+from datajunction_server.internal.materializations import (
+    schedule_materialization_jobs_bg,
+)
+
+
+@pytest.mark.asyncio
+async def test_propagate_update_downstream_swallows_exceptions(caplog):
+    with patch(
+        "datajunction_server.internal.nodes.session_context",
+    ) as mock_ctx:
+        mock_session = AsyncMock()
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "datajunction_server.internal.nodes._propagate_update_downstream",
+            side_effect=RuntimeError("boom"),
+        ):
+            with caplog.at_level(
+                logging.ERROR,
+                logger="datajunction_server.internal.nodes",
+            ):
+                await propagate_update_downstream(
+                    node=MagicMock(name="test.node"),
+                    current_user=MagicMock(),
+                    save_history=MagicMock(),
+                )
+
+    assert any("propagating update" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_derive_frozen_measures_swallows_exceptions(caplog):
+    with patch(
+        "datajunction_server.internal.nodes.session_context",
+    ) as mock_ctx:
+        mock_session = AsyncMock()
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "datajunction_server.internal.nodes._derive_frozen_measures_impl",
+            side_effect=RuntimeError("boom"),
+        ):
+            with caplog.at_level(
+                logging.ERROR,
+                logger="datajunction_server.internal.nodes",
+            ):
+                result = await derive_frozen_measures(node_revision_id=99)
+
+    assert result == []
+    assert any("deriving frozen measures" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_save_column_level_lineage_swallows_exceptions(caplog):
+    with patch(
+        "datajunction_server.internal.nodes.session_context",
+    ) as mock_ctx:
+        mock_session = AsyncMock()
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute.side_effect = RuntimeError("boom")
+
+        with caplog.at_level(
+            logging.ERROR,
+            logger="datajunction_server.internal.nodes",
+        ):
+            await save_column_level_lineage(node_revision_id=99)
+
+    assert any("column-level lineage" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_schedule_materialization_jobs_bg_swallows_exceptions(caplog):
+    with patch(
+        "datajunction_server.internal.materializations.session_context",
+    ) as mock_ctx:
+        mock_session = AsyncMock()
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "datajunction_server.internal.materializations.schedule_materialization_jobs",
+            side_effect=RuntimeError("boom"),
+        ):
+            with caplog.at_level(
+                logging.ERROR,
+                logger="datajunction_server.internal.materializations",
+            ):
+                await schedule_materialization_jobs_bg(
+                    node_revision_id=99,
+                    materialization_names=["mat1"],
+                    query_service_client=MagicMock(),
+                )
+
+    assert any(
+        "scheduling materialization" in r.message.lower() for r in caplog.records
+    )


### PR DESCRIPTION
### Summary

Background tasks in FastAPI/Starlette run after the response is sent, so ASGI exception handlers can't intercept their failures. Instead, uncaught exceptions propagate to Starlette's `ServerErrorMiddleware`, which logs the generic `Exception in ASGI application`.

This fix wraps the four background task entry points (`propagate_update_downstream`, `derive_frozen_measures`, `save_column_level_lineage`, `schedule_materialization_jobs_bg`) in try/except + `_logger.exception(...)` so failures are logged under the real exception name and context.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
