### PR TITLE
Allow materialization for git-managed namespaces

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -156,6 +156,7 @@ export default function NodeMaterializationTab({
             alignItems: 'center',
             justifyContent: 'flex-end',
             marginBottom: '20px',
+            paddingTop: '16px',
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: '15px' }}>

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -158,11 +158,7 @@ export function NodePage() {
       // Other nodes (transform, metric, dimension) use pre-aggregations tab
       tabToDisplay =
         node?.type === 'cube' ? (
-          <NodeMaterializationTab
-            node={node}
-            djClient={djClient}
-            readOnly={!!gitConfig?.git_only}
-          />
+          <NodeMaterializationTab node={node} djClient={djClient} />
         ) : (
           <NodePreAggregationsTab node={node} />
         );


### PR DESCRIPTION
### Summary

The `+ Add Materialization` button on cube node pages was hidden whenever a namespace had `git_only: true` set on its git configuration. This caused the button to flash briefly on page load (while the git config was still loading) and then disappear once the config resolved, making it impossible to add materializations to any cube in a git-managed namespace through the UI.

The `git_only` flag is intended to prevent direct UI edits to node definitions (queries, columns, dimension links), since those are managed via git. Materialization is an operational concern independent of node definition management, so there is no reason to gate it behind `git_only` (for now).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
