### PR TITLE
Add ability to filter namespace list by git backing

### DIFF
--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -153,6 +153,14 @@ async def create_node_namespace(
     status_code=200,
 )
 async def list_namespaces(
+    git_backed: Optional[bool] = Query(
+        default=None,
+        description=(
+            "Filter to namespaces by git backing. ``true`` returns only "
+            "namespaces with a ``github_repo_path`` set, ``false`` returns "
+            "only those without, omitted returns all."
+        ),
+    ),
     session: AsyncSession = Depends(get_session),
     access_checker: AccessChecker = Depends(get_access_checker),
 ) -> List[NamespaceOutput]:
@@ -166,6 +174,10 @@ async def list_namespaces(
         .where(NodeNamespace.deactivated_at.is_(None))
         .group_by(NodeNamespace.namespace)
     )
+    if git_backed is True:
+        statement = statement.where(NodeNamespace.github_repo_path.is_not(None))
+    elif git_backed is False:
+        statement = statement.where(NodeNamespace.github_repo_path.is_(None))
 
     result = await session.execute(statement)
     results = result.all()
@@ -180,6 +192,8 @@ async def list_namespaces(
         NamespaceOutput(
             namespace=ns.namespace,
             num_nodes=num_nodes or 0,
+            github_repo_path=ns.github_repo_path,
+            git_branch=ns.git_branch,
         )
         for ns, num_nodes in results
         if ns.namespace in approved_namespaces

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -1172,11 +1172,14 @@ LineageColumn.model_rebuild()
 
 class NamespaceOutput(BaseModel):
     """
-    Output for a namespace that includes the number of nodes.
+    Output for a namespace that includes the number of nodes and (when set)
+    its git repository configuration.
     """
 
     namespace: str
     num_nodes: int
+    github_repo_path: Optional[str] = None
+    git_branch: Optional[str] = None
 
 
 class BranchNamespaceOutput(BaseModel):

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -67,24 +67,150 @@ async def test_list_all_namespaces(
     response = await module__client_with_all_examples.get("/namespaces/")
     assert response.status_code in (200, 201)
     assert response.json() == [
-        {"namespace": "basic", "num_nodes": 8},
-        {"namespace": "basic.dimension", "num_nodes": 2},
-        {"namespace": "basic.source", "num_nodes": 2},
-        {"namespace": "basic.transform", "num_nodes": 1},
-        {"namespace": "dbt.dimension", "num_nodes": 1},
-        {"namespace": "dbt.source", "num_nodes": 0},
-        {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
-        {"namespace": "dbt.source.stripe", "num_nodes": 1},
-        {"namespace": "dbt.transform", "num_nodes": 1},
-        {"namespace": "default", "num_nodes": 82},
-        {"namespace": "different.basic", "num_nodes": 2},
-        {"namespace": "different.basic.dimension", "num_nodes": 2},
-        {"namespace": "different.basic.source", "num_nodes": 2},
-        {"namespace": "different.basic.transform", "num_nodes": 1},
-        {"namespace": "foo.bar", "num_nodes": 26},
-        {"namespace": "hll", "num_nodes": 4},
-        {"namespace": "v3", "num_nodes": 47},
+        {
+            "namespace": "basic",
+            "num_nodes": 8,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "basic.dimension",
+            "num_nodes": 2,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "basic.source",
+            "num_nodes": 2,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "basic.transform",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.dimension",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.source",
+            "num_nodes": 0,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.source.jaffle_shop",
+            "num_nodes": 2,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.source.stripe",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.transform",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "default",
+            "num_nodes": 82,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "different.basic",
+            "num_nodes": 2,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "different.basic.dimension",
+            "num_nodes": 2,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "different.basic.source",
+            "num_nodes": 2,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "different.basic.transform",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "foo.bar",
+            "num_nodes": 26,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "hll",
+            "num_nodes": 4,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "v3",
+            "num_nodes": 47,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
     ]
+
+
+@pytest.mark.asyncio
+async def test_list_namespaces_filter_git_backed(
+    client_with_service_setup: AsyncClient,
+) -> None:
+    """
+    ``GET /namespaces/?git_backed=true|false`` filters to namespaces by
+    git backing; the response also exposes ``github_repo_path`` and
+    ``git_branch`` so callers don't have to N+1 to ``/namespaces/{n}/git``.
+    """
+    await client_with_service_setup.post("/namespaces/git_root")
+    await client_with_service_setup.patch(
+        "/namespaces/git_root/git",
+        json={"github_repo_path": "myorg/myrepo"},
+    )
+    await client_with_service_setup.post("/namespaces/plain_ns")
+
+    git_only = await client_with_service_setup.get("/namespaces/?git_backed=true")
+    assert git_only.status_code == 200
+    assert git_only.json() == [
+        {
+            "namespace": "git_root",
+            "num_nodes": 0,
+            "github_repo_path": "myorg/myrepo",
+            "git_branch": None,
+        },
+    ]
+
+    non_git = await client_with_service_setup.get("/namespaces/?git_backed=false")
+    assert non_git.status_code == 200
+    non_git_names = [ns["namespace"] for ns in non_git.json()]
+    assert "plain_ns" in non_git_names
+    assert "git_root" not in non_git_names
+    assert all(ns["github_repo_path"] is None for ns in non_git.json())
+
+    all_ns = await client_with_service_setup.get("/namespaces/")
+    assert all_ns.status_code == 200
+    by_name = {ns["namespace"]: ns for ns in all_ns.json()}
+    assert by_name["git_root"]["github_repo_path"] == "myorg/myrepo"
+    assert by_name["plain_ns"]["github_repo_path"] is None
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -1105,11 +1105,36 @@ async def test_list_all_namespaces_access_limited(
 
     assert response.status_code in (200, 201)
     assert response.json() == [
-        {"namespace": "dbt.dimension", "num_nodes": 1},
-        {"namespace": "dbt.source", "num_nodes": 0},
-        {"namespace": "dbt.source.jaffle_shop", "num_nodes": 2},
-        {"namespace": "dbt.source.stripe", "num_nodes": 1},
-        {"namespace": "dbt.transform", "num_nodes": 1},
+        {
+            "namespace": "dbt.dimension",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.source",
+            "num_nodes": 0,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.source.jaffle_shop",
+            "num_nodes": 2,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.source.stripe",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
+        {
+            "namespace": "dbt.transform",
+            "num_nodes": 1,
+            "github_repo_path": None,
+            "git_branch": None,
+        },
     ]
 
 


### PR DESCRIPTION
### Summary

See #2239. Today `GET /namespaces/` returns only (namespace, num_nodes), so consumers that need to know whether a namespace is git-backed have to follow up with `GET /namespaces/{name}/git` for each one, an N+1 pattern for any tool wanting to audit, lint against, or surface only source-controlled namespaces.

The endpoint's own docstring already promises "List namespaces with node counts and git repository information," but the response model never contained git info.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
