### PR TITLE
GraphQL API perf optimizations

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_06_11_1840-3c7a9f1b2e4d_add_index_on_node_type.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_06_11_1840-3c7a9f1b2e4d_add_index_on_node_type.py
@@ -1,0 +1,27 @@
+"""add index on node type
+
+Revision ID: 3c7a9f1b2e4d
+Revises: 7e1b9c4a2d3f
+Create Date: 2026-06-11 18:40:18.157912+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3c7a9f1b2e4d"
+down_revision = "7e1b9c4a2d3f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.create_index("type_index", ["type"], unique=False)
+
+
+def downgrade():
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.drop_index("type_index")

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -31,16 +31,35 @@ from datajunction_server.internal.access.group_membership import (
 )
 from datajunction_server.models.node import NodeMode, NodeStatus, NodeType
 
-_CUBE_NAME_ONLY_FIELDS: frozenset[str] = frozenset({"name"})
+_CUBE_SCALAR_ONLY_FIELDS: frozenset[str] = frozenset(
+    {
+        "id",
+        "name",
+        "display_name",
+        "description",
+        "mode",
+        "type",
+        "version",
+        "status",
+        "updated_at",
+        "custom_metadata",
+    },
+)
 
 
-def _is_name_only(fields) -> bool:
-    """Check if requested fields are all derivable from column names alone."""
-    return fields is not None and set(fields.keys()).issubset(_CUBE_NAME_ONLY_FIELDS)
+def _is_scalar_only(fields) -> bool:
+    """
+    Check if requested cube-metric fields are all plain noderevision scalars.
+    Such selections need no relationship loads, so they can be served from the
+    scalar fast path instead of hydrating full metric NodeRevision objects.
+    """
+    return fields is not None and set(fields.keys()).issubset(
+        _CUBE_SCALAR_ONLY_FIELDS,
+    )
 
 
 class _RawColumn:
-    """Lightweight stand-in for Column ORM objects in the name-only path."""
+    """Lightweight stand-in for Column ORM objects in the scalar-only path."""
 
     __slots__ = ("name", "dimension_column", "type", "order")
 
@@ -84,27 +103,67 @@ async def _attach_raw_columns(session, nodes):
             _RawColumn(name, dim_col, col_type, order),
         )
 
-    # Fetch metric element names per cube via the cube join table.
+    # Fetch metric element names per cube via the cube join table, along with
+    # the metric NodeRevision's plain scalar fields. The cube element Column's
+    # ``node_revision_id`` points at the metric revision, so a single extra join
+    # gives us displayName/description/mode without hydrating any ORM objects.
     # Metrics have _DOT_ in the element column name; dimensions don't.
     metric_result = await session.execute(
-        sa_select(CubeRelationship.cube_id, Column.name)
+        sa_select(
+            CubeRelationship.cube_id,
+            Column.name,
+            DBNodeRevision.id,
+            DBNodeRevision.display_name,
+            DBNodeRevision.description,
+            DBNodeRevision.mode,
+            DBNodeRevision.version,
+            DBNodeRevision.status,
+            DBNodeRevision.updated_at,
+            DBNodeRevision.custom_metadata,
+        )
         .join(Column, Column.id == CubeRelationship.cube_element_id)
+        .join(DBNodeRevision, DBNodeRevision.id == Column.node_revision_id)
         .where(
             CubeRelationship.cube_id.in_(rev_ids),
             Column.name.like("%\\_DOT\\_%"),
+            DBNodeRevision.type == NodeType.METRIC,
         ),
     )
     metric_names_by_rev: dict[int, set[str]] = {}
-    for cube_id, elem_name in metric_result:
-        metric_names_by_rev.setdefault(cube_id, set()).add(
-            elem_name.replace("_DOT_", "."),
-        )
+    metric_scalars_by_rev: dict[int, dict[str, dict]] = {}
+    for (
+        cube_id,
+        elem_name,
+        rev_id,
+        display_name,
+        description,
+        mode,
+        version,
+        status,
+        updated_at,
+        custom_metadata,
+    ) in metric_result:
+        metric_name = elem_name.replace("_DOT_", ".")
+        metric_names_by_rev.setdefault(cube_id, set()).add(metric_name)
+        metric_scalars_by_rev.setdefault(cube_id, {})[metric_name] = {
+            "id": rev_id,
+            "name": metric_name,
+            "display_name": display_name,
+            "description": description,
+            "mode": mode,
+            "version": version,
+            "status": status,
+            "updated_at": updated_at,
+            "custom_metadata": custom_metadata,
+            "type": NodeType.METRIC,
+        }
 
-    # Inject raw columns and metric names into each cube revision
+    # Inject raw columns, metric names, and metric scalars into each cube revision
     for node in cube_nodes:
         rev_id = node.current.id
         set_committed_value(node.current, "columns", cols_by_rev.get(rev_id, []))
         node.current._cube_metric_names = metric_names_by_rev.get(rev_id, set())
+        node.current._cube_metric_scalars = metric_scalars_by_rev.get(rev_id, {})
 
 
 async def _attach_git_info(info: Info, nodes: list[DBNode]) -> None:
@@ -140,13 +199,18 @@ async def _attach_git_info(info: Info, nodes: list[DBNode]) -> None:
         node._resolved_git_info = by_ns.get(node.namespace)  # type: ignore
 
 
-def _is_cube_name_only_request(current_fields: dict) -> bool:
-    """Check if the current revision fields only need cube metric/dimension names.
+def _is_cube_scalar_only_request(current_fields: dict) -> bool:
+    """Check if the current revision fields only need cube metric/dimensions scalars.
 
     The fast path replaces ``current.columns`` with lightweight ``_RawColumn``
     stand-ins, so it's only safe when the client hasn't also asked for
     ``columns`` or ``primary_key`` — both of which read attributes
     (``display_name`` etc.) that ``_RawColumn`` doesn't carry.
+
+    ``cubeMetrics`` may request any plain ``noderevision`` scalar (name,
+    displayName, description, mode, …): those are pre-fetched as raw rows in
+    ``_attach_raw_columns``. ``cubeDimensions`` builds ``DimensionAttribute``
+    objects from the cube's own raw columns, so it stays name-derivable only.
     """
     cube_metric_fields = current_fields.get("cube_metrics")
     cube_dimension_fields = current_fields.get("cube_dimensions")
@@ -155,8 +219,8 @@ def _is_cube_name_only_request(current_fields: dict) -> bool:
         return False
     if "columns" in current_fields or "primary_key" in current_fields:
         return False
-    return (cube_metric_fields is None or _is_name_only(cube_metric_fields)) and (
-        cube_dimension_fields is None or _is_name_only(cube_dimension_fields)
+    return (cube_metric_fields is None or _is_scalar_only(cube_metric_fields)) and (
+        cube_dimension_fields is None or _is_scalar_only(cube_dimension_fields)
     )
 
 
@@ -199,10 +263,10 @@ async def find_nodes_by(
         )
         options = load_node_options(node_fields)
 
-        # Signal to cube resolvers whether the name-only fast path is active
+        # Signal to cube resolvers whether the scalar-only fast path is active
         current_fields = node_fields.get("current") or {}
-        is_cube_name_only = _is_cube_name_only_request(current_fields)
-        info.context["cube_name_only"] = is_cube_name_only  # type: ignore
+        is_cube_scalar_only = _is_cube_scalar_only_request(current_fields)
+        info.context["cube_scalar_only"] = is_cube_scalar_only  # type: ignore
 
         # When include_team is set with an ownedBy filter, expand to the user's
         # groups so nodes owned directly by the user OR by any of their groups
@@ -242,9 +306,9 @@ async def find_nodes_by(
             search=search,
         )
 
-        # For the name-only cube path, fetch column data as raw tuples instead
+        # For the scalar-only cube path, fetch column data as raw tuples instead
         # of ORM objects.  This avoids hydrating ~20k Column instances.
-        if is_cube_name_only and result:
+        if is_cube_scalar_only and result:
             await _attach_raw_columns(session, result)
 
         # Pre-resolve gitInfo at the parent level when requested. Per-item async
@@ -501,14 +565,14 @@ def load_node_revision_options(node_revision_fields):
         node_revision_fields.get("cube_dimensions") if node_revision_fields else None
     )
 
-    # When cubeMetrics/cubeDimensions only need "name", we can skip loading
-    # both cube_elements AND columns as ORM objects — the resolver will use
-    # raw column data fetched post-query instead. Must match the fast-path
-    # predicate (_is_cube_name_only_request) so we don't noload
+    # When cubeMetrics/cubeDimensions only need plain scalar fields, we can skip
+    # loading both cube_elements AND columns as ORM objects — the resolver will
+    # use raw column/revision data fetched post-query instead. Must match the
+    # fast-path predicate (_is_cube_scalar_only_request) so we don't noload
     # cube_elements while also letting `_attach_raw_columns` be skipped.
-    all_name_only = is_cube_request and (
-        (cube_metric_fields is None or _is_name_only(cube_metric_fields))
-        and (cube_dimension_fields is None or _is_name_only(cube_dimension_fields))
+    all_scalar_only = is_cube_request and (
+        (cube_metric_fields is None or _is_scalar_only(cube_metric_fields))
+        and (cube_dimension_fields is None or _is_scalar_only(cube_dimension_fields))
         and "columns" not in node_revision_fields
         and "primary_key" not in node_revision_fields
     )
@@ -528,7 +592,7 @@ def load_node_revision_options(node_revision_fields):
                 ),
             )
         options.append(selectinload(DBNodeRevision.columns).options(*col_opts))
-    elif is_cube_request and not all_name_only:
+    elif is_cube_request and not all_scalar_only:
         # Minimal ORM columns for cube element resolution
         options.append(
             selectinload(DBNodeRevision.columns).options(
@@ -545,7 +609,7 @@ def load_node_revision_options(node_revision_fields):
             ),
         )
     else:
-        # Name-only cube path: columns injected as raw tuples post-query
+        # Scalar-only cube path: columns injected as raw tuples post-query
         # via _attach_raw_columns. No cube request: not needed.
         options.append(noload(DBNodeRevision.columns))
 
@@ -602,8 +666,8 @@ def load_node_revision_options(node_revision_fields):
     # Handle cube_elements (only needed when cubeMetrics/cubeDimensions request
     # fields beyond just "name")
     if is_cube_request:
-        if all_name_only:
-            # Name-only: metric names fetched via raw query in
+        if all_scalar_only:
+            # Scalar-only: metric names fetched via raw query in
             # _attach_raw_columns; no need to load cube_elements ORM objects.
             options.append(noload(DBNodeRevision.cube_elements))
         else:
@@ -622,7 +686,7 @@ def load_node_revision_options(node_revision_fields):
                 noload(Column.measure),
             ]
 
-            if cube_metric_fields and not _is_name_only(cube_metric_fields):
+            if cube_metric_fields and not _is_scalar_only(cube_metric_fields):
                 nested_options = build_cube_metrics_node_revision_options(
                     cube_metric_fields,
                 )

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -416,8 +416,8 @@ def load_node_options(fields):
     else:
         options.append(noload(DBNode.revisions))
 
-    if fields.get("current"):
-        node_revision_options = load_node_revision_options(fields["current"])
+    if "current" in fields:
+        node_revision_options = load_node_revision_options(fields["current"] or {})
         options.append(joinedload(DBNode.current).options(*node_revision_options))
     else:
         options.append(noload(DBNode.current))

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -107,7 +107,6 @@ async def _attach_raw_columns(session, nodes):
     # the metric NodeRevision's plain scalar fields. The cube element Column's
     # ``node_revision_id`` points at the metric revision, so a single extra join
     # gives us displayName/description/mode without hydrating any ORM objects.
-    # Metrics have _DOT_ in the element column name; dimensions don't.
     metric_result = await session.execute(
         sa_select(
             CubeRelationship.cube_id,
@@ -125,7 +124,6 @@ async def _attach_raw_columns(session, nodes):
         .join(DBNodeRevision, DBNodeRevision.id == Column.node_revision_id)
         .where(
             CubeRelationship.cube_id.in_(rev_ids),
-            Column.name.like("%\\_DOT\\_%"),
             DBNodeRevision.type == NodeType.METRIC,
         ),
     )

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -8,11 +8,14 @@ from typing import Any, List, Optional
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer, joinedload, load_only, noload, selectinload
-from sqlalchemy.orm.attributes import set_committed_value
 from strawberry.types import Info
 
 from datajunction_server.errors import DJNodeNotFound
-from datajunction_server.api.graphql.scalars.node import NodeName, NodeSortField
+from datajunction_server.api.graphql.scalars.node import (
+    NodeName,
+    NodeSortField,
+    is_scalar_only,
+)
 from datajunction_server.api.graphql.scalars.sql import CubeDefinition
 from datajunction_server.api.graphql.utils import (
     dedupe_append,
@@ -30,32 +33,6 @@ from datajunction_server.internal.access.group_membership import (
     get_group_membership_service,
 )
 from datajunction_server.models.node import NodeMode, NodeStatus, NodeType
-
-_CUBE_SCALAR_ONLY_FIELDS: frozenset[str] = frozenset(
-    {
-        "id",
-        "name",
-        "display_name",
-        "description",
-        "mode",
-        "type",
-        "version",
-        "status",
-        "updated_at",
-        "custom_metadata",
-    },
-)
-
-
-def _is_scalar_only(fields) -> bool:
-    """
-    Check if requested cube-metric fields are all plain noderevision scalars.
-    Such selections need no relationship loads, so they can be served from the
-    scalar fast path instead of hydrating full metric NodeRevision objects.
-    """
-    return fields is not None and set(fields.keys()).issubset(
-        _CUBE_SCALAR_ONLY_FIELDS,
-    )
 
 
 class _RawColumn:
@@ -156,10 +133,15 @@ async def _attach_raw_columns(session, nodes):
             "type": NodeType.METRIC,
         }
 
-    # Inject raw columns, metric names, and metric scalars into each cube revision
+    # Inject raw columns, metric names, and metric scalars into each cube
+    # revision on *separate* attributes. We must NOT overwrite ``current.columns``
+    # (the ORM relationship): ``node.current`` shares identity with the matching
+    # entry in ``node.revisions``, so clobbering it with ``_RawColumn`` stubs
+    # would break a sibling ``revisions { columns }`` selection. The cube_metrics
+    # /cube_dimensions fast paths read ``_cube_raw_columns`` instead.
     for node in cube_nodes:
         rev_id = node.current.id
-        set_committed_value(node.current, "columns", cols_by_rev.get(rev_id, []))
+        node.current._cube_raw_columns = cols_by_rev.get(rev_id, [])
         node.current._cube_metric_names = metric_names_by_rev.get(rev_id, set())
         node.current._cube_metric_scalars = metric_scalars_by_rev.get(rev_id, {})
 
@@ -200,10 +182,12 @@ async def _attach_git_info(info: Info, nodes: list[DBNode]) -> None:
 def _is_cube_scalar_only_request(current_fields: dict) -> bool:
     """Check if the current revision fields only need cube metric/dimensions scalars.
 
-    The fast path replaces ``current.columns`` with lightweight ``_RawColumn``
-    stand-ins, so it's only safe when the client hasn't also asked for
-    ``columns`` or ``primary_key`` — both of which read attributes
-    (``display_name`` etc.) that ``_RawColumn`` doesn't carry.
+    The fast path serves cube_metrics/cube_dimensions from raw rows attached by
+    ``_attach_raw_columns`` (on ``_cube_raw_columns`` etc.), so it's only useful
+    when the client hasn't also asked for ``columns`` or ``primary_key`` — those
+    need the full ORM ``Column`` objects, which the raw rows don't carry. (The
+    raw rows live on a separate attribute and never touch ``current.columns``,
+    so a sibling ``revisions { columns }`` selection is unaffected.)
 
     ``cubeMetrics`` may request any plain ``noderevision`` scalar (name,
     displayName, description, mode, …): those are pre-fetched as raw rows in
@@ -217,8 +201,8 @@ def _is_cube_scalar_only_request(current_fields: dict) -> bool:
         return False
     if "columns" in current_fields or "primary_key" in current_fields:
         return False
-    return (cube_metric_fields is None or _is_scalar_only(cube_metric_fields)) and (
-        cube_dimension_fields is None or _is_scalar_only(cube_dimension_fields)
+    return is_scalar_only(cube_metric_fields) and is_scalar_only(
+        cube_dimension_fields,
     )
 
 
@@ -261,10 +245,14 @@ async def find_nodes_by(
         )
         options = load_node_options(node_fields)
 
-        # Signal to cube resolvers whether the scalar-only fast path is active
+        # Decide whether to attach raw cube scalars to current below. The cube
+        # resolvers gate the fast path on the per-revision ``_cube_raw_columns``
+        # marker that ``_attach_raw_columns`` sets, NOT on request context: a
+        # single operation may have multiple aliased findNodes selections sharing
+        # one ``info.context``, so a context flag could be flipped by a sibling
+        # selection before this result's nested fields resolve.
         current_fields = node_fields.get("current") or {}
         is_cube_scalar_only = _is_cube_scalar_only_request(current_fields)
-        info.context["cube_scalar_only"] = is_cube_scalar_only  # type: ignore
 
         # When include_team is set with an ownedBy filter, expand to the user's
         # groups so nodes owned directly by the user OR by any of their groups
@@ -409,7 +397,10 @@ def load_node_options(fields):
     options = []
 
     if "revisions" in fields:
-        node_revision_options = load_node_revision_options(fields["revisions"])
+        node_revision_options = load_node_revision_options(
+            fields["revisions"],
+            is_current=False,
+        )
         options.append(joinedload(DBNode.revisions).options(*node_revision_options))
     else:
         options.append(noload(DBNode.revisions))
@@ -531,10 +522,15 @@ def build_cube_dimensions_node_revision_options():
     ]
 
 
-def load_node_revision_options(node_revision_fields):
+def load_node_revision_options(node_revision_fields, is_current: bool = True):
     """
     Based on the GraphQL query input fields, builds a list of node revision
     load options. Uses noload() to prevent lazy loading for unrequested fields.
+
+    ``is_current`` gates the cube scalar-only fast path: the raw column/scalar
+    attachment (``_attach_raw_columns``) only populates ``node.current``, so for
+    the ``revisions`` subtree we must keep loading ``cube_elements`` as ORM
+    objects, otherwise cubeMetrics/cubeDimensions resolve empty.
     """
     # Defer heavy columns not needed for most GraphQL queries
     options = [
@@ -568,9 +564,11 @@ def load_node_revision_options(node_revision_fields):
     # use raw column/revision data fetched post-query instead. Must match the
     # fast-path predicate (_is_cube_scalar_only_request) so we don't noload
     # cube_elements while also letting `_attach_raw_columns` be skipped.
-    all_scalar_only = is_cube_request and (
-        (cube_metric_fields is None or _is_scalar_only(cube_metric_fields))
-        and (cube_dimension_fields is None or _is_scalar_only(cube_dimension_fields))
+    all_scalar_only = (
+        is_current
+        and is_cube_request
+        and is_scalar_only(cube_metric_fields)
+        and is_scalar_only(cube_dimension_fields)
         and "columns" not in node_revision_fields
         and "primary_key" not in node_revision_fields
     )
@@ -684,7 +682,11 @@ def load_node_revision_options(node_revision_fields):
                 noload(Column.measure),
             ]
 
-            if cube_metric_fields and not _is_scalar_only(cube_metric_fields):
+            if cube_metric_fields:
+                # Metrics requested (scalar-only or with relationships): load the
+                # metric NodeRevision's scalar columns without the dimensions-only
+                # ``load_only(id, name, type)`` restriction, which would otherwise
+                # drop fields like ``description`` on a scalar-only revisions query.
                 nested_options = build_cube_metrics_node_revision_options(
                     cube_metric_fields,
                 )

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -52,20 +52,53 @@ JoinType = strawberry.enum(JoinType_)
 JoinCardinality = strawberry.enum(JoinCardinality_)
 
 
-_DOT = "_DOT_"
-
-
-class _NameOnlyRevision:
+class _ScalarOnlyRevision:
     """
-    Minimal stand-in returned by the cube_metrics fast path when only ``name``
-    is requested.  A plain object is ~100x cheaper to construct than a full
-    ``DBNodeRevision`` ORM instance.
+    Minimal stand-in returned by the cube_metrics fast path when only plain
+    ``noderevision`` scalar fields are requested.  A plain object is ~100x
+    cheaper to construct than a full ``DBNodeRevision`` ORM instance and avoids
+    loading each metric's columns and their attributes.
+
+    Carries the scalar fields pre-fetched as raw rows by ``_attach_raw_columns``;
+    any field not in that fetch defaults to ``None``.
     """
 
-    __slots__ = ("name",)
+    __slots__ = (
+        "id",
+        "name",
+        "display_name",
+        "description",
+        "mode",
+        "version",
+        "status",
+        "updated_at",
+        "custom_metadata",
+        "type",
+    )
 
-    def __init__(self, name: str):
+    def __init__(
+        self,
+        name: str,
+        id=None,
+        display_name=None,
+        description=None,
+        mode=None,
+        version=None,
+        status=None,
+        updated_at=None,
+        custom_metadata=None,
+        type=None,
+    ):
+        self.id = id
         self.name = name
+        self.display_name = display_name
+        self.description = description
+        self.mode = mode
+        self.version = version
+        self.status = status
+        self.updated_at = updated_at
+        self.custom_metadata = custom_metadata
+        self.type = type
 
 
 @strawberry.enum
@@ -442,11 +475,16 @@ class NodeRevision:
             return []
         ordering = root.ordering()
 
-        # Name-only path: metric names pre-fetched by _attach_raw_columns.
-        if info.context.get("cube_name_only"):  # type: ignore
+        # Fast path: metric names + scalar fields pre-fetched by
+        # _attach_raw_columns. Avoids hydrating each metric's NodeRevision (and
+        # its columns + attributes) just to read plain scalar fields.
+        if info.context.get("cube_scalar_only"):  # type: ignore
             metric_names: set[str] = getattr(root, "_cube_metric_names", set())
+            metric_scalars: dict = getattr(root, "_cube_metric_scalars", {})
             stubs: list = [
-                _NameOnlyRevision(name=col.name)
+                _ScalarOnlyRevision(**metric_scalars[col.name])
+                if col.name in metric_scalars
+                else _ScalarOnlyRevision(name=col.name)
                 for col in root.columns
                 if col.name in metric_names
             ]
@@ -483,8 +521,8 @@ class NodeRevision:
         if root.type != NodeType.CUBE:
             return []
 
-        # Name-only path: metric names pre-fetched by _attach_raw_columns.
-        if info.context.get("cube_name_only"):  # type: ignore
+        # Scalar-only path: metric names pre-fetched by _attach_raw_columns.
+        if info.context.get("cube_scalar_only"):  # type: ignore
             metric_names: set[str] = getattr(root, "_cube_metric_names", set())
             ordering = root.ordering()
             return sorted(

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -64,6 +64,7 @@ _CUBE_SCALAR_ONLY_FIELDS: frozenset = frozenset(
         "updated_at",
         "custom_metadata",
         "type",
+        "role",  # Derivable from each raw column's `dimension_column`
     },
 )
 
@@ -580,10 +581,10 @@ class NodeRevision:
                     DimensionAttribute(  # type: ignore
                         name=col.name + (col.dimension_column or ""),
                         attribute=None,
-                        role=col.dimension_column,
-                        _dimension_node=None,
-                        type=str(col.type) if col.type else "",
+                        role=col.dimension_column or "",
                         properties=[],
+                        type=str(col.type) if col.type else "",
+                        _dimension_node=None,
                     )
                     for col in root._cube_raw_columns
                     if col.name not in metric_names

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -2,7 +2,7 @@
 
 import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import strawberry
 from strawberry.scalars import JSON
@@ -52,6 +52,48 @@ JoinType = strawberry.enum(JoinType_)
 JoinCardinality = strawberry.enum(JoinCardinality_)
 
 
+_CUBE_SCALAR_ONLY_FIELDS: frozenset = frozenset(
+    {
+        "name",
+        "id",
+        "display_name",
+        "description",
+        "mode",
+        "version",
+        "status",
+        "updated_at",
+        "custom_metadata",
+        "type",
+    },
+)
+
+
+def is_scalar_only(fields: Optional[dict[str, Any]]) -> bool:
+    """
+    Check if requested cube-metric fields are all plain noderevision scalars.
+    Such selections need no relationship loads, so they can be served from the
+    scalar fast path instead of hydrating full metric NodeRevision objects.
+
+    ``fields`` is the requested sub-selection map. ``None`` means the cube field
+    was not requested at all, which is trivially scalar-only (nothing forces the
+    full ORM path), so it returns ``True``.
+    """
+    return fields is None or set(fields.keys()).issubset(_CUBE_SCALAR_ONLY_FIELDS)
+
+
+def _raw_columns_ordering(raw_columns: list) -> dict:
+    """Column ordering for the cube fast path, mirroring ``NodeRevision.ordering``.
+
+    The fast path doesn't load the ORM ``columns`` relationship, so we derive the
+    same ``{dotted_name: order}`` mapping from the pre-fetched raw columns that
+    ``_attach_raw_columns`` attaches on ``_cube_raw_columns``.
+    """
+    return {
+        col.name.replace("_DOT_", "."): (col.order if col.order is not None else idx)
+        for idx, col in enumerate(raw_columns)
+    }
+
+
 class _ScalarOnlyRevision:
     """
     Minimal stand-in returned by the cube_metrics fast path when only plain
@@ -64,8 +106,8 @@ class _ScalarOnlyRevision:
     """
 
     __slots__ = (
-        "id",
         "name",
+        "id",
         "display_name",
         "description",
         "mode",
@@ -89,8 +131,8 @@ class _ScalarOnlyRevision:
         custom_metadata=None,
         type=None,
     ):
-        self.id = id
         self.name = name
+        self.id = id
         self.display_name = display_name
         self.description = description
         self.mode = mode
@@ -473,24 +515,29 @@ class NodeRevision:
         """
         if root.type != NodeType.CUBE:
             return []
-        ordering = root.ordering()
 
-        # Fast path: metric names + scalar fields pre-fetched by
-        # _attach_raw_columns. Avoids hydrating each metric's NodeRevision (and
-        # its columns + attributes) just to read plain scalar fields.
-        if info.context.get("cube_scalar_only"):  # type: ignore
+        # Fast path: raw columns + metric names + scalar fields pre-fetched by
+        # _attach_raw_columns onto separate attributes (``_cube_raw_columns`` etc.)
+        # so the real ``columns`` ORM relationship stays intact. Avoids hydrating
+        # each metric's NodeRevision (and its columns + attributes) just to read
+        # plain scalar fields.
+        if hasattr(root, "_cube_raw_columns") and is_scalar_only(extract_fields(info)):
             metric_names: set[str] = getattr(root, "_cube_metric_names", set())
             metric_scalars: dict = getattr(root, "_cube_metric_scalars", {})
+            # Ordering is derived from the raw columns (the ORM ``columns``
+            # relationship is intentionally not loaded on the fast path).
+            ordering = _raw_columns_ordering(root._cube_raw_columns)
             stubs: list = [
                 _ScalarOnlyRevision(**metric_scalars[col.name])
                 if col.name in metric_scalars
                 else _ScalarOnlyRevision(name=col.name)
-                for col in root.columns
+                for col in root._cube_raw_columns
                 if col.name in metric_names
             ]
             return sorted(stubs, key=lambda x: ordering[x.name])
 
         # Full path: node_revision loaded on each cube element
+        ordering = root.ordering()
         return sorted(
             [
                 node_revision
@@ -521,10 +568,13 @@ class NodeRevision:
         if root.type != NodeType.CUBE:
             return []
 
-        # Scalar-only path: metric names pre-fetched by _attach_raw_columns.
-        if info.context.get("cube_scalar_only"):  # type: ignore
+        # Scalar-only path: raw columns + metric names pre-fetched by
+        # _attach_raw_columns onto separate attributes (the real ``columns``
+        # relationship is left untouched).
+        if hasattr(root, "_cube_raw_columns") and is_scalar_only(extract_fields(info)):
             metric_names: set[str] = getattr(root, "_cube_metric_names", set())
-            ordering = root.ordering()
+            # Ordering derived from the raw columns (ORM ``columns`` not loaded).
+            ordering = _raw_columns_ordering(root._cube_raw_columns)
             return sorted(
                 [
                     DimensionAttribute(  # type: ignore
@@ -535,7 +585,7 @@ class NodeRevision:
                         type=str(col.type) if col.type else "",
                         properties=[],
                     )
-                    for col in root.columns
+                    for col in root._cube_raw_columns
                     if col.name not in metric_names
                 ],
                 key=lambda x: ordering.get(

--- a/datajunction-server/datajunction_server/api/graphql/utils.py
+++ b/datajunction-server/datajunction_server/api/graphql/utils.py
@@ -74,11 +74,9 @@ def _merge_fields(dst: Dict[str, Any], src: Dict[str, Any]) -> None:
     selections overlap — would cause the second occurrence to clobber the
     first, and the eager-loader would miss fields.
 
-    Known limitation: ``@skip`` / ``@include`` directives are ignored, so a
-    conditionally-skipped field is still treated as requested. This only
-    causes over-eager-loading, not wrong results. Inline-fragment
-    ``type_condition`` is also not checked; if the schema grows polymorphic
-    types, revisit to avoid loading for types the object isn't.
+    Known limitation: inline-fragment ``type_condition`` is not checked; if the
+    schema grows polymorphic types, revisit to avoid loading for types the
+    object isn't.
     """
     for name, sub in src.items():
         if name not in dst:
@@ -96,6 +94,11 @@ def _walk_selections(selections) -> Dict[str, Any]:
     """
     out: Dict[str, Any] = {}
     for sel in selections:
+        if sel.directives and (
+            sel.directives.get("include", {}).get("if") is False
+            or sel.directives.get("skip", {}).get("if") is True
+        ):
+            continue
         if isinstance(sel, (FragmentSpread, InlineFragment)):
             _merge_fields(out, _walk_selections(sel.selections))
             continue

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     String,
     TypeDecorator,
     UniqueConstraint,
+    exists,
     select,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -881,25 +882,6 @@ class Node(Base):
             order_by = Node.created_at
         NodeRevisionAlias = aliased(NodeRevision)
 
-        nodes_with_tags = []
-        if tags:
-            # Only fetch node IDs — no need to load full Tag/Node objects
-            # or their relationships (created_by, etc.)
-            statement = (
-                select(Node.id)
-                .join(
-                    TagNodeRelationship,
-                    Node.id == TagNodeRelationship.node_id,
-                )
-                .join(Tag, Tag.id == TagNodeRelationship.tag_id)
-                .where(Tag.name.in_(tags))
-            )
-            nodes_with_tags = list(
-                (await session.execute(statement)).scalars().all(),
-            )
-            if not nodes_with_tags:  # pragma: no cover
-                return None, NodeRevisionAlias, None, order_by
-
         # Filter by dimensions (supports node names or attributes)
         nodes_with_dimensions: list[str] | None = None
         if dimensions:
@@ -930,10 +912,17 @@ class Node(Base):
             statement = statement.where(
                 (Node.namespace.like(f"{namespace}.%")) | (Node.namespace == namespace),
             )
-        if nodes_with_tags:
+        if tags:
             statement = statement.where(
-                Node.id.in_(nodes_with_tags),
-            )  # pragma: no cover
+                exists(
+                    select(TagNodeRelationship.node_id)
+                    .join(Tag, Tag.id == TagNodeRelationship.tag_id)
+                    .where(
+                        TagNodeRelationship.node_id == Node.id,
+                        Tag.name.in_(tags),
+                    ),
+                ),
+            )
         if nodes_with_dimensions:
             statement = statement.where(
                 Node.name.in_(nodes_with_dimensions),

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -379,6 +379,7 @@ class Node(Base):
             postgresql_using="btree",
             postgresql_ops={"identifier": "varchar_pattern_ops"},
         ),
+        Index("type_index", "type"),
     )
 
     id: Mapped[int] = mapped_column(

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3568,10 +3568,14 @@ async def test_find_nodes_paginated_total_count_no_matches(
     """
     ``totalCount`` is 0 when no nodes match (covers the early-return path
     inside ``count_by`` for filters that rule out every row).
+
+    An unresolvable dimension filter makes ``_build_filtered_node_statement``
+    return ``None`` (no rows can possibly match), so ``count_by`` short-circuits
+    to 0 without building a count query.
     """
     query = """
     {
-      findNodesPaginated(tags: ["__nonexistent_tag__"], limit: 5) {
+      findNodesPaginated(dimensions: ["default.__nonexistent_dimension__"], limit: 5) {
         totalCount
         edges { node { name } }
       }

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3454,6 +3454,82 @@ async def test_cube_scalar_current_with_full_revisions_columns(
 
 
 @pytest.mark.asyncio
+async def test_cube_dimensions_role_stays_on_fast_path(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    ``cubeDimensions { name role type }`` must serve from the scalar-only fast
+    path: ``role`` is derivable from each raw column's ``dimension_column``, so it
+    should not force the full ORM cube_elements load.
+
+    Asserts the fast path is engaged (``_attach_raw_columns`` runs) and that the
+    resolved values are correct — including the role normalization (a missing
+    role serializes as ``""``, never ``null``, matching the full ORM path in
+    ``test_find_cubes_full_query``).
+
+    NOTE: this test must not also fire a *full*-path query against the same cube.
+    The test harness shares one ``AsyncSession`` across requests (see the
+    ``client_with_roads`` fixture, ``expire_on_commit=False``), so once the fast
+    path has ``noload``ed ``cube_elements`` on the cached revision, a later
+    full-path request reuses that instance with no elements loaded and resolves
+    empty. That's a fixture artifact (production uses a fresh session per
+    request); the full-path values are pinned by ``test_find_cubes_full_query``.
+    """
+    response = await client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": ["default.num_repair_orders", "default.avg_repair_price"],
+            "dimensions": ["default.hard_hat.city", "default.hard_hat.state"],
+            "description": "role fast-path test cube",
+            "mode": "published",
+            "name": "default.role_fast_path_cube",
+        },
+    )
+    assert response.status_code < 400, response.json()
+
+    # { name role type } — scalar-only: must hit the fast path (raw attach runs).
+    fast_query = """
+    {
+        findNodes(names: ["default.role_fast_path_cube"]) {
+            current {
+                cubeDimensions { name role type }
+            }
+        }
+    }
+    """
+    import datajunction_server.api.graphql.resolvers.nodes as nodes_module
+
+    raw_attach_calls = []
+    original_attach = nodes_module._attach_raw_columns
+
+    async def _spy_attach(session, result):
+        raw_attach_calls.append(len(result))
+        return await original_attach(session, result)
+
+    with mock.patch.object(nodes_module, "_attach_raw_columns", _spy_attach):
+        fast_response = await client_with_roads.post(
+            "/graphql",
+            json={"query": fast_query},
+        )
+    assert fast_response.status_code == 200
+    fast_data = fast_response.json()
+    assert "errors" not in fast_data, fast_data
+    # The raw-column attach ran -> the scalar-only fast path was taken, i.e. the
+    # added `role` field did NOT bump the selection onto the full ORM path.
+    assert raw_attach_calls, "expected _attach_raw_columns to run on the fast path"
+
+    dims = {
+        d["name"]: d
+        for d in fast_data["data"]["findNodes"][0]["current"]["cubeDimensions"]
+    }
+    assert set(dims) == {"default.hard_hat.city", "default.hard_hat.state"}
+    for dim in dims.values():
+        # role normalized to "" (not None) on the fast path, matching full path.
+        assert dim["role"] == ""
+        assert dim["type"] == "string"
+
+
+@pytest.mark.asyncio
 async def test_cube_metrics_under_revisions(
     client_with_roads: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -2733,11 +2733,11 @@ async def test_is_derived_metric_field(
 
 
 @pytest.mark.asyncio
-async def test_find_cubes_name_only_with_tag_filter(
+async def test_find_cubes_scalar_only_with_tag_filter(
     client_with_roads: AsyncClient,
 ) -> None:
     """
-    Test the name-only fast path for cubeMetrics/cubeDimensions with a tag
+    Test the scalar-only fast path for cubeMetrics/cubeDimensions with a tag
     filter.  Exercises: tag ID pre-filter, raw column attachment, _DOT_
     metric identification, git info DataLoader, user load_only, and tag noload.
     """
@@ -2763,16 +2763,16 @@ async def test_find_cubes_name_only_with_tag_filter(
                 "default.hard_hat.city",
                 "default.hard_hat.state",
             ],
-            "description": "Name-only test cube",
+            "description": "Scalar-only test cube",
             "mode": "published",
-            "name": "default.name_only_cube",
+            "name": "default.scalar_only_cube",
         },
     )
     assert response.status_code < 400, response.json()
 
     # Tag the cube
     response = await client_with_roads.post(
-        "/nodes/default.name_only_cube/tags/?tag_names=cube_perf_test",
+        "/nodes/default.scalar_only_cube/tags/?tag_names=cube_perf_test",
     )
     assert response.status_code < 400, response.json()
 
@@ -2818,12 +2818,12 @@ async def test_find_cubes_name_only_with_tag_filter(
     assert len(data["data"]["findNodes"]) == 1
     cube = data["data"]["findNodes"][0]
 
-    assert cube["name"] == "default.name_only_cube"
+    assert cube["name"] == "default.scalar_only_cube"
     assert cube["createdBy"]["username"] == "dj"
     assert cube["tags"] == [{"name": "cube_perf_test"}]
     assert cube["currentVersion"] == "v1.0"
-    assert cube["current"]["description"] == "Name-only test cube"
-    assert cube["current"]["displayName"] == "Name Only Cube"
+    assert cube["current"]["description"] == "Scalar-only test cube"
+    assert cube["current"]["displayName"] == "Scalar Only Cube"
     assert cube["gitInfo"] is None  # No git config in test fixture
 
     metric_names = sorted(m["name"] for m in cube["current"]["cubeMetrics"])
@@ -3325,7 +3325,7 @@ async def test_cube_columns_and_cube_metrics_together(
 ) -> None:
     """
     Requesting ``columns { displayName }`` alongside ``cubeMetrics { name }``
-    on a cube must not crash. Regression for the case where the name-only
+    on a cube must not crash. Regression for the case where the scalar-only
     fast path overwrote ``current.columns`` with lightweight ``_RawColumn``
     stand-ins — which don't carry ``display_name`` — even though the client
     also asked for the full columns data.
@@ -3380,12 +3380,12 @@ async def test_cube_columns_and_cube_metrics_together(
 
 
 @pytest.mark.asyncio
-async def test_cube_name_only_fast_path_on_non_cube_node(
+async def test_cube_scalar_only_fast_path_on_non_cube_node(
     client_with_roads: AsyncClient,
 ) -> None:
     """
     Requesting ``cubeMetrics``/``cubeDimensions`` on a non-cube node engages
-    the name-only fast path but finds no cube nodes in the result — the raw
+    the scalar-only fast path but finds no cube nodes in the result — the raw
     column attachment should short-circuit cleanly rather than doing anything.
     """
     query = """
@@ -3394,7 +3394,10 @@ async def test_cube_name_only_fast_path_on_non_cube_node(
             name
             type
             current {
-                cubeMetrics { name }
+                cubeMetrics {
+                    name
+                    displayName
+                }
             }
         }
     }

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3380,6 +3380,284 @@ async def test_cube_columns_and_cube_metrics_together(
 
 
 @pytest.mark.asyncio
+async def test_cube_scalar_current_with_full_revisions_columns(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Requesting a scalar-only ``current { cubeMetrics }`` alongside
+    ``revisions { columns { displayName } }`` must return correct data for both.
+
+    ``node.current`` shares ORM identity with the matching entry in
+    ``node.revisions`` (same NodeRevision row in one session). The cube fast
+    path attaches its raw rows onto separate attributes (``_cube_raw_columns``
+    etc.) and never overwrites the ``columns`` relationship, so:
+      - ``revisions { columns }`` sees real ``Column`` objects (display_name,
+        partition, …) — previously these were clobbered ``_RawColumn`` stubs and
+        the query crashed on ``'_RawColumn' object has no attribute 'partition'``;
+      - ``current { cubeMetrics }`` is still served correctly from the raw rows.
+    """
+    response = await client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": [
+                "default.num_repair_orders",
+                "default.avg_repair_price",
+            ],
+            "dimensions": [
+                "default.hard_hat.city",
+                "default.hard_hat.state",
+            ],
+            "description": "Scalar current + full revisions columns test cube",
+            "mode": "published",
+            "name": "default.scalar_current_full_revisions_cube",
+        },
+    )
+    assert response.status_code < 400, response.json()
+
+    query = """
+    {
+        findNodes(names: ["default.scalar_current_full_revisions_cube"]) {
+            current {
+                cubeMetrics {
+                    name
+                }
+            }
+            revisions {
+                columns {
+                    name
+                    displayName
+                }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    # No crash (before the fix this raised "'_RawColumn' object has no attribute
+    # 'partition'" while resolving the shared current/revisions instance's
+    # columns).
+    assert "errors" not in data, data
+
+    node = data["data"]["findNodes"][0]
+    # current cube metrics still resolve from the raw rows...
+    assert sorted(m["name"] for m in node["current"]["cubeMetrics"]) == [
+        "default.avg_repair_price",
+        "default.num_repair_orders",
+    ]
+    # ...and every revision's columns are real Column objects (display_name
+    # present), not clobbered _RawColumn stubs.
+    assert node["revisions"]
+    for revision in node["revisions"]:
+        assert revision["columns"]
+        assert all(col["name"] and col["displayName"] for col in revision["columns"])
+
+
+@pytest.mark.asyncio
+async def test_cube_metrics_under_revisions(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Regression: ``revisions { cubeMetrics { ... } }`` must return the cube's
+    metrics, not an empty list.
+
+    The cube scalar-only fast path (``noload(cube_elements)`` plus raw scalar
+    attachment) is only wired up for ``current`` — ``_attach_raw_columns`` never
+    populates historical ``revisions``. Because ``load_node_revision_options``
+    is shared between ``current`` and ``revisions``, the scalar-only noload used
+    to apply to ``revisions`` too, leaving the resolver with neither ORM
+    cube_elements nor attached raw scalars, so ``cubeMetrics``/``cubeDimensions``
+    resolved empty for every scalar-only revisions selection (name-only and the
+    broadened ``description``/``displayName`` siblings alike).
+    """
+    response = await client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "metrics": [
+                "default.num_repair_orders",
+                "default.avg_repair_price",
+            ],
+            "dimensions": [
+                "default.hard_hat.city",
+                "default.hard_hat.state",
+            ],
+            "description": "Revisions cube-metrics test cube",
+            "mode": "published",
+            "name": "default.revisions_cube_metrics_cube",
+        },
+    )
+    assert response.status_code < 400, response.json()
+
+    expected_metrics = [
+        "default.avg_repair_price",
+        "default.num_repair_orders",
+    ]
+    expected_descriptions = {
+        "default.num_repair_orders": "Number of repair orders",
+        "default.avg_repair_price": "Average repair price",
+    }
+
+    # 1. Scalar-only cubeMetrics under revisions: name + sibling scalar fields.
+    #    Asserting on description/displayName proves the fast path's sibling
+    #    fields flow through the (full) revisions path, not just `name`.
+    query = """
+    {
+        findNodes(names: ["default.revisions_cube_metrics_cube"]) {
+            revisions {
+                cubeMetrics {
+                    name
+                    description
+                    displayName
+                }
+                cubeDimensions {
+                    name
+                }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert "errors" not in data, data
+
+    revisions = data["data"]["findNodes"][0]["revisions"]
+    assert revisions, "expected at least one revision"
+    for revision in revisions:
+        metric_names = sorted(m["name"] for m in revision["cubeMetrics"])
+        assert metric_names == expected_metrics
+        # Sibling scalar fields resolve (not just name) on the revisions path.
+        for metric in revision["cubeMetrics"]:
+            assert metric["description"] == expected_descriptions[metric["name"]]
+            assert metric["displayName"]
+        dim_names = sorted(d["name"] for d in revision["cubeDimensions"])
+        assert "default.hard_hat.city" in dim_names
+        assert "default.hard_hat.state" in dim_names
+
+    # 2. Combined current + revisions in one query: the current scalar-only fast
+    #    path must not suppress the revisions metrics. (The request-level flag is
+    #    on for `current`; the resolver must still take the full path per-revision
+    #    where the raw scalars were never attached.)
+    combined_query = """
+    {
+        findNodes(names: ["default.revisions_cube_metrics_cube"]) {
+            current {
+                cubeMetrics {
+                    name
+                }
+            }
+            revisions {
+                cubeMetrics {
+                    name
+                }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post(
+        "/graphql",
+        json={"query": combined_query},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "errors" not in data, data
+
+    node = data["data"]["findNodes"][0]
+    assert sorted(m["name"] for m in node["current"]["cubeMetrics"]) == expected_metrics
+    for revision in node["revisions"]:
+        assert sorted(m["name"] for m in revision["cubeMetrics"]) == expected_metrics
+
+
+@pytest.mark.asyncio
+async def test_cube_metrics_aliased_scalar_and_full_selections(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Regression: two aliased ``findNodes`` selections in one operation — one
+    scalar-only, one full — must both resolve their cubeMetrics correctly.
+
+    Both selections share a single ``info.context``. When the fast path was
+    gated on a ``cube_scalar_only`` context flag, the full selection's resolver
+    overwrote that flag before the scalar-only selection resolved its nested
+    fields. The scalar-only result has ``cube_elements`` noloaded and raw
+    scalars attached, so falling through to the full path returned empty
+    metrics. The resolvers now key off the per-revision marker plus this
+    selection's own requested fields, so neither result depends on shared
+    request state.
+
+    Two distinct cubes are used so the full selection genuinely flips what was
+    the shared flag without colliding on a shared ORM instance (the test harness
+    uses one session for all resolvers; production uses one per resolver).
+    """
+    for name, description in (
+        ("default.aliased_scalar_cube", "Scalar-only side"),
+        ("default.aliased_full_cube", "Full side"),
+    ):
+        response = await client_with_roads.post(
+            "/nodes/cube/",
+            json={
+                "metrics": [
+                    "default.num_repair_orders",
+                    "default.avg_repair_price",
+                ],
+                "dimensions": [
+                    "default.hard_hat.city",
+                    "default.hard_hat.state",
+                ],
+                "description": description,
+                "mode": "published",
+                "name": name,
+            },
+        )
+        assert response.status_code < 400, response.json()
+
+    expected_metrics = [
+        "default.avg_repair_price",
+        "default.num_repair_orders",
+    ]
+
+    # ``scalarA`` (scalar-only) is declared before ``fullB`` (a full cube load on
+    # a different cube). ``fullB`` resolving sets what used to be the shared
+    # ``cube_scalar_only`` flag to False before ``scalarA``'s nested cube fields
+    # resolve — the exact ordering that previously emptied ``scalarA``.
+    query = """
+    {
+        scalarA: findNodes(names: ["default.aliased_scalar_cube"]) {
+            current {
+                cubeMetrics { name }
+                cubeDimensions { name }
+            }
+        }
+        fullB: findNodes(names: ["default.aliased_full_cube"]) {
+            current {
+                cubeMetrics {
+                    name
+                    columns { name }
+                }
+            }
+        }
+    }
+    """
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert "errors" not in data, data
+
+    scalar_a = data["data"]["scalarA"][0]["current"]
+    full_b = data["data"]["fullB"][0]["current"]
+
+    # The scalar-only selection must NOT have been emptied by the full sibling.
+    assert sorted(m["name"] for m in scalar_a["cubeMetrics"]) == expected_metrics
+    scalar_dims = sorted(d["name"] for d in scalar_a["cubeDimensions"])
+    assert "default.hard_hat.city" in scalar_dims
+    assert "default.hard_hat.state" in scalar_dims
+    # The full selection resolves independently and correctly, including the
+    # per-metric ``columns`` relationship that the scalar stubs can't carry.
+    assert sorted(m["name"] for m in full_b["cubeMetrics"]) == expected_metrics
+    assert all(m["columns"] for m in full_b["cubeMetrics"])
+
+
+@pytest.mark.asyncio
 async def test_cube_scalar_only_fast_path_on_non_cube_node(
     client_with_roads: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
@@ -317,9 +317,10 @@ class TestLoadNodeRevisionOptions:
 
     def test_with_cube_dimensions_scalar_only(self):
         """cube_dimensions with only raw-column-derivable fields uses fast path."""
-        # name/type/role are all reconstructable from the cube's raw columns,
-        # so cube_elements and ORM columns can be skipped.
-        fields = {"cube_dimensions": {"name": {}, "type": {}}}
+        # name/type/role are all reconstructable from the cube's raw columns
+        # (role from each column's ``dimension_column``), so cube_elements and
+        # ORM columns can be skipped.
+        fields = {"cube_dimensions": {"name": {}, "type": {}, "role": {}}}
         options = load_node_revision_options(fields)
 
         assert has_noload_for(options, "cube_elements")

--- a/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
@@ -259,6 +259,27 @@ class TestLoadNodeRevisionOptions:
         assert has_noload_for(options, "cube_elements")
         assert has_noload_for(options, "columns")
 
+    def test_scalar_only_cube_metrics_under_revisions_loads_cube_elements(self):
+        """The scalar-only fast path is current-only; revisions need the full load.
+
+        ``_attach_raw_columns`` only populates ``node.current``, so for the
+        ``revisions`` subtree (``is_current=False``) the scalar-only noload would
+        leave the resolver with neither ORM cube_elements nor attached raw
+        scalars — cubeMetrics would resolve empty. Revisions must therefore load
+        cube_elements as ORM objects even for a scalar-only selection.
+        """
+        fields = {
+            "cube_metrics": {
+                "name": {},
+                "description": {},
+                "display_name": {},
+            },
+        }
+        options = load_node_revision_options(fields, is_current=False)
+
+        assert has_selectinload_for(options, "cube_elements")
+        assert has_selectinload_for(options, "columns")
+
     def test_with_cube_metrics_query_field_is_not_scalar(self):
         """``query`` is a plain column but is intentionally not fast-pathed.
 

--- a/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
+++ b/datajunction-server/tests/api/graphql/resolvers/test_load_options.py
@@ -232,9 +232,49 @@ class TestLoadNodeRevisionOptions:
 
         assert has_selectinload_for(options, "required_dimensions")
 
-    def test_with_cube_metrics(self):
-        """cube_metrics field requested - should load cube_elements with nested options."""
-        fields = {"cube_metrics": {"name": {}, "displayName": {}}}
+    def test_with_cube_metrics_scalar_only(self):
+        """Scalar-only cube_metrics stay on the raw fast path.
+
+        Every field here lives directly on the metric's noderevision row, so
+        they're pre-fetched as raw rows by ``_attach_raw_columns`` — no need to
+        load cube_elements or ORM columns. Field names arrive snake-cased from
+        ``extract_fields``, so the fixture uses ``display_name`` etc.
+        """
+        fields = {
+            "cube_metrics": {
+                "id": {},
+                "name": {},
+                "display_name": {},
+                "description": {},
+                "mode": {},
+                "type": {},
+                "version": {},
+                "status": {},
+                "updated_at": {},
+                "custom_metadata": {},
+            },
+        }
+        options = load_node_revision_options(fields)
+
+        assert has_noload_for(options, "cube_elements")
+        assert has_noload_for(options, "columns")
+
+    def test_with_cube_metrics_query_field_is_not_scalar(self):
+        """``query`` is a plain column but is intentionally not fast-pathed.
+
+        It's the heavy SQL text other paths ``defer()``, and isn't pre-fetched
+        into the metric stub, so requesting it must take the full ORM path.
+        """
+        fields = {"cube_metrics": {"name": {}, "query": {}}}
+        options = load_node_revision_options(fields)
+
+        assert has_selectinload_for(options, "cube_elements")
+
+    def test_with_cube_metrics_non_scalar(self):
+        """cube_metrics requesting a relationship field takes the full ORM path."""
+        # ``columns`` on the metric requires hydrating metric NodeRevisions, so
+        # the cube's columns must be loaded as ORM objects (not raw tuples).
+        fields = {"cube_metrics": {"name": {}, "columns": {"name": {}}}}
         options = load_node_revision_options(fields)
 
         # Should load cube_elements for cube_metrics
@@ -242,9 +282,11 @@ class TestLoadNodeRevisionOptions:
         # Should load minimal columns for cube request
         assert has_selectinload_for(options, "columns")
 
-    def test_with_cube_dimensions(self):
-        """cube_dimensions field requested - should load cube_elements with minimal options."""
-        fields = {"cube_dimensions": {"name": {}, "type": {}}}
+    def test_with_cube_dimensions_non_scalar(self):
+        """cube_dimensions requesting a relationship field loads cube_elements."""
+        # ``attribute`` is built from the dimension's node revision, so the raw
+        # fast path can't serve it — this must take the full ORM path.
+        fields = {"cube_dimensions": {"name": {}, "attribute": {}}}
         options = load_node_revision_options(fields)
 
         # Should load cube_elements for cube_dimensions
@@ -252,26 +294,22 @@ class TestLoadNodeRevisionOptions:
         # Should load minimal columns for cube request
         assert has_selectinload_for(options, "columns")
 
+    def test_with_cube_dimensions_scalar_only(self):
+        """cube_dimensions with only raw-column-derivable fields uses fast path."""
+        # name/type/role are all reconstructable from the cube's raw columns,
+        # so cube_elements and ORM columns can be skipped.
+        fields = {"cube_dimensions": {"name": {}, "type": {}}}
+        options = load_node_revision_options(fields)
+
+        assert has_noload_for(options, "cube_elements")
+        assert has_noload_for(options, "columns")
+
     def test_without_cube_request_noloads_cube_elements(self):
         """No cube fields requested — cube_elements should be noloaded."""
         fields = {"description": {}}
         options = load_node_revision_options(fields)
 
         assert has_noload_for(options, "cube_elements")
-
-    def test_cube_name_only_noloads_columns(self):
-        """Name-only cube requests noload columns (fetched as raw tuples post-query)."""
-        fields = {"cube_metrics": {"name": {}}}
-        options = load_node_revision_options(fields)
-
-        assert has_noload_for(options, "columns")
-
-    def test_cube_full_request_loads_minimal_columns(self):
-        """Non-name-only cube requests should selectinload columns."""
-        fields = {"cube_metrics": {"name": {}, "description": {}}}
-        options = load_node_revision_options(fields)
-
-        assert has_selectinload_for(options, "columns")
 
     def test_query_ast_always_deferred(self):
         """query_ast should always be deferred."""
@@ -412,8 +450,8 @@ class TestLoadOptionsIntegration:
         fields = {
             "name": {},
             "current": {
-                "displayName": {},
-                "cube_metrics": {"name": {}, "displayName": {}},
+                "display_name": {},
+                "cube_metrics": {"name": {}, "display_name": {}},
             },
         }
         options = load_node_options(fields)
@@ -434,20 +472,20 @@ class TestLoadOptionsIntegration:
             "created_by": {"username": {}},
             "current": {
                 "description": {},
-                "displayName": {},
+                "display_name": {},
                 "cube_metrics": {
                     "name": {},
                     "version": {},
                     "type": {},
-                    "displayName": {},
-                    "updatedAt": {},
+                    "display_name": {},
+                    "updated_at": {},
                     "id": {},
                 },
                 "cube_dimensions": {
                     "name": {},
                     "type": {},
                     "role": {},
-                    "dimensionNode": {"name": {}},
+                    "dimension_node": {"name": {}},
                     "attribute": {},
                 },
             },

--- a/datajunction-server/tests/api/graphql/utils_test.py
+++ b/datajunction-server/tests/api/graphql/utils_test.py
@@ -10,10 +10,10 @@ from datajunction_server.api.graphql.utils import (
 )
 
 
-def _field(name: str, *subselections) -> SelectedField:
+def _field(name: str, *subselections, directives=None) -> SelectedField:
     return SelectedField(
         name=name,
-        directives={},
+        directives=directives or {},
         arguments={},
         alias=None,
         selections=list(subselections),
@@ -198,3 +198,105 @@ class TestExtractFields:
         ) == {
             "current": {"columns": {"name": None, "type": None}},
         }
+
+
+class TestSkipInclude:
+    """
+    ``@include(if: false)`` and ``@skip(if: true)`` selections must be dropped so
+    the eager-loader and the cube scalar-only fast path don't load or compute
+    fields the GraphQL runtime won't resolve. Strawberry resolves ``if: $var``
+    against the query variables before we see it, so the ``if`` value is always
+    a concrete bool here.
+    """
+
+    def test_include_false_drops_field(self):
+        assert extract_fields(
+            _info(
+                _field("name"),
+                _field("displayName", directives={"include": {"if": False}}),
+            ),
+        ) == {"name": None}
+
+    def test_include_true_keeps_field(self):
+        assert extract_fields(
+            _info(
+                _field("name"),
+                _field("displayName", directives={"include": {"if": True}}),
+            ),
+        ) == {"name": None, "display_name": None}
+
+    def test_skip_false_keeps_field(self):
+        assert extract_fields(
+            _info(
+                _field("name"),
+                _field("description", directives={"skip": {"if": False}}),
+            ),
+        ) == {"name": None, "description": None}
+
+    def test_skip_true_drops_field(self):
+        assert extract_fields(
+            _info(
+                _field("name"),
+                _field("description", directives={"skip": {"if": True}}),
+            ),
+        ) == {"name": None}
+
+    def test_skipped_object_field_drops_subselection(self):
+        """A skipped object field takes its whole subtree with it."""
+        assert extract_fields(
+            _info(
+                _field("name"),
+                _field(
+                    "current",
+                    _field("mode"),
+                    directives={"skip": {"if": True}},
+                ),
+            ),
+        ) == {"name": None}
+
+    def test_duplicate_field_one_skipped_keeps_unskipped(self):
+        """
+        ``{ name @skip(if: true) name }`` still resolves ``name`` — the
+        unskipped occurrence merges in after the skipped one is dropped.
+        """
+        assert extract_fields(
+            _info(
+                _field("name", directives={"skip": {"if": True}}),
+                _field("name"),
+            ),
+        ) == {"name": None}
+
+    def test_skipped_fragment_spread_is_dropped(self):
+        """A ``...Frag @skip(if: true)`` contributes none of its fields."""
+        fragment = FragmentSpread(
+            name="NodeInfo",
+            type_condition="Node",
+            directives={"skip": {"if": True}},
+            selections=[_field("name"), _field("type")],
+        )
+        assert extract_fields(
+            _info(fragment, _field("current", _field("mode"))),
+        ) == {"current": {"mode": None}}
+
+    def test_excluded_inline_fragment_is_dropped(self):
+        """A ``... on Type @include(if: false)`` contributes none of its fields."""
+        inline_frag = InlineFragment(
+            type_condition="Node",
+            directives={"include": {"if": False}},
+            selections=[_field("name"), _field("type")],
+        )
+        assert extract_fields(
+            _info(inline_frag, _field("current", _field("mode"))),
+        ) == {"current": {"mode": None}}
+
+    def test_skip_within_subselection(self):
+        """``@skip`` applies at any depth, not just the top level."""
+        assert extract_fields(
+            _info(
+                _field(
+                    "current",
+                    _field("mode"),
+                    _field("status", directives={"skip": {"if": True}}),
+                ),
+            ),
+        ) == {"current": {"mode": None}}


### PR DESCRIPTION
This PR optimizes the performance of fetching cubes via GraphQL.

* Extends the existing optimization for `name` to sibling fields. That's the largest gain; around 2x faster when running locally against a copy of our database. I didn't measure a significant perf regression for name-only use cases.
* Adds an index to `node.type`, which is useful when fetching cubes since they only represent a small fraction of the overall nodes.
* Avoids a DB round-trip & materializing a potentially long list of node IDs by using an `EXISTS` subquery instead, which the Postgres planner will optimize as needed.
* Remove an apparently obsolete `LIKE '%_DOT_%` filter which couldn't use indexes—I'll need confirmation that this is indeed safe to remove.

Also adds support for `@include` and `@skip` directives; before clients would have to alter the query string itself to get the expected perf gains, which is inconvenient.

Finally, fixes an existing bug (happening on `main`) where metrics and dimensions within revisions are empty unless non-`name` fields are also selected. For example, the query below returns empty metrics and dimensions, unless you uncomment some of the fields:

```
{
  findNodes(nodeTypes: [CUBE], limit: 1) {
    revisions {
      cubeMetrics {
        name
        # columns {
        #   name
        # }
      }
      cubeDimensions {
        name
        # attribute
      }
    }
  }
}
```

