### PR TITLE
Fail deployment on hardcoded references to the current namespace

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -3191,6 +3191,7 @@ class DeploymentOrchestrator:
                     node_graph,
                     self.session,
                     dependency_nodes=dependency_nodes,
+                    deployment_namespace=self.deployment_spec.namespace,
                 )
             p.append(f"{len(validation_results)} results")
 

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -64,6 +64,7 @@ class ValidationContext:
     session: AsyncSession
     node_graph: Dict[str, List[str]]
     dependency_nodes: Dict[str, Node]
+    deployment_namespace: Optional[str] = None
 
 
 @dataclass
@@ -478,6 +479,10 @@ class NodeSpecBulkValidator:
             if cross_fact_error is not None:
                 errors.append(cross_fact_error)  # pragma: no cover
 
+            hardcoded_ref_error = self._check_hardcoded_namespace_ref(spec, dep_names)
+            if hardcoded_ref_error is not None:
+                errors.append(hardcoded_ref_error)
+
             return NodeValidationResult(
                 spec=spec,
                 status=NodeStatus.VALID if not errors else NodeStatus.INVALID,
@@ -821,6 +826,39 @@ class NodeSpecBulkValidator:
             dependencies=[],
         )
 
+    def _check_hardcoded_namespace_ref(
+        self,
+        spec: NodeSpec,
+        dep_names: list[str],
+    ) -> DJError | None:
+        """Detect hardcoded references to the current deployment namespace.
+
+        When a node is deployed to namespace X, any dependency whose name starts
+        with X + "." is a hardcoded self-reference that should use ${prefix}
+        instead.  After the branch is merged and cleaned up, these references
+        become dangling.
+
+        Example: a metric deployed to myteam.feature_branch that references
+        myteam.feature_branch.transforms.some_transform — this will break once
+        myteam.feature_branch is removed post-merge.
+        """
+        ns = self.context.deployment_namespace
+        if not ns:
+            return None
+        prefix = f"{ns}{SEPARATOR}"
+        hardcoded = [name for name in dep_names if name.startswith(prefix)]
+        if not hardcoded:
+            return None
+        refs = ", ".join(hardcoded)
+        return DJError(
+            code=ErrorCode.INVALID_NAMESPACE,
+            message=(
+                f"Node {spec.rendered_name!r} contains hardcoded reference(s) to "
+                f"the current deployment namespace ({ns!r}): {refs}. "
+                f"Use ${{prefix}} instead so the reference survives branch merges."
+            ),
+        )
+
     def process_validation(
         self,
         spec: NodeSpec,
@@ -842,6 +880,7 @@ async def bulk_validate_node_data(
     node_graph: Dict[str, List[str]],
     session: AsyncSession,
     dependency_nodes: Dict[str, Node],
+    deployment_namespace: Optional[str] = None,
 ) -> List[NodeValidationResult]:
     """
     Bulk validate node specifications.
@@ -863,6 +902,7 @@ async def bulk_validate_node_data(
         session=session,
         node_graph=node_graph,
         dependency_nodes=dependency_nodes,
+        deployment_namespace=deployment_namespace,
     )
     validator = NodeSpecBulkValidator(context)
 

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -3,6 +3,7 @@ Validation logic for node specifications during deployment
 """
 
 import logging
+import re
 from dataclasses import dataclass, field
 import time
 from typing import Dict, List, Optional
@@ -479,7 +480,7 @@ class NodeSpecBulkValidator:
             if cross_fact_error is not None:
                 errors.append(cross_fact_error)  # pragma: no cover
 
-            hardcoded_ref_error = self._check_hardcoded_namespace_ref(spec, dep_names)
+            hardcoded_ref_error = self._check_hardcoded_namespace_ref(spec)
             if hardcoded_ref_error is not None:
                 errors.append(hardcoded_ref_error)
 
@@ -826,36 +827,45 @@ class NodeSpecBulkValidator:
             dependencies=[],
         )
 
-    def _check_hardcoded_namespace_ref(
-        self,
-        spec: NodeSpec,
-        dep_names: list[str],
-    ) -> DJError | None:
+    def _check_hardcoded_namespace_ref(self, spec: NodeSpec) -> DJError | None:
         """Detect hardcoded references to the current deployment namespace.
 
-        When a node is deployed to namespace X, any dependency whose name starts
-        with X + "." is a hardcoded self-reference that should use ${prefix}
-        instead.  After the branch is merged and cleaned up, these references
-        become dangling.
+        A correctly-written query references other nodes via ${prefix}, which is
+        substituted with the deployment namespace at render time. If the raw
+        query instead embeds the literal deployment namespace, that reference is
+        hardcoded and will break once the namespace is cleaned up (e.g. after a
+        branch is merged and its temporary namespace is removed).
 
-        Example: a metric deployed to myteam.feature_branch that references
-        myteam.feature_branch.transforms.some_transform — this will break once
+        We check the RAW query (with ${prefix} placeholders intact), not the
+        rendered query or extracted dependencies: after rendering, a correct
+        ${prefix}-based reference is indistinguishable from a hardcoded one
+        (both become "<namespace>.<...>"). The distinction only survives in the
+        raw query, where a correct reference contains "${prefix}" while a
+        hardcoded one contains the literal namespace.
+
+        Example: a metric deployed to myteam.feature_branch whose raw query says
+        FROM myteam.feature_branch.transforms.some_transform (instead of
+        FROM ${prefix}transforms.some_transform) breaks once
         myteam.feature_branch is removed post-merge.
         """
         ns = self.context.deployment_namespace
-        if not ns:
+        raw_query = getattr(spec, "query", None)
+        if not ns or not raw_query:
             return None
-        prefix = f"{ns}{SEPARATOR}"
-        hardcoded = [name for name in dep_names if name.startswith(prefix)]
-        if not hardcoded:
+        # Match the namespace literal followed by SEPARATOR, only at an
+        # identifier boundary so a namespace like "team_a" doesn't match
+        # "team_abc". The preceding char must not be an identifier char or dot.
+        pattern = re.compile(
+            r"(?<![A-Za-z0-9_.])" + re.escape(ns) + re.escape(SEPARATOR),
+        )
+        if not pattern.search(raw_query):
             return None
-        refs = ", ".join(hardcoded)
         return DJError(
             code=ErrorCode.INVALID_NAMESPACE,
             message=(
-                f"Node {spec.rendered_name!r} contains hardcoded reference(s) to "
-                f"the current deployment namespace ({ns!r}): {refs}. "
-                f"Use ${{prefix}} instead so the reference survives branch merges."
+                f"Node {spec.rendered_name!r} contains a hardcoded reference to "
+                f"the current deployment namespace ({ns!r}). Use ${{prefix}} "
+                f"instead so the reference survives branch merges."
             ),
         )
 

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -1788,3 +1788,96 @@ class TestToColumnSpecsPreservesMetadata:
         # Explicit type should win
         assert result[0].type == "bigint"
         assert result[0].display_name == "User ID"
+
+
+class TestHardcodedNamespaceRefCheck:
+    """Tests for _check_hardcoded_namespace_ref."""
+
+    def _make_validator(self, deployment_namespace, node_graph, dependency_nodes=None):
+        context = ValidationContext(
+            session=MagicMock(),
+            node_graph=node_graph,
+            dependency_nodes=dependency_nodes or {},
+            deployment_namespace=deployment_namespace,
+        )
+        return NodeSpecBulkValidator(context)
+
+    def test_hardcoded_self_ref_produces_error(self):
+        """A dep whose name starts with the deployment namespace is flagged."""
+        validator = self._make_validator(
+            deployment_namespace="myteam.feature_branch",
+            node_graph={
+                "myteam.feature_branch.metrics.total_revenue": [
+                    "myteam.feature_branch.transforms.revenue_fact",
+                ],
+            },
+        )
+        spec = MetricSpec(
+            name="total_revenue",
+            query="SELECT SUM(revenue) FROM myteam.feature_branch.transforms.revenue_fact",
+            mode="published",
+        )
+        spec.namespace = "myteam.feature_branch"
+
+        dep_names = ["myteam.feature_branch.transforms.revenue_fact"]
+        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+
+        assert error is not None
+        assert error.code == ErrorCode.INVALID_NAMESPACE
+        assert "myteam.feature_branch" in error.message
+        assert "${prefix}" in error.message
+        assert "myteam.feature_branch.transforms.revenue_fact" in error.message
+
+    def test_cross_namespace_ref_is_allowed(self):
+        """A dep from a different namespace is fine — not flagged."""
+        validator = self._make_validator(
+            deployment_namespace="myteam.feature_branch",
+            node_graph={
+                "myteam.feature_branch.metrics.total_revenue": [
+                    "shared.transforms.revenue_fact",
+                ],
+            },
+        )
+        spec = MetricSpec(
+            name="total_revenue",
+            query="SELECT SUM(x) FROM shared.transforms.revenue_fact",
+            mode="published",
+        )
+        spec.namespace = "myteam.feature_branch"
+
+        dep_names = ["shared.transforms.revenue_fact"]
+        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+
+        assert error is None
+
+    def test_no_deployment_namespace_skips_check(self):
+        """When deployment_namespace is None (e.g. REST API path), check is skipped."""
+        validator = self._make_validator(
+            deployment_namespace=None,
+            node_graph={},
+        )
+        spec = MetricSpec(
+            name="my_metric",
+            query="SELECT SUM(x) FROM ns.transforms.t",
+            mode="published",
+        )
+        dep_names = ["ns.transforms.t"]
+        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+
+        assert error is None
+
+    def test_no_hardcoded_refs_no_error(self):
+        """No deps starting with the namespace → no error."""
+        validator = self._make_validator(
+            deployment_namespace="myteam.feature_branch",
+            node_graph={},
+        )
+        spec = MetricSpec(
+            name="my_metric",
+            query="SELECT SUM(x) FROM other.ns.transforms.t",
+            mode="published",
+        )
+        dep_names = ["other.ns.transforms.t"]
+        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+
+        assert error is None

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -1803,14 +1803,10 @@ class TestHardcodedNamespaceRefCheck:
         return NodeSpecBulkValidator(context)
 
     def test_hardcoded_self_ref_produces_error(self):
-        """A dep whose name starts with the deployment namespace is flagged."""
+        """A raw query embedding the literal deployment namespace is flagged."""
         validator = self._make_validator(
             deployment_namespace="myteam.feature_branch",
-            node_graph={
-                "myteam.feature_branch.metrics.total_revenue": [
-                    "myteam.feature_branch.transforms.revenue_fact",
-                ],
-            },
+            node_graph={},
         )
         spec = MetricSpec(
             name="total_revenue",
@@ -1819,24 +1815,35 @@ class TestHardcodedNamespaceRefCheck:
         )
         spec.namespace = "myteam.feature_branch"
 
-        dep_names = ["myteam.feature_branch.transforms.revenue_fact"]
-        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+        error = validator._check_hardcoded_namespace_ref(spec)
 
         assert error is not None
         assert error.code == ErrorCode.INVALID_NAMESPACE
         assert "myteam.feature_branch" in error.message
         assert "${prefix}" in error.message
-        assert "myteam.feature_branch.transforms.revenue_fact" in error.message
 
-    def test_cross_namespace_ref_is_allowed(self):
-        """A dep from a different namespace is fine — not flagged."""
+    def test_prefix_based_ref_is_allowed(self):
+        """A query using ${prefix} renders to the namespace but is NOT flagged."""
         validator = self._make_validator(
             deployment_namespace="myteam.feature_branch",
-            node_graph={
-                "myteam.feature_branch.metrics.total_revenue": [
-                    "shared.transforms.revenue_fact",
-                ],
-            },
+            node_graph={},
+        )
+        spec = MetricSpec(
+            name="total_revenue",
+            query="SELECT SUM(revenue) FROM ${prefix}transforms.revenue_fact",
+            mode="published",
+        )
+        spec.namespace = "myteam.feature_branch"
+
+        error = validator._check_hardcoded_namespace_ref(spec)
+
+        assert error is None
+
+    def test_cross_namespace_ref_is_allowed(self):
+        """A reference to a different namespace is fine — not flagged."""
+        validator = self._make_validator(
+            deployment_namespace="myteam.feature_branch",
+            node_graph={},
         )
         spec = MetricSpec(
             name="total_revenue",
@@ -1845,8 +1852,24 @@ class TestHardcodedNamespaceRefCheck:
         )
         spec.namespace = "myteam.feature_branch"
 
-        dep_names = ["shared.transforms.revenue_fact"]
-        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+        error = validator._check_hardcoded_namespace_ref(spec)
+
+        assert error is None
+
+    def test_namespace_prefix_substring_not_flagged(self):
+        """A namespace that is a string prefix of another isn't falsely matched."""
+        validator = self._make_validator(
+            deployment_namespace="team_a",
+            node_graph={},
+        )
+        spec = MetricSpec(
+            name="m",
+            query="SELECT SUM(x) FROM team_abc.transforms.t",
+            mode="published",
+        )
+        spec.namespace = "team_a"
+
+        error = validator._check_hardcoded_namespace_ref(spec)
 
         assert error is None
 
@@ -1861,13 +1884,12 @@ class TestHardcodedNamespaceRefCheck:
             query="SELECT SUM(x) FROM ns.transforms.t",
             mode="published",
         )
-        dep_names = ["ns.transforms.t"]
-        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+        error = validator._check_hardcoded_namespace_ref(spec)
 
         assert error is None
 
     def test_no_hardcoded_refs_no_error(self):
-        """No deps starting with the namespace → no error."""
+        """A query that doesn't mention the namespace → no error."""
         validator = self._make_validator(
             deployment_namespace="myteam.feature_branch",
             node_graph={},
@@ -1877,7 +1899,6 @@ class TestHardcodedNamespaceRefCheck:
             query="SELECT SUM(x) FROM other.ns.transforms.t",
             mode="published",
         )
-        dep_names = ["other.ns.transforms.t"]
-        error = validator._check_hardcoded_namespace_ref(spec, dep_names)
+        error = validator._check_hardcoded_namespace_ref(spec)
 
         assert error is None

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -251,6 +251,42 @@ class TestValidateQuery:
                 )
 
     @pytest.mark.asyncio
+    async def test_validate_query_node_flags_hardcoded_namespace(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """Full validate_query_node path appends a hardcoded-namespace error.
+
+        Exercises the error-append branch in validate_query_node (not just the
+        helper) by running the whole validation flow on a transform whose raw
+        query embeds the literal deployment namespace.
+        """
+        context = ValidationContext(
+            session=session,
+            node_graph={"test.transform": ["test.parent"]},
+            dependency_nodes={parent_node.name: parent_node},
+            deployment_namespace="test",
+        )
+        validator = NodeSpecBulkValidator(context)
+        spec = TransformSpec(
+            name="transform",
+            query="SELECT id, name FROM test.parent",
+            description="A transform with a hardcoded namespace reference",
+            mode="published",
+        )
+        spec.namespace = "test"
+
+        result = validator.validate_query_node(spec)
+
+        assert result.status == NodeStatus.INVALID
+        namespace_errors = [
+            e for e in result.errors if e.code == ErrorCode.INVALID_NAMESPACE
+        ]
+        assert len(namespace_errors) == 1
+        assert "${prefix}" in namespace_errors[0].message
+
+    @pytest.mark.asyncio
     async def test_validate_query_node_with_skip_validation(
         self,
         validation_context: ValidationContext,


### PR DESCRIPTION
### Summary

When working in a branch namespace (`<namespace>.<branch>.<...>`), it's possible to write a node query that hardcodes a reference to the current branch namespace instead of using `${prefix}`. For example, a metric deployed to `myteam.feature_branch` that references `myteam.feature_branch.transforms.revenue_fact` directly.

The change will validate and deploy cleanly while the branch exists, but breaks after merge. Once the branch is merged to main and the temporary branch namespace is cleaned up, the hardcoded reference becomes a dangling pointer to a namespace that no longer exists. The failure only surfaces later, at SQL-request time, with a confusing "cannot find join path" or missing-node error far removed from the actual cause.

Thus, during deployment validation, we should flag any node whose query references a dependency starting with the deployment namespace prefix. Such a reference should always go through `${prefix}` so it survives branch merges.

To do this, we added `_check_hardcoded_namespace_ref` to `NodeSpecBulkValidator`, where for each dependency in the node's already-computed dependency list, we check whether it starts with `deployment_namespace`. If so, we mark the node `INVALID` with an `INVALID_NAMESPACE` error directing the user to use `${prefix}`. Other nodes in the push are unaffected.

This change makes no additional DB queries, so there should be perf degradation for deploying. 

### Test Plan

Added four unit tests covering: hardcoded self-reference produces the error, cross-namespace references are allowed, the check is skipped when no deployment namespace is set (REST API path), and clean queries produce no error.

- [x] PR has an associated issue: #2249
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
