### PR TITLE
Fix v3 filter pushdown

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1173,7 +1173,7 @@ def _resolve_pushdown_filters_for_cte(
 
         for _link in node.current.dimension_links:
             for _dim_col_fqn, _fk_fqn in (_link.foreign_keys_reversed or {}).items():
-                if _fk_fqn:
+                if _fk_fqn:  # pragma: no branch
                     fk_col_names.add(get_short_name(_fk_fqn))
 
     blocked_refs: set[str] = set()

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1114,6 +1114,7 @@ def _resolve_pushdown_filters_for_cte(
     pushdown_filters: list[str],
     filter_column_aliases: dict[str, str],
     ctx: Optional["BuildContext"] = None,
+    outer_only_refs: Optional[set[str]] = None,
 ) -> tuple[list[tuple[ast.Select, ast.Expression]], set[str]]:
     """Determine which user filters can be pushed into this CTE.
 
@@ -1153,10 +1154,25 @@ def _resolve_pushdown_filters_for_cte(
     # dim CTEs whose local columns are named differently are missed.
     # Consult the current node's own ``dimension_links`` and override the
     # parent's mapping where the node has its own link for the dim.
+    local_aliases = _build_local_dim_aliases(node)
     effective_aliases = {
         **filter_column_aliases,
-        **_build_local_dim_aliases(node),
+        **local_aliases,
     }
+
+    # Refs that resolve only to a joined dimension's bare attribute name must
+    # not be pushed into this CTE unless the CTE legitimately exposes that
+    # attribute — i.e. it is the dimension's own node, or it has a dim link
+    # whose FK/PK maps the ref to a real local column.  Both of those show up
+    # in ``local_aliases``; anything else stays in the outer WHERE only, so we
+    # block it here (matching ``_rewrite_filter_for_scope``'s dim-link-aware
+    # policy).  Role-qualified refs are safe when their role-stripped base
+    # resolves locally (e.g. a multi-hop dim's own CTE).
+    blocked_refs: set[str] = set()
+    for ref in outer_only_refs or set():
+        base = ref.split("[")[0]
+        if ref not in local_aliases and base not in local_aliases:
+            blocked_refs.add(ref)
 
     target_select = cast(ast.Select, cte_query.select)
     results: list[tuple[ast.Select, ast.Expression]] = []
@@ -1249,6 +1265,7 @@ def _resolve_pushdown_filters_for_cte(
             effective_aliases,
             node_output_cols,
             target_select,
+            blocked_refs,
         )
         if rewritten is not None:
             results.append((target_select, rewritten))
@@ -1766,6 +1783,7 @@ def _rewrite_filter_for_select(
     filter_column_aliases: dict[str, str],
     cte_output_cols: set[str],
     cte_select: ast.Select,
+    blocked_refs: set[str] | None = None,
 ) -> ast.Expression | None:
     """Rewrite a dimension filter for injection into a specific Select.
 
@@ -1787,11 +1805,31 @@ def _rewrite_filter_for_select(
     ref's column isn't exposed by this Select, the whole filter is skipped —
     pushing a partial OR-predicate into the wrong scope produces invalid SQL.
 
+    ``blocked_refs`` lists dimension refs that resolve only to a joined
+    dimension's bare attribute name and so must never be pushed into this CTE
+    (the same-named local column is the raw FK value, not the attribute).  A
+    filter referencing any blocked ref is skipped entirely (returns None) so
+    the predicate stays in the post-join outer WHERE — never partially pushed.
+
     Returns the rewritten filter AST, or None when the filter can't be
     safely pushed into this Select.
     """
+    blocked_refs = blocked_refs or set()
     projection_map = _build_select_projection_map(cte_select)
     filter_ast = parse_filter(filter_str)
+
+    # Outer-only refs (joined-dimension attributes that resolve only to a bare
+    # column name) must never be pushed into this CTE — a same-named local
+    # column is the raw FK value, not the attribute.  If the filter touches
+    # one, bail entirely so the predicate stays in the post-join outer WHERE;
+    # a partial push would either bind to the wrong column or leave the rest
+    # of an OR-predicate dangling.  Role-qualified refs surface here as their
+    # role-stripped base column, which is what ``blocked_refs`` is keyed on.
+    if blocked_refs:
+        for col in filter_ast.find_all(ast.Column):
+            ref = get_column_full_name(col)
+            if ref and (ref in blocked_refs or ref.split("[")[0] in blocked_refs):
+                return None
 
     # First pass: plan the rewrites by walking the AST.  Role-qualified refs
     # appear as Subscript(Column(base), Column/Lambda(role)) and are handled
@@ -2106,6 +2144,7 @@ def collect_node_ctes(
                 pushdown.filters,
                 pushdown.column_aliases,
                 ctx,
+                pushdown.outer_only_refs,
             )
             for target_select, filter_ast in injections:
                 inject_filter_into_select(target_select, filter_ast)

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1160,18 +1160,29 @@ def _resolve_pushdown_filters_for_cte(
         **local_aliases,
     }
 
-    # Refs that resolve only to a joined dimension's bare attribute name must
-    # not be pushed into this CTE unless the CTE legitimately exposes that
-    # attribute — i.e. it is the dimension's own node, or it has a dim link
-    # whose FK/PK maps the ref to a real local column.  Both of those show up
-    # in ``local_aliases``; anything else stays in the outer WHERE only, so we
-    # block it here (matching ``_rewrite_filter_for_scope``'s dim-link-aware
-    # policy).  Role-qualified refs are safe when their role-stripped base
-    # resolves locally (e.g. a multi-hop dim's own CTE).
+    # Block a filter ref only when its resolved bare column is an FK column on
+    # this node (i.e. the node has a dimension link that uses that column as a
+    # FK) but the ref itself has no local mapping — meaning the filter targets
+    # a dim's non-PK attribute whose name collides with the FK integer column,
+    # which would produce a type mismatch.  Only FK columns from dimension
+    # links qualify; the node's own output columns (added to local_aliases by
+    # #2179 for dimension nodes) are the genuine attribute and are not blocked.
+    fk_col_names: set[str] = set()
+    if node.current and node.current.dimension_links:
+        from datajunction_server.construction.build_v3.utils import get_short_name
+
+        for _link in node.current.dimension_links:
+            for _dim_col_fqn, _fk_fqn in (_link.foreign_keys_reversed or {}).items():
+                if _fk_fqn:
+                    fk_col_names.add(get_short_name(_fk_fqn))
+
     blocked_refs: set[str] = set()
     for ref in outer_only_refs or set():
         base = ref.split("[")[0]
-        if ref not in local_aliases and base not in local_aliases:
+        if ref in local_aliases or base in local_aliases:
+            continue  # properly mapped locally — safe to push
+        bare_col = effective_aliases.get(ref) or effective_aliases.get(base)
+        if bare_col and bare_col in fk_col_names:
             blocked_refs.add(ref)
 
     target_select = cast(ast.Select, cte_query.select)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -639,6 +639,41 @@ def build_filter_column_aliases(
     return aliases
 
 
+def outer_only_filter_refs(
+    resolved_dimensions: list[ResolvedDimension],
+) -> set[str]:
+    """Dimension refs whose filter may only be applied *after* the join.
+
+    A **joined** (non-local) dimension resolves, in
+    :func:`build_filter_column_aliases`, to the dimension's bare column name.
+    That bare name is correct for the outer WHERE — where it is qualified with
+    the dimension's own post-join table alias — but it must never be pushed
+    into an upstream transform/source CTE under that name: a same-named column
+    there is the raw foreign-key value, not the dimension's attribute, so the
+    predicate would silently bind to the wrong column (and, when the two have
+    different types, match nothing).
+
+    Every joined dimension ref is reported.  Pushdown refuses them for
+    non-dimension CTEs, but the genuinely safe paths still apply: a filter on
+    the dimension's *own* CTE resolves through the dimension columns in
+    ``_build_local_dim_aliases``, and a filter on the join key resolves to the
+    parent's FK column through ``foreign_keys_reversed`` — both override this
+    restriction where the ref maps to a real local column.
+
+    Both the role-qualified ref (``v3.location.country[customer->home]``) and
+    its role-stripped base (``v3.location.country``) are included so callers
+    can match either form.
+    """
+    refs: set[str] = set()
+    for resolved_dim in resolved_dimensions:
+        if resolved_dim.is_local:
+            continue
+        refs.add(resolved_dim.original_ref)
+        if "[" in resolved_dim.original_ref:
+            refs.add(resolved_dim.original_ref.split("[")[0])
+    return refs
+
+
 def build_outer_where(
     filters: list[str],
     filter_column_aliases: dict[str, str],
@@ -1404,12 +1439,14 @@ def build_select_ast(
     # Build outer WHERE clause from filters
     where_clause: Optional[ast.Expression] = None
     filter_column_aliases: dict[str, str] = {}
+    pushdown_outer_only_refs: set[str] = set()
     if all_filters:
         filter_column_aliases = build_filter_column_aliases(
             ctx,
             resolved_dimensions,
             parent_node,
         )
+        pushdown_outer_only_refs = outer_only_filter_refs(resolved_dimensions)
         where_clause = build_outer_where(
             all_filters,
             filter_column_aliases,
@@ -1431,6 +1468,7 @@ def build_select_ast(
         pushdown=PushdownFilters(
             filters=all_filters,
             column_aliases=filter_column_aliases,
+            outer_only_refs=pushdown_outer_only_refs,
         )
         if all_filters
         else None,

--- a/datajunction-server/datajunction_server/construction/build_v3/node_query.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/node_query.py
@@ -46,6 +46,7 @@ from datajunction_server.construction.build_v3.measures import (
     build_filter_column_aliases,
     build_outer_where,
     collect_cte_nodes_and_needed_columns,
+    outer_only_filter_refs,
 )
 from datajunction_server.construction.build_v3.types import (
     BuildContext,
@@ -420,6 +421,11 @@ def _build_with_dimensions(
     filter_column_aliases = (
         build_filter_column_aliases(ctx, resolved_dims, starting) if filter_list else {}
     )
+    # Joined-dimension attributes with no FK/key path must stay in the outer
+    # WHERE rather than bind to a same-named raw FK column in an upstream CTE.
+    pushdown_outer_only_refs = (
+        outer_only_filter_refs(resolved_dims) if filter_list else set()
+    )
 
     # ``collect_node_ctes`` skips sources (they get inlined as physical refs)
     # and produces bodies in dep order. We deliberately don't pass
@@ -432,6 +438,7 @@ def _build_with_dimensions(
         pushdown=PushdownFilters(
             filters=filter_list,
             column_aliases=filter_column_aliases,
+            outer_only_refs=pushdown_outer_only_refs,
         )
         if filter_list
         else None,

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -184,10 +184,17 @@ class PushdownFilters:
         column_aliases: Map from dimension ref to bare column name.  Identity
             for most dimensions (``category`` → ``category``), but differs when
             a FK rename is involved (``date_id`` → ``order_date``).
+        outer_only_refs: Dimension refs that resolve only to a joined
+            dimension's bare attribute name and so must not be pushed into an
+            upstream transform/source CTE under that name (the same-named
+            column there is the raw FK value, not the attribute).  Such a
+            filter still pushes into the dimension's *own* CTE and lands in the
+            outer WHERE.  See ``outer_only_filter_refs``.
     """
 
     filters: list[str]
     column_aliases: dict[str, str]
+    outer_only_refs: set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1229,3 +1229,128 @@ class TestFilterPushdownViaSourceFKLinkAtTopLevel:
             """,
             normalize_aliases=True,
         )
+
+
+class TestDimLabelFilterNameCollision:
+    """Regression: a filter on a lookup dimension's *label* attribute whose
+    name collides with an upstream transform's foreign-key column must NOT be
+    pushed into the transform/source CTE.
+
+    The transform's same-named column holds the raw integer FK key, while the
+    label is a string. Pushing ``label = 'false'`` down to the int key column
+    produces ``int_col = 'false'`` which matches zero rows (NULL in non-ANSI
+    Spark / cast error in ANSI), silently emptying every downstream result.
+
+    The label predicate is only correct *after* the key->label join, so it
+    must stay in the post-join outer WHERE and the dimension's own CTE — never
+    in the upstream transform CTE.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dim_label_filter_not_pushed_to_transform_cte(
+        self,
+        client_with_build_v3,
+    ):
+        client = client_with_build_v3
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_lbl_events",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "is_bot", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "lbl_events",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.lbl_events_xform",
+                "query": "SELECT account_id, is_bot, amount FROM v3.src_lbl_events",
+                "mode": "published",
+                "primary_key": ["account_id"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        # Dim has is_bot_key (int PK) and is_bot (string label) — the dim's
+        # non-PK label column shares a name with the transform's int FK.
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.lbl_is_bot_dim",
+                "query": (
+                    "SELECT t.is_bot_key, t.is_bot "
+                    "FROM (SELECT 0 AS is_bot_key, 'false' AS is_bot "
+                    "UNION ALL SELECT 1, 'true') t"
+                ),
+                "mode": "published",
+                "primary_key": ["is_bot_key"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/v3.lbl_events_xform/link/",
+            json={
+                "dimension_node": "v3.lbl_is_bot_dim",
+                "join_type": "left",
+                "join_on": (
+                    "v3.lbl_events_xform.is_bot = v3.lbl_is_bot_dim.is_bot_key"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.lbl_total_amount",
+                "query": "SELECT SUM(amount) FROM v3.lbl_events_xform",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.lbl_total_amount"],
+                "dimensions": ["v3.lbl_is_bot_dim.is_bot"],
+                "filters": ["v3.lbl_is_bot_dim.is_bot = 'false'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # The label predicate is pushed into the dimension's own CTE
+        # (string = string, correct) and applied at the post-join outer
+        # WHERE, but NOT into the transform CTE (which exposes the int FK).
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_lbl_events_xform AS (
+              SELECT is_bot, amount
+              FROM default.v3.lbl_events
+            ),
+            v3_lbl_is_bot_dim AS (
+              SELECT t.is_bot_key, t.is_bot
+              FROM (
+                SELECT 0 AS is_bot_key, 'false' AS is_bot
+                UNION ALL
+                SELECT 1, 'true'
+              ) t
+              WHERE t.is_bot = 'false'
+            )
+            SELECT t2.is_bot,
+                   SUM(t1.amount) amount_sum_HASH
+            FROM v3_lbl_events_xform t1
+            LEFT OUTER JOIN v3_lbl_is_bot_dim t2
+              ON t1.is_bot = t2.is_bot_key
+            WHERE t2.is_bot = 'false'
+            GROUP BY t2.is_bot
+            """,
+            normalize_aliases=True,
+        )


### PR DESCRIPTION
### Summary

When filtering on a dimension's label (e.g. `is_bot = 'false'`), the v3 SQL builder could apply that filter to an upstream table's foreign-key column if it happened to have the same name. That meant comparing a string label against an integer key, which matches no rows and quietly returns empty results.

This fix keeps such filters where they belong after the join (and in the dimension's own table) instead of pushing them onto the wrong column.

### Test Plan
Added a regression test, here is the output of the SQL of that test before and after the change:

with the fix:
```
WITH
v3_lbl_events_xform AS (
SELECT  is_bot,
	amount 
 FROM default.v3.lbl_events
),
v3_lbl_is_bot_dim AS (
SELECT  t.is_bot_key,
	t.is_bot 
 FROM (SELECT  0 AS is_bot_key,
	'false' AS is_bot

UNION ALL
SELECT  1,
	'true') t 
 WHERE  t.is_bot = 'false'
)

SELECT  t2.is_bot,
	SUM(t1.amount) amount_sum_0ca4bf1a 
 FROM v3_lbl_events_xform t1 LEFT OUTER JOIN v3_lbl_is_bot_dim t2 ON t1.is_bot = t2.is_bot_key 
 WHERE  t2.is_bot = 'false' 
 GROUP BY  t2.is_bot
```

without the fix:
```
WITH
v3_lbl_events_xform AS (
SELECT  is_bot,
	amount 
 FROM default.v3.lbl_events 
 WHERE  is_bot = 'false'
),
v3_lbl_is_bot_dim AS (
SELECT  t.is_bot_key,
	t.is_bot 
 FROM (SELECT  0 AS is_bot_key,
	'false' AS is_bot

UNION ALL
SELECT  1,
	'true') t 
 WHERE  t.is_bot = 'false'
)

SELECT  t2.is_bot,
	SUM(t1.amount) amount_sum_0ca4bf1a 
 FROM v3_lbl_events_xform t1 LEFT OUTER JOIN v3_lbl_is_bot_dim t2 ON t1.is_bot = t2.is_bot_key 
 WHERE  t2.is_bot = 'false' 
 GROUP BY  t2.is_bot
```

Notice the WHERE  is_bot = 'false' in the first SQL statement.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

Open to suggestions for other ways to test this or ways to simplify the contribution!
