### PR TITLE
Register inline/inline_outer as table-valued functions

### DIFF
--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -4928,6 +4928,35 @@ def infer_type(
     return [arg.key, arg.value]  # pragma: no cover
 
 
+class Inline(TableFunction):
+    """
+    inline(array_of_struct) - Explodes an array of structs into a table,
+    producing one output column per field of the struct.
+    """
+
+
+@Inline.register
+def infer_type(
+    arg: ct.ListType,
+) -> List[ct.NestedField]:
+    # array<struct<f1, f2, ...>> -> one table column per struct field
+    return list(arg.element.type.fields)
+
+
+class InlineOuter(TableFunction):
+    """
+    inline_outer(array_of_struct) - Like inline, but emits a single row of nulls
+    when the array is empty or null rather than producing no rows.
+    """
+
+
+@InlineOuter.register
+def infer_type(
+    arg: ct.ListType,
+) -> List[ct.NestedField]:
+    return list(arg.element.type.fields)
+
+
 class FunctionRegistryDict(dict):
     """
     Custom dictionary mapping for functions

--- a/datajunction-server/datajunction_server/sql/functions.py
+++ b/datajunction-server/datajunction_server/sql/functions.py
@@ -2664,8 +2664,10 @@ class Inline(Function):
 
 @Inline.register  # type: ignore
 def infer_type(arg: ct.ListType) -> ct.ColumnType:
-    # The output type is the type of the struct's fields
-    return arg.type.element.type
+    # Scalar variant: shadowed by the Inline(TableFunction) below, so this is
+    # unreachable via parsing (inline resolves to a table function). Kept for
+    # registry parity with explode; see Explode(Function).
+    return arg.type.element.type  # pragma: no cover
 
 
 class InlineOuter(Function):
@@ -2677,8 +2679,8 @@ class InlineOuter(Function):
 
 @InlineOuter.register  # type: ignore
 def infer_type(arg: ct.ListType) -> ct.ColumnType:
-    # The output type is the type of the struct's fields
-    return arg.type.element.type
+    # Scalar variant: shadowed by the InlineOuter(TableFunction) below.
+    return arg.type.element.type  # pragma: no cover
 
 
 class InputFileBlockLength(Function):

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2207,25 +2207,24 @@ async def test_initcap_func(session: AsyncSession):
 @pytest.mark.asyncio
 async def test_inline_func(session: AsyncSession):
     """
-    Test the `inline` function
+    `inline` / `inline_outer` are table-generating functions: used in a LATERAL
+    VIEW they explode an array of structs into one output column per struct field.
     """
-    # This test assumes there's a table with a column of type ARRAY<STRUCT<a: INT, b: STRING>>
     query = parse(
-        "SELECT inline(col1), "
-        "inline_outer(array("
-        "struct(1 AS f1, 'a' AS f2), "
-        "struct(2 AS f1, 'b' AS f2)"
-        ")) "
-        "FROM (SELECT (array(struct("
-        "'a' AS k1, 1 AS v1, 'b' AS k2, '222' AS v2"
-        "))) AS col1)",
+        "SELECT a.f1, a.f2, b.f1, b.f2 "
+        "FROM (SELECT array(struct(1 AS f1, 'x' AS f2)) AS col1) src "
+        "LATERAL VIEW inline(col1) a AS f1, f2 "
+        "LATERAL VIEW inline_outer(col1) b AS f1, f2",
     )
     exc = DJException()
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.compile(ctx)
     assert not exc.errors
-    assert isinstance(query.select.projection[0].type, ct.StructType)  # type: ignore
-    assert isinstance(query.select.projection[1].type, ct.StructType)  # type: ignore
+    types_by_name = {}
+    for col in query.columns:
+        types_by_name.setdefault(col.name.name, col.type)  # type: ignore
+    assert isinstance(types_by_name["f1"], ct.IntegerType)
+    assert isinstance(types_by_name["f2"], ct.StringType)
 
 
 def test_inline_registered_as_table_function():

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2228,6 +2228,29 @@ async def test_inline_func(session: AsyncSession):
     assert isinstance(query.select.projection[1].type, ct.StructType)  # type: ignore
 
 
+def test_inline_registered_as_table_function():
+    """
+    Regression: `inline`/`inline_outer` must be registered as table-valued
+    functions so that `LATERAL VIEW inline(array_of_struct)` resolves via the
+    table_function_registry instead of raising DJNotImplementedException. They
+    explode an array of structs into one output column per struct field.
+    """
+    assert "INLINE" in F.table_function_registry
+    assert "INLINE_OUTER" in F.table_function_registry
+
+    array_of_struct = ct.ListType(
+        element_type=ct.StructType(
+            ct.NestedField(name="f1", field_type=ct.IntegerType()),  # type: ignore
+            ct.NestedField(name="f2", field_type=ct.StringType()),  # type: ignore
+        ),
+    )
+    for name in ("INLINE", "INLINE_OUTER"):
+        fields = F.table_function_registry[name].infer_type(array_of_struct)
+        assert [field.name.name for field in fields] == ["f1", "f2"]
+        assert isinstance(fields[0].type, ct.IntegerType)
+        assert isinstance(fields[1].type, ct.StringType)
+
+
 @pytest.mark.asyncio
 async def test_input_file_block_length_func(session: AsyncSession):
     """

--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -2220,7 +2220,7 @@ async def test_inline_func(session: AsyncSession):
     ctx = ast.CompileContext(session=session, exception=exc)
     await query.compile(ctx)
     assert not exc.errors
-    types_by_name = {}
+    types_by_name: dict[str, ct.ColumnType] = {}
     for col in query.columns:
         types_by_name.setdefault(col.name.name, col.type)  # type: ignore
     assert isinstance(types_by_name["f1"], ct.IntegerType)


### PR DESCRIPTION
### Summary

`inline(array_of_struct)` and `inline_outer(...)` are table-generating functions but were defined only as scalar `Function` subclasses, so they were absent from `table_function_registry`. Using them in a table position (e.g. `LATERAL VIEW inline(...)`) raised "The function INLINE hasn't been implemented in DJ yet", since FunctionTable's type resolves via `table_function_registry`.

This adds `TableFunction` variants of `Inline`/`InlineOuter` (mirroring Explode/Unnest), each inferring one output column per field of the input array's struct element. Add a regression test asserting both are registered and infer the struct fields.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
