### PR TITLE
Add YAML-based deployment support for hierarchies

### DIFF
--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 
 import yaml
 from fastapi import BackgroundTasks, Depends, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_node_namespace
@@ -193,7 +193,6 @@ async def _fetch_deployment_spec_from_git(
     )
 
     # Extract and parse YAML files
-    nodes: List[dict] = []
     with tempfile.TemporaryDirectory() as tmpdir:
         with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
             tar.extractall(tmpdir)
@@ -217,27 +216,31 @@ async def _fetch_deployment_spec_from_git(
                 message=f"Path '{git_path}' not found in repository at ref '{ref}'",
             )
 
-        # Parse all YAML files (skip dj.yaml project file)
+        # Parse all YAML files, routing by type: hierarchy vs nodes
+        nodes: List[dict] = []
+        hierarchies: List[dict] = []
         for yaml_file in files_dir.rglob("*.yaml"):
             if yaml_file.name == "dj.yaml":
                 continue
             try:
                 with open(yaml_file, "r", encoding="utf-8") as f:
-                    node = yaml.safe_load(f)
-                if isinstance(node, dict) and "name" in node:
-                    nodes.append(node)
-                    _logger.debug("Loaded node spec: %s", node.get("name"))
+                    spec = yaml.safe_load(f)
+                if not isinstance(spec, dict) or "name" not in spec:
+                    continue
+                if spec.get("type") == "hierarchy" and "node_type" not in spec:
+                    hierarchies.append(spec)
+                    _logger.debug("Loaded hierarchy spec: %s", spec.get("name"))
+                else:
+                    nodes.append(spec)
+                    _logger.debug("Loaded node spec: %s", spec.get("name"))
             except Exception as e:
-                _logger.warning(
-                    "Skipping invalid YAML file %s: %s",
-                    yaml_file,
-                    e,
-                )
+                _logger.warning("Skipping invalid YAML file %s: %s", yaml_file, e)
                 continue
 
     _logger.info(
-        "Fetched %d node specs from git: %s @ %s",
+        "Fetched %d node specs and %d hierarchy specs from git: %s @ %s",
         len(nodes),
+        len(hierarchies),
         repo_path,
         ref[:12] if len(ref) > 12 else ref,
     )
@@ -246,6 +249,7 @@ async def _fetch_deployment_spec_from_git(
         "namespace": namespace,
         "nodes": nodes,
         "tags": [],
+        "hierarchies": hierarchies,
     }
 
 
@@ -857,9 +861,11 @@ async def sync_namespace_from_git(
             message=f"Failed to fetch from git: {e.message}",
         ) from e
 
-    if not deployment_spec_dict.get("nodes"):
+    if not deployment_spec_dict.get("nodes") and not deployment_spec_dict.get(
+        "hierarchies",
+    ):
         raise DJInvalidInputException(
-            message=f"No node definitions found in repository '{github_repo_path}' "
+            message=f"No node or hierarchy definitions found in repository '{github_repo_path}' "
             f"at branch '{git_branch}'"
             + (f" in path '{git_path}'" if git_path else ""),
         )
@@ -876,7 +882,10 @@ async def sync_namespace_from_git(
 
     # 6. Deploy using existing orchestrator
     deployment_id = str(uuid.uuid4())
-    deployment_spec = DeploymentSpec(**deployment_spec_dict)
+    try:
+        deployment_spec = DeploymentSpec(**deployment_spec_dict)
+    except ValidationError as e:
+        raise DJInvalidInputException(message=str(e)) from e
 
     orchestrator = DeploymentOrchestrator(
         deployment_id=deployment_id,

--- a/datajunction-server/datajunction_server/api/hierarchies.py
+++ b/datajunction-server/datajunction_server/api/hierarchies.py
@@ -10,7 +10,7 @@ from typing import Callable, List, cast
 from fastapi import Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from datajunction_server.api.helpers import get_save_history
+from datajunction_server.api.helpers import get_save_history, get_node_namespace
 from datajunction_server.database.hierarchy import (
     Hierarchy,
     HierarchyLevel,
@@ -179,6 +179,18 @@ async def create_hierarchy(
     """
     Create a new hierarchy definition.
     """
+    # Validate that the hierarchy name is namespace-prefixed
+    if "." not in hierarchy_data.name:
+        raise DJInvalidInputException(
+            message=f"Hierarchy name '{hierarchy_data.name}' must be namespace-prefixed "
+            f"(e.g. 'my_namespace.{hierarchy_data.name}')",
+        )
+    # Hierarchy name convention: "{namespace}.{local_name}" where local_name is
+    # a single dotless segment (same convention as nodes).  rsplit(".", 1) gives
+    # the namespace prefix regardless of how many dots the namespace itself contains.
+    namespace_prefix = hierarchy_data.name.rsplit(".", 1)[0]
+    await get_node_namespace(session, namespace_prefix, raise_if_not_exists=True)
+
     # Check if hierarchy already exists
     existing = await Hierarchy.get_by_name(session, hierarchy_data.name)
     if existing:

--- a/datajunction-server/datajunction_server/database/hierarchy.py
+++ b/datajunction-server/datajunction_server/database/hierarchy.py
@@ -144,6 +144,37 @@ class Hierarchy(Base):  # type: ignore
         return list(result.scalars().all())
 
     @classmethod
+    async def get_by_namespace(
+        cls,
+        session: AsyncSession,
+        namespace: str,
+    ) -> list["Hierarchy"]:
+        """Fetch all hierarchies owned by a namespace (name starts with 'namespace.')."""
+        result = await session.execute(
+            select(cls)
+            .options(selectinload(cls.levels))
+            .where(
+                cls.name.like(f"{namespace}.%"),
+                ~cls.name.like(f"{namespace}.%.%"),
+            ),
+        )
+        return list(result.scalars().all())
+
+    @classmethod
+    async def get_by_names(
+        cls,
+        session: AsyncSession,
+        names: list[str],
+    ) -> list["Hierarchy"]:
+        """Bulk-fetch hierarchies by name with levels loaded."""
+        if not names:
+            return []
+        result = await session.execute(
+            select(cls).options(selectinload(cls.levels)).where(cls.name.in_(names)),
+        )
+        return list(result.scalars().all())
+
+    @classmethod
     async def get_using_dimension(
         cls,
         session: AsyncSession,
@@ -163,12 +194,16 @@ class Hierarchy(Base):  # type: ignore
         cls,
         session: AsyncSession,
         levels: list[HierarchyLevelInput],
+        existing_nodes: dict[str, Node] | None = None,
     ) -> tuple[list[str], dict[str, Node]]:
         """
         Validate hierarchy level definitions and return any validation errors.
+
+        If ``existing_nodes`` is provided (a pre-fetched name→Node mapping), it
+        is used directly instead of issuing a new DB query — avoiding N+1 fetches
+        when the caller has already bulk-loaded the relevant dimension nodes.
         """
         errors = []
-        existing_nodes: dict[str, Node] = {}
 
         # Check for unique level names
         names = [level.name for level in levels]
@@ -177,10 +212,11 @@ class Hierarchy(Base):  # type: ignore
 
         # Resolve dimension node names to IDs and validate they exist (single DB call)
         dimension_node_names = [level.dimension_node for level in levels]
-        existing_nodes = {
-            node.name: node
-            for node in await Node.get_by_names(session, dimension_node_names)
-        }
+        if existing_nodes is None:
+            existing_nodes = {
+                node.name: node
+                for node in await Node.get_by_names(session, dimension_node_names)
+            }
 
         # Check each level's dimension node and resolve to IDs
         for level in levels:

--- a/datajunction-server/datajunction_server/database/hierarchy.py
+++ b/datajunction-server/datajunction_server/database/hierarchy.py
@@ -161,20 +161,6 @@ class Hierarchy(Base):  # type: ignore
         return list(result.scalars().all())
 
     @classmethod
-    async def get_by_names(
-        cls,
-        session: AsyncSession,
-        names: list[str],
-    ) -> list["Hierarchy"]:
-        """Bulk-fetch hierarchies by name with levels loaded."""
-        if not names:
-            return []
-        result = await session.execute(
-            select(cls).options(selectinload(cls.levels)).where(cls.name.in_(names)),
-        )
-        return list(result.scalars().all())
-
-    @classmethod
     async def get_using_dimension(
         cls,
         session: AsyncSession,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1462,11 +1462,10 @@ class DeploymentOrchestrator:
                 derived = await self._derive_measures_for_deployed_metrics()
                 p.append(f"{derived} metrics")
 
-        # Hierarchies are globally scoped and run unconditionally so that
-        # hierarchy-only pushes (no node changes) are not silently dropped.
+        # Hierarchies run unconditionally so that hierarchy-only pushes
+        # (no node changes) are not silently dropped.
         with timer.phase("deploy hierarchies"):
             await self._setup_hierarchies()
-        await self._update_deployment_status()
 
         # Run impact propagation before deletions so deleted nodes'
         # children are still reachable via NodeRelationship.

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -26,6 +26,8 @@ from datajunction_server.database.metricmetadata import MetricMetadata
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import MissingParent, NodeRelationship
 from datajunction_server.database.partition import Partition
+from datajunction_server.database.hierarchy import Hierarchy, HierarchyLevel
+from datajunction_server.models.hierarchy import HierarchyLevelInput
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.user import User, OAuthProvider
 from datajunction_server.instrumentation.provider import get_metrics_provider
@@ -431,7 +433,7 @@ class DeploymentOrchestrator:
                 )
             self.deployed_results.extend(pre_results)
 
-        if deployment_plan.is_empty():
+        if deployment_plan.is_empty() and not self.deployment_spec.hierarchies:
             return DeploymentExecuteResult(
                 results=await self._handle_no_changes(),
                 downstream_impacts=[],
@@ -883,6 +885,135 @@ class DeploymentOrchestrator:
             await self.session.flush()  # Get IDs but don't commit
         return existing_tags
 
+    async def _setup_hierarchies(self) -> None:
+        """
+        Upsert all hierarchies defined in the deployment spec.
+        Hierarchies are namespace-scoped: their stored name is rendered_name
+        (i.e., namespace.hierarchy_name).
+        This phase runs unconditionally (not gated on plan.to_deploy) so that
+        hierarchy-only pushes — where no node changes are detected — are still applied.
+        Runs after dimension links so referenced dimension nodes are guaranteed to exist.
+        Validation delegates to Hierarchy.validate_levels so the same rules apply
+        as the POST /hierarchies endpoint (including dimension-link cardinality checks).
+        """
+        if not self.deployment_spec.hierarchies:
+            return
+
+        specs = self.deployment_spec.hierarchies
+        spec_rendered_names = {spec.rendered_name for spec in specs}
+
+        # Scope existing-hierarchy fetch to the current namespace
+        existing_hierarchies = {
+            h.name: h
+            for h in await Hierarchy.get_by_namespace(
+                self.session,
+                self.deployment_spec.namespace,
+            )
+        }
+
+        # Bulk-fetch dimension node IDs for level insertion (scalars only — no full graph)
+        all_dim_node_names = list(
+            {
+                lvl.rendered_dimension_node(spec.namespace)
+                for spec in specs
+                for lvl in spec.levels
+            },
+        )
+        dimension_nodes = {
+            node.name: node
+            for node in await Node.get_by_names(
+                self.session,
+                all_dim_node_names,
+                options=[load_only(Node.id, Node.name, Node.type)],
+            )
+        }
+
+        # Validate using the same logic as POST /hierarchies (includes link cardinality).
+        # Validation runs BEFORE any deletions so that a fully-invalid push does not
+        # wipe existing hierarchies from the namespace.
+        valid_specs = []
+        for spec in specs:
+            level_inputs = [
+                HierarchyLevelInput(
+                    name=lvl.name,
+                    dimension_node=lvl.rendered_dimension_node(spec.namespace),
+                    grain_columns=lvl.grain_columns,
+                )
+                for lvl in spec.levels
+            ]
+            # Pass the pre-fetched dimension_nodes to avoid N+1 DB round-trips
+            validation_errors, _ = await Hierarchy.validate_levels(
+                self.session,
+                level_inputs,
+                existing_nodes=dimension_nodes,
+            )
+            if validation_errors:
+                self.errors.append(
+                    DJError(
+                        code=ErrorCode.INVALID_DIMENSION,
+                        message=f"Hierarchy '{spec.rendered_name}' validation failed: "
+                        f"{'; '.join(validation_errors)}",
+                    ),
+                )
+            else:
+                valid_specs.append(spec)
+
+        # Compute deletions after validation:
+        # - Remove hierarchies that have been dropped from the spec entirely.
+        # - Remove hierarchies whose spec passed validation (safe to replace).
+        # - Keep hierarchies whose spec failed validation (preserve existing data).
+        names_with_valid_specs = {spec.rendered_name for spec in valid_specs}
+        to_delete = [
+            h
+            for name, h in existing_hierarchies.items()
+            if name not in spec_rendered_names  # removed from repo
+            or name in names_with_valid_specs  # has valid replacement
+        ]
+        for h in to_delete:
+            await self.session.delete(h)
+
+        # Upsert valid hierarchies, collecting (hierarchy_obj, spec) for level insertion
+        to_add_levels = []
+        for spec in valid_specs:
+            existing = existing_hierarchies.get(spec.rendered_name)
+            if existing:
+                if spec.display_name is not None:
+                    existing.display_name = spec.display_name
+                if spec.description is not None:
+                    existing.description = spec.description
+                existing.levels.clear()
+                self.session.add(existing)
+                to_add_levels.append((existing, spec))
+            else:
+                hierarchy = Hierarchy(
+                    name=spec.rendered_name,
+                    display_name=spec.display_name,
+                    description=spec.description,
+                    created_by_id=self.context.current_user.id,
+                )
+                hierarchy.levels = []  # initialize collection to avoid lazy-load on append
+                self.session.add(hierarchy)
+                to_add_levels.append((hierarchy, spec))
+
+        # Flush to issue DELETEs for cleared levels and get IDs for new hierarchies.
+        # Then append new levels directly to the collection so that the ORM's
+        # delete-orphan cascade does not interfere with the newly added objects.
+        await self.session.flush()
+        for hierarchy, spec in to_add_levels:
+            for idx, lvl in enumerate(spec.levels):
+                rendered_dim_node = lvl.rendered_dimension_node(spec.namespace)
+                hierarchy.levels.append(
+                    HierarchyLevel(
+                        name=lvl.name,
+                        dimension_node_id=dimension_nodes[rendered_dim_node].id,
+                        level_order=idx,
+                        grain_columns=lvl.grain_columns,
+                    ),
+                )
+
+        await self.session.flush()
+        logger.info("Upserted %d hierarchies", len(valid_specs))
+
     async def _setup_owners(self):
         """
         Validate that all owners defined in the deployment spec exist.
@@ -1330,6 +1461,12 @@ class DeploymentOrchestrator:
             with timer.phase("derive measures") as p:
                 derived = await self._derive_measures_for_deployed_metrics()
                 p.append(f"{derived} metrics")
+
+        # Hierarchies are globally scoped and run unconditionally so that
+        # hierarchy-only pushes (no node changes) are not silently dropped.
+        with timer.phase("deploy hierarchies"):
+            await self._setup_hierarchies()
+        await self._update_deployment_status()
 
         # Run impact propagation before deletions so deleted nodes'
         # children are still reachable via NodeRelationship.

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -62,6 +62,59 @@ class TagSpec(BaseModel):
     tag_metadata: dict | None = None
 
 
+class HierarchyLevelSpec(BaseModel):
+    """
+    Specification for a single level within a hierarchy.
+    """
+
+    name: str
+    dimension_node: str
+    grain_columns: list[str] | None = None
+
+    def rendered_dimension_node(self, namespace: str | None) -> str:
+        """Return the dimension_node name with namespace prefix applied."""
+        return (
+            render_prefixes(self.dimension_node, namespace)
+            if namespace
+            else self.dimension_node
+        )
+
+
+class NamespacedSpec(BaseModel):
+    """
+    Base class for specs that carry a namespace and need a rendered_name.
+
+    Both HierarchySpec and NodeSpec share identical name/namespace fields and
+    rendered_name logic; this base class deduplts that to avoid drift.
+    """
+
+    name: str
+
+    # Not user-supplied, gets injected by DeploymentSpec.set_namespaces
+    namespace: str | None = Field(default=None, exclude=True)
+
+    @property
+    def rendered_name(self) -> str:
+        if self.namespace:
+            if "${prefix}" in self.name:
+                return render_prefixes(self.name, self.namespace)
+            prefix = f"{self.namespace}{SEPARATOR}"
+            if self.name.startswith(prefix):
+                return self.name  # already fully qualified
+            return f"{prefix}{self.name}"
+        return self.name
+
+
+class HierarchySpec(NamespacedSpec):
+    """
+    Specification for a dimensional hierarchy.
+    """
+
+    display_name: str | None = None
+    description: str | None = None
+    levels: list[HierarchyLevelSpec] = Field(default_factory=list, min_length=2)
+
+
 class PartitionSpec(BaseModel):
     """
     Represents a partition
@@ -226,16 +279,11 @@ def render_prefixes(parameterized_string: str, prefix: str | None = None) -> str
     )
 
 
-class NodeSpec(BaseModel):
+class NodeSpec(NamespacedSpec):
     """
     Specification of a node as declared in a deployment.
     The name is relative and will be hydrated with the deployment namespace.
     """
-
-    name: str
-
-    # Not user-supplied, gets injected
-    namespace: str | None = Field(default=None, exclude=True)
 
     node_type: NodeType
     owners: list[str] = Field(default_factory=list)
@@ -265,7 +313,10 @@ class NodeSpec(BaseModel):
         if self.namespace:
             if "${prefix}" in self.name:  # pragma: no cover
                 return render_prefixes(self.name, self.namespace)
-            return f"{self.namespace}{SEPARATOR}{self.name}"
+            prefix = f"{self.namespace}{SEPARATOR}"
+            if self.name.startswith(prefix):
+                return self.name  # already fully qualified
+            return f"{prefix}{self.name}"
         return self.name
 
     @property
@@ -771,6 +822,7 @@ class DeploymentSpec(BaseModel):
     namespace: str
     nodes: list[NodeUnion] = Field(default_factory=list)
     tags: list[TagSpec] = Field(default_factory=list)
+    hierarchies: list[HierarchySpec] = Field(default_factory=list)
     source: DeploymentSource | None = None  # CI/CD provenance tracking
     git_config: NamespaceGitConfig | None = None  # Git branch management config
     force: bool = Field(
@@ -824,6 +876,9 @@ class DeploymentSpec(BaseModel):
                 for link in node.dimension_links:
                     if not link.namespace:
                         link.namespace = self.namespace
+        for hierarchy in self.hierarchies:
+            if not hierarchy.namespace:
+                hierarchy.namespace = self.namespace
         return self
 
 

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -4964,7 +4964,9 @@ columns:
             )
 
             assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-            assert "No node definitions found" in response.json()["message"]
+            assert (
+                "No node or hierarchy definitions found" in response.json()["message"]
+            )
 
     @pytest.mark.asyncio
     async def test_sync_from_git_source_records_branch_and_sha(
@@ -5422,3 +5424,547 @@ columns:
             assert data["status"] == "success"
             assert data["source"]["commit_author_name"] is None
             assert data["source"]["commit_author_email"] is None
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_hierarchy_only_push_applies_hierarchies(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """Hierarchy-only pushes (no node changes) must not be silently dropped.
+
+        Regression test for: _setup_hierarchies was gated on plan.to_deploy,
+        so a push with only hierarchy changes never applied them.
+        Two pushes: first creates the dimension nodes, second has only a hierarchy.
+        """
+        await client_with_service_setup.post("/namespaces/hier_only_ns")
+        await client_with_service_setup.patch(
+            "/namespaces/hier_only_ns/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        # Single-dimension node — same node referenced at two grains
+        # (single-dimension hierarchies skip the inter-level link check)
+        dim_date_yaml = """
+name: ${prefix}dim_date
+node_type: dimension
+query: "SELECT date_id, month_id FROM default.raw_dates"
+"""
+        # First push: create the dimension node
+        first_tarball = create_mock_tarball({"dim_date.yaml": dim_date_yaml})
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha000")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=first_tarball)
+            mock_cls.return_value = mock_gh
+            r = await client_with_service_setup.post(
+                "/namespaces/hier_only_ns/sync-from-git",
+            )
+            assert r.status_code == HTTPStatus.OK, r.text
+
+        # Second push: same node YAML (no node changes) plus a new hierarchy
+        hierarchy_yaml = """
+type: hierarchy
+name: hier_only_date_hierarchy
+levels:
+  - name: month
+    dimension_node: hier_only_ns.dim_date
+    grain_columns: [month_id]
+  - name: day
+    dimension_node: hier_only_ns.dim_date
+    grain_columns: [date_id]
+"""
+        second_tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": dim_date_yaml,
+                "hier_only_date_hierarchy.yaml": hierarchy_yaml,
+            },
+        )
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha001")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=second_tarball)
+            mock_cls.return_value = mock_gh
+            response = await client_with_service_setup.post(
+                "/namespaces/hier_only_ns/sync-from-git",
+            )
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        hier_response = await client_with_service_setup.get(
+            "/hierarchies/hier_only_ns.hier_only_date_hierarchy",
+        )
+        assert hier_response.status_code == HTTPStatus.OK
+        data = hier_response.json()
+        assert data["name"] == "hier_only_ns.hier_only_date_hierarchy"
+        assert len(data["levels"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_hierarchy_with_single_level_rejected(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """A hierarchy YAML with fewer than 2 levels must be rejected, not silently accepted.
+
+        Regression test for: HierarchySpec.levels had no min_length=2 constraint,
+        allowing 1-level hierarchies that POST /hierarchies correctly rejects.
+        """
+        await client_with_service_setup.post("/namespaces/single_level_ns")
+        await client_with_service_setup.patch(
+            "/namespaces/single_level_ns/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        # Hierarchy with only one level — invalid per HierarchyCreateRequest rules
+        hierarchy_yaml = """
+type: hierarchy
+name: bad_hierarchy
+levels:
+  - name: only_level
+    dimension_node: single_level_ns.dim_date
+    grain_columns: [date_id]
+"""
+        node_yaml = """
+name: ${prefix}dim_date
+node_type: dimension
+query: "SELECT date_id FROM default.raw_dates"
+"""
+        tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": node_yaml,
+                "bad_hierarchy.yaml": hierarchy_yaml,
+            },
+        )
+
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha002")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=tarball)
+            mock_cls.return_value = mock_gh
+
+            response = await client_with_service_setup.post(
+                "/namespaces/single_level_ns/sync-from-git",
+            )
+
+        # The deployment itself may succeed (node deploys), but the hierarchy must not be created
+        hier_response = await client_with_service_setup.get(
+            "/hierarchies/single_level_ns.bad_hierarchy",
+        )
+        assert hier_response.status_code == HTTPStatus.NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_hierarchies_in_subdirectory_are_loaded(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """Hierarchy files nested under hierarchies/ subdirectories must be loaded.
+
+        Regression test for: hierarchy loop used glob() (depth-1 only) while the
+        node exclusion used is_relative_to() (recursive), causing files at
+        hierarchies/subdir/foo.yaml to be silently dropped from both collections.
+        """
+        await client_with_service_setup.post("/namespaces/nested_hier_ns")
+        await client_with_service_setup.patch(
+            "/namespaces/nested_hier_ns/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        node_yaml = """
+name: ${prefix}dim_date
+node_type: dimension
+query: "SELECT date_id, month_id, year_id FROM default.raw_dates"
+"""
+        hierarchy_yaml = """
+type: hierarchy
+name: nested_date_hierarchy
+levels:
+  - name: year
+    dimension_node: nested_hier_ns.dim_date
+    grain_columns: [year_id]
+  - name: month
+    dimension_node: nested_hier_ns.dim_date
+    grain_columns: [year_id, month_id]
+  - name: day
+    dimension_node: nested_hier_ns.dim_date
+    grain_columns: [year_id, month_id, date_id]
+"""
+        # Hierarchy YAML is inside a subdirectory (no longer requires hierarchies/ dir)
+        tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": node_yaml,
+                "time/nested_date_hierarchy.yaml": hierarchy_yaml,
+            },
+        )
+
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha003")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=tarball)
+            mock_cls.return_value = mock_gh
+
+            response = await client_with_service_setup.post(
+                "/namespaces/nested_hier_ns/sync-from-git",
+            )
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        # Hierarchy must have been parsed and is present in the response
+        hier_response = await client_with_service_setup.get(
+            "/hierarchies/nested_hier_ns.nested_date_hierarchy",
+        )
+        assert hier_response.status_code == HTTPStatus.OK
+        assert hier_response.json()["name"] == "nested_hier_ns.nested_date_hierarchy"
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_hierarchy_update_replaces_levels(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """A second push that changes an existing hierarchy's levels must update it.
+
+        Exercises the update branch of _setup_hierarchies (clear + re-add), not just create.
+        """
+        await client_with_service_setup.post("/namespaces/hier_update_ns")
+        await client_with_service_setup.patch(
+            "/namespaces/hier_update_ns/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        dim_yaml = """
+name: ${prefix}dim_date
+node_type: dimension
+query: "SELECT date_id, month_id FROM default.raw_dates"
+"""
+        v1_hierarchy_yaml = """
+type: hierarchy
+name: updateable_hierarchy
+levels:
+  - name: month
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [month_id]
+  - name: day
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [date_id]
+"""
+        # First push: create hierarchy with 2 levels
+        first_tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": dim_yaml,
+                "updateable_hierarchy.yaml": v1_hierarchy_yaml,
+            },
+        )
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha010")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=first_tarball)
+            mock_cls.return_value = mock_gh
+            r = await client_with_service_setup.post(
+                "/namespaces/hier_update_ns/sync-from-git",
+            )
+            assert r.status_code == HTTPStatus.OK, r.text
+
+        data = (
+            await client_with_service_setup.get(
+                "/hierarchies/hier_update_ns.updateable_hierarchy",
+            )
+        ).json()
+        assert len(data["levels"]) == 2
+
+        # Second push: updated hierarchy with 3 levels (add year)
+        v2_hierarchy_yaml = """
+type: hierarchy
+name: updateable_hierarchy
+levels:
+  - name: year
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [year_id]
+  - name: month
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [month_id]
+  - name: day
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [date_id]
+"""
+        v2_dim_yaml = """
+name: ${prefix}dim_date
+node_type: dimension
+query: "SELECT date_id, month_id, year_id FROM default.raw_dates"
+"""
+        second_tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": v2_dim_yaml,
+                "updateable_hierarchy.yaml": v2_hierarchy_yaml,
+            },
+        )
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha011")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=second_tarball)
+            mock_cls.return_value = mock_gh
+            r = await client_with_service_setup.post(
+                "/namespaces/hier_update_ns/sync-from-git",
+            )
+            assert r.status_code == HTTPStatus.OK, r.text
+
+        data = (
+            await client_with_service_setup.get(
+                "/hierarchies/hier_update_ns.updateable_hierarchy",
+            )
+        ).json()
+        assert len(data["levels"]) == 3
+        assert [lvl["name"] for lvl in data["levels"]] == ["year", "month", "day"]
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_hierarchy_files_not_treated_as_nodes(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """Files under hierarchies/ must be excluded from node deployment.
+
+        A hierarchy YAML has a 'name' key, so without the exclusion it would be
+        picked up as a node spec and cause a deployment error.
+        """
+        await client_with_service_setup.post("/namespaces/hier_excl_ns")
+        await client_with_service_setup.patch(
+            "/namespaces/hier_excl_ns/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        dim_yaml = """
+name: ${prefix}dim_date
+node_type: dimension
+query: "SELECT date_id, month_id FROM default.raw_dates"
+"""
+        # Hierarchy YAML has type: hierarchy — routed to hierarchy path, not node path
+        hierarchy_yaml = """
+type: hierarchy
+name: excl_test_hierarchy
+levels:
+  - name: month
+    dimension_node: hier_excl_ns.dim_date
+    grain_columns: [month_id]
+  - name: day
+    dimension_node: hier_excl_ns.dim_date
+    grain_columns: [date_id]
+"""
+        tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": dim_yaml,
+                "excl_test_hierarchy.yaml": hierarchy_yaml,
+            },
+        )
+
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha020")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=tarball)
+            mock_cls.return_value = mock_gh
+            response = await client_with_service_setup.post(
+                "/namespaces/hier_excl_ns/sync-from-git",
+            )
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        results = response.json()["results"]
+        # Only the dim_date node should appear in deployment results — not the hierarchy
+        result_names = [r["name"] for r in results]
+        assert not any("excl_test_hierarchy" in n for n in result_names)
+        # Hierarchy was still deployed correctly via the hierarchy path
+        hier_response = await client_with_service_setup.get(
+            "/hierarchies/hier_excl_ns.excl_test_hierarchy",
+        )
+        assert hier_response.status_code == HTTPStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_invalid_hierarchy_preserves_existing(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """Failing hierarchy validation must NOT delete the pre-existing hierarchy.
+
+        Regression test for: deletion was staged before validation, so a fully-
+        invalid push would wipe the existing hierarchy from the namespace before
+        discovering the spec was broken.
+        """
+        await client_with_service_setup.post("/namespaces/hier_preserve_ns")
+        await client_with_service_setup.patch(
+            "/namespaces/hier_preserve_ns/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        # First push: create a valid hierarchy (single-dimension, no link check needed)
+        dim_yaml = """
+name: ${prefix}dim_date
+node_type: dimension
+query: "SELECT date_id, month_id FROM default.raw_dates"
+"""
+        valid_hierarchy_yaml = """
+type: hierarchy
+name: existing_hier
+levels:
+  - name: month
+    dimension_node: hier_preserve_ns.dim_date
+    grain_columns: [month_id]
+  - name: day
+    dimension_node: hier_preserve_ns.dim_date
+    grain_columns: [date_id]
+"""
+        first_tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": dim_yaml,
+                "existing_hier.yaml": valid_hierarchy_yaml,
+            },
+        )
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha_preserve_001")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=first_tarball)
+            mock_cls.return_value = mock_gh
+            r = await client_with_service_setup.post(
+                "/namespaces/hier_preserve_ns/sync-from-git",
+            )
+            assert r.status_code == HTTPStatus.OK, r.text
+
+        # Confirm hierarchy was created
+        assert (
+            await client_with_service_setup.get(
+                "/hierarchies/hier_preserve_ns.existing_hier",
+            )
+        ).status_code == HTTPStatus.OK
+
+        # Second push: a hierarchy spec that references a nonexistent dimension node
+        # (will fail validation) — the existing hierarchy must survive.
+        invalid_hierarchy_yaml = """
+type: hierarchy
+name: existing_hier
+levels:
+  - name: level_a
+    dimension_node: hier_preserve_ns.nonexistent_dim
+    grain_columns: [col_a]
+  - name: level_b
+    dimension_node: hier_preserve_ns.nonexistent_dim
+    grain_columns: [col_b]
+"""
+        second_tarball = create_mock_tarball(
+            {
+                "existing_hier.yaml": invalid_hierarchy_yaml,
+            },
+        )
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha_preserve_002")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=second_tarball)
+            mock_cls.return_value = mock_gh
+            r2 = await client_with_service_setup.post(
+                "/namespaces/hier_preserve_ns/sync-from-git",
+            )
+            assert r2.status_code == HTTPStatus.OK, r2.text
+
+        # The existing hierarchy must still be present (validation failure = no delete)
+        survive_response = await client_with_service_setup.get(
+            "/hierarchies/hier_preserve_ns.existing_hier",
+        )
+        assert survive_response.status_code == HTTPStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_node_type_hierarchy_routed_to_nodes(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """A YAML with both type: hierarchy AND node_type must be routed to nodes, not hierarchies.
+
+        Regression test for: the routing check only tested spec.get("type") == "hierarchy"
+        without verifying the absence of node_type, so a node YAML that happened to set
+        type: hierarchy (a valid node field) would be misrouted to the hierarchy path.
+        """
+        await client_with_service_setup.post("/namespaces/routing_test_ns")
+        await client_with_service_setup.patch(
+            "/namespaces/routing_test_ns/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        # A YAML that has BOTH type: hierarchy AND node_type: dimension
+        # This should be treated as a node spec, not a hierarchy spec.
+        ambiguous_yaml = """
+name: ${prefix}dim_with_type
+node_type: dimension
+type: hierarchy
+query: "SELECT date_id FROM default.raw_dates"
+"""
+        tarball = create_mock_tarball({"dim_with_type.yaml": ambiguous_yaml})
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha_routing_001")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=tarball)
+            mock_cls.return_value = mock_gh
+            response = await client_with_service_setup.post(
+                "/namespaces/routing_test_ns/sync-from-git",
+            )
+
+        assert response.status_code == HTTPStatus.OK, response.text
+        results = response.json()["results"]
+        result_names = [r["name"] for r in results]
+        # The spec must have been routed to the node path, not ignored as a hierarchy
+        assert any("dim_with_type" in n for n in result_names)
+
+
+class TestHierarchySpecRenderedName:
+    """Unit tests for HierarchySpec.rendered_name double-prefix guard."""
+
+    def test_rendered_name_no_double_prefix(self):
+        """HierarchySpec.rendered_name must not double-prefix an already-qualified name.
+
+        Regression test for: rendered_name blindly prepended namespace+SEPARATOR without
+        checking whether the name already started with that prefix.
+        """
+        from datajunction_server.models.deployment import HierarchySpec
+
+        spec = HierarchySpec(
+            name="common.date_hier",
+            levels=[
+                {"name": "year", "dimension_node": "common.year_dim"},
+                {"name": "month", "dimension_node": "common.month_dim"},
+            ],
+        )
+        spec.namespace = "common"
+        assert spec.rendered_name == "common.date_hier"
+
+    def test_rendered_name_adds_prefix_when_missing(self):
+        """rendered_name should still prefix an unqualified name."""
+        from datajunction_server.models.deployment import HierarchySpec
+
+        spec = HierarchySpec(
+            name="date_hier",
+            levels=[
+                {"name": "year", "dimension_node": "common.year_dim"},
+                {"name": "month", "dimension_node": "common.month_dim"},
+            ],
+        )
+        spec.namespace = "common"
+        assert spec.rendered_name == "common.date_hier"

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -5647,6 +5647,8 @@ query: "SELECT date_id, month_id FROM default.raw_dates"
         v1_hierarchy_yaml = """
 type: hierarchy
 name: updateable_hierarchy
+display_name: Old Display Name
+description: Old description
 levels:
   - name: month
     dimension_node: hier_update_ns.dim_date
@@ -5686,6 +5688,8 @@ levels:
         v2_hierarchy_yaml = """
 type: hierarchy
 name: updateable_hierarchy
+display_name: New Display Name
+description: New description
 levels:
   - name: year
     dimension_node: hier_update_ns.dim_date
@@ -5728,6 +5732,8 @@ query: "SELECT date_id, month_id, year_id FROM default.raw_dates"
         ).json()
         assert len(data["levels"]) == 3
         assert [lvl["name"] for lvl in data["levels"]] == ["year", "month", "day"]
+        assert data["display_name"] == "New Display Name"
+        assert data["description"] == "New description"
 
     @pytest.mark.asyncio
     async def test_sync_from_git_hierarchy_files_not_treated_as_nodes(
@@ -5968,3 +5974,46 @@ class TestHierarchySpecRenderedName:
         )
         spec.namespace = "common"
         assert spec.rendered_name == "common.date_hier"
+
+    def test_rendered_name_with_prefix_placeholder(self):
+        """rendered_name resolves ${prefix} when present in name."""
+        from datajunction_server.models.deployment import HierarchySpec
+
+        spec = HierarchySpec(
+            name="${prefix}date_hier",
+            levels=[
+                {"name": "year", "dimension_node": "common.year_dim"},
+                {"name": "month", "dimension_node": "common.month_dim"},
+            ],
+        )
+        spec.namespace = "common"
+        assert spec.rendered_name == "common.date_hier"
+
+    def test_rendered_name_no_namespace(self):
+        """rendered_name returns bare name when namespace is not set."""
+        from datajunction_server.models.deployment import HierarchySpec
+
+        spec = HierarchySpec(
+            name="date_hier",
+            levels=[
+                {"name": "year", "dimension_node": "common.year_dim"},
+                {"name": "month", "dimension_node": "common.month_dim"},
+            ],
+        )
+        assert spec.rendered_name == "date_hier"
+
+    def test_deployment_spec_skips_namespace_injection_when_already_set(self):
+        """set_namespaces must not overwrite a namespace that is already set on a HierarchySpec."""
+        from datajunction_server.models.deployment import DeploymentSpec, HierarchySpec
+
+        spec = HierarchySpec(
+            name="other.date_hier",
+            levels=[
+                {"name": "year", "dimension_node": "other.year_dim"},
+                {"name": "month", "dimension_node": "other.month_dim"},
+            ],
+        )
+        spec.namespace = "other"
+        deployment = DeploymentSpec(namespace="common", nodes=[], hierarchies=[spec])
+        # Namespace was already set to "other"; set_namespaces must not overwrite it
+        assert deployment.hierarchies[0].namespace == "other"

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -5549,7 +5549,7 @@ query: "SELECT date_id FROM default.raw_dates"
             mock_gh.download_archive = AsyncMock(return_value=tarball)
             mock_cls.return_value = mock_gh
 
-            response = await client_with_service_setup.post(
+            await client_with_service_setup.post(
                 "/namespaces/single_level_ns/sync-from-git",
             )
 

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -5735,6 +5735,48 @@ query: "SELECT date_id, month_id, year_id FROM default.raw_dates"
         assert data["display_name"] == "New Display Name"
         assert data["description"] == "New description"
 
+        # Third push: same levels, no display_name/description — covers the
+        # spec.display_name is None and spec.description is None branches in _setup_hierarchies
+        v3_hierarchy_yaml = """
+type: hierarchy
+name: updateable_hierarchy
+levels:
+  - name: year
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [year_id]
+  - name: month
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [month_id]
+  - name: day
+    dimension_node: hier_update_ns.dim_date
+    grain_columns: [date_id]
+"""
+        third_tarball = create_mock_tarball(
+            {
+                "dim_date.yaml": v2_dim_yaml,
+                "updateable_hierarchy.yaml": v3_hierarchy_yaml,
+            },
+        )
+        with patch("datajunction_server.api.git_sync.GitHubService") as mock_cls:
+            mock_gh = MagicMock()
+            mock_gh.resolve_ref_to_sha = AsyncMock(return_value="sha012")
+            mock_gh.get_commit_author = AsyncMock(
+                return_value=("Bot", "bot@example.com"),
+            )
+            mock_gh.download_archive = AsyncMock(return_value=third_tarball)
+            mock_cls.return_value = mock_gh
+            r = await client_with_service_setup.post(
+                "/namespaces/hier_update_ns/sync-from-git",
+            )
+            assert r.status_code == HTTPStatus.OK, r.text
+
+        data = (
+            await client_with_service_setup.get(
+                "/hierarchies/hier_update_ns.updateable_hierarchy",
+            )
+        ).json()
+        assert len(data["levels"]) == 3
+
     @pytest.mark.asyncio
     async def test_sync_from_git_hierarchy_files_not_treated_as_nodes(
         self,

--- a/datajunction-server/tests/api/hierarchies_test.py
+++ b/datajunction-server/tests/api/hierarchies_test.py
@@ -107,7 +107,7 @@ class TestHierarchiesAPI:
         dimensions, _ = time_dimensions
 
         hierarchy_data = {
-            "name": "api_test_hierarchy",
+            "name": "default.api_test_hierarchy",
             "display_name": "API Test Hierarchy",
             "description": "A hierarchy created via API test",
             "levels": [
@@ -133,27 +133,30 @@ class TestHierarchiesAPI:
         assert response.status_code == HTTPStatus.CREATED
         data = response.json()
 
-        assert data["name"] == "api_test_hierarchy"
+        assert data["name"] == "default.api_test_hierarchy"
         assert data["display_name"] == "API Test Hierarchy"
         assert len(data["levels"]) == 3
 
         # Verify the hierarchy can be retrieved
-        get_response = await client_with_basic.get("/hierarchies/api_test_hierarchy")
+        get_response = await client_with_basic.get(
+            "/hierarchies/default.api_test_hierarchy",
+        )
         assert get_response.status_code == HTTPStatus.OK
 
     async def test_create_hierarchy_duplicate_name(
         self,
         client_with_basic: AsyncClient,
-        calendar_hierarchy: Hierarchy,
         time_dimensions: tuple[dict[str, Node], dict[str, NodeRevision]],
+        time_dimension_links,
+        month_year_link,
     ):
         """Test creating a hierarchy with a duplicate name."""
         dimensions, _ = time_dimensions
 
         hierarchy_data = {
-            "name": "calendar_hierarchy",  # Same name as existing
+            "name": "default.dup_calendar_hierarchy",
             "display_name": "Duplicate Calendar",
-            "description": "This should fail",
+            "description": "First creation",
             "levels": [
                 {
                     "name": "year",
@@ -166,6 +169,14 @@ class TestHierarchiesAPI:
             ],
         }
 
+        # First creation should succeed
+        first_response = await client_with_basic.post(
+            "/hierarchies/",
+            json=hierarchy_data,
+        )
+        assert first_response.status_code == HTTPStatus.CREATED
+
+        # Second creation with same name should fail
         response = await client_with_basic.post(
             "/hierarchies/",
             json=hierarchy_data,
@@ -178,7 +189,7 @@ class TestHierarchiesAPI:
     ):
         """Test creating a hierarchy with non-existent dimension node."""
         hierarchy_data = {
-            "name": "invalid_hierarchy",
+            "name": "default.invalid_hierarchy",
             "display_name": "Invalid Hierarchy",
             "description": "This should fail",
             "levels": [
@@ -507,7 +518,7 @@ class TestHierarchiesAPI:
 
         # Create a hierarchy
         hierarchy_data = {
-            "name": "history_test",
+            "name": "default.history_test",
             "display_name": "History Test",
             "levels": [
                 {
@@ -533,13 +544,15 @@ class TestHierarchiesAPI:
         }
 
         update_response = await client_with_basic.put(
-            "/hierarchies/history_test",
+            "/hierarchies/default.history_test",
             json=update_data,
         )
         assert update_response.status_code == HTTPStatus.OK
 
         # Delete the hierarchy
-        delete_response = await client_with_basic.delete("/hierarchies/history_test")
+        delete_response = await client_with_basic.delete(
+            "/hierarchies/default.history_test",
+        )
         assert delete_response.status_code == HTTPStatus.NO_CONTENT
 
         # Query the History table to verify all operations were tracked
@@ -547,7 +560,7 @@ class TestHierarchiesAPI:
             select(History)
             .where(
                 History.entity_type == EntityType.HIERARCHY,
-                History.entity_name == "history_test",
+                History.entity_name == "default.history_test",
             )
             .order_by(History.created_at),
         )
@@ -559,10 +572,10 @@ class TestHierarchiesAPI:
         # Verify CREATE entry
         create_entry = history[0]
         assert create_entry.activity_type == ActivityType.CREATE
-        assert create_entry.entity_name == "history_test"
+        assert create_entry.entity_name == "default.history_test"
         assert create_entry.entity_type == EntityType.HIERARCHY
         assert create_entry.user == "dj"
-        assert create_entry.post["name"] == "history_test"
+        assert create_entry.post["name"] == "default.history_test"
         assert create_entry.post["display_name"] == "History Test"
         assert len(create_entry.post["levels"]) == 2
         assert create_entry.pre == {}
@@ -570,7 +583,7 @@ class TestHierarchiesAPI:
         # Verify UPDATE entry
         update_entry = history[1]
         assert update_entry.activity_type == ActivityType.UPDATE
-        assert update_entry.entity_name == "history_test"
+        assert update_entry.entity_name == "default.history_test"
         assert update_entry.pre["description"] is None
         assert (
             update_entry.post["description"] == "Updated description for history test"
@@ -579,8 +592,8 @@ class TestHierarchiesAPI:
         # Verify DELETE entry
         delete_entry = history[2]
         assert delete_entry.activity_type == ActivityType.DELETE
-        assert delete_entry.entity_name == "history_test"
-        assert delete_entry.pre["name"] == "history_test"
+        assert delete_entry.entity_name == "default.history_test"
+        assert delete_entry.pre["name"] == "default.history_test"
         assert len(delete_entry.pre["levels"]) == 2
         assert delete_entry.post == {}
 
@@ -694,3 +707,41 @@ class TestHierarchiesAPI:
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         data = response.json()
         assert "Node 'default.year_source' is not a dimension node" in data["message"]
+
+
+class TestHierarchyGetByNamespace:
+    """Tests for Hierarchy.get_by_namespace — verifies LIKE over-match is fixed."""
+
+    async def test_get_by_namespace_excludes_child_namespaces(
+        self,
+        session: AsyncSession,
+        current_user,
+    ):
+        """get_by_namespace('default') must NOT return hierarchies from 'default.child'.
+
+        Regression test for: the original LIKE('{ns}.%') pattern matched
+        'default.child.some_hier' as well as 'default.some_hier'.
+        The fix adds ~LIKE('{ns}.%.%') to restrict to exactly one dotless segment.
+        """
+        from datajunction_server.database.hierarchy import Hierarchy
+
+        # Create a hierarchy in the 'default' namespace
+        parent_hier = Hierarchy(
+            name="default.parent_hier",
+            display_name="Parent Hierarchy",
+            created_by_id=current_user.id,
+        )
+        # Create a hierarchy in the child namespace 'default.child'
+        child_hier = Hierarchy(
+            name="default.child.child_hier",
+            display_name="Child Hierarchy",
+            created_by_id=current_user.id,
+        )
+        session.add_all([parent_hier, child_hier])
+        await session.commit()
+
+        result = await Hierarchy.get_by_namespace(session, "default")
+        result_names = {h.name for h in result}
+
+        assert "default.parent_hier" in result_names
+        assert "default.child.child_hier" not in result_names

--- a/datajunction-server/tests/api/hierarchies_test.py
+++ b/datajunction-server/tests/api/hierarchies_test.py
@@ -143,6 +143,24 @@ class TestHierarchiesAPI:
         )
         assert get_response.status_code == HTTPStatus.OK
 
+    async def test_create_hierarchy_requires_namespace_prefix(
+        self,
+        client_with_basic: AsyncClient,
+    ):
+        """Hierarchy names without a namespace prefix must be rejected."""
+        response = await client_with_basic.post(
+            "/hierarchies/",
+            json={
+                "name": "bare_hierarchy",
+                "levels": [
+                    {"name": "year", "dimension_node": "default.year_dim"},
+                    {"name": "month", "dimension_node": "default.month_dim"},
+                ],
+            },
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert "namespace-prefixed" in response.json()["message"]
+
     async def test_create_hierarchy_duplicate_name(
         self,
         client_with_basic: AsyncClient,

--- a/datajunction-server/tests/internal/deployment_test.py
+++ b/datajunction-server/tests/internal/deployment_test.py
@@ -63,7 +63,7 @@ def basic_nodes():
     metric_node = MetricSpec(
         name="example.metric_node",
         node_type=NodeType.METRIC,
-        query="SELECT SUM(value) FROM ${prefix}example.transform_node",
+        query="SELECT SUM(value) FROM example.transform_node",
     )
     dimension_node = DimensionSpec(
         name="example.dimension_node",
@@ -74,8 +74,8 @@ def basic_nodes():
     cube_node = CubeSpec(
         name="example.cube_node",
         node_type=NodeType.CUBE,
-        metrics=["${prefix}example.metric_node"],
-        dimensions=["${prefix}example.dimension_node.category"],
+        metrics=["example.metric_node"],
+        dimensions=["example.dimension_node.category"],
     )
     return [transform_node, source_node, metric_node, dimension_node, cube_node]
 

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -227,6 +227,7 @@ def test_deployment_spec():
             },
         ],
         "tags": [],
+        "hierarchies": [],
         "source": None,
         "auto_register_sources": True,
         "force": False,


### PR DESCRIPTION
### Summary

Hierarchies were previously a REST API-only feature and had no integration with the git-backed deployment pipeline. This PR makes hierarchies first-class citizens of the deployment model.

#### What changed

Hierarchies are now namespace-scoped (e.g., `common.date_hierarchy`) using the same convention as nodes. The `POST /hierarchies/` endpoint validates that the name is prefixed with an existing namespace. Deployment YAML uses `${prefix}` substitution, so name: `${prefix}date_hierarchy` in a repo for the common namespace becomes `common.date_hierarchy`.

Hierarchy definitions live alongside node YAML files in the same directory, identified by `type: hierarchy`:
```yaml
  name: ${prefix}date_hierarchy
  type: hierarchy
  levels:
    - name: month
      dimension_node: ${prefix}dim_date
      grain_columns: [month_id]
    - name: day
      dimension_node: ${prefix}dim_date
      grain_columns: [date_id]
```

`dj push` now creates, updates, and deletes hierarchies as part of deployment. Hierarchies present in a namespace but absent from the current spec are deleted. Hierarchy-only pushes (no node changes) work correctly without being silently dropped.

Deployment-time validation delegates to `Hierarchy.validate_levels`, including dimension-link cardinality checks, which are the same rules enforced by `POST /hierarchies/`. Deletions only happen after validation, so a push where all specs are invalid does not wipe existing hierarchies.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
