### PR TITLE
Allow running planner queries with zero dimensions

### DIFF
--- a/datajunction-ui/src/app/pages/QueryPlannerPage/SelectionPanel.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/SelectionPanel.jsx
@@ -1144,12 +1144,9 @@ export function SelectionPanel({
                 </>
               )}
             </button>
-            {!canRunQuery && selectedMetrics.length > 0 && (
-              <span className="run-hint">Select at least one dimension</span>
-            )}
-            {!canRunQuery && selectedMetrics.length === 0 && (
+            {!canRunQuery && (
               <span className="run-hint">
-                Select metrics and dimensions to run a query
+                Select at least one metric to run a query
               </span>
             )}
           </div>

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/__tests__/SelectionPanel.test.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/__tests__/SelectionPanel.test.jsx
@@ -1376,20 +1376,7 @@ describe('SelectionPanel', () => {
       expect(onRunQuery).toHaveBeenCalled();
     });
 
-    it('shows hint when metrics selected but no dimensions', () => {
-      render(
-        <SelectionPanel
-          {...defaultProps}
-          selectedMetrics={['default.num_repair_orders']}
-          canRunQuery={false}
-        />,
-      );
-      expect(
-        screen.getByText('Select at least one dimension'),
-      ).toBeInTheDocument();
-    });
-
-    it('shows hint when no metrics and no dimensions selected', () => {
+    it('shows metric hint when query cannot run (no metrics selected)', () => {
       render(
         <SelectionPanel
           {...defaultProps}
@@ -1398,8 +1385,26 @@ describe('SelectionPanel', () => {
         />,
       );
       expect(
-        screen.getByText('Select metrics and dimensions to run a query'),
+        screen.getByText('Select at least one metric to run a query'),
       ).toBeInTheDocument();
+    });
+
+    it('shows no run hint once a metric is selected (dimensions optional)', () => {
+      render(
+        <SelectionPanel
+          {...defaultProps}
+          selectedMetrics={['default.num_repair_orders']}
+          selectedDimensions={[]}
+          canRunQuery={true}
+          onRunQuery={vi.fn()}
+        />,
+      );
+      expect(
+        screen.queryByText('Select at least one metric to run a query'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText('Run Query').closest('button'),
+      ).not.toBeDisabled();
     });
   });
 });

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/__tests__/index.test.jsx
@@ -1622,7 +1622,7 @@ describe('QueryPlannerPage', () => {
       });
 
       expect(
-        screen.getByText('Select metrics and dimensions to run a query'),
+        screen.getByText('Select at least one metric to run a query'),
       ).toBeInTheDocument();
     });
   });

--- a/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
+++ b/datajunction-ui/src/app/pages/QueryPlannerPage/index.jsx
@@ -388,7 +388,7 @@ export function QueryPlannerPage() {
   // Fetch V3 measures and metrics SQL when selection, filters, or engine changes
   useEffect(() => {
     const fetchData = async () => {
-      if (selectedMetrics.length > 0 && selectedDimensions.length > 0) {
+      if (selectedMetrics.length > 0) {
         setLoading(true);
         setError(null);
         setSelectedNode(null);
@@ -1267,7 +1267,7 @@ export function QueryPlannerPage() {
 
   // Refresh measures result (after setting partition)
   const handleRefreshMeasures = useCallback(async () => {
-    if (selectedMetrics.length > 0 && selectedDimensions.length > 0) {
+    if (selectedMetrics.length > 0) {
       try {
         const [measures, metrics] = await Promise.all([
           djClient.measuresV3(selectedMetrics, selectedDimensions),
@@ -1291,8 +1291,8 @@ export function QueryPlannerPage() {
 
   // Run query and fetch results
   const handleRunQuery = useCallback(async () => {
-    if (selectedMetrics.length === 0 || selectedDimensions.length === 0) {
-      setQueryError('Select at least one metric and one dimension');
+    if (selectedMetrics.length === 0) {
+      setQueryError('Select at least one metric');
       return;
     }
 
@@ -1375,9 +1375,7 @@ export function QueryPlannerPage() {
             selectedEngine={selectedEngine}
             onEngineChange={setSelectedEngine}
             onRunQuery={handleRunQuery}
-            canRunQuery={
-              selectedMetrics.length > 0 && selectedDimensions.length > 0
-            }
+            canRunQuery={selectedMetrics.length > 0}
             queryLoading={queryLoading}
             compatibleMetrics={compatibleMetrics}
           />


### PR DESCRIPTION
### Summary

The query planner required at least one dimension to generate a SQL preview or run a query, but the server fully supports metric-only (scalar aggregate) and filters-only queries. This PR relaxes the guards to require only a metric; dimensions are now optional.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
