### PR TITLE
Fix unqualified dimension filters leak onto role-qualified links

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1478,10 +1478,19 @@ def _build_local_dim_aliases(node: "Node") -> dict[str, str]:
     for link in node.current.dimension_links:
         # ``foreign_keys_reversed`` maps dim PK columns → node FK columns.
         # Both sides are fully-qualified (``<node>.<col>``) identifiers.
+        #
+        # A *role-qualified* link is keyed WITH its role (e.g.
+        # ``v3.date.date_id[planned_launch]``) so it only matches a filter
+        # that carries that same role. Keying it by the bare, role-stripped
+        # FQN would let an *unqualified* filter (e.g. ``v3.date.date_id``,
+        # meaning the fact's own date) silently bind to this dim's role
+        # column, over-filtering the CTE. Unqualified links (role=None) keep
+        # the bare key.
         for dim_col_fqn, fk_fqn in (link.foreign_keys_reversed or {}).items():
             if not fk_fqn:  # pragma: no cover
                 continue
-            result[dim_col_fqn] = get_short_name(fk_fqn)
+            key = f"{dim_col_fqn}[{link.role}]" if link.role else dim_col_fqn
+            result[key] = get_short_name(fk_fqn)
     return result
 
 

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -1936,3 +1936,163 @@ class TestDimLabelFilterNameCollision:
             """,
             normalize_aliases=True,
         )
+
+
+class TestFilterPushdownRoleQualifiedSharedDim:
+    """A filter on an *unqualified* shared dimension must bind only to nodes
+    that link to it via an *unqualified* link — it must not fan out onto other
+    nodes that reach the same dimension through a *role-qualified* link.
+
+    Regression: a fact linked a date dimension unqualified while a dimension
+    node in the same join graph linked that date dimension via a role. An
+    unqualified filter on the date leaked onto the dimension's role link,
+    over-filtering the dimension subquery to near-zero rows and silently
+    dropping the result.
+    """
+
+    @pytest.fixture
+    async def setup_show_activity_chain(self, client_with_build_v3):
+        """Fact ``v3.show_activity`` links to the shared ``v3.date`` dimension
+        UNqualified (role=None) via ``region_date``. The ``v3.show`` dimension
+        links to the same ``v3.date`` via role ``planned_launch``. Reproduces
+        the fact/dimension shape that surfaces the shared-dimension leak.
+
+        Defined locally so only this test pays the setup cost; the global
+        BUILD_V3 fixture is unaffected.
+        """
+        c = client_with_build_v3
+        r = await c.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_show_events",
+                "description": "Per-show viewing events by region date",
+                "columns": [
+                    {"name": "show_id", "type": "int"},
+                    {"name": "region_date", "type": "int"},
+                    {"name": "view_secs", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "show_events",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+        r = await c.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.src_shows",
+                "description": "Show catalog with planned launch date",
+                "columns": [
+                    {"name": "show_id", "type": "int"},
+                    {"name": "show_title", "type": "string"},
+                    {"name": "planned_launch_date", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "shows",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+        r = await c.post(
+            "/nodes/transform/",
+            json={
+                "name": "v3.show_activity",
+                "query": (
+                    "SELECT show_id, region_date, view_secs FROM v3.src_show_events"
+                ),
+                "mode": "published",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+        r = await c.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.show",
+                "query": (
+                    "SELECT show_id, show_title, planned_launch_date FROM v3.src_shows"
+                ),
+                "primary_key": ["show_id"],
+                "mode": "published",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+        r = await c.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.show_view_secs",
+                "query": "SELECT SUM(view_secs) FROM v3.show_activity",
+                "mode": "published",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+        # fact -> date, UNqualified (role=None) on region_date
+        r = await c.post(
+            "/nodes/v3.show_activity/link",
+            json={
+                "dimension_node": "v3.date",
+                "join_on": "v3.show_activity.region_date = v3.date.date_id",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+        # fact -> show (role=None) on show_id
+        r = await c.post(
+            "/nodes/v3.show_activity/link",
+            json={
+                "dimension_node": "v3.show",
+                "join_on": "v3.show_activity.show_id = v3.show.show_id",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+        # show dim -> date, role 'planned_launch' on planned_launch_date
+        r = await c.post(
+            "/nodes/v3.show/link",
+            json={
+                "dimension_node": "v3.date",
+                "join_on": "v3.show.planned_launch_date = v3.date.date_id",
+                "role": "planned_launch",
+            },
+        )
+        assert r.status_code in (200, 201, 409), r.json()
+
+    @pytest.mark.asyncio
+    async def test_unqualified_shared_dim_filter_does_not_leak_into_role_link(
+        self,
+        client_with_build_v3,
+        setup_show_activity_chain,
+    ):
+        """Filtering unqualified ``v3.date.date_id`` must push into the fact CTE
+        (``region_date``, the unqualified link) and MUST NOT be injected into the
+        ``v3_show`` CTE via its role-qualified ``planned_launch`` link.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.show_view_secs"],
+                "dimensions": ["v3.show.show_title"],
+                "filters": ["v3.date.date_id BETWEEN 20240101 AND 20240201"],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_show AS (
+              SELECT show_id, show_title
+              FROM default.v3.shows
+            ),
+            v3_show_activity AS (
+              SELECT show_id, region_date, view_secs
+              FROM default.v3.show_events
+              WHERE region_date BETWEEN 20240101 AND 20240201
+            )
+            SELECT t2.show_title,
+              SUM(t1.view_secs) view_secs_sum_HASH
+            FROM v3_show_activity t1
+            LEFT OUTER JOIN v3_show t2 ON t1.show_id = t2.show_id
+            GROUP BY t2.show_title
+            """,
+            normalize_aliases=True,
+        )

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -2096,3 +2096,46 @@ class TestFilterPushdownRoleQualifiedSharedDim:
             """,
             normalize_aliases=True,
         )
+
+    @pytest.mark.asyncio
+    async def test_role_qualified_shared_dim_filter_binds_to_role_link(
+        self,
+        client_with_build_v3,
+        setup_show_activity_chain,
+    ):
+        """The role-qualified counterpart still works: filtering
+        ``v3.date.date_id[planned_launch]`` binds to the ``v3.show`` role link
+        (``planned_launch_date``) and does NOT touch the fact's own date.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.show_view_secs"],
+                "dimensions": ["v3.show.show_title"],
+                "filters": [
+                    "v3.date.date_id[planned_launch] BETWEEN 20240101 AND 20240201",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            WITH
+            v3_show AS (
+              SELECT show_id, show_title, planned_launch_date
+              FROM default.v3.shows
+            ),
+            v3_show_activity AS (
+              SELECT show_id, view_secs
+              FROM default.v3.show_events
+            )
+            SELECT t2.show_title,
+              SUM(t1.view_secs) view_secs_sum_HASH
+            FROM v3_show_activity t1
+            LEFT OUTER JOIN v3_show t2 ON t1.show_id = t2.show_id
+            WHERE t2.planned_launch_date BETWEEN 20240101 AND 20240201
+            GROUP BY t2.show_title
+            """,
+            normalize_aliases=True,
+        )


### PR DESCRIPTION
### Summary

When a metric query filters on an unqualified shared dimension (e.g. `some_ns.date.date_id`), the v3 SQL builder could push that filter into a dimension node's CTE via a role-qualified link to the same dimension, binding it to a semantically different column.

Concretely, given a join graph where:
- a fact links to a date dimension unqualified (its own event date), and
- a dimension node in the same query links to that same date dimension via a role (e.g. a "planned launch" date),

a filter like `date.date_id BETWEEN X AND Y` was applied to both nodes: correctly to the fact's date column, but also wrongly injected into the dimension's CTE against its role column. That over-filters the dimension subquery down to near-zero rows, and the join then silently drops most/all results, a wrong answer with no error surfaced.

The root cause is that `_build_local_dim_aliases` built a dimension node's per-CTE filter alias map keyed by the role-stripped dimension FQN. A role-qualified link would register an unqualified `ns.date.date_id` → `planned_launch_date` entry, and an unqualified `ns.date.date_id` filter matched it and got pushed into that CTE against the wrong (role) column.

The fix is to key a role-qualified link with its role, and have unqualified links (`role=None`) keep the bare key.

The existing filter matcher (`_rewrite_filter_for_select`) already prefers the role-qualified alias key and falls back to the bare one, so behavior is now:

- `ns.date.date_id` (unqualified) matches only unqualified links, then binds to the fact's own date column, so it's not injected into the role-linked dimension CTE.
- `ns.date.date_id[planned_launch]` (role-qualified) matches the role key and still binds to the dimension's role column.

### Test Plan

Added `test_unqualified_shared_dim_filter_does_not_leak_into_role_link` to check that the unqualified filter binds to the fact and the role-linked dimension CTE has no injected `WHERE` and `test_role_qualified_shared_dim_filter_binds_to_role_link`, which asserts that the role-qualified counterpart still resolves to the dimension's role column.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
