### PR TITLE
Add support for pmod

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -3915,6 +3915,19 @@ def infer_type(arg: ct.NumberType) -> ct.DoubleType:
     return ct.DoubleType()
 
 
+class Pmod(Function):
+    """
+    pmod(expr1, expr2) - Returns the positive value of expr1 mod expr2.
+    """
+
+    dialects = [Dialect.SPARK]
+
+
+@Pmod.register  # type: ignore
+def infer_type(expr1: ct.NumberType, expr2: ct.NumberType) -> ct.NumberType:
+    return expr1.type
+
+
 class Pow(Function):
     """
     Raises a base expression to the power of an exponent expression.

--- a/datajunction-server/tests/construction/inference_test.py
+++ b/datajunction-server/tests/construction/inference_test.py
@@ -783,3 +783,26 @@ async def test_infer_types_hashing(construction_session: AsyncSession):
         BigIntType(),
         BigIntType(),
     ]
+
+
+@pytest.mark.asyncio
+async def test_infer_types_pmod(construction_session: AsyncSession):
+    """
+    Test type inference for PMOD, which returns the positive modulo and
+    preserves the numeric type of its first argument.
+    """
+    query = parse(
+        """
+        SELECT
+          PMOD(id, 7),
+          PMOD(id, 2.5)
+        FROM dbt.source.jaffle_shop.customers
+        """,
+    )
+    exc = DJException()
+    ctx = CompileContext(session=construction_session, exception=exc)
+    await query.compile(ctx)
+    assert [exp.type for exp in query.select.projection] == [  # type: ignore
+        IntegerType(),
+        IntegerType(),
+    ]


### PR DESCRIPTION
### Summary

This adds support for `PMOD`, a Spark function. It preserves the first operand's numeric type, matching `Abs`/`Greatest`. This is more precise than the sibling `Mod`, which flattens to `FloatType`: `pmod(int, int)` correctly stays `int`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
