### PR TITLE
Fix cube materialization for cubes with derived metrics

### DIFF
--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -113,7 +113,11 @@ async def upsert_materialization(
             message=f"Cannot set materialization config for source node `{node_name}`!",
         )
     if node.type == NodeType.CUBE:  # type: ignore
-        node = await Node.get_cube_by_name(session, node_name)
+        node = await Node.get_cube_by_name(
+            session,
+            node_name,
+            with_metric_current=True,
+        )
     _logger.info(
         "Upserting materialization for node=%s version=%s",
         node.name,  # type: ignore

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -113,11 +113,7 @@ async def upsert_materialization(
             message=f"Cannot set materialization config for source node `{node_name}`!",
         )
     if node.type == NodeType.CUBE:  # type: ignore
-        node = await Node.get_cube_by_name(
-            session,
-            node_name,
-            with_metric_current=True,
-        )
+        node = await Node.get_cube_by_name(session, node_name)
     _logger.info(
         "Upserting materialization for node=%s version=%s",
         node.name,  # type: ignore

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -294,12 +294,9 @@ async def _v3_grain_group_to_measures_query(
             " ".join(str(info.derived_ast).split()),
         )
 
-    # ``gg.metrics`` only lists metrics whose aggregation happens inside this
-    # grain group. Derived metrics like ``aht = total_handle_secs / num_answered``
-    # are still part of the cube but are computed downstream from already-emitted
-    # components. Register them on the grain group that covers all of their
-    # components so ``build_cube_materialization`` can emit a CubeMetric entry
-    # for them.
+    # Derived metrics aren't in ``gg.metrics`` but are computed downstream
+    # from emitted components. Attach them to whichever grain group covers
+    # all their components.
     gg_component_names = {c.name for c in gg.components}
     for metric_name, info in decomposed_metrics.items():
         if metric_name in metrics:

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -294,6 +294,23 @@ async def _v3_grain_group_to_measures_query(
             " ".join(str(info.derived_ast).split()),
         )
 
+    # ``gg.metrics`` only lists metrics whose aggregation happens inside this
+    # grain group. Derived metrics like ``aht = total_handle_secs / num_answered``
+    # are still part of the cube but are computed downstream from already-emitted
+    # components. Register them on the grain group that covers all of their
+    # components so ``build_cube_materialization`` can emit a CubeMetric entry
+    # for them.
+    gg_component_names = {c.name for c in gg.components}
+    for metric_name, info in decomposed_metrics.items():
+        if metric_name in metrics:
+            continue
+        component_names = {c.name for c in info.components}
+        if component_names and component_names.issubset(gg_component_names):
+            metrics[metric_name] = (
+                info.components,
+                " ".join(str(info.derived_ast).split()),
+            )
+
     columns_raw = [_v3_col_to_model_column(c) for c in gg.columns]
     # For measure columns v3's semantic_name is "namespace.metric:component" which
     # gives the wrong node/column when split on ".". Normalize them to the v2 shape
@@ -471,6 +488,14 @@ async def build_cube_materialization(
         )
     ).all()
     metric_display_names = dict(display_name_rows)
+
+    missing_from_build = [m.name for m in cube_metrics if m.name not in metrics_mapping]
+    if missing_from_build:  # pragma: no cover
+        raise DJInvalidInputException(
+            f"Cube `{current_revision.name}` has metric(s) that the v3 "
+            f"measures-SQL builder did not return: {missing_from_build}. "
+            f"Built metrics: {sorted(metrics_mapping)}.",
+        )
     config = DruidCubeConfig(
         cube=NodeNameVersion(
             name=current_revision.name,

--- a/datajunction-server/tests/internal/cube_materializations_test.py
+++ b/datajunction-server/tests/internal/cube_materializations_test.py
@@ -109,13 +109,21 @@ def _make_ctx(nodes, parent_map):
     return ctx
 
 
-def _make_gg(parent_name, columns=None, grain=None, metrics=None, query=None):
+def _make_gg(
+    parent_name,
+    columns=None,
+    grain=None,
+    metrics=None,
+    query=None,
+    components=None,
+):
     gg = MagicMock(spec=GrainGroupSQL)
     gg.parent_name = parent_name
     gg.columns = columns or []
     gg.grain = grain or []
     gg.metrics = metrics or []
     gg.sql = query or "SELECT 1"
+    gg.components = components or []
     return gg
 
 

--- a/datajunction-server/tests/internal/cube_materializations_test.py
+++ b/datajunction-server/tests/internal/cube_materializations_test.py
@@ -333,3 +333,102 @@ class TestV3GrainGroupToMeasuresQuery:
             )
 
         assert result.upstream_tables == []
+
+    @pytest.mark.asyncio
+    async def test_derived_metric_registered_when_components_covered(self, session):
+        """
+        A derived metric (e.g. ``aht = total_handle_secs / num_answered``) is not
+        listed in ``gg.metrics`` but its components are present in ``gg.components``.
+        The adapter should register the derived metric on the grain group so the
+        materialization config can emit a ``CubeMetric`` for it.
+        """
+        fact_rev = MagicMock()
+        fact_rev.name = "cs.fact"
+        fact_rev.version = "v1.0"
+        fact_rev.display_name = "CS Fact"
+        fact_node = _make_node("cs.fact", NodeType.TRANSFORM, fact_rev)
+
+        ctx = _make_ctx(
+            nodes={"cs.fact": fact_node},
+            parent_map={"cs.fact": []},
+        )
+
+        comp_handle = SimpleNamespace(name="total_handle_secs")
+        comp_answered = SimpleNamespace(name="num_answered")
+
+        base_info = MagicMock()
+        base_info.components = [comp_answered]
+        base_info.derived_ast = "SELECT SUM(num_answered) FROM cs.fact"
+
+        derived_info = MagicMock()
+        derived_info.components = [comp_handle, comp_answered]
+        derived_info.derived_ast = (
+            "SELECT SUM(total_handle_secs) / SUM(num_answered) FROM cs.fact"
+        )
+
+        gg = _make_gg(
+            parent_name="cs.fact",
+            columns=[],
+            grain=[],
+            metrics=["cs.num_answered"],
+            components=[comp_handle, comp_answered],
+        )
+
+        with patch("datajunction_server.utils.refresh_if_needed", AsyncMock()):
+            result = await _v3_grain_group_to_measures_query(
+                session,
+                gg,
+                ctx,
+                decomposed_metrics={
+                    "cs.num_answered": base_info,
+                    "cs.aht": derived_info,
+                },
+            )
+
+        assert set(result.metrics) == {"cs.num_answered", "cs.aht"}
+        assert result.metrics["cs.aht"][0] == [comp_handle, comp_answered]
+        assert result.metrics["cs.aht"][1] == (
+            "SELECT SUM(total_handle_secs) / SUM(num_answered) FROM cs.fact"
+        )
+
+    @pytest.mark.asyncio
+    async def test_derived_metric_skipped_when_components_not_covered(self, session):
+        """
+        A derived metric whose components are NOT all in ``gg.components`` must
+        not be registered on this grain group — it belongs to a different one.
+        """
+        fact_rev = MagicMock()
+        fact_rev.name = "cs.fact"
+        fact_rev.version = "v1.0"
+        fact_rev.display_name = "CS Fact"
+        fact_node = _make_node("cs.fact", NodeType.TRANSFORM, fact_rev)
+
+        ctx = _make_ctx(
+            nodes={"cs.fact": fact_node},
+            parent_map={"cs.fact": []},
+        )
+
+        comp_a = SimpleNamespace(name="comp_a")
+        comp_b = SimpleNamespace(name="comp_b")
+
+        derived_info = MagicMock()
+        derived_info.components = [comp_a, comp_b]
+        derived_info.derived_ast = "SELECT comp_a / comp_b FROM cs.fact"
+
+        gg = _make_gg(
+            parent_name="cs.fact",
+            columns=[],
+            grain=[],
+            metrics=[],
+            components=[comp_a],
+        )
+
+        with patch("datajunction_server.utils.refresh_if_needed", AsyncMock()):
+            result = await _v3_grain_group_to_measures_query(
+                session,
+                gg,
+                ctx,
+                decomposed_metrics={"cs.derived": derived_info},
+            )
+
+        assert result.metrics == {}


### PR DESCRIPTION
### Summary

Cubes containing derived ratio metrics failed with `'NoneType' object is not subscriptable` because those metrics weren't being returned by the v3 measures-SQL builder.

The fix is to register derived metrics on their grain group. The v3 builder tracks derived metrics in `BuildContext.decomposed_metrics` but doesn't list them in any `GrainGroupSQL.metrics`. The v2-shape adapter
  `_v3_grain_group_to_measures_query` now also walks `decomposed_metrics` and registers any derived metric whose components are fully covered by this grain group's components, so downstream `build_cube_materialization` can emit a CubeMetric for it.

Also added a defensive error for missing-metric-mapping. If a cube metric isn't in the built `metrics_mapping`, raise a `descriptive` DJInvalidInputException naming the missing metric(s) instead of crashing with NoneType is not subscriptable deeper in the comprehension.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
