### PR TITLE
Defer node popover data fetches to open-time

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddMaterializationPopover.jsx
@@ -16,7 +16,12 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
 
   const ref = useRef(null);
 
+  // Fetch materialization options only when the popover is opened (once), not on
+  // every materialization-tab load — the options are only used inside the form.
+  const fetchedRef = useRef(false);
   useEffect(() => {
+    if (!popoverAnchor || fetchedRef.current) return;
+    fetchedRef.current = true;
     const fetchData = async () => {
       const options = await djClient.materializationInfo();
       setOptions(options);
@@ -26,6 +31,9 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
       setJobs(allowedJobs);
     };
     fetchData().catch(console.error);
+  }, [popoverAnchor, djClient, node.type]);
+
+  useEffect(() => {
     const handleClickOutside = event => {
       if (ref.current && !ref.current.contains(event.target)) {
         setPopoverAnchor(false);
@@ -35,7 +43,7 @@ export default function AddMaterializationPopover({ node, onSubmit }) {
     return () => {
       document.removeEventListener('click', handleClickOutside, true);
     };
-  }, [djClient, setPopoverAnchor]);
+  }, []);
 
   const materialize = async (values, setStatus) => {
     const config = {};

--- a/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/ClientCodePopover.jsx
@@ -11,17 +11,30 @@ export default function ClientCodePopover({ nodeName, buttonStyle }) {
   const modalRef = useRef(null);
   const [code, setCode] = useState(null);
 
+  // Drop any cached code when the node changes.
   useEffect(() => {
+    setCode(null);
+  }, [nodeName]);
+
+  // The generated client code is only shown inside the modal, and generating it
+  // is expensive (~1s server round trip). Fetch it lazily the first time the
+  // popover is opened rather than on every node-page load.
+  useEffect(() => {
+    if (!showModal || code !== null) return;
+    let cancelled = false;
     async function fetchCode() {
       try {
-        const code = await djClient.clientCode(nodeName);
-        setCode(code);
+        const result = await djClient.clientCode(nodeName);
+        if (!cancelled) setCode(result);
       } catch (err) {
         console.log(err);
       }
     }
     fetchCode();
-  }, [nodeName, djClient]);
+    return () => {
+      cancelled = true;
+    };
+  }, [showModal, nodeName, djClient, code]);
 
   useEffect(() => {
     const handleClickOutside = event => {


### PR DESCRIPTION
### Summary

`ClientCodePopover` (for client code) and `AddMaterializationPopover` fetched on mount but only use the data inside the closed-by-default popover. Fetch on first open instead to remove ~6-8 redundant server calls per node-page load and a materializationInfo call per materialization-tab load.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
