### PR TITLE
Enforce EXECUTE permission on data-running endpoints

### DIFF
--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -63,6 +63,25 @@ settings = get_settings()
 router = SecureAPIRouter(tags=["data"])
 
 
+async def enforce_execute(
+    access_checker: AccessChecker,
+    node_names: List[str],
+) -> None:
+    """
+    Require EXECUTE on every node a query is being run against.
+
+    EXECUTE implies READ in the permission hierarchy, so this also covers the
+    cache-hit path where SQL is not rebuilt and the build-time READ checks would
+    otherwise be skipped.
+    """
+    for node_name in node_names:
+        access_checker.add_request_by_node_name(
+            node_name,
+            access.ResourceAction.EXECUTE,
+        )
+    await access_checker.check(on_denied=AccessDenialMode.RAISE)
+
+
 @router.post("/data/{node_name}/availability/", name="Add Availability State to Node")
 async def add_availability_state(
     node_name: str,
@@ -281,10 +300,13 @@ async def get_data(
     engine_version: Optional[str] = None,
     background_tasks: BackgroundTasks,
     cache: Cache = Depends(get_cache),
+    access_checker: AccessChecker = Depends(get_access_checker),
 ) -> QueryWithResults:
     """
     Gets data for a node
     """
+    await enforce_execute(access_checker, [node_name])
+
     request_headers = dict(request.headers)
     query_cache_manager = QueryCacheManager(
         cache=cache,
@@ -356,10 +378,13 @@ async def get_data_stream_for_node(
     engine_version: Optional[str] = None,
     background_tasks: BackgroundTasks,
     cache: Cache = Depends(get_cache),
+    access_checker: AccessChecker = Depends(get_access_checker),
 ) -> QueryWithResults:
     """
     Return data for a node using server side events
     """
+    await enforce_execute(access_checker, [node_name])
+
     request_headers = dict(request.headers)
     node = cast(
         Node,
@@ -461,6 +486,7 @@ async def get_data_for_metrics(
     query_service_client: QueryServiceClient = Depends(get_query_service_client),
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
+    access_checker: AccessChecker = Depends(get_access_checker),
 ) -> QueryWithResults:
     """
     Return data for a set of metrics with dimensions and filters.
@@ -470,6 +496,8 @@ async def get_data_for_metrics(
     - Cube matching for materialized tables
     - Grain group joins for metrics from different facts
     """
+    await enforce_execute(access_checker, metrics)
+
     request_headers = dict(request.headers)
 
     # Resolve dialect and engine in a single lookup (avoids duplicate cube matching).
@@ -545,6 +573,7 @@ async def get_data_stream_for_metrics(
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
     current_user: User = Depends(get_current_user),
+    access_checker: AccessChecker = Depends(get_access_checker),
 ) -> QueryWithResults:
     """
     Return data for a set of metrics with dimensions and filters using server sent events.
@@ -554,6 +583,8 @@ async def get_data_stream_for_metrics(
     - Cube matching for materialized tables
     - Grain group joins for metrics from different facts
     """
+    await enforce_execute(access_checker, metrics)
+
     request_headers = dict(request.headers)
 
     # Resolve dialect and engine in a single lookup (avoids duplicate cube matching)

--- a/datajunction-server/tests/api/access_test.py
+++ b/datajunction-server/tests/api/access_test.py
@@ -47,6 +47,26 @@ class NamespaceOnlyAuthorizationService(AuthorizationService):
         return decisions
 
 
+class ExecuteDenyingAuthorizationService(AuthorizationService):
+    """
+    Authorization service that approves everything except EXECUTE.
+
+    Models a read-only user: they can view metadata but cannot run queries.
+    """
+
+    name = "deny_execute"
+
+    def authorize(self, auth_context, requests):
+        return [
+            access.AccessDecision(
+                request=request,
+                approved=request.access_object
+                and request.verb != access.ResourceAction.EXECUTE,
+            )
+            for request in requests
+        ]
+
+
 class PartialNodeAuthorizationService(AuthorizationService):
     """
     Authorization service that allows access to specific namespaces and nodes.
@@ -139,6 +159,56 @@ class TestDataAccessControl:
         assert "Access denied to" in data["message"]
         assert "foo.bar" in data["message"]
         assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+class TestExecuteAccessControl:
+    """
+    Test that running queries requires the EXECUTE action.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_node_data_requires_execute(
+        self,
+        module__client_with_examples: AsyncClient,
+        mocker,
+    ) -> None:
+        """A read-only user (no EXECUTE) cannot run node data queries."""
+
+        def get_deny_execute_service():
+            return ExecuteDenyingAuthorizationService()
+
+        mocker.patch(
+            "datajunction_server.internal.access.authorization.validator.get_authorization_service",
+            get_deny_execute_service,
+        )
+        response = await module__client_with_examples.get("/data/basic.num_comments/")
+        data = response.json()
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert "Access denied" in data["message"]
+        assert "basic.num_comments" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_data_requires_execute(
+        self,
+        module__client_with_examples: AsyncClient,
+        mocker,
+    ) -> None:
+        """A read-only user (no EXECUTE) cannot run metrics data queries."""
+
+        def get_deny_execute_service():
+            return ExecuteDenyingAuthorizationService()
+
+        mocker.patch(
+            "datajunction_server.internal.access.authorization.validator.get_authorization_service",
+            get_deny_execute_service,
+        )
+        response = await module__client_with_examples.get(
+            "/data/",
+            params={"metrics": ["basic.num_comments"]},
+        )
+        data = response.json()
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert "Access denied" in data["message"]
 
 
 class TestNamespaceAccessControl:


### PR DESCRIPTION
Tracking: #2234 (step 10, optional, of the RBAC enablement sequence).

`EXECUTE` is part of the RBAC permission hierarchy but was never checked anywhere, so running queries was gated only by build-time `READ` checks (and not at all on cache hits). This adds explicit `EXECUTE` enforcement on the query-running endpoints.

- **Node data:** `GET /data/{node}/` and `GET /stream/{node}` require `EXECUTE` on the node.
- **Metrics data:** `GET /data/` and `GET /stream/` require `EXECUTE` on each requested metric.
- Because `EXECUTE` implies `READ` in the hierarchy, this also closes the cache-hit gap where SQL isn't rebuilt and the build-time `READ` check would be skipped.

Note: this is an **independent, optional gate**. In deployments where the underlying query engine already enforces data access, a DJ-level `EXECUTE` gate is a redundant second plane and can be left permissive. Semantics: a read-only user can view metadata/SQL but cannot run queries. No-op under the default `permissive` policy, so nothing breaks today.