### PR TITLE
Include exception detail in save_column_level_lineage error log

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2245,10 +2245,14 @@ async def save_column_level_lineage(node_revision_id: int):
                 ]
                 session.add(node_revision)
                 await session.commit()
-    except Exception:
+    except Exception as exc:
+        # Include the exception repr in the *message* (not just exc_info): some
+        # log backends retain only the formatted message and drop the traceback,
+        # which otherwise leaves this generic error undiagnosable.
         _logger.exception(
-            "Error saving column-level lineage for node revision %s",
+            "Error saving column-level lineage for node revision %s: %r",
             node_revision_id,
+            exc,
         )
 
 

--- a/datajunction-server/tests/internal/nodes/background_tasks_test.py
+++ b/datajunction-server/tests/internal/nodes/background_tasks_test.py
@@ -84,7 +84,11 @@ async def test_save_column_level_lineage_swallows_exceptions(caplog):
         ):
             await save_column_level_lineage(node_revision_id=99)
 
+    # The exception must be folded into the message itself (not just exc_info),
+    # so backends that retain only the formatted message stay diagnosable.
     assert any("column-level lineage" in r.message.lower() for r in caplog.records)
+    assert any("boom" in r.message for r in caplog.records)
+    assert any("RuntimeError" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`save_column_level_lineage catches` all exceptions and logs via `_logger.exception(...)`, which attaches the traceback as `exc_info`. Log backends that retain only the formatted message (dropping `exc_info`) then surface a generic "Error saving column-level lineage for node revision N" with no cause, making the failure undiagnosable.

This PR folds the exception repr into the message so it survives message-only log retention. We also extend the existing swallow-exceptions test to assert the exception detail appears in the message.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #2267 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
