### PR TITLE
Preserve column metadata across revalidate and updates

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3503,35 +3503,31 @@ async def revalidate_node(
             to_remove.add(link)  # pragma: no cover
             await session.delete(link)  # pragma: no cover
 
-    # Check if any columns have been updated. Track *why* the validator
-    # decided a column changed so the history event can explain the bump
-    # (otherwise revalidate-driven version bumps look mysterious in the
-    # audit trail).
-    updated_columns = False
+    # Detect column changes from the validator. We DON'T mutate node.current
+    # here — if any changes are detected we fork into a new revision below
+    # and apply the mutations there, so the previous revision's stored
+    # columns remain a faithful snapshot of what was committed at that
+    # version. Track *why* the validator decided a column changed so the
+    # history event can explain the bump.
     type_changes: list[dict] = []
     order_fixed: list[str] = []
     added_columns: list[str] = []
-    for idx, col in enumerate(node_validator.columns):
-        if existing_col := existing_columns.get(col.name):
-            if existing_col.type != col.type:
-                type_changes.append(
-                    {
-                        "column": col.name,
-                        "from": str(existing_col.type),
-                        "to": str(col.type),
-                    },
-                )
-                existing_col.type = col.type
-                updated_columns = True
-            if existing_col.order is None:  # pragma: no branch
-                order_fixed.append(col.name)
-                existing_col.order = idx
-                updated_columns = True
-        else:
-            col.order = idx
-            node.current.columns.append(col)  # type: ignore  # pragma: no cover
-            added_columns.append(col.name)  # pragma: no cover
-            updated_columns = True  # pragma: no cover
+    for col in node_validator.columns:
+        existing_col = existing_columns.get(col.name)
+        if existing_col is None:
+            added_columns.append(col.name)
+            continue
+        if existing_col.type != col.type:
+            type_changes.append(
+                {
+                    "column": col.name,
+                    "from": str(existing_col.type),
+                    "to": str(col.type),
+                },
+            )
+        if existing_col.order is None:
+            order_fixed.append(col.name)
+    updated_columns = bool(type_changes or order_fixed or added_columns)
 
     _logger.info(
         "Columns updated: %s for node %s (current version: %s) — "
@@ -3578,23 +3574,29 @@ async def revalidate_node(
         node_validator.updated_columns = node_validator.modified_columns(
             new_revision,  # type: ignore
         )
-        # Reorder/prune new_revision.columns to match the validator's output
-        # set, keeping the deep-copied columns (and their user-supplied
-        # description/display_name/unit/partition) intact. The first loop
-        # above already mutated type/order onto node.current.columns and
-        # appended any new columns, then copy_existing_node_revision deep-
-        # copied that state into new_revision.columns — so every column the
-        # validator returned is guaranteed to be present here.
+        # Build new_revision.columns in validator order. Existing columns
+        # come from the deep copy (preserving description / display_name /
+        # unit / partition); brand-new columns come straight from the
+        # validator output. Type and order fixes are applied here — not on
+        # node.current — so the previous revision's stored columns remain a
+        # faithful snapshot of what was committed at that version.
         #
-        # Wholesale-replacing with node_validator.columns previously wiped
-        # all user metadata; columns missing from validator output (e.g.,
-        # query changed to SELECT fewer fields) are dropped here naturally
-        # because they won't appear in merged_columns.
-        old_col_by_name = {col.name: col for col in new_revision.columns}
-        new_revision.columns = [
-            old_col_by_name[validator_col.name]
-            for validator_col in node_validator.columns
-        ]
+        # Columns missing from validator output (e.g., the query changed to
+        # SELECT fewer fields) are dropped naturally by rebuilding the list.
+        copied_by_name = {col.name: col for col in new_revision.columns}
+        merged_columns: list[Column] = []
+        for idx, validator_col in enumerate(node_validator.columns):
+            copied = copied_by_name.get(validator_col.name)
+            if copied is not None:
+                if copied.type != validator_col.type:
+                    copied.type = validator_col.type
+                if copied.order is None:
+                    copied.order = idx
+                merged_columns.append(copied)
+            else:
+                validator_col.order = idx
+                merged_columns.append(validator_col)
+        new_revision.columns = merged_columns
 
         # Save the new revision of the child
         node.current_version = new_revision.version  # type: ignore

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3502,7 +3502,28 @@ async def revalidate_node(
         node_validator.updated_columns = node_validator.modified_columns(
             new_revision,  # type: ignore
         )
-        new_revision.columns = node_validator.columns
+        # Merge validator-supplied type/order onto the existing columns so
+        # user-supplied metadata (description, display_name, unit, partition,
+        # attributes beyond what the validator infers) survives the revision
+        # bump. Wholesale-replacing with node_validator.columns wipes that
+        # metadata, which causes the deploy → revalidate cycle to oscillate
+        # column descriptions on/off across revisions.
+        old_col_by_name = {col.name: col for col in new_revision.columns}
+        merged_columns: list[Column] = []
+        for idx, validator_col in enumerate(node_validator.columns):
+            old_col = old_col_by_name.get(validator_col.name)
+            if old_col is not None:
+                old_col.type = validator_col.type
+                if validator_col.order is not None:
+                    old_col.order = validator_col.order
+                elif old_col.order is None:
+                    old_col.order = idx
+                merged_columns.append(old_col)
+            else:
+                if validator_col.order is None:
+                    validator_col.order = idx
+                merged_columns.append(validator_col)
+        new_revision.columns = merged_columns
 
         # Save the new revision of the child
         node.current_version = new_revision.version  # type: ignore

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3578,28 +3578,23 @@ async def revalidate_node(
         node_validator.updated_columns = node_validator.modified_columns(
             new_revision,  # type: ignore
         )
-        # Merge validator-supplied type/order onto the existing columns so
-        # user-supplied metadata (description, display_name, unit, partition,
-        # attributes beyond what the validator infers) survives the revision
-        # bump. Wholesale-replacing with node_validator.columns wipes that
-        # metadata, which causes the deploy → revalidate cycle to oscillate
-        # column descriptions on/off across revisions.
+        # Reorder/prune new_revision.columns to match the validator's output
+        # set, keeping the deep-copied columns (and their user-supplied
+        # description/display_name/unit/partition) intact. The first loop
+        # above already mutated type/order onto node.current.columns and
+        # appended any new columns, then copy_existing_node_revision deep-
+        # copied that state into new_revision.columns — so every column the
+        # validator returned is guaranteed to be present here.
+        #
+        # Wholesale-replacing with node_validator.columns previously wiped
+        # all user metadata; columns missing from validator output (e.g.,
+        # query changed to SELECT fewer fields) are dropped here naturally
+        # because they won't appear in merged_columns.
         old_col_by_name = {col.name: col for col in new_revision.columns}
-        merged_columns: list[Column] = []
-        for idx, validator_col in enumerate(node_validator.columns):
-            old_col = old_col_by_name.get(validator_col.name)
-            if old_col is not None:
-                old_col.type = validator_col.type
-                if validator_col.order is not None:
-                    old_col.order = validator_col.order
-                elif old_col.order is None:
-                    old_col.order = idx
-                merged_columns.append(old_col)
-            else:
-                if validator_col.order is None:
-                    validator_col.order = idx
-                merged_columns.append(validator_col)
-        new_revision.columns = merged_columns
+        new_revision.columns = [
+            old_col_by_name[validator_col.name]
+            for validator_col in node_validator.columns
+        ]
 
         # Save the new revision of the child
         node.current_version = new_revision.version  # type: ignore

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3446,26 +3446,45 @@ async def revalidate_node(
             to_remove.add(link)  # pragma: no cover
             await session.delete(link)  # pragma: no cover
 
-    # Check if any columns have been updated
+    # Check if any columns have been updated. Track *why* the validator
+    # decided a column changed so the history event can explain the bump
+    # (otherwise revalidate-driven version bumps look mysterious in the
+    # audit trail).
     updated_columns = False
+    type_changes: list[dict] = []
+    order_fixed: list[str] = []
+    added_columns: list[str] = []
     for idx, col in enumerate(node_validator.columns):
         if existing_col := existing_columns.get(col.name):
-            # Update type if changed
             if existing_col.type != col.type:
+                type_changes.append(
+                    {
+                        "column": col.name,
+                        "from": str(existing_col.type),
+                        "to": str(col.type),
+                    },
+                )
                 existing_col.type = col.type
                 updated_columns = True
-            # Set order if not already set (based on position in validated columns)
             if existing_col.order is None:  # pragma: no branch
+                order_fixed.append(col.name)
                 existing_col.order = idx
                 updated_columns = True
         else:
-            # New column - add with order
             col.order = idx
             node.current.columns.append(col)  # type: ignore  # pragma: no cover
+            added_columns.append(col.name)  # pragma: no cover
             updated_columns = True  # pragma: no cover
 
     _logger.info(
-        f"Columns updated: {updated_columns} for node {node.name} (current version: {node.current.version})",
+        "Columns updated: %s for node %s (current version: %s) — "
+        "type_changes=%s, order_fixed=%s, added_columns=%s",
+        updated_columns,
+        node.name,
+        node.current.version,
+        type_changes,
+        order_fixed,
+        added_columns,
     )
     # Only create a new revision if the columns have been updated
     if updated_columns:  # type: ignore
@@ -3530,6 +3549,32 @@ async def revalidate_node(
         new_revision.node_id = node.id  # type: ignore
         session.add(node)
         session.add(new_revision)
+
+        # Record the revision bump so the audit trail reflects revalidate-
+        # driven version changes, not just deploy-driven ones, and explains
+        # *which* validator-detected differences triggered it (type changes,
+        # missing column orders, new columns).
+        history_details: dict = {
+            "version": new_revision.version,
+            "reason": "revalidate",
+        }
+        if type_changes:
+            history_details["type_changes"] = type_changes
+        if order_fixed:
+            history_details["order_fixed"] = order_fixed
+        if added_columns:
+            history_details["added_columns"] = added_columns
+        await save_history(
+            event=History(
+                entity_type=EntityType.NODE,
+                entity_name=node.name,  # type: ignore
+                node=node.name,  # type: ignore
+                activity_type=ActivityType.UPDATE,
+                details=history_details,
+                user=current_user.username,
+            ),
+            session=session,
+        )
     await session.commit()
     await session.refresh(node.current)  # type: ignore
     await session.refresh(node, ["current"])

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3570,9 +3570,15 @@ async def revalidate_node(
             for lineage in await get_column_level_lineage(session, new_revision)
         ]
 
-        # Save which columns were modified and update the columns with the changes
+        # Save which columns were modified vs the previous revision. Compare
+        # against node.current — not new_revision — because new_revision.columns
+        # is the deep copy that's about to be overwritten by the merge below,
+        # while node.current is the unmodified pre-fork snapshot. Pre-refactor
+        # this compared against new_revision and got the same answer only
+        # because node.current had been mutated in place; with the in-place
+        # mutation removed, the right baseline is node.current.
         node_validator.updated_columns = node_validator.modified_columns(
-            new_revision,  # type: ignore
+            node.current,  # type: ignore
         )
         # Build new_revision.columns in validator order. Existing columns
         # come from the deep copy (preserving description / display_name /

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1732,6 +1732,10 @@ async def _propagate_update_downstream(
             session,
             current_user=current_user,
             save_history=save_history,
+            # propagate_update_downstream writes its own richer history event
+            # below (with upstream context); skip the inner one to avoid
+            # duplicate audit rows for the same revision bump.
+            record_revision_bump_event=False,
         )
 
         # Reset the upstreams DAG cache of any downstream nodes
@@ -1917,6 +1921,55 @@ async def create_node_from_inactive(
     return None
 
 
+def _build_columns_for_revision_update(
+    old_revision: NodeRevision,
+    data: "UpdateNode | None",
+    node_type: NodeType,
+) -> list[Column]:
+    """
+    Build the columns list for a new NodeRevision when updating an existing
+    node, preserving user-supplied metadata (display_name, description, unit,
+    partition) from columns of the same name on the old revision.
+
+    The patch payload (``data.columns``) carries name/type/dimension/attributes
+    — but not the full set of column fields. Constructing Column rows only
+    from the payload silently wipes metadata that wasn't part of the patch.
+    """
+    if data is None or not data.columns:
+        return [col.copy() for col in old_revision.columns]
+
+    old_by_name = {col.name: col for col in old_revision.columns}
+    columns: list[Column] = []
+    for idx, column_data in enumerate(data.columns):
+        name = (
+            column_data.name.lower()
+            if node_type != NodeType.METRIC
+            else column_data.name
+        )
+        existing = old_by_name.get(name)
+        partition = None
+        if existing is not None and existing.partition is not None:
+            partition = Partition(
+                type_=existing.partition.type_,
+                granularity=existing.partition.granularity,
+                format=existing.partition.format,
+            )
+        columns.append(
+            Column(
+                name=name,
+                type=column_data.type,
+                dimension_column=column_data.dimension,
+                attributes=column_data.attributes or [],
+                order=idx,
+                display_name=existing.display_name if existing else None,
+                description=existing.description if existing else None,
+                unit=existing.unit if existing else None,
+                partition=partition,
+            ),
+        )
+    return columns
+
+
 async def create_new_revision_from_existing(
     session: AsyncSession,
     old_revision: NodeRevision,
@@ -2002,20 +2055,17 @@ async def create_new_revision_from_existing(
         ),
         query=(data.query if data and data.query else old_revision.query),
         type=old_revision.type,
-        columns=[
-            Column(
-                name=column_data.name.lower()
-                if node.type != NodeType.METRIC
-                else column_data.name,
-                type=column_data.type,
-                dimension_column=column_data.dimension,
-                attributes=column_data.attributes or [],
-                order=idx,
-            )
-            for idx, column_data in enumerate(data.columns)
-        ]
-        if data and data.columns
-        else [col.copy() for col in old_revision.columns],
+        # Preserve user-supplied column metadata (display_name, description,
+        # unit, partition) from the previous revision when the PATCH payload
+        # supplies a column with the same name. Constructing a bare Column
+        # here previously wiped those fields and forced consumers (UI, dj
+        # push, sync jobs) to repopulate them on every refresh — see the
+        # equivalent fix in revalidate_node for the same antipattern.
+        columns=_build_columns_for_revision_update(
+            old_revision,
+            data,
+            node.type,
+        ),
         catalog=old_revision.catalog,
         schema_=old_revision.schema_,
         table=old_revision.table,
@@ -3321,9 +3371,16 @@ async def revalidate_node(
     save_history: Callable,
     update_query_ast: bool = False,
     background_tasks: BackgroundTasks = None,
+    record_revision_bump_event: bool = True,
 ) -> NodeValidator:
     """
-    Revalidate a single existing node and update its status appropriately
+    Revalidate a single existing node and update its status appropriately.
+
+    ``record_revision_bump_event`` controls whether this function emits a
+    history event when it creates a new revision. Callers that already write
+    their own (richer) event for the same revision bump — notably
+    ``propagate_update_downstream`` — pass False to avoid duplicate audit
+    rows for the same version change.
     """
     node = await Node.get_by_name(
         session,
@@ -3553,28 +3610,30 @@ async def revalidate_node(
         # Record the revision bump so the audit trail reflects revalidate-
         # driven version changes, not just deploy-driven ones, and explains
         # *which* validator-detected differences triggered it (type changes,
-        # missing column orders, new columns).
-        history_details: dict = {
-            "version": new_revision.version,
-            "reason": "revalidate",
-        }
-        if type_changes:
-            history_details["type_changes"] = type_changes
-        if order_fixed:
-            history_details["order_fixed"] = order_fixed
-        if added_columns:
-            history_details["added_columns"] = added_columns
-        await save_history(
-            event=History(
-                entity_type=EntityType.NODE,
-                entity_name=node.name,  # type: ignore
-                node=node.name,  # type: ignore
-                activity_type=ActivityType.UPDATE,
-                details=history_details,
-                user=current_user.username,
-            ),
-            session=session,
-        )
+        # missing column orders, new columns). Skip when the caller will
+        # write its own (richer) event for the same bump.
+        if record_revision_bump_event:
+            history_details: dict = {
+                "version": new_revision.version,
+                "reason": "revalidate",
+            }
+            if type_changes:
+                history_details["type_changes"] = type_changes
+            if order_fixed:
+                history_details["order_fixed"] = order_fixed
+            if added_columns:
+                history_details["added_columns"] = added_columns
+            await save_history(
+                event=History(
+                    entity_type=EntityType.NODE,
+                    entity_name=node.name,  # type: ignore
+                    node=node.name,  # type: ignore
+                    activity_type=ActivityType.UPDATE,
+                    details=history_details,
+                    user=current_user.username,
+                ),
+                session=session,
+            )
     await session.commit()
     await session.refresh(node.current)  # type: ignore
     await session.refresh(node, ["current"])

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -6198,6 +6198,71 @@ class TestValidateNodes:
         # nothing to preserve), but they're still present.
         assert "extra" in cols_by_name
 
+    @pytest.mark.asyncio
+    async def test_update_node_preserves_column_partition(
+        self,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
+    ):
+        """PATCH /nodes with a columns payload must deep-copy the existing
+        column's partition onto the new revision so partition metadata
+        isn't silently dropped.
+        """
+        response = await client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.test_patch_partition",
+                "node_type": "source",
+                "catalog": "default",
+                "schema_": "test",
+                "table": "patch_partition",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "event_date", "type": "date"},
+                ],
+                "mode": "published",
+            },
+        )
+        assert response.status_code in (200, 201), response.text
+
+        # Seed a partition on event_date.
+        await session.execute(
+            text(
+                """
+                INSERT INTO partition (type_, granularity, format, column_id)
+                SELECT 'TEMPORAL', 'day', 'yyyyMMdd', c.id
+                FROM "column" c
+                JOIN noderevision nr ON c.node_revision_id = nr.id
+                WHERE nr.name = 'default.test_patch_partition' AND c.name = 'event_date'
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        # PATCH with a columns payload that doesn't repeat the partition.
+        patch_response = await client_with_roads.patch(
+            "/nodes/default.test_patch_partition/",
+            json={
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "event_date", "type": "date"},
+                ],
+            },
+        )
+        assert patch_response.status_code == 200, patch_response.text
+
+        node_after = (
+            await client_with_roads.get("/nodes/default.test_patch_partition/")
+        ).json()
+        cols_by_name = {col["name"]: col for col in node_after["columns"]}
+        partition = cols_by_name["event_date"]["partition"]
+        assert partition is not None, (
+            f"partition was wiped on PATCH: {cols_by_name['event_date']}"
+        )
+        assert partition["type_"] == "temporal"
+        assert partition["granularity"] == "day"
+
 
 @pytest.mark.asyncio
 async def test_node_similarity(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -5763,6 +5763,80 @@ class TestValidateNodes:
         column_names = [col["name"] for col in node_data["columns"]]
         assert set(column_names) == {"repair_order_id", "dispatcher_id"}
 
+    @pytest.mark.asyncio
+    async def test_revalidate_preserves_column_metadata(
+        self,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
+    ):
+        """When revalidation triggers a new revision, user-supplied column
+        metadata (description, display_name) on the old revision must survive
+        the bump. Previously revalidate_node wholesale-replaced new_revision
+        columns with the validator's bare columns, wiping descriptions.
+        """
+        response = await client_with_roads.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.test_meta_preserved",
+                "query": "SELECT repair_order_id, dispatcher_id FROM default.repair_orders",
+                "description": "Test transform",
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201
+
+        # Seed descriptions and display_names on the current revision's columns
+        # to simulate user-supplied metadata.
+        await session.execute(
+            text(
+                """
+                UPDATE "column"
+                SET description = 'desc-' || name,
+                    display_name = 'Display ' || name
+                WHERE node_revision_id IN (
+                    SELECT id FROM noderevision WHERE name = 'default.test_meta_preserved'
+                )
+                """,
+            ),
+        )
+        # Also clear the order so revalidate detects a change and creates a
+        # new revision (matching the existing test_revalidate_sets_column_order
+        # trigger).
+        await session.execute(
+            text(
+                """
+                UPDATE "column"
+                SET "order" = NULL
+                WHERE node_revision_id IN (
+                    SELECT id FROM noderevision WHERE name = 'default.test_meta_preserved'
+                )
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        result = await client_with_roads.post(
+            "/nodes/default.test_meta_preserved/validate/",
+        )
+        assert result.status_code == 200
+        assert result.json()["status"] == "valid"
+
+        node_data = (
+            await client_with_roads.get("/nodes/default.test_meta_preserved/")
+        ).json()
+        cols_by_name = {col["name"]: col for col in node_data["columns"]}
+        assert set(cols_by_name) == {"repair_order_id", "dispatcher_id"}
+        for col_name, col in cols_by_name.items():
+            assert col["description"] == f"desc-{col_name}", (
+                f"description was wiped on revalidation for {col_name}: "
+                f"got {col['description']!r}"
+            )
+            assert col["display_name"] == f"Display {col_name}", (
+                f"display_name was wiped on revalidation for {col_name}: "
+                f"got {col['display_name']!r}"
+            )
+
 
 @pytest.mark.asyncio
 async def test_node_similarity(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -6045,6 +6045,159 @@ class TestValidateNodes:
         )
         assert len(history_after) > len(history_before)
 
+    @pytest.mark.asyncio
+    async def test_revalidate_via_propagation_writes_one_history_event(
+        self,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
+    ):
+        """revalidate_node accepts ``record_revision_bump_event`` so that
+        callers which write their own (richer) history event don't end up
+        with two audit rows per downstream version bump.
+
+        ``propagate_update_downstream`` already records an UPDATE event with
+        upstream context for each downstream it bumps; the inner revalidate
+        event would duplicate that row.
+        """
+        from datajunction_server.database.user import User
+        from datajunction_server.internal.nodes import revalidate_node
+
+        async def capture_history(event, session):  # type: ignore
+            captured.append(event)
+
+        captured: list = []
+
+        response = await client_with_roads.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.test_one_event_only",
+                "query": "SELECT repair_order_id FROM default.repair_orders",
+                "description": "Test transform",
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201
+
+        # Force the revalidate code path to create a new revision.
+        await session.execute(
+            text(
+                """
+                UPDATE "column"
+                SET "order" = NULL
+                WHERE node_revision_id IN (
+                    SELECT id FROM noderevision WHERE name = 'default.test_one_event_only'
+                )
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        user = (
+            await session.execute(select(User).where(User.username == "dj"))
+        ).scalar_one()
+
+        await revalidate_node(
+            name="default.test_one_event_only",
+            session=session,
+            current_user=user,
+            save_history=capture_history,
+            record_revision_bump_event=False,
+        )
+
+        # The opt-out caller path emits no inner history event.
+        revalidate_events = [
+            e
+            for e in captured
+            if getattr(e, "activity_type", None) == "update"
+            and (getattr(e, "details", None) or {}).get("reason") == "revalidate"
+        ]
+        assert revalidate_events == [], (
+            f"Expected no revalidate-reason history event when "
+            f"record_revision_bump_event=False; got {revalidate_events}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_node_preserves_column_metadata(
+        self,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
+    ):
+        """PATCH /nodes/{name} with a columns payload must preserve
+        user-supplied metadata (description, display_name, unit, partition)
+        on surviving columns, even when those fields aren't in the payload.
+
+        The PATCH path goes through ``update_any_node`` →
+        ``create_new_revision_from_existing``, which previously built fresh
+        Column objects with only name/type/dimension/attributes/order —
+        silently wiping the rest. This is the same antipattern that
+        ``revalidate_node`` had; the fix mirrors the merge-by-name pattern.
+        """
+        response = await client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.test_patch_meta",
+                "node_type": "source",
+                "catalog": "default",
+                "schema_": "test",
+                "table": "patch_meta",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "name", "type": "string"},
+                ],
+                "mode": "published",
+            },
+        )
+        assert response.status_code in (200, 201), response.text
+
+        await session.execute(
+            text(
+                """
+                UPDATE "column"
+                SET description = 'desc-' || name,
+                    display_name = 'Display ' || name
+                WHERE node_revision_id IN (
+                    SELECT id FROM noderevision WHERE name = 'default.test_patch_meta'
+                )
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        # PATCH with a columns payload that doesn't repeat description/display_name.
+        patch_response = await client_with_roads.patch(
+            "/nodes/default.test_patch_meta/",
+            json={
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "name", "type": "string"},
+                    {"name": "extra", "type": "string"},
+                ],
+            },
+        )
+        assert patch_response.status_code == 200, patch_response.text
+
+        node_after = (
+            await client_with_roads.get("/nodes/default.test_patch_meta/")
+        ).json()
+        cols_by_name = {col["name"]: col for col in node_after["columns"]}
+
+        # Surviving columns retain their seeded metadata.
+        for col_name in ("id", "name"):
+            assert cols_by_name[col_name]["description"] == f"desc-{col_name}", (
+                f"description was wiped on PATCH for {col_name}: "
+                f"{cols_by_name[col_name]}"
+            )
+            assert cols_by_name[col_name]["display_name"] == f"Display {col_name}", (
+                f"display_name was wiped on PATCH for {col_name}: "
+                f"{cols_by_name[col_name]}"
+            )
+
+        # Newly added columns have no preserved metadata (correct — there's
+        # nothing to preserve), but they're still present.
+        assert "extra" in cols_by_name
+
 
 @pytest.mark.asyncio
 async def test_node_similarity(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -6263,6 +6263,156 @@ class TestValidateNodes:
         assert partition["type_"] == "temporal"
         assert partition["granularity"] == "day"
 
+    @pytest.mark.asyncio
+    async def test_patch_column_fields_are_categorized(self):
+        """Every Column field must be categorized as either preserved-on-PATCH,
+        settable-via-PATCH, or infrastructure. This is the meta-guard that
+        catches the failure mode of this PR's bug at the source: someone adds
+        a new Column field and forgets to thread it through
+        ``_build_columns_for_revision_update``.
+
+        When this test fails for an uncategorized field, the maintainer must
+        make a deliberate choice and update both the categorization sets here
+        AND ``_build_columns_for_revision_update`` (or the PATCH payload
+        schema, ``SourceColumnOutput``).
+        """
+        from sqlalchemy import inspect as sa_inspect
+
+        # Fields PATCH must preserve when the payload doesn't repeat them.
+        # Adding to this set requires also updating
+        # ``_build_columns_for_revision_update`` to copy from the existing column.
+        preserved_scalars = {"display_name", "description", "unit"}
+        preserved_relationships = {"partition"}
+
+        # Fields the PATCH payload (SourceColumnOutput) lets the user set.
+        # Adding to this set requires also updating ``SourceColumnOutput``
+        # and ``_build_columns_for_revision_update``'s constructor args.
+        settable_scalars = {"name", "type", "order", "dimension_id", "dimension_column"}
+        settable_relationships = {"attributes", "dimension"}
+
+        # FK plumbing / backrefs / admin-managed fields not touched by PATCH.
+        infrastructure_scalars = {
+            "id",
+            "node_revision_id",
+            "partition_id",
+            "measure_id",
+        }
+        infrastructure_relationships = {"node_revision", "measure"}
+
+        all_scalars = {c.key for c in sa_inspect(Column).columns}
+        all_relationships = {r.key for r in sa_inspect(Column).mapper.relationships}
+
+        categorized_scalars = (
+            preserved_scalars | settable_scalars | infrastructure_scalars
+        )
+        uncategorized_scalars = all_scalars - categorized_scalars
+        assert uncategorized_scalars == set(), (
+            f"Column has uncategorized scalar field(s) {uncategorized_scalars}. "
+            "Decide one: (a) PATCH preserves it — add to `preserved_scalars` "
+            "here AND to `_build_columns_for_revision_update` (copy from "
+            "`existing`); (b) PATCH sets it — add to `settable_scalars` here, "
+            "to `SourceColumnOutput`, and as a constructor arg in "
+            "`_build_columns_for_revision_update`; or (c) it's plumbing — "
+            "add to `infrastructure_scalars` here."
+        )
+
+        categorized_relationships = (
+            preserved_relationships
+            | settable_relationships
+            | infrastructure_relationships
+        )
+        uncategorized_relationships = all_relationships - categorized_relationships
+        assert uncategorized_relationships == set(), (
+            f"Column has uncategorized relationship(s) {uncategorized_relationships}. "
+            "Decide one: preserved on PATCH (add to `preserved_relationships` "
+            "AND to `_build_columns_for_revision_update`), settable via PATCH "
+            "(add to `settable_relationships` AND to `SourceColumnOutput`), or "
+            "infrastructure (add to `infrastructure_relationships`)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_patch_preserves_all_metadata_fields(
+        self,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
+    ):
+        """Seed every preserved-on-PATCH field on a column, PATCH with just
+        name/type, and assert each survives. Companion to
+        ``test_patch_column_fields_are_categorized`` — that test asserts the
+        categorization is complete; this one asserts the categorization holds
+        end-to-end through ``_build_columns_for_revision_update``.
+        """
+        response = await client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.test_patch_all_meta",
+                "node_type": "source",
+                "catalog": "default",
+                "schema_": "test",
+                "table": "patch_all_meta",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "event_date", "type": "date"},
+                ],
+                "mode": "published",
+            },
+        )
+        assert response.status_code in (200, 201), response.text
+
+        # Seed every preserved-on-PATCH scalar field plus the partition
+        # relationship on event_date.
+        await session.execute(
+            text(
+                """
+                UPDATE "column"
+                SET description = 'seeded-desc',
+                    display_name = 'Seeded Display',
+                    unit = '{"kind": "currency", "code": "USD"}'::jsonb
+                WHERE node_revision_id IN (
+                    SELECT id FROM noderevision WHERE name = 'default.test_patch_all_meta'
+                ) AND name = 'event_date'
+                """,
+            ),
+        )
+        await session.execute(
+            text(
+                """
+                INSERT INTO partition (type_, granularity, format, column_id)
+                SELECT 'TEMPORAL', 'DAY', 'yyyyMMdd', c.id
+                FROM "column" c
+                JOIN noderevision nr ON c.node_revision_id = nr.id
+                WHERE nr.name = 'default.test_patch_all_meta' AND c.name = 'event_date'
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        # PATCH with name+type only — every preserved field must survive.
+        patch_response = await client_with_roads.patch(
+            "/nodes/default.test_patch_all_meta/",
+            json={
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "event_date", "type": "date"},
+                ],
+            },
+        )
+        assert patch_response.status_code == 200, patch_response.text
+
+        node_after = (
+            await client_with_roads.get("/nodes/default.test_patch_all_meta/")
+        ).json()
+        col = {c["name"]: c for c in node_after["columns"]}["event_date"]
+
+        assert col["description"] == "seeded-desc", col
+        assert col["display_name"] == "Seeded Display", col
+        assert col["unit"] == {"kind": "currency", "code": "USD"}, col
+        assert col["partition"] is not None, col
+        assert col["partition"]["type_"] == "temporal"
+        assert col["partition"]["granularity"] == "day"
+        assert col["partition"]["format"] == "yyyyMMdd"
+
 
 @pytest.mark.asyncio
 async def test_node_similarity(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2,6 +2,7 @@
 Tests for the nodes API.
 """
 
+import asyncio
 import re
 from typing import Any, Dict
 from unittest import mock
@@ -5836,6 +5837,213 @@ class TestValidateNodes:
                 f"display_name was wiped on revalidation for {col_name}: "
                 f"got {col['display_name']!r}"
             )
+
+    @pytest.mark.asyncio
+    async def test_revalidate_preserves_column_metadata_post_deployment(
+        self,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
+    ):
+        """End-to-end: a node deployed via POST /deployments with user-supplied
+        column descriptions must keep those descriptions across a subsequent
+        revalidate_node call.
+
+        Production pattern: dj-arc CI deploys → descriptions land in
+        revision N. Some external POST /nodes/{name}/validate/ (or a PATCH on
+        an upstream that schedules propagate_update_downstream) fires
+        revalidate_node, which used to wipe descriptions when it bumped to
+        revision N+1. This test exercises that full sequence: deploy via the
+        modern deployments API, then revalidate, and assert descriptions
+        survive.
+        """
+        # Use a fresh namespace so the deployment doesn't try to delete the
+        # client_with_roads fixture's existing nodes in 'default'.
+        ns = "meta_preserve_test"
+        deployment_spec = {
+            "namespace": ns,
+            "nodes": [
+                {
+                    "node_type": "source",
+                    "name": "src",
+                    "catalog": "default",
+                    "schema": "test",
+                    "table": "src",
+                    "columns": [
+                        {"name": "repair_order_id", "type": "int"},
+                        {"name": "dispatcher_id", "type": "int"},
+                    ],
+                },
+                {
+                    "node_type": "transform",
+                    "name": "test_deploy_meta",
+                    "query": "SELECT repair_order_id, dispatcher_id FROM ${prefix}src",
+                    "description": "Transform deployed with column metadata",
+                    "mode": "published",
+                    "columns": [
+                        {
+                            "name": "repair_order_id",
+                            "type": "int",
+                            "display_name": "Repair Order ID",
+                            "description": "The repair order identifier",
+                        },
+                        {
+                            "name": "dispatcher_id",
+                            "type": "int",
+                            "display_name": "Dispatcher ID",
+                            "description": "The dispatcher's identifier",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        deploy_response = await client_with_roads.post(
+            "/deployments",
+            json=deployment_spec,
+        )
+        assert deploy_response.status_code in (200, 201), deploy_response.text
+        deployment_id = deploy_response.json()["uuid"]
+        # Wait for deployment to complete.
+        status_data = None
+        for _ in range(30):
+            status_response = await client_with_roads.get(
+                f"/deployments/{deployment_id}",
+            )
+            status_data = status_response.json()
+            if status_data["status"] in ("success", "failed"):
+                break
+            await asyncio.sleep(0.1)
+        assert status_data is not None and status_data["status"] == "success", (
+            f"Deployment did not succeed: {status_data}"
+        )
+
+        # Confirm descriptions landed in the deploy.
+        node_after_deploy = (
+            await client_with_roads.get("/nodes/meta_preserve_test.test_deploy_meta/")
+        ).json()
+        post_deploy_descriptions = {
+            col["name"]: col["description"] for col in node_after_deploy["columns"]
+        }
+        assert post_deploy_descriptions == {
+            "repair_order_id": "The repair order identifier",
+            "dispatcher_id": "The dispatcher's identifier",
+        }, f"Deploy did not land descriptions: {post_deploy_descriptions}"
+
+        # Force revalidate_node to detect a column change so it creates a new
+        # revision (same trigger as test_revalidate_sets_column_order_when_missing).
+        await session.execute(
+            text(
+                """
+                UPDATE "column"
+                SET "order" = NULL
+                WHERE node_revision_id IN (
+                    SELECT id FROM noderevision WHERE name = 'meta_preserve_test.test_deploy_meta'
+                )
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        result = await client_with_roads.post(
+            "/nodes/meta_preserve_test.test_deploy_meta/validate/",
+        )
+        assert result.status_code == 200
+        assert result.json()["status"] == "valid"
+
+        # Descriptions must still be present on the new revision.
+        node_after_validate = (
+            await client_with_roads.get("/nodes/meta_preserve_test.test_deploy_meta/")
+        ).json()
+        post_validate_descriptions = {
+            col["name"]: col["description"] for col in node_after_validate["columns"]
+        }
+        assert post_validate_descriptions == post_deploy_descriptions, (
+            f"Revalidation wiped descriptions deployed via the deployment API. "
+            f"Before: {post_deploy_descriptions}, after: {post_validate_descriptions}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_revalidate_writes_history_event(
+        self,
+        client_with_roads: AsyncClient,
+        session: AsyncSession,
+    ):
+        """revalidate_node must record a history event when it creates a new
+        revision. Without it, /history?node=<name> only shows deploy-driven
+        updates and silently masks revalidate-driven version bumps (UI
+        validate, downstream propagation, manual /validate calls).
+        """
+        response = await client_with_roads.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.test_revalidate_history",
+                "query": "SELECT repair_order_id FROM default.repair_orders",
+                "description": "Test transform",
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201
+
+        # Force revalidate_node to create a new revision (same trigger as the
+        # column-order-cleared tests above).
+        await session.execute(
+            text(
+                """
+                UPDATE "column"
+                SET "order" = NULL
+                WHERE node_revision_id IN (
+                    SELECT id FROM noderevision WHERE name = 'default.test_revalidate_history'
+                )
+                """,
+            ),
+        )
+        await session.commit()
+        session.expire_all()
+
+        history_before = (
+            await client_with_roads.get(
+                "/history?node=default.test_revalidate_history",
+            )
+        ).json()
+
+        result = await client_with_roads.post(
+            "/nodes/default.test_revalidate_history/validate/",
+        )
+        assert result.status_code == 200
+        assert result.json()["status"] == "valid"
+
+        history_after = (
+            await client_with_roads.get(
+                "/history?node=default.test_revalidate_history",
+            )
+        ).json()
+
+        # An additional history event was emitted by revalidate_node
+        # specifically (reason: revalidate) when it bumped the revision.
+        revalidate_events = [
+            e
+            for e in history_after
+            if e.get("activity_type") == "update"
+            and (e.get("details") or {}).get("reason") == "revalidate"
+        ]
+        assert len(revalidate_events) >= 1, (
+            f"Expected a revalidate-reason history event after revision bump; "
+            f"got events: {history_after}"
+        )
+        # The event details explain WHY the validator bumped the revision —
+        # in this case, by recording which columns had their missing order
+        # backfilled. Without this the audit trail says "revalidate happened"
+        # but not "this is what it changed".
+        details = revalidate_events[0]["details"]
+        assert details.get("order_fixed"), (
+            f"Expected order_fixed in revalidate event details; got {details}"
+        )
+        assert set(details["order_fixed"]) == {"repair_order_id"}, (
+            f"Expected order_fixed to list the column whose order was cleared; "
+            f"got {details}"
+        )
+        assert len(history_after) > len(history_before)
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -6230,7 +6230,7 @@ class TestValidateNodes:
             text(
                 """
                 INSERT INTO partition (type_, granularity, format, column_id)
-                SELECT 'TEMPORAL', 'day', 'yyyyMMdd', c.id
+                SELECT 'TEMPORAL', 'DAY', 'yyyyMMdd', c.id
                 FROM "column" c
                 JOIN noderevision nr ON c.node_revision_id = nr.id
                 WHERE nr.name = 'default.test_patch_partition' AND c.name = 'event_date'

--- a/datajunction-server/tests/api/nodes_update_test.py
+++ b/datajunction-server/tests/api/nodes_update_test.py
@@ -73,7 +73,10 @@ async def test_update_source_node(
                 "created_at": mock.ANY,
                 "details": {
                     "changes": {
-                        "updated_columns": [],
+                        "updated_columns": [
+                            "avg_repair_amount_in_region",
+                            "total_amount_in_region",
+                        ],
                     },
                     "reason": "Caused by update of `default.repair_order_details` to v2.0",
                     "upstream": {

--- a/datajunction-server/tests/api/nodes_update_test.py
+++ b/datajunction-server/tests/api/nodes_update_test.py
@@ -50,7 +50,7 @@ async def test_update_source_node(
                 "activity_type": "update",
                 "created_at": mock.ANY,
                 "details": {
-                    "changes": {"updated_columns": []},
+                    "changes": {"updated_columns": ["total_amount_nationwide"]},
                     "reason": "Caused by update of `default.repair_order_details` to "
                     "v2.0",
                     "upstream": {
@@ -98,7 +98,7 @@ async def test_update_source_node(
                 "activity_type": "update",
                 "created_at": mock.ANY,
                 "details": {
-                    "changes": {"updated_columns": []},
+                    "changes": {"updated_columns": ["default_DOT_avg_repair_price"]},
                     "reason": "Caused by update of `default.repair_order_details` to "
                     "v2.0",
                     "upstream": {
@@ -121,7 +121,9 @@ async def test_update_source_node(
                 "created_at": mock.ANY,
                 "details": {
                     "changes": {
-                        "updated_columns": [],
+                        "updated_columns": [
+                            "default_DOT_regional_repair_efficiency",
+                        ],
                     },
                     "reason": "Caused by update of `default.repair_order_details` to "
                     "v2.0",


### PR DESCRIPTION
### Summary

Two related fixes for column metadata preservation + an audit-trail improvement:
1. `POST /nodes/{name}/validate`: when a revalidate detects a column change and bumps the revision, it was creating the new revision's columns from the node validator output's columns, wiping every column's description, display_name, unit, and partition. The merge logic now keeps the existing column object and applies validator-supplied type/order updates onto it.
2. `PATCH /nodes/{name})`: updating a node has the same antipattern for columns. When a caller patches a node with a columns payload, fresh Column rows were constructed with only name/type/dimension/attributes/order, silently dropping description/display_name/unit/partition. This fix wraps construction in a helper that merges the patch payload onto the prior revision's columns by name.
3. Add history event for revalidate-driven revision bumps so the audit trail explains what the validator detected and why the version bumped.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
