### PR TITLE
`dj generate-codeowners` should support defaults + excluded dirs

### DIFF
--- a/datajunction-clients/python/datajunction/cli.py
+++ b/datajunction-clients/python/datajunction/cli.py
@@ -958,6 +958,27 @@ class DJCLI:
             default="GITHUB_TOKEN",
             help="Name of the env var holding the GitHub token (default: GITHUB_TOKEN)",
         )
+        codeowners_parser.add_argument(
+            "--default-owner",
+            type=str,
+            default=None,
+            help=(
+                "Owner for a leading `* <owner>` rule. Unmatched files and any "
+                "--exclude'd directories fall through to it (e.g. '@org/team')."
+            ),
+        )
+        codeowners_parser.add_argument(
+            "--exclude",
+            action="append",
+            default=None,
+            dest="exclude_dirs",
+            metavar="DIR",
+            help=(
+                "Directory (relative to <directory>) whose nodes get no per-file "
+                "owners — they fall through to --default-owner. Repeatable. Use for "
+                "machine-generated trees like 'nodes/generated'."
+            ),
+        )
 
         # `dj pull <namespace> <directory>`
         pull_parser = subparsers.add_parser(
@@ -1489,6 +1510,8 @@ class DJCLI:
                 output=args.output,
                 github_api_url=args.github_api_url,
                 github_token_env=args.github_token_env,
+                default_owner=args.default_owner,
+                exclude_dirs=args.exclude_dirs,
             )
             console = Console()
             console.print(

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -304,6 +304,8 @@ class DeploymentService:
         output: str | Path = ".github/CODEOWNERS",
         github_api_url: str | None = None,
         github_token_env: str = "GITHUB_TOKEN",
+        default_owner: str | None = None,
+        exclude_dirs: list[str] | None = None,
     ) -> int:
         """
         Generate a CODEOWNERS file from the owners fields in DJ node YAML files.
@@ -317,9 +319,24 @@ class DeploymentService:
         email addresses in owners fields are resolved to GitHub usernames via the
         search API.  Unresolvable emails are emitted as-is with a warning comment.
 
-        Returns the number of entries written.
+        ``default_owner``, when set, emits a leading ``* <default_owner>`` rule so
+        unmatched files (and any excluded directories) fall through to it. Because
+        CODEOWNERS is last-match-wins, the per-file rules below it still take
+        precedence for the files they name.
+
+        ``exclude_dirs`` lists directories (relative to base_dir) whose nodes are
+        NOT given per-file owners — they fall through to ``default_owner`` instead.
+        This is for machine-generated trees (e.g. ``nodes/generated``) that have no
+        individual human owner and should be team-owned as a block.
+
+        Returns the number of per-file entries written (excludes the default rule).
         """
         base = Path(base_dir).resolve()
+        excluded_dirs = [(base / d).resolve() for d in (exclude_dirs or [])]
+
+        def _is_excluded(path: Path) -> bool:
+            return any(d == path or d in path.parents for d in excluded_dirs)
+
         _token = os.getenv(github_token_env)
         # Only resolve if both API URL and token are available
         lookup: tuple[str, str] | None = (
@@ -353,6 +370,8 @@ class DeploymentService:
         for path in sorted(base.rglob("*.yaml")):
             if path.name == "dj.yaml":
                 continue
+            if _is_excluded(path):
+                continue
             try:
                 node = DeploymentService.read_yaml_file(path)
             except Exception:  # skip unreadable / non-dict files
@@ -376,7 +395,12 @@ class DeploymentService:
             )
             for w in warnings:
                 lines.append(f"#   {w}")
-        lines += ["", *entries, ""]
+        lines.append("")
+        # Default rule first so per-file rules below win (last-match-wins).
+        if default_owner:
+            lines.append(f"* {default_owner}")
+            lines.append("")
+        lines += [*entries, ""]
         content = "\n".join(lines)
 
         output_path = Path(output)

--- a/datajunction-clients/python/tests/test_cli.py
+++ b/datajunction-clients/python/tests/test_cli.py
@@ -2346,6 +2346,57 @@ class TestGenerateCodeowners:
         assert "/revenue.metric.yaml alice@example.com" in content
         assert "no_owner" not in content
 
+    def test_default_owner_emitted_first(self, tmp_path):
+        """default_owner adds a leading `* <owner>` rule before per-file rules."""
+        from datajunction.deployment import DeploymentService
+
+        self._write_node(tmp_path, "revenue.metric.yaml", owners=["alice@example.com"])
+        output = tmp_path / "CODEOWNERS"
+
+        count = DeploymentService.build_codeowners(
+            tmp_path,
+            output=output,
+            default_owner="@org/team",
+        )
+
+        content = output.read_text()
+        lines = [ln for ln in content.splitlines() if ln and not ln.startswith("#")]
+        # The `*` rule comes before the per-file rule so per-file wins (last-match).
+        assert lines[0] == "* @org/team"
+        assert "/revenue.metric.yaml alice@example.com" in content
+        assert content.index("* @org/team") < content.index("/revenue.metric.yaml")
+        # count is per-file entries only, not the default rule
+        assert count == 1
+
+    def test_exclude_dir_falls_through_to_default(self, tmp_path):
+        """Nodes under an excluded dir get no per-file rule (team-owned via default)."""
+        from datajunction.deployment import DeploymentService
+
+        generated = tmp_path / "nodes" / "generated"
+        generated.mkdir(parents=True)
+        authored = tmp_path / "nodes"
+        self._write_node(generated, "account_d.yaml", owners=["bot@example.com"])
+        self._write_node(
+            authored,
+            "shoot_volume.metric.yaml",
+            owners=["alice@example.com"],
+        )
+
+        output = tmp_path / "CODEOWNERS"
+        count = DeploymentService.build_codeowners(
+            tmp_path,
+            output=output,
+            default_owner="@org/team",
+            exclude_dirs=["nodes/generated"],
+        )
+
+        content = output.read_text()
+        # Generated node is excluded -> no per-file rule, covered by the default.
+        assert "account_d.yaml" not in content
+        # Hand-authored node keeps its real owner.
+        assert "/nodes/shoot_volume.metric.yaml alice@example.com" in content
+        assert count == 1
+
     def test_dj_yaml_is_skipped(self, tmp_path):
         """dj.yaml project config must never appear in CODEOWNERS."""
         from datajunction.deployment import DeploymentService
@@ -2520,7 +2571,40 @@ class TestGenerateCodeowners:
             output=str(output),
             github_api_url=None,
             github_token_env="GITHUB_TOKEN",
+            default_owner=None,
+            exclude_dirs=None,
         )
+
+    def test_cli_generate_codeowners_default_owner_and_exclude(self, tmp_path):
+        """--default-owner and repeated --exclude are forwarded to build_codeowners."""
+        from datajunction.cli import DJCLI
+
+        cli = DJCLI(builder_client=mock.MagicMock())
+
+        with patch(
+            "datajunction.deployment.DeploymentService.build_codeowners",
+            return_value=0,
+        ) as mock_build:
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "dj",
+                    "generate-codeowners",
+                    str(tmp_path),
+                    "--default-owner",
+                    "@org/team",
+                    "--exclude",
+                    "nodes/generated",
+                    "--exclude",
+                    "nodes/legacy",
+                ],
+            ):
+                cli.run()
+
+        _, kwargs = mock_build.call_args
+        assert kwargs["default_owner"] == "@org/team"
+        assert kwargs["exclude_dirs"] == ["nodes/generated", "nodes/legacy"]
 
     def test_cli_generate_codeowners_github_flags(self, tmp_path):
         """--github-api-url and --github-token-env are forwarded to build_codeowners."""


### PR DESCRIPTION
### Summary

The cli command for generating `CODEOWNERS`: `dj generate-codeowners` could be more useful by supporting the setting of default owners, as well as supporting excluded directories.

Examples:
```sh
dj generate-codeowners --default-owner @shangyian 
dj generate-codeowners --exclude <some-dir>
```
### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
