### PR TITLE
Wrap the namespace toolbar actions on narrow screens

### DIFF
--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -288,6 +288,10 @@ export default function NamespaceHeader({
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
+          // Wrap so the action buttons drop below the breadcrumb on narrow
+          // screens instead of overflowing / being clipped off the right edge.
+          flexWrap: 'wrap',
+          gap: '8px',
           padding: '12px 12px 12px 20px',
           marginBottom: '16px',
           borderTop: '1px solid #e2e8f0',
@@ -1039,7 +1043,19 @@ export default function NamespaceHeader({
         </div>
 
         {/* Right side: git actions + children */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            // Let the buttons wrap among themselves, staying right-aligned, when
+            // they can't fit on one line. marginLeft:auto keeps them right-
+            // aligned even after they wrap onto their own row below the crumb.
+            flexWrap: 'wrap',
+            justifyContent: 'flex-end',
+            marginLeft: 'auto',
+          }}
+        >
           {/* Git controls for namespaces not inside a branch (git roots,
               orphan namespaces). Subnamespaces under a branch fall through
               to the branch-scoped block below so we don't render two sets

--- a/datajunction-ui/src/app/components/__tests__/__snapshots__/NamespaceHeader.test.jsx.snap
+++ b/datajunction-ui/src/app/components/__tests__/__snapshots__/NamespaceHeader.test.jsx.snap
@@ -18,6 +18,8 @@ exports[`<NamespaceHeader /> > should render and match the snapshot 1`] = `
         "borderBottom": "1px solid #e2e8f0",
         "borderTop": "1px solid #e2e8f0",
         "display": "flex",
+        "flexWrap": "wrap",
+        "gap": "8px",
         "justifyContent": "space-between",
         "marginBottom": "16px",
         "padding": "12px 12px 12px 20px",
@@ -162,7 +164,10 @@ exports[`<NamespaceHeader /> > should render and match the snapshot 1`] = `
         {
           "alignItems": "center",
           "display": "flex",
+          "flexWrap": "wrap",
           "gap": "8px",
+          "justifyContent": "flex-end",
+          "marginLeft": "auto",
         }
       }
     />


### PR DESCRIPTION
### Summary

The breadcrumb + git action buttons (Git Settings, Sync, Create PR, Export YAML, …) sat in a non-wrapping space-between row, so on a small window the buttons overflowed and were clipped off the right edge. Let the row wrap: the action group drops below the breadcrumb (staying right-aligned via marginLeft:auto) and the buttons wrap among themselves.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
