### PR TITLE
Fix MissingGreenlet on cube materialization upsert

### DIFF
--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -113,7 +113,11 @@ async def upsert_materialization(
             message=f"Cannot set materialization config for source node `{node_name}`!",
         )
     if node.type == NodeType.CUBE:  # type: ignore
-        node = await Node.get_cube_by_name(session, node_name)
+        node = await Node.get_cube_by_name(
+            session,
+            node_name,
+            with_metric_current=True,
+        )
     _logger.info(
         "Upserting materialization for node=%s version=%s",
         node.name,  # type: ignore

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -113,11 +113,7 @@ async def upsert_materialization(
             message=f"Cannot set materialization config for source node `{node_name}`!",
         )
     if node.type == NodeType.CUBE:  # type: ignore
-        node = await Node.get_cube_by_name(
-            session,
-            node_name,
-            with_metric_current=True,
-        )
+        node = await Node.get_cube_by_name(session, node_name)
     _logger.info(
         "Upserting materialization for node=%s version=%s",
         node.name,  # type: ignore

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -12,7 +12,9 @@ from datajunction_server.construction.build_v3.types import (
     DecomposedMetricInfo,
     GrainGroupSQL,
 )
-from datajunction_server.database.node import Column, NodeRevision
+from sqlalchemy import select
+
+from datajunction_server.database.node import Column, Node, NodeRevision
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.column import SemanticType
 from datajunction_server.models.cube_materialization import (
@@ -451,6 +453,24 @@ async def build_cube_materialization(
         for measures_query in measures_queries
         for metric, measures in measures_query.metrics.items()  # type: ignore
     }
+    # Resolve metric display names via a single query so this builder is
+    # self-contained — callers don't need to pre-load Node.current on each
+    # metric (otherwise metric.current.display_name lazy-loads and trips
+    # MissingGreenlet under AsyncSession).
+    cube_metrics = current_revision.cube_metrics()
+    metric_names = [m.name for m in cube_metrics]
+    display_name_rows = (
+        await session.execute(
+            select(Node.name, NodeRevision.display_name)
+            .join(
+                NodeRevision,
+                (NodeRevision.node_id == Node.id)
+                & (NodeRevision.version == Node.current_version),
+            )
+            .where(Node.name.in_(metric_names)),
+        )
+    ).all()
+    metric_display_names = dict(display_name_rows)
     config = DruidCubeConfig(
         cube=NodeNameVersion(
             name=current_revision.name,
@@ -462,7 +482,7 @@ async def build_cube_materialization(
                 metric=NodeNameVersion(
                     name=metric.name,
                     version=metric.current_version,
-                    display_name=metric.current.display_name,
+                    display_name=metric_display_names[metric.name],
                 ),
                 required_measures=[
                     MeasureKey(
@@ -476,7 +496,7 @@ async def build_cube_materialization(
                     metrics_mapping.get(metric.name)[1][1],  # type: ignore
                 ),
             )
-            for metric in current_revision.cube_metrics()
+            for metric in cube_metrics
         ],
         dimensions=current_revision.cube_node_dimensions,
         measures_materializations=measures_materializations,


### PR DESCRIPTION
### Summary

Follow-up to #2203. That PR added `with_metric_current` to plug a `MissingGreenlet` on `metric.current.display_name`, but only fixed the cubes API. The same lazy-load fires from `POST /nodes/{name}/materialization` (called by the UI's "Add Materialization" button on cube nodes).

Rather than threading the flag through another caller, this makes the call self-sufficient: one SELECT resolves all metric display names by name, so the builder no longer depends on `Node.current` being eager-loaded on the caller's side.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
