### PR TITLE
fix: push dimension filters into nested scopes when the CTE doesn't project the filtered column

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1250,66 +1250,38 @@ def _resolve_pushdown_filters_for_cte(
             node_output_cols,
             target_select,
         )
-        if rewritten is None:
-            continue
-        results.append((target_select, rewritten))
-        consumed.add(filter_str)
+        if rewritten is not None:
+            results.append((target_select, rewritten))
+            consumed.add(filter_str)
 
-        # First pass — alias-substitution by physical table.  For
-        # every alias used in the primary rewrite, find sibling
-        # Table references to the same physical source and inject a
-        # retargeted copy at each enclosing Select.  Preferred over
-        # column-aware retargeting because it unambiguously routes
-        # the filter to the same physical source the primary
-        # rewrite came from, even when sibling tables in the scope
-        # share the bare column name.
+        # First pass — alias-substitution by physical table.
         alias_subst_scopes: set[int] = set()
-        for primary_alias in _qualifier_aliases(rewritten):
-            # Skip when the primary qualifier is a subquery alias at
-            # target_select (not a direct Table).  A coincidental
-            # name collision between the subquery alias and a Table
-            # alias deeper in the body would otherwise inject
-            # ``alias.col`` at the inner scope, where ``alias``
-            # refers to a Table that doesn't have ``col``.
-            if primary_alias not in target_direct_table_aliases:
-                continue
-            physical = alias_to_phys.get(primary_alias)
-            if not physical:  # pragma: no cover
-                continue
-            for ref_alias, enclosing_select in _find_table_refs(
-                cte_query,
-                physical,
-            ):
-                if ref_alias == primary_alias and enclosing_select is target_select:
+        if rewritten is not None:
+            for primary_alias in _qualifier_aliases(rewritten):
+                if primary_alias not in target_direct_table_aliases:
                     continue
-                cloned = _retarget_filter_qualifier(
-                    rewritten,
-                    primary_alias,
-                    ref_alias,
-                )
-                results.append((enclosing_select, cloned))
-                alias_subst_scopes.add(id(enclosing_select))
+                physical = alias_to_phys.get(primary_alias)
+                if not physical:  # pragma: no cover
+                    continue
+                for ref_alias, enclosing_select in _find_table_refs(
+                    cte_query,
+                    physical,
+                ):
+                    if ref_alias == primary_alias and enclosing_select is target_select:
+                        continue
+                    cloned = _retarget_filter_qualifier(
+                        rewritten,
+                        primary_alias,
+                        ref_alias,
+                    )
+                    results.append((enclosing_select, cloned))
+                    alias_subst_scopes.add(id(enclosing_select))
 
-        # Second pass — column-aware retargeting.  Walk every other
-        # Select scope inside the body and rebuild the filter using
-        # that scope's resolver map.  Handles cases the
-        # alias-substitution pass can't reach (CROSS-joined dim
-        # subqueries with different physical sources, source-table
-        # references that share columns with the primary).
-        #
-        # Skipped at scopes whose direct FROM contains ONLY
-        # subquery aliases and no Tables — at such scopes the
-        # only candidate aliases are the OUTER alias of inner
-        # subqueries, and pushing a filter qualified by one of
-        # those triggers the existing
-        # ``_try_push_filter_into_outer_join_side`` outer-join
-        # safety wrap, which ANDs the filter into the inner
-        # subquery's WHERE without retargeting — producing a
-        # qualifier that's invalid inside the subquery
-        # (e.g. ``numerator.utc_date`` referenced inside the
-        # body of a subquery the OUTER calls ``numerator``).
-        # Also skipped at scopes already handled by
-        # alias-substitution to avoid duplicate injections.
+        # Second pass — column-aware retargeting into nested scopes.
+        # Runs regardless of primary success: a filter column may exist
+        # in a nested scope even when absent from the CTE's declared
+        # output (e.g. a transform that CROSS JOINs a dimension and
+        # aggregates its column away without projecting it).
         for inner_select, col_to_alias in scope_column_aliases.items():
             if inner_select is target_select:
                 continue
@@ -1327,6 +1299,8 @@ def _resolve_pushdown_filters_for_cte(
             if inner_rewrite is None:
                 continue
             results.append((inner_select, inner_rewrite))
+            consumed.add(filter_str)
+
     return results, consumed
 
 

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1005,11 +1005,12 @@ class TestFilterPushdownCrossJoinAggregatesColumnAway:
         )
         assert resp.status_code in (200, 201), resp.json()
 
-        # Inner transform: CROSS JOINs time_window_dim and uses window_size
-        # for a MAX computation, but does NOT project window_id.
-        # This is the pattern that was broken: the primary rewrite fails
-        # (window_id absent from this node's output), so without the fix the
-        # second pass was skipped and the filter never reached the inner scope.
+        # Inner transform: mirrors the exp_meta pattern exactly.
+        # CROSS JOINs with an inline subquery reading the dim directly —
+        # uses window_size for the MAX but does NOT project window_id.
+        # The primary rewrite fails (window_id not in output), so without
+        # the fix the second pass was skipped and the filter never reached
+        # the inner CROSS JOIN scope.
         resp = await client.post(
             "/nodes/transform/",
             json={
@@ -1018,7 +1019,10 @@ class TestFilterPushdownCrossJoinAggregatesColumnAway:
                     "SELECT e.entity_id, "
                     "MAX(e.base_value + w.window_size) AS max_bound "
                     "FROM v3.src_entity_facts AS e "
-                    "CROSS JOIN v3.time_window_dim AS w "
+                    "CROSS JOIN ("
+                    "SELECT window_id, window_size "
+                    "FROM v3.time_window_dim"
+                    ") AS w "
                     "GROUP BY e.entity_id"
                 ),
                 "mode": "published",
@@ -1073,17 +1077,38 @@ class TestFilterPushdownCrossJoinAggregatesColumnAway:
             },
         )
         assert response.status_code == 200, response.json()
-        sql = get_first_grain_group(response.json())["sql"]
-
-        # The filter must appear inside entity_window_config's CTE —
-        # specifically in the inner CROSS JOIN scope where time_window_dim is
-        # scanned as a direct Table.  Without the fix the second pass was
-        # skipped when the primary rewrite failed, so this assertion would fail.
-        inner_cte_start = sql.find("v3_entity_window_config AS (")
-        assert inner_cte_start != -1, "entity_window_config CTE not found in SQL"
-        inner_cte = sql[inner_cte_start : sql.find("\n)", inner_cte_start) + 2]
-        assert "window_id" in inner_cte and "7day" in inner_cte, (
-            "Filter window_id IN ('7day') was not pushed into the inner "
-            "CROSS JOIN scope of entity_window_config — the second pass "
-            "did not fire when the primary rewrite failed."
+        # The fix: filter is injected into the inner CROSS JOIN subquery of
+        # entity_window_config even though window_id is not in its output.
+        # Without the fix (second pass gated on primary success), the filter
+        # would be absent from the inner scope and all windows would be used.
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_time_window_dim AS (
+              SELECT window_id, window_size
+              FROM default.v3.time_window
+              WHERE window_id IN ('7day')
+            ),
+            v3_entity_window_config AS (
+              SELECT e.entity_id,
+                MAX(e.base_value + w.window_size) AS max_bound
+              FROM default.v3.entity_facts AS e
+              CROSS JOIN (
+                SELECT window_id, window_size
+                FROM v3_time_window_dim
+                WHERE v3_time_window_dim.window_id IN ('7day')
+              ) AS w
+              GROUP BY e.entity_id
+            ),
+            v3_entity_report AS (
+              SELECT c.entity_id, w.window_id
+              FROM v3_entity_window_config AS c
+              CROSS JOIN v3_time_window_dim AS w
+              WHERE w.window_id IN ('7day')
+            )
+            SELECT COUNT(t1.entity_id) entity_id_count_HASH
+            FROM v3_entity_report t1
+            """,
+            normalize_aliases=True,
         )

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -937,3 +937,140 @@ class TestDimCteFilterOnNonFkColumn:
             """,
             normalize_aliases=True,
         )
+
+
+class TestFilterPushdownCrossJoinAggregatesColumnAway:
+    """
+    Regression: when a transform CROSS JOINs a dimension and aggregates its
+    key column away (never projects it), a filter on that key must still be
+    pushed into the inner CROSS JOIN subquery via the second pass.
+
+    Without the fix the loop did ``if rewritten is None: continue``, skipping
+    the second pass entirely.  The filter landed only in the outer transform's
+    CTE (which *does* project the column) but was silently dropped for the
+    inner transform that does not — causing the CROSS JOIN to return all
+    window rows instead of the requested one, multiplying every metric by the
+    number of window rows.
+    """
+
+    @pytest.mark.asyncio
+    async def test_filter_pushed_into_inner_cross_join_when_column_not_in_output(
+        self,
+        client_with_build_v3,
+    ):
+        client = client_with_build_v3
+
+        # Dimension: time_window with (window_id PK, window_size)
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_time_window",
+                "columns": [
+                    {"name": "window_id", "type": "string"},
+                    {"name": "window_size", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "time_window",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.time_window_dim",
+                "query": "SELECT window_id, window_size FROM v3.src_time_window",
+                "mode": "published",
+                "primary_key": ["window_id"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Fact source
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_entity_facts",
+                "columns": [
+                    {"name": "entity_id", "type": "int"},
+                    {"name": "base_value", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "entity_facts",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Inner transform: CROSS JOINs time_window_dim and uses window_size
+        # for a MAX computation, but does NOT project window_id.
+        # This is the pattern that was broken: the primary rewrite fails
+        # (window_id absent from this node's output), so without the fix the
+        # second pass was skipped and the filter never reached the inner scope.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.entity_window_config",
+                "query": (
+                    "SELECT e.entity_id, "
+                    "MAX(e.base_value + w.window_size) AS max_bound "
+                    "FROM v3.src_entity_facts AS e "
+                    "CROSS JOIN v3.time_window_dim AS w "
+                    "GROUP BY e.entity_id"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Outer transform: projects window_id, which puts it into
+        # filter_column_aliases so the pushdown system recognises the filter.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.entity_report",
+                "query": (
+                    "SELECT c.entity_id, c.max_bound, w.window_id "
+                    "FROM v3.entity_window_config AS c "
+                    "CROSS JOIN v3.time_window_dim AS w"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.entity_count",
+                "query": "SELECT COUNT(entity_id) FROM v3.entity_report",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.entity_count"],
+                "filters": ["v3.time_window_dim.window_id IN ('7day')"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+
+        # The filter must appear inside entity_window_config's CTE —
+        # specifically in the inner CROSS JOIN scope where time_window_dim is
+        # scanned as a direct Table.  Without the fix the second pass was
+        # skipped when the primary rewrite failed, so this assertion would fail.
+        inner_cte_start = sql.find("v3_entity_window_config AS (")
+        assert inner_cte_start != -1, "entity_window_config CTE not found in SQL"
+        inner_cte = sql[inner_cte_start : sql.find("\n)", inner_cte_start) + 2]
+        assert "window_id" in inner_cte and "7day" in inner_cte, (
+            "Filter window_id IN ('7day') was not pushed into the inner "
+            "CROSS JOIN scope of entity_window_config — the second pass "
+            "did not fire when the primary rewrite failed."
+        )

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1042,6 +1042,19 @@ class TestFilterPushdownCrossJoinAggregatesColumnAway:
         )
         assert resp.status_code in (200, 201), resp.json()
 
+        # Link entity_report to the dimension so DJ can resolve the filter.
+        resp = await client.post(
+            "/nodes/v3.entity_report/link/",
+            json={
+                "dimension_node": "v3.time_window_dim",
+                "join_type": "left",
+                "join_on": (
+                    "v3.entity_report.window_id = v3.time_window_dim.window_id"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
         resp = await client.post(
             "/nodes/metric/",
             json={


### PR DESCRIPTION
### Summary

In `_resolve_pushdown_filters_for_cte`, when the primary rewrite failed (the filter column was absent from the CTE's declared output), the loop would continue, skipping the second pass entirely. The second pass was column-aware retargeting via `scope_column_aliases` and resolves a filter into a nested scope even when the outer CTE doesn't project the column. However, since it was gated on primary success, it never got a chance to run.

The pattern this missed: a transform that joins a dimension to compute a derived value but aggregates the dimension's key column away and never projects it.

The fix is to restructure the loop so the column-aware second pass always runs.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
