### PR TITLE
Shareable cube filters, faster cube loads, and chip/filter ergonomics

### DIFF
--- a/datajunction-ui/src/app/pages/QueryPlannerPage/SelectionPanel.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/SelectionPanel.jsx
@@ -6,6 +6,13 @@ const ENGINE_OPTIONS = [
   { value: 'trino', label: 'Trino' },
 ];
 
+// MIME type used to carry a dimension name during drag-to-filter.
+const DIM_DRAG_MIME = 'application/x-dj-dimension';
+
+// Append a filter expression onto an in-progress one, ANDing if non-empty.
+const andAppend = (prev, expr) =>
+  (prev.trim() ? prev.trimEnd() + ' AND ' : '') + expr;
+
 /**
  * Label that clips the START under truncation, keeping the END visible:
  * "…erience_f__cart_initiation". Metric/dimension names share long common
@@ -511,22 +518,18 @@ export function SelectionPanel({
   // Click a filter chip to edit it: pull it back into the input (preserving any
   // in-progress text by ANDing onto it) and remove the chip.
   const handleEditFilter = filter => {
-    setFilterInput(prev =>
-      prev.trim() ? prev.trimEnd() + ' AND ' + filter : filter,
-    );
+    setFilterInput(prev => andAppend(prev, filter));
     if (onFiltersChange) {
       onFiltersChange(filters.filter(f => f !== filter));
     }
     filterInputRef.current?.focus();
   };
 
-  // Append a dimension to the filter input, ANDing onto any existing expression,
+  // Append a dimension to the filter input (ANDing onto any existing expression)
   // then focus so the user can type the operator/value. Functional update keeps
   // it correct whether called from a click or a drag-and-drop handler.
   const appendDimToFilterInput = dimName => {
-    setFilterInput(
-      prev => (prev.trim() ? prev.trimEnd() + ' AND ' : '') + dimName + ' ',
-    );
+    setFilterInput(prev => andAppend(prev, dimName + ' '));
     filterInputRef.current?.focus();
   };
 
@@ -537,8 +540,6 @@ export function SelectionPanel({
   };
 
   // Drag a dimension chip/row onto the Filters section to start filtering on it.
-  const DIM_DRAG_MIME = 'application/x-dj-dimension';
-
   const handleDimDragStart = (e, dimName) => {
     e.dataTransfer.setData(DIM_DRAG_MIME, dimName);
     // Plain-text fallback so the drag has a sensible payload everywhere.

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/SelectionPanel.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/SelectionPanel.jsx
@@ -7,6 +7,22 @@ const ENGINE_OPTIONS = [
 ];
 
 /**
+ * Label that clips the START under truncation, keeping the END visible:
+ * "…erience_f__cart_initiation". Metric/dimension names share long common
+ * prefixes, so a normal right-side ellipsis hides the only part that differs;
+ * clipping the start surfaces the distinguishing tail. The text stays a single
+ * node (the CSS direction trick puts the ellipsis on the left), so the full
+ * value remains in the title tooltip and queryable by tests.
+ */
+function TailLabel({ text }) {
+  return (
+    <span className="chip-label chip-label-clip" title={text}>
+      <bdi className="chip-label-inner">{text}</bdi>
+    </span>
+  );
+}
+
+/**
  * SelectionPanel - Browse and select metrics and dimensions
  * Features selected items as chips at the top for visibility
  * Includes cube preset loading for quick configuration
@@ -42,6 +58,8 @@ export function SelectionPanel({
   const [metricsChipsExpanded, setMetricsChipsExpanded] = useState(false);
   const [dimensionsChipsExpanded, setDimensionsChipsExpanded] = useState(false);
   const [filterInput, setFilterInput] = useState('');
+  // Highlights the Filters section while a dimension is dragged over it.
+  const [filterDropActive, setFilterDropActive] = useState(false);
   const [split1, setSplit1] = useState(35); // metrics / dims boundary (%)
   const [split2, setSplit2] = useState(65); // dims / filters boundary (%)
   const [split3, setSplit3] = useState(85); // filters / engine+run boundary (%)
@@ -490,12 +508,66 @@ export function SelectionPanel({
     }
   };
 
+  // Click a filter chip to edit it: pull it back into the input (preserving any
+  // in-progress text by ANDing onto it) and remove the chip.
+  const handleEditFilter = filter => {
+    setFilterInput(prev =>
+      prev.trim() ? prev.trimEnd() + ' AND ' + filter : filter,
+    );
+    if (onFiltersChange) {
+      onFiltersChange(filters.filter(f => f !== filter));
+    }
+    filterInputRef.current?.focus();
+  };
+
+  // Append a dimension to the filter input, ANDing onto any existing expression,
+  // then focus so the user can type the operator/value. Functional update keeps
+  // it correct whether called from a click or a drag-and-drop handler.
+  const appendDimToFilterInput = dimName => {
+    setFilterInput(
+      prev => (prev.trim() ? prev.trimEnd() + ' AND ' : '') + dimName + ' ',
+    );
+    filterInputRef.current?.focus();
+  };
+
   const addDimAsFilter = (e, dimName) => {
     e.preventDefault();
     e.stopPropagation();
-    const prefix = filterInput.trim() ? filterInput.trimEnd() + ' AND ' : '';
-    setFilterInput(prefix + dimName + ' ');
-    filterInputRef.current?.focus();
+    appendDimToFilterInput(dimName);
+  };
+
+  // Drag a dimension chip/row onto the Filters section to start filtering on it.
+  const DIM_DRAG_MIME = 'application/x-dj-dimension';
+
+  const handleDimDragStart = (e, dimName) => {
+    e.dataTransfer.setData(DIM_DRAG_MIME, dimName);
+    // Plain-text fallback so the drag has a sensible payload everywhere.
+    e.dataTransfer.setData('text/plain', dimName);
+    e.dataTransfer.effectAllowed = 'copy';
+  };
+
+  const handleFilterDragOver = e => {
+    if (e.dataTransfer.types.includes(DIM_DRAG_MIME)) {
+      e.preventDefault(); // allow drop
+      e.dataTransfer.dropEffect = 'copy';
+      if (!filterDropActive) setFilterDropActive(true);
+    }
+  };
+
+  const handleFilterDragLeave = e => {
+    // Ignore leaves into child elements of the filters section.
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setFilterDropActive(false);
+    }
+  };
+
+  const handleFilterDrop = e => {
+    const dimName = e.dataTransfer.getData(DIM_DRAG_MIME);
+    if (dimName) {
+      e.preventDefault();
+      appendDimToFilterInput(dimName);
+    }
+    setFilterDropActive(false);
   };
 
   return (
@@ -599,7 +671,7 @@ export function SelectionPanel({
               >
                 {selectedMetrics.map(metric => (
                   <span key={metric} className="selected-chip metric-chip">
-                    {getShortName(metric)}
+                    <TailLabel text={getShortName(metric)} />
                     <button
                       className="chip-remove"
                       onClick={e => {
@@ -793,12 +865,12 @@ export function SelectionPanel({
                     {selectedDimensions.map(dimName => (
                       <span
                         key={dimName}
-                        className="selected-chip dimension-chip"
-                        title={dimName}
+                        className="selected-chip dimension-chip draggable-dim"
+                        title={`${dimName} — drag to Filters to filter on it`}
+                        draggable
+                        onDragStart={e => handleDimDragStart(e, dimName)}
                       >
-                        <span className="chip-label">
-                          {getDimDisplayName(dimName)}
-                        </span>
+                        <TailLabel text={getDimDisplayName(dimName)} />
                         <button
                           className="chip-remove"
                           onClick={e => {
@@ -902,8 +974,12 @@ export function SelectionPanel({
                                 rp.dimensions.map(dim => (
                                   <label
                                     key={dim.name}
-                                    className="selection-item dimension-item dim-role-item"
-                                    title={dim.name}
+                                    className="selection-item dimension-item dim-role-item draggable-dim"
+                                    title={`${dim.name} — drag to Filters to filter on it`}
+                                    draggable
+                                    onDragStart={e =>
+                                      handleDimDragStart(e, dim.name)
+                                    }
                                   >
                                     <input
                                       type="checkbox"
@@ -953,22 +1029,39 @@ export function SelectionPanel({
           onMouseDown={e => handleDividerMouseDown(e, 2)}
         />
 
-        {/* Filters Section */}
+        {/* Filters Section (drop target for dragged dimensions) */}
         <div
-          className="selection-section filters-section"
+          className={`selection-section filters-section${
+            filterDropActive ? ' drop-active' : ''
+          }`}
           style={{ flex: split3 - split2 }}
+          onDragOver={handleFilterDragOver}
+          onDragLeave={handleFilterDragLeave}
+          onDrop={handleFilterDrop}
         >
           <div className="section-header">
             <h3>Filters</h3>
             <span className="selection-count">{filters.length} applied</span>
           </div>
+          {filterDropActive && (
+            <div className="filter-drop-hint">
+              Drop to filter on this dimension
+            </div>
+          )}
 
           {/* Filter chips */}
           {filters.length > 0 && (
             <div className="filter-chips-container">
               {filters.map((filter, idx) => (
                 <span key={idx} className="filter-chip">
-                  <span className="filter-chip-text">{filter}</span>
+                  <button
+                    type="button"
+                    className="filter-chip-text filter-chip-edit"
+                    onClick={() => handleEditFilter(filter)}
+                    title={`${filter} — click to edit`}
+                  >
+                    {filter}
+                  </button>
                   <button
                     className="filter-chip-remove"
                     onClick={() => handleRemoveFilter(filter)}

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/__tests__/index.test.jsx
@@ -7,7 +7,7 @@ import {
 } from '@testing-library/react';
 import DJClientContext from '../../../providers/djclient';
 import { QueryPlannerPage } from '../index';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import React from 'react';
 
 // Mock the MetricFlowGraph component to avoid dagre dependency issues
@@ -164,6 +164,15 @@ const mockCubes = [
 const mockCubeData = {
   cube_node_metrics: ['default.num_repair_orders', 'default.avg_repair_price'],
   cube_node_dimensions: ['default.date_dim.dateint'],
+  cube_dimension_objects: [
+    {
+      name: 'default.date_dim.dateint',
+      type: 'timestamp',
+      attribute: 'dateint',
+      role: '',
+      properties: [],
+    },
+  ],
   cubeMaterialization: {
     schedule: '0 6 * * *',
     strategy: 'incremental_time',
@@ -399,6 +408,32 @@ describe('QueryPlannerPage', () => {
           'default.test_cube',
         );
       });
+    });
+
+    it('selects cube dimensions immediately from the preset without waiting on common dimensions', async () => {
+      mockDjClient.cubeForPlanner.mockResolvedValue(mockCubeData);
+      // Simulate the (slow) common-dimensions intersection never resolving;
+      // the cube's dimensions must still be shown and selected from the preset.
+      mockDjClient.commonDimensions.mockReturnValue(new Promise(() => {}));
+
+      renderPage(['/planner?cube=default.test_cube']);
+
+      await waitFor(() => {
+        expect(mockDjClient.cubeForPlanner).toHaveBeenCalledWith(
+          'default.test_cube',
+        );
+      });
+
+      // Dimensions section is populated and the cube's dimension is selected,
+      // even though commonDimensions never resolved (no spinner, no empty list).
+      await waitFor(() => {
+        expect(
+          screen.getByText(/1 selected \/ 1 available/),
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText('Loading dimensions...'),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -762,6 +797,67 @@ describe('QueryPlannerPage', () => {
       });
     });
 
+    it('clears existing filters when a new cube is loaded', async () => {
+      mockDjClient.cubeForPlanner.mockResolvedValue(mockCubeData);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(mockDjClient.listCubesForPreset).toHaveBeenCalled();
+      });
+
+      // Set a filter in the current (ad-hoc) session.
+      const filterInput = screen.getByPlaceholderText(
+        /e\.g\. v3\.date\.date_id/i,
+      );
+      fireEvent.change(filterInput, { target: { value: "status = 'active'" } });
+      fireEvent.click(screen.getByText('Add'));
+
+      await waitFor(() => {
+        expect(screen.getByText("status = 'active'")).toBeInTheDocument();
+      });
+
+      // Load a cube preset from the dropdown.
+      fireEvent.click(screen.getByText('Load from Cube'));
+      fireEvent.click(screen.getByText('Test Cube'));
+
+      await waitFor(() => {
+        expect(mockDjClient.cubeForPlanner).toHaveBeenCalled();
+      });
+
+      // The stale filter from the previous selection is gone.
+      await waitFor(() => {
+        expect(screen.queryByText("status = 'active'")).not.toBeInTheDocument();
+      });
+    });
+
+    it('moves a filter back into the input when its chip is clicked (edit)', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(mockDjClient.metrics).toHaveBeenCalled();
+      });
+
+      const filterInput = screen.getByPlaceholderText(
+        /e\.g\. v3\.date\.date_id/i,
+      );
+      fireEvent.change(filterInput, { target: { value: "status = 'active'" } });
+      fireEvent.click(screen.getByText('Add'));
+
+      await waitFor(() => {
+        expect(screen.getByText("status = 'active'")).toBeInTheDocument();
+      });
+
+      // Click the chip text to edit it.
+      fireEvent.click(screen.getByText("status = 'active'"));
+
+      // The expression returns to the input and the chip is gone.
+      await waitFor(() => {
+        expect(filterInput.value).toBe("status = 'active'");
+      });
+      expect(screen.queryByText("status = 'active'")).not.toBeInTheDocument();
+    });
+
     it('disables add button when filter input is empty', async () => {
       renderPage();
 
@@ -771,6 +867,112 @@ describe('QueryPlannerPage', () => {
 
       const addButton = screen.getByText('Add');
       expect(addButton).toBeDisabled();
+    });
+
+    it('prefills the filter input when a dimension is dragged onto the Filters section', async () => {
+      mockDjClient.cubeForPlanner.mockResolvedValue(mockCubeData);
+
+      renderPage(['/planner?cube=default.test_cube']);
+
+      // Cube preset loads and selects its dimension (rendered as a draggable chip).
+      await waitFor(() => {
+        expect(
+          screen.getByText(/1 selected \/ 1 available/),
+        ).toBeInTheDocument();
+      });
+
+      // Minimal DataTransfer stand-in for jsdom.
+      const dataTransfer = {
+        store: {},
+        types: ['application/x-dj-dimension'],
+        setData(type, val) {
+          this.store[type] = val;
+        },
+        getData(type) {
+          return this.store[type] || '';
+        },
+      };
+      dataTransfer.setData(
+        'application/x-dj-dimension',
+        'default.date_dim.dateint',
+      );
+
+      const filtersSection = document.querySelector('.filters-section');
+      fireEvent.dragOver(filtersSection, { dataTransfer });
+      fireEvent.drop(filtersSection, { dataTransfer });
+
+      const filterInput = screen.getByPlaceholderText(
+        /e\.g\. v3\.date\.date_id/i,
+      );
+      await waitFor(() => {
+        expect(filterInput.value).toContain('default.date_dim.dateint');
+      });
+    });
+
+    it('expands a cube-based URL to metrics/dimensions/filters when a filter is added', async () => {
+      mockDjClient.cubeForPlanner.mockResolvedValue(mockCubeData);
+
+      const LocationDisplay = () => {
+        const location = useLocation();
+        return <div data-testid="location-search">{location.search}</div>;
+      };
+
+      render(
+        <MemoryRouter initialEntries={['/planner?cube=default.test_cube']}>
+          <Routes>
+            <Route
+              path="/planner"
+              element={
+                <DJClientContext.Provider
+                  value={{ DataJunctionAPI: mockDjClient }}
+                >
+                  <>
+                    <QueryPlannerPage />
+                    <LocationDisplay />
+                  </>
+                </DJClientContext.Provider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>,
+      );
+
+      // Cube preset loads from the URL...
+      await waitFor(() => {
+        expect(mockDjClient.cubeForPlanner).toHaveBeenCalledWith(
+          'default.test_cube',
+        );
+      });
+      // ...and the URL stays compact (just the cube name) until the user edits.
+      await waitFor(() => {
+        expect(screen.getByTestId('location-search').textContent).toContain(
+          'cube=default.test_cube',
+        );
+      });
+      // Cube dimensions are applied once common dimensions resolve.
+      await waitFor(() => {
+        expect(mockDjClient.commonDimensions).toHaveBeenCalled();
+      });
+
+      // Apply a filter on the cube-based URL.
+      const filterInput = screen.getByPlaceholderText(
+        /e\.g\. v3\.date\.date_id/i,
+      );
+      fireEvent.change(filterInput, {
+        target: { value: 'default.date_dim.dateint = 20260101' },
+      });
+      fireEvent.click(screen.getByText('Add'));
+
+      // The URL must expand to its fully-qualified form so the filter is
+      // reflected and the link is shareable: the cube param is dropped and
+      // metrics, dimensions, and filters are all encoded.
+      await waitFor(() => {
+        const search = screen.getByTestId('location-search').textContent;
+        expect(search).not.toContain('cube=');
+        expect(search).toContain('metrics=');
+        expect(search).toContain('dimensions=');
+        expect(search).toContain('filters=');
+      });
     });
   });
 

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
@@ -52,6 +52,10 @@ export function QueryPlannerPage() {
   const initializedFromUrl = useRef(false);
   const pendingDimensionsFromUrl = useRef([]);
   const pendingCubeFromUrl = useRef(null);
+  // Dimension objects seeded directly from a loaded cube preset. Kept so the
+  // background common-dimensions fetch can be merged in (union) without dropping
+  // the cube's own dimensions from the available list or the selection.
+  const cubeDimensionObjects = useRef([]);
 
   // Compatible metrics when dimensions are selected (phase 1: dimension-first flow)
   const [compatibleMetrics, setCompatibleMetrics] = useState(null); // null = no filter active
@@ -260,9 +264,15 @@ export function QueryPlannerPage() {
           if (cubeData && Array.isArray(cubeData.cube_node_metrics)) {
             const cubeMetrics = cubeData.cube_node_metrics || [];
             const cubeDimensions = cubeData.cube_node_dimensions || [];
+            const cubeDimObjects = cubeData.cube_dimension_objects || [];
             setLoadedCubeName(cubeName);
             setSelectedMetrics(cubeMetrics);
-            pendingDimensionsFromUrl.current = cubeDimensions;
+            // Seed the dimension picker and selection straight from the cube so
+            // they appear instantly and correctly; the full common-dimensions
+            // list is fetched in the background (and merged) for adding more.
+            cubeDimensionObjects.current = cubeDimObjects;
+            setCommonDimensions(cubeDimObjects);
+            setSelectedDimensions(cubeDimensions);
 
             // Materialization info is included in the GraphQL response
             const cubeMat = cubeData.cubeMaterialization;
@@ -283,7 +293,14 @@ export function QueryPlannerPage() {
   useEffect(() => {
     const fetchData = async () => {
       if (selectedMetrics.length > 0) {
-        setDimensionsLoading(true);
+        // Capture cube-seeded dimensions for this run. When a cube preset is
+        // loaded its dimensions are already shown and selected, so the (slow)
+        // common-dimensions intersection runs in the background — don't blank
+        // the list behind a spinner, and merge rather than replace below.
+        const seeded = cubeDimensionObjects.current;
+        if (seeded.length === 0) {
+          setDimensionsLoading(true);
+        }
         try {
           const dims = await djClient.commonDimensions(selectedMetrics);
           // Server returns an error body (e.g. {message: "..."}) on 404/422 with
@@ -291,14 +308,23 @@ export function QueryPlannerPage() {
           // against passing a non-array into setCommonDimensions.
           if (!Array.isArray(dims)) {
             console.error('commonDimensions returned non-array:', dims);
-            setCommonDimensions([]);
+            // Keep the cube-seeded dims (if any) rather than blanking the list.
+            setCommonDimensions(seeded);
             return;
           }
-          setCommonDimensions(dims);
+          // Merge: fetched dims win (richer: path/type), but keep any cube
+          // dimensions the intersection omits so the cube's selection stays valid.
+          const fetchedNames = new Set(dims.map(d => d.name));
+          const merged = [
+            ...dims,
+            ...seeded.filter(d => !fetchedNames.has(d.name)),
+          ];
+          setCommonDimensions(merged);
 
-          // Apply pending dimensions from URL if we have them
+          // Apply pending dimensions from URL if we have them (metrics+dimensions
+          // URL path; cube presets seed their dimensions directly instead).
           if (pendingDimensionsFromUrl.current.length > 0) {
-            const validDimNames = dims.map(d => d.name);
+            const validDimNames = merged.map(d => d.name);
             const validPending = pendingDimensionsFromUrl.current.filter(d =>
               validDimNames.includes(d),
             );
@@ -309,7 +335,8 @@ export function QueryPlannerPage() {
           }
         } catch (err) {
           console.error('Failed to fetch dimensions:', err);
-          setCommonDimensions([]);
+          // Preserve cube-seeded dims on failure rather than blanking the list.
+          setCommonDimensions(seeded);
         }
         setDimensionsLoading(false);
       } else {
@@ -530,6 +557,8 @@ export function QueryPlannerPage() {
     // Clear loaded cube name to indicate user is manually changing selection
     // (workflowUrls and cubeMaterialization will be updated by the effect when metricsResult changes)
     setLoadedCubeName(null);
+    // Leaving cube-preset mode: cube-seeded dims are no longer authoritative.
+    cubeDimensionObjects.current = [];
   }, []);
 
   // Load a cube preset - sets both metrics and dimensions from the cube definition
@@ -545,13 +574,21 @@ export function QueryPlannerPage() {
           // Extract metrics and dimensions from the cube
           const cubeMetrics = cubeData.cube_node_metrics || [];
           const cubeDimensions = cubeData.cube_node_dimensions || [];
+          const cubeDimObjects = cubeData.cube_dimension_objects || [];
 
           // Set the cube name for URL and display
           setLoadedCubeName(cubeName);
-          // Set the metrics first - dimensions will be loaded and filtered via the effect
+          // Set the metrics first - common dimensions load in the background
           setSelectedMetrics(cubeMetrics);
-          // Store dimensions to apply after common dimensions are loaded
-          pendingDimensionsFromUrl.current = cubeDimensions;
+          // Seed the dimension picker and selection straight from the cube so
+          // they appear instantly and correctly, without waiting on the slow
+          // common-dimensions intersection over every cube metric.
+          cubeDimensionObjects.current = cubeDimObjects;
+          setCommonDimensions(cubeDimObjects);
+          setSelectedDimensions(cubeDimensions);
+          // Start with a clean slate: filters from a previously loaded cube may
+          // reference dimensions this cube doesn't have, so don't carry them over.
+          setFilters([]);
           setSelectedNode(null);
 
           // Materialization and availability info is included in the GraphQL response
@@ -573,9 +610,11 @@ export function QueryPlannerPage() {
   const handleClearSelection = useCallback(() => {
     setSelectedMetrics([]);
     setSelectedDimensions([]);
+    setFilters([]);
     setLoadedCubeName(null);
     setWorkflowUrls([]);
     setCubeMaterialization(null);
+    cubeDimensionObjects.current = [];
   }, []);
 
   const handleDimensionsChange = useCallback(newDimensions => {
@@ -584,6 +623,8 @@ export function QueryPlannerPage() {
     // Clear loaded cube name to indicate user is manually changing selection
     // (workflowUrls and cubeMaterialization will be updated by the effect when metricsResult changes)
     setLoadedCubeName(null);
+    // Leaving cube-preset mode: cube-seeded dims are no longer authoritative.
+    cubeDimensionObjects.current = [];
   }, []);
 
   const handleNodeSelect = useCallback(node => {
@@ -1289,6 +1330,14 @@ export function QueryPlannerPage() {
   // Handle filter changes
   const handleFiltersChange = useCallback(newFilters => {
     setFilters(newFilters);
+    // A cube-based URL (?cube=...) only encodes the cube name, so filters can't
+    // be represented while a cube preset is loaded. Clear loadedCubeName to
+    // expand the URL into its fully-qualified metrics/dimensions/filters form
+    // (matching handleMetricsChange/handleDimensionsChange) so the applied
+    // filter is reflected in the URL and the link stays shareable.
+    setLoadedCubeName(null);
+    // Leaving cube-preset mode: cube-seeded dims are no longer authoritative.
+    cubeDimensionObjects.current = [];
   }, []);
 
   return (

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
@@ -551,15 +551,22 @@ export function QueryPlannerPage() {
     fetchCubeInfo();
   }, [metricsResult?.cube_name, loadedCubeName, djClient]);
 
-  const handleMetricsChange = useCallback(newMetrics => {
-    setSelectedMetrics(newMetrics);
-    setSelectedNode(null);
-    // Clear loaded cube name to indicate user is manually changing selection
-    // (workflowUrls and cubeMaterialization will be updated by the effect when metricsResult changes)
+  // Leave cube-preset mode: drop the cube name (so the URL expands to its
+  // components and workflow/materialization state is recomputed) and forget the
+  // cube-seeded dims, which are no longer authoritative once the user edits.
+  const leaveCubeMode = useCallback(() => {
     setLoadedCubeName(null);
-    // Leaving cube-preset mode: cube-seeded dims are no longer authoritative.
     cubeDimensionObjects.current = [];
   }, []);
+
+  const handleMetricsChange = useCallback(
+    newMetrics => {
+      setSelectedMetrics(newMetrics);
+      setSelectedNode(null);
+      leaveCubeMode();
+    },
+    [leaveCubeMode],
+  );
 
   // Load a cube preset - sets both metrics and dimensions from the cube definition
   const handleLoadCubePreset = useCallback(
@@ -611,21 +618,19 @@ export function QueryPlannerPage() {
     setSelectedMetrics([]);
     setSelectedDimensions([]);
     setFilters([]);
-    setLoadedCubeName(null);
     setWorkflowUrls([]);
     setCubeMaterialization(null);
-    cubeDimensionObjects.current = [];
-  }, []);
+    leaveCubeMode();
+  }, [leaveCubeMode]);
 
-  const handleDimensionsChange = useCallback(newDimensions => {
-    setSelectedDimensions(newDimensions);
-    setSelectedNode(null);
-    // Clear loaded cube name to indicate user is manually changing selection
-    // (workflowUrls and cubeMaterialization will be updated by the effect when metricsResult changes)
-    setLoadedCubeName(null);
-    // Leaving cube-preset mode: cube-seeded dims are no longer authoritative.
-    cubeDimensionObjects.current = [];
-  }, []);
+  const handleDimensionsChange = useCallback(
+    newDimensions => {
+      setSelectedDimensions(newDimensions);
+      setSelectedNode(null);
+      leaveCubeMode();
+    },
+    [leaveCubeMode],
+  );
 
   const handleNodeSelect = useCallback(node => {
     setSelectedNode(node);
@@ -1328,17 +1333,17 @@ export function QueryPlannerPage() {
   }, []);
 
   // Handle filter changes
-  const handleFiltersChange = useCallback(newFilters => {
-    setFilters(newFilters);
-    // A cube-based URL (?cube=...) only encodes the cube name, so filters can't
-    // be represented while a cube preset is loaded. Clear loadedCubeName to
-    // expand the URL into its fully-qualified metrics/dimensions/filters form
-    // (matching handleMetricsChange/handleDimensionsChange) so the applied
-    // filter is reflected in the URL and the link stays shareable.
-    setLoadedCubeName(null);
-    // Leaving cube-preset mode: cube-seeded dims are no longer authoritative.
-    cubeDimensionObjects.current = [];
-  }, []);
+  const handleFiltersChange = useCallback(
+    newFilters => {
+      setFilters(newFilters);
+      // A cube-based URL (?cube=...) only encodes the cube name, so filters can't
+      // be represented while a cube preset is loaded. Leaving cube mode expands
+      // the URL into its fully-qualified metrics/dimensions/filters form so the
+      // applied filter is reflected in the URL and the link stays shareable.
+      leaveCubeMode();
+    },
+    [leaveCubeMode],
+  );
 
   return (
     <div className="planner-page">

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/styles.css
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/styles.css
@@ -3593,6 +3593,28 @@ a.action-btn {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* Allow the label to shrink below its content width so the ellipsis applies
+     within the chip's max-width instead of overflowing the panel. */
+  min-width: 0;
+}
+
+/* Start-clipping label: ellipsis on the LEFT so the distinguishing end of a
+   long, common-prefixed name stays visible ("…erience_f__cart_initiation").
+   direction: rtl moves the ellipsis to the start; the inner <bdi> keeps the
+   text in normal reading order. Text stays a single node for accessibility. */
+.chip-label-clip {
+  display: inline-block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+}
+
+.chip-label-clip .chip-label-inner {
+  direction: ltr;
+  unicode-bidi: bidi-override;
 }
 
 /* Metrics: Pink (matches node_type__metric background #fad7dd) */
@@ -3660,6 +3682,28 @@ a.action-btn {
   overflow-y: auto;
 }
 
+/* Dimensions can be dragged onto the Filters section to start a filter. */
+.draggable-dim {
+  cursor: grab;
+}
+
+.draggable-dim:active {
+  cursor: grabbing;
+}
+
+.filters-section.drop-active {
+  outline: 2px dashed var(--node_type__dimension, #a96621);
+  outline-offset: -4px;
+  background: rgba(169, 102, 33, 0.06);
+}
+
+.filter-drop-hint {
+  padding: 6px 12px;
+  font-size: 11px;
+  font-style: italic;
+  color: #a96621;
+}
+
 .filter-chips-container {
   display: flex;
   flex-wrap: wrap;
@@ -3685,6 +3729,24 @@ a.action-btn {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Filter chip text doubles as a click-to-edit button. */
+.filter-chip-edit {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.filter-chip-edit:hover {
+  text-decoration: underline;
 }
 
 .filter-chip-remove {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -223,6 +223,10 @@ export const DataJunctionAPI = {
             }
             cubeDimensions {
               name
+              type
+              attribute
+              role
+              properties
             }
             availability {
               catalog
@@ -266,7 +270,17 @@ export const DataJunctionAPI = {
       // Transform to match the shape expected by QueryPlannerPage
       const current = node.current || {};
       const cubeMetrics = (current.cubeMetrics || []).map(m => m.name);
-      const cubeDimensions = (current.cubeDimensions || []).map(d => d.name);
+      // Full dimension objects (name/type/role/...) so the planner can render and
+      // pre-select the cube's dimensions directly, without a slow common-dimensions
+      // intersection over every cube metric just to validate known-good dims.
+      const cubeDimensionObjects = (current.cubeDimensions || []).map(d => ({
+        name: d.name,
+        type: d.type,
+        attribute: d.attribute,
+        role: d.role,
+        properties: d.properties || [],
+      }));
+      const cubeDimensions = cubeDimensionObjects.map(d => d.name);
 
       // Extract druid_cube materialization if present (v3 or legacy)
       const druidMat = (current.materializations || []).find(
@@ -290,6 +304,7 @@ export const DataJunctionAPI = {
         display_name: current.displayName,
         cube_node_metrics: cubeMetrics,
         cube_node_dimensions: cubeDimensions,
+        cube_dimension_objects: cubeDimensionObjects,
         cubeMaterialization, // Included so we don't need a second fetch
         availability: current.availability || null,
       };

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -2175,7 +2175,15 @@ describe('DataJunctionAPI', () => {
               current: {
                 displayName: 'Cube 1',
                 cubeMetrics: [{ name: 'metric1' }, { name: 'metric2' }],
-                cubeDimensions: [{ name: 'dim1' }],
+                cubeDimensions: [
+                  {
+                    name: 'dim1',
+                    type: 'int',
+                    attribute: 'dim1',
+                    role: '',
+                    properties: [],
+                  },
+                ],
                 materializations: [
                   {
                     name: 'druid_cube',
@@ -2204,6 +2212,15 @@ describe('DataJunctionAPI', () => {
       display_name: 'Cube 1',
       cube_node_metrics: ['metric1', 'metric2'],
       cube_node_dimensions: ['dim1'],
+      cube_dimension_objects: [
+        {
+          name: 'dim1',
+          type: 'int',
+          attribute: 'dim1',
+          role: '',
+          properties: [],
+        },
+      ],
       cubeMaterialization: {
         strategy: 'incremental_time',
         schedule: '0 6 * * *',


### PR DESCRIPTION
### Summary

On a cube-based Planner URL (`/planner?cube=…`), applying a filter did not get reflected in the URL and so wasn't shareable. Adding/removing a metric or dimension was the only way to get filters to "stick." Investigating that surfaced two more issues with cube loading (slow, and dimensions silently not selected), plus a few chip/filter usability gaps.

### Changes

**Filters on cube-based URLs are now shareable**

The Planner kept the URL in two mutually-exclusive modes keyed on `loadedCubeName`: cube mode wrote only `cube=…`; ad-hoc mode wrote `metrics=…&dimensions=…&filters=….`. Metric/dimension edits left cube mode, but the filter handler didn't, so filter edits were dropped from the URL. Applying a filter now leaves cube mode, expanding the URL to its fully-qualified, shareable form.

**Cube loading is fast and reliably selects its dimensions**

Previously, loading a cube set its metrics, which triggered `commonDimensions(allCubeMetrics)`, an expensive dimension-intersection over every metric in the cube, and then kept only the cube dims that matched that response verbatim. That was both slow and lossy. Now `cubeForPlanner` returns full dimension objects (via expanded GraphQL cubeDimensions fields), and the cube load seeds the dimension picker and selection directly from the cube. The common-dimensions fetch still runs in the background (for adding more dims) and is merged in later.

**Loading a cube clears stale filters**

Switching cubes used to carry over filters from the previous cube, which could reference dimensions the new cube doesn't have. Cube reload or clearing now resets filters.

**Drag a dimension onto Filters**

Selected-dimension chips and available-dimension rows are now draggable onto the Filters section (with hover + drag + drop). Dropping prefills the filter input with the dimension name, ready for an operator/value.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
