### PR TITLE
Display SQL validation errors in the node editor

### DIFF
--- a/datajunction-server/datajunction_server/errors.py
+++ b/datajunction-server/datajunction_server/errors.py
@@ -5,6 +5,7 @@ Errors and warnings.
 from http import HTTPStatus
 from typing import Any, Dict, List, Literal, Optional, TypedDict
 
+from pydantic import field_serializer
 from pydantic.main import BaseModel
 
 from datajunction_server.enum import IntEnum
@@ -85,7 +86,7 @@ class DJErrorType(TypedDict):
     Type for serialized errors.
     """
 
-    code: int
+    code: str
     message: str
     debug: Optional[DebugType]
 
@@ -99,6 +100,13 @@ class DJError(BaseModel):
     message: str
     debug: Optional[Dict[str, Any]] = None
     context: str = ""
+
+    @field_serializer("code")
+    def serialize_code(self, code: ErrorCode) -> str:
+        # Serialize as the symbolic name (e.g. "INVALID_SQL_QUERY") rather than
+        # the integer value. The names are far more useful to UI/CLI consumers
+        # and obviate the need for clients to maintain a parallel int→name map.
+        return code.name
 
     def __str__(self) -> str:
         """

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -169,7 +169,7 @@ async def test_create_invalid_cube(module__client_with_account_revenue: AsyncCli
         "Did you mean to add a dimension attribute?",
         "errors": [
             {
-                "code": 204,
+                "code": "NODE_TYPE_ERROR",
                 "context": "",
                 "debug": None,
                 "message": "Node default.account_type of type dimension cannot be added to a "
@@ -195,7 +195,7 @@ async def test_create_invalid_cube(module__client_with_account_revenue: AsyncCli
     assert data == {
         "errors": [
             {
-                "code": 601,
+                "code": "INVALID_DIMENSION",
                 "context": "",
                 "debug": None,
                 "message": "The dimension attribute `default.payment_type.payment_type_name` "
@@ -500,7 +500,7 @@ async def test_invalid_cube(module__client_with_roads: AsyncClient):
     assert response.json() == {
         "errors": [
             {
-                "code": 601,
+                "code": "INVALID_DIMENSION",
                 "context": "",
                 "debug": None,
                 "message": "The dimension attribute `default.contractor.company_name` is not "
@@ -553,7 +553,7 @@ async def test_create_cube_failures(
         "message": "The following metric nodes were not found: default.metric_that_doesnt_exist",
         "errors": [
             {
-                "code": 203,
+                "code": "UNKNOWN_NODE",
                 "context": "",
                 "debug": None,
                 "message": "The following metric nodes were not found: "

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -753,7 +753,7 @@ async def test_raise_common_dimensions_metric_not_found(
     assert response.json() == {
         "errors": [
             {
-                "code": 203,
+                "code": "UNKNOWN_NODE",
                 "context": "",
                 "debug": None,
                 "message": "Metric nodes not found: default.foo,default.bar",

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -1130,7 +1130,7 @@ class TestNodeCRUD:
             "columns as required dimensions that are not on parent nodes.",
             "errors": [
                 {
-                    "code": 206,
+                    "code": "INVALID_COLUMN",
                     "message": "Node definition contains references to columns "
                     "as required dimensions that are not on parent nodes.",
                     "debug": {"invalid_required_dimensions": ["testdld.messages.foo"]},
@@ -2661,7 +2661,7 @@ class TestNodeCRUD:
             ),
             "errors": [
                 {
-                    "code": 302,
+                    "code": "TYPE_INFERENCE",
                     "message": (
                         "Incompatible types in binary operation NOW() - "
                         "foo.bar.hard_hats.hire_date + 1. Got left timestamp, right int."
@@ -4421,7 +4421,7 @@ class TestValidateNodes:
             for e in data["errors"]
             if e
             == {
-                "code": 301,
+                "code": "MISSING_PARENT",
                 "message": "Node definition contains references to nodes that do not exist: "
                 "large_revenue_payments_only",
                 "debug": {"missing_parents": ["large_revenue_payments_only"]},
@@ -4484,7 +4484,7 @@ class TestValidateNodes:
         assert data["status"] == "invalid"
         assert data["errors"] == [
             {
-                "code": 201,
+                "code": "INVALID_SQL_QUERY",
                 "message": (
                     "Error parsing SQL `SUPER invalid SQL query`: "
                     "('Parse error 1:0:', \"mismatched input 'SUPER' expecting "
@@ -4539,7 +4539,7 @@ class TestValidateNodes:
             ],
             "errors": [
                 {
-                    "code": 301,
+                    "code": "MISSING_PARENT",
                     "message": "Node definition contains references to nodes that do not exist: "
                     "node_that_does_not_exist",
                     "debug": {"missing_parents": ["node_that_does_not_exist"]},
@@ -4588,7 +4588,7 @@ class TestValidateNodes:
         assert data["missing_parents"] == ["node_that_does_not_exist"]
         assert data["errors"] == [
             {
-                "code": 301,
+                "code": "MISSING_PARENT",
                 "context": "",
                 "debug": {"missing_parents": ["node_that_does_not_exist"]},
                 "message": "Node definition contains references to nodes that do not exist: "

--- a/datajunction-server/tests/api/query_params_test.py
+++ b/datajunction-server/tests/api/query_params_test.py
@@ -135,7 +135,7 @@ async def test_query_parameters_measures_sql(
     )
     assert response.json()[0]["errors"] == [
         {
-            "code": 303,
+            "code": "MISSING_PARAMETER",
             "message": "Missing value for parameter: default.hard_hat.hard_hat_id",
             "debug": None,
             "context": "",
@@ -193,7 +193,7 @@ async def test_query_parameters_metrics_sql(
     )
     assert response.json()["errors"] == [
         {
-            "code": 303,
+            "code": "MISSING_PARAMETER",
             "message": "Missing value for parameter: default.hard_hat.hard_hat_id",
             "debug": None,
             "context": "",

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -1159,7 +1159,7 @@ async def test_measures_sql_errors(
     data = response.json()
     assert data[0]["errors"] == [
         {
-            "code": 208,
+            "code": "INVALID_ORDER_BY",
             "message": "['default.dispatcher.company_name'] is not a valid ORDER BY request",
             "debug": {
                 "node_revision": "default.repair_orders_fact",
@@ -1647,7 +1647,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
         data = response.json()
         assert data[0]["errors"] == [
             {
-                "code": 205,
+                "code": "INVALID_DIMENSION_JOIN",
                 "context": mock.ANY,
                 "debug": None,
                 "message": "This dimension attribute cannot be joined in: "

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -3644,7 +3644,7 @@ class TestMetricsSQLOrderByLimit:
             "message": expected_message,
             "errors": [
                 {
-                    "code": 208,
+                    "code": "INVALID_ORDER_BY",
                     "message": expected_message,
                     "debug": None,
                     "context": "",
@@ -3679,7 +3679,7 @@ class TestMetricsSQLOrderByLimit:
             "message": expected_message,
             "errors": [
                 {
-                    "code": 208,
+                    "code": "INVALID_ORDER_BY",
                     "message": expected_message,
                     "debug": None,
                     "context": "",
@@ -3720,8 +3720,18 @@ class TestMetricsSQLOrderByLimit:
         assert response.json() == {
             "message": f"{msg_a}\n{msg_b}",
             "errors": [
-                {"code": 208, "message": msg_a, "debug": None, "context": ""},
-                {"code": 208, "message": msg_b, "debug": None, "context": ""},
+                {
+                    "code": "INVALID_ORDER_BY",
+                    "message": msg_a,
+                    "debug": None,
+                    "context": "",
+                },
+                {
+                    "code": "INVALID_ORDER_BY",
+                    "message": msg_b,
+                    "debug": None,
+                    "context": "",
+                },
             ],
             "warnings": [],
         }

--- a/datajunction-server/tests/construction/build_v3/node_query_test.py
+++ b/datajunction-server/tests/construction/build_v3/node_query_test.py
@@ -1205,7 +1205,7 @@ async def test_sql_orderby_unknown_column_raises(
         "message": expected_message,
         "errors": [
             {
-                "code": 208,
+                "code": "INVALID_ORDER_BY",
                 "message": expected_message,
                 "debug": None,
                 "context": "",
@@ -1321,7 +1321,7 @@ async def test_sql_with_filter_on_nonexistent_column_on_local_node(
         "message": expected_message,
         "errors": [
             {
-                "code": 206,
+                "code": "INVALID_COLUMN",
                 "message": expected_message,
                 "debug": None,
                 "context": "",
@@ -1357,7 +1357,7 @@ async def test_sql_with_filter_on_nonexistent_column_on_joined_dim(
         "message": expected_message,
         "errors": [
             {
-                "code": 206,
+                "code": "INVALID_COLUMN",
                 "message": expected_message,
                 "debug": None,
                 "context": "",

--- a/datajunction-server/tests/internal/authentication/basic_test.py
+++ b/datajunction-server/tests/internal/authentication/basic_test.py
@@ -146,7 +146,7 @@ async def test_fail_on_user_already_exists(client: AsyncClient):
         "message": "User dj1 already exists.",
         "errors": [
             {
-                "code": 2,
+                "code": "ALREADY_EXISTS",
                 "message": "User dj1 already exists.",
                 "debug": None,
                 "context": "",

--- a/datajunction-server/tests/internal/authentication/service_accounts_test.py
+++ b/datajunction-server/tests/internal/authentication/service_accounts_test.py
@@ -73,7 +73,7 @@ async def test_create_sa_with_non_user_identity(module__client: AsyncClient):
     assert create_resp.status_code == 401
     error = create_resp.json()
     assert error["errors"][0] == {
-        "code": 400,
+        "code": "AUTHENTICATION_ERROR",
         "context": "",
         "debug": None,
         "message": "Only users can create service accounts",
@@ -139,7 +139,7 @@ async def test_service_account_login_invalid_client_id(module__client: AsyncClie
     assert resp.status_code == 401
     error = resp.json()
     assert error["errors"][0] == {
-        "code": 403,
+        "code": "USER_NOT_FOUND",
         "context": "",
         "debug": None,
         "message": "Service account `non-existent-id` not found",
@@ -193,7 +193,7 @@ async def test_service_account_login_invalid_secret(module__client: AsyncClient)
     assert resp.status_code == 401
     error = resp.json()
     assert error["errors"][0] == {
-        "code": 402,
+        "code": "INVALID_LOGIN_CREDENTIALS",
         "context": "",
         "debug": None,
         "message": "Invalid service account credentials",

--- a/datajunction-ui/src/app/pages/AddEditNodePage/ColumnsSelect.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/ColumnsSelect.jsx
@@ -44,8 +44,16 @@ export const ColumnsSelect = ({
           json.columns.map(col => ({ value: col.name, label: col.name })),
         );
         setValidationError(null);
-      } else if (json?.message) {
-        setValidationError(json.message);
+      } else {
+        // Prefer the structured per-error messages (e.g. parse failures with
+        // INVALID_SQL_QUERY) over the generic `Node X is invalid.` summary.
+        const detailed = Array.isArray(json?.errors)
+          ? json.errors
+              .map(e => e.message)
+              .filter(Boolean)
+              .join('\n')
+          : '';
+        setValidationError(detailed || json?.message || null);
         setAvailableColumns([]);
       }
     } catch (error) {

--- a/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/NodeQueryField.jsx
@@ -14,6 +14,31 @@ import {
 } from './djNodeBadges';
 import { djEditorExtensions } from './djEditorTheme';
 
+// Friendly labels for the most common DJ error codes the validate endpoint
+// returns from a node query. Falls back to a title-cased version of the code.
+const ERROR_CODE_LABELS = {
+  INVALID_SQL_QUERY: 'Invalid SQL',
+  TYPE_INFERENCE: 'Type inference',
+  INVALID_COLUMN: 'Invalid column',
+  INVALID_ARGUMENTS_TO_FUNCTION: 'Invalid function arguments',
+  MISSING_COLUMNS: 'Missing columns',
+  UNKNOWN_NODE: 'Unknown node',
+  MISSING_PARENT: 'Missing parent',
+  NODE_TYPE_ERROR: 'Node type',
+  NOT_IMPLEMENTED_ERROR: 'Not implemented',
+};
+
+const errorLabel = code => {
+  if (code === undefined || code === null || code === '') return 'Error';
+  const key = String(code);
+  if (ERROR_CODE_LABELS[key]) return ERROR_CODE_LABELS[key];
+  return key
+    .toLowerCase()
+    .split('_')
+    .map(word => (word ? word[0].toUpperCase() + word.slice(1) : ''))
+    .join(' ');
+};
+
 export const NodeQueryField = ({ djClient, value }) => {
   // Schema is `{ [nodeName]: string[] }` — passed to @codemirror/lang-sql so
   // it can offer table + column autocompletion. Must be an OBJECT, not array,
@@ -27,6 +52,11 @@ export const NodeQueryField = ({ djClient, value }) => {
   const registeredTables = React.useRef(new Set());
   // useRef so the onChange closure always sees the latest catalog list
   const knownCatalogsRef = React.useRef([]);
+
+  // Query-level validation errors (parse failures, type-inference failures, etc.)
+  // surfaced from /nodes/validate's `errors` field. Rendered as a banner under
+  // the editor so the user sees *why* their SQL is invalid, not just that it is.
+  const [queryErrors, setQueryErrors] = React.useState([]);
 
   // Per-`catalog.schema.table` registration status, surfaced as badges in
   // the editor. Mirrored into a ref so the CodeMirror extension (built once,
@@ -132,6 +162,7 @@ export const NodeQueryField = ({ djClient, value }) => {
     const json = response?.json || {};
     const deps = json.dependencies || [];
     const missing = json.missing_parents || [];
+    setQueryErrors(Array.isArray(json.errors) ? json.errors : []);
     // Update the ref synchronously in one shot before dispatching, so the
     // ViewPlugin only redraws once even though we set many keys.
     const next = { ...tableStatusRef.current };
@@ -255,6 +286,20 @@ export const NodeQueryField = ({ djClient, value }) => {
         name="query"
         id="Query"
       />
+      {queryErrors.length > 0 && (
+        <div className="query-validation-errors" role="alert">
+          {queryErrors.map((err, idx) => (
+            <div key={idx} className="query-validation-error">
+              <span className="query-validation-error-code">
+                {errorLabel(err.code)}
+              </span>
+              <span className="query-validation-error-message">
+                {err.message}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
       <div role="button" tabIndex={0} className="relative flex bg-[#282a36]">
         <CodeMirror
           id={'query'}

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/NodeQueryField.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/NodeQueryField.test.jsx
@@ -1,20 +1,30 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { Formik, Form } from 'formik';
 import { NodeQueryField } from '../NodeQueryField';
 
 describe('NodeQueryField', () => {
   const mockDjClient = {
-    nodes: vi.fn(),
+    nodes: vi.fn().mockResolvedValue([]),
     node: vi.fn(),
     catalogs: vi.fn().mockResolvedValue([]),
     registerTable: vi
       .fn()
       .mockResolvedValue({ status: 200, json: { name: '' } }),
+    validateNode: vi.fn(),
   };
-  const renderWithFormik = (djClient = mockDjClient) => {
+  const renderWithFormik = (
+    djClient = mockDjClient,
+    initialValues = { query: '', type: 'transform', name: 'draft' },
+  ) => {
     return render(
-      <Formik initialValues={{ query: '' }} onSubmit={vi.fn()}>
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <Form>
           <NodeQueryField djClient={djClient} />
         </Form>
@@ -24,11 +34,56 @@ describe('NodeQueryField', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('renders without crashing', () => {
     renderWithFormik();
     expect(screen.getByRole('textbox')).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('surfaces server-side validation errors as an alert banner', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const djClient = {
+      ...mockDjClient,
+      validateNode: vi.fn().mockResolvedValue({
+        status: 422,
+        json: {
+          status: 'invalid',
+          message: 'Node `draft` is invalid.',
+          errors: [
+            {
+              code: 'INVALID_SQL_QUERY',
+              message:
+                'All rows in a VALUES clause must have the same number of columns; got widths [1, 2].',
+            },
+          ],
+          dependencies: [],
+          missing_parents: [],
+        },
+      }),
+    };
+    renderWithFormik(djClient);
+
+    // Type a query — the editor's onChange triggers a 700ms-debounced call to
+    // validateNode. Use fireEvent on the contenteditable to simulate typing.
+    const editor = document.querySelector('.cm-content');
+    expect(editor).not.toBeNull();
+    await act(async () => {
+      fireEvent.focus(editor);
+      fireEvent.input(editor, {
+        target: { textContent: "SELECT * FROM VALUES (1, 'a'), AS t(x, y)" },
+      });
+      // advance past the 700ms debounce
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    await waitFor(() => expect(djClient.validateNode).toHaveBeenCalled());
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Invalid SQL');
+    expect(alert).toHaveTextContent(
+      'All rows in a VALUES clause must have the same number of columns',
+    );
   });
 });

--- a/datajunction-ui/src/styles/node-creation.scss
+++ b/datajunction-ui/src/styles/node-creation.scss
@@ -210,6 +210,33 @@ form {
       overflow-wrap: anywhere !important;
     }
   }
+  .query-validation-errors {
+    margin: 4px 0 12px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .query-validation-error {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 10px;
+    background: #fdecea;
+    border: 1px solid #f5c2c0;
+    border-radius: 4px;
+    color: #8a1f11;
+    font-size: 0.9em;
+  }
+  .query-validation-error-code {
+    font-family: monospace;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+  .query-validation-error-message {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
   .MetricQueryInput {
     height: 200px;
   }


### PR DESCRIPTION
### Summary

Validation errors from `/nodes/validate` were silently dropped by the UI. The columns picker only rendered the generic `Node X is invalid` summary, so users would not understand why their SQL was rejected.

This PR surfaces those errors and tightens their format.

#### Server

- `DJError.code` now serializes to its symbolic name (e.g. `INVALID_SQL_QUERY`) instead of the integer enum value (201).
- Updated all affected test assertions from `"code": 208` to `"code": "INVALID_ORDER_BY"` style.

#### UI

- Render a banner above the CodeMirror editor whenever `/nodes/validate` returns errors. Each entry shows a friendly label (e.g. `INVALID_SQL_QUERY` maps to `Invalid SQL`, `TYPE_INFERENCE` to `Type inference`) plus the server's message. 
- When columns can't be resolved, prefer the structured errors over the generic message.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
