### PR TITLE
Add grouped nodeTypeCounts query; use COUNT(*) for totalCount

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/main.py
+++ b/datajunction-server/datajunction_server/api/graphql/main.py
@@ -33,6 +33,7 @@ from datajunction_server.api.graphql.queries.engines import list_engines, list_d
 from datajunction_server.api.graphql.queries.nodes import (
     find_nodes,
     find_nodes_paginated,
+    node_counts,
 )
 from datajunction_server.api.graphql.queries.sql import (
     measures_sql,
@@ -51,7 +52,11 @@ from datajunction_server.api.graphql.scalars.catalog_engine import (
 )
 from datajunction_server.api.graphql.scalars.collection import Collection
 from datajunction_server.api.graphql.scalars.namespace import Namespace
-from datajunction_server.api.graphql.scalars.node import DimensionAttribute, Node
+from datajunction_server.api.graphql.scalars.node import (
+    DimensionAttribute,
+    Node,
+    NodeCount,
+)
 from datajunction_server.api.graphql.scalars.sql import (
     GeneratedSQL,
     MaterializationPlan,
@@ -250,6 +255,10 @@ class Query:
     find_nodes_paginated: Connection[Node] = strawberry.field(
         resolver=log_resolver(find_nodes_paginated),
         description="Find nodes based on the search parameters with pagination",
+    )
+    node_counts: list[NodeCount] = strawberry.field(
+        resolver=log_resolver(node_counts),
+        description="Count nodes grouped by a field (e.g. type) in a namespace",
     )
 
     # DAG queries

--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -3,6 +3,7 @@ Find nodes GraphQL queries.
 """
 
 import logging
+from enum import Enum
 from typing import Annotated
 
 import strawberry
@@ -10,17 +11,61 @@ from strawberry.types import Info
 
 from datajunction_server.api.graphql.resolvers.nodes import (
     count_nodes_by,
+    count_nodes_grouped,
     find_nodes_by,
 )
 from datajunction_server.api.graphql.scalars import Connection
-from datajunction_server.api.graphql.scalars.node import Node, NodeSortField
+from datajunction_server.api.graphql.scalars.node import (
+    Node,
+    NodeCount,
+    NodeGroupBy,
+    NodeSortField,
+)
 from datajunction_server.api.graphql.utils import extract_fields
+from datajunction_server.database.node import Node as DBNode
 from datajunction_server.models.node import NodeCursor, NodeMode, NodeStatus, NodeType
 
 DEFAULT_LIMIT = 1000
 UPPER_LIMIT = 10000
 
 logger = logging.getLogger(__name__)
+
+# Maps a groupable field to the column the count is grouped on.
+_GROUP_BY_COLUMNS = {
+    NodeGroupBy.TYPE: DBNode.type,
+}
+
+
+async def node_counts(
+    group_by: Annotated[
+        NodeGroupBy,
+        strawberry.argument(description="Field to group node counts by"),
+    ],
+    namespace: Annotated[
+        str | None,
+        strawberry.argument(
+            description="Count nodes in this namespace (and its descendants)",
+        ),
+    ] = None,
+    *,
+    info: Info,
+) -> list[NodeCount]:
+    """
+    Count nodes grouped by a field (e.g. type), in a single grouped query rather
+    than one count per value. Values with zero nodes are omitted.
+    """
+    counts = await count_nodes_grouped(
+        info=info,
+        group_by=_GROUP_BY_COLUMNS[group_by],
+        namespace=namespace,
+    )
+    return [
+        NodeCount(  # type: ignore
+            value=key.name if isinstance(key, Enum) else str(key),
+            count=count,
+        )
+        for key, count in counts.items()
+    ]
 
 
 async def find_nodes(

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -361,6 +361,19 @@ async def count_nodes_by(
         )
 
 
+async def count_nodes_grouped(
+    info: Info,
+    group_by: Any,
+    namespace: Optional[str] = None,
+) -> dict:
+    """
+    Count nodes grouped by a column in a single query. Backs the generic
+    nodeCounts facet field (e.g. per-type filter counts).
+    """
+    async with resolver_session(info) as session:
+        return await DBNode.count_grouped(session, group_by, namespace=namespace)
+
+
 async def get_node_by_name(
     session: AsyncSession,
     fields: dict[str, Any] | None,

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -52,6 +52,21 @@ JoinType = strawberry.enum(JoinType_)
 JoinCardinality = strawberry.enum(JoinCardinality_)
 
 
+@strawberry.enum
+class NodeGroupBy(Enum):
+    """Field to group node counts by (for filter facets / summaries)."""
+
+    TYPE = "type"
+
+
+@strawberry.type
+class NodeCount:
+    """Number of nodes for one value of a grouped field (e.g. a node type)."""
+
+    value: str
+    count: int
+
+
 _CUBE_SCALAR_ONLY_FIELDS: frozenset = frozenset(
     {
         "name",

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -330,8 +330,17 @@ type NodeConnection {
   totalCount: Int
 }
 
+type NodeCount {
+  value: String!
+  count: Int!
+}
+
 type NodeEdge {
   node: Node!
+}
+
+enum NodeGroupBy {
+  TYPE
 }
 
 enum NodeMode {
@@ -582,6 +591,15 @@ type Query {
     orderBy: NodeSortField! = CREATED_AT
     ascending: Boolean! = false
   ): NodeConnection!
+
+  """Count nodes grouped by a field (e.g. type) in a namespace"""
+  nodeCounts(
+    """Field to group node counts by"""
+    groupBy: NodeGroupBy!
+
+    """Count nodes in this namespace (and its descendants)"""
+    namespace: String = null
+  ): [NodeCount!]!
 
   """Get common dimensions for one or more nodes"""
   commonDimensions(

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -1260,11 +1260,62 @@ class Node(Base):
         )
         if statement is None:
             return 0
-        count_stmt = statement.with_only_columns(
-            func.count(func.distinct(Node.id)),
-        ).order_by(None)
+        # Every filter above uses exists()/IN(subquery)/1:1 joins, so no row is
+        # duplicated — COUNT(*) is equivalent to COUNT(DISTINCT id) and avoids the
+        # sort/hash the DISTINCT would force (which scales badly on large tables).
+        count_stmt = statement.with_only_columns(func.count()).order_by(None)
         result = await session.execute(count_stmt)
         return int(result.scalar() or 0)
+
+    @classmethod
+    async def count_grouped(
+        cls,
+        session: AsyncSession,
+        group_by: Any,
+        namespace: str | None = None,
+        node_types: list[NodeType] | None = None,
+        tags: list[str] | None = None,
+        edited_by: str | None = None,
+        mode: NodeMode | None = None,
+        owned_by: list[str] | None = None,
+        missing_description: bool = False,
+        missing_owner: bool = False,
+        dimensions: list[str] | None = None,
+        statuses: list[NodeStatus] | None = None,
+        has_materialization: bool = False,
+        orphaned_dimension: bool = False,
+        search: str | None = None,
+    ) -> dict[Any, int]:
+        """
+        Count matching nodes grouped by the ``group_by`` column in a single query,
+        rather than one count per value. Returns a ``{value: count}`` mapping
+        (values with zero matches are omitted).
+        """
+        statement, _, _, _ = await cls._build_filtered_node_statement(
+            session,
+            node_types=node_types,
+            tags=tags,
+            edited_by=edited_by,
+            namespace=namespace,
+            mode=mode,
+            owned_by=owned_by,
+            missing_description=missing_description,
+            missing_owner=missing_owner,
+            dimensions=dimensions,
+            statuses=statuses,
+            has_materialization=has_materialization,
+            orphaned_dimension=orphaned_dimension,
+            search=search,
+        )
+        if statement is None:  # pragma: no cover - only when a filter excludes all
+            return {}
+        grouped_stmt = (
+            statement.with_only_columns(group_by, func.count())
+            .order_by(None)
+            .group_by(group_by)
+        )
+        result = await session.execute(grouped_stmt)
+        return {row[0]: int(row[1]) for row in result.all()}
 
     @classmethod
     async def _resolve_dimension_filter(

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3968,3 +3968,63 @@ async def test_find_nodes_paginated_total_count_no_matches(
     paginated = resp.json()["data"]["findNodesPaginated"]
     assert paginated["edges"] == []
     assert paginated["totalCount"] == 0
+
+
+@pytest.mark.asyncio
+async def test_node_counts_by_type(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    nodeCounts(groupBy: TYPE) returns one grouped count per node type, matching
+    the per-type totals from findNodes.
+    """
+    resp = await client_with_roads.post(
+        "/graphql",
+        json={"query": "{ nodeCounts(groupBy: TYPE) { value count } }"},
+    )
+    assert resp.status_code == 200
+    counts = {
+        row["value"]: row["count"] for row in resp.json()["data"]["nodeCounts"]
+    }
+    # Only values that actually have nodes are returned, and every count is positive.
+    assert counts
+    assert all(count > 0 for count in counts.values())
+
+    # Each grouped count matches counting that type directly via findNodes.
+    for node_type in ["SOURCE", "TRANSFORM", "DIMENSION", "METRIC", "CUBE"]:
+        resp = await client_with_roads.post(
+            "/graphql",
+            json={"query": f"{{ findNodes(nodeTypes: [{node_type}]) {{ name }} }}"},
+        )
+        expected = len(resp.json()["data"]["findNodes"])
+        assert counts.get(node_type, 0) == expected
+
+
+@pytest.mark.asyncio
+async def test_node_counts_scoped_to_namespace(
+    client_with_roads: AsyncClient,
+) -> None:
+    """nodeCounts honors the namespace filter."""
+    resp = await client_with_roads.post(
+        "/graphql",
+        json={
+            "query": (
+                '{ nodeCounts(groupBy: TYPE, namespace: "foo.bar") { value count } }'
+            ),
+        },
+    )
+    assert resp.status_code == 200
+    scoped = {
+        row["value"]: row["count"] for row in resp.json()["data"]["nodeCounts"]
+    }
+    for node_type, count in scoped.items():
+        resp = await client_with_roads.post(
+            "/graphql",
+            json={
+                "query": (
+                    f'{{ findNodesPaginated(namespace: "foo.bar", '
+                    f"nodeTypes: [{node_type}], limit: 1) {{ totalCount }} }}"
+                ),
+            },
+        )
+        assert resp.json()["data"]["findNodesPaginated"]["totalCount"] == count

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -3983,9 +3983,7 @@ async def test_node_counts_by_type(
         json={"query": "{ nodeCounts(groupBy: TYPE) { value count } }"},
     )
     assert resp.status_code == 200
-    counts = {
-        row["value"]: row["count"] for row in resp.json()["data"]["nodeCounts"]
-    }
+    counts = {row["value"]: row["count"] for row in resp.json()["data"]["nodeCounts"]}
     # Only values that actually have nodes are returned, and every count is positive.
     assert counts
     assert all(count > 0 for count in counts.values())
@@ -4014,9 +4012,7 @@ async def test_node_counts_scoped_to_namespace(
         },
     )
     assert resp.status_code == 200
-    scoped = {
-        row["value"]: row["count"] for row in resp.json()["data"]["nodeCounts"]
-    }
+    scoped = {row["value"]: row["count"] for row in resp.json()["data"]["nodeCounts"]}
     for node_type, count in scoped.items():
         resp = await client_with_roads.post(
             "/graphql",


### PR DESCRIPTION
### Summary

The namespace landing page shows per-type filter pills ("Metric (342)", "Source (…)" etc). Today the UI populates them by firing one `findNodesPaginated(nodeTypes:[X], limit:1){ totalCount }` per node type, which results in 5 separate count scans per page load (aliased into a single request, but still N scans server-side).

This PR adds a generic server-side primitive to do it in one grouped scan, plus a small fix to the count query that backs every paginated totalCount.

**New generic `nodeCounts` query**
```gql
nodeCounts(groupBy: NodeGroupBy!, namespace: String): [NodeCount!]!

type NodeCount { value: String!, count: Int! }
enum NodeGroupBy { TYPE }
```
This runs the existing filter builder with `GROUP BY <column>` and returns `{value: count}` in one query. We deliberately kept this as a separate field, not folded into `findNodesPaginated` since counting and pagination are different concerns. `NodeGroupBy` starts at `TYPE`, but adding `STATUS`/`MODE` later is just an enum value + a column mapping.

**`COUNT(*)` instead of `COUNT(DISTINCT id)` for `totalCount`**

`Node.count_by` (which backs every paginated `totalCount`) used `COUNT(DISTINCT Node.id)`. However, `COUNT(*)` is exactly equivalent and skips the sort/hash `DISTINCT` forces. This change yields identical results, and it stops degrading with table size.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
