### PR TITLE
Fix v3 filter pushdown: block FK-name collision in upstream CTEs

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1108,6 +1108,26 @@ def _inject_filter_into_where(
     inject_filter_into_select(cast(ast.Select, query_ast.select), filter_expr)
 
 
+def _fk_key_column_names(node: "Node") -> set[str]:
+    """Short names of the foreign-key *value* columns on ``node``'s dim links.
+
+    Each link's ``foreign_keys_reversed`` maps a dimension PK column to the raw
+    FK column on this node; we return those FK column short names.  A filter on a
+    joined dimension's non-key attribute whose bare name collides with one of
+    these must never be pushed onto it (it would bind a string-attribute
+    predicate to the int FK column).
+    """
+    from datajunction_server.construction.build_v3.utils import get_short_name
+
+    cols: set[str] = set()
+    if node.current and node.current.dimension_links:
+        for link in node.current.dimension_links:
+            for _pk_fqn, fk_fqn in (link.foreign_keys_reversed or {}).items():
+                if fk_fqn:  # pragma: no branch
+                    cols.add(get_short_name(fk_fqn))
+    return cols
+
+
 def _resolve_pushdown_filters_for_cte(
     node: "Node",
     cte_query: ast.Query,
@@ -1115,6 +1135,7 @@ def _resolve_pushdown_filters_for_cte(
     filter_column_aliases: dict[str, str],
     ctx: Optional["BuildContext"] = None,
     outer_only_refs: Optional[set[str]] = None,
+    fk_collision_cols: Optional[set[str]] = None,
 ) -> tuple[list[tuple[ast.Select, ast.Expression]], set[str]]:
     """Determine which user filters can be pushed into this CTE.
 
@@ -1160,29 +1181,29 @@ def _resolve_pushdown_filters_for_cte(
         **local_aliases,
     }
 
-    # Block a filter ref only when its resolved bare column is an FK column on
-    # this node (i.e. the node has a dimension link that uses that column as a
-    # FK) but the ref itself has no local mapping — meaning the filter targets
-    # a dim's non-PK attribute whose name collides with the FK integer column,
-    # which would produce a type mismatch.  Only FK columns from dimension
-    # links qualify; the node's own output columns (added to local_aliases by
-    # #2179 for dimension nodes) are the genuine attribute and are not blocked.
-    fk_col_names: set[str] = set()
-    if node.current and node.current.dimension_links:
-        from datajunction_server.construction.build_v3.utils import get_short_name
-
-        for _link in node.current.dimension_links:
-            for _dim_col_fqn, _fk_fqn in (_link.foreign_keys_reversed or {}).items():
-                if _fk_fqn:  # pragma: no branch
-                    fk_col_names.add(get_short_name(_fk_fqn))
-
+    # Block a filter ref when its resolved bare column is a foreign-key *value*
+    # column (the raw int key on a fact/transform) but the ref has no local
+    # mapping — i.e. the filter targets a joined dimension's non-key attribute
+    # whose name collides with that FK column.  Pushing it would bind a (string)
+    # attribute predicate to the (int) FK column and silently match nothing.
+    #
+    # The FK-column set is the union of THIS node's links and the linking
+    # (parent) node's links (``fk_collision_cols``, threaded in).  The parent
+    # set is essential: the filter can be pushed UPSTREAM into an ancestor CTE
+    # that merely projects the FK column without carrying the link (e.g. a base
+    # transform feeding a linked one) — where a node-local check is blind.  This
+    # single ``blocked_refs`` set is consulted by every pushdown path below.
+    # Genuine dimension attributes (e.g. ``state``) are not FK columns, so they
+    # are never blocked; the dim's own CTE / join-key filters stay exempt via
+    # ``local_aliases``.
+    collision_cols = _fk_key_column_names(node) | (fk_collision_cols or set())
     blocked_refs: set[str] = set()
     for ref in outer_only_refs or set():
         base = ref.split("[")[0]
         if ref in local_aliases or base in local_aliases:
-            continue  # properly mapped locally — safe to push
+            continue  # properly mapped locally (dim's own CTE / join key) — safe
         bare_col = effective_aliases.get(ref) or effective_aliases.get(base)
-        if bare_col and bare_col in fk_col_names:
+        if bare_col and bare_col in collision_cols:
             blocked_refs.add(ref)
 
     target_select = cast(ast.Select, cte_query.select)
@@ -1322,6 +1343,7 @@ def _resolve_pushdown_filters_for_cte(
                 filter_str,
                 effective_aliases,
                 col_to_alias,
+                blocked_refs,
             )
             if inner_rewrite is None:
                 continue
@@ -1668,9 +1690,15 @@ def _rewrite_filter_for_scope(
     filter_str: str,
     filter_column_aliases: dict[str, str],
     column_to_alias: dict[str, tuple[str, str]],
+    blocked_refs: Optional[set[str]] = None,
 ) -> Optional[ast.Expression]:
     """Parse a filter fresh and qualify each dim-ref column using the
     scope's resolver map.
+
+    ``blocked_refs`` carries the same outer-only/FK-collision guard the primary
+    rewrite honors (see :func:`_resolve_pushdown_filters_for_cte`): a filter
+    referencing any blocked ref is skipped entirely so this column-aware
+    retargeting pass cannot reintroduce a push the primary path refused.
 
     The resolver map keys are fully-qualified dim refs (e.g.
     ``common.dimensions.xp.allocation_snapshot_date.dateint``)
@@ -1690,11 +1718,21 @@ def _rewrite_filter_for_scope(
     Returns ``None`` when no column resolves — atomic per filter
     to mirror the primary-rewrite behavior.
     """
+    filter_ast = parse_filter(filter_str)
+    cols = list(filter_ast.find_all(ast.Column))
+    # Guard first, before any early-out: a filter referencing a blocked ref
+    # (outer-only / FK-name collision) must never be retargeted into a scope —
+    # it stays at the outer WHERE.  Checked up front so it holds regardless of
+    # whether this scope's resolver map happens to be empty.
+    if blocked_refs:
+        for col in cols:
+            full = get_column_full_name(col)
+            if full and (full in blocked_refs or full.split("[")[0] in blocked_refs):
+                return None
     if not column_to_alias:
         return None
-    filter_ast = parse_filter(filter_str)
     rewrites: list[tuple[ast.Column, ast.Column]] = []
-    for col in filter_ast.find_all(ast.Column):
+    for col in cols:
         full = get_column_full_name(col)
         if not full:  # pragma: no cover
             continue
@@ -2156,6 +2194,7 @@ def collect_node_ctes(
                 pushdown.column_aliases,
                 ctx,
                 pushdown.outer_only_refs,
+                pushdown.fk_collision_cols,
             )
             for target_select, filter_ast in injections:
                 inject_filter_into_select(target_select, filter_ast)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from datajunction_server.database.preaggregation import PreAggregation
 
 from datajunction_server.construction.build_v3.cte import (
+    _fk_key_column_names,
     collect_node_ctes,
     extract_dimension_node,
     inject_filter_into_select,
@@ -1447,6 +1448,7 @@ def build_select_ast(
     where_clause: Optional[ast.Expression] = None
     filter_column_aliases: dict[str, str] = {}
     pushdown_outer_only_refs: set[str] = set()
+    pushdown_fk_collision_cols: set[str] = set()
     if all_filters:
         filter_column_aliases = build_filter_column_aliases(
             ctx,
@@ -1454,6 +1456,10 @@ def build_select_ast(
             parent_node,
         )
         pushdown_outer_only_refs = outer_only_filter_refs(resolved_dimensions)
+        # FK columns on the linking (parent) node — used to refuse pushing a
+        # joined dim's same-named non-key attribute filter onto the raw FK
+        # column in any CTE, including upstream ancestors that lack the link.
+        pushdown_fk_collision_cols = _fk_key_column_names(parent_node)
         where_clause = build_outer_where(
             all_filters,
             filter_column_aliases,
@@ -1476,6 +1482,7 @@ def build_select_ast(
             filters=all_filters,
             column_aliases=filter_column_aliases,
             outer_only_refs=pushdown_outer_only_refs,
+            fk_collision_cols=pushdown_fk_collision_cols,
         )
         if all_filters
         else None,

--- a/datajunction-server/datajunction_server/construction/build_v3/node_query.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/node_query.py
@@ -29,7 +29,10 @@ from datajunction_server.internal.access.authorization import (
     AccessDenialMode,
 )
 from datajunction_server.models import access
-from datajunction_server.construction.build_v3.cte import collect_node_ctes
+from datajunction_server.construction.build_v3.cte import (
+    _fk_key_column_names,
+    collect_node_ctes,
+)
 from datajunction_server.construction.build_v3.dimensions import (
     parse_dimension_ref,
     resolve_dimensions,
@@ -439,6 +442,7 @@ def _build_with_dimensions(
             filters=filter_list,
             column_aliases=filter_column_aliases,
             outer_only_refs=pushdown_outer_only_refs,
+            fk_collision_cols=_fk_key_column_names(starting),
         )
         if filter_list
         else None,

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -190,11 +190,18 @@ class PushdownFilters:
             column there is the raw FK value, not the attribute).  Such a
             filter still pushes into the dimension's *own* CTE and lands in the
             outer WHERE.  See ``outer_only_filter_refs``.
+        fk_collision_cols: Foreign-key *value* column short-names on the linking
+            (parent) node's dimension links.  An ``outer_only`` ref whose bare
+            column collides with one of these is a joined dimension's non-key
+            attribute sharing a name with the raw FK column, so it must not be
+            pushed into ANY CTE (incl. an upstream ancestor that projects the FK
+            without owning the link).  See ``_resolve_pushdown_filters_for_cte``.
     """
 
     filters: list[str]
     column_aliases: dict[str, str]
     outer_only_refs: set[str] = field(default_factory=set)
+    fk_collision_cols: set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1805,3 +1805,134 @@ class TestDimLabelFilterNameCollision:
             """,
             normalize_aliases=True,
         )
+
+    @pytest.mark.asyncio
+    async def test_dim_label_filter_not_pushed_into_upstream_cte_without_link(
+        self,
+        client_with_build_v3,
+    ):
+        """Regression: the label predicate must not be pushed UPSTREAM either.
+
+        When the linked transform projects its int FK from an *intermediate*
+        transform that does not itself carry the dimension link, the filter can
+        be pushed past the link into that ancestor's CTE — where a node-local
+        FK-column guard is blind because the ancestor has no link.  The label
+        predicate must stay in the dimension's own CTE and the post-join outer
+        WHERE; no upstream CTE may receive ``is_bot = 'false'`` on the raw int
+        column.  (The linked transform selects its FK column from an upstream
+        transform that only projects the raw key and carries no link of its own.)
+        """
+        client = client_with_build_v3
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.ml_alloc_src",
+                "columns": [
+                    {"name": "account_id", "type": "int"},
+                    {"name": "is_bot", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "ml_alloc_src",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        # Intermediate transform: projects the raw int FK, carries NO dim link.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.ml_alloc",
+                "query": "SELECT account_id, is_bot, amount FROM v3.ml_alloc_src",
+                "mode": "published",
+                "primary_key": ["account_id"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        # Downstream transform: selects the FK from the intermediate, holds the link.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.ml_long",
+                "query": "SELECT account_id, is_bot, amount FROM v3.ml_alloc",
+                "mode": "published",
+                "primary_key": ["account_id"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.ml_is_bot_dim",
+                "query": (
+                    "SELECT t.is_bot_key, t.is_bot "
+                    "FROM (SELECT 0 AS is_bot_key, 'false' AS is_bot "
+                    "UNION ALL SELECT 1, 'true') t"
+                ),
+                "mode": "published",
+                "primary_key": ["is_bot_key"],
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        resp = await client.post(
+            "/nodes/v3.ml_long/link/",
+            json={
+                "dimension_node": "v3.ml_is_bot_dim",
+                "join_type": "left",
+                "join_on": "v3.ml_long.is_bot = v3.ml_is_bot_dim.is_bot_key",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.ml_total_amount",
+                "query": "SELECT SUM(amount) FROM v3.ml_long",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.ml_total_amount"],
+                "dimensions": ["v3.ml_is_bot_dim.is_bot"],
+                "filters": ["v3.ml_is_bot_dim.is_bot = 'false'"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = get_first_grain_group(response.json())["sql"]
+        # Neither the intermediate (v3_ml_alloc) nor the linked transform
+        # (v3_ml_long) CTE may carry the label predicate on the raw int column.
+        assert_sql_equal(
+            sql,
+            """
+            WITH v3_ml_alloc AS (
+              SELECT account_id, is_bot, amount
+              FROM default.v3.ml_alloc_src
+            ),
+            v3_ml_is_bot_dim AS (
+              SELECT t.is_bot_key, t.is_bot
+              FROM (
+                SELECT 0 AS is_bot_key, 'false' AS is_bot
+                UNION ALL
+                SELECT 1, 'true'
+              ) t
+              WHERE t.is_bot = 'false'
+            ),
+            v3_ml_long AS (
+              SELECT is_bot, amount
+              FROM v3_ml_alloc
+            )
+            SELECT t2.is_bot,
+                   SUM(t1.amount) amount_sum_HASH
+            FROM v3_ml_long t1
+            LEFT OUTER JOIN v3_ml_is_bot_dim t2
+              ON t1.is_bot = t2.is_bot_key
+            WHERE t2.is_bot = 'false'
+            GROUP BY t2.is_bot
+            """,
+            normalize_aliases=True,
+        )


### PR DESCRIPTION
### Summary

A filter on a joined dimension's non-key (string) attribute whose name collides with a node's raw integer foreign-key column was being pushed onto that FK column inside an upstream CTE that projects the FK but does not own the dimension link. On Spark `int_col = 'false'` evaluates to NULL, so the scan returns zero rows (silent empty results); on Trino it errors with a type mismatch.

`_resolve_pushdown_filters_for_cte` only consulted the current CTE node's own dimension links when building its block-list, so a push into an ancestor CTE without the link was unguarded. Source the FK-collision columns from the linking (parent) node as well, threaded via a new `PushdownFilters.fk_collision_cols`, and union it with the node-local set. Also pass `blocked_refs` into the second-pass column-aware retargeting (`_rewrite_filter_for_scope`) so it honors the same guard. Genuine dimension attributes (not FK columns) still push.

Adds a regression test with a multi-level transform chain (FK projected through an intermediate node that lacks the link) — the shape prior single-level tests for this collision never exercised.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
