### PR TITLE
Fix `IndexError` in `commonDimensions` for unknown/empty node inputs

### DIFF
--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -1309,8 +1309,11 @@ async def get_common_dimensions(session: AsyncSession, nodes: list[Node]):
     """
     metric_nodes = [node for node in nodes if node.type == NodeType.METRIC]
     other_nodes = [node for node in nodes if node.type != NodeType.METRIC]
-    if metric_nodes:  # pragma: no branch
+    if metric_nodes:
         nodes = list(set(other_nodes + await get_metric_parents(session, metric_nodes)))
+
+    if not nodes:
+        return []
 
     common = await group_dimensions_by_name(session, nodes[0])
     for node in nodes[1:]:

--- a/datajunction-server/tests/api/graphql/common_dimensions_test.py
+++ b/datajunction-server/tests/api/graphql/common_dimensions_test.py
@@ -216,3 +216,48 @@ async def test_get_common_dimensions_non_metric_nodes(
         "name": "default.us_state.state_name",
         "type": "string",
     } in data["data"]["commonDimensions"]
+
+
+@pytest.mark.asyncio
+async def test_get_common_dimensions_unknown_node(
+    client_with_roads: AsyncClient,
+):
+    """
+    Unknown node names resolve to zero nodes, so common dimensions should be
+    an empty list rather than raising an IndexError.
+    """
+
+    query = """
+    {
+      commonDimensions(nodes: ["default.does_not_exist"]) {
+        name
+      }
+    }
+    """
+
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"data": {"commonDimensions": []}}
+
+
+@pytest.mark.asyncio
+async def test_get_common_dimensions_empty_input(
+    client_with_roads: AsyncClient,
+):
+    """
+    Passing no nodes at all should return an empty list of common dimensions.
+    """
+
+    query = """
+    {
+      commonDimensions(nodes: []) {
+        name
+      }
+    }
+    """
+
+    response = await client_with_roads.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"data": {"commonDimensions": []}}


### PR DESCRIPTION
### Summary

`get_common_dimensions()` indexed `nodes[0]` without guarding against an empty list, so the `commonDimensions` GraphQL query crashed with `IndexError: list index out of range` whenever the input resolved to zero nodes:
```
query { commonDimensions(nodes: ["default.does_not_exist"]) { name } }
```

The fix is to return `[]` early when there are no nodes, since there are no common dimensions of zero nodes.

### Test Plan

Added two regression tests: `test_get_common_dimensions_unknown_node` and `test_get_common_dimensions_empty_input`.

- [ ] PR has an associated issue: #2290 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
