### PR TITLE
Join dimensions referenced inside metric expressions in v3 measures SQL

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -11,6 +11,7 @@ from typing import Callable, Optional, cast
 
 from datajunction_server.construction.build_v3.utils import (
     get_short_name,
+    iter_namespaced_columns,
     make_name,
 )
 from datajunction_server.errors import (
@@ -741,7 +742,7 @@ def resolve_dimensions(
 def resolve_metric_expression_dimensions(
     ctx: BuildContext,
     parent_node: Node,
-    metric_expressions: list[tuple[str, ast.Expression]],
+    expressions: list[ast.Expression],
     requested_dimensions: list[ResolvedDimension],
 ) -> list[ResolvedDimension]:
     """
@@ -777,36 +778,33 @@ def resolve_metric_expression_dimensions(
 
     extra: list[ResolvedDimension] = []
     handled_nodes: set[str] = set()
-    for _, expr in metric_expressions:
-        for col in expr.find_all(ast.Column):
-            if not (col.name and col.name.namespace and col.name.namespace.name):
+    for expr in expressions:
+        for nc in iter_namespaced_columns(expr):
+            if nc.node in already_joined or nc.node in handled_nodes:
                 continue
-            ns = col.name.namespace.identifier(quotes=False)
-            if ns in already_joined or ns in handled_nodes:
-                continue
-            handled_nodes.add(ns)
+            handled_nodes.add(nc.node)
 
             # The referenced column itself is validated against the dimension
             # node at metric-creation time, so we only need the join path here.
-            join_path = find_join_path(ctx, parent_node, ns, None)
+            join_path = find_join_path(ctx, parent_node, nc.node, None)
             if not join_path:
                 raise DJException(
                     http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
                     message=(
                         f"Cannot find join path from {parent_node.name} to "
-                        f"dimension {ns} referenced in a metric expression. "
+                        f"dimension {nc.node} referenced in a metric expression. "
                         f"Please create a dimension link between these nodes."
                     ),
                 )
 
-            original_ref = f"{ns}{SEPARATOR}{col.name.name}"
+            original_ref = f"{nc.node}{SEPARATOR}{nc.name}"
             # Join the dim, but keep it out of the projection and GROUP BY.
             ctx.filter_dimensions.add(original_ref)
             extra.append(
                 ResolvedDimension(
                     original_ref=original_ref,
-                    node_name=ns,
-                    column_name=col.name.name,
+                    node_name=nc.node,
+                    column_name=nc.name,
                     role=None,
                     join_path=join_path,
                     is_local=False,

--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -738,6 +738,84 @@ def resolve_dimensions(
     return resolved
 
 
+def resolve_metric_expression_dimensions(
+    ctx: BuildContext,
+    parent_node: Node,
+    metric_expressions: list[tuple[str, ast.Expression]],
+    requested_dimensions: list[ResolvedDimension],
+) -> list[ResolvedDimension]:
+    """
+    Resolve dimension-node column refs that appear *inside* metric expressions.
+
+    A metric's aggregate expression may reference a column on a joined
+    dimension node via the fully-qualified ``<dim_node>.<column>`` form, e.g.
+    ``COUNT(DISTINCT CASE WHEN ... THEN customer.days_since ELSE NULL END)``.
+    When that dimension node is *not* also part of the requested grain, no join
+    is generated for it, so the reference leaks into the SQL as a raw,
+    unresolved node path and the engine fails with "column does not exist".
+
+    This resolves each such dimension node as a *join-only* dimension (one per
+    referenced node): it is joined and CTE-projected, but excluded from the
+    SELECT projection and GROUP BY by registering its ref in
+    ``ctx.filter_dimensions``. The namespace rewrite in measures'
+    ``_resolve_dim_namespace_refs`` then resolves the reference to the join
+    alias.
+
+    Dimension nodes already joined for the requested grain are skipped — their
+    aliases are already available for the rewrite.
+
+    Returns the list of newly resolved join-only ResolvedDimensions (empty when
+    no metric expression references an unjoined dimension node).
+    """
+    # Dimension nodes already joined for the requested grain. A local /
+    # skip-joined requested dim does not produce an alias, so only non-local
+    # requested dims count as "already joined".
+    already_joined: set[str] = {parent_node.name}
+    for rdim in requested_dimensions:
+        if not rdim.is_local:
+            already_joined.add(parse_dimension_ref(rdim.original_ref).node_name)
+
+    extra: list[ResolvedDimension] = []
+    handled_nodes: set[str] = set()
+    for _, expr in metric_expressions:
+        for col in expr.find_all(ast.Column):
+            if not (col.name and col.name.namespace and col.name.namespace.name):
+                continue
+            ns = col.name.namespace.identifier(quotes=False)
+            if ns in already_joined or ns in handled_nodes:
+                continue
+            handled_nodes.add(ns)
+
+            # The referenced column itself is validated against the dimension
+            # node at metric-creation time, so we only need the join path here.
+            join_path = find_join_path(ctx, parent_node, ns, None)
+            if not join_path:
+                raise DJException(
+                    http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    message=(
+                        f"Cannot find join path from {parent_node.name} to "
+                        f"dimension {ns} referenced in a metric expression. "
+                        f"Please create a dimension link between these nodes."
+                    ),
+                )
+
+            original_ref = f"{ns}{SEPARATOR}{col.name.name}"
+            # Join the dim, but keep it out of the projection and GROUP BY.
+            ctx.filter_dimensions.add(original_ref)
+            extra.append(
+                ResolvedDimension(
+                    original_ref=original_ref,
+                    node_name=ns,
+                    column_name=col.name.name,
+                    role=None,
+                    join_path=join_path,
+                    is_local=False,
+                ),
+            )
+
+    return extra
+
+
 def _rewrite_column_refs_with_aliases(
     expr: ast.Node,
     left_node_name: str,

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -17,6 +17,7 @@ from datajunction_server.database.preaggregation import PreAggregation
 from datajunction_server.models.node_type import NodeType
 
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
+from datajunction_server.sql.parsing import ast
 from datajunction_server.construction.build_v3.types import BuildContext
 from datajunction_server.construction.build_v3.utils import collect_required_dimensions
 
@@ -28,6 +29,30 @@ JoinPathState = namedtuple(
     "JoinPathState",
     ["source_rev_id", "node_id", "path_so_far", "role_path", "visited"],
 )
+
+
+def _collect_metric_expression_dim_nodes(ctx: BuildContext) -> set[str]:
+    """
+    Collect node namespaces of dimension-column refs inside metric query bodies.
+
+    A metric's aggregate expression may reference a column on a joined
+    dimension node via the fully-qualified ``<dim_node>.<column>`` form (e.g.
+    ``COUNT(DISTINCT customer.tier)``). Such dimension nodes are reachable only
+    through dimension links — not parent/child dependencies — so the upstream
+    traversal does not surface them. Returns the set of namespace strings so the
+    caller can register them as join-path targets. Namespaces that are not
+    actually linked dimensions simply yield no join path and are harmless.
+    """
+    dim_nodes: set[str] = set()
+    for node in ctx.nodes.values():
+        if node.type != NodeType.METRIC or not (
+            node.current and node.current.query
+        ):  # pragma: no cover
+            continue
+        for col in ctx.get_parsed_query(node).find_all(ast.Column):
+            if col.name and col.name.namespace and col.name.namespace.name:
+                dim_nodes.add(col.name.namespace.identifier(quotes=False))
+    return dim_nodes
 
 
 async def batch_load_nodes_with_dependencies(
@@ -479,6 +504,14 @@ async def load_nodes(ctx: BuildContext) -> None:
                     f"[BuildV3] Auto-adding required dimension {req_dim} from metric",
                 )
                 ctx.dimensions.append(req_dim)
+
+    # Dimension nodes referenced *inside* metric query bodies (e.g.
+    # COUNT(DISTINCT customer.tier)) are not parent/child dependencies, so the
+    # upstream traversal does not discover them. Register them as join-path
+    # targets so the join can be generated for the metric expression. They are
+    # NOT added to ctx.dimensions — they are joined only to resolve the
+    # expression, never projected or grouped.
+    target_dim_names.update(_collect_metric_expression_dim_nodes(ctx))
 
     # Collect parent revision IDs for join path lookup (using parent_map from Query 1)
     # For derived metrics, we need to recursively find fact parents through the metric chain

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -17,9 +17,11 @@ from datajunction_server.database.preaggregation import PreAggregation
 from datajunction_server.models.node_type import NodeType
 
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
-from datajunction_server.sql.parsing import ast
 from datajunction_server.construction.build_v3.types import BuildContext
-from datajunction_server.construction.build_v3.utils import collect_required_dimensions
+from datajunction_server.construction.build_v3.utils import (
+    collect_required_dimensions,
+    iter_namespaced_columns,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +51,8 @@ def _collect_metric_expression_dim_nodes(ctx: BuildContext) -> set[str]:
             node.current and node.current.query
         ):  # pragma: no cover
             continue
-        for col in ctx.get_parsed_query(node).find_all(ast.Column):
-            if col.name and col.name.namespace and col.name.namespace.name:
-                dim_nodes.add(col.name.namespace.identifier(quotes=False))
+        for nc in iter_namespaced_columns(ctx.get_parsed_query(node)):
+            dim_nodes.add(nc.node)
     return dim_nodes
 
 

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -37,6 +37,7 @@ from datajunction_server.construction.build_v3.utils import (
     get_column_type,
     get_cte_name,
     get_short_name,
+    iter_namespaced_columns,
     make_column_ref,
     make_name,
 )
@@ -99,12 +100,12 @@ def _rewrite_col_refs(expr: Any, table_alias: str) -> None:
 
 
 def _resolve_dim_namespace_refs(
-    metric_expressions: list[tuple[str, ast.Expression]],
+    expressions: list[ast.Expression],
     dim_node_to_alias: dict[str, str],
 ) -> dict[str, set[str]]:
-    """Resolve dim-namespaced column refs in metric expressions.
+    """Resolve dim-namespaced column refs in metric/grain expressions.
 
-    A metric expression may contain a fully-qualified column like
+    A metric or grain expression may contain a fully-qualified column like
     ``v3.customer.tier`` referring to a column on a dimension node that the
     parent fact joins to. In one walk per expression, this function:
 
@@ -116,17 +117,14 @@ def _resolve_dim_namespace_refs(
        drops them as unused).
     """
     dim_cols: dict[str, set[str]] = {}
-    for _, expr in metric_expressions:
-        for col in expr.find_all(ast.Column):
-            if not (col.name and col.name.namespace and col.name.namespace.name):
+    for expr in expressions:
+        for nc in iter_namespaced_columns(expr):
+            if nc.node not in dim_node_to_alias:
                 continue
-            ns = col.name.namespace.identifier(quotes=False)
-            if ns not in dim_node_to_alias:
-                continue
-            dim_cols.setdefault(ns, set()).add(col.name.name)
-            col.name = ast.Name(
-                col.name.name,
-                namespace=ast.Name(dim_node_to_alias[ns]),
+            dim_cols.setdefault(nc.node, set()).add(nc.name)
+            nc.column.name = ast.Name(
+                nc.name,
+                namespace=ast.Name(dim_node_to_alias[nc.node]),
             )
     return dim_cols
 
@@ -1269,6 +1267,7 @@ def build_select_ast(
     parent_node: Node,
     grain_columns: list[str] | None = None,
     grain_col_aliases: dict[str, str] | None = None,
+    grain_col_specs: list[tuple[ast.Expression, str]] | None = None,
     filters: list[str] | None = None,
     skip_aggregation: bool = False,
 ) -> tuple[ast.Query, list[str]]:
@@ -1326,7 +1325,10 @@ def build_select_ast(
         )
         projection.append(col_expr)
 
-    grain_col_specs = _parse_grain_col_specs(grain_columns, grain_col_aliases)
+    # Callers that already parsed the grain columns (to discover dimension
+    # references) can pass ``grain_col_specs`` to avoid re-parsing them here.
+    if grain_col_specs is None:
+        grain_col_specs = _parse_grain_col_specs(grain_columns, grain_col_aliases)
 
     # Add grain columns for LIMITED aggregability (e.g., customer_id for COUNT DISTINCT)
     # These are added to the output so the result can be re-aggregated.
@@ -1366,7 +1368,8 @@ def build_select_ast(
     # objects already placed in the projection above, so rewriting them here is
     # reflected in the emitted SQL.
     metric_dim_cols = _resolve_dim_namespace_refs(
-        metric_expressions + [(alias, expr) for expr, alias in grain_col_specs],
+        [expr for _, expr in metric_expressions]
+        + [expr for expr, _ in grain_col_specs],
         dim_node_to_alias,
     )
 
@@ -2055,23 +2058,25 @@ def build_grain_group_sql(
         # FULL: no additional grain columns
         effective_grain_columns = []
 
+    # Parse the grain columns once here; the specs are reused for dimension
+    # resolution below and threaded into build_select_ast to avoid re-parsing.
+    grain_col_specs = _parse_grain_col_specs(
+        effective_grain_columns,
+        grain_group.grain_col_aliases,
+    )
+
     # A dimension column may be referenced inside a metric's aggregate
     # expression AND inside a COUNT(DISTINCT ...) level/grain expression (e.g.
     # COUNT(DISTINCT customer.tier) without grouping by customer). Scan both so
     # any referenced dimension that is not part of the requested grain is still
     # joined (as a join-only dimension) and rewritten to its table alias
     # instead of leaking into the SQL as a raw node path.
-    grain_exprs_for_dims = [
-        (alias, expr)
-        for expr, alias in _parse_grain_col_specs(
-            effective_grain_columns,
-            grain_group.grain_col_aliases,
-        )
-    ]
     extra_dimensions = resolve_metric_expression_dimensions(
         ctx,
         parent_node,
-        component_expressions + non_decomposable_columns + grain_exprs_for_dims,
+        [expr for _, expr in component_expressions]
+        + [expr for _, expr in non_decomposable_columns]
+        + [expr for expr, _ in grain_col_specs],
         resolved_dimensions,
     )
     effective_resolved_dimensions = resolved_dimensions + extra_dimensions
@@ -2114,6 +2119,7 @@ def build_grain_group_sql(
             parent_node=parent_node,
             grain_columns=effective_grain_columns,
             grain_col_aliases=grain_group.grain_col_aliases or None,
+            grain_col_specs=grain_col_specs,  # already parsed above
             filters=ctx.dimension_filters,  # Use dimension_filters only (not metric_filters)
             skip_aggregation=skip_agg,
         )

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -67,6 +67,7 @@ from datajunction_server.construction.build_v3.decomposition import (
 from datajunction_server.construction.build_v3.dimensions import (
     parse_dimension_ref,
     resolve_dimensions,
+    resolve_metric_expression_dimensions,
 )
 from datajunction_server.construction.build_v3.preagg_matcher import (
     find_matching_preagg,
@@ -2033,6 +2034,19 @@ def build_grain_group_sql(
                 col_ast = make_column_ref(col_name)
                 non_decomposable_columns.append((col_name, col_ast))
 
+    # A metric's aggregate expression may reference a column on a joined
+    # dimension node that is not part of the requested grain (e.g.
+    # COUNT(DISTINCT customer.tier) without grouping by customer). Resolve
+    # those as join-only dimensions so the reference is joined and rewritten
+    # to its table alias instead of leaking into the SQL as a raw node path.
+    extra_dimensions = resolve_metric_expression_dimensions(
+        ctx,
+        parent_node,
+        component_expressions + non_decomposable_columns,
+        resolved_dimensions,
+    )
+    effective_resolved_dimensions = resolved_dimensions + extra_dimensions
+
     # Determine grain columns for this group
     if grain_group.is_merged:
         # Merged: use finest grain (all grain columns from merged groups)
@@ -2060,7 +2074,7 @@ def build_grain_group_sql(
         query_ast, scanned_sources = build_select_ast(
             ctx,
             metric_expressions=[],  # No aggregated expressions
-            resolved_dimensions=resolved_dimensions,
+            resolved_dimensions=effective_resolved_dimensions,
             parent_node=parent_node,
             grain_columns=pass_through_columns,
             filters=ctx.dimension_filters,  # Use dimension_filters only (not metric_filters)
@@ -2081,7 +2095,7 @@ def build_grain_group_sql(
         query_ast, scanned_sources = build_select_ast(
             ctx,
             metric_expressions=all_metric_expressions,
-            resolved_dimensions=resolved_dimensions,
+            resolved_dimensions=effective_resolved_dimensions,
             parent_node=parent_node,
             grain_columns=effective_grain_columns,
             grain_col_aliases=grain_group.grain_col_aliases or None,

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1361,7 +1361,14 @@ def build_select_ast(
     for (dim_node_name, role), alias in dim_aliases.items():
         if dim_node_name not in dim_node_to_alias or not role:
             dim_node_to_alias[dim_node_name] = alias
-    metric_dim_cols = _resolve_dim_namespace_refs(metric_expressions, dim_node_to_alias)
+    # Rewrite dim-namespaced refs in both the metric expressions and the grain
+    # (COUNT DISTINCT level) expressions. The grain specs hold the same AST
+    # objects already placed in the projection above, so rewriting them here is
+    # reflected in the emitted SQL.
+    metric_dim_cols = _resolve_dim_namespace_refs(
+        metric_expressions + [(alias, expr) for expr, alias in grain_col_specs],
+        dim_node_to_alias,
+    )
 
     # Add metric expressions
     for alias_name, expr in metric_expressions:
@@ -2034,19 +2041,6 @@ def build_grain_group_sql(
                 col_ast = make_column_ref(col_name)
                 non_decomposable_columns.append((col_name, col_ast))
 
-    # A metric's aggregate expression may reference a column on a joined
-    # dimension node that is not part of the requested grain (e.g.
-    # COUNT(DISTINCT customer.tier) without grouping by customer). Resolve
-    # those as join-only dimensions so the reference is joined and rewritten
-    # to its table alias instead of leaking into the SQL as a raw node path.
-    extra_dimensions = resolve_metric_expression_dimensions(
-        ctx,
-        parent_node,
-        component_expressions + non_decomposable_columns,
-        resolved_dimensions,
-    )
-    effective_resolved_dimensions = resolved_dimensions + extra_dimensions
-
     # Determine grain columns for this group
     if grain_group.is_merged:
         # Merged: use finest grain (all grain columns from merged groups)
@@ -2060,6 +2054,27 @@ def build_grain_group_sql(
     else:
         # FULL: no additional grain columns
         effective_grain_columns = []
+
+    # A dimension column may be referenced inside a metric's aggregate
+    # expression AND inside a COUNT(DISTINCT ...) level/grain expression (e.g.
+    # COUNT(DISTINCT customer.tier) without grouping by customer). Scan both so
+    # any referenced dimension that is not part of the requested grain is still
+    # joined (as a join-only dimension) and rewritten to its table alias
+    # instead of leaking into the SQL as a raw node path.
+    grain_exprs_for_dims = [
+        (alias, expr)
+        for expr, alias in _parse_grain_col_specs(
+            effective_grain_columns,
+            grain_group.grain_col_aliases,
+        )
+    ]
+    extra_dimensions = resolve_metric_expression_dimensions(
+        ctx,
+        parent_node,
+        component_expressions + non_decomposable_columns + grain_exprs_for_dims,
+        resolved_dimensions,
+    )
+    effective_resolved_dimensions = resolved_dimensions + extra_dimensions
 
     # Build AST
     # For non-decomposable metrics (NONE aggregability with no components),

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterator, NamedTuple
 
 from datajunction_server.construction.build_v3.filters import (
     extract_subscript_role,
@@ -113,6 +113,34 @@ def extract_columns_from_expression(expr: ast.Expression) -> set[str]:
         if col.name:  # pragma: no branch
             columns.add(col.name.name)
     return columns
+
+
+class NamespacedColumn(NamedTuple):
+    """A column written as ``<node>.<column>`` with its parts pre-extracted."""
+
+    column: ast.Column  # the AST node (mutate ``column.name`` to rewrite the ref)
+    node: str  # the namespace identifier, e.g. ``v3.customer``
+    name: str  # the column name, e.g. ``tier``
+
+
+def iter_namespaced_columns(expr: ast.Expression) -> Iterator[NamespacedColumn]:
+    """
+    Yield columns in ``expr`` that carry an explicit node namespace.
+
+    A namespaced column is one written as ``<node>.<column>`` (e.g.
+    ``v3.customer.tier``) — i.e. ``col.name.namespace`` is set. These are
+    references to a column on a node other than the local one, so callers use
+    them to discover dimension-node references inside metric/grain expressions.
+    The node and column name are pre-extracted so callers don't repeat the
+    optional-attribute guard.
+    """
+    for col in expr.find_all(ast.Column):
+        if col.name and col.name.namespace and col.name.namespace.name:
+            yield NamespacedColumn(
+                col,
+                col.name.namespace.identifier(quotes=False),
+                col.name.name,
+            )
 
 
 def extract_columns_referenced_from_node(

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -825,7 +825,7 @@ class TestResolveDimNamespaceRefs:
     def test_rewrites_known_dim_and_collects_col(self):
         expr = self._expr("v3.customer.tier")
         cols = _resolve_dim_namespace_refs(
-            [("alias", expr)],
+            [expr],
             {"v3.customer": "t2"},
         )
         assert str(expr) == "t2.tier"
@@ -836,7 +836,7 @@ class TestResolveDimNamespaceRefs:
         not recorded."""
         expr = self._expr("v3.fact.amount + v3.customer.threshold")
         cols = _resolve_dim_namespace_refs(
-            [("alias", expr)],
+            [expr],
             {"v3.customer": "t2"},
         )
         rendered = str(expr)
@@ -849,7 +849,7 @@ class TestResolveDimNamespaceRefs:
         the main-alias rewrite runs separately."""
         expr = self._expr("SUM(amount)")
         cols = _resolve_dim_namespace_refs(
-            [("alias", expr)],
+            [expr],
             {"v3.customer": "t2"},
         )
         assert str(expr) == "SUM(amount)"
@@ -862,7 +862,7 @@ class TestResolveDimNamespaceRefs:
             "THEN v3.customer.tier ELSE 'x' END)",
         )
         cols = _resolve_dim_namespace_refs(
-            [("alias", expr)],
+            [expr],
             {"v3.customer": "t2"},
         )
         rendered = str(expr)

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -5533,10 +5533,35 @@ class TestMetricExprReferencesUnrequestedDimColumn:
         assert resp.status_code == 200, resp.text
         sql = resp.json()["grain_groups"][0]["sql"]
         # Exactly one join to the customer dim, both columns rewritten + kept.
-        assert sql.count(f"{ns}_customer t") == 1
-        assert sql.count(f"JOIN {ns}_customer") == 1
-        assert f"{ns}.customer." not in sql
-        assert "t3.threshold" in sql and "t3.discount" in sql
+        # One join to customer; both threshold and discount rewritten to the
+        # alias and kept in the customer CTE.
+        assert_sql_equal(
+            sql,
+            f"""
+            WITH {ns}_customer AS (
+                SELECT customer_id, threshold, discount
+                FROM default.{ns}.src_customer
+            ),
+            {ns}_fact AS (
+                SELECT customer_id, region_id, amount
+                FROM default.{ns}.src_fact
+            ),
+            {ns}_region AS (
+                SELECT region_id, name
+                FROM default.{ns}.src_region
+            )
+            SELECT
+                t2.name,
+                SUM(CASE WHEN t1.amount >= t3.threshold
+                    THEN t1.amount * t3.discount ELSE 0 END)
+                    amount_{ns}_DOT_customer_DOT_threshold_{ns}_DOT_customer_DOT_discount_sum_HASH
+            FROM {ns}_fact t1
+            LEFT OUTER JOIN {ns}_region t2 ON t1.region_id = t2.region_id
+            LEFT OUTER JOIN {ns}_customer t3 ON t1.customer_id = t3.customer_id
+            GROUP BY t2.name
+            """,
+            normalize_aliases=True,
+        )
 
     @pytest.mark.asyncio
     async def test_local_grain_dim_does_not_mask_metric_expr_dim(
@@ -5580,9 +5605,30 @@ class TestMetricExprReferencesUnrequestedDimColumn:
         )
         assert resp.status_code == 200, resp.text
         sql = resp.json()["grain_groups"][0]["sql"]
-        assert f"{ns}.customer.threshold" not in sql
-        assert "t2.threshold" in sql
-        assert f"JOIN {ns}_customer" in sql
+        # Grouping by a local fact column (region_id) still joins customer for
+        # the metric-expression reference and rewrites it to the alias.
+        assert_sql_equal(
+            sql,
+            f"""
+            WITH {ns}_customer AS (
+                SELECT customer_id, threshold
+                FROM default.{ns}.src_customer
+            ),
+            {ns}_fact AS (
+                SELECT customer_id, region_id, amount
+                FROM default.{ns}.src_fact
+            )
+            SELECT
+                t1.region_id,
+                SUM(CASE WHEN t1.amount >= t2.threshold
+                    THEN t1.amount ELSE 0 END)
+                    amount_{ns}_DOT_customer_DOT_threshold_sum_HASH
+            FROM {ns}_fact t1
+            LEFT OUTER JOIN {ns}_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY t1.region_id
+            """,
+            normalize_aliases=True,
+        )
 
     @pytest.mark.asyncio
     async def test_metric_expr_dim_without_link_errors(self, client_with_service_setup):
@@ -5614,6 +5660,154 @@ class TestMetricExprReferencesUnrequestedDimColumn:
         assert resp.status_code == 422, resp.text
         assert "Cannot find join path" in resp.text
         assert f"{ns}.customer" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_dim_in_count_distinct_level_expr_also_grouped(
+        self,
+        client_with_service_setup,
+    ):
+        # A dim column referenced inside COUNT(DISTINCT ...) becomes the
+        # distinct "level"/grain expression (LIMITED aggregability), NOT a plain
+        # metric expression. Even when the dim is joined for the requested grain,
+        # the grain expression must be rewritten to the join alias (and its
+        # column kept in the dim CTE) instead of leaking as a raw node path.
+        client = client_with_service_setup
+        ns = "mz6"
+        await self._setup(client, ns)
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.distinct_qualifying_threshold",
+                "mode": "published",
+                "query": (
+                    f"SELECT COUNT(DISTINCT CASE WHEN amount > 0 "
+                    f"THEN {ns}.customer.threshold ELSE NULL END) FROM {ns}.fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        resp = await client.post(
+            f"/nodes/{ns}.fact/link",
+            json={
+                "dimension_node": f"{ns}.customer",
+                "join_type": "left",
+                "join_on": f"{ns}.fact.customer_id = {ns}.customer.customer_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # customer.tier requested as the grouping dim -> customer is joined.
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.distinct_qualifying_threshold"],
+                "dimensions": [f"{ns}.customer.tier"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+        # The COUNT(DISTINCT ...) level expression references t2.threshold (not
+        # the raw node path), threshold is kept in the customer CTE, and the
+        # level expression appears in GROUP BY for re-aggregation.
+        assert_sql_equal(
+            sql,
+            f"""
+            WITH {ns}_customer AS (
+                SELECT customer_id, tier, threshold
+                FROM default.{ns}.src_customer
+            ),
+            {ns}_fact AS (
+                SELECT customer_id, amount
+                FROM default.{ns}.src_fact
+            )
+            SELECT
+                t2.tier,
+                CASE WHEN t1.amount > 0 THEN t2.threshold ELSE NULL END
+                    amount_{ns}_DOT_customer_DOT_threshold_distinct_HASH
+            FROM {ns}_fact t1
+            LEFT OUTER JOIN {ns}_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY
+                t2.tier,
+                CASE WHEN t1.amount > 0 THEN t2.threshold ELSE NULL END
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_dim_in_count_distinct_level_expr_not_grouped(
+        self,
+        client_with_service_setup,
+    ):
+        # Same as above, but the dim referenced in the COUNT(DISTINCT ...) level
+        # is NOT part of the requested grain -> it must be added as a join-only
+        # dimension AND rewritten to the alias.
+        client = client_with_service_setup
+        ns = "mz7"
+        await self._setup(client, ns)
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.distinct_qualifying_threshold",
+                "mode": "published",
+                "query": (
+                    f"SELECT COUNT(DISTINCT CASE WHEN amount > 0 "
+                    f"THEN {ns}.customer.threshold ELSE NULL END) FROM {ns}.fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        resp = await client.post(
+            f"/nodes/{ns}.fact/link",
+            json={
+                "dimension_node": f"{ns}.customer",
+                "join_type": "left",
+                "join_on": f"{ns}.fact.customer_id = {ns}.customer.customer_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # Group by region.name only -> customer is NOT in the requested grain.
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.distinct_qualifying_threshold"],
+                "dimensions": [f"{ns}.region.name"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+        # customer is not in the requested grain, so it is added as a join-only
+        # dimension; the COUNT(DISTINCT ...) level references t3.threshold.
+        assert_sql_equal(
+            sql,
+            f"""
+            WITH {ns}_customer AS (
+                SELECT customer_id, threshold
+                FROM default.{ns}.src_customer
+            ),
+            {ns}_fact AS (
+                SELECT customer_id, region_id, amount
+                FROM default.{ns}.src_fact
+            ),
+            {ns}_region AS (
+                SELECT region_id, name
+                FROM default.{ns}.src_region
+            )
+            SELECT
+                t2.name,
+                CASE WHEN t1.amount > 0 THEN t3.threshold ELSE NULL END
+                    amount_{ns}_DOT_customer_DOT_threshold_distinct_HASH
+            FROM {ns}_fact t1
+            LEFT OUTER JOIN {ns}_region t2 ON t1.region_id = t2.region_id
+            LEFT OUTER JOIN {ns}_customer t3 ON t1.customer_id = t3.customer_id
+            GROUP BY
+                t2.name,
+                CASE WHEN t1.amount > 0 THEN t3.threshold ELSE NULL END
+            """,
+            normalize_aliases=True,
+        )
 
 
 class TestSparkJoinHints:

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -5302,6 +5302,320 @@ class TestMetricExprReferencesDimColumn:
         )
 
 
+class TestMetricExprReferencesUnrequestedDimColumn:
+    """
+    A metric aggregate expression may reference a column on a joined dimension
+    node (``<dim_node>.<column>``) that is NOT part of the requested grain, e.g.
+    ``SUM(CASE WHEN amount >= customer.threshold THEN amount ELSE 0 END)``
+    grouped only by ``region.name``.
+
+    Such dimension nodes are reachable only via dimension links — not
+    parent/child dependencies — so the upstream traversal does not surface them.
+    Without an explicit join, the reference leaks into the SQL as a raw,
+    unresolved node path and the engine fails with "column does not exist".
+
+    The builder must instead join the dimension node (as a *join-only*
+    dimension: joined + CTE-projected, but not selected or grouped) and rewrite
+    the reference to the join alias.
+    """
+
+    async def _setup(self, client, ns: str):
+        resp = await client.post(f"/namespaces/{ns}/")
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_fact",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_fact",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "region_id", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_customer",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_customer",
+                "columns": [
+                    {"name": "customer_id", "type": "int"},
+                    {"name": "tier", "type": "string"},
+                    {"name": "threshold", "type": "double"},
+                    {"name": "discount", "type": "double"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_region",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_region",
+                "columns": [
+                    {"name": "region_id", "type": "int"},
+                    {"name": "name", "type": "string"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.customer",
+                "mode": "published",
+                "primary_key": ["customer_id"],
+                "query": (
+                    f"SELECT customer_id, tier, threshold, discount "
+                    f"FROM {ns}.src_customer"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.region",
+                "mode": "published",
+                "primary_key": ["region_id"],
+                "query": f"SELECT region_id, name FROM {ns}.src_region",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": f"{ns}.fact",
+                "mode": "published",
+                "query": (
+                    f"SELECT id, customer_id, region_id, amount FROM {ns}.src_fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            f"/nodes/{ns}.fact/link",
+            json={
+                "dimension_node": f"{ns}.region",
+                "join_type": "left",
+                "join_on": f"{ns}.fact.region_id = {ns}.region.region_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+    @pytest.mark.asyncio
+    async def test_unrequested_dim_in_metric_expr_is_joined(
+        self,
+        client_with_service_setup,
+    ):
+        client = client_with_service_setup
+        ns = "mz1"
+        await self._setup(client, ns)
+
+        # customer.threshold referenced inside the aggregate; customer is NOT in
+        # the requested grain (we only group by region.name).
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.qualifying_amount",
+                "mode": "published",
+                "query": (
+                    f"SELECT SUM(CASE WHEN amount >= {ns}.customer.threshold "
+                    f"THEN amount ELSE 0 END) FROM {ns}.fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        resp = await client.post(
+            f"/nodes/{ns}.fact/link",
+            json={
+                "dimension_node": f"{ns}.customer",
+                "join_type": "left",
+                "join_on": f"{ns}.fact.customer_id = {ns}.customer.customer_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.qualifying_amount"],
+                "dimensions": [f"{ns}.region.name"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+
+        # The dim is joined (CTE + JOIN), the reference is rewritten to the
+        # alias, and customer is neither projected nor grouped.
+        assert f"{ns}.customer.threshold" not in sql
+        assert_sql_equal(
+            sql,
+            f"""
+            WITH {ns}_customer AS (
+                SELECT customer_id, threshold
+                FROM default.{ns}.src_customer
+            ),
+            {ns}_fact AS (
+                SELECT customer_id, region_id, amount
+                FROM default.{ns}.src_fact
+            ),
+            {ns}_region AS (
+                SELECT region_id, name
+                FROM default.{ns}.src_region
+            )
+            SELECT
+                t2.name,
+                SUM(CASE WHEN t1.amount >= t3.threshold
+                    THEN t1.amount ELSE 0 END)
+                    amount_{ns}_DOT_customer_DOT_threshold_sum_HASH
+            FROM {ns}_fact t1
+            LEFT OUTER JOIN {ns}_region t2 ON t1.region_id = t2.region_id
+            LEFT OUTER JOIN {ns}_customer t3 ON t1.customer_id = t3.customer_id
+            GROUP BY t2.name
+            """,
+            normalize_aliases=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_columns_same_dim_join_once(self, client_with_service_setup):
+        client = client_with_service_setup
+        ns = "mz2"
+        await self._setup(client, ns)
+
+        # Two columns from the same (unrequested) dim node — only one join.
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.qualifying_amount",
+                "mode": "published",
+                "query": (
+                    f"SELECT SUM(CASE WHEN amount >= {ns}.customer.threshold "
+                    f"THEN amount * {ns}.customer.discount ELSE 0 END) "
+                    f"FROM {ns}.fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        resp = await client.post(
+            f"/nodes/{ns}.fact/link",
+            json={
+                "dimension_node": f"{ns}.customer",
+                "join_type": "left",
+                "join_on": f"{ns}.fact.customer_id = {ns}.customer.customer_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.qualifying_amount"],
+                "dimensions": [f"{ns}.region.name"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+        # Exactly one join to the customer dim, both columns rewritten + kept.
+        assert sql.count(f"{ns}_customer t") == 1
+        assert sql.count(f"JOIN {ns}_customer") == 1
+        assert f"{ns}.customer." not in sql
+        assert "t3.threshold" in sql and "t3.discount" in sql
+
+    @pytest.mark.asyncio
+    async def test_local_grain_dim_does_not_mask_metric_expr_dim(
+        self,
+        client_with_service_setup,
+    ):
+        client = client_with_service_setup
+        ns = "mz3"
+        await self._setup(client, ns)
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.qualifying_amount",
+                "mode": "published",
+                "query": (
+                    f"SELECT SUM(CASE WHEN amount >= {ns}.customer.threshold "
+                    f"THEN amount ELSE 0 END) FROM {ns}.fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        resp = await client.post(
+            f"/nodes/{ns}.fact/link",
+            json={
+                "dimension_node": f"{ns}.customer",
+                "join_type": "left",
+                "join_on": f"{ns}.fact.customer_id = {ns}.customer.customer_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # Group by a LOCAL column on the fact itself (region_id) — exercises the
+        # is_local branch when computing already-joined dim nodes.
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.qualifying_amount"],
+                "dimensions": [f"{ns}.fact.region_id"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+        assert f"{ns}.customer.threshold" not in sql
+        assert "t2.threshold" in sql
+        assert f"JOIN {ns}_customer" in sql
+
+    @pytest.mark.asyncio
+    async def test_metric_expr_dim_without_link_errors(self, client_with_service_setup):
+        client = client_with_service_setup
+        ns = "mz4"
+        await self._setup(client, ns)
+
+        # Reference customer in the metric expression but never link it.
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.qualifying_amount",
+                "mode": "published",
+                "query": (
+                    f"SELECT SUM(CASE WHEN amount >= {ns}.customer.threshold "
+                    f"THEN amount ELSE 0 END) FROM {ns}.fact"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.qualifying_amount"],
+                "dimensions": [f"{ns}.region.name"],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert "Cannot find join path" in resp.text
+        assert f"{ns}.customer" in resp.text
+
+
 class TestSparkJoinHints:
     """
     Tests for Spark SQL join hints emitted via spark_hints on DimensionLink.


### PR DESCRIPTION
### Summary

A metric's aggregate expression may reference a column on a joined dimension node via the fully-qualified `<dim_node>.<column>` form, e.g. `SUM(CASE WHEN amount >= customer.threshold THEN amount ELSE 0 END)`. When that dimension node is not also part of the requested grain, the v3 measures builder did not join it: no CTE or JOIN was emitted and the reference leaked into the generated SQL as a raw, unresolved node path, so the engine failed with "column does not exist".

Dimension nodes referenced only inside a metric expression are reachable solely through dimension links, not parent/child dependencies, so the upstream traversal never surfaced them and no join path was preloaded. And the dim-namespace rewrite only applied to dimensions already joined for the requested grain.

We should treat such references as join-only dimensions and join + project them in the dim CTE, but exclude them from the SELECT projection and GROUP BY. The join is added per grain group (only where the expression references the dim) so OUTER-join links do not affect unrelated grain groups.

### Test Plan

Adds tests covering the unrequested-dim case (measures + metrics SQL), multiple columns from one dim joined once, a local grain dimension, and the no-link error path. The pre-existing already-joined case stays covered.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
