### PR TITLE
Speed up namespace landing data loading

### DIFF
--- a/datajunction-ui/src/app/pages/NamespacePage/CompactSelect.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/CompactSelect.jsx
@@ -1,4 +1,32 @@
-import Select from 'react-select';
+import Select, { components } from 'react-select';
+
+// react-select renders a DOM node per option with no virtualization, so a large
+// list (e.g. all users) makes the menu sluggish to open/scroll. Cap how many
+// options are rendered at once; react-select still filters the full list as the
+// user types, so any option remains reachable by searching.
+const MAX_RENDERED_OPTIONS = 100;
+
+const WindowedMenuList = props => {
+  const { children } = props;
+  if (Array.isArray(children) && children.length > MAX_RENDERED_OPTIONS) {
+    return (
+      <components.MenuList {...props}>
+        {children.slice(0, MAX_RENDERED_OPTIONS)}
+        <div
+          style={{
+            padding: '6px 12px',
+            fontSize: '11px',
+            color: '#888',
+          }}
+        >
+          Showing first {MAX_RENDERED_OPTIONS} of {children.length}. Type to
+          narrow…
+        </div>
+      </components.MenuList>
+    );
+  }
+  return <components.MenuList {...props}>{children}</components.MenuList>;
+};
 
 // Compact select with label above - saves horizontal space
 export default function CompactSelect({
@@ -15,6 +43,7 @@ export default function CompactSelect({
   isLoading = false,
   testId = null,
   formatOptionLabel = undefined,
+  onMenuOpen = undefined,
 }) {
   // For single select, find the matching option
   // For multi select, filter to matching options
@@ -55,8 +84,10 @@ export default function CompactSelect({
         isLoading={isLoading}
         placeholder={placeholder}
         onChange={onChange}
+        onMenuOpen={onMenuOpen}
         value={selectedValue}
         formatOptionLabel={formatOptionLabel}
+        components={{ MenuList: WindowedMenuList }}
         styles={{
           control: base => ({
             ...base,

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -1,5 +1,12 @@
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
-import { useContext, useEffect, useState, useCallback } from 'react';
+import {
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+} from 'react';
 import NodeStatus from '../NodePage/NodeStatus';
 import DJClientContext from '../../providers/djclient';
 import { useCurrentUser } from '../../providers/UserProvider';
@@ -61,27 +68,50 @@ export function NamespacePage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Data for select options
+  // Data for select options. These populate filter dropdowns only, so they're
+  // fetched lazily on first dropdown open instead of on page load — except when a
+  // users/tags filter is already active from the URL, where we need the options to
+  // render the selected label.
   const [users, setUsers] = useState([]);
   const [tags, setTags] = useState([]);
-  const [usersLoading, setUsersLoading] = useState(true);
-  const [tagsLoading, setTagsLoading] = useState(true);
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [tagsLoading, setTagsLoading] = useState(false);
+  const usersRequested = useRef(false);
+  const tagsRequested = useRef(false);
 
-  // Load users and tags for dropdowns
-  useEffect(() => {
-    const fetchUsers = async () => {
+  const ensureUsers = useCallback(async () => {
+    if (usersRequested.current) return;
+    usersRequested.current = true;
+    setUsersLoading(true);
+    try {
       const data = await djClient.users();
       setUsers(data || []);
+    } finally {
       setUsersLoading(false);
-    };
-    const fetchTags = async () => {
+    }
+  }, [djClient]);
+
+  const ensureTags = useCallback(async () => {
+    if (tagsRequested.current) return;
+    tagsRequested.current = true;
+    setTagsLoading(true);
+    try {
       const data = await djClient.listTags();
       setTags(data || []);
+    } finally {
       setTagsLoading(false);
-    };
-    fetchUsers().catch(console.error);
-    fetchTags().catch(console.error);
+    }
   }, [djClient]);
+
+  // Eagerly fetch only what an already-applied filter needs to render its label.
+  useEffect(() => {
+    if (searchParams.get('editedBy') || searchParams.get('ownedBy')) {
+      ensureUsers().catch(console.error);
+    }
+    if (searchParams.get('tags')) {
+      ensureTags().catch(console.error);
+    }
+  }, [searchParams, ensureUsers, ensureTags]);
 
   // Parse all filters from URL
   const getFiltersFromUrl = useCallback(
@@ -102,8 +132,15 @@ export function NamespacePage() {
   const [filters, setFilters] = useState(getFiltersFromUrl);
   const [moreFiltersOpen, setMoreFiltersOpen] = useState(false);
 
-  // Sync filters state when URL changes
+  // Sync filters state when the URL changes. `filters` is already seeded from the
+  // URL via useState, so we skip the initial run — otherwise it would replace
+  // filters with an equal-but-new object and trigger a redundant node refetch.
+  const didSyncFilters = useRef(false);
   useEffect(() => {
+    if (!didSyncFilters.current) {
+      didSyncFilters.current = true;
+      return;
+    }
     setFilters(getFiltersFromUrl());
   }, [searchParams, getFiltersFromUrl]);
 
@@ -258,6 +295,8 @@ export function NamespacePage() {
   const createSubNamespace = async fullNamespace => {
     const response = await djClient.addNamespace(fullNamespace);
     if (response.status === 200 || response.status === 201) {
+      // The cached namespace list is now stale — refetch it on next mount.
+      djClient.invalidateNamespacesCache?.();
       navigate(`/namespaces/${fullNamespace}`);
       return {};
     }
@@ -288,6 +327,9 @@ export function NamespacePage() {
   // Per-type node counts (recursive) for the current namespace, shown inline in
   // the TYPE filter options (e.g. "Metric (342)").
   useEffect(() => {
+    // Wait until git config resolves so tableNamespace is final — otherwise a
+    // git root fetches its provisional namespace, then refetches after redirect.
+    if (!gitConfigLoaded) return;
     if (isGitRoot && gitConfig?.default_branch) return;
     let cancelled = false;
     if (!tableNamespace) {
@@ -305,7 +347,7 @@ export function NamespacePage() {
     return () => {
       cancelled = true;
     };
-  }, [djClient, tableNamespace]);
+  }, [djClient, tableNamespace, gitConfigLoaded, isGitRoot, gitConfig]);
 
   const requestSort = key => {
     let direction = ASC;
@@ -326,30 +368,36 @@ export function NamespacePage() {
 
   const createNamespaceHierarchy = namespaceList => {
     const hierarchy = [];
+    // Map lookups (path -> node's children map) keep insertion O(n · depth); we sort
+    // each level once at the end rather than on every insert (which was O(n² log n)).
+    const rootMap = new Map();
+    const childMaps = new Map();
 
     for (const item of namespaceList) {
-      const namespaces = item.namespace.split('.');
+      const segments = item.namespace.split('.');
       let currentLevel = hierarchy;
-
+      let levelMap = rootMap;
       let path = '';
-      for (const ns of namespaces) {
+      for (const ns of segments) {
         path += ns;
-
-        let existingNamespace = currentLevel.find(el => el.namespace === ns);
-        if (!existingNamespace) {
-          existingNamespace = {
-            namespace: ns,
-            children: [],
-            path: path,
-          };
-          currentLevel.push(existingNamespace);
-          currentLevel.sort((a, b) => a.namespace.localeCompare(b.namespace));
+        let node = levelMap.get(ns);
+        if (!node) {
+          node = { namespace: ns, children: [], path };
+          currentLevel.push(node);
+          levelMap.set(ns, node);
+          childMaps.set(path, new Map());
         }
-
-        currentLevel = existingNamespace.children;
+        currentLevel = node.children;
+        levelMap = childMaps.get(path);
         path += '.';
       }
     }
+
+    const sortLevel = level => {
+      level.sort((a, b) => a.namespace.localeCompare(b.namespace));
+      level.forEach(node => sortLevel(node.children));
+    };
+    sortLevel(hierarchy);
     return hierarchy;
   };
 
@@ -374,6 +422,9 @@ export function NamespacePage() {
   }, [djClient]);
 
   useEffect(() => {
+    // Wait until git config resolves so tableNamespace is final — otherwise a
+    // git root fetches its provisional namespace, then refetches after redirect.
+    if (!gitConfigLoaded) return;
     if (isGitRoot && gitConfig?.default_branch) return;
     const fetchData = async () => {
       setRetrieved(false);
@@ -441,6 +492,9 @@ export function NamespacePage() {
     tableNamespace,
     namespace,
     debouncedSearch,
+    gitConfigLoaded,
+    isGitRoot,
+    gitConfig,
   ]);
 
   const loadNext = () => {
@@ -517,11 +571,14 @@ export function NamespacePage() {
     { value: 'INVALID', label: 'Invalid' },
   ];
 
-  const userOptions = users.map(u => ({
-    value: u.username,
-    label: u.username,
-  }));
-  const tagOptions = tags.map(t => ({ value: t.name, label: t.display_name }));
+  const userOptions = useMemo(
+    () => users.map(u => ({ value: u.username, label: u.username })),
+    [users],
+  );
+  const tagOptions = useMemo(
+    () => tags.map(t => ({ value: t.name, label: t.display_name })),
+    [tags],
+  );
 
   const nodesList = retrieved ? (
     state.nodes.length > 0 ? (
@@ -819,6 +876,7 @@ export function NamespacePage() {
                   }
                   isMulti
                   isLoading={tagsLoading}
+                  onMenuOpen={ensureTags}
                   flex={1.5}
                   minWidth="100px"
                   testId="select-tag"
@@ -832,6 +890,7 @@ export function NamespacePage() {
                     updateFilters({ ...filters, edited_by: e?.value || '' })
                   }
                   isLoading={usersLoading}
+                  onMenuOpen={ensureUsers}
                   flex={1}
                   minWidth="80px"
                   testId="select-user"
@@ -856,6 +915,7 @@ export function NamespacePage() {
                     updateFilters({ ...filters, ownedBy: e?.value || '' })
                   }
                   isLoading={usersLoading}
+                  onMenuOpen={ensureUsers}
                   flex={1}
                   minWidth="80px"
                 />

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -13,6 +13,14 @@ const DJ_GQL = process.env.REACT_APP_DJ_GQL
 // Export the base URL for components that need direct access
 export const getDJUrl = () => DJ_URL;
 
+// The namespace list is large (every namespace, with counts + git config) and
+// changes rarely, but is fetched on every landing/namespace-page mount. Cache it
+// for a short window so re-entering namespace pages doesn't refetch it each time.
+// Mutations that add/remove namespaces should call invalidateNamespacesCache().
+let _namespacesCache = null;
+let _namespacesCacheAt = 0;
+const NAMESPACES_CACHE_TTL_MS = 60000;
+
 // URL builder that works with either an absolute or relative DJ_URL.
 const _djURL = path => {
   const base =
@@ -31,15 +39,13 @@ export const DataJunctionAPI = {
   // never hydrates node rows, unlike listNodesForLanding. Returns a { type: count } map.
   // `types` are trusted enum names (e.g. 'metric') from a fixed constant, not user input.
   nodeTypeCounts: async function (namespace, types) {
-    const fields = types
-      .map(
-        (type, i) =>
-          `c${i}: findNodesPaginated(namespace: $namespace, nodeTypes: [${type.toUpperCase()}], limit: 1) { totalCount }`,
-      )
-      .join('\n        ');
+    // Generic grouped-count query (one scan) instead of one count per node type.
     const query = `
-      query NodeTypeCounts($namespace: String) {
-        ${fields}
+      query NodeCounts($namespace: String) {
+        nodeCounts(groupBy: TYPE, namespace: $namespace) {
+          value
+          count
+        }
       }
     `;
     const result = await (
@@ -50,9 +56,14 @@ export const DataJunctionAPI = {
         body: JSON.stringify({ query, variables: { namespace } }),
       })
     ).json();
+    const byType = {};
+    (result?.data?.nodeCounts || []).forEach(({ value, count }) => {
+      byType[value] = count;
+    });
+    // Preserve the requested order and default missing types to 0.
     const counts = {};
-    types.forEach((type, i) => {
-      counts[type] = result?.data?.[`c${i}`]?.totalCount ?? 0;
+    types.forEach(type => {
+      counts[type] = byType[type.toUpperCase()] ?? 0;
     });
     return counts;
   },
@@ -1259,7 +1270,20 @@ export const DataJunctionAPI = {
     ).json();
   },
 
-  listNamespacesWithGit: async function () {
+  invalidateNamespacesCache: function () {
+    _namespacesCache = null;
+    _namespacesCacheAt = 0;
+  },
+
+  listNamespacesWithGit: async function ({ force = false } = {}) {
+    const now = Date.now();
+    if (
+      !force &&
+      _namespacesCache &&
+      now - _namespacesCacheAt < NAMESPACES_CACHE_TTL_MS
+    ) {
+      return _namespacesCache;
+    }
     const query = `
       query ListNamespaces {
         listNamespaces {
@@ -1294,7 +1318,9 @@ export const DataJunctionAPI = {
         body: JSON.stringify({ query }),
       })
     ).json();
-    return result?.data?.listNamespaces || [];
+    _namespacesCache = result?.data?.listNamespaces || [];
+    _namespacesCacheAt = now;
+    return _namespacesCache;
   },
 
   namespaceSources: async function (namespace) {
@@ -1960,11 +1986,19 @@ export const DataJunctionAPI = {
     return { nodes, tags };
   },
   users: async function () {
-    return await (
-      await fetch(`${DJ_URL}/users?with_activity=true`, {
-        credentials: 'include',
-      })
-    ).json();
+    // Only usernames are consumed by callers (filter/owner dropdowns), so we skip
+    // `with_activity` — it makes the endpoint join the entire history table.
+    // Without that flag the endpoint returns a bare list of usernames, so we
+    // normalize back to the `{ username }` shape callers expect.
+    const data =
+      (await (
+        await fetch(`${DJ_URL}/users`, {
+          credentials: 'include',
+        })
+      ).json()) || [];
+    return data.map(user =>
+      typeof user === 'string' ? { username: user } : user,
+    );
   },
   getTag: async function (tagName) {
     const response = await fetch(`${DJ_URL}/tags/${tagName}`, {

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -2114,18 +2114,69 @@ describe('DataJunctionAPI', () => {
   });
 
   // Test users (lines 1194-1198)
-  it('calls users correctly', async () => {
-    fetch.mockResponseOnce(
-      JSON.stringify([{ username: 'user1' }, { username: 'user2' }]),
-    );
+  it('calls users correctly and normalizes the username list', async () => {
+    // The endpoint (without with_activity) returns a bare list of usernames.
+    fetch.mockResponseOnce(JSON.stringify(['user1', 'user2']));
 
     const result = await DataJunctionAPI.users();
 
     expect(fetch).toHaveBeenCalledWith(
-      'http://localhost:8000/users?with_activity=true',
+      'http://localhost:8000/users',
       expect.objectContaining({ credentials: 'include' }),
     );
-    expect(result).toHaveLength(2);
+    expect(result).toEqual([{ username: 'user1' }, { username: 'user2' }]);
+  });
+
+  it('nodeTypeCounts maps grouped counts to the requested types', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: {
+          nodeCounts: [
+            { value: 'SOURCE', count: 3 },
+            { value: 'METRIC', count: 5 },
+          ],
+        },
+      }),
+    );
+
+    const result = await DataJunctionAPI.nodeTypeCounts('default', [
+      'source',
+      'metric',
+      'cube',
+    ]);
+
+    // Types are matched case-insensitively; requested types missing from the
+    // response default to 0.
+    expect(result).toEqual({ source: 3, metric: 5, cube: 0 });
+  });
+
+  it('caches listNamespacesWithGit and refetches after invalidation', async () => {
+    DataJunctionAPI.invalidateNamespacesCache();
+    fetch.mockResponse(
+      JSON.stringify({
+        data: { listNamespaces: [{ namespace: 'a', numNodes: 1 }] },
+      }),
+    );
+
+    const first = await DataJunctionAPI.listNamespacesWithGit();
+    const callsAfterFirst = fetch.mock.calls.length;
+
+    // Second call is served from cache — no additional fetch.
+    const second = await DataJunctionAPI.listNamespacesWithGit();
+    expect(fetch.mock.calls.length).toBe(callsAfterFirst);
+    expect(second).toEqual(first);
+
+    // force bypasses the cache.
+    await DataJunctionAPI.listNamespacesWithGit({ force: true });
+    expect(fetch.mock.calls.length).toBe(callsAfterFirst + 1);
+
+    // Invalidation causes the next call to refetch.
+    DataJunctionAPI.invalidateNamespacesCache();
+    await DataJunctionAPI.listNamespacesWithGit();
+    expect(fetch.mock.calls.length).toBe(callsAfterFirst + 2);
+
+    // Leave the cache clean for any subsequent tests.
+    DataJunctionAPI.invalidateNamespacesCache();
   });
 
   // Test listCubesForPreset (lines 121-155)


### PR DESCRIPTION
### Summary

A batch of independent optimizations to how the namespace landing page (`NamespacePage`) fetches and renders its data.

#### `DJService.js`

  - `users()` drops `with_activity`: The landing page and owner/edited-by dropdowns only use usernames, but `with_activity=true` made the endpoint join the entire history table.
  - `listNamespacesWithGit` caching: the namespace list is cached for 60s with an `invalidateNamespacesCache()` escape hatch, so re-entering namespace pages doesn't refetch it every mount.
  - `nodeTypeCounts` uses the new generic `nodeCounts(groupBy: TYPE)` query (one grouped scan) instead of 6 aliased per-type counts.

#### `NamespacePage/index.jsx`

  - Lazy load filter data: users and tags (for the Edited By / Owner / Tags dropdowns) are fetched on first dropdown open, not on mount. They still fetch eagerly when a matching filter is already active in the URL, so a pre-applied filter renders its label.
  - Gate table + count fetches on `gitConfigLoaded`: for git-root namespaces the table used to fetch a provisional namespace, then refetch after the redirect to the default branch. Waiting for git config resolves that duplicate.
  - Filters mount-guard: the URL to filters sync effect no longer refetches on first mount (state is already seeded from the URL).
  - Invalidate the namespace cache when a sub-namespace is created.

#### `CompactSelect.jsx`

Add a windowed menu list (cap rendered options at 100) so large lists like the full user list don't make the dropdown super slow and unusable.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
