### PR TITLE
Make DimensionReferenceLinkSpec hashable

### DIFF
--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -258,6 +258,17 @@ class DimensionReferenceLinkSpec(DimensionLinkSpec):
     def dimension_attribute(self) -> str:
         return self.dimension.rsplit(".", 1)[-1]
 
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.type,
+                self.role,
+                self.rendered_dimension_node,
+                self.dimension_attribute,
+                self.node_column,
+            ),
+        )
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DimensionReferenceLinkSpec):
             return False

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -168,6 +168,21 @@ def test_reference_link_spec():
     assert link_spec_no_role.dimension == "test_dimension_no_role"
     assert link_spec != link_spec_no_role
 
+    # Reference link specs must be hashable so link reconciliation can build a
+    # set of existing links during deployment (see DeploymentOrchestrator.
+    # _deploy_links). Regression: a missing __hash__ made this raise
+    # "TypeError: unhashable type: 'DimensionReferenceLinkSpec'".
+    equal_link_spec = DimensionReferenceLinkSpec(
+        role="test_role",
+        node_column="dim_name",
+        dimension="some.dimension.name",
+    )
+    assert link_spec == equal_link_spec
+    assert hash(link_spec) == hash(equal_link_spec)
+    # Equal specs collapse in a set; distinct specs stay separate.
+    assert {link_spec, equal_link_spec} == {link_spec}
+    assert len({link_spec, link_spec_no_role}) == 2
+
 
 def test_deployment_spec():
     spec = DeploymentSpec(


### PR DESCRIPTION
### Summary

`DimensionReferenceLinkSpec` overrides `__eq__` but did not define `__hash__`, so Python set `__hash__ = None` and instances were unhashable. Deploying a node that has a dimension **reference** link then crashed with `TypeError: unhashable type: 'DimensionReferenceLinkSpec'` in `DeploymentOrchestrator._deploy_links`, which builds a `set` of existing link specs to reconcile deletions. Join links were unaffected because `DimensionJoinLinkSpec` already defines both `__eq__` and `__hash__`.

This adds a `__hash__` to `DimensionReferenceLinkSpec` over the same fields its `__eq__` compares (type, role, rendered dimension node, dimension attribute, node column), mirroring the sibling join spec.

Fixes #2287

### Test Plan

Extended `test_reference_link_spec` to assert equal specs hash equal, that reference specs can be placed in a `set`, and that equal specs collapse / distinct specs stay separate — this fails with `TypeError` before the fix.

- [x] PR has an associated issue: #2287
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

No migrations or config changes.
