### PR TITLE
Redesign the browse namespace left-nav

### DIFF
--- a/datajunction-ui/src/app/pages/NamespacePage/Explorer.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/Explorer.jsx
@@ -7,8 +7,9 @@ import DJClientContext from '../../providers/djclient';
 const Explorer = ({
   item = [],
   current,
-  isTopLevel = false,
   gitRoots = new Set(),
+  pinnedSet,
+  onTogglePin,
 }) => {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
   const [items, setItems] = useState([]);
@@ -18,8 +19,10 @@ const Explorer = ({
   const [isCreatingChild, setIsCreatingChild] = useState(false);
   const [newNamespace, setNewNamespace] = useState('');
   const [error, setError] = useState('');
+  const [menuOpen, setMenuOpen] = useState(false);
   const inputRef = useRef(null);
   const formRef = useRef(null);
+  const menuRef = useRef(null);
 
   useEffect(() => {
     setItems(item);
@@ -49,6 +52,20 @@ const Explorer = ({
       };
     }
   }, [isCreatingChild]);
+
+  useEffect(() => {
+    const handleClickOutside = event => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    };
+    if (menuOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+  }, [menuOpen]);
 
   const handleClickOnParent = e => {
     e.stopPropagation();
@@ -92,6 +109,13 @@ const Explorer = ({
       handleCancelAdd();
     }
   };
+
+  // A namespace is git-backed when it IS a git root or sits under one. Git-backed
+  // namespaces are managed via git, so we don't offer "add child" in the UI.
+  const path = items.path;
+  const isGitBacked =
+    !!path && [...gitRoots].some(r => path === r || path.startsWith(`${r}.`));
+  const isPinned = !!(pinnedSet && path && pinnedSet.has(path));
 
   return (
     <>
@@ -174,30 +198,91 @@ const Explorer = ({
               Git
             </span>
           )}
-          <button
-            className="namespace-add-button"
-            onClick={e => {
-              e.stopPropagation();
-              setIsCreatingChild(true);
-              setExpand(true);
-            }}
-            title="Add child namespace"
-            style={{
-              position: 'absolute',
-              right: '0',
-              padding: '2px 6px',
-              border: 'none',
-              background: 'transparent',
-              cursor: 'pointer',
-              opacity: showAddButton ? 0.6 : 0,
-              visibility: showAddButton ? 'visible' : 'hidden',
-              display: 'inline-flex',
-              alignItems: 'center',
-              transition: 'opacity 0.15s ease',
-            }}
-          >
-            <AddItemIcon />
-          </button>
+          {(onTogglePin || !isGitBacked) && (
+            <div
+              ref={menuRef}
+              className="dj-ns-row-actions"
+              onClick={e => e.stopPropagation()}
+            >
+              {isPinned && onTogglePin && (
+                <span
+                  className="dj-ns-pin-indicator"
+                  aria-hidden="true"
+                  title="Pinned"
+                >
+                  ★
+                </span>
+              )}
+              <button
+                type="button"
+                className="dj-ns-kebab"
+                aria-label={`Actions for ${path}`}
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                onClick={e => {
+                  e.stopPropagation();
+                  setMenuOpen(o => !o);
+                }}
+                style={{
+                  opacity: showAddButton || menuOpen ? 1 : 0,
+                  visibility: showAddButton || menuOpen ? 'visible' : 'hidden',
+                }}
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <circle cx="5" cy="12" r="2" />
+                  <circle cx="12" cy="12" r="2" />
+                  <circle cx="19" cy="12" r="2" />
+                </svg>
+              </button>
+              {menuOpen && (
+                <div role="menu" className="dj-ns-row-menu">
+                  {onTogglePin && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="dj-ns-row-menu-item"
+                      onClick={e => {
+                        e.stopPropagation();
+                        onTogglePin(path);
+                        setMenuOpen(false);
+                      }}
+                    >
+                      <span
+                        className={`dj-ns-mi-icon${isPinned ? ' pinned' : ''}`}
+                      >
+                        ★
+                      </span>
+                      {isPinned ? 'Unpin namespace' : 'Pin namespace'}
+                    </button>
+                  )}
+                  {!isGitBacked && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="dj-ns-row-menu-item"
+                      onClick={e => {
+                        e.stopPropagation();
+                        setIsCreatingChild(true);
+                        setExpand(true);
+                        setMenuOpen(false);
+                      }}
+                    >
+                      <span className="dj-ns-mi-icon">
+                        <AddItemIcon />
+                      </span>
+                      Add child namespace
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
       {(items.children || isCreatingChild) && (
@@ -279,8 +364,9 @@ const Explorer = ({
                   <Explorer
                     item={item}
                     current={highlight}
-                    isTopLevel={false}
                     gitRoots={gitRoots}
+                    pinnedSet={pinnedSet}
+                    onTogglePin={onTogglePin}
                   />
                 </div>
               </div>

--- a/datajunction-ui/src/app/pages/NamespacePage/NamespaceNav.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/NamespaceNav.jsx
@@ -5,7 +5,7 @@ import CollapsedIcon from '../../icons/CollapsedIcon';
 import ExpandedIcon from '../../icons/ExpandedIcon';
 import {
   buildNamespaceOptions,
-  filterNamespaceGroups,
+  searchNamespaces,
   findHierarchyNode,
 } from './namespaceOptions';
 import { getPinned, togglePinned } from './namespaceShortcuts';
@@ -45,10 +45,10 @@ export default function NamespaceNav({
   const [pinned, setPinned] = useState(() => getPinned());
 
   const isFiltering = filter.trim() !== '';
-  const groups = filterNamespaceGroups(
-    buildNamespaceOptions(namespaces || []),
-    filter,
-  );
+  // Filtering searches ALL namespaces (any depth) as one flat result list; the
+  // unfiltered default stays the curated jump-list (Git-backed roots + top-levels).
+  const matches = isFiltering ? searchNamespaces(namespaces || [], filter) : [];
+  const groups = isFiltering ? [] : buildNamespaceOptions(namespaces || []);
   const showList = isFiltering || !currentNamespace;
 
   const gitByNs = {};
@@ -200,10 +200,12 @@ export default function NamespaceNav({
           {!isFiltering && pinned.length > 0
             ? renderGroup('Pinned', pinned, 'pin')
             : null}
-          {groups.length === 0 ? (
+          {isFiltering && matches.length === 0 ? (
             <div style={{ padding: '6px', color: '#64748b', fontSize: '12px' }}>
               No namespaces match "{filter.trim()}".
             </div>
+          ) : isFiltering ? (
+            renderGroup('Matches', matches, 'matches')
           ) : (
             groups.map(group =>
               renderGroup(

--- a/datajunction-ui/src/app/pages/NamespacePage/NamespaceNav.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/NamespaceNav.jsx
@@ -1,0 +1,313 @@
+import React, { useState } from 'react';
+import Explorer from './Explorer';
+import NamespaceTypeSummary from './NamespaceTypeSummary';
+import CollapsedIcon from '../../icons/CollapsedIcon';
+import ExpandedIcon from '../../icons/ExpandedIcon';
+import {
+  buildNamespaceOptions,
+  filterNamespaceGroups,
+  findHierarchyNode,
+} from './namespaceOptions';
+import { getPinned, togglePinned } from './namespaceShortcuts';
+
+// Git context for a selected namespace, derived from the raw namespace list.
+function gitContext(gitByNs, ns) {
+  const g = gitByNs[ns];
+  if (!g) return null;
+  if (g.__typename === 'GitRootConfig') {
+    return {
+      root: ns,
+      defaultBranch: g.defaultBranch,
+      activeBranch: g.defaultBranch,
+      isRoot: true,
+    };
+  }
+  if (g.__typename === 'GitBranchConfig') {
+    return {
+      root: g.parentNamespace,
+      defaultBranch: g.root?.defaultBranch,
+      activeBranch: g.branch,
+      isRoot: false,
+    };
+  }
+  return null;
+}
+
+export default function NamespaceNav({
+  namespaces,
+  hierarchy,
+  currentNamespace,
+  gitRoots,
+  onSelect,
+}) {
+  const [filter, setFilter] = useState('');
+  const [collapsed, setCollapsed] = useState({ 'Top-level': true });
+  const [pinned, setPinned] = useState(() => getPinned());
+
+  const isFiltering = filter.trim() !== '';
+  const groups = filterNamespaceGroups(
+    buildNamespaceOptions(namespaces || []),
+    filter,
+  );
+  const showList = isFiltering || !currentNamespace;
+
+  const gitByNs = {};
+  for (const ns of namespaces || []) {
+    gitByNs[ns.namespace] = ns.git;
+  }
+  const pinnedSet = new Set(pinned);
+
+  const isOpen = label => isFiltering || !collapsed[label];
+  const toggleGroup = label =>
+    setCollapsed(c => ({ ...c, [label]: !c[label] }));
+
+  const select = value => {
+    setFilter('');
+    onSelect(value);
+  };
+  const onPin = (e, ns) => {
+    e.stopPropagation();
+    setPinned(togglePinned(ns));
+  };
+
+  const renderRow = (ns, keyPrefix) => (
+    <div
+      key={`${keyPrefix}-${ns}`}
+      className="dj-ns-nav-item"
+      role="button"
+      tabIndex={0}
+      title={ns}
+      onClick={() => select(ns)}
+      onKeyDown={e => {
+        if (e.key === 'Enter') select(ns);
+      }}
+    >
+      <span className="dj-ns-nav-name">{ns}</span>
+      <button
+        type="button"
+        className={`dj-ns-star${pinnedSet.has(ns) ? ' pinned' : ''}`}
+        aria-label={`${pinnedSet.has(ns) ? 'Unpin' : 'Pin'} ${ns}`}
+        aria-pressed={pinnedSet.has(ns)}
+        onClick={e => onPin(e, ns)}
+      >
+        {pinnedSet.has(ns) ? '★' : '☆'}
+      </button>
+    </div>
+  );
+
+  // One uniform collapsible section used for Pinned and the git groups.
+  const renderGroup = (label, names, keyPrefix) => {
+    const open = isOpen(label);
+    return (
+      <div key={keyPrefix}>
+        <button
+          type="button"
+          className="dj-ns-group-heading"
+          aria-expanded={open}
+          onClick={() => toggleGroup(label)}
+        >
+          <span className="dj-ns-chevron">
+            {open ? <ExpandedIcon /> : <CollapsedIcon />}
+          </span>
+          <span className="dj-ns-group-label">{label}</span>
+          <span className="dj-ns-group-count">{names.length}</span>
+        </button>
+        {open ? names.map(ns => renderRow(ns, keyPrefix)) : null}
+      </div>
+    );
+  };
+
+  // Selected (subtree) state, with git default-branch + branch switcher.
+  const ctx = currentNamespace ? gitContext(gitByNs, currentNamespace) : null;
+  const branchList = ctx?.root
+    ? (namespaces || [])
+        .filter(
+          ns =>
+            ns.git?.__typename === 'GitBranchConfig' &&
+            ns.git.parentNamespace === ctx.root,
+        )
+        .map(ns => ({ branch: ns.git.branch, namespace: ns.namespace }))
+        .sort((a, b) => a.branch.localeCompare(b.branch))
+    : [];
+  const subtreePath =
+    ctx?.isRoot && ctx.defaultBranch
+      ? `${ctx.root}.${ctx.defaultBranch}`
+      : currentNamespace;
+  const subtreeNode = currentNamespace
+    ? findHierarchyNode(hierarchy || [], subtreePath)
+    : null;
+  // At the branch root the switcher already names the branch, so render its
+  // children directly instead of repeating the branch as the tree root.
+  const atBranchRoot =
+    !!ctx && subtreePath === `${ctx.root}.${ctx.activeBranch}`;
+  const currentPinned = currentNamespace
+    ? pinnedSet.has(currentNamespace)
+    : false;
+  // For a git namespace, show just the root in the box (e.g. "arc") — the branch part
+  // is owned by the branch switcher below, so the full "arc.<branch>" would be redundant.
+  const scopeLabel = ctx?.root || currentNamespace || '';
+
+  return (
+    <div>
+      {/* The filter box doubles as the scope selector: when a namespace is selected it
+          shows that namespace (with a pin + a ✕ that returns to All namespaces); typing
+          turns it back into a filter over the list below. */}
+      <div className="dj-ns-filter">
+        <input
+          type="text"
+          className="dj-ns-filter-input"
+          value={isFiltering ? filter : scopeLabel}
+          title={
+            !isFiltering && currentNamespace ? currentNamespace : undefined
+          }
+          onChange={e => setFilter(e.target.value)}
+          onFocus={e => {
+            // Showing a selection → select-all so the first keystroke replaces it
+            // with filter text rather than appending to the namespace name.
+            if (!isFiltering && currentNamespace) e.target.select();
+          }}
+          placeholder="Filter namespaces…"
+          aria-label="Filter or select a namespace"
+        />
+        {currentNamespace && !isFiltering ? (
+          <button
+            type="button"
+            className={`dj-ns-filter-pin${currentPinned ? ' pinned' : ''}`}
+            aria-label={`${
+              currentPinned ? 'Unpin' : 'Pin'
+            } ${currentNamespace}`}
+            aria-pressed={currentPinned}
+            title={currentPinned ? 'Pinned' : 'Pin this namespace'}
+            onClick={() => setPinned(togglePinned(currentNamespace))}
+          >
+            {currentPinned ? '★' : '☆'}
+          </button>
+        ) : null}
+        {isFiltering || currentNamespace ? (
+          <button
+            type="button"
+            className="dj-ns-filter-clear"
+            aria-label={isFiltering ? 'Clear filter' : 'All namespaces'}
+            title={isFiltering ? 'Clear filter' : 'All namespaces'}
+            onClick={() => (isFiltering ? setFilter('') : select(null))}
+          >
+            ✕
+          </button>
+        ) : null}
+      </div>
+      {showList ? (
+        <>
+          {!isFiltering && pinned.length > 0
+            ? renderGroup('Pinned', pinned, 'pin')
+            : null}
+          {groups.length === 0 ? (
+            <div style={{ padding: '6px', color: '#64748b', fontSize: '12px' }}>
+              No namespaces match "{filter.trim()}".
+            </div>
+          ) : (
+            groups.map(group =>
+              renderGroup(
+                group.label,
+                group.options.map(o => o.value),
+                `grp-${group.label}`,
+              ),
+            )
+          )}
+        </>
+      ) : (
+        <div>
+          {/* The selected namespace + pin + back-to-all now live in the filter box
+              above; here we just nest its branch switcher and node counts. */}
+          {ctx && branchList.length > 0 ? (
+            // Borderless branch switcher: the icon + branch name + caret read as plain
+            // text (no box, so it doesn't look like a second selector); a transparent
+            // native <select> overlays the row for the real dropdown + accessibility.
+            <div className="dj-ns-scope-branch-row">
+              <svg
+                className="dj-ns-branch-glyph"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="6" y1="3" x2="6" y2="15" />
+                <circle cx="18" cy="6" r="3" />
+                <circle cx="6" cy="18" r="3" />
+                <path d="M18 9a9 9 0 0 1-9 9" />
+              </svg>
+              <span className="dj-ns-branch-value">{ctx.activeBranch}</span>
+              <svg
+                className="dj-ns-branch-caret"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+              <select
+                className="dj-ns-branch-native"
+                aria-label="Branch"
+                title="Branch"
+                value={ctx.activeBranch || ''}
+                onChange={e => {
+                  const b = branchList.find(x => x.branch === e.target.value);
+                  if (b) select(b.namespace);
+                }}
+              >
+                {branchList.map(b => (
+                  <option key={b.namespace} value={b.branch}>
+                    {b.branch}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+          {/* This branch only renders when a namespace is selected (showList is false),
+              so currentNamespace is always truthy here — no guard needed. */}
+          <NamespaceTypeSummary namespace={subtreePath} showHeading={false} />
+          {(
+            atBranchRoot
+              ? (subtreeNode?.children || []).length > 0
+              : !!subtreeNode
+          ) ? (
+            <div className="dj-ns-tree-heading">Namespaces</div>
+          ) : null}
+          {subtreeNode && atBranchRoot ? (
+            (subtreeNode.children || []).map(child => (
+              <Explorer
+                item={child}
+                current={subtreePath}
+                key={child.namespace}
+                gitRoots={gitRoots}
+                pinnedSet={pinnedSet}
+                onTogglePin={ns => setPinned(togglePinned(ns))}
+              />
+            ))
+          ) : subtreeNode ? (
+            <Explorer
+              item={subtreeNode}
+              current={subtreePath}
+              key={subtreeNode.namespace}
+              gitRoots={gitRoots}
+              pinnedSet={pinnedSet}
+              onTogglePin={ns => setPinned(togglePinned(ns))}
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/pages/NamespacePage/NamespaceTypeSummary.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/NamespaceTypeSummary.jsx
@@ -1,0 +1,88 @@
+import React, { useContext, useEffect, useState } from 'react';
+import DJClientContext from '../../providers/djclient';
+
+const NODE_TYPE_ORDER = ['metric', 'cube', 'dimension', 'transform', 'source'];
+const NODE_TYPE_COLORS = {
+  metric: { bg: '#fad7dd', color: '#a2283e' },
+  cube: { bg: '#dbafff', color: '#580076' },
+  dimension: { bg: '#ffefd0', color: '#a96621' },
+  transform: { bg: '#ccefff', color: '#0063b4' },
+  source: { bg: '#ccf7e5', color: '#00b368' },
+};
+
+// A compact, clickable summary of the node counts (by type) under a namespace.
+// Each row deep-links to the type-filtered node list for the selected branch.
+// One cheap limit:1 count query per type — we only read totalCount.
+export default function NamespaceTypeSummary({
+  namespace,
+  showHeading = true,
+}) {
+  const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const [counts, setCounts] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!namespace) {
+      setCounts(null);
+      return;
+    }
+    setCounts(null);
+    Promise.all(
+      NODE_TYPE_ORDER.map(type =>
+        djClient
+          .listNodesForLanding(
+            namespace,
+            [type.toUpperCase()],
+            [],
+            null,
+            null,
+            null,
+            1,
+            { key: 'name', direction: 'ascending' },
+            null,
+            {},
+          )
+          .then(result => ({
+            type,
+            count: result?.data?.findNodesPaginated?.totalCount ?? 0,
+          }))
+          .catch(() => ({ type, count: 0 })),
+      ),
+    ).then(results => {
+      if (!cancelled) setCounts(results);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [djClient, namespace]);
+
+  if (!counts) return null;
+  const nonEmpty = counts.filter(c => c.count > 0);
+  if (nonEmpty.length === 0) return null;
+
+  return (
+    <div className="dj-ns-type-summary">
+      {showHeading ? (
+        <div className="dj-ns-type-summary-heading">Nodes</div>
+      ) : null}
+      {nonEmpty.map(({ type, count }) => (
+        <a
+          key={type}
+          className="dj-ns-type-row"
+          href={`/namespaces/${namespace}?type=${type}`}
+        >
+          <span className="dj-ns-type-name">{`${type}s`}</span>
+          <span
+            className="dj-ns-type-count"
+            style={{
+              backgroundColor: NODE_TYPE_COLORS[type]?.bg ?? '#f1f5f9',
+              color: NODE_TYPE_COLORS[type]?.color ?? '#475569',
+            }}
+          >
+            {count}
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/pages/NamespacePage/NamespaceTypeSummary.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/NamespaceTypeSummary.jsx
@@ -1,18 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
 import DJClientContext from '../../providers/djclient';
-
-const NODE_TYPE_ORDER = ['metric', 'cube', 'dimension', 'transform', 'source'];
-const NODE_TYPE_COLORS = {
-  metric: { bg: '#fad7dd', color: '#a2283e' },
-  cube: { bg: '#dbafff', color: '#580076' },
-  dimension: { bg: '#ffefd0', color: '#a96621' },
-  transform: { bg: '#ccefff', color: '#0063b4' },
-  source: { bg: '#ccf7e5', color: '#00b368' },
-};
+import { NODE_TYPE_ORDER, NODE_TYPE_COLORS } from './nodeTypes';
 
 // A compact, clickable summary of the node counts (by type) under a namespace.
 // Each row deep-links to the type-filtered node list for the selected branch.
-// One cheap limit:1 count query per type — we only read totalCount.
+// Counts come from a single count-only request (djClient.nodeTypeCounts).
 export default function NamespaceTypeSummary({
   namespace,
   showHeading = true,
@@ -27,30 +19,18 @@ export default function NamespaceTypeSummary({
       return;
     }
     setCounts(null);
-    Promise.all(
-      NODE_TYPE_ORDER.map(type =>
-        djClient
-          .listNodesForLanding(
-            namespace,
-            [type.toUpperCase()],
-            [],
-            null,
-            null,
-            null,
-            1,
-            { key: 'name', direction: 'ascending' },
-            null,
-            {},
-          )
-          .then(result => ({
-            type,
-            count: result?.data?.findNodesPaginated?.totalCount ?? 0,
-          }))
-          .catch(() => ({ type, count: 0 })),
-      ),
-    ).then(results => {
-      if (!cancelled) setCounts(results);
-    });
+    djClient
+      .nodeTypeCounts(namespace, NODE_TYPE_ORDER)
+      .then(byType => {
+        if (!cancelled) {
+          setCounts(
+            NODE_TYPE_ORDER.map(type => ({ type, count: byType[type] ?? 0 })),
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setCounts([]);
+      });
     return () => {
       cancelled = true;
     };

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/Explorer.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/Explorer.test.jsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Explorer from '../Explorer';
+import DJClientContext from '../../../providers/djclient';
+
+function renderExplorer(props) {
+  return render(
+    <DJClientContext.Provider value={{ DataJunctionAPI: {} }}>
+      <Explorer {...props} />
+    </DJClientContext.Provider>,
+  );
+}
+
+const leaf = { namespace: 'yshang', path: 'users.yshang', children: [] };
+
+describe('Explorer row actions (kebab menu)', () => {
+  it('opens a menu offering Pin and Add child for non-git-backed namespaces', () => {
+    renderExplorer({
+      item: leaf,
+      current: 'users.yshang',
+      gitRoots: new Set(),
+      pinnedSet: new Set(),
+      onTogglePin: vi.fn(),
+    });
+    fireEvent.click(screen.getByLabelText('Actions for users.yshang'));
+    expect(screen.getByText('Pin namespace')).toBeInTheDocument();
+    expect(screen.getByText('Add child namespace')).toBeInTheDocument();
+  });
+
+  it('omits Add child under a git root (git-managed)', () => {
+    const item = { namespace: 'cubes', path: 'arc.main.cubes', children: [] };
+    renderExplorer({
+      item,
+      current: 'arc.main.cubes',
+      gitRoots: new Set(['arc']),
+      pinnedSet: new Set(),
+      onTogglePin: vi.fn(),
+    });
+    fireEvent.click(screen.getByLabelText('Actions for arc.main.cubes'));
+    expect(screen.getByText('Pin namespace')).toBeInTheDocument();
+    expect(screen.queryByText('Add child namespace')).not.toBeInTheDocument();
+  });
+
+  it('fires onTogglePin with the full path from the menu', () => {
+    const onTogglePin = vi.fn();
+    renderExplorer({
+      item: leaf,
+      current: 'users.yshang',
+      gitRoots: new Set(),
+      pinnedSet: new Set(),
+      onTogglePin,
+    });
+    fireEvent.click(screen.getByLabelText('Actions for users.yshang'));
+    fireEvent.click(screen.getByText('Pin namespace'));
+    expect(onTogglePin).toHaveBeenCalledWith('users.yshang');
+  });
+
+  it('reflects pinned state in the menu', () => {
+    renderExplorer({
+      item: leaf,
+      current: 'users.yshang',
+      gitRoots: new Set(),
+      pinnedSet: new Set(['users.yshang']),
+      onTogglePin: vi.fn(),
+    });
+    fireEvent.click(screen.getByLabelText('Actions for users.yshang'));
+    expect(screen.getByText('Unpin namespace')).toBeInTheDocument();
+  });
+
+  it('offers only Add child when onTogglePin is not provided', () => {
+    renderExplorer({
+      item: leaf,
+      current: 'users.yshang',
+      gitRoots: new Set(),
+    });
+    fireEvent.click(screen.getByLabelText('Actions for users.yshang'));
+    expect(screen.getByText('Add child namespace')).toBeInTheDocument();
+    expect(screen.queryByText('Pin namespace')).not.toBeInTheDocument();
+  });
+});

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceNav.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceNav.test.jsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NamespaceNav from '../NamespaceNav';
+
+// Explorer pulls DJClientContext + router; stub it so we can test NamespaceNav alone.
+vi.mock('../Explorer', () => ({
+  default: () => <div data-testid="explorer" />,
+}));
+// NamespaceTypeSummary fetches counts via DJClientContext; stub it out here.
+vi.mock('../NamespaceTypeSummary', () => ({
+  default: () => <div data-testid="type-summary" />,
+}));
+
+const namespaces = [
+  { namespace: 'ads', numNodes: 42, git: { __typename: 'GitRootConfig' } },
+  { namespace: 'member', numNodes: 7, git: null },
+  {
+    namespace: 'member.cds',
+    numNodes: 156,
+    git: { __typename: 'GitRootConfig' },
+  },
+];
+
+function renderNav(props = {}) {
+  return render(
+    <NamespaceNav
+      namespaces={namespaces}
+      hierarchy={[]}
+      currentNamespace={undefined}
+      gitRoots={new Set(['ads', 'member.cds'])}
+      onSelect={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => localStorage.clear());
+
+describe('NamespaceNav', () => {
+  it('by default shows no Pinned section; Git-backed open, Top-level collapsed', () => {
+    renderNav();
+    expect(screen.queryByText('Pinned')).not.toBeInTheDocument();
+    expect(screen.getByText('ads')).toBeInTheDocument();
+    expect(screen.getByText('member.cds')).toBeInTheDocument();
+    expect(screen.getByText('Top-level')).toBeInTheDocument();
+    expect(screen.queryByText('member')).not.toBeInTheDocument();
+  });
+
+  it('expands Top-level when its heading is clicked', () => {
+    renderNav();
+    fireEvent.click(screen.getByText('Top-level'));
+    expect(screen.getByText('member')).toBeInTheDocument();
+  });
+
+  it('selecting a row calls onSelect', () => {
+    const onSelect = vi.fn();
+    renderNav({ onSelect });
+    fireEvent.click(screen.getByText('ads'));
+    expect(onSelect).toHaveBeenCalledWith('ads');
+  });
+
+  it('pinning a row surfaces a Pinned section', () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText('Pin ads'));
+    expect(screen.getByText('Pinned')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('Unpin ads').length).toBeGreaterThan(0);
+  });
+
+  it('filtering hides the Pinned section and narrows the list', () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText('Pin ads'));
+    fireEvent.change(screen.getByPlaceholderText('Filter namespaces…'), {
+      target: { value: 'cds' },
+    });
+    expect(screen.queryByText('Pinned')).not.toBeInTheDocument();
+    expect(screen.getByText('member.cds')).toBeInTheDocument();
+    expect(screen.queryByText('member')).not.toBeInTheDocument();
+  });
+
+  it('lets you pin the current namespace at any depth from the selected view', () => {
+    renderNav({ currentNamespace: 'users.yshang', hierarchy: [] });
+    const pinBtn = screen.getByLabelText('Pin users.yshang');
+    expect(pinBtn).toHaveTextContent('☆');
+    fireEvent.click(pinBtn);
+    expect(screen.getByLabelText('Unpin users.yshang')).toHaveTextContent('★');
+  });
+
+  it('exposes a back-to-all-namespaces control in the selected view', () => {
+    const onSelect = vi.fn();
+    renderNav({ currentNamespace: 'users.yshang', hierarchy: [], onSelect });
+    fireEvent.click(screen.getByLabelText('All namespaces'));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('on a git root, shows a branch switcher defaulting to the default branch', () => {
+    const onSelect = vi.fn();
+    const ns = [
+      {
+        namespace: 'arc',
+        numNodes: 0,
+        git: { __typename: 'GitRootConfig', defaultBranch: 'main' },
+      },
+      {
+        namespace: 'arc.main',
+        numNodes: 0,
+        git: {
+          __typename: 'GitBranchConfig',
+          branch: 'main',
+          parentNamespace: 'arc',
+          root: { defaultBranch: 'main' },
+        },
+      },
+      {
+        namespace: 'arc.featurex',
+        numNodes: 0,
+        git: {
+          __typename: 'GitBranchConfig',
+          branch: 'featurex',
+          parentNamespace: 'arc',
+          root: { defaultBranch: 'main' },
+        },
+      },
+    ];
+    const hierarchy = [
+      {
+        namespace: 'arc',
+        path: 'arc',
+        children: [
+          { namespace: 'main', path: 'arc.main', children: [] },
+          { namespace: 'featurex', path: 'arc.featurex', children: [] },
+        ],
+      },
+    ];
+    render(
+      <NamespaceNav
+        namespaces={ns}
+        hierarchy={hierarchy}
+        currentNamespace="arc"
+        gitRoots={new Set(['arc'])}
+        onSelect={onSelect}
+      />,
+    );
+    const sel = screen.getByLabelText('Branch');
+    expect(sel.value).toBe('main');
+    expect(screen.getByRole('option', { name: 'main' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'featurex' }),
+    ).toBeInTheDocument();
+    fireEvent.change(sel, { target: { value: 'featurex' } });
+    expect(onSelect).toHaveBeenCalledWith('arc.featurex');
+  });
+});

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceNav.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceNav.test.jsx
@@ -77,6 +77,30 @@ describe('NamespaceNav', () => {
     expect(screen.queryByText('member')).not.toBeInTheDocument();
   });
 
+  it('filtering surfaces deep nested namespaces (not just roots/top-levels)', () => {
+    renderNav({
+      namespaces: [
+        { namespace: 'default', numNodes: 5, git: null },
+        {
+          namespace: 'default.fruits.citrus.lemons',
+          numNodes: 1,
+          git: null,
+        },
+      ],
+    });
+    // Unfiltered, the nested namespace is not in the curated list...
+    expect(
+      screen.queryByText('default.fruits.citrus.lemons'),
+    ).not.toBeInTheDocument();
+    // ...but filtering finds it.
+    fireEvent.change(screen.getByPlaceholderText('Filter namespaces…'), {
+      target: { value: 'lemons' },
+    });
+    expect(
+      screen.getByText('default.fruits.citrus.lemons'),
+    ).toBeInTheDocument();
+  });
+
   it('lets you pin the current namespace at any depth from the selected view', () => {
     renderNav({ currentNamespace: 'users.yshang', hierarchy: [] });
     const pinBtn = screen.getByLabelText('Pin users.yshang');

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceTypeSummary.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceTypeSummary.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import NamespaceTypeSummary from '../NamespaceTypeSummary';
+import DJClientContext from '../../../providers/djclient';
+
+function makeClient(countsByType) {
+  return {
+    listNodesForLanding: vi.fn((ns, [TYPE]) =>
+      Promise.resolve({
+        data: { findNodesPaginated: { totalCount: countsByType[TYPE] ?? 0 } },
+      }),
+    ),
+  };
+}
+
+function renderSummary(djClient, namespace = 'member.cds.main') {
+  return render(
+    <DJClientContext.Provider value={{ DataJunctionAPI: djClient }}>
+      <NamespaceTypeSummary namespace={namespace} />
+    </DJClientContext.Provider>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('NamespaceTypeSummary', () => {
+  it('lists only non-empty types and deep-links to the filtered list', async () => {
+    const djClient = makeClient({ METRIC: 12, DIMENSION: 4 });
+    renderSummary(djClient);
+
+    const metrics = await screen.findByText('metrics');
+    expect(metrics).toBeInTheDocument();
+    expect(screen.getByText('Nodes')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(metrics.closest('a').getAttribute('href')).toBe(
+      '/namespaces/member.cds.main?type=metric',
+    );
+
+    expect(screen.getByText('dimensions')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+
+    // Zero-count types are omitted.
+    expect(screen.queryByText('cubes')).not.toBeInTheDocument();
+    expect(screen.queryByText('transforms')).not.toBeInTheDocument();
+    expect(screen.queryByText('sources')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the namespace has no nodes', async () => {
+    const djClient = makeClient({});
+    const { container } = renderSummary(djClient);
+    await waitFor(() => {
+      expect(djClient.listNodesForLanding).toHaveBeenCalledTimes(5);
+    });
+    expect(screen.queryByText('Nodes')).not.toBeInTheDocument();
+    expect(container.querySelector('.dj-ns-type-summary')).toBeNull();
+  });
+});

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceTypeSummary.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/NamespaceTypeSummary.test.jsx
@@ -5,10 +5,12 @@ import DJClientContext from '../../../providers/djclient';
 
 function makeClient(countsByType) {
   return {
-    listNodesForLanding: vi.fn((ns, [TYPE]) =>
-      Promise.resolve({
-        data: { findNodesPaginated: { totalCount: countsByType[TYPE] ?? 0 } },
-      }),
+    nodeTypeCounts: vi.fn((ns, types) =>
+      Promise.resolve(
+        Object.fromEntries(
+          types.map(type => [type, countsByType[type.toUpperCase()] ?? 0]),
+        ),
+      ),
     ),
   };
 }
@@ -49,7 +51,7 @@ describe('NamespaceTypeSummary', () => {
     const djClient = makeClient({});
     const { container } = renderSummary(djClient);
     await waitFor(() => {
-      expect(djClient.listNodesForLanding).toHaveBeenCalledTimes(5);
+      expect(djClient.nodeTypeCounts).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByText('Nodes')).not.toBeInTheDocument();
     expect(container.querySelector('.dj-ns-type-summary')).toBeNull();

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
@@ -11,6 +11,7 @@ const mockDjClient = {
   listNamespacesWithGit: vi.fn(),
   namespace: vi.fn(),
   listNodesForLanding: vi.fn(),
+  nodeTypeCounts: vi.fn().mockResolvedValue({}),
   addNamespace: vi.fn(),
   whoami: vi.fn(),
   users: vi.fn(),

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
@@ -153,7 +153,7 @@ describe('NamespacePage', () => {
       </DJClientContext.Provider>
     );
     render(
-      <MemoryRouter initialEntries={['/namespaces/test.namespace']}>
+      <MemoryRouter initialEntries={['/namespaces/default']}>
         <Routes>
           <Route path="namespaces/:namespace" element={element} />
         </Routes>
@@ -166,12 +166,19 @@ describe('NamespacePage', () => {
       expect(screen.getByText('Namespaces')).toBeInTheDocument();
     });
 
-    // Check that it displays namespaces (wait — the namespace tree loads
-    // asynchronously, so the labels may appear a tick after the heading).
-    await screen.findByText('common');
-    expect(screen.getByText('one')).toBeInTheDocument();
+    // Check that it displays the selected namespace's subtree (wait — the
+    // namespace tree loads asynchronously, so the labels may appear a tick
+    // after the heading).  Route is /namespaces/default so the rail shows the
+    // "default" node and its direct children.
+    // Note: "default" appears in both the NamespaceSelector value and the
+    // Explorer link, so we assert at least one occurrence.
+    expect(
+      (await screen.findAllByRole('link', { name: 'default' })).length,
+    ).toBeGreaterThan(0);
     expect(screen.getByText('fruits')).toBeInTheDocument();
     expect(screen.getByText('vegetables')).toBeInTheDocument();
+    // Scoping: a sibling top-level namespace not under "default" must NOT render in the rail.
+    expect(screen.queryByText('common')).not.toBeInTheDocument();
 
     // Check that it renders nodes
     expect(screen.getByText('Test Node')).toBeInTheDocument();
@@ -242,8 +249,10 @@ describe('NamespacePage', () => {
     }
 
     // --- Expand/Collapse Namespace ---
-    fireEvent.click(screen.getByText('common'));
-    fireEvent.click(screen.getByText('common'));
+    // Use the first Explorer link for expand/collapse.
+    const explorerLinks = screen.getAllByRole('link', { name: 'default' });
+    fireEvent.click(explorerLinks[0]);
+    fireEvent.click(explorerLinks[0]);
   });
 
   it('can add new namespace via inline creation', async () => {
@@ -285,16 +294,9 @@ describe('NamespacePage', () => {
     });
     fireEvent.mouseEnter(defaultNamespace);
 
-    // Find the add namespace button (it exists but is hidden, so use getAllByTitle)
-    const addButtons = screen.getAllByTitle('Add child namespace');
-    const defaultAddButton = addButtons.find(btn =>
-      btn
-        .closest('.namespace-item')
-        ?.querySelector('a[href="/namespaces/default"]'),
-    );
-
-    expect(defaultAddButton).toBeInTheDocument();
-    fireEvent.click(defaultAddButton);
+    // Open the row's actions menu, then choose "Add child namespace".
+    fireEvent.click(screen.getByLabelText('Actions for default'));
+    fireEvent.click(screen.getByText('Add child namespace'));
 
     // Type in the new namespace name
     await waitFor(() => {
@@ -347,16 +349,9 @@ describe('NamespacePage', () => {
     });
     fireEvent.mouseEnter(defaultNamespace);
 
-    // Find the add namespace button (it exists but is hidden, so use getAllByTitle)
-    const addButtons = screen.getAllByTitle('Add child namespace');
-    const defaultAddButton = addButtons.find(btn =>
-      btn
-        .closest('.namespace-item')
-        ?.querySelector('a[href="/namespaces/default"]'),
-    );
-
-    expect(defaultAddButton).toBeInTheDocument();
-    fireEvent.click(defaultAddButton);
+    // Open the row's actions menu, then choose "Add child namespace".
+    fireEvent.click(screen.getByLabelText('Actions for default'));
+    fireEvent.click(screen.getByText('Add child namespace'));
 
     // Type in the new namespace name
     await waitFor(() => {

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/namespaceOptions.test.js
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/namespaceOptions.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildNamespaceOptions,
   findHierarchyNode,
-  filterNamespaceGroups,
+  searchNamespaces,
 } from '../namespaceOptions';
 
 const sample = [
@@ -42,6 +42,28 @@ const hierarchy = [
   { namespace: 'ae', path: 'ae', children: [] },
 ];
 
+describe('searchNamespaces', () => {
+  it('matches nested namespaces that the curated list excludes', () => {
+    // member.scratch is a deep non-git namespace — absent from buildNamespaceOptions,
+    // but search must find it.
+    expect(searchNamespaces(sample, 'scratch')).toEqual(['member.scratch']);
+  });
+
+  it('matches across depth, sorted by full path', () => {
+    expect(searchNamespaces(sample, 'member')).toEqual([
+      'member',
+      'member.cds',
+      'member.cds.branchx',
+      'member.scratch',
+    ]);
+  });
+
+  it('returns nothing for empty/whitespace filter', () => {
+    expect(searchNamespaces(sample, '')).toEqual([]);
+    expect(searchNamespaces(sample, '   ')).toEqual([]);
+  });
+});
+
 describe('findHierarchyNode', () => {
   it('finds a top-level node by path', () => {
     expect(findHierarchyNode(hierarchy, 'ae')?.path).toBe('ae');
@@ -52,38 +74,5 @@ describe('findHierarchyNode', () => {
   it('returns null for unknown or empty path', () => {
     expect(findHierarchyNode(hierarchy, 'nope')).toBeNull();
     expect(findHierarchyNode(hierarchy, '')).toBeNull();
-  });
-});
-
-describe('filterNamespaceGroups', () => {
-  const groups = [
-    {
-      label: 'Git-backed',
-      options: [
-        { value: 'ads', isGitRoot: true },
-        { value: 'member.cds', isGitRoot: true },
-      ],
-    },
-    {
-      label: 'Top-level namespaces',
-      options: [
-        { value: 'ae', isGitRoot: false },
-        { value: 'member', isGitRoot: false },
-      ],
-    },
-  ];
-  it('returns groups unchanged for empty text', () => {
-    expect(filterNamespaceGroups(groups, '')).toEqual(groups);
-  });
-  it('narrows options case-insensitively and drops empty groups', () => {
-    const r = filterNamespaceGroups(groups, 'MEM');
-    expect(r.map(g => g.label)).toEqual(['Git-backed', 'Top-level namespaces']);
-    expect(r[0].options.map(o => o.value)).toEqual(['member.cds']);
-    expect(r[1].options.map(o => o.value)).toEqual(['member']);
-  });
-  it('drops a group with no matches', () => {
-    const r = filterNamespaceGroups(groups, 'ae');
-    expect(r.map(g => g.label)).toEqual(['Top-level namespaces']);
-    expect(r[0].options.map(o => o.value)).toEqual(['ae']);
   });
 });

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/namespaceOptions.test.js
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/namespaceOptions.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildNamespaceOptions,
+  findHierarchyNode,
+  filterNamespaceGroups,
+} from '../namespaceOptions';
+
+const sample = [
+  { namespace: 'ads', git: { __typename: 'GitRootConfig' } },
+  { namespace: 'member', git: null },
+  { namespace: 'member.cds', git: { __typename: 'GitRootConfig' } },
+  { namespace: 'member.scratch', git: null },
+  { namespace: 'member.cds.branchx', git: { __typename: 'GitBranchConfig' } },
+  { namespace: 'ae', git: null },
+];
+
+describe('buildNamespaceOptions', () => {
+  it('groups git roots (any depth) and non-root top-levels, dedups, sorts', () => {
+    const groups = buildNamespaceOptions(sample);
+    expect(groups.map(g => g.label)).toEqual(['Git-backed', 'Top-level']);
+    expect(groups[0].options.map(o => o.value)).toEqual(['ads', 'member.cds']);
+    expect(groups[0].options.every(o => o.isGitRoot)).toBe(true);
+    expect(groups[1].options.map(o => o.value)).toEqual(['ae', 'member']);
+    expect(groups[1].options.every(o => o.isGitRoot)).toBe(false);
+  });
+
+  it('omits an empty group', () => {
+    const groups = buildNamespaceOptions([{ namespace: 'ae', git: null }]);
+    expect(groups.map(g => g.label)).toEqual(['Top-level']);
+  });
+});
+
+const hierarchy = [
+  {
+    namespace: 'member',
+    path: 'member',
+    children: [
+      { namespace: 'cds', path: 'member.cds', children: [] },
+      { namespace: 'scratch', path: 'member.scratch', children: [] },
+    ],
+  },
+  { namespace: 'ae', path: 'ae', children: [] },
+];
+
+describe('findHierarchyNode', () => {
+  it('finds a top-level node by path', () => {
+    expect(findHierarchyNode(hierarchy, 'ae')?.path).toBe('ae');
+  });
+  it('finds a nested node by full dotted path', () => {
+    expect(findHierarchyNode(hierarchy, 'member.cds')?.path).toBe('member.cds');
+  });
+  it('returns null for unknown or empty path', () => {
+    expect(findHierarchyNode(hierarchy, 'nope')).toBeNull();
+    expect(findHierarchyNode(hierarchy, '')).toBeNull();
+  });
+});
+
+describe('filterNamespaceGroups', () => {
+  const groups = [
+    {
+      label: 'Git-backed',
+      options: [
+        { value: 'ads', isGitRoot: true },
+        { value: 'member.cds', isGitRoot: true },
+      ],
+    },
+    {
+      label: 'Top-level namespaces',
+      options: [
+        { value: 'ae', isGitRoot: false },
+        { value: 'member', isGitRoot: false },
+      ],
+    },
+  ];
+  it('returns groups unchanged for empty text', () => {
+    expect(filterNamespaceGroups(groups, '')).toEqual(groups);
+  });
+  it('narrows options case-insensitively and drops empty groups', () => {
+    const r = filterNamespaceGroups(groups, 'MEM');
+    expect(r.map(g => g.label)).toEqual(['Git-backed', 'Top-level namespaces']);
+    expect(r[0].options.map(o => o.value)).toEqual(['member.cds']);
+    expect(r[1].options.map(o => o.value)).toEqual(['member']);
+  });
+  it('drops a group with no matches', () => {
+    const r = filterNamespaceGroups(groups, 'ae');
+    expect(r.map(g => g.label)).toEqual(['Top-level namespaces']);
+    expect(r[0].options.map(o => o.value)).toEqual(['ae']);
+  });
+});

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/namespaceShortcuts.test.js
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/namespaceShortcuts.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getPinned, togglePinned } from '../namespaceShortcuts';
+
+beforeEach(() => localStorage.clear());
+
+describe('pinned namespaces (localStorage)', () => {
+  it('togglePinned adds then removes', () => {
+    expect(getPinned()).toEqual([]);
+    expect(togglePinned('x')).toEqual(['x']);
+    expect(getPinned()).toEqual(['x']);
+    expect(togglePinned('x')).toEqual([]);
+  });
+
+  it('tolerates malformed storage', () => {
+    localStorage.setItem('dj.ns.pinned', 'not json');
+    expect(getPinned()).toEqual([]);
+  });
+});

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -19,8 +19,7 @@ import CompactSelect from './CompactSelect';
 import NamespaceNav from './NamespaceNav';
 import { NodeBadge, NodeLink } from '../../components/NodeComponents';
 import { getDJUrl } from '../../services/DJService';
-
-const NODE_TYPE_ORDER = ['metric', 'cube', 'dimension', 'transform', 'source'];
+import { NODE_TYPE_ORDER, NODE_TYPE_COLORS } from './nodeTypes';
 
 const AVATAR_COLORS = [
   ['#dbeafe', '#1e40af'], // blue
@@ -40,14 +39,6 @@ function avatarColorIndex(username) {
   return hash % AVATAR_COLORS.length;
 }
 const MAX_PER_TYPE = 8;
-
-const NODE_TYPE_COLORS = {
-  metric: { bg: '#fad7dd', color: '#a2283e' },
-  cube: { bg: '#dbafff', color: '#580076' },
-  dimension: { bg: '#ffefd0', color: '#a96621' },
-  transform: { bg: '#ccefff', color: '#0063b4' },
-  source: { bg: '#ccf7e5', color: '#00b368' },
-};
 
 function DefaultBranchPreview({ groups, defaultBranchNs }) {
   const filtered = groups.filter(g => g.nodes.length > 0);

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { useContext, useEffect, useState, useCallback } from 'react';
 import NodeStatus from '../NodePage/NodeStatus';
 import DJClientContext from '../../providers/djclient';
@@ -16,6 +16,7 @@ import {
 } from '../../components/buttonStyles';
 import LoadingIcon from '../../icons/LoadingIcon';
 import CompactSelect from './CompactSelect';
+import NamespaceNav from './NamespaceNav';
 import { NodeBadge, NodeLink } from '../../components/NodeComponents';
 import { getDJUrl } from '../../services/DJService';
 
@@ -229,6 +230,7 @@ export function NamespacePage() {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
   const { currentUser } = useCurrentUser();
   var { namespace } = useParams();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Data for select options
@@ -373,6 +375,7 @@ export function NamespacePage() {
   const [retrieved, setRetrieved] = useState(false);
 
   const [namespaceHierarchy, setNamespaceHierarchy] = useState([]);
+  const [rawNamespaces, setRawNamespaces] = useState([]);
   const [gitRoots, setGitRoots] = useState(new Set());
   // Use undefined to indicate "not yet loaded", null means "loaded but no config"
   const [gitConfig, setGitConfig] = useState(undefined);
@@ -519,6 +522,7 @@ export function NamespacePage() {
   useEffect(() => {
     const fetchData = async () => {
       const namespaces = await djClient.listNamespacesWithGit();
+      setRawNamespaces(namespaces);
       const hierarchy = createNamespaceHierarchy(namespaces);
       setNamespaceHierarchy(hierarchy);
 
@@ -1115,36 +1119,16 @@ export function NamespacePage() {
               className={`sidebar`}
               style={{ borderRight: '1px solid #e2e8f0', paddingRight: '1rem' }}
             >
-              <div
-                style={{
-                  paddingBottom: '12px',
-                  marginBottom: '8px',
-                }}
-              >
-                <span
-                  style={{
-                    fontSize: '11px',
-                    fontWeight: '600',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                    color: '#64748b',
-                  }}
-                >
-                  Namespaces
-                </span>
-              </div>
-              {namespaceHierarchy
-                ? namespaceHierarchy.map(child => (
-                    <Explorer
-                      item={child}
-                      current={state.namespace}
-                      defaultExpand={true}
-                      isTopLevel={true}
-                      key={child.namespace}
-                      gitRoots={gitRoots}
-                    />
-                  ))
-                : null}
+              <NamespaceNav
+                namespaces={rawNamespaces}
+                hierarchy={namespaceHierarchy}
+                currentNamespace={namespace}
+                stateNamespace={state.namespace}
+                gitRoots={gitRoots}
+                onSelect={value =>
+                  navigate(value ? `/namespaces/${value}` : '/')
+                }
+              />
             </div>
             <div style={{ flex: 1, minWidth: 0, marginLeft: '1.5rem' }}>
               <NamespaceHeader

--- a/datajunction-ui/src/app/pages/NamespacePage/namespaceOptions.js
+++ b/datajunction-ui/src/app/pages/NamespacePage/namespaceOptions.js
@@ -1,0 +1,67 @@
+// src/app/pages/NamespacePage/namespaceOptions.js
+
+// A namespace is a git ROOT (vs a git branch) when its git config is a GitRootConfig.
+const isGitRoot = ns => ns.git?.__typename === 'GitRootConfig';
+const isTopLevel = ns => !ns.namespace.includes('.');
+
+/**
+ * Build grouped react-select options for the namespace selector.
+ * Group 1 "Git-backed": every git root, at any depth.
+ * Group 2 "Top-level namespaces": top-levels that are not themselves git roots.
+ * Deep non-git namespaces are intentionally excluded (reached via drill-in).
+ */
+export function buildNamespaceOptions(namespaces) {
+  const gitBacked = [];
+  const topLevel = [];
+
+  for (const ns of namespaces) {
+    if (isGitRoot(ns)) {
+      gitBacked.push({
+        value: ns.namespace,
+        label: ns.namespace,
+        isGitRoot: true,
+        count: ns.numNodes ?? 0,
+      });
+    } else if (isTopLevel(ns)) {
+      topLevel.push({
+        value: ns.namespace,
+        label: ns.namespace,
+        isGitRoot: false,
+        count: ns.numNodes ?? 0,
+      });
+    }
+  }
+
+  const byValue = (a, b) => a.value.localeCompare(b.value);
+  gitBacked.sort(byValue);
+  topLevel.sort(byValue);
+
+  const groups = [];
+  if (gitBacked.length)
+    groups.push({ label: 'Git-backed', options: gitBacked });
+  if (topLevel.length) groups.push({ label: 'Top-level', options: topLevel });
+  return groups;
+}
+
+/** Recursively find the hierarchy node whose full dotted `path` matches. */
+export function findHierarchyNode(hierarchy, path) {
+  if (!path) return null;
+  for (const node of hierarchy) {
+    if (node.path === path) return node;
+    const found = findHierarchyNode(node.children || [], path);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Narrow grouped options by a case-insensitive substring on the namespace value; drops empty groups. */
+export function filterNamespaceGroups(groups, text) {
+  const t = (text || '').trim().toLowerCase();
+  if (!t) return groups;
+  return groups
+    .map(g => ({
+      ...g,
+      options: g.options.filter(o => o.value.toLowerCase().includes(t)),
+    }))
+    .filter(g => g.options.length > 0);
+}

--- a/datajunction-ui/src/app/pages/NamespacePage/namespaceOptions.js
+++ b/datajunction-ui/src/app/pages/NamespacePage/namespaceOptions.js
@@ -43,6 +43,20 @@ export function buildNamespaceOptions(namespaces) {
   return groups;
 }
 
+/**
+ * Sorted full paths of EVERY namespace (any depth) whose dotted path matches `text`.
+ * Used while filtering so search reaches nested namespaces — not just the git roots /
+ * top-levels in the curated default list.
+ */
+export function searchNamespaces(namespaces, text) {
+  const t = (text || '').trim().toLowerCase();
+  if (!t) return [];
+  return namespaces
+    .map(ns => ns.namespace)
+    .filter(name => name.toLowerCase().includes(t))
+    .sort((a, b) => a.localeCompare(b));
+}
+
 /** Recursively find the hierarchy node whose full dotted `path` matches. */
 export function findHierarchyNode(hierarchy, path) {
   if (!path) return null;
@@ -52,16 +66,4 @@ export function findHierarchyNode(hierarchy, path) {
     if (found) return found;
   }
   return null;
-}
-
-/** Narrow grouped options by a case-insensitive substring on the namespace value; drops empty groups. */
-export function filterNamespaceGroups(groups, text) {
-  const t = (text || '').trim().toLowerCase();
-  if (!t) return groups;
-  return groups
-    .map(g => ({
-      ...g,
-      options: g.options.filter(o => o.value.toLowerCase().includes(t)),
-    }))
-    .filter(g => g.options.length > 0);
 }

--- a/datajunction-ui/src/app/pages/NamespacePage/namespaceShortcuts.js
+++ b/datajunction-ui/src/app/pages/NamespacePage/namespaceShortcuts.js
@@ -1,0 +1,32 @@
+// Per-device pinned namespaces, backed by localStorage (no backend).
+const PINNED_KEY = 'dj.ns.pinned';
+
+function read(key) {
+  try {
+    const v = JSON.parse(localStorage.getItem(key));
+    return Array.isArray(v) ? v.filter(x => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(key, list) {
+  try {
+    localStorage.setItem(key, JSON.stringify(list));
+  } catch {
+    /* ignore quota / unavailable storage */
+  }
+}
+
+export function getPinned() {
+  return read(PINNED_KEY);
+}
+
+export function togglePinned(ns) {
+  const cur = read(PINNED_KEY);
+  const next = cur.includes(ns) ? cur.filter(x => x !== ns) : [...cur, ns];
+  write(PINNED_KEY, next);
+  return next;
+}
+
+export { PINNED_KEY };

--- a/datajunction-ui/src/app/pages/NamespacePage/nodeTypes.js
+++ b/datajunction-ui/src/app/pages/NamespacePage/nodeTypes.js
@@ -1,0 +1,20 @@
+// Canonical node-type ordering + badge colors for the NamespacePage views.
+// Single source of truth shared by the namespace landing preview (index.jsx) and the
+// rail's per-namespace type summary (NamespaceTypeSummary.jsx) so the order and colors
+// can't drift between them.
+
+export const NODE_TYPE_ORDER = [
+  'metric',
+  'cube',
+  'dimension',
+  'transform',
+  'source',
+];
+
+export const NODE_TYPE_COLORS = {
+  metric: { bg: '#fad7dd', color: '#a2283e' },
+  cube: { bg: '#dbafff', color: '#580076' },
+  dimension: { bg: '#ffefd0', color: '#a96621' },
+  transform: { bg: '#ccefff', color: '#0063b4' },
+  source: { bg: '#ccf7e5', color: '#00b368' },
+};

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -26,6 +26,37 @@ const QUERY_END_STATES = ['FINISHED', 'CANCELED', 'FAILED'];
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 export const DataJunctionAPI = {
+  // Count-only node counts per type for a namespace, in a SINGLE request. Each type is
+  // an aliased findNodesPaginated selecting only totalCount (no edges) — so the server
+  // never hydrates node rows, unlike listNodesForLanding. Returns a { type: count } map.
+  // `types` are trusted enum names (e.g. 'metric') from a fixed constant, not user input.
+  nodeTypeCounts: async function (namespace, types) {
+    const fields = types
+      .map(
+        (type, i) =>
+          `c${i}: findNodesPaginated(namespace: $namespace, nodeTypes: [${type.toUpperCase()}], limit: 1) { totalCount }`,
+      )
+      .join('\n        ');
+    const query = `
+      query NodeTypeCounts($namespace: String) {
+        ${fields}
+      }
+    `;
+    const result = await (
+      await fetch(DJ_GQL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ query, variables: { namespace } }),
+      })
+    ).json();
+    const counts = {};
+    types.forEach((type, i) => {
+      counts[type] = result?.data?.[`c${i}`]?.totalCount ?? 0;
+    });
+    return counts;
+  },
+
   listNodesForLanding: async function (
     namespace,
     nodeTypes,

--- a/datajunction-ui/src/styles/node-list.css
+++ b/datajunction-ui/src/styles/node-list.css
@@ -2,3 +2,313 @@ table {
   width: 100%;
   height: min-content;
 }
+
+/* Namespace nav (filter-over-list) */
+.dj-ns-group-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  border-top: 1px solid #eef2f6;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #94a3b8;
+  margin: 6px 0 2px;
+  padding: 10px 2px 4px;
+}
+.dj-ns-group-heading:hover {
+  color: #64748b;
+}
+.dj-ns-chevron {
+  display: inline-flex;
+  align-items: center;
+  width: 14px;
+  min-width: 14px;
+  flex-shrink: 0;
+}
+.dj-ns-group-label {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dj-ns-group-count {
+  margin-left: auto;
+  padding-left: 6px;
+  color: #cbd5e1;
+  flex-shrink: 0;
+}
+.dj-ns-nav-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px 8px 8px 20px;
+  font-size: 15px;
+  line-height: 1.4;
+  color: #334155;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.dj-ns-nav-item:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+.dj-ns-nav-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+/* Namespace nav — the filter box doubles as the scope selector. When a namespace is
+   selected it shows in the input; an inset pin (★) and clear (✕) sit on the right. */
+.dj-ns-filter {
+  position: relative;
+  margin-bottom: 6px;
+}
+.dj-ns-filter-input {
+  width: 100%;
+  box-sizing: border-box;
+  /* right padding leaves room for the inset pin + clear buttons */
+  padding: 9px 52px 9px 11px;
+  font-size: 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+}
+.dj-ns-filter-pin,
+.dj-ns-filter-clear {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: 0 4px;
+  line-height: 1;
+  cursor: pointer;
+}
+.dj-ns-filter-clear {
+  right: 8px;
+  font-size: 13px;
+  color: #94a3b8;
+}
+.dj-ns-filter-clear:hover {
+  color: #475569;
+}
+.dj-ns-filter-pin {
+  right: 30px;
+  font-size: 15px;
+  color: #cbd5e1;
+}
+.dj-ns-filter-pin:hover {
+  color: #94a3b8;
+}
+.dj-ns-filter-pin.pinned {
+  color: #f59e0b;
+}
+/* Branch switcher: borderless — icon + branch name + caret read as plain text (no box,
+   so it doesn't look like a second selector), with a transparent native <select>
+   overlaid for the dropdown + accessibility. The row shrink-wraps its content. */
+.dj-ns-scope-branch-row {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+  margin: 2px 0 8px;
+  padding: 2px 4px 2px 12px;
+  cursor: pointer;
+}
+.dj-ns-branch-glyph {
+  color: #94a3b8;
+  flex-shrink: 0;
+}
+.dj-ns-branch-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1e293b;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dj-ns-branch-caret {
+  color: #64748b;
+  flex-shrink: 0;
+}
+.dj-ns-scope-branch-row:hover .dj-ns-branch-value {
+  color: #2563eb;
+}
+.dj-ns-scope-branch-row:hover .dj-ns-branch-glyph,
+.dj-ns-scope-branch-row:hover .dj-ns-branch-caret {
+  color: #2563eb;
+}
+/* The real <select>, made invisible and stretched over the row so a click anywhere
+   opens the native dropdown; keeps keyboard + screen-reader behavior. */
+.dj-ns-branch-native {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  border: none;
+  opacity: 0;
+  cursor: pointer;
+}
+
+/* Namespace nav — pin star */
+.dj-ns-star {
+  margin-left: 6px;
+  padding: 0 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  color: #cbd5e1;
+  opacity: 0;
+  flex-shrink: 0;
+}
+.dj-ns-nav-item:hover .dj-ns-star {
+  opacity: 1;
+}
+.dj-ns-star.pinned {
+  opacity: 1;
+  color: #f59e0b;
+}
+
+/* Namespace nav — contents-by-type summary (selected view) */
+.dj-ns-type-summary {
+  margin: 2px 0 4px;
+  padding: 0 4px 8px;
+  border-bottom: 1px solid #eef2f6;
+}
+.dj-ns-type-summary-heading {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #94a3b8;
+  margin: 2px 0 4px;
+}
+.dj-ns-type-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* left pad aligns node names with the namespace tree's text column */
+  padding: 6px 4px 6px 24px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: #334155;
+  font-size: 14px;
+}
+.dj-ns-type-row:hover {
+  background: #f1f5f9;
+}
+.dj-ns-type-name {
+  text-transform: capitalize;
+}
+.dj-ns-type-count {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-variant-numeric: tabular-nums;
+}
+.dj-ns-tree-heading {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #94a3b8;
+  margin: 8px 0 4px;
+  padding: 0 4px;
+}
+
+/* Namespace tree (Explorer) — row actions: persistent pin + kebab menu */
+.dj-ns-row-actions {
+  position: absolute;
+  right: 4px;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.dj-ns-pin-indicator {
+  color: #f59e0b;
+  font-size: 13px;
+  line-height: 1;
+}
+.dj-ns-kebab {
+  padding: 2px 3px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #94a3b8;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: opacity 0.15s ease;
+}
+.dj-ns-kebab:hover {
+  background: #e2e8f0;
+  color: #475569;
+}
+.dj-ns-row-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 30;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.14);
+  padding: 4px;
+  min-width: 170px;
+}
+.dj-ns-row-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 7px 10px;
+  font-size: 13px;
+  color: #334155;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+.dj-ns-row-menu-item:hover {
+  background: #f1f5f9;
+}
+.dj-ns-mi-icon {
+  width: 16px;
+  min-width: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  font-size: 14px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.dj-ns-mi-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+.dj-ns-mi-icon.pinned {
+  color: #f59e0b;
+}


### PR DESCRIPTION
### Summary

The left-nav namespace list is now a filter box that doubles as the namespace selector, with the selected namespace's context nested beneath it:

- Filter / select in one box -- typing filters the namespace list (grouped Pinned / Git-backed / Top-level, collapsible) and selecting one scopes both the list and the node table to it.
- When a namespace is selected, the box shows it, with an inline pin (★) and a ✕ that returns to all namespaces.
- For a git namespace, the box shows just the root. A branch switcher (`⎇ main`) below owns the branch, defaulting to the default branch and listing the rest.
- Added a clickable node-type summary (Metrics / Cubes / Dimensions / Transforms counts) for the selected namespace, with each row deep-linking to the type-filtered list.
- Pinned namespaces persist via localStorage and the Explorer tree drills into anything deeper.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
