### PR TITLE
Fix pushdown targets

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -450,7 +450,7 @@ def _resolve_pushdown_targets(
             or not child.current
             or not child.current.query
         ):
-            continue
+            continue  # pragma: no cover
         try:
             child_query = ctx.get_parsed_query(child)
         except Exception:  # pragma: no cover
@@ -478,7 +478,7 @@ def _resolve_pushdown_targets(
                 continue  # pragma: no cover
             matches.append((alias, containing_select))
         if not matches:
-            continue
+            continue  # pragma: no cover
         # Optimization: a single match in the top-level Select of a
         # non-set-op body can reuse the normal CTE-WHERE injection path
         # (it targets that same Select).

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -441,7 +441,8 @@ def _resolve_pushdown_targets(
     """
     if linked_node.type != NodeType.SOURCE:
         return [(linked_node.name, None, None)]
-    for child_name in children_of(linked_node.name):  # pragma: no branch
+    all_targets: list[tuple[str, Optional[str], Optional["ast.Select"]]] = []
+    for child_name in children_of(linked_node.name):
         child = ctx.nodes.get(child_name)
         if (
             child is None
@@ -449,7 +450,7 @@ def _resolve_pushdown_targets(
             or not child.current
             or not child.current.query
         ):
-            continue  # pragma: no cover
+            continue
         try:
             child_query = ctx.get_parsed_query(child)
         except Exception:  # pragma: no cover
@@ -462,7 +463,7 @@ def _resolve_pushdown_targets(
         # match so a self-join (two refs to the same source) produces
         # two filter injections, one per alias.
         matches: list[tuple[str, "ast.Select"]] = []
-        for tbl in child_query.find_all(ast.Table):  # pragma: no branch
+        for tbl in child_query.find_all(ast.Table):
             try:
                 tbl_name = tbl.name.identifier(quotes=False)
             except Exception:  # pragma: no cover
@@ -477,16 +478,17 @@ def _resolve_pushdown_targets(
                 continue  # pragma: no cover
             matches.append((alias, containing_select))
         if not matches:
-            continue  # pragma: no cover
+            continue
         # Optimization: a single match in the top-level Select of a
         # non-set-op body can reuse the normal CTE-WHERE injection path
         # (it targets that same Select).
         if len(matches) == 1:
             alias, sel = matches[0]
             if sel is top_select and top_select.set_op is None:
-                return [(child.name, alias, None)]
-        return [(child.name, alias, sel) for alias, sel in matches]
-    return []  # pragma: no cover
+                all_targets.append((child.name, alias, None))
+                continue
+        all_targets.extend((child.name, alias, sel) for alias, sel in matches)
+    return all_targets
 
 
 def _enclosing_select(node: ast.Node) -> Optional["ast.Select"]:

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1231,6 +1231,131 @@ class TestFilterPushdownViaSourceFKLinkAtTopLevel:
         )
 
 
+class TestFilterPushdownToMultipleSiblingTransforms:
+    """Regression: when a source node with an FK dimension link has multiple
+    child transforms, the snapshot filter must be pushed into ALL of them.
+
+    Previously _resolve_pushdown_targets returned early after the first
+    matching child, so only whichever sibling happened to be processed first
+    received the filter; the others were silently skipped.  This mirrors the
+    exp_alloc / payments_member pattern where both transforms read
+    allocation_core_d but only one was getting the snapshot_utc_date pin.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fk_filter_pushed_to_all_sibling_transforms(
+        self,
+        client_with_build_v3,
+    ):
+        client = client_with_build_v3
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_multi_child",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                    {"name": "snap_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "multi_child_src",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.snap_dim",
+                "query": "SELECT snap_date AS dateint FROM v3.src_multi_child GROUP BY snap_date",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/v3.src_multi_child/link/",
+            json={
+                "dimension_node": "v3.snap_dim",
+                "join_type": "left",
+                "join_on": "v3.src_multi_child.snap_date = v3.snap_dim.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Two sibling transforms — neither projects snap_date.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.child_a",
+                "query": (
+                    "SELECT a.account_id, SUM(a.amount) AS total_a "
+                    "FROM v3.src_multi_child AS a "
+                    "GROUP BY a.account_id"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.child_b",
+                "query": (
+                    "SELECT b.account_id, SUM(b.amount) AS total_b "
+                    "FROM v3.src_multi_child AS b "
+                    "GROUP BY b.account_id"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.metric_a",
+                "query": "SELECT SUM(total_a) FROM v3.child_a",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.metric_b",
+                "query": "SELECT SUM(total_b) FROM v3.child_b",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.metric_a", "v3.metric_b"],
+                "filters": ["v3.snap_dim.dateint = 20240101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        # Each metric may land in its own grain group; collect all SQL.
+        all_sql = " ".join(gg["sql"] for gg in response.json().get("grain_groups", []))
+        # Both sibling transforms must have the snapshot filter injected.
+        assert "a.snap_date = 20240101" in all_sql, (
+            "snapshot filter missing from v3_child_a CTE"
+        )
+        assert "b.snap_date = 20240101" in all_sql, (
+            "snapshot filter missing from v3_child_b CTE — "
+            "upstream pushdown stopped at the first sibling"
+        )
+
+
 class TestDimLabelFilterNameCollision:
     """Regression: a filter on a lookup dimension's *label* attribute whose
     name collides with an upstream transform's foreign-key column must NOT be

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1232,15 +1232,12 @@ class TestFilterPushdownViaSourceFKLinkAtTopLevel:
 
 
 class TestFilterPushdownToMultipleSiblingTransforms:
-    """Regression: when a source node with an FK dimension link has multiple
-    child transforms, the snapshot filter must be pushed into ALL of them.
+    """Regression: FK dimension filter must reach all sibling transforms that
+    read the same source, not just the first one found.
 
-    Previously _resolve_pushdown_targets returned early after the first
-    matching child, so only whichever sibling happened to be processed first
-    received the filter; the others were silently skipped.  This mirrors the
-    exp_alloc / payments_member pattern where both transforms read
-    allocation_core_d but only one was getting the snapshot_utc_date pin.
-    """
+    Both sibling transforms are upstream of the same metric so they land in
+    the same grain group — exactly mirroring the prod pattern where multiple
+    transforms read from the same snapshot source table."""
 
     @pytest.mark.asyncio
     async def test_fk_filter_pushed_to_all_sibling_transforms(
@@ -1287,7 +1284,7 @@ class TestFilterPushdownToMultipleSiblingTransforms:
         )
         assert resp.status_code in (200, 201), resp.json()
 
-        # Two sibling transforms — neither projects snap_date.
+        # Two sibling transforms reading from the same source — neither projects snap_date.
         resp = await client.post(
             "/nodes/transform/",
             json={
@@ -1316,11 +1313,17 @@ class TestFilterPushdownToMultipleSiblingTransforms:
         )
         assert resp.status_code in (200, 201), resp.json()
 
+        # A single parent transform that joins both siblings — this makes both
+        # sibling CTEs appear in the same grain group, matching the prod pattern.
         resp = await client.post(
-            "/nodes/metric/",
+            "/nodes/transform/",
             json={
-                "name": "v3.metric_a",
-                "query": "SELECT SUM(total_a) FROM v3.child_a",
+                "name": "v3.combined",
+                "query": (
+                    "SELECT a.account_id, a.total_a, b.total_b "
+                    "FROM v3.child_a AS a "
+                    "JOIN v3.child_b AS b ON a.account_id = b.account_id"
+                ),
                 "mode": "published",
             },
         )
@@ -1329,8 +1332,8 @@ class TestFilterPushdownToMultipleSiblingTransforms:
         resp = await client.post(
             "/nodes/metric/",
             json={
-                "name": "v3.metric_b",
-                "query": "SELECT SUM(total_b) FROM v3.child_b",
+                "name": "v3.combined_total",
+                "query": "SELECT SUM(total_a + total_b) FROM v3.combined",
                 "mode": "published",
             },
         )
@@ -1339,20 +1342,35 @@ class TestFilterPushdownToMultipleSiblingTransforms:
         response = await client.get(
             "/sql/measures/v3/",
             params={
-                "metrics": ["v3.metric_a", "v3.metric_b"],
+                "metrics": ["v3.combined_total"],
                 "filters": ["v3.snap_dim.dateint = 20240101"],
             },
         )
         assert response.status_code == 200, response.json()
-        # Each metric may land in its own grain group; collect all SQL.
-        all_sql = " ".join(gg["sql"] for gg in response.json().get("grain_groups", []))
-        # Both sibling transforms must have the snapshot filter injected.
-        assert "a.snap_date = 20240101" in all_sql, (
-            "snapshot filter missing from v3_child_a CTE"
-        )
-        assert "b.snap_date = 20240101" in all_sql, (
-            "snapshot filter missing from v3_child_b CTE — "
-            "upstream pushdown stopped at the first sibling"
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH v3_child_a AS (
+              SELECT a.account_id, SUM(a.amount) AS total_a
+              FROM default.v3.multi_child_src AS a
+              WHERE a.snap_date = 20240101
+              GROUP BY a.account_id
+            ),
+            v3_child_b AS (
+              SELECT b.account_id, SUM(b.amount) AS total_b
+              FROM default.v3.multi_child_src AS b
+              WHERE b.snap_date = 20240101
+              GROUP BY b.account_id
+            ),
+            v3_combined AS (
+              SELECT a.total_a, b.total_b
+              FROM v3_child_a AS a
+              JOIN v3_child_b AS b ON a.account_id = b.account_id
+            )
+            SELECT SUM(t1.total_a + t1.total_b) total_a_total_b_sum_HASH
+            FROM v3_combined t1
+            """,
+            normalize_aliases=True,
         )
 
 


### PR DESCRIPTION
### Summary

Fixed a filter pushdown bug where a snapshot dimension filter was only reaching the first sibling transform that reads from a shared source node.

### Test Plan

Added a regression test `TestFilterPushdownToMultipleSiblingTransforms`

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
