### PR TITLE
MCP Query Service Client Override

### DIFF
--- a/datajunction-server/datajunction_server/mcp/context.py
+++ b/datajunction-server/datajunction_server/mcp/context.py
@@ -39,9 +39,11 @@ def get_mcp_session() -> AsyncSession:
     return session
 
 
-_qsc_provider_var: ContextVar[Optional[Callable[[], "QueryServiceClient"]]] = ContextVar(
-    "dj_mcp_qsc_provider",
-    default=None,
+_qsc_provider_var: ContextVar[Optional[Callable[[], "QueryServiceClient"]]] = (
+    ContextVar(
+        "dj_mcp_qsc_provider",
+        default=None,
+    )
 )
 
 

--- a/datajunction-server/datajunction_server/mcp/context.py
+++ b/datajunction-server/datajunction_server/mcp/context.py
@@ -9,9 +9,12 @@ request. Lives in its own module to break the
 from __future__ import annotations
 
 from contextvars import ContextVar
-from typing import Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from datajunction_server.service_clients import QueryServiceClient
 
 
 _session_var: ContextVar[Optional[AsyncSession]] = ContextVar(
@@ -34,3 +37,21 @@ def get_mcp_session() -> AsyncSession:
             "from inside an MCP tool handler running under mount_mcp.",
         )
     return session
+
+
+_qsc_provider_var: ContextVar[Optional[Callable[[], "QueryServiceClient"]]] = ContextVar(
+    "dj_mcp_qsc_provider",
+    default=None,
+)
+
+
+def get_mcp_query_service_client() -> Optional["QueryServiceClient"]:
+    """Return a request-scoped query-service client if a provider is bound.
+
+    Deployments bind a provider via ``mount_mcp(request_context=...)`` that
+    returns an identity-aware, TLS-configured client. Returns ``None`` when no
+    provider is bound, so callers fall back to the default OSS factory. A
+    fail-closed provider may raise — the error propagates to the tool handler.
+    """
+    provider = _qsc_provider_var.get()
+    return provider() if provider is not None else None

--- a/datajunction-server/datajunction_server/mcp/tools.py
+++ b/datajunction-server/datajunction_server/mcp/tools.py
@@ -21,10 +21,16 @@ from datajunction_server.construction.build_v3.builder import (
     build_measures_sql,
     build_metrics_sql,
 )
+from datajunction_server.construction.build_v3.cube_matcher import (
+    resolve_dialect_and_engine_for_metrics,
+)
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.internal.namespaces import get_git_info_for_namespace
-from datajunction_server.mcp.context import get_mcp_session
+from datajunction_server.mcp.context import (
+    get_mcp_query_service_client,
+    get_mcp_session,
+)
 from datajunction_server.mcp.formatters import (
     format_dimensions_compatibility,
     format_node_details,
@@ -400,9 +406,6 @@ async def _execute_metrics_query(
     Raises ``ValueError`` (string-message) which the caller turns into an
     MCP-facing error block.
     """
-    from datajunction_server.construction.build_v3.cube_matcher import (
-        resolve_dialect_and_engine_for_metrics,
-    )
     from datajunction_server.models.query import QueryCreate
 
     session = get_mcp_session()
@@ -441,8 +444,9 @@ async def _execute_metrics_query(
             f"frequent query — ask the data owner to materialize a cube for it.",
         )
 
-    settings = get_settings()
-    query_service_client = get_query_service_client(settings=settings)
+    query_service_client = get_mcp_query_service_client() or get_query_service_client(
+        settings=get_settings(),
+    )
     if query_service_client is None:
         raise ValueError(
             "Query service client is not configured on this DJ instance.",

--- a/datajunction-server/datajunction_server/mcp/transport.py
+++ b/datajunction-server/datajunction_server/mcp/transport.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, nullcontext
 from typing import Optional
 
 from fastapi import FastAPI
@@ -38,12 +38,18 @@ logger = logging.getLogger(__name__)
 __all__ = ["mount_mcp", "get_mcp_session"]
 
 
-def mount_mcp(app: FastAPI, path: str = "/mcp") -> None:
+def mount_mcp(app: FastAPI, path: str = "/mcp", *, request_context=None) -> None:
     """Mount the MCP HTTP transport on ``app`` at ``path``.
 
     Stateless mode: every request is independent (no MCP session tracking
     on the server side). Simpler, scales horizontally, and matches the
     DJ usage pattern where each tool call is a discrete query.
+
+    ``request_context``: optional callable ``(scope) -> contextmanager``. Invoked
+    inside the per-request scope (where the DB session is bound) so deployments
+    can bind additional request-scoped ContextVars — e.g. an identity-aware
+    query-service-client provider. The contextmanager is entered before the MCP
+    request is handled and exited (even on error) afterward.
 
     Must be called once during app construction.
     """
@@ -84,8 +90,10 @@ def mount_mcp(app: FastAPI, path: str = "/mcp") -> None:
         session_factory = get_session_manager().get_writer_session_factory()
         async with session_factory() as session:
             token = _session_var.set(session)
+            cm = request_context(scope) if request_context is not None else nullcontext()
             try:
-                await session_manager.handle_request(scope, receive, send)
+                with cm:
+                    await session_manager.handle_request(scope, receive, send)
             finally:
                 _session_var.reset(token)
 

--- a/datajunction-server/datajunction_server/mcp/transport.py
+++ b/datajunction-server/datajunction_server/mcp/transport.py
@@ -21,7 +21,12 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from contextlib import AbstractContextManager, AsyncExitStack, asynccontextmanager, nullcontext
+from contextlib import (
+    AbstractContextManager,
+    AsyncExitStack,
+    asynccontextmanager,
+    nullcontext,
+)
 from typing import Optional
 
 from fastapi import FastAPI
@@ -97,7 +102,11 @@ def mount_mcp(
         async with session_factory() as session:
             token = _session_var.set(session)
             try:
-                cm = request_context(scope) if request_context is not None else nullcontext()
+                cm = (
+                    request_context(scope)
+                    if request_context is not None
+                    else nullcontext()
+                )
                 with cm:
                     await session_manager.handle_request(scope, receive, send)
             finally:

--- a/datajunction-server/datajunction_server/mcp/transport.py
+++ b/datajunction-server/datajunction_server/mcp/transport.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from contextlib import AsyncExitStack, asynccontextmanager, nullcontext
+from collections.abc import Callable
+from contextlib import AbstractContextManager, AsyncExitStack, asynccontextmanager, nullcontext
 from typing import Optional
 
 from fastapi import FastAPI
@@ -38,7 +39,12 @@ logger = logging.getLogger(__name__)
 __all__ = ["mount_mcp", "get_mcp_session"]
 
 
-def mount_mcp(app: FastAPI, path: str = "/mcp", *, request_context=None) -> None:
+def mount_mcp(
+    app: FastAPI,
+    path: str = "/mcp",
+    *,
+    request_context: Optional[Callable[[Scope], AbstractContextManager[object]]] = None,
+) -> None:
     """Mount the MCP HTTP transport on ``app`` at ``path``.
 
     Stateless mode: every request is independent (no MCP session tracking
@@ -90,8 +96,8 @@ def mount_mcp(app: FastAPI, path: str = "/mcp", *, request_context=None) -> None
         session_factory = get_session_manager().get_writer_session_factory()
         async with session_factory() as session:
             token = _session_var.set(session)
-            cm = request_context(scope) if request_context is not None else nullcontext()
             try:
+                cm = request_context(scope) if request_context is not None else nullcontext()
                 with cm:
                     await session_manager.handle_request(scope, receive, send)
             finally:

--- a/datajunction-server/tests/dj_mcp/test_context.py
+++ b/datajunction-server/tests/dj_mcp/test_context.py
@@ -7,6 +7,34 @@ import pytest
 from datajunction_server.mcp import context
 
 
+def test_get_mcp_query_service_client_none_when_unbound() -> None:
+    """No provider bound → returns None so callers fall back to the OSS factory."""
+    assert context.get_mcp_query_service_client() is None
+
+
+def test_get_mcp_query_service_client_calls_provider_when_bound() -> None:
+    """When a provider is bound, it is invoked and its client returned."""
+    sentinel = object()
+    token = context._qsc_provider_var.set(lambda: sentinel)
+    try:
+        assert context.get_mcp_query_service_client() is sentinel
+    finally:
+        context._qsc_provider_var.reset(token)
+
+
+def test_get_mcp_query_service_client_propagates_provider_error() -> None:
+    """A fail-closed provider that raises must surface to the caller."""
+    def _boom():
+        raise ValueError("no caller identity")
+
+    token = context._qsc_provider_var.set(_boom)
+    try:
+        with pytest.raises(ValueError, match="no caller identity"):
+            context.get_mcp_query_service_client()
+    finally:
+        context._qsc_provider_var.reset(token)
+
+
 def test_get_mcp_session_raises_outside_request() -> None:
     """Tools call this from inside an MCP request handler. Outside that
     context, the ContextVar is unset — must raise loudly."""

--- a/datajunction-server/tests/dj_mcp/test_context.py
+++ b/datajunction-server/tests/dj_mcp/test_context.py
@@ -2,9 +2,12 @@
 Tests for ``datajunction_server.mcp.context``.
 """
 
+from typing import cast
+
 import pytest
 
 from datajunction_server.mcp import context
+from datajunction_server.service_clients import QueryServiceClient
 
 
 def test_get_mcp_query_service_client_none_when_unbound() -> None:
@@ -14,7 +17,7 @@ def test_get_mcp_query_service_client_none_when_unbound() -> None:
 
 def test_get_mcp_query_service_client_calls_provider_when_bound() -> None:
     """When a provider is bound, it is invoked and its client returned."""
-    sentinel = object()
+    sentinel = cast(QueryServiceClient, object())
     token = context._qsc_provider_var.set(lambda: sentinel)
     try:
         assert context.get_mcp_query_service_client() is sentinel
@@ -24,6 +27,7 @@ def test_get_mcp_query_service_client_calls_provider_when_bound() -> None:
 
 def test_get_mcp_query_service_client_propagates_provider_error() -> None:
     """A fail-closed provider that raises must surface to the caller."""
+
     def _boom():
         raise ValueError("no caller identity")
 

--- a/datajunction-server/tests/dj_mcp/test_tools.py
+++ b/datajunction-server/tests/dj_mcp/test_tools.py
@@ -762,10 +762,7 @@ async def test_execute_metrics_query_no_query_service_configured(
             ),
         )
 
-    monkeypatch.setattr(
-        "datajunction_server.construction.build_v3.cube_matcher.resolve_dialect_and_engine_for_metrics",
-        fake_resolve,
-    )
+    monkeypatch.setattr(tools, "resolve_dialect_and_engine_for_metrics", fake_resolve)
     monkeypatch.setattr(tools, "build_metrics_sql", fake_build)
     monkeypatch.setattr(tools, "get_query_service_client", lambda settings: None)
 
@@ -1236,10 +1233,7 @@ async def test_execute_metrics_query_full_round_trip(
             ),
         )
 
-    monkeypatch.setattr(
-        "datajunction_server.construction.build_v3.cube_matcher.resolve_dialect_and_engine_for_metrics",
-        fake_resolve,
-    )
+    monkeypatch.setattr(tools, "resolve_dialect_and_engine_for_metrics", fake_resolve)
     monkeypatch.setattr(tools, "build_metrics_sql", fake_build)
     monkeypatch.setattr(
         tools,
@@ -1323,10 +1317,7 @@ async def test_execute_metrics_query_empty_results_skips_column_inject(
             ),
         )
 
-    monkeypatch.setattr(
-        "datajunction_server.construction.build_v3.cube_matcher.resolve_dialect_and_engine_for_metrics",
-        fake_resolve,
-    )
+    monkeypatch.setattr(tools, "resolve_dialect_and_engine_for_metrics", fake_resolve)
     monkeypatch.setattr(tools, "build_metrics_sql", fake_build)
     monkeypatch.setattr(
         tools,
@@ -1387,3 +1378,103 @@ async def test_visualize_metrics_handles_none_metric_values(
         dimensions=["d.d"],
     )
     assert blocks[0].text.endswith("📊 amount | 3 points | line")
+
+
+@pytest.mark.asyncio
+async def test_execute_metrics_query_prefers_bound_provider(monkeypatch) -> None:
+    """When an MCP provider is bound, _execute_metrics_query uses that client
+    and does NOT call the OSS get_query_service_client factory."""
+    fake_ctx = MagicMock()
+    fake_ctx.dialect = Dialect.SPARK
+    fake_ctx.engine.name = "spark"
+    fake_ctx.engine.version = "3.5"
+    fake_ctx.catalog_name = "prod"
+
+    async def fake_resolve(**_kwargs):
+        return fake_ctx
+
+    fake_generated = MagicMock(spec=GeneratedSQL)
+    fake_generated.scan_estimate = None
+    fake_generated.sql = "SELECT 1"
+    fake_generated.columns = []
+
+    async def fake_build(**_kwargs):
+        return fake_generated
+
+    monkeypatch.setattr(
+        tools, "resolve_dialect_and_engine_for_metrics", fake_resolve, raising=False,
+    )
+    monkeypatch.setattr(tools, "build_metrics_sql", fake_build)
+    monkeypatch.setattr(tools, "get_mcp_session", lambda: MagicMock())
+
+    provider_client = MagicMock()
+
+    async def fake_submit(query_create):
+        result = MagicMock()
+        result.results.root = []
+        return result
+
+    provider_client.submit_query = fake_submit
+
+    def _oss_should_not_run(**_kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("OSS get_query_service_client must not be called")
+
+    monkeypatch.setattr(tools, "get_query_service_client", _oss_should_not_run)
+
+    token = context._qsc_provider_var.set(lambda: provider_client)
+    try:
+        result, generated = await tools._execute_metrics_query(
+            ["m"], ["d"], None, None, None,
+        )
+    finally:
+        context._qsc_provider_var.reset(token)
+
+    assert generated is fake_generated
+    assert result.results.root == []
+
+
+@pytest.mark.asyncio
+async def test_execute_metrics_query_falls_back_when_no_provider(monkeypatch) -> None:
+    """No provider bound → falls back to OSS get_query_service_client."""
+    fake_ctx = MagicMock()
+    fake_ctx.dialect = Dialect.SPARK
+    fake_ctx.engine.name = "spark"
+    fake_ctx.engine.version = "3.5"
+    fake_ctx.catalog_name = "prod"
+
+    async def fake_resolve(**_kwargs):
+        return fake_ctx
+
+    fake_generated = MagicMock(spec=GeneratedSQL)
+    fake_generated.scan_estimate = None
+    fake_generated.sql = "SELECT 1"
+    fake_generated.columns = []
+
+    async def fake_build(**_kwargs):
+        return fake_generated
+
+    monkeypatch.setattr(
+        tools, "resolve_dialect_and_engine_for_metrics", fake_resolve, raising=False,
+    )
+    monkeypatch.setattr(tools, "build_metrics_sql", fake_build)
+    monkeypatch.setattr(tools, "get_mcp_session", lambda: MagicMock())
+
+    fallback_client = MagicMock()
+
+    async def fake_submit(query_create):
+        result = MagicMock()
+        result.results.root = []
+        return result
+
+    fallback_client.submit_query = fake_submit
+    called = {"oss": False}
+
+    def _oss_factory(**_kwargs):
+        called["oss"] = True
+        return fallback_client
+
+    monkeypatch.setattr(tools, "get_query_service_client", _oss_factory)
+
+    assert context.get_mcp_query_service_client() is None
+    result, _ = await tools._execute_metrics_query(["m"], None, None, None, None)
+    assert called["oss"] is True

--- a/datajunction-server/tests/dj_mcp/test_tools.py
+++ b/datajunction-server/tests/dj_mcp/test_tools.py
@@ -1402,7 +1402,10 @@ async def test_execute_metrics_query_prefers_bound_provider(monkeypatch) -> None
         return fake_generated
 
     monkeypatch.setattr(
-        tools, "resolve_dialect_and_engine_for_metrics", fake_resolve, raising=False,
+        tools,
+        "resolve_dialect_and_engine_for_metrics",
+        fake_resolve,
+        raising=False,
     )
     monkeypatch.setattr(tools, "build_metrics_sql", fake_build)
     monkeypatch.setattr(tools, "get_mcp_session", lambda: MagicMock())
@@ -1424,7 +1427,11 @@ async def test_execute_metrics_query_prefers_bound_provider(monkeypatch) -> None
     token = context._qsc_provider_var.set(lambda: provider_client)
     try:
         result, generated = await tools._execute_metrics_query(
-            ["m"], ["d"], None, None, None,
+            ["m"],
+            ["d"],
+            None,
+            None,
+            None,
         )
     finally:
         context._qsc_provider_var.reset(token)
@@ -1454,7 +1461,10 @@ async def test_execute_metrics_query_falls_back_when_no_provider(monkeypatch) ->
         return fake_generated
 
     monkeypatch.setattr(
-        tools, "resolve_dialect_and_engine_for_metrics", fake_resolve, raising=False,
+        tools,
+        "resolve_dialect_and_engine_for_metrics",
+        fake_resolve,
+        raising=False,
     )
     monkeypatch.setattr(tools, "build_metrics_sql", fake_build)
     monkeypatch.setattr(tools, "get_mcp_session", lambda: MagicMock())

--- a/datajunction-server/tests/dj_mcp/test_transport.py
+++ b/datajunction-server/tests/dj_mcp/test_transport.py
@@ -82,3 +82,45 @@ async def test_mount_mcp_invokes_request_context_per_request() -> None:
 
     assert events == ["enter", "exit"]
     assert seen_scope["type"] == "http"
+
+
+@pytest.mark.asyncio
+async def test_mount_mcp_request_context_exits_on_handler_error(monkeypatch) -> None:
+    """If MCP request handling raises, the request_context is still exited."""
+    from contextlib import contextmanager
+
+    events: list[str] = []
+
+    @contextmanager
+    def recorder(scope):
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    app = FastAPI()
+    transport.mount_mcp(app, request_context=recorder)
+
+    async with LifespanManager(app):
+        # Patch the mounted handler so request handling raises after the
+        # binder is entered.
+        async def boom(*_a, **_k):
+            raise RuntimeError("boom")
+
+        # The Mount's app is the asgi_handler closure; patch the session
+        # manager's handle_request which it awaits.
+        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+        monkeypatch.setattr(StreamableHTTPSessionManager, "handle_request", boom)
+
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=True,
+        ) as client:
+            try:
+                await client.get("/mcp/")
+            except Exception:
+                pass  # the handler raising may surface as a transport error
+
+    assert events == ["enter", "exit"]

--- a/datajunction-server/tests/dj_mcp/test_transport.py
+++ b/datajunction-server/tests/dj_mcp/test_transport.py
@@ -111,6 +111,7 @@ async def test_mount_mcp_request_context_exits_on_handler_error(monkeypatch) -> 
         # The Mount's app is the asgi_handler closure; patch the session
         # manager's handle_request which it awaits.
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
         monkeypatch.setattr(StreamableHTTPSessionManager, "handle_request", boom)
 
         async with httpx.AsyncClient(

--- a/datajunction-server/tests/dj_mcp/test_transport.py
+++ b/datajunction-server/tests/dj_mcp/test_transport.py
@@ -49,3 +49,36 @@ async def test_mount_mcp_lifespan_runs_combined_lifespan(
         ) as client:
             response = await client.get("/mcp/")
         assert 400 <= response.status_code < 500
+
+
+@pytest.mark.asyncio
+async def test_mount_mcp_invokes_request_context_per_request() -> None:
+    """A request_context binder is entered before the MCP request is handled
+    and exited afterward, receiving the ASGI scope."""
+    from contextlib import contextmanager
+
+    events: list[str] = []
+    seen_scope: dict = {}
+
+    @contextmanager
+    def recorder(scope):
+        seen_scope["type"] = scope.get("type")
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    app = FastAPI()
+    transport.mount_mcp(app, request_context=recorder)
+
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=True,
+        ) as client:
+            await client.get("/mcp/")
+
+    assert events == ["enter", "exit"]
+    assert seen_scope["type"] == "http"


### PR DESCRIPTION
### Summary

MCP tools that run queries (`get_metric_data`, `visualize_metrics`) currently always execute through the default query-service client. Deployments that need a per-request client (e.g. to attach the caller's identity or a deployment-specific TLS/transport) have no ability to do so; the existing FastAPI dependency-override mechanism doesn't reach the MCP tools because the server is mounted as a raw Starlette mount whose handlers don't use `Depends`. This PR adds that setup generically so that downstream deployments can bind a custom query service client.

MCP tools have their own per-request binding point that the transport populates from the ASGI scope, independent of FastAPI's request lifecycle. A deployment supplies the client via `mount_mcp(app, request_context=...)` and the executor picks it up through `get_mcp_query_service_client()`.

Changes:

1. In `mcp/context.py` added a ContextVar (`_qsc_provider_var`) holding an optional provider callable, plus an accessor `get_mcp_query_service_client()` that returns the bound provider's client, or None when unbound.
2. In `mcp/tools.py`, `_execute_metrics_query` now does `get_mcp_query_service_client()` or `get_query_service_client(settings=get_settings())`. When no provider is bound, behavior is identical to today.
3. In `mcp/transport.py`, `mount_mcp(...)` gains a keyword-only `request_context`, invoked inside the per-request scope (same place the DB session is bound, wrapping handle_request) so a deployment can bind request-scoped context vars. 

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
