### PR TITLE
Remove react-syntax-highlighter from the landing bundle

### DIFF
--- a/datajunction-ui/src/app/components/QueryInfo.jsx
+++ b/datajunction-ui/src/app/components/QueryInfo.jsx
@@ -1,5 +1,5 @@
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { solarizedDark } from 'react-syntax-highlighter/src/styles/hljs';
+import solarizedDark from 'react-syntax-highlighter/dist/esm/styles/hljs/solarized-dark';
 import React from 'react';
 
 export default function QueryInfo({

--- a/datajunction-ui/src/app/index.tsx
+++ b/datajunction-ui/src/app/index.tsx
@@ -14,7 +14,7 @@ import { SystemMetricsExplorerPage } from './pages/SystemMetricsExplorerPage/Loa
 import { SettingsPage } from './pages/SettingsPage/Loadable';
 import { NotificationsPage } from './pages/NotificationsPage/Loadable';
 import { NodePage } from './pages/NodePage/Loadable';
-import RevisionDiff from './pages/NodePage/RevisionDiff';
+import { RevisionDiff } from './pages/NodePage/RevisionDiffLoadable';
 import { SQLBuilderPage } from './pages/SQLBuilderPage/Loadable';
 import { CubeBuilderPage } from './pages/CubeBuilderPage/Loadable';
 import { QueryPlannerPage } from './pages/QueryPlannerPage/Loadable';

--- a/datajunction-ui/src/app/pages/CubeBuilderPage/CubePreviewPanel.jsx
+++ b/datajunction-ui/src/app/pages/CubeBuilderPage/CubePreviewPanel.jsx
@@ -11,7 +11,7 @@ import React, {
 } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
-import { atomOneLight } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import atomOneLight from 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light';
 import DJClientContext from '../../providers/djclient';
 import {
   formatBytes,

--- a/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
@@ -1,7 +1,7 @@
 import DJClientContext from '../../providers/djclient';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { useEffect, useRef, useState, useContext } from 'react';
-import { nightOwl } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import nightOwl from 'react-syntax-highlighter/dist/esm/styles/hljs/night-owl';
 import PythonIcon from '../../icons/PythonIcon';
 import LoadingIcon from 'app/icons/LoadingIcon';
 

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -7,7 +7,7 @@ import AddComplexDimensionLinkPopover from './AddComplexDimensionLinkPopover';
 import { labelize } from '../../../utils/form';
 import PartitionColumnPopover from './PartitionColumnPopover';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 
 export default function NodeColumnTab({ node, djClient, readOnly = false }) {
   const [attributes, setAttributes] = useState([]);

--- a/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeInfoTab.jsx
@@ -1,6 +1,6 @@
 import { useState, useContext, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
 import NodeStatus from './NodeStatus';
 import ListGroupItem from '../../components/ListGroupItem';

--- a/datajunction-ui/src/app/pages/NodePage/NodeStatus.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeStatus.jsx
@@ -2,15 +2,10 @@ import { Component, useContext, useEffect, useRef, useState } from 'react';
 import ValidIcon from '../../icons/ValidIcon';
 import InvalidIcon from '../../icons/InvalidIcon';
 import DJClientContext from '../../providers/djclient';
-import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
-import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import markdown from 'react-syntax-highlighter/dist/cjs/languages/hljs/markdown';
 import * as React from 'react';
 import { AlertMessage } from '../AddEditNodePage/AlertMessage';
 import AlertIcon from '../../icons/AlertIcon';
 import { labelize } from '../../../utils/form';
-
-SyntaxHighlighter.registerLanguage('markdown', markdown);
 
 export default function NodeStatus({ node, revalidate = true }) {
   const MAX_ERROR_LENGTH = 200;

--- a/datajunction-ui/src/app/pages/NodePage/NodeValidateTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeValidateTab.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Select from 'react-select';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 import { labelize } from '../../../utils/form';
 import { Form, Formik } from 'formik';
 import DimensionFilter from './DimensionFilter';

--- a/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
@@ -9,7 +9,7 @@ import NamespaceHeader from '../../components/NamespaceHeader';
 import { labelize } from '../../../utils/form';
 import DiffIcon from '../../icons/DiffIcon';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 import sql from 'react-syntax-highlighter/dist/cjs/languages/hljs/sql';
 
 SyntaxHighlighter.registerLanguage('sql', sql);

--- a/datajunction-ui/src/app/pages/NodePage/RevisionDiffLoadable.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/RevisionDiffLoadable.jsx
@@ -1,0 +1,20 @@
+/**
+ * Asynchronously loads RevisionDiff.
+ *
+ * RevisionDiff pulls in react-syntax-highlighter (and its language/theme
+ * modules). Loading it lazily keeps that large dependency out of the landing
+ * bundle so it's only fetched when a revision diff is actually viewed.
+ */
+
+import * as React from 'react';
+import { lazyLoad } from '../../../utils/loadable';
+
+export const RevisionDiff = props => {
+  return lazyLoad(
+    () => import('./RevisionDiff'),
+    module => module.default,
+    {
+      fallback: <div></div>,
+    },
+  )(props);
+};

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/PreAggDetailsPanel.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/PreAggDetailsPanel.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { atomOneLight } from 'react-syntax-highlighter/src/styles/hljs';
+import atomOneLight from 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light';
 import {
   SCAN_WARNING_THRESHOLD,
   SCAN_CRITICAL_THRESHOLD,

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/ResultsView.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/ResultsView.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect, useRef, memo } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql';
 import {
   LineChart,

--- a/datajunction-ui/src/app/pages/SQLBuilderPage/index.jsx
+++ b/datajunction-ui/src/app/pages/SQLBuilderPage/index.jsx
@@ -3,7 +3,7 @@ import NamespaceHeader from '../../components/NamespaceHeader';
 import { DataJunctionAPI } from '../../services/DJService';
 import DJClientContext from '../../providers/djclient';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { foundation } from 'react-syntax-highlighter/src/styles/hljs';
+import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 import Select from 'react-select';
 import QueryInfo from '../../components/QueryInfo';
 import 'react-querybuilder/dist/query-builder.scss';


### PR DESCRIPTION
### Summary

The namespace landing page was pulling in `react-syntax-highlighter` and its ~99 theme modules, ballooning the initial load. Three fixes:

  1. **Delete dead imports in `NodeStatus.jsx`**
  NodeStatus renders on every node-list row and statically imported `SyntaxHighlighter`, a theme, a
  language, and called `registerLanguage('markdown', …)`, but never renders a highlighter (the
  error popover is plain text). This was removed as it dragged the whole library onto the landing page.

  2. **Lazy-load `RevisionDiff`**
  `RevisionDiff` was the one route imported eagerly instead of via the lazy `Loadable` wrapper, and it
  legitimately uses the highlighter. Wrapped it in `lazyLoad(...)` so it (and the highlighter) only
  load when a revision diff is actually viewed.

  3. **Single-theme imports instead of the all-themes barrel**
  Files across `NodePage`/`QueryPlanner`/`CubeBuilder`/`SQLBuilder` imported a theme from
  `react-syntax-highlighter/src/styles/hljs`, a barrel that pulls every theme. Switched each to the
  specific module.

The landing page went from ~612 requests / 9.1 MB to ~119 / 4.2 MB with zero highlighter chunks. There's no behavior change as a result of this PR; the highlighter just loads on demand.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
