### PR TITLE
Catch extra comma in `VALUES` list in authored SQL

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/type_inference.py
+++ b/datajunction-server/datajunction_server/internal/deployment/type_inference.py
@@ -260,13 +260,13 @@ def _resolve_inline_table(query: ast.Query) -> OutputColumns:
             return BooleanType()
         return UnknownType()
 
+    # The parser enforces that every row has the same arity as the alias
+    # column list, so it's safe to index `row[i]` without bounds-checking.
     result: OutputColumns = []
     for i, name in enumerate(col_names):
         col_type: ColumnType = UnknownType()
         saw_only_null = True
         for row in select.values:
-            if i >= len(row):
-                continue
             inferred = _literal_type(row[i])
             if inferred is None:
                 continue  # NULL — try next row

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -391,8 +391,25 @@ def _(ctx: sbp.InlineTableContext):
     args = visit(ctx.expression())
     alias, columns = visit(ctx.tableAlias())
 
-    # Generate default column aliases if they weren't specified
-    col_args = args[0] if isinstance(args[0], list) else args
+    rows = [[value] if not isinstance(value, list) else value for value in args]
+
+    # Every row must have the same arity. Catches malformed VALUES like a stray
+    # trailing comma that the grammar otherwise tolerates because `AS` is a
+    # nonReserved keyword and gets parsed as a phantom single-column row.
+    row_widths = {len(row) for row in rows}
+    if len(row_widths) > 1:
+        raise DJParseException(
+            "All rows in a VALUES clause must have the same number of columns; "
+            f"got widths {sorted(row_widths)}.",
+        )
+    row_width = next(iter(row_widths))
+    if columns and len(columns) != row_width:
+        raise DJParseException(
+            f"VALUES clause has {row_width} column(s) but alias `{alias}` "
+            f"declares {len(columns)}.",
+        )
+
+    col_args = rows[0]
     inline_table_columns = (
         [ast.Column(col, _type=value.type) for col, value in zip(columns, col_args)]
         if columns
@@ -405,7 +422,7 @@ def _(ctx: sbp.InlineTableContext):
         name=alias,
         _columns=inline_table_columns,
         explicit_columns=len(columns) > 0,
-        values=[[value] if not isinstance(value, list) else value for value in args],
+        values=rows,
     )
 
 

--- a/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
+++ b/datajunction-server/datajunction_server/sql/parsing/backends/antlr4.py
@@ -403,6 +403,10 @@ def _(ctx: sbp.InlineTableContext):
             f"got widths {sorted(row_widths)}.",
         )
     row_width = next(iter(row_widths))
+    # An explicit column-alias list must match the row arity. Spark rejects
+    # mismatches outright; DJ used to silently truncate via zip(columns, row),
+    # masking typos like `(arr1, arr2) AS w(a)` when the author meant a single
+    # `array(struct1, struct2) AS w(a)`.
     if columns and len(columns) != row_width:
         raise DJParseException(
             f"VALUES clause has {row_width} column(s) but alias `{alias}` "

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.errors import DJException
 from datajunction_server.sql.parsing import ast, types
 from datajunction_server.sql.parsing.backends.antlr4 import parse
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from tests.sql.utils import compare_query_strings
 
 
@@ -1401,6 +1402,37 @@ def test_values_clause_explicit_column_aliases():
     assert inner_q.alias.name == "v"
     col_names = [col.name.name for col in inner_q.select._columns]
     assert col_names == ["a", "b"], f"Expected ['a', 'b'], got {col_names}"
+
+
+def test_values_clause_trailing_comma_rejected():
+    """
+    A stray trailing comma in a VALUES list used to slip through because `AS` is
+    a nonReserved keyword and got parsed as a phantom single-column row. The
+    InlineTable visitor now rejects row-width mismatches.
+    """
+    sql = """SELECT
+      CAST(country_id AS BIGINT) AS country_id
+      , country_name
+    FROM VALUES
+      (1, 'US'),
+      (2, 'CA'),
+      (3, 'MX'),
+      (4, 'BR'),
+    AS t(country_id, country_name)"""
+    with pytest.raises(
+        DJParseException,
+        match=r"All rows in a VALUES clause must have the same number of columns",
+    ):
+        parse(sql)
+
+
+def test_values_clause_alias_arity_mismatch_rejected():
+    """Explicit column alias count must match the VALUES row width."""
+    with pytest.raises(
+        DJParseException,
+        match=r"VALUES clause has 2 column\(s\) but alias `t` declares 1",
+    ):
+        parse("SELECT * FROM VALUES (1, 'a'), (2, 'b') AS t(only_one)")
 
 
 def test_struct_column_name_two_level():

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1145,7 +1145,7 @@ async def test_ast_subscript_handling(session: AsyncSession):
   w.a[1]['a'] as a_,
   w.a[1]['b'] as b_
 FROM VALUES
-  (array(named_struct('a', 1, 'b', 2)), array(named_struct('a', 300, 'b', 20))) AS w(a)"""
+  (array(named_struct('a', 1, 'b', 2), named_struct('a', 300, 'b', 20))) AS w(a)"""
     query = parse(str(query_str))
     assert str(parse(str(query))) == str(parse(str(query_str)))
     exc = DJException()
@@ -1427,7 +1427,8 @@ def test_values_clause_trailing_comma_rejected():
 
 
 def test_values_clause_alias_arity_mismatch_rejected():
-    """Explicit column alias count must match the VALUES row width."""
+    """Explicit column alias count must match the VALUES row width — Spark
+    rejects this and DJ used to silently truncate, masking author typos."""
     with pytest.raises(
         DJParseException,
         match=r"VALUES clause has 2 column\(s\) but alias `t` declares 1",


### PR DESCRIPTION
### Summary

When users authored transform SQL with an extra trailing comma in a `VALUES` list, this was accepted as valid because `AS` is a nonReserved keyword and got parsed as a phantom single-column row. The `InlineTable` visitor now rejects row-width mismatches to catch this issue.

### Test Plan

Added two tests of the offending SQL

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
