### PR TITLE
Add dialect transpilation to v3 SQL output

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -134,8 +134,24 @@ def to_sql(query: "Query", dialect: Optional["Dialect"] = None) -> str:
     """
     if dialect is None:
         return str(query)
+
+    # Two passes: render_for_dialect applies DJ's AST-level dialect rules, then the
+    # generic transpiler handles the function-name translation it doesn't cover.
+    from datajunction_server.transpilation import (
+        transpile_sql,
+    )  # local: avoids import cycle
+
     with render_for_dialect(dialect):
-        return str(query)
+        rendered = str(query)
+    try:
+        return transpile_sql(rendered, dialect)
+    except Exception:  # pragma: no cover - fall back to native render
+        logger.warning(
+            "Transpilation to %s failed; falling back to native render",
+            dialect,
+            exc_info=True,
+        )
+        return rendered
 
 
 # When True, skip parent-pointer wiring in __post_init__ and __setattr__.

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1496,13 +1496,25 @@ def test_binaryop_and_with_empty_spread_does_not_raise():
     assert ast.BinaryOp.And(*conditions) is None
 
 
-def test_to_sql_transpiles_functions_for_dialect():
+def test_to_sql_transpiles_functions_for_dialect(monkeypatch):
     """
     ``to_sql`` should run the rendered SQL through the generic transpiler, not just
     DJ's native dialect rendering. ``collect_list`` is a Spark-only function with no
     entry in ``render_for_dialect``'s function map, so it only becomes Trino's
     ``array_agg`` if real transpilation happens.
     """
+    # The dialect->plugin registry is process-global and other tests/fixtures mutate
+    # it; pin the dialects under test to the real sqlglot plugin (auto-restored).
+    from datajunction_server.models.dialect import DialectRegistry
+    from datajunction_server.transpilation import SQLGlotTranspilationPlugin
+
+    for name in ("spark", "trino"):
+        monkeypatch.setitem(
+            DialectRegistry._registry,
+            name,
+            SQLGlotTranspilationPlugin,
+        )
+
     query = parse("SELECT collect_list(x) AS c FROM t")
 
     trino = ast.to_sql(query, Dialect.TRINO)

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.errors import DJException
+from datajunction_server.models.dialect import Dialect
 from datajunction_server.sql.parsing import ast, types
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
@@ -1493,3 +1494,24 @@ def test_binaryop_and_with_empty_spread_does_not_raise():
     conditions = []
     # Should not raise TypeError
     assert ast.BinaryOp.And(*conditions) is None
+
+
+def test_to_sql_transpiles_functions_for_dialect():
+    """
+    ``to_sql`` should run the rendered SQL through the generic transpiler, not just
+    DJ's native dialect rendering. ``collect_list`` is a Spark-only function with no
+    entry in ``render_for_dialect``'s function map, so it only becomes Trino's
+    ``array_agg`` if real transpilation happens.
+    """
+    query = parse("SELECT collect_list(x) AS c FROM t")
+
+    trino = ast.to_sql(query, Dialect.TRINO)
+    assert "ARRAY_AGG" in trino.upper()
+    assert "COLLECT_LIST" not in trino.upper()
+
+    # Spark is the canonical dialect, so the Spark-native function is preserved.
+    spark = ast.to_sql(query, Dialect.SPARK)
+    assert "COLLECT_LIST" in spark.upper()
+
+    # No dialect => no transpilation, canonical names returned verbatim.
+    assert "COLLECT_LIST" in ast.to_sql(query, None).upper()


### PR DESCRIPTION
### Summary

Requesting specific dialects using `/sql/metrics/v3` (and the other endpoints that use `build_v3`) returned SQL containing the exact functions from the original definition. This was because it wasn't being threaded through the configured transpiler for transpilation.

The `build_v3` path renders SQL through `to_sql(query, dialect)`, which calls `render_for_dialect(dialect)`. Despite the name, `render_for_dialect` is not a transpiler; it only rewrites a function name when that function is registered in DJ's function registry and has a populated `dialect_names[target]` entry. In practice those maps are empty for most functions, so unmapped functions fall through to their original naming regardless of the requested dialect. The only live dialect-specific behavior was the Druid `SAFE_DIVIDE` substitution. Meanwhile DJ already has a sqlglot-backed transpiler, but it was only wired into the legacy SQL paths and not `build_v3`.

The fix is to make `to_sql` apply two passes when a dialect is given:
1. `render_for_dialect(dialect)`: this keeps DJ's AST-level dialect rules (e.g. Druid `SAFE_DIVIDE`).
2. `transpile_sql(rendered, dialect)`: this is the generic transpiler

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
