### PR TITLE
Add support for various hash functions in Spark and Trino

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2441,6 +2441,20 @@ def infer_type(arg1: ct.StringType, arg2: ct.StringType) -> ct.ColumnType:
     return ct.TimestampType()
 
 
+class FromBigEndian_64(Function):
+    """
+    from_big_endian_64(binary) - Decodes a 64-bit two's complement big endian value
+    from a varbinary and returns it as a bigint. Trino-specific.
+    """
+
+    dialects = [Dialect.TRINO]
+
+
+@FromBigEndian_64.register  # type: ignore
+def infer_type(arg: ct.BinaryType) -> ct.BigIntType:
+    return ct.BigIntType()
+
+
 class Get(Function):
     """
     get(expr, index) - Retrieves an element from an array at the specified
@@ -4443,6 +4457,20 @@ def infer_type(
     return ct.TimestampType()
 
 
+class ToUtf8(Function):
+    """
+    to_utf8(string) - Encodes the string value into a UTF-8 varbinary representation.
+    Trino-specific.
+    """
+
+    dialects = [Dialect.TRINO]
+
+
+@ToUtf8.register  # type: ignore
+def infer_type(arg: ct.StringType) -> ct.BinaryType:
+    return ct.BinaryType()
+
+
 class Transform(Function):
     """
     transform(expr, func) - Transforms elements in an array
@@ -4798,6 +4826,26 @@ class Week(Function):
 
 @Week.register
 def infer_type(arg: Union[ct.StringType, ct.DateTimeBase]) -> ct.BigIntType:
+    return ct.BigIntType()
+
+
+class Xxhash64(Function):
+    """
+    xxhash64(col1, col2, ...) - Returns a consistent 64-bit hash value.
+
+    In Spark, accepts one or more columns of any type and returns bigint.
+    In Trino, accepts a single varbinary argument and returns varbinary;
+    use from_big_endian_64(xxhash64(to_utf8(...))) to obtain a bigint.
+    """
+
+
+@Xxhash64.register  # type: ignore
+def infer_type(arg: ct.BinaryType) -> ct.BinaryType:
+    return ct.BinaryType()
+
+
+@Xxhash64.register  # type: ignore
+def infer_type(*args: ct.ColumnType) -> ct.BigIntType:
     return ct.BigIntType()
 
 

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -11,6 +11,7 @@ from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.sql.parsing.types import (
     BigIntType,
+    BinaryType,
     BooleanType,
     ColumnType,
     DateType,
@@ -751,3 +752,34 @@ async def test_infer_types_datetime(construction_session: AsyncSession):
         BigIntType(),
     ]
     assert types == [exp.type for exp in query.select.projection]  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_infer_types_hashing(construction_session: AsyncSession):
+    """
+    Test type inference for hashing functions: TO_UTF8, XXHASH64, FROM_BIG_ENDIAN_64.
+
+    Covers both the Trino sampling pattern:
+        from_big_endian_64(xxhash64(to_utf8(col)))
+    and the Spark sampling pattern:
+        xxhash64(col)
+    """
+    query = parse(
+        """
+        SELECT
+          TO_UTF8(first_name),
+          XXHASH64(TO_UTF8(first_name)),
+          FROM_BIG_ENDIAN_64(XXHASH64(TO_UTF8(first_name))),
+          XXHASH64(id)
+        FROM dbt.source.jaffle_shop.customers
+        """,
+    )
+    exc = DJException()
+    ctx = CompileContext(session=construction_session, exception=exc)
+    await query.compile(ctx)
+    assert [exp.type for exp in query.select.projection] == [  # type: ignore
+        BinaryType(),
+        BinaryType(),
+        BigIntType(),
+        BigIntType(),
+    ]


### PR DESCRIPTION
### Summary

This PR adds support for:
* `from_big_endian_64` (Trino)
* `xxhash64` (Spark)

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #2247 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
