### PR TITLE
Speed up `GET /namespaces/{namespace}/branches`

### DIFF
--- a/datajunction-server/datajunction_server/api/branches.py
+++ b/datajunction-server/datajunction_server/api/branches.py
@@ -8,19 +8,18 @@ to git branches for the git-backed workflow.
 import asyncio
 import logging
 import time
-from datetime import datetime
 from http import HTTPStatus
-from typing import Callable, List, Optional
+from typing import Callable, List
 
 from fastapi import Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from sqlalchemy import func, or_, select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.helpers import get_node_namespace, get_save_history
 from datajunction_server.database.namespace import NodeNamespace
-from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.node import Node
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJAlreadyExistsException,
@@ -35,6 +34,7 @@ from datajunction_server.internal.access.authorization import (
 from datajunction_server.internal.git.github_service import GitHubService
 from datajunction_server.internal.git.github_service import GitHubServiceError
 from datajunction_server.internal.namespaces import (
+    get_branches,
     hard_delete_namespace,
     resolve_git_config,
     validate_sibling_relationship,
@@ -42,6 +42,7 @@ from datajunction_server.internal.namespaces import (
 from datajunction_server.internal.nodes import copy_nodes_to_namespace
 from datajunction_server.models.access import ResourceAction
 from datajunction_server.models.deployment import DeploymentResult
+from datajunction_server.models.namespace import BranchInfo
 from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.utils import SEPARATOR, get_current_user, get_session
 
@@ -53,19 +54,6 @@ class CreateBranchRequest(BaseModel):
     """Request to create a new branch namespace."""
 
     branch_name: str  # e.g., "feature-x"
-
-
-class BranchInfo(BaseModel):
-    """Information about a branch namespace."""
-
-    namespace: str  # e.g., "myproject.feature_x"
-    git_branch: str  # e.g., "feature-x"
-    parent_namespace: str  # e.g., "myproject.main"
-    github_repo_path: str  # e.g., "owner/repo"
-    num_nodes: int = 0
-    invalid_node_count: int = 0
-    git_only: bool = False
-    last_updated_at: Optional[datetime] = None
 
 
 class CreateBranchResult(BaseModel):
@@ -490,98 +478,10 @@ async def list_branches(
 ) -> List[BranchInfo]:
     """
     List all branch namespaces that were created from this namespace.
-
-    Returns:
-    - Direct children: where parent_namespace equals the given namespace (git root branches)
-    - Siblings: where parent_namespace equals this namespace's parent (branch-from-branch)
     """
     access_checker.add_namespace(namespace, ResourceAction.READ)
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
-
-    source_ns = await get_node_namespace(session, namespace)
-
-    # Root namespace → direct children; branch namespace → siblings (same parent, excl. self)
-    parent = source_ns.parent_namespace if source_ns.parent_namespace else namespace
-    base_filter = NodeNamespace.parent_namespace == parent
-    if source_ns.parent_namespace:
-        base_filter = base_filter & (NodeNamespace.namespace != namespace)
-
-    # Correlated subqueries for counts and last deployment
-    node_count_subq = (
-        select(func.count(Node.id))
-        .where(
-            or_(
-                Node.namespace == NodeNamespace.namespace,
-                Node.namespace.like(NodeNamespace.namespace + ".%"),
-            ),
-        )
-        .correlate(NodeNamespace)
-        .scalar_subquery()
-    )
-    invalid_count_subq = (
-        select(func.count(Node.id))
-        .join(
-            NodeRevision,
-            (NodeRevision.node_id == Node.id)
-            & (NodeRevision.version == Node.current_version),
-        )
-        .where(
-            or_(
-                Node.namespace == NodeNamespace.namespace,
-                Node.namespace.like(NodeNamespace.namespace + ".%"),
-            ),
-            NodeRevision.status == "invalid",
-        )
-        .correlate(NodeNamespace)
-        .scalar_subquery()
-    )
-    last_updated_subq = (
-        select(func.max(NodeRevision.updated_at))
-        .join(Node, Node.id == NodeRevision.node_id)
-        .where(
-            or_(
-                Node.namespace == NodeNamespace.namespace,
-                Node.namespace.like(NodeNamespace.namespace + ".%"),
-            ),
-        )
-        .correlate(NodeNamespace)
-        .scalar_subquery()
-    )
-
-    stmt = select(
-        NodeNamespace,
-        node_count_subq.label("num_nodes"),
-        invalid_count_subq.label("invalid_node_count"),
-        last_updated_subq.label("last_updated_at"),
-    ).where(base_filter, NodeNamespace.deactivated_at.is_(None))
-
-    result = await session.execute(stmt)
-    rows = result.all()
-
-    github_repo_path, _, _ = await resolve_git_config(session, namespace)
-
-    # Default branch comes first, then alphabetically by namespace
-    default_branch = source_ns.default_branch or ""
-    rows.sort(
-        key=lambda row: (
-            0 if (row[0].git_branch or "") == default_branch else 1,
-            row[0].namespace,
-        ),
-    )
-
-    return [
-        BranchInfo(
-            namespace=ns.namespace,
-            git_branch=ns.git_branch or "",
-            parent_namespace=ns.parent_namespace or "",
-            github_repo_path=github_repo_path or "",
-            num_nodes=num_nodes or 0,
-            invalid_node_count=invalid_node_count or 0,
-            git_only=ns.git_only,
-            last_updated_at=last_updated_at,
-        )
-        for ns, num_nodes, invalid_node_count, last_updated_at in rows
-    ]
+    return await get_branches(session, namespace)
 
 
 @router.delete(

--- a/datajunction-server/datajunction_server/database/namespace.py
+++ b/datajunction-server/datajunction_server/database/namespace.py
@@ -1,8 +1,9 @@
 """Namespace database schema."""
 
+from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, select
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import (
     Mapped,
@@ -105,6 +106,68 @@ class NodeNamespace(Base):
                     http_status_code=404,
                 )
         return node_namespace
+
+    @classmethod
+    async def list_branch_namespaces(
+        cls,
+        session: AsyncSession,
+        parent: str,
+        exclude_namespace: Optional[str] = None,
+    ) -> List["NodeNamespace"]:
+        """
+        List the active branch namespaces whose parent is ``parent``.
+
+        Root namespaces resolve to their direct children; branch namespaces resolve
+        to their siblings, which is why ``exclude_namespace`` is used to drop self.
+        """
+        base_filter = cls.parent_namespace == parent
+        if exclude_namespace:
+            base_filter = base_filter & (cls.namespace != exclude_namespace)
+        statement = select(cls).where(base_filter, cls.deactivated_at.is_(None))
+        return list((await session.execute(statement)).scalars().all())
+
+    @classmethod
+    async def node_counts_by_namespace(
+        cls,
+        session: AsyncSession,
+        root_namespace: str,
+    ) -> dict[str, tuple[int, int, Optional[datetime]]]:
+        """
+        Aggregate node counts grouped by namespace for ``root_namespace`` and all of
+        its descendants, in a single indexed pass.
+
+        ``root_namespace`` is a literal, so ``LIKE root.%`` uses the
+        varchar_pattern_ops index on node.namespace rather than a full table scan.
+        ``updated_at`` is set only at revision insert time, so the current revision's
+        timestamp is the latest per node — no need to scan historical revisions.
+
+        Returns dict[namespace -> (num_nodes, invalid_node_count, last_updated_at)].
+        """
+        statement = (
+            select(
+                Node.namespace,
+                func.count(Node.id),
+                func.sum(case((NodeRevision.status == "invalid", 1), else_=0)),
+                func.max(NodeRevision.updated_at),
+            )
+            .join(
+                NodeRevision,
+                (NodeRevision.node_id == Node.id)
+                & (NodeRevision.version == Node.current_version),
+            )
+            .where(
+                or_(
+                    Node.namespace == root_namespace,
+                    Node.namespace.like(f"{root_namespace}.%"),
+                ),
+            )
+            .group_by(Node.namespace)
+        )
+        result = await session.execute(statement)
+        return {
+            namespace: (num_nodes, invalid_node_count, last_updated_at)
+            for namespace, num_nodes, invalid_node_count, last_updated_at in result
+        }
 
     @classmethod
     async def list_nodes(

--- a/datajunction-server/datajunction_server/database/namespace.py
+++ b/datajunction-server/datajunction_server/database/namespace.py
@@ -131,7 +131,7 @@ class NodeNamespace(Base):
         cls,
         session: AsyncSession,
         root_namespace: str,
-    ) -> dict[str, tuple[int, int, Optional[datetime]]]:
+    ) -> dict[str, tuple[int, int, datetime]]:
         """
         Aggregate node counts grouped by namespace for ``root_namespace`` and all of
         its descendants, in a single indexed pass.
@@ -139,7 +139,8 @@ class NodeNamespace(Base):
         ``root_namespace`` is a literal, so ``LIKE root.%`` uses the
         varchar_pattern_ops index on node.namespace rather than a full table scan.
         ``updated_at`` is set only at revision insert time, so the current revision's
-        timestamp is the latest per node — no need to scan historical revisions.
+        timestamp is the latest per node — no need to scan historical revisions. It's
+        never NULL here (non-nullable column, and every emitted group has a row).
 
         Returns dict[namespace -> (num_nodes, invalid_node_count, last_updated_at)].
         """

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -1937,10 +1937,13 @@ async def resolve_git_config(
 
 def _rollup_branch_counts(
     branch_ns: str,
-    counts_by_ns: dict[str, tuple[int, int, Optional[datetime]]],
+    counts_by_ns: dict[str, tuple[int, int, datetime]],
 ) -> tuple[int, int, Optional[datetime]]:
     """
     Sum node counts for a branch namespace and all of its sub-namespaces.
+
+    ``last_updated_at`` is None only when the branch contains no nodes; per-node
+    timestamps are always populated (see ``node_counts_by_namespace``).
 
     Returns (num_nodes, invalid_node_count, last_updated_at).
     """
@@ -1951,12 +1954,11 @@ def _rollup_branch_counts(
         if node_ns == branch_ns or node_ns.startswith(prefix):
             num_nodes += num
             invalid_node_count += invalid
-            if updated_at is not None:
-                last_updated_at = (
-                    updated_at
-                    if last_updated_at is None
-                    else max(last_updated_at, updated_at)
-                )
+            last_updated_at = (
+                updated_at
+                if last_updated_at is None
+                else max(last_updated_at, updated_at)
+            )
     return num_nodes, invalid_node_count, last_updated_at
 
 

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -42,6 +42,7 @@ from datajunction_server.models.deployment import (
 )
 from datajunction_server.models.dimensionlink import LinkType
 from datajunction_server.models.namespace import (
+    BranchInfo,
     HardDeleteResponse,
     ImpactedNode,
     ImpactedNodes,
@@ -1932,6 +1933,87 @@ async def resolve_git_config(
     if not git_info:
         return None, None, None
     return git_info["repo"], git_info["path"], git_info["branch"]
+
+
+def _rollup_branch_counts(
+    branch_ns: str,
+    counts_by_ns: dict[str, tuple[int, int, Optional[datetime]]],
+) -> tuple[int, int, Optional[datetime]]:
+    """
+    Sum node counts for a branch namespace and all of its sub-namespaces.
+
+    Returns (num_nodes, invalid_node_count, last_updated_at).
+    """
+    prefix = branch_ns + SEPARATOR
+    num_nodes = invalid_node_count = 0
+    last_updated_at: Optional[datetime] = None
+    for node_ns, (num, invalid, updated_at) in counts_by_ns.items():
+        if node_ns == branch_ns or node_ns.startswith(prefix):
+            num_nodes += num
+            invalid_node_count += invalid
+            if updated_at is not None:
+                last_updated_at = (
+                    updated_at
+                    if last_updated_at is None
+                    else max(last_updated_at, updated_at)
+                )
+    return num_nodes, invalid_node_count, last_updated_at
+
+
+async def get_branches(
+    session: AsyncSession,
+    namespace: str,
+) -> List[BranchInfo]:
+    """
+    Canonical listing of the branch namespaces created from ``namespace``.
+
+    Does not perform access control — callers exposing this over HTTP are
+    responsible for authorization.
+
+    Returns:
+    - Direct children: where parent_namespace equals the given namespace (git root branches)
+    - Siblings: where parent_namespace equals this namespace's parent (branch-from-branch)
+    """
+    source_ns = await get_node_namespace(session, namespace)
+
+    # Root namespace → direct children; branch namespace → siblings (same parent, excl. self)
+    parent = source_ns.parent_namespace if source_ns.parent_namespace else namespace
+    branch_namespaces = await NodeNamespace.list_branch_namespaces(
+        session,
+        parent,
+        exclude_namespace=namespace if source_ns.parent_namespace else None,
+    )
+    counts_by_ns = await NodeNamespace.node_counts_by_namespace(session, parent)
+
+    github_repo_path, _, _ = await resolve_git_config(session, namespace)
+
+    rows = [
+        (ns, *_rollup_branch_counts(ns.namespace, counts_by_ns))
+        for ns in branch_namespaces
+    ]
+
+    # Default branch comes first, then alphabetically by namespace
+    default_branch = source_ns.default_branch or ""
+    rows.sort(
+        key=lambda row: (
+            0 if (row[0].git_branch or "") == default_branch else 1,
+            row[0].namespace,
+        ),
+    )
+
+    return [
+        BranchInfo(
+            namespace=ns.namespace,
+            git_branch=ns.git_branch or "",
+            parent_namespace=ns.parent_namespace or "",
+            github_repo_path=github_repo_path or "",
+            num_nodes=num_nodes or 0,
+            invalid_node_count=invalid_node_count or 0,
+            git_only=ns.git_only,
+            last_updated_at=last_updated_at,
+        )
+        for ns, num_nodes, invalid_node_count, last_updated_at in rows
+    ]
 
 
 def validate_sibling_relationship(

--- a/datajunction-server/datajunction_server/models/namespace.py
+++ b/datajunction-server/datajunction_server/models/namespace.py
@@ -1,5 +1,19 @@
-from typing import List
+from datetime import datetime
+from typing import List, Optional
 from pydantic import BaseModel
+
+
+class BranchInfo(BaseModel):
+    """Information about a branch namespace."""
+
+    namespace: str  # e.g., "myproject.feature_x"
+    git_branch: str  # e.g., "feature-x"
+    parent_namespace: str  # e.g., "myproject.main"
+    github_repo_path: str  # e.g., "owner/repo"
+    num_nodes: int = 0
+    invalid_node_count: int = 0
+    git_only: bool = False
+    last_updated_at: Optional[datetime] = None
 
 
 class ImpactedNode(BaseModel):

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -707,6 +707,96 @@ class TestBranchManagement:
         ]
 
     @pytest.mark.asyncio
+    async def test_list_branches_rolls_up_node_counts(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """
+        Node counts for a branch include nodes in the branch namespace itself and
+        all of its sub-namespaces.
+        """
+        await client_with_service_setup.post("/namespaces/count_parent")
+        await client_with_service_setup.patch(
+            "/namespaces/count_parent/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "default_branch": "main",
+                "git_path": "nodes/",
+            },
+        )
+        await client_with_service_setup.post("/namespaces/count_parent.main")
+        await client_with_service_setup.patch(
+            "/namespaces/count_parent.main/git",
+            json={"parent_namespace": "count_parent", "git_branch": "main"},
+        )
+        # A sub-namespace under the main branch; its nodes roll up into main.
+        await client_with_service_setup.post("/namespaces/count_parent.main.sub")
+
+        with patch(
+            "datajunction_server.api.branches.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.create_branch = AsyncMock(
+                return_value={"ref": "refs/heads/feat1", "object": {"sha": "abc"}},
+            )
+            mock_github_class.return_value = mock_github
+            await client_with_service_setup.post(
+                "/namespaces/count_parent/branches",
+                json={"branch_name": "feat1"},
+            )
+
+        # Two nodes under main (one directly, one in a sub-namespace) and one under feat1.
+        for name in (
+            "count_parent.main.src_a",
+            "count_parent.main.sub.src_b",
+            "count_parent.feat1.src_c",
+        ):
+            response = await client_with_service_setup.post(
+                "/nodes/source/",
+                json={
+                    "name": name,
+                    "description": "Source table",
+                    "catalog": "default",
+                    "schema_": "public",
+                    "table": name.replace(".", "_"),
+                    "columns": [{"name": "id", "type": "int"}],
+                },
+            )
+            assert response.status_code in (HTTPStatus.CREATED, HTTPStatus.OK)
+
+        response = await client_with_service_setup.get(
+            "/namespaces/count_parent/branches",
+        )
+        assert response.status_code == HTTPStatus.OK
+        branches = response.json()
+
+        # last_updated_at is a non-deterministic timestamp; assert it's populated,
+        # then assert full equality on the deterministic fields.
+        for branch in branches:
+            assert branch.pop("last_updated_at") is not None
+
+        assert branches == [
+            {
+                "namespace": "count_parent.main",
+                "git_branch": "main",
+                "parent_namespace": "count_parent",
+                "github_repo_path": "myorg/myrepo",
+                "num_nodes": 2,
+                "invalid_node_count": 0,
+                "git_only": False,
+            },
+            {
+                "namespace": "count_parent.feat1",
+                "git_branch": "feat1",
+                "parent_namespace": "count_parent",
+                "github_repo_path": "myorg/myrepo",
+                "num_nodes": 1,
+                "invalid_node_count": 0,
+                "git_only": False,
+            },
+        ]
+
+    @pytest.mark.asyncio
     async def test_delete_branch(
         self,
         client_with_service_setup: AsyncClient,

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -797,6 +797,198 @@ class TestBranchManagement:
         ]
 
     @pytest.mark.asyncio
+    async def test_list_branches_from_branch_returns_siblings(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """
+        Listing branches from a *branch* namespace returns its siblings (branches
+        sharing the same DB parent_namespace), excluding the branch itself.
+        """
+        await client_with_service_setup.post("/namespaces/sib_parent")
+        await client_with_service_setup.patch(
+            "/namespaces/sib_parent/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "default_branch": "main",
+                "git_path": "nodes/",
+            },
+        )
+        await client_with_service_setup.post("/namespaces/sib_parent.main")
+        await client_with_service_setup.patch(
+            "/namespaces/sib_parent.main/git",
+            json={"parent_namespace": "sib_parent", "git_branch": "main"},
+        )
+        for suffix in ("feat1", "feat2"):
+            with patch(
+                "datajunction_server.api.branches.GitHubService",
+            ) as mock_github_class:
+                mock_github = MagicMock()
+                mock_github.create_branch = AsyncMock(
+                    return_value={
+                        "ref": f"refs/heads/{suffix}",
+                        "object": {"sha": "abc"},
+                    },
+                )
+                mock_github_class.return_value = mock_github
+                await client_with_service_setup.post(
+                    "/namespaces/sib_parent/branches",
+                    json={"branch_name": suffix},
+                )
+
+        # Listing from the branch itself, not the root.
+        response = await client_with_service_setup.get(
+            "/namespaces/sib_parent.main/branches",
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert [branch["namespace"] for branch in response.json()] == [
+            "sib_parent.feat1",
+            "sib_parent.feat2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_list_branches_counts_invalid_nodes(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """invalid_node_count reflects nodes whose current revision is invalid."""
+        await client_with_service_setup.post("/namespaces/inv_parent")
+        await client_with_service_setup.patch(
+            "/namespaces/inv_parent/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "default_branch": "main",
+                "git_path": "nodes/",
+            },
+        )
+        await client_with_service_setup.post("/namespaces/inv_parent.main")
+        await client_with_service_setup.patch(
+            "/namespaces/inv_parent.main/git",
+            json={"parent_namespace": "inv_parent", "git_branch": "main"},
+        )
+        # One valid source ...
+        response = await client_with_service_setup.post(
+            "/nodes/source/",
+            json={
+                "name": "inv_parent.main.src",
+                "description": "Source table",
+                "catalog": "default",
+                "schema_": "public",
+                "table": "src",
+                "columns": [{"name": "id", "type": "int"}],
+            },
+        )
+        assert response.status_code in (HTTPStatus.CREATED, HTTPStatus.OK)
+        # ... and one invalid transform (references a nonexistent table, draft mode).
+        response = await client_with_service_setup.post(
+            "/nodes/transform/",
+            json={
+                "name": "inv_parent.main.bad",
+                "description": "Invalid transform",
+                "query": "SELECT x FROM inv_parent.main.does_not_exist",
+                "mode": "draft",
+            },
+        )
+        assert response.status_code in (HTTPStatus.CREATED, HTTPStatus.OK)
+
+        response = await client_with_service_setup.get(
+            "/namespaces/inv_parent/branches",
+        )
+        assert response.status_code == HTTPStatus.OK
+        branches = {branch["namespace"]: branch for branch in response.json()}
+        assert branches["inv_parent.main"]["num_nodes"] == 2
+        assert branches["inv_parent.main"]["invalid_node_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_branches_excludes_deactivated(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """Deactivated branch namespaces are not listed."""
+        await client_with_service_setup.post("/namespaces/deact_parent")
+        await client_with_service_setup.patch(
+            "/namespaces/deact_parent/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "default_branch": "main",
+                "git_path": "nodes/",
+            },
+        )
+        for suffix in ("main", "old"):
+            await client_with_service_setup.post(f"/namespaces/deact_parent.{suffix}")
+            await client_with_service_setup.patch(
+                f"/namespaces/deact_parent.{suffix}/git",
+                json={"parent_namespace": "deact_parent", "git_branch": suffix},
+            )
+
+        # Deactivate the 'old' branch (no nodes, so cascade is unnecessary).
+        response = await client_with_service_setup.delete(
+            "/namespaces/deact_parent.old/?cascade=false",
+        )
+        assert response.status_code == HTTPStatus.OK
+
+        response = await client_with_service_setup.get(
+            "/namespaces/deact_parent/branches",
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert [branch["namespace"] for branch in response.json()] == [
+            "deact_parent.main",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_list_branches_prefix_boundary(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """
+        A branch's node count must not absorb a sibling whose name shares a leading
+        substring (e.g. 'main' must not swallow 'main2').
+        """
+        await client_with_service_setup.post("/namespaces/pfx_parent")
+        await client_with_service_setup.patch(
+            "/namespaces/pfx_parent/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "default_branch": "main",
+                "git_path": "nodes/",
+            },
+        )
+        for suffix in ("main", "main2"):
+            await client_with_service_setup.post(f"/namespaces/pfx_parent.{suffix}")
+            await client_with_service_setup.patch(
+                f"/namespaces/pfx_parent.{suffix}/git",
+                json={"parent_namespace": "pfx_parent", "git_branch": suffix},
+            )
+
+        # One node under main, three under main2.
+        for name in (
+            "pfx_parent.main.a",
+            "pfx_parent.main2.a",
+            "pfx_parent.main2.b",
+            "pfx_parent.main2.c",
+        ):
+            response = await client_with_service_setup.post(
+                "/nodes/source/",
+                json={
+                    "name": name,
+                    "description": "Source table",
+                    "catalog": "default",
+                    "schema_": "public",
+                    "table": name.replace(".", "_"),
+                    "columns": [{"name": "id", "type": "int"}],
+                },
+            )
+            assert response.status_code in (HTTPStatus.CREATED, HTTPStatus.OK)
+
+        response = await client_with_service_setup.get(
+            "/namespaces/pfx_parent/branches",
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert {
+            branch["namespace"]: branch["num_nodes"] for branch in response.json()
+        } == {"pfx_parent.main": 1, "pfx_parent.main2": 3}
+
+    @pytest.mark.asyncio
     async def test_delete_branch(
         self,
         client_with_service_setup: AsyncClient,


### PR DESCRIPTION
### Summary

`GET /namespaces/{namespace}/branches` is inefficient; it built its response with three correlated scalar subqueries per branch (for `num_nodes`, `invalid_node_count`, `last_updated_at`), each filtering node with:
```
Node.namespace == NodeNamespace.namespace OR Node.namespace LIKE NodeNamespace.namespace || '.%'
```

Because the `LIKE` prefix was a correlated column rather than a literal, Postgres couldn't use the `namespace_index` and fell back to a full sequential scan of the entire node table. This was repeated 3 times, along with `noderevision` joins on two of them. Thus the cost to run this query grew quadratically with the number of branches.

The fix is to replace the correlated subqueries with a single indexed, grouped scan, then roll counts up to each branch in Python:
- Filter by the literal parent namespace (`LIKE 'parent.%'`), so the `varchar_pattern_ops` index does one range scan with a hash aggregate instead of N sequential scans.
- Fold `last_updated_at` into that same query. `NodeRevision.updated_at` is never updated, so the current revision's timestamp is already the latest per node and there is no need to scan historical revisions. This dropped the query count from 3 to 1.
- Each `node.namespace` is rolled up to its owning branch by prefix (branches are siblings, so each node belongs to exactly one branch).

**Refactor (layering)**

Moved the logic out of the API module to match repo conventions:
  - `database/namespace.py`: DB queries as `NodeNamespace` classmethods
  - `internal/namespaces.py`: canonical `get_branches()` business logic + helpers, reusable by any future caller.
  - `models/namespace.py`: `BranchInfo` model (relocated from the API module to avoid an internal → api circular import)
  - `api/branches.py`: the API endpoint now just does the access check and delegates to `get_branches()`

### Test Plan

Added `test_list_branches_rolls_up_node_counts` covering counts across a branch and its sub-namespaces (the previous branch tests only exercised the empty/zero case).

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
