### PR TITLE
Fix filter pushdown for FK-linked columns not projected by the CTE

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1277,14 +1277,13 @@ def _resolve_pushdown_filters_for_cte(
                     results.append((enclosing_select, cloned))
                     alias_subst_scopes.add(id(enclosing_select))
 
-        # Second pass — column-aware retargeting into nested scopes.
-        # Runs regardless of primary success: a filter column may exist
-        # in a nested scope even when absent from the CTE's declared
-        # output (e.g. a transform that CROSS JOINs a dimension and
-        # aggregates its column away without projecting it).
+        # Second pass — column-aware retargeting.
+        # Runs regardless of primary success.  Includes target_select when
+        # primary failed: FK-linked source tables read at the top level (not
+        # in a nested subquery) only appear in the target_select scope map.
         for inner_select, col_to_alias in scope_column_aliases.items():
-            if inner_select is target_select:
-                continue
+            if inner_select is target_select and rewritten is not None:
+                continue  # primary already handled target_select
             if id(inner_select) in alias_subst_scopes:
                 continue
             if id(inner_select) in wrapped_setop_arms:

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1112,3 +1112,131 @@ class TestFilterPushdownCrossJoinAggregatesColumnAway:
             """,
             normalize_aliases=True,
         )
+
+
+class TestFilterPushdownViaSourceFKLinkAtTopLevel:
+    """
+    Regression: when a transform reads from a source whose FK dimension link
+    maps the filter column, and the transform does NOT project that column,
+    the filter must still be pushed into the transform's WHERE clause.
+
+    This mirrors the exp_alloc / allocation_snapshot_date pattern: the source
+    table has snapshot_utc_date as a FK to a snapshot dimension.  The transform
+    wraps the source without projecting snapshot_date, so the primary rewrite
+    fails.  The second pass previously skipped target_select entirely; the fix
+    allows it when primary failed, so the FK link found in the source's scope
+    map is used to inject the filter at the transform's top-level WHERE.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fk_filter_pushed_via_source_link_when_not_projected(
+        self,
+        client_with_build_v3,
+    ):
+        client = client_with_build_v3
+
+        # Source with a snapshot_date FK column (analogous to allocation_core_d)
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_snapped_events",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "value", "type": "double"},
+                    {"name": "report_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "snapped_events",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Snapshot dimension (analogous to allocation_snapshot_date)
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.snap_date_dim",
+                "query": "SELECT dateint FROM v3.src_snapped_events GROUP BY dateint",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Add FK link on the SOURCE node: report_date → snap_date_dim.dateint.
+        # This is the pattern: the source exposes the snapshot column as a FK
+        # so _populate_scope_column_aliases can find it when processing the
+        # transform's top-level FROM.
+        resp = await client.post(
+            "/nodes/v3.src_snapped_events/link/",
+            json={
+                "dimension_node": "v3.snap_date_dim",
+                "join_type": "left",
+                "join_on": "v3.src_snapped_events.report_date = v3.snap_date_dim.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Transform: reads from source but only projects account_id and total —
+        # report_date is NOT in the output.  Primary rewrite fails; the filter
+        # must reach the transform's WHERE via the second pass on target_select.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.event_summary",
+                "query": (
+                    "SELECT a.account_id, SUM(a.value) AS total "
+                    "FROM v3.src_snapped_events AS a "
+                    "GROUP BY a.account_id"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Also link the transform so the filter is recognised in filter_column_aliases
+        resp = await client.post(
+            "/nodes/v3.event_summary/link/",
+            json={
+                "dimension_node": "v3.snap_date_dim",
+                "join_type": "left",
+                "join_on": "v3.event_summary.report_date = v3.snap_date_dim.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.total_event_value",
+                "query": "SELECT SUM(total) FROM v3.event_summary",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_event_value"],
+                "filters": ["v3.snap_date_dim.dateint = 20240101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH v3_event_summary AS (
+              SELECT a.account_id,
+                SUM(a.value) AS total
+              FROM default.v3.snapped_events AS a
+              WHERE a.report_date = 20240101
+              GROUP BY a.account_id
+            )
+            SELECT SUM(t1.total) total_sum_HASH
+            FROM v3_event_summary t1
+            """,
+            normalize_aliases=True,
+        )

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1158,7 +1158,7 @@ class TestFilterPushdownViaSourceFKLinkAtTopLevel:
             "/nodes/dimension/",
             json={
                 "name": "v3.snap_date_dim",
-                "query": "SELECT dateint FROM v3.src_snapped_events GROUP BY dateint",
+                "query": "SELECT report_date AS dateint FROM v3.src_snapped_events GROUP BY report_date",
                 "mode": "published",
                 "primary_key": ["dateint"],
             },
@@ -1192,17 +1192,6 @@ class TestFilterPushdownViaSourceFKLinkAtTopLevel:
                     "GROUP BY a.account_id"
                 ),
                 "mode": "published",
-            },
-        )
-        assert resp.status_code in (200, 201), resp.json()
-
-        # Also link the transform so the filter is recognised in filter_column_aliases
-        resp = await client.post(
-            "/nodes/v3.event_summary/link/",
-            json={
-                "dimension_node": "v3.snap_date_dim",
-                "join_type": "left",
-                "join_on": "v3.event_summary.report_date = v3.snap_date_dim.dateint",
             },
         )
         assert resp.status_code in (200, 201), resp.json()


### PR DESCRIPTION
### Summary

When a transform reads from a source that has a FK dimension link, but doesn't project the FK column in its own output, dimension filters on that FK were silently dropped. The primary rewrite failed (column absent from declared output), and the second pass always skipped `target_select`, which is the only scope where top-level source tables appear.

The fix is to include `target_select` in the second pass when the primary rewrite failed. The FK link registered on the source node is then found in the `target_select` scope map, allowing `_rewrite_filter_for_scope` to inject the filter directly into the CTE's WHERE clause.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
