### PR TITLE
Add accessible tooltip and unify namespace toolbar actions

### DIFF
--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -1,5 +1,15 @@
 import { useContext, useEffect, useState, useRef } from 'react';
 import DJClientContext from '../providers/djclient';
+import Tooltip from './Tooltip';
+import {
+  secondaryButtonStyle as buttonStyle,
+  primaryButtonStyle,
+  dangerButtonStyle,
+  onSecondaryHover,
+  onSecondaryOut,
+  onDangerHover,
+  onDangerOut,
+} from './buttonStyles';
 import {
   GitSettingsModal,
   CreateBranchModal,
@@ -238,33 +248,6 @@ export default function NamespaceHeader({
       namespace,
       deleteGitBranch,
     );
-  };
-
-  // Button style helpers. React warns if a rerender swaps `border` shorthand
-  // for `borderColor` longhand on the same element, so we keep all three
-  // border properties in longhand form here.
-  const buttonStyle = {
-    height: '28px',
-    padding: '0 10px',
-    fontSize: '12px',
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: '#e2e8f0',
-    borderRadius: '4px',
-    backgroundColor: '#ffffff',
-    color: '#475569',
-    cursor: 'pointer',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '4px',
-    whiteSpace: 'nowrap',
-  };
-
-  const primaryButtonStyle = {
-    ...buttonStyle,
-    backgroundColor: '#3b82f6',
-    borderColor: '#3b82f6',
-    color: '#ffffff',
   };
 
   return (
@@ -882,7 +865,8 @@ export default function NamespaceHeader({
               <button
                 style={buttonStyle}
                 onClick={() => setShowGitSettings(true)}
-                title="Git Settings"
+                onMouseOver={onSecondaryHover}
+                onMouseOut={onSecondaryOut}
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -933,7 +917,8 @@ export default function NamespaceHeader({
               <button
                 style={buttonStyle}
                 onClick={() => setShowGitSettings(true)}
-                title="Git Settings"
+                onMouseOver={onSecondaryHover}
+                onMouseOut={onSecondaryOut}
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -958,6 +943,8 @@ export default function NamespaceHeader({
                   <button
                     style={buttonStyle}
                     onClick={() => setShowSyncToGit(true)}
+                    onMouseOver={onSecondaryHover}
+                    onMouseOut={onSecondaryOut}
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -1055,31 +1042,31 @@ export default function NamespaceHeader({
                   )}
 
                   {/* Delete Branch - only for editable branches */}
-                  <button
-                    style={{
-                      ...buttonStyle,
-                      color: '#dc2626',
-                      borderColor: '#fecaca',
-                    }}
-                    onClick={() => setShowDeleteBranch(true)}
-                    title="Delete Branch"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="14"
-                      height="14"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
+                  <Tooltip content="Delete this branch">
+                    <button
+                      style={dangerButtonStyle}
+                      onClick={() => setShowDeleteBranch(true)}
+                      onMouseOver={onDangerHover}
+                      onMouseOut={onDangerOut}
+                      aria-label="Delete branch"
                     >
-                      <path d="M3 6h18" />
-                      <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-                      <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-                    </svg>
-                  </button>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M3 6h18" />
+                        <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                      </svg>
+                    </button>
+                  </Tooltip>
                 </>
               )}
             </>

--- a/datajunction-ui/src/app/components/Tooltip.jsx
+++ b/datajunction-ui/src/app/components/Tooltip.jsx
@@ -51,7 +51,6 @@ export default function Tooltip({
           }}
         >
           {content}
-          {/* Caret sits on the edge nearest the trigger. */}
           <span
             style={{
               position: 'absolute',

--- a/datajunction-ui/src/app/components/Tooltip.jsx
+++ b/datajunction-ui/src/app/components/Tooltip.jsx
@@ -1,0 +1,85 @@
+import { useId, useState } from 'react';
+
+/**
+ * Lightweight, accessible tooltip.
+ *
+ * Unlike the native `title` attribute (slow to appear, unstyled, and invisible
+ * to keyboard/touch users), this shows quickly on hover *and* keyboard focus,
+ * is announced to assistive tech via `aria-describedby`, and can be styled.
+ *
+ * Usage:
+ *   <Tooltip content="Download all nodes as YAML">
+ *     <button>…</button>
+ *   </Tooltip>
+ */
+export default function Tooltip({
+  content,
+  placement = 'bottom',
+  children,
+  maxWidth = 240,
+}) {
+  const [visible, setVisible] = useState(false);
+  const tooltipId = useId();
+
+  if (!content) return children;
+
+  const show = () => setVisible(true);
+  const hide = () => setVisible(false);
+
+  const isTop = placement === 'top';
+
+  return (
+    <span
+      style={{ position: 'relative', display: 'inline-flex' }}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {/* Link the trigger to the tooltip for screen readers */}
+      <span aria-describedby={visible ? tooltipId : undefined}>{children}</span>
+      {visible && (
+        <span
+          role="tooltip"
+          id={tooltipId}
+          style={{
+            position: 'absolute',
+            [isTop ? 'bottom' : 'top']: 'calc(100% + 6px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            backgroundColor: '#1e293b',
+            color: '#ffffff',
+            fontSize: '12px',
+            lineHeight: 1.4,
+            fontWeight: 400,
+            padding: '6px 10px',
+            borderRadius: '6px',
+            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.18)',
+            maxWidth: `${maxWidth}px`,
+            width: 'max-content',
+            textAlign: 'center',
+            whiteSpace: 'normal',
+            zIndex: 2000,
+            pointerEvents: 'none',
+          }}
+        >
+          {content}
+          {/* Caret pointing back at the trigger. When the tooltip is below
+              the trigger (placement="bottom"), the caret sits on its top edge;
+              when above, on its bottom edge. */}
+          <span
+            style={{
+              position: 'absolute',
+              [isTop ? 'bottom' : 'top']: '-4px',
+              left: '50%',
+              transform: 'translateX(-50%) rotate(45deg)',
+              width: '8px',
+              height: '8px',
+              backgroundColor: '#1e293b',
+            }}
+          />
+        </span>
+      )}
+    </span>
+  );
+}

--- a/datajunction-ui/src/app/components/Tooltip.jsx
+++ b/datajunction-ui/src/app/components/Tooltip.jsx
@@ -1,17 +1,5 @@
 import { useId, useState } from 'react';
 
-/**
- * Lightweight, accessible tooltip.
- *
- * Unlike the native `title` attribute (slow to appear, unstyled, and invisible
- * to keyboard/touch users), this shows quickly on hover *and* keyboard focus,
- * is announced to assistive tech via `aria-describedby`, and can be styled.
- *
- * Usage:
- *   <Tooltip content="Download all nodes as YAML">
- *     <button>…</button>
- *   </Tooltip>
- */
 export default function Tooltip({
   content,
   placement = 'bottom',
@@ -36,7 +24,6 @@ export default function Tooltip({
       onFocus={show}
       onBlur={hide}
     >
-      {/* Link the trigger to the tooltip for screen readers */}
       <span aria-describedby={visible ? tooltipId : undefined}>{children}</span>
       {visible && (
         <span
@@ -64,9 +51,7 @@ export default function Tooltip({
           }}
         >
           {content}
-          {/* Caret pointing back at the trigger. When the tooltip is below
-              the trigger (placement="bottom"), the caret sits on its top edge;
-              when above, on its bottom edge. */}
+          {/* Caret sits on the edge nearest the trigger. */}
           <span
             style={{
               position: 'absolute',

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -612,8 +612,9 @@ describe('<NamespaceHeader />', () => {
     await waitFor(() => {
       expect(screen.getByText('Create PR')).toBeInTheDocument();
     });
-    // Delete Branch button only has an icon with title attribute
-    expect(screen.getByTitle('Delete Branch')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete branch' }),
+    ).toBeInTheDocument();
   });
 
   it('should open Create Branch modal when button is clicked', async () => {
@@ -1051,18 +1052,18 @@ describe('<NamespaceHeader />', () => {
     );
 
     await waitFor(() => {
-      // Delete Branch button in header only has icon with title attribute
-      expect(screen.getByTitle('Delete Branch')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Delete branch' }),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTitle('Delete Branch'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete branch' }));
 
     await waitFor(() => {
       expect(screen.getByRole('checkbox')).toBeInTheDocument();
     });
 
-    // There are two buttons with "Delete Branch" - header icon and modal button
-    // Get all and click the last one (modal's submit button)
+    // The modal's submit button is named "Delete Branch"; click it.
     const deleteBranchButtons = screen.getAllByRole('button', {
       name: 'Delete Branch',
     });

--- a/datajunction-ui/src/app/components/buttonStyles.js
+++ b/datajunction-ui/src/app/components/buttonStyles.js
@@ -1,0 +1,67 @@
+/**
+ * Shared styling for the namespace toolbar action buttons.
+ *
+ * Centralizing these keeps the header's actions (Git Settings, Sync to Git,
+ * Create PR, Export YAML, …) visually parallel so the toolbar reads as a set of
+ * peer actions rather than a grab-bag of one-off buttons.
+ *
+ * Border properties are kept in longhand form on purpose: React warns when a
+ * rerender swaps the `border` shorthand for a `borderColor` longhand (or vice
+ * versa) on the same element, which happens once we mutate colors on hover.
+ */
+
+export const secondaryButtonStyle = {
+  height: '28px',
+  padding: '0 10px',
+  fontSize: '12px',
+  fontWeight: '500',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: '#e2e8f0',
+  borderRadius: '4px',
+  backgroundColor: '#ffffff',
+  color: '#475569',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  whiteSpace: 'nowrap',
+  transition: 'all 0.15s ease',
+};
+
+export const primaryButtonStyle = {
+  ...secondaryButtonStyle,
+  backgroundColor: '#3b82f6',
+  borderColor: '#3b82f6',
+  color: '#ffffff',
+};
+
+export const dangerButtonStyle = {
+  ...secondaryButtonStyle,
+  color: '#dc2626',
+  borderColor: '#fecaca',
+};
+
+/** Hover in/out handlers for the white "secondary" buttons. */
+export const onSecondaryHover = e => {
+  e.currentTarget.style.color = '#1e293b';
+  e.currentTarget.style.borderColor = '#cbd5e1';
+  e.currentTarget.style.backgroundColor = '#f8fafc';
+};
+
+export const onSecondaryOut = e => {
+  e.currentTarget.style.color = '#475569';
+  e.currentTarget.style.borderColor = '#e2e8f0';
+  e.currentTarget.style.backgroundColor = '#ffffff';
+};
+
+/** Hover in/out handlers for the red "danger" button (Delete Branch). */
+export const onDangerHover = e => {
+  e.currentTarget.style.backgroundColor = '#fef2f2';
+  e.currentTarget.style.borderColor = '#fca5a5';
+};
+
+export const onDangerOut = e => {
+  e.currentTarget.style.backgroundColor = '#ffffff';
+  e.currentTarget.style.borderColor = '#fecaca';
+};

--- a/datajunction-ui/src/app/components/buttonStyles.js
+++ b/datajunction-ui/src/app/components/buttonStyles.js
@@ -1,14 +1,5 @@
-/**
- * Shared styling for the namespace toolbar action buttons.
- *
- * Centralizing these keeps the header's actions (Git Settings, Sync to Git,
- * Create PR, Export YAML, …) visually parallel so the toolbar reads as a set of
- * peer actions rather than a grab-bag of one-off buttons.
- *
- * Border properties are kept in longhand form on purpose: React warns when a
- * rerender swaps the `border` shorthand for a `borderColor` longhand (or vice
- * versa) on the same element, which happens once we mutate colors on hover.
- */
+// Border props stay longhand: swapping the `border` shorthand for `borderColor`
+// on rerender (as the hover handlers do) triggers a React warning.
 
 export const secondaryButtonStyle = {
   height: '28px',
@@ -42,7 +33,6 @@ export const dangerButtonStyle = {
   borderColor: '#fecaca',
 };
 
-/** Hover in/out handlers for the white "secondary" buttons. */
 export const onSecondaryHover = e => {
   e.currentTarget.style.color = '#1e293b';
   e.currentTarget.style.borderColor = '#cbd5e1';
@@ -55,7 +45,6 @@ export const onSecondaryOut = e => {
   e.currentTarget.style.backgroundColor = '#ffffff';
 };
 
-/** Hover in/out handlers for the red "danger" button (Delete Branch). */
 export const onDangerHover = e => {
   e.currentTarget.style.backgroundColor = '#fef2f2';
   e.currentTarget.style.borderColor = '#fca5a5';

--- a/datajunction-ui/src/app/components/buttonStyles.js
+++ b/datajunction-ui/src/app/components/buttonStyles.js
@@ -1,6 +1,3 @@
-// Border props stay longhand: swapping the `border` shorthand for `borderColor`
-// on rerender (as the hover handlers do) triggers a React warning.
-
 export const secondaryButtonStyle = {
   height: '28px',
   padding: '0 10px',

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -8,6 +8,12 @@ import Explorer from '../NamespacePage/Explorer';
 import AddNodeDropdown from '../../components/AddNodeDropdown';
 import NodeListActions from '../../components/NodeListActions';
 import NamespaceHeader from '../../components/NamespaceHeader';
+import Tooltip from '../../components/Tooltip';
+import {
+  secondaryButtonStyle,
+  onSecondaryHover,
+  onSecondaryOut,
+} from '../../components/buttonStyles';
 import LoadingIcon from '../../icons/LoadingIcon';
 import CompactSelect from './CompactSelect';
 import { NodeBadge, NodeLink } from '../../components/NodeComponents';
@@ -1145,65 +1151,54 @@ export function NamespacePage() {
                 namespace={namespace}
                 onGitConfigLoaded={setGitConfig}
               >
-                <button
-                  type="button"
-                  onClick={async () => {
-                    const response = await fetch(
-                      `${getDJUrl()}/namespaces/${namespace}/export/yaml`,
-                      { method: 'POST', credentials: 'include' },
-                    );
-                    if (!response.ok) {
-                      return;
-                    }
-                    const blob = await response.blob();
-                    const url = URL.createObjectURL(blob);
-                    const link = document.createElement('a');
-                    const safeName = namespace.replace(/\./g, '_');
-                    link.href = url;
-                    link.download = `${safeName}_export.zip`;
-                    document.body.appendChild(link);
-                    link.click();
-                    document.body.removeChild(link);
-                    URL.revokeObjectURL(url);
-                  }}
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: '4px',
-                    fontSize: '13px',
-                    fontWeight: '500',
-                    color: '#475569',
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    borderRadius: '6px',
-                    cursor: 'pointer',
-                    transition: 'all 0.15s ease',
-                    margin: '0.5em 0px 0px 1em',
-                  }}
-                  onMouseOver={e => {
-                    e.currentTarget.style.color = '#333333';
-                  }}
-                  onMouseOut={e => {
-                    e.currentTarget.style.color = '#475569';
-                  }}
-                  title="Export namespace to YAML"
-                >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+                {namespace && (
+                  <Tooltip
+                    content={`Download every node in "${namespace}" as a YAML project (.zip) you can version in git and re-deploy with the DJ client.`}
                   >
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                    <polyline points="7 10 12 15 17 10"></polyline>
-                    <line x1="12" y1="15" x2="12" y2="3"></line>
-                  </svg>
-                </button>
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        const response = await fetch(
+                          `${getDJUrl()}/namespaces/${namespace}/export/yaml`,
+                          { method: 'POST', credentials: 'include' },
+                        );
+                        if (!response.ok) {
+                          return;
+                        }
+                        const blob = await response.blob();
+                        const url = URL.createObjectURL(blob);
+                        const link = document.createElement('a');
+                        const safeName = namespace.replace(/\./g, '_');
+                        link.href = url;
+                        link.download = `${safeName}_export.zip`;
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                        URL.revokeObjectURL(url);
+                      }}
+                      style={secondaryButtonStyle}
+                      onMouseOver={onSecondaryHover}
+                      onMouseOut={onSecondaryOut}
+                      aria-label="Export namespace to YAML"
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                        <polyline points="7 10 12 15 17 10"></polyline>
+                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                      </svg>
+                      Export YAML
+                    </button>
+                  </Tooltip>
+                )}
                 {showEditControls && <AddNodeDropdown namespace={namespace} />}
               </NamespaceHeader>
 


### PR DESCRIPTION
Replaces the icon-only namespace export control with a labeled "Export YAML" button and a reusable, accessible Tooltip component. The tooltip appears on hover and keyboard focus and uses aria-describedby instead of relying on the native title attribute.

Shared toolbar button styles are extracted into buttonStyles.js so the export, git, and add node actions render consistently. The export button is hidden when no namespace is selected.

Before:
<img width="678" height="166" alt="before" src="https://github.com/user-attachments/assets/986efe59-1525-4910-8346-1482a98606ef" />


After:
<img width="850" height="288" alt="after" src="https://github.com/user-attachments/assets/18d739eb-0120-4d84-85a4-85a87b6d3f7c" />

