### PR TITLE
Make node search prominent in the namespace filter bar

### DIFF
--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -850,6 +850,62 @@ export function NamespacePage() {
                   gap: '12px',
                 }}
               >
+                {/* Search — the primary way to find a node, grouped with the
+                    other filter controls as the first item in the bar. */}
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '2px',
+                    flex: 1.5,
+                    minWidth: '180px',
+                  }}
+                >
+                  <label
+                    htmlFor="node-search"
+                    style={{
+                      fontSize: '10px',
+                      fontWeight: '600',
+                      color: '#666',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.5px',
+                    }}
+                  >
+                    Search
+                  </label>
+                  <div style={{ position: 'relative', display: 'flex' }}>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="#94a3b8"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      style={{
+                        position: 'absolute',
+                        left: '8px',
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        pointerEvents: 'none',
+                      }}
+                    >
+                      <circle cx="11" cy="11" r="8" />
+                      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                    </svg>
+                    <input
+                      id="node-search"
+                      type="text"
+                      className="dj-node-search"
+                      value={nodeSearch}
+                      onChange={e => setNodeSearch(e.target.value)}
+                      placeholder="Search nodes…"
+                      aria-label="Search nodes in this namespace"
+                    />
+                  </div>
+                </div>
                 <CompactSelect
                   label="Type"
                   name="type"
@@ -1157,17 +1213,6 @@ export function NamespacePage() {
                 marginLeft: '1.5rem',
               }}
             >
-              {gitConfigLoaded && (
-                <input
-                  type="text"
-                  className="dj-node-search"
-                  value={nodeSearch}
-                  onChange={e => setNodeSearch(e.target.value)}
-                  placeholder="Search nodes in this namespace…"
-                  aria-label="Search nodes in this namespace"
-                />
-              )}
-
               {/* NODES: nodes that live directly in this namespace */}
               {!gitConfigLoaded ? null : (
                 <table className="card-table table" style={{ marginBottom: 0 }}>

--- a/datajunction-ui/src/styles/node-list.css
+++ b/datajunction-ui/src/styles/node-list.css
@@ -236,13 +236,18 @@ table {
 /* Node search box in the namespace main panel */
 .dj-node-search {
   width: 100%;
-  max-width: 360px;
   box-sizing: border-box;
-  padding: 9px 12px;
-  font-size: 14px;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
-  margin-bottom: 12px;
+  height: 32px;
+  padding: 0 10px 0 28px; /* left room for the search icon */
+  font-size: 12px;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  background-color: #ffffff;
+}
+.dj-node-search:focus {
+  outline: none;
+  border-color: #2684ff;
+  box-shadow: 0 0 0 1px #2684ff;
 }
 .dj-node-search::placeholder {
   color: #94a3b8;


### PR DESCRIPTION
### Summary

The namespace-scoped node search was a plain, unlabeled box floating above the results table with no search icon, which is easy to miss. This PR moves it into the filter bar as the first control, with a magnifying-glass icon and a SEARCH label styled like the other filters, so find-and-filter controls live together.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
