### PR TITLE
Check for existence of namespace prior to hard deletes

### DIFF
--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -448,8 +448,23 @@ async def hard_delete_node_namespace(
     access_checker.add_namespace(namespace, ResourceAction.DELETE)
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
 
+    # Only apply the default-branch guard when the namespace exists. Git config
+    # is inherited from ancestors, so a missing namespace under a git-backed root
+    # still resolves is_default_branch=True (no branch -> treated as default) and
+    # would wrongly 422 instead of falling through to the 404 path below.
+    namespace_exists = await NodeNamespace.get(
+        session,
+        namespace,
+        raise_if_not_exists=False,
+    )
+
     git_info = await get_git_info_for_namespace(session, namespace)
-    if git_info and git_info.get("is_default_branch") and git_info.get("repo"):
+    if (
+        namespace_exists
+        and git_info
+        and git_info.get("is_default_branch")
+        and git_info.get("repo")
+    ):
         raise DJInvalidInputException(
             message=f"Cannot delete namespace `{namespace}`: it is the default branch "
             f"of a git-backed namespace ({git_info['repo']}). "

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -36,7 +36,9 @@ from datajunction_server.models.partition import PartitionType, Granularity
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.internal.access.authorization import (
     AuthorizationService,
 )
@@ -602,6 +604,45 @@ async def test_hard_delete_namespace(client_example_loader: AsyncClient):
     assert response.json() == {
         "errors": [],
         "message": "Namespace `jaffle_shop` does not exist.",
+        "warnings": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_nonexistent_namespace_under_git_root_404s(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """
+    Hard deleting a namespace that doesn't exist must 404 even when an ancestor
+    is a git-backed namespace.
+
+    Regression: ``get_git_info_for_namespace`` resolves git config by ancestor
+    inheritance, so for a missing namespace under a git-backed root it returns
+    ``is_default_branch=True`` (no branch namespace resolves, so ``branch is
+    None``, treated as the default branch). The endpoint's default-branch guard
+    then wrongly raised a 422 instead of a 404 — breaking branch-cleanup
+    pipelines that re-delete an already-removed branch namespace.
+    """
+    session.add(
+        NodeNamespace(
+            namespace="gitroot",
+            github_repo_path="org/repo",
+            default_branch="main",
+            parent_namespace=None,
+        ),
+    )
+    await session.commit()
+
+    # ``gitroot.feature_gone`` was never created (or already cleaned up). Its
+    # ancestor ``gitroot`` is git-backed, which used to trigger the false 422.
+    response = await client_with_roads.delete(
+        "/namespaces/gitroot.feature_gone/hard/?cascade=true",
+    )
+    assert response.status_code == 404, response.json()
+    assert response.json() == {
+        "errors": [],
+        "message": "Namespace `gitroot.feature_gone` does not exist.",
         "warnings": [],
     }
 


### PR DESCRIPTION
### Summary

If we try to hard-delete a namespace that does not exist, we should raise a 404 namespace not found error, not a 422 cannot delete default namespace error.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
