### PR TITLE
Include exception detail in create_cube_views error log

### DIFF
--- a/datajunction-server/datajunction_server/internal/views.py
+++ b/datajunction-server/datajunction_server/internal/views.py
@@ -210,10 +210,14 @@ async def create_cube_views(
             tags={**_tags, "status": "success"},
         )
 
-    except Exception:
+    except Exception as exc:
+        # Include the exception repr in the message (not just exc_info): some log
+        # backends retain only the formatted message and drop the traceback,
+        # which otherwise leaves this generic error undiagnosable.
         _logger.exception(
-            "[views] Failed to create views for cube %s (non-blocking)",
+            "[views] Failed to create views for cube %s (non-blocking): %r",
             cube_name,
+            exc,
         )
         get_metrics_provider().counter(
             "dj.views.create",

--- a/datajunction-server/tests/api/cube_views_test.py
+++ b/datajunction-server/tests/api/cube_views_test.py
@@ -2,6 +2,7 @@
 Tests for cube view DDL generation and lifecycle hooks.
 """
 
+import logging
 from unittest import mock
 
 import pytest
@@ -452,6 +453,7 @@ class TestViewCreationOnLifecycle:
         self,
         module__client_with_roads: AsyncClient,
         spy_metrics,
+        caplog,
     ):
         """If create_view raises, the cube create still succeeds and the failure metric is emitted."""
         qs_client = module__client_with_roads.app.dependency_overrides[
@@ -470,18 +472,26 @@ class TestViewCreationOnLifecycle:
         qs_client.create_view = failing_create_view_async
 
         try:
-            response = await module__client_with_roads.post(
-                "/nodes/cube/",
-                json={
-                    "metrics": ["default.num_repair_orders"],
-                    "dimensions": ["default.hard_hat.country"],
-                    "description": "Cube whose view creation will fail",
-                    "mode": "published",
-                    "name": "default.failing_view_cube",
-                },
-            )
+            with caplog.at_level(
+                logging.ERROR,
+                logger="datajunction_server.internal.views",
+            ):
+                response = await module__client_with_roads.post(
+                    "/nodes/cube/",
+                    json={
+                        "metrics": ["default.num_repair_orders"],
+                        "dimensions": ["default.hard_hat.country"],
+                        "description": "Cube whose view creation will fail",
+                        "mode": "published",
+                        "name": "default.failing_view_cube",
+                    },
+                )
             # Cube create succeeds — view creation is fire-and-forget.
             assert response.status_code == 201, response.json()
+
+            # The swallowed exception must be folded into the log message (not
+            # just exc_info), so message-only log backends stay diagnosable.
+            assert "query service exploded" in caplog.text
 
             failure_counters = [
                 c


### PR DESCRIPTION
### Summary

`create_cube_views` catches all exceptions and logs via `_logger.exception(...)`, which attaches the traceback as `exc_info`. Log backends that retain only the formatted message then surface a generic "[views] Failed to create views for cube <name> (non-blocking)" with no cause, making the failure undiagnosable.

This PR folds the exception repr into the message so it survives message-only log retention. It also extends the existing view-creation-failure test to assert the exception detail appears in the message.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #2270 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
