### PR TITLE
Fix non-deterministic & incorrect filter-only dimension resolution

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -295,11 +295,15 @@ def _resolve_filter_only_dim(
         ) == dim_ref.column_name:  # pragma: no cover
             return col.name
 
-    # Single BFS up parent_map; track both passthrough hits and pushdown
-    # candidates. Each upstream node is visited at most once.
+    # BFS up parent_map in sorted order so resolution is deterministic across
+    # processes (never set/hash order). Passthrough is only valid for DIRECT
+    # parents — a transitive upstream may share a column name without sharing
+    # lineage, so it goes to pushdown_candidates instead.
+    direct_parents_set: set[str] = set(ctx.parent_map.get(parent_node.name, []))
     visited: set[str] = {parent_node.name}
-    queue: list[str] = list(ctx.parent_map.get(parent_node.name, []))
-    pushdown_candidates: list[tuple[Node, str]] = []  # (linked_node, fk_col)
+    queue: list[str] = sorted(direct_parents_set)
+    passthrough: list[tuple[Node, str]] = []
+    pushdown_candidates: list[tuple[Node, str]] = []
     while queue:
         up_name = queue.pop(0)
         if up_name in visited:
@@ -314,12 +318,25 @@ def _resolve_filter_only_dim(
                 if fk_fqn is None:  # pragma: no cover
                     continue
                 fk_col = get_short_name(fk_fqn)
-                if fk_col in parent_cols:
-                    # Upstream FK passthrough: filter resolves on the
-                    # parent directly. No pushdown needed.
-                    return fk_col
-                pushdown_candidates.append((up_node, fk_col))
-        queue.extend(ctx.parent_map.get(up_name, []))
+                if fk_col in parent_cols and up_name in direct_parents_set:
+                    passthrough.append((up_node, fk_col))
+                else:
+                    pushdown_candidates.append((up_node, fk_col))
+        queue.extend(sorted(ctx.parent_map.get(up_name, [])))
+
+    # One passthrough col → resolve locally. Multiple → a filter-only dim has
+    # no output-column ambiguity, so apply to all: push each into its owning CTE.
+    passthrough_cols = sorted({fk_col for _, fk_col in passthrough})
+    if len(passthrough_cols) == 1:
+        return passthrough_cols[0]
+    if len(passthrough_cols) > 1:
+        if _register_pushdown_into_upstream(  # pragma: no branch
+            ctx,
+            original_ref,
+            passthrough,
+        ):
+            ctx.pushdown_resolved_dims.add(original_ref)
+        return None
 
     if pushdown_candidates and _register_pushdown_into_upstream(
         ctx,

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1374,6 +1374,314 @@ class TestFilterPushdownToMultipleSiblingTransforms:
         )
 
 
+class TestFilterPushedToAllMultipleDirectParentFKColumns:
+    """Multiple direct parents each link a different column to the same filter-only
+    dimension. The filter must be pushed to *all* of them, not just the first one
+    (which would be hash-order non-deterministic)."""
+
+    @pytest.mark.asyncio
+    async def test_filter_applied_to_all_fk_columns_across_direct_parents(
+        self,
+        client_with_build_v3,
+    ):
+        client = client_with_build_v3
+
+        # Source A: links event_date via send_date
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_events_a",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "value_a", "type": "double"},
+                    {"name": "send_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "events_a",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # date dimension (the filter target) — created after its source exists
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.event_date",
+                "query": "SELECT send_date AS dateint FROM v3.src_events_a GROUP BY send_date",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/v3.src_events_a/link/",
+            json={
+                "dimension_node": "v3.event_date",
+                "join_type": "left",
+                "join_on": "v3.src_events_a.send_date = v3.event_date.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Source B: links event_date via alloc_date (different column name)
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_events_b",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "value_b", "type": "double"},
+                    {"name": "alloc_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "events_b",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/v3.src_events_b/link/",
+            json={
+                "dimension_node": "v3.event_date",
+                "join_type": "left",
+                "join_on": "v3.src_events_b.alloc_date = v3.event_date.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Fact transform: joins both sources, projects both date columns
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.combined_events",
+                "query": (
+                    "SELECT a.account_id, a.value_a, b.value_b, "
+                    "a.send_date, b.alloc_date "
+                    "FROM v3.src_events_a AS a "
+                    "JOIN v3.src_events_b AS b ON a.account_id = b.account_id"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.combined_value",
+                "query": "SELECT SUM(value_a + value_b) FROM v3.combined_events",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.combined_value"],
+                "filters": ["v3.event_date.dateint = 20240101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+
+        # Both sources must be filtered — not just whichever hash-order surfaces first
+        assert "send_date = 20240101" in sql, (
+            "filter missing from src_events_a (send_date)"
+        )
+        assert "alloc_date = 20240101" in sql, (
+            "filter missing from src_events_b (alloc_date)"
+        )
+
+
+class TestFilterNotPushedToTransitiveUpstreamByColumnNameCollision:
+    """Regression: a snapshot filter must not leak onto a fact transform that
+    happens to project a same-named column via an unrelated lineage path.
+
+    Setup:
+      source_snap   (snap_date FK → snap_dim)
+          ↓
+      xform_alloc   (entity_id, snap_date)  — direct child of source_snap
+
+      source_revenue (entity_id, revenue, snap_date — different semantics)
+          ↓
+      xform_revenue  (entity_id, revenue, snap_date)
+
+      combined_fact  (entity_id, value, revenue, snap_date)
+          ← reads from xform_alloc JOIN xform_revenue
+
+    `combined_fact` projects `snap_date` but it comes from `xform_revenue`,
+    not from `source_snap`.  `source_snap` is a transitive upstream (2 hops
+    away via xform_alloc) — NOT a direct parent.  The filter
+    `snap_dim.dateint = X` must only land in `xform_alloc`'s CTE WHERE,
+    never in `combined_fact`'s outer WHERE.
+    """
+
+    @pytest.mark.asyncio
+    async def test_snapshot_filter_not_applied_to_transitive_fact(
+        self,
+        client_with_build_v3,
+    ):
+        client = client_with_build_v3
+
+        # Snapshot source with FK dim link
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.source_snap",
+                "columns": [
+                    {"name": "entity_id", "type": "int"},
+                    {"name": "value", "type": "double"},
+                    {"name": "snap_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "snap_src",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.snap_dim",
+                "query": "SELECT snap_date AS dateint FROM v3.source_snap GROUP BY snap_date",
+                "mode": "published",
+                "primary_key": ["dateint"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/v3.source_snap/link/",
+            json={
+                "dimension_node": "v3.snap_dim",
+                "join_type": "left",
+                "join_on": "v3.source_snap.snap_date = v3.snap_dim.dateint",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # xform_alloc: direct child of source_snap, projects snap_date
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.xform_alloc",
+                "query": (
+                    "SELECT a.entity_id, SUM(a.value) AS total_value, a.snap_date "
+                    "FROM v3.source_snap AS a "
+                    "GROUP BY a.entity_id, a.snap_date"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Unrelated revenue source that also has a snap_date column (name collision)
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.source_revenue",
+                "columns": [
+                    {"name": "entity_id", "type": "int"},
+                    {"name": "revenue", "type": "double"},
+                    {"name": "snap_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "revenue_src",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.xform_revenue",
+                "query": (
+                    "SELECT r.entity_id, SUM(r.revenue) AS total_revenue, r.snap_date "
+                    "FROM v3.source_revenue AS r "
+                    "GROUP BY r.entity_id, r.snap_date"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # combined_fact joins both — snap_date comes from xform_revenue
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.combined_fact",
+                "query": (
+                    "SELECT a.entity_id, a.total_value, r.total_revenue, r.snap_date "
+                    "FROM v3.xform_alloc AS a "
+                    "JOIN v3.xform_revenue AS r ON a.entity_id = r.entity_id "
+                    "AND a.snap_date = r.snap_date"
+                ),
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.combined_revenue",
+                "query": "SELECT SUM(total_revenue) FROM v3.combined_fact",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.combined_revenue"],
+                "filters": ["v3.snap_dim.dateint = 20240101"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+
+        # xform_alloc must be filtered (it's the direct child of source_snap)
+        assert "snap_date = 20240101" in sql
+
+        # The filter must appear in v3_xform_alloc's CTE, not on v3_combined_fact
+        # in the outer query.  Verify by checking the combined_fact CTE has no
+        # snap_date filter of its own.
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_xform_alloc AS (
+              SELECT a.entity_id, SUM(a.value) AS total_value, a.snap_date
+              FROM default.v3.snap_src AS a
+              WHERE a.snap_date = 20240101
+              GROUP BY a.entity_id, a.snap_date
+            ),
+            v3_xform_revenue AS (
+              SELECT r.entity_id, SUM(r.revenue) AS total_revenue, r.snap_date
+              FROM default.v3.revenue_src AS r
+              GROUP BY r.entity_id, r.snap_date
+            ),
+            v3_combined_fact AS (
+              SELECT r.total_revenue
+              FROM v3_xform_alloc AS a
+              JOIN v3_xform_revenue AS r ON a.entity_id = r.entity_id
+              AND a.snap_date = r.snap_date
+            )
+            SELECT SUM(t1.total_revenue) total_revenue_sum_HASH
+            FROM v3_combined_fact t1
+            """,
+            normalize_aliases=True,
+        )
+
+
 class TestDimLabelFilterNameCollision:
     """Regression: a filter on a lookup dimension's *label* attribute whose
     name collides with an upstream transform's foreign-key column must NOT be


### PR DESCRIPTION
### Summary

#### Problem

`_resolve_filter_only_dim` resolves a dimension that appears only in filters (not in the group-by) by walking the fact node's upstream lineage for an FK link, then applying the filter to the column that link points at. There were a few issues with that:

1. Non-deterministic resolution. The walk iterated over a set of parent names (`list(set(...))`), so when more than one candidate existed the "winner" depended on `PYTHONHASHSEED` (i.e. it changed across process restarts). The same request could emit a filter on column A in one worker and column B in another, silently. (Reproduced with a ~50/50 split across 25 fresh workers)
2. Filter leaking onto a same-named column from unrelated lineage. The passthrough shortcut ("the FK column survives on the parent's projection, so filter locally") fired for any upstream at any depth. A transitive upstream that happens to expose a column of the same name, but derived from unrelated data, would apply the filter to the wrong column.
3. Only one column filtered when several legitimately qualify. When two direct parents each link the same dimension via different columns (both genuinely that dimension), only the first was filtered. For a filter-only dim there's no output-column ambiguity, so the filter should constrain all of them.

#### Fix

- Iterate parents in sorted order.
- Restrict traversal so that transitive upstreams go through the pushdown path, which targets the correct CTE
rather than a coincide.
- When multiple direct-parent columns qualify, apply the filter to all of them (each pushed into its owning CTE), instead of returning the first.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
