### PR TITLE
Bulk-delete nodes in the deployment orchestrator via bulk `hard_delete_nodes`

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -57,7 +57,6 @@ from datajunction_server.internal.history import EntityType
 from datajunction_server.sql.dag import get_metric_parents_map
 from datajunction_server.internal.nodes import (
     derive_frozen_measures_bulk,
-    hard_delete_node,
 )
 from datajunction_server.models.base import labelize
 from datajunction_server.models.deployment import (
@@ -2776,6 +2775,24 @@ class DeploymentOrchestrator:
                     references[dim_name] = []
                 references[dim_name].append(f"{node.name} (dimension link)")
 
+        # Find hierarchy levels that reference any of the to-delete nodes.
+        # HierarchyLevel.dimension_node_id -> Node.id has no ON DELETE CASCADE, so
+        # a dimension still referenced by a hierarchy level cannot be hard-deleted
+        # (the bulk delete would hit a ForeignKeyViolation). Treat it as a
+        # reference that blocks deletion, like NodeRelationship / DimensionLink.
+        stmt = (
+            select(HierarchyLevel.dimension_node_id, Hierarchy.name)
+            .join(Hierarchy, HierarchyLevel.hierarchy_id == Hierarchy.id)
+            .where(HierarchyLevel.dimension_node_id.in_(deleted_node_ids))
+        )
+        result = await self.session.execute(stmt)
+        for dimension_node_id, hierarchy_name in result:
+            dim_name = id_to_name.get(dimension_node_id)
+            if dim_name:  # pragma: no branch
+                if dim_name not in references:
+                    references[dim_name] = []
+                references[dim_name].append(f"{hierarchy_name} (hierarchy)")
+
         return references
 
     async def _delete_nodes(self, to_delete: list[NodeSpec]) -> list[DeploymentResult]:
@@ -2783,6 +2800,40 @@ class DeploymentOrchestrator:
 
         # Check which nodes have references that would prevent deletion
         references = await self._validate_node_deletion(to_delete)
+
+        # Bulk-delete every deletable node via the shared ``hard_delete_nodes``
+        # helper (the same machinery ``hard_delete_namespace`` uses): it
+        # attributes downstream + dimension-link impact in two bulk CTEs, stages
+        # history, and removes the nodes in one statement (FK ``ON DELETE
+        # CASCADE`` drops all child rows + noderelationship edges). This replaces
+        # a per-node ``hard_delete_node`` loop that re-walked the downstream DAG
+        # for each node — O(N) BFS traversals that dominated large deletions.
+        # Downstream nodes were already revalidated/invalidated by
+        # ``propagate_impact`` (run before deletion). Local import avoids a
+        # module-level import cycle; runs inside the orchestrator SAVEPOINT so
+        # the caller owns the commit and dry-runs still roll back.
+        deletable_names = [
+            spec.rendered_name
+            for spec in to_delete
+            if spec.rendered_name not in references
+        ]
+        deleted_names: set[str] = set()
+        if deletable_names:
+            from datajunction_server.internal.namespaces import hard_delete_nodes
+
+            id_rows = (
+                await self.session.execute(
+                    select(Node.id, Node.name).where(Node.name.in_(deletable_names)),
+                )
+            ).all()
+            deleted_names = {row.name for row in id_rows}
+            node_ids = [row.id for row in id_rows]
+            if node_ids:
+                await hard_delete_nodes(
+                    self.session,
+                    node_ids,
+                    self.context.current_user,
+                )
 
         results = []
         for node_spec in to_delete:
@@ -2804,41 +2855,29 @@ class DeploymentOrchestrator:
                         message=error_msg,
                     ),
                 )
+            elif node_name in deleted_names:
+                results.append(
+                    DeploymentResult(
+                        name=node_name,
+                        deploy_type=DeploymentResult.Type.NODE,
+                        status=DeploymentResult.Status.SUCCESS,
+                        operation=DeploymentResult.Operation.DELETE,
+                        message=f"Node {node_name} has been removed.",
+                    ),
+                )
             else:
-                # Node can be safely deleted
-                results.append(await self._deploy_delete_node(node_name))
+                # Requested for deletion but no longer present in the DB.
+                results.append(
+                    DeploymentResult(
+                        name=node_name,
+                        deploy_type=DeploymentResult.Type.NODE,
+                        status=DeploymentResult.Status.FAILED,
+                        operation=DeploymentResult.Operation.DELETE,
+                        message=f"Node {node_name} not found.",
+                    ),
+                )
 
         return results
-
-    async def _deploy_delete_node(self, name: str) -> DeploymentResult:
-        async def add_history(event, session):  # pragma: no cover
-            """Add history to session without committing"""
-            session.add(event)
-
-        try:
-            await hard_delete_node(
-                name=name,
-                session=self.session,
-                current_user=self.context.current_user,
-                save_history=add_history,
-                flush_only=True,
-            )
-            return DeploymentResult(
-                name=name,
-                deploy_type=DeploymentResult.Type.NODE,
-                status=DeploymentResult.Status.SUCCESS,
-                operation=DeploymentResult.Operation.DELETE,
-                message=f"Node {name} has been removed.",
-            )
-        except Exception as exc:
-            logger.exception(exc)
-            return DeploymentResult(
-                name=name,
-                deploy_type=DeploymentResult.Type.NODE,
-                status=DeploymentResult.Status.FAILED,
-                operation=DeploymentResult.Operation.DELETE,
-                message=str(exc),
-            )
 
     async def _delete_namespaces(
         self,

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -379,102 +379,75 @@ async def create_namespace(
     return parents
 
 
-async def hard_delete_namespace(
+async def hard_delete_nodes(
     session: AsyncSession,
-    namespace: str,
+    node_ids: list[int],
     current_user: User,
-    save_history: Callable,
-    cascade: bool = False,
-) -> HardDeleteResponse:
+) -> ImpactedNodes:
     """
-    Hard delete a node namespace.
+    Bulk hard-delete a set of nodes by id, attributing downstream + dimension-link
+    impact and staging history, then removing the nodes in a single statement.
+
+    FK ``ON DELETE CASCADE`` removes all child rows (revisions, columns, links,
+    availability, materializations) and the ``noderelationship`` edges — fast as
+    long as every cascade-target FK is indexed (see ``add_missing_fk_indexes``).
+    Instead of an O(N) per-node downstream BFS, impact is computed with two bulk
+    recursive CTEs.
+
+    Does NOT commit — the caller owns the transaction (the namespace hard-delete
+    endpoint, or a deployment SAVEPOINT). Shared by ``hard_delete_namespace`` and
+    the deployment orchestrator so both apply identical semantics.
     """
+    impacted_downstreams: Dict[str, List[str]] = defaultdict(list)
+    impacted_links: Dict[str, List[str]] = defaultdict(list)
+    if not node_ids:
+        return ImpactedNodes(downstreams=[], links=[])
+
     node_rows = (
         await session.execute(
             select(Node.id, Node.name, Node.type)
-            .where(
-                or_(
-                    Node.namespace.like(f"{namespace}.%"),
-                    Node.namespace == namespace,
-                ),
-            )
+            .where(Node.id.in_(node_ids))
             .order_by(Node.name),
         )
     ).all()
-    node_names = [row.name for row in node_rows]
-    node_ids = [row.id for row in node_rows]
     node_id_to_name = {row.id: row.name for row in node_rows}
     dimension_ids = [row.id for row in node_rows if row.type == NodeType.DIMENSION]
 
-    if not cascade and node_names:
-        raise DJActionNotAllowedException(
-            message=(
-                f"Cannot hard delete namespace `{namespace}` as there are still the "
-                f"following nodes under it: `{node_names}`. Set `cascade` to true to "
-                "additionally hard delete the above nodes in this namespace. WARNING:"
-                " this action cannot be undone."
-            ),
-        )
-    impacts = {
-        node_name: {"type": "node in namespace", "status": "hard deleted"}
-        for node_name in node_names
-    }
-
-    # Track downstream nodes affected by deletions. Instead of calling
-    # get_downstream_nodes / get_nodes_with_common_dimensions per deleted node
-    # (which is O(N) BFS traversals for N nodes), compute direct edges in two
-    # bulk queries:
-    #   1. NodeRelationship rows where parent is deleted and child is not.
-    #   2. Column.dimension_id / DimensionLink.dimension_id rows pointing at
-    #      a deleted dimension from a non-deleted consumer.
-    impacted_downstreams: Dict[str, List[str]] = defaultdict(list)
-    impacted_links: Dict[str, List[str]] = defaultdict(list)
-
-    if node_ids:
-        # Transitive downstream attribution: a downstream node D is "caused
-        # by" every deleted ancestor X for which there is a path X -> ... -> D
-        # in the noderelationship graph. We compute this with one recursive
-        # CTE seeded at the deleted nodes, propagating each deleted ancestor
-        # label down through current revisions.
-        downstream_rows = await session.execute(
-            text(
-                """
-                WITH RECURSIVE descendants(deleted_id, current_id) AS (
-                    SELECT id, id FROM node WHERE id IN :deleted_ids
-                  UNION
-                    SELECT d.deleted_id, n.id
-                    FROM descendants d
-                    JOIN noderelationship rel ON rel.parent_id = d.current_id
-                    JOIN noderevision nr ON nr.id = rel.child_id
-                    JOIN node n
-                      ON n.id = nr.node_id
-                     AND n.current_version = nr.version
-                    WHERE n.deactivated_at IS NULL
-                )
-                SELECT DISTINCT d.deleted_id, n.name
+    # Transitive downstream attribution: a downstream node D is "caused by" every
+    # deleted ancestor X with a path X -> ... -> D in the noderelationship graph.
+    downstream_rows = await session.execute(
+        text(
+            """
+            WITH RECURSIVE descendants(deleted_id, current_id) AS (
+                SELECT id, id FROM node WHERE id IN :deleted_ids
+              UNION
+                SELECT d.deleted_id, n.id
                 FROM descendants d
-                JOIN node n ON n.id = d.current_id
-                WHERE d.current_id NOT IN :deleted_ids
-                """,
-            ).bindparams(bindparam("deleted_ids", expanding=True)),
-            {"deleted_ids": node_ids},
-        )
-        # Preserve attribution ordering by deleted-node sort order (node_names
-        # is already sorted), so tests can assert on the caused_by list.
-        downstream_pairs: Dict[str, List[int]] = defaultdict(list)
-        for parent_id, child_name in downstream_rows.all():
-            downstream_pairs[child_name].append(parent_id)
-        for child_name, parent_ids in downstream_pairs.items():
-            ordered = sorted(parent_ids, key=lambda pid: node_id_to_name[pid])
-            impacted_downstreams[child_name] = [node_id_to_name[pid] for pid in ordered]
+                JOIN noderelationship rel ON rel.parent_id = d.current_id
+                JOIN noderevision nr ON nr.id = rel.child_id
+                JOIN node n
+                  ON n.id = nr.node_id
+                 AND n.current_version = nr.version
+                WHERE n.deactivated_at IS NULL
+            )
+            SELECT DISTINCT d.deleted_id, n.name
+            FROM descendants d
+            JOIN node n ON n.id = d.current_id
+            WHERE d.current_id NOT IN :deleted_ids
+            """,
+        ).bindparams(bindparam("deleted_ids", expanding=True)),
+        {"deleted_ids": node_ids},
+    )
+    downstream_pairs: Dict[str, List[int]] = defaultdict(list)
+    for parent_id, child_name in downstream_rows.all():
+        downstream_pairs[child_name].append(parent_id)
+    for child_name, parent_ids in downstream_pairs.items():
+        ordered = sorted(parent_ids, key=lambda pid: node_id_to_name[pid])
+        impacted_downstreams[child_name] = [node_id_to_name[pid] for pid in ordered]
 
     if dimension_ids:
-        # Walk the dimension graph upstream: any dimension D' whose current
-        # revision has a column or dimension link pointing at a deleted
-        # dimension D (transitively) means consumers of D' lose a path that
-        # leads to D. We propagate the original deleted-dim attribution
-        # through the recursive expansion, then find non-deleted consumers
-        # of any dimension in the expanded set.
+        # Consumers (transitively) of any deleted dimension via column /
+        # dimension-link edges that aren't themselves being deleted.
         link_rows = await session.execute(
             text(
                 """
@@ -523,12 +496,8 @@ async def hard_delete_namespace(
             ordered = sorted(set(dim_ids), key=lambda d: node_id_to_name[d])
             impacted_links[consumer_name] = [node_id_to_name[d] for d in ordered]
 
-    # Stage history events on the session without committing — the whole
-    # hard-delete operation (history + node deletes + namespace deletes)
-    # commits atomically at the end. ``save_history`` commits per-event, so
-    # we ``session.add`` directly here. Notifications are intentionally
-    # skipped on bulk hard-delete (the notifier is a per-event side effect
-    # that isn't useful at this scale).
+    # Stage history without committing (caller commits atomically). Notifications
+    # are intentionally skipped on bulk hard-delete.
     for impacted_node, causes in impacted_downstreams.items():
         session.add(
             History(
@@ -539,7 +508,6 @@ async def hard_delete_namespace(
                 details={"caused_by": causes},
             ),
         )
-
     for impacted_node, causes in impacted_links.items():
         session.add(
             History(
@@ -551,11 +519,55 @@ async def hard_delete_namespace(
             ),
         )
 
-    # Delete the nodes — FK CASCADE handles all child tables. Fast as long
-    # as every cascade-target FK column is indexed; otherwise Postgres
-    # seq-scans each child table per row deleted (catastrophic). See the
-    # add_missing_fk_indexes migration.
     await session.execute(delete(Node).where(Node.id.in_(node_ids)))
+
+    return ImpactedNodes(
+        downstreams=[
+            ImpactedNode(name=downstream, caused_by=caused_by)
+            for downstream, caused_by in impacted_downstreams.items()
+        ],
+        links=[
+            ImpactedNode(name=linked, caused_by=caused_by)
+            for linked, caused_by in impacted_links.items()
+        ],
+    )
+
+
+async def hard_delete_namespace(
+    session: AsyncSession,
+    namespace: str,
+    current_user: User,
+    save_history: Callable,
+    cascade: bool = False,
+) -> HardDeleteResponse:
+    """
+    Hard delete a node namespace.
+    """
+    node_rows = (
+        await session.execute(
+            select(Node.id, Node.name, Node.type)
+            .where(
+                or_(
+                    Node.namespace.like(f"{namespace}.%"),
+                    Node.namespace == namespace,
+                ),
+            )
+            .order_by(Node.name),
+        )
+    ).all()
+    node_names = [row.name for row in node_rows]
+    node_ids = [row.id for row in node_rows]
+
+    if not cascade and node_names:
+        raise DJActionNotAllowedException(
+            message=(
+                f"Cannot hard delete namespace `{namespace}` as there are still the "
+                f"following nodes under it: `{node_names}`. Set `cascade` to true to "
+                "additionally hard delete the above nodes in this namespace. WARNING:"
+                " this action cannot be undone."
+            ),
+        )
+    impacted = await hard_delete_nodes(session, node_ids, current_user)
 
     # Delete namespaces in the same transaction so the whole operation is
     # atomic.
@@ -574,10 +586,6 @@ async def hard_delete_namespace(
     )
 
     for _namespace in namespaces:
-        impacts[_namespace.namespace] = {
-            "type": "namespace",
-            "status": "hard deleted",
-        }
         await session.delete(_namespace)
 
     await session.commit()
@@ -585,16 +593,7 @@ async def hard_delete_namespace(
     return HardDeleteResponse(
         deleted_namespaces=deleted_namespaces,
         deleted_nodes=node_names,
-        impacted=ImpactedNodes(
-            downstreams=[
-                ImpactedNode(name=downstream, caused_by=caused_by)
-                for downstream, caused_by in impacted_downstreams.items()
-            ],
-            links=[
-                ImpactedNode(name=linked, caused_by=caused_by)
-                for linked, caused_by in impacted_links.items()
-            ],
-        ),
+        impacted=impacted,
     )
 
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3658,15 +3658,10 @@ async def hard_delete_node(
     session: AsyncSession,
     current_user: User,
     save_history: Callable,
-    flush_only: bool = False,
 ):
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
     This should be used with caution, deactivating a node is preferred.
-
-    When ``flush_only=True`` (used by the deployment orchestrator inside a savepoint),
-    the deletion is flushed rather than committed and downstream revalidation is skipped
-    (the orchestrator handles downstream invalidation via ``_revalidate_downstream``).
     """
     node = await Node.get_by_name(
         session,
@@ -3694,10 +3689,6 @@ async def hard_delete_node(
         )
 
     await session.delete(node)
-    if flush_only:
-        await session.flush()
-        return
-
     await session.commit()
     impact = []  # Aggregate all impact of this deletion to include in response
 

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2229,13 +2229,15 @@ async def test_deploy_reference_link_on_invalid_node(
 
 
 @pytest.mark.asyncio
-async def test_deploy_delete_node_calls_add_history(
+async def test_delete_nodes_bulk_deletes_existing_node(
     session,
     current_user,
     mock_deployment_context,
 ):
-    """_deploy_delete_node with a real existing node calls hard_delete_node which
-    invokes the nested add_history callback (covers line 2196)."""
+    """_delete_nodes bulk-deletes a deletable node via a single cascade DELETE
+    (no per-node hard_delete_node loop). Downstream invalidation is handled
+    separately by propagate_impact, so here we only assert the node is removed
+    and the result is a successful DELETE."""
     orch = DeploymentOrchestrator(
         deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
         deployment_id="delete-test",
@@ -2243,13 +2245,58 @@ async def test_deploy_delete_node_calls_add_history(
         context=mock_deployment_context,
         dry_run=False,
     )
+    # "default.hard_hat" is present in the pre-loaded roads example DB.
+    spec = Mock()
+    spec.rendered_name = "default.hard_hat"
+    # No external references block the delete.
+    with patch.object(orch, "_validate_node_deletion", AsyncMock(return_value={})):
+        results = await orch._delete_nodes([spec])
 
-    # "default.hard_hat" is present in the pre-loaded roads example DB
-    result = await orch._deploy_delete_node("default.hard_hat")
+    assert len(results) == 1
+    assert results[0].status == DeploymentResult.Status.SUCCESS
+    assert results[0].operation == DeploymentResult.Operation.DELETE
+    assert results[0].name == "default.hard_hat"
 
-    # The node was found and deleted successfully
-    assert result.status == DeploymentResult.Status.SUCCESS
-    assert result.operation == DeploymentResult.Operation.DELETE
+    # The node row is gone.
+    gone = (
+        await session.execute(
+            select(Node).where(Node.name == "default.hard_hat"),
+        )
+    ).scalar_one_or_none()
+    assert gone is None
+
+
+@pytest.mark.asyncio
+async def test_delete_nodes_reports_referenced_and_missing(
+    session,
+    mock_deployment_context,
+):
+    """A referenced node is FAILED (blocked); a deletable-but-absent node is
+    FAILED (not found). Covers both non-success branches without a real delete."""
+    orch = DeploymentOrchestrator(
+        deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
+        deployment_id="delete-test-2",
+        session=session,
+        context=mock_deployment_context,
+        dry_run=False,
+    )
+    referenced = Mock()
+    referenced.rendered_name = "default.referenced"
+    absent = Mock()
+    absent.rendered_name = "default.does_not_exist"
+
+    with patch.object(
+        orch,
+        "_validate_node_deletion",
+        AsyncMock(return_value={"default.referenced": ["default.consumer"]}),
+    ):
+        results = await orch._delete_nodes([referenced, absent])
+
+    by_name = {r.name: r for r in results}
+    assert by_name["default.referenced"].status == DeploymentResult.Status.FAILED
+    assert "referenced by" in by_name["default.referenced"].message
+    assert by_name["default.does_not_exist"].status == DeploymentResult.Status.FAILED
+    assert "not found" in by_name["default.does_not_exist"].message
 
 
 class TestGenerateChangelog:

--- a/datajunction-server/tests/internal/deployment_test.py
+++ b/datajunction-server/tests/internal/deployment_test.py
@@ -487,39 +487,55 @@ async def date(session: AsyncSession, catalog: Catalog, current_user: User) -> N
     return node
 
 
-async def test_deploy_delete_node_success(
+async def test_delete_nodes_success(
     session: AsyncSession,
     current_user: User,
     categories: Node,
 ):
     await default_attribute_types(session)
     orchestrator = create_orchestrator(session, current_user, [])
-    result = await orchestrator._deploy_delete_node(categories.name)
-    assert result == DeploymentResult(
-        name="catalog.dim.categories",
-        deploy_type=DeploymentResult.Type.NODE,
-        status=DeploymentResult.Status.SUCCESS,
-        operation=DeploymentResult.Operation.DELETE,
-        message="Node catalog.dim.categories has been removed.",
-    )
+    spec = MagicMock(rendered_name=categories.name)
+    with patch.object(
+        orchestrator,
+        "_validate_node_deletion",
+        AsyncMock(return_value={}),
+    ):
+        results = await orchestrator._delete_nodes([spec])
+    assert results == [
+        DeploymentResult(
+            name="catalog.dim.categories",
+            deploy_type=DeploymentResult.Type.NODE,
+            status=DeploymentResult.Status.SUCCESS,
+            operation=DeploymentResult.Operation.DELETE,
+            message="Node catalog.dim.categories has been removed.",
+        ),
+    ]
     assert await Node.get_by_name(session, categories.name) is None
 
 
-async def test_deploy_delete_node_failure(
+async def test_delete_nodes_missing(
     session: AsyncSession,
     current_user: User,
     categories: Node,
 ):
     await default_attribute_types(session)
     orchestrator = create_orchestrator(session, current_user, [])
-    result = await orchestrator._deploy_delete_node(categories.name + "bogus")
-    assert result == DeploymentResult(
-        name="catalog.dim.categoriesbogus",
-        deploy_type=DeploymentResult.Type.NODE,
-        status=DeploymentResult.Status.FAILED,
-        operation=DeploymentResult.Operation.DELETE,
-        message="A node with name `catalog.dim.categoriesbogus` does not exist.",
-    )
+    spec = MagicMock(rendered_name=categories.name + "bogus")
+    with patch.object(
+        orchestrator,
+        "_validate_node_deletion",
+        AsyncMock(return_value={}),
+    ):
+        results = await orchestrator._delete_nodes([spec])
+    assert results == [
+        DeploymentResult(
+            name="catalog.dim.categoriesbogus",
+            deploy_type=DeploymentResult.Type.NODE,
+            status=DeploymentResult.Status.FAILED,
+            operation=DeploymentResult.Operation.DELETE,
+            message="Node catalog.dim.categoriesbogus not found.",
+        ),
+    ]
 
 
 def test_find_upstreams_for_derived_metric():


### PR DESCRIPTION
### Summary

The orchestrator deleted nodes one at a time (a call to `hard_delete_node` per node), which re-walked the downstream DAG (`get_downstream_nodes`) for each node, resulting in O(N) BFS traversals that dominate large deletions. Thus, a namespace cleanup deleting thousands of nodes ran ~50 min in one transaction and was prone to a mid-flight DB connection drop.

This PR extracts the bulk machinery from `hard_delete_namespace` into the existing `hard_delete_nodes` function that does two bulk recursive CTEs for downstream + dimension-link impact attribution, history staging, and a single bulk delete call on nodes. `hard_delete_namespace` now calls this and the orchestrator's `_delete_nodes` also calls it on the deletable set.

### Test Plan

<!-- How did you test your change? -->

- [x] PR has an associated issue: #2272 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP