### PR TITLE
Guard against namespaces pointed to branches that don't exist

### DIFF
--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -338,6 +338,18 @@ async def sync_node_to_git(
     try:
         github = GitHubService()
 
+        # A sync targeting a branch that no longer exists on the remote would
+        # otherwise fail deep inside commit_file with an opaque "get ref Not Found".
+        # Check up front so the user gets a clear, actionable message instead.
+        if await github.get_branch(github_repo_path, git_branch) is None:
+            raise DJInvalidInputException(
+                message=(
+                    f"Branch '{git_branch}' does not exist in '{github_repo_path}'. "
+                    f"It may have been deleted on the remote. Recreate the branch or "
+                    f"update this namespace's git configuration before syncing."
+                ),
+            )
+
         # Try to read existing YAML content to preserve comments
         # Also get the file SHA if it exists for the commit
         existing_yaml = None
@@ -442,12 +454,34 @@ async def sync_namespace_to_git(
         )
 
     # Fetch existing YAML from the repo so the serializer can preserve comments
-    # and key ordering in files that already exist in the branch.
-    existing_files_map = await fetch_existing_yaml_map(
-        github_repo_path,
-        git_branch,
-        git_path,
-    )
+    # and key ordering in files that already exist in the branch. This map is also
+    # the baseline for orphan-deletion detection, so we must NOT silently treat an
+    # unreadable branch as empty — that could delete/clobber files. A missing branch
+    # (404) is the ghost-branch case; any other failure means we can't trust the
+    # baseline. Either way, abort loudly rather than committing blind.
+    try:
+        existing_files_map = await fetch_existing_yaml_map(
+            github_repo_path,
+            git_branch,
+            git_path,
+            raise_on_error=True,
+        )
+    except GitHubServiceError as e:
+        if e.github_status == 404:
+            raise DJInvalidInputException(
+                message=(
+                    f"Branch '{git_branch}' does not exist in '{github_repo_path}'. "
+                    f"It may have been deleted on the remote. Recreate the branch or "
+                    f"update this namespace's git configuration before syncing."
+                ),
+            ) from e
+        raise DJInvalidInputException(
+            message=(
+                f"Could not read the current state of branch '{git_branch}' in "
+                f"'{github_repo_path}' ({e.message}). Aborting sync to avoid "
+                f"committing against an incomplete view of the branch."
+            ),
+        ) from e
 
     files = await generate_namespace_yaml_files(
         session,

--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -72,6 +72,20 @@ router = SecureAPIRouter(tags=["git-sync"])
 _node_spec_adapter = TypeAdapter(NodeUnion)
 
 
+def _ghost_branch_exception(
+    git_branch: str,
+    github_repo_path: str,
+) -> DJInvalidInputException:
+    """Consistent error for syncing to a branch that no longer exists on the remote."""
+    return DJInvalidInputException(
+        message=(
+            f"Branch '{git_branch}' does not exist in '{github_repo_path}'. "
+            f"It may have been deleted on the remote. Recreate the branch or "
+            f"update this namespace's git configuration before syncing."
+        ),
+    )
+
+
 def _specs_are_equivalent(existing_yaml: str, new_spec: NodeUnion) -> bool:
     """
     Compare a YAML spec from git with a NodeSpec using semantic comparison.
@@ -341,14 +355,8 @@ async def sync_node_to_git(
         # A sync targeting a branch that no longer exists on the remote would
         # otherwise fail deep inside commit_file with an opaque "get ref Not Found".
         # Check up front so the user gets a clear, actionable message instead.
-        if await github.get_branch(github_repo_path, git_branch) is None:
-            raise DJInvalidInputException(
-                message=(
-                    f"Branch '{git_branch}' does not exist in '{github_repo_path}'. "
-                    f"It may have been deleted on the remote. Recreate the branch or "
-                    f"update this namespace's git configuration before syncing."
-                ),
-            )
+        if not await github.branch_exists(github_repo_path, git_branch):
+            raise _ghost_branch_exception(git_branch, github_repo_path)
 
         # Try to read existing YAML content to preserve comments
         # Also get the file SHA if it exists for the commit
@@ -468,13 +476,7 @@ async def sync_namespace_to_git(
         )
     except GitHubServiceError as e:
         if e.github_status == 404:
-            raise DJInvalidInputException(
-                message=(
-                    f"Branch '{git_branch}' does not exist in '{github_repo_path}'. "
-                    f"It may have been deleted on the remote. Recreate the branch or "
-                    f"update this namespace's git configuration before syncing."
-                ),
-            ) from e
+            raise _ghost_branch_exception(git_branch, github_repo_path) from e
         raise DJInvalidInputException(
             message=(
                 f"Could not read the current state of branch '{git_branch}' in "

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -29,6 +29,10 @@ from datajunction_server.models.deployment import (
 )
 
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.git.github_service import (
+    GitHubService,
+    GitHubServiceError,
+)
 from datajunction_server.internal.git.yaml_export import (
     fetch_existing_yaml_map,
     generate_namespace_yaml_files,
@@ -886,6 +890,75 @@ async def update_namespace_git_config(
                 f"path '{new_path or '(root)'}'. Each namespace must have a unique "
                 "git location to avoid overwriting files.",
             )
+
+    # --- Git-config invariants (guard against the class of misconfiguration that
+    # silently strands namespaces on branches that don't exist) ---
+    if config.git_branch is not None:
+        new_branch_val = config.git_branch or None
+        branch_changing = new_branch_val != node_namespace.git_branch
+
+        # Resolve the effective git config for THIS namespace before the update so
+        # both guards can reason about the default branch and the repo to check.
+        current_info = await get_git_info_for_namespace(session, namespace)
+        default_branch = (current_info or {}).get("default_branch")
+
+        # Guard 1: protect the canonical default-branch namespace. If this namespace
+        # is currently pinned to its repo's default branch, its git_branch must not
+        # be repointed to some other branch here — that is what corrupts the "main"
+        # view for everyone. Branch work belongs in Create Branch, which spins up a
+        # separate branch namespace instead of mutating the default one.
+        if (
+            branch_changing
+            and node_namespace.git_branch
+            and default_branch
+            and node_namespace.git_branch == default_branch
+            and new_branch_val != default_branch
+        ):
+            raise DJInvalidInputException(
+                message=(
+                    f"'{namespace}' is pinned to the default branch "
+                    f"'{default_branch}' and its git branch cannot be repointed here. "
+                    f"Use Create Branch to make a new branch namespace instead of "
+                    f"changing the default branch."
+                ),
+            )
+
+        # Guard 2: the target branch must actually exist on the remote. A branch that
+        # was deleted (or never created) leaves the namespace pointing at a ghost ref,
+        # so every sync silently fails. Only enforced when GitHub is configured; if the
+        # API is unreachable we fail open rather than blocking namespace administration.
+        if (
+            branch_changing
+            and new_branch_val
+            and (settings.github_service_token or settings.github_app_id)
+        ):
+            check_repo = new_repo
+            if not check_repo and new_parent:
+                check_repo, _, _ = await resolve_git_config(session, new_parent)
+            if check_repo:
+                try:
+                    branch_exists = bool(
+                        await GitHubService().get_branch(
+                            check_repo,
+                            new_branch_val,
+                        ),
+                    )
+                except GitHubServiceError as exc:  # pragma: no cover
+                    _logger.warning(
+                        "Could not verify branch '%s' in '%s' (%s); allowing update.",
+                        new_branch_val,
+                        check_repo,
+                        exc,
+                    )
+                    branch_exists = True
+                if not branch_exists:
+                    raise DJInvalidInputException(
+                        message=(
+                            f"Branch '{new_branch_val}' does not exist in "
+                            f"'{check_repo}'. Create the branch on the remote (or use "
+                            f"Create Branch) before pointing this namespace at it."
+                        ),
+                    )
 
     # Update only provided fields (None means no change)
     if config.github_repo_path is not None:

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -892,13 +892,12 @@ async def update_namespace_git_config(
             )
 
     # --- Git-config invariants (guard against the class of misconfiguration that
-    # silently strands namespaces on branches that don't exist) ---
-    if config.git_branch is not None:
-        new_branch_val = config.git_branch or None
-        branch_changing = new_branch_val != node_namespace.git_branch
-
+    # silently strands namespaces on branches that don't exist). Only relevant when
+    # the branch is actually changing, so we skip the DB/GitHub lookups otherwise. ---
+    new_branch_val = config.git_branch or None
+    if config.git_branch is not None and new_branch_val != node_namespace.git_branch:
         # Resolve the effective git config for THIS namespace before the update so
-        # both guards can reason about the default branch and the repo to check.
+        # the guards can reason about the default branch and the repo to check.
         current_info = await get_git_info_for_namespace(session, namespace)
         default_branch = (current_info or {}).get("default_branch")
 
@@ -907,13 +906,7 @@ async def update_namespace_git_config(
         # be repointed to some other branch here — that is what corrupts the "main"
         # view for everyone. Branch work belongs in Create Branch, which spins up a
         # separate branch namespace instead of mutating the default one.
-        if (
-            branch_changing
-            and node_namespace.git_branch
-            and default_branch
-            and node_namespace.git_branch == default_branch
-            and new_branch_val != default_branch
-        ):
+        if default_branch and node_namespace.git_branch == default_branch:
             raise DJInvalidInputException(
                 message=(
                     f"'{namespace}' is pinned to the default branch "
@@ -927,21 +920,15 @@ async def update_namespace_git_config(
         # was deleted (or never created) leaves the namespace pointing at a ghost ref,
         # so every sync silently fails. Only enforced when GitHub is configured; if the
         # API is unreachable we fail open rather than blocking namespace administration.
-        if (
-            branch_changing
-            and new_branch_val
-            and (settings.github_service_token or settings.github_app_id)
-        ):
+        if new_branch_val and (settings.github_service_token or settings.github_app_id):
             check_repo = new_repo
             if not check_repo and new_parent:
                 check_repo, _, _ = await resolve_git_config(session, new_parent)
             if check_repo:
                 try:
-                    branch_exists = bool(
-                        await GitHubService().get_branch(
-                            check_repo,
-                            new_branch_val,
-                        ),
+                    exists = await GitHubService().branch_exists(
+                        check_repo,
+                        new_branch_val,
                     )
                 except GitHubServiceError as exc:  # pragma: no cover
                     _logger.warning(
@@ -950,8 +937,8 @@ async def update_namespace_git_config(
                         check_repo,
                         exc,
                     )
-                    branch_exists = True
-                if not branch_exists:
+                    exists = True
+                if not exists:
                     raise DJInvalidInputException(
                         message=(
                             f"Branch '{new_branch_val}' does not exist in "

--- a/datajunction-server/datajunction_server/internal/git/github_service.py
+++ b/datajunction-server/datajunction_server/internal/git/github_service.py
@@ -191,6 +191,10 @@ class GitHubService:
             self._handle_error(resp, "get branch")
             return resp.json()
 
+    async def branch_exists(self, repo_path: str, branch: str) -> bool:
+        """Return True if the branch exists on the remote (False on 404)."""
+        return await self.get_branch(repo_path, branch) is not None
+
     async def create_branch(
         self,
         repo_path: str,

--- a/datajunction-server/datajunction_server/internal/git/yaml_export.py
+++ b/datajunction-server/datajunction_server/internal/git/yaml_export.py
@@ -35,13 +35,22 @@ async def fetch_existing_yaml_map(
     github_repo_path: str,
     git_branch: str,
     git_path: Optional[str],
+    *,
+    raise_on_error: bool = False,
 ) -> Dict[str, str]:
     """
     Download the configured git branch as a tarball and return a mapping of
     `<git_path>/<file>.yaml` -> file contents for every YAML in the repo
     (or under git_path if configured).
 
-    Returns an empty dict if the archive cannot be fetched or extracted.
+    When ``raise_on_error`` is False (default) this returns an empty dict if the
+    archive cannot be fetched — appropriate for best-effort comment preservation.
+
+    When ``raise_on_error`` is True the underlying ``GitHubServiceError`` is
+    re-raised instead. Callers that use this map as the *baseline* for a commit
+    (e.g. sync-to-git, which computes orphan deletions from it) must pass True:
+    silently treating an unreadable branch as empty would let the commit clobber
+    or mis-diff the branch — a silent failure with real data consequences.
     """
     existing_files_map: Dict[str, str] = {}
 
@@ -53,6 +62,8 @@ async def fetch_existing_yaml_map(
             format="tarball",
         )
     except GitHubServiceError as e:
+        if raise_on_error:
+            raise
         _logger.warning(
             "Failed to download git archive for namespace export merge: %s",
             e,

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -395,6 +395,98 @@ class TestNamespaceGitConfig:
         assert response.json()["git_branch"] == "real-branch"
 
     @pytest.mark.asyncio
+    async def test_update_git_config_branch_check_resolves_repo_from_parent(
+        self,
+        client_with_service_setup: AsyncClient,
+        monkeypatch,
+    ):
+        """A branch namespace inherits no repo of its own, so the branch-existence
+        guard must resolve the repo to check from its parent namespace."""
+        from datajunction_server.api import namespaces as namespaces_module
+
+        # Parent owns the repo; no default_branch is set so Guard 1 is skipped.
+        await client_with_service_setup.post("/namespaces/inherit_proj.root")
+        await client_with_service_setup.patch(
+            "/namespaces/inherit_proj.root/git",
+            json={"github_repo_path": "myorg/inheritrepo"},
+        )
+        # Child points at the parent on some feature branch (GitHub not yet
+        # configured, so the branch check is skipped during this setup).
+        await client_with_service_setup.post("/namespaces/inherit_proj.child")
+        await client_with_service_setup.patch(
+            "/namespaces/inherit_proj.child/git",
+            json={
+                "parent_namespace": "inherit_proj.root",
+                "git_branch": "feature-a",
+            },
+        )
+
+        monkeypatch.setattr(
+            namespaces_module.settings,
+            "github_service_token",
+            "test-token",
+        )
+        mock_service = MagicMock()
+        mock_service.branch_exists = AsyncMock(return_value=True)
+        with patch(
+            "datajunction_server.api.namespaces.GitHubService",
+            return_value=mock_service,
+        ):
+            response = await client_with_service_setup.patch(
+                "/namespaces/inherit_proj.child/git",
+                json={"git_branch": "feature-b"},
+            )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["git_branch"] == "feature-b"
+        # The repo checked was the one inherited from the parent namespace.
+        mock_service.branch_exists.assert_awaited_once_with(
+            "myorg/inheritrepo",
+            "feature-b",
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_git_config_branch_check_skipped_without_repo(
+        self,
+        client_with_service_setup: AsyncClient,
+        monkeypatch,
+    ):
+        """When no repo can be resolved (no repo of its own, no parent), the
+        branch-existence guard is skipped and the update proceeds."""
+        from datajunction_server.api import namespaces as namespaces_module
+
+        monkeypatch.setattr(
+            namespaces_module.settings,
+            "github_service_token",
+            "test-token",
+        )
+
+        await client_with_service_setup.post("/namespaces/no_repo_branch_ns")
+        mock_service = MagicMock()
+        mock_service.branch_exists = AsyncMock(return_value=False)
+        with patch(
+            "datajunction_server.api.namespaces.GitHubService",
+            return_value=mock_service,
+        ):
+            response = await client_with_service_setup.patch(
+                "/namespaces/no_repo_branch_ns/git",
+                json={"git_branch": "some-branch"},
+            )
+        assert response.status_code == HTTPStatus.OK
+        # No git root is resolvable, so the effective config comes back empty.
+        assert response.json() == {
+            "github_repo_path": None,
+            "git_path": None,
+            "git_branch": None,
+            "default_branch": None,
+            "parent_namespace": None,
+            "git_only": False,
+            "branch_namespace": None,
+            "git_root_namespace": None,
+        }
+        # No repo to check against, so the remote was never consulted.
+        mock_service.branch_exists.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_update_git_config_same_repo_different_path_ok(
         self,
         client_with_service_setup: AsyncClient,

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -283,6 +283,118 @@ class TestNamespaceGitConfig:
         )
 
     @pytest.mark.asyncio
+    async def test_update_git_config_cannot_repoint_default_branch(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """The default-branch namespace cannot be repointed to another branch.
+
+        This is the invariant that prevents a user from silently redirecting the
+        canonical 'main' view of a namespace onto an arbitrary branch (which is
+        what corrupted production).
+        """
+        root = "guard_default.root"
+        branch_ns = "guard_default.root.main"
+
+        await client_with_service_setup.post(f"/namespaces/{root}")
+        await client_with_service_setup.patch(
+            f"/namespaces/{root}/git",
+            json={"github_repo_path": "myorg/guardrepo", "default_branch": "main"},
+        )
+
+        # Pinning the branch namespace to the default branch is the canonical
+        # 'main' namespace setup and is allowed.
+        await client_with_service_setup.post(f"/namespaces/{branch_ns}")
+        ok = await client_with_service_setup.patch(
+            f"/namespaces/{branch_ns}/git",
+            json={"parent_namespace": root, "git_branch": "main"},
+        )
+        assert ok.status_code == HTTPStatus.OK
+
+        # Repointing it off the default branch must be rejected.
+        response = await client_with_service_setup.patch(
+            f"/namespaces/{branch_ns}/git",
+            json={"parent_namespace": root, "git_branch": "some-feature"},
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert "pinned to the default branch 'main'" in response.json()["message"]
+        assert "Create Branch" in response.json()["message"]
+
+        # The stored branch is unchanged.
+        get_response = await client_with_service_setup.get(
+            f"/namespaces/{branch_ns}/git",
+        )
+        assert get_response.json()["git_branch"] == "main"
+
+    @pytest.mark.asyncio
+    async def test_update_git_config_rejects_nonexistent_branch(
+        self,
+        client_with_service_setup: AsyncClient,
+        monkeypatch,
+    ):
+        """A namespace cannot be pointed at a branch that doesn't exist on the remote."""
+        from datajunction_server.api import namespaces as namespaces_module
+
+        monkeypatch.setattr(
+            namespaces_module.settings,
+            "github_service_token",
+            "test-token",
+        )
+
+        mock_service = MagicMock()
+        mock_service.get_branch = AsyncMock(return_value=None)  # 404 -> ghost branch
+        await client_with_service_setup.post("/namespaces/ghost_branch_ns")
+        with patch(
+            "datajunction_server.api.namespaces.GitHubService",
+            return_value=mock_service,
+        ):
+            response = await client_with_service_setup.patch(
+                "/namespaces/ghost_branch_ns/git",
+                json={
+                    "github_repo_path": "myorg/ghostrepo",
+                    "git_branch": "does-not-exist",
+                },
+            )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert "does not exist in 'myorg/ghostrepo'" in response.json()["message"]
+        mock_service.get_branch.assert_awaited_once_with(
+            "myorg/ghostrepo",
+            "does-not-exist",
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_git_config_allows_existing_branch(
+        self,
+        client_with_service_setup: AsyncClient,
+        monkeypatch,
+    ):
+        """When the target branch exists on the remote, the update succeeds."""
+        from datajunction_server.api import namespaces as namespaces_module
+
+        monkeypatch.setattr(
+            namespaces_module.settings,
+            "github_service_token",
+            "test-token",
+        )
+
+        mock_service = MagicMock()
+        mock_service.get_branch = AsyncMock(return_value={"name": "real-branch"})
+        await client_with_service_setup.post("/namespaces/real_branch_ns")
+        with patch(
+            "datajunction_server.api.namespaces.GitHubService",
+            return_value=mock_service,
+        ):
+            response = await client_with_service_setup.patch(
+                "/namespaces/real_branch_ns/git",
+                json={
+                    "github_repo_path": "myorg/realrepo",
+                    "git_branch": "real-branch",
+                },
+            )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["git_branch"] == "real-branch"
+
+    @pytest.mark.asyncio
     async def test_update_git_config_same_repo_different_path_ok(
         self,
         client_with_service_setup: AsyncClient,
@@ -1925,6 +2037,7 @@ class TestGitSync:
         ) as mock_github_class:
             mock_github = MagicMock()
             # File doesn't exist yet
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 return_value={
@@ -1969,6 +2082,7 @@ class TestGitSync:
         ) as mock_github_class:
             mock_github = MagicMock()
             # File exists
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-sha-123",
@@ -2030,6 +2144,7 @@ class TestGitSync:
             ) as mock_node_spec_to_yaml,
         ):
             mock_github = MagicMock()
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-sha-456",
@@ -2117,6 +2232,7 @@ class TestGitSync:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 return_value={
@@ -2158,6 +2274,7 @@ class TestGitSync:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 side_effect=GitHubServiceError(
@@ -2195,9 +2312,14 @@ class TestGitSync:
             },
         )
 
-        with patch(
-            "datajunction_server.api.git_sync.GitHubService",
-        ) as mock_github_class:
+        with (
+            patch(
+                "datajunction_server.api.git_sync.GitHubService",
+            ) as mock_github_class,
+            patch(
+                "datajunction_server.internal.git.yaml_export.GitHubService",
+            ) as mock_fetch_github_class,
+        ):
             mock_github = MagicMock()
             # Mock download_archive to return empty tarball
             mock_github.download_archive = AsyncMock(
@@ -2211,6 +2333,7 @@ class TestGitSync:
                 },
             )
             mock_github_class.return_value = mock_github
+            mock_fetch_github_class.return_value = mock_github
 
             response = await client_with_roads.post(
                 "/namespaces/default/sync-to-git",
@@ -2592,6 +2715,7 @@ columns:
         ) as mock_github_class:
             mock_github = MagicMock()
             # Simulate file not existing by raising exception
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(side_effect=Exception("File not found"))
             mock_github.commit_file = AsyncMock(
                 return_value={
@@ -2644,6 +2768,7 @@ mode: published
         ) as mock_github_class:
             mock_github = MagicMock()
             # Return existing file with base64 content
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-file-sha",
@@ -2730,6 +2855,7 @@ dimensions:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-cube-sha",
@@ -2881,9 +3007,14 @@ dimensions:
             },
         )
 
-        with patch(
-            "datajunction_server.api.git_sync.GitHubService",
-        ) as mock_github_class:
+        with (
+            patch(
+                "datajunction_server.api.git_sync.GitHubService",
+            ) as mock_github_class,
+            patch(
+                "datajunction_server.internal.git.yaml_export.GitHubService",
+            ) as mock_fetch_github_class,
+        ):
             mock_github = MagicMock()
             # Mock download_archive to return empty tarball
             mock_github.download_archive = AsyncMock(
@@ -2897,6 +3028,7 @@ dimensions:
                 ),
             )
             mock_github_class.return_value = mock_github
+            mock_fetch_github_class.return_value = mock_github
 
             response = await client_with_roads.post(
                 "/namespaces/default/sync-to-git",
@@ -2908,6 +3040,133 @@ dimensions:
                 "Failed to sync to git: Repository not found"
                 in response.json()["message"]
             )
+
+    @pytest.mark.asyncio
+    async def test_sync_namespace_missing_branch_fails_loudly(
+        self,
+        client_with_roads: AsyncClient,
+    ):
+        """Syncing to a branch that no longer exists must abort with a clear error.
+
+        Previously the baseline fetch swallowed the 404 and treated the branch as
+        empty, so the sync would silently proceed against a wrong view.
+        """
+        from datajunction_server.internal.git.github_service import GitHubServiceError
+
+        await client_with_roads.patch(
+            "/namespaces/default/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "ghost-branch"},
+        )
+
+        with (
+            patch(
+                "datajunction_server.api.git_sync.GitHubService",
+            ) as mock_github_class,
+            patch(
+                "datajunction_server.internal.git.yaml_export.GitHubService",
+            ) as mock_fetch_github_class,
+        ):
+            mock_github = MagicMock()
+            # The branch no longer exists on the remote -> archive download 404s.
+            mock_github.download_archive = AsyncMock(
+                side_effect=GitHubServiceError(
+                    "GitHub download tarball failed: Not Found",
+                    http_status_code=502,
+                    github_status=404,
+                ),
+            )
+            mock_github.commit_files = AsyncMock()
+            mock_github_class.return_value = mock_github
+            mock_fetch_github_class.return_value = mock_github
+
+            response = await client_with_roads.post(
+                "/namespaces/default/sync-to-git",
+                json={},
+            )
+
+            assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+            assert (
+                "Branch 'ghost-branch' does not exist in 'myorg/myrepo'"
+                in response.json()["message"]
+            )
+            # Crucially, we never attempted to commit against the wrong baseline.
+            mock_github.commit_files.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_namespace_unreadable_baseline_fails_loudly(
+        self,
+        client_with_roads: AsyncClient,
+    ):
+        """A non-404 failure reading the baseline must also abort, not commit blind."""
+        from datajunction_server.internal.git.github_service import GitHubServiceError
+
+        await client_with_roads.patch(
+            "/namespaces/default/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        with (
+            patch(
+                "datajunction_server.api.git_sync.GitHubService",
+            ) as mock_github_class,
+            patch(
+                "datajunction_server.internal.git.yaml_export.GitHubService",
+            ) as mock_fetch_github_class,
+        ):
+            mock_github = MagicMock()
+            mock_github.download_archive = AsyncMock(
+                side_effect=GitHubServiceError(
+                    "GitHub download tarball failed: Server Error",
+                    http_status_code=502,
+                    github_status=500,
+                ),
+            )
+            mock_github.commit_files = AsyncMock()
+            mock_github_class.return_value = mock_github
+            mock_fetch_github_class.return_value = mock_github
+
+            response = await client_with_roads.post(
+                "/namespaces/default/sync-to-git",
+                json={},
+            )
+
+            assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+            assert (
+                "Could not read the current state of branch 'main'"
+                in response.json()["message"]
+            )
+            mock_github.commit_files.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_node_missing_branch_fails_loudly(
+        self,
+        client_with_roads: AsyncClient,
+    ):
+        """Syncing a node to a branch that no longer exists aborts with a clear error."""
+        await client_with_roads.patch(
+            "/namespaces/default/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "ghost-branch"},
+        )
+
+        with patch(
+            "datajunction_server.api.git_sync.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.get_branch = AsyncMock(return_value=None)  # branch is gone
+            mock_github.commit_file = AsyncMock()
+            mock_github_class.return_value = mock_github
+
+            response = await client_with_roads.post(
+                "/nodes/default.repair_orders/sync-to-git",
+                json={},
+            )
+
+            assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+            assert (
+                "Branch 'ghost-branch' does not exist in 'myorg/myrepo'"
+                in response.json()["message"]
+            )
+            mock_github.commit_file.assert_not_called()
 
 
 class TestPullRequest:
@@ -4452,6 +4711,7 @@ class TestGitHubServiceErrorHandling:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(return_value=None)
             # Simulate a GitHub error with detailed errors array
             mock_github.commit_file = AsyncMock(
@@ -5050,6 +5310,7 @@ class TestGitSyncEdgeCases:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
+            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 return_value={

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -342,7 +342,7 @@ class TestNamespaceGitConfig:
         )
 
         mock_service = MagicMock()
-        mock_service.get_branch = AsyncMock(return_value=None)  # 404 -> ghost branch
+        mock_service.branch_exists = AsyncMock(return_value=False)  # ghost branch
         await client_with_service_setup.post("/namespaces/ghost_branch_ns")
         with patch(
             "datajunction_server.api.namespaces.GitHubService",
@@ -357,7 +357,7 @@ class TestNamespaceGitConfig:
             )
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         assert "does not exist in 'myorg/ghostrepo'" in response.json()["message"]
-        mock_service.get_branch.assert_awaited_once_with(
+        mock_service.branch_exists.assert_awaited_once_with(
             "myorg/ghostrepo",
             "does-not-exist",
         )
@@ -378,7 +378,7 @@ class TestNamespaceGitConfig:
         )
 
         mock_service = MagicMock()
-        mock_service.get_branch = AsyncMock(return_value={"name": "real-branch"})
+        mock_service.branch_exists = AsyncMock(return_value=True)
         await client_with_service_setup.post("/namespaces/real_branch_ns")
         with patch(
             "datajunction_server.api.namespaces.GitHubService",
@@ -2037,7 +2037,7 @@ class TestGitSync:
         ) as mock_github_class:
             mock_github = MagicMock()
             # File doesn't exist yet
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 return_value={
@@ -2082,7 +2082,7 @@ class TestGitSync:
         ) as mock_github_class:
             mock_github = MagicMock()
             # File exists
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-sha-123",
@@ -2144,7 +2144,7 @@ class TestGitSync:
             ) as mock_node_spec_to_yaml,
         ):
             mock_github = MagicMock()
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-sha-456",
@@ -2232,7 +2232,7 @@ class TestGitSync:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 return_value={
@@ -2274,7 +2274,7 @@ class TestGitSync:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 side_effect=GitHubServiceError(
@@ -2715,7 +2715,7 @@ columns:
         ) as mock_github_class:
             mock_github = MagicMock()
             # Simulate file not existing by raising exception
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(side_effect=Exception("File not found"))
             mock_github.commit_file = AsyncMock(
                 return_value={
@@ -2768,7 +2768,7 @@ mode: published
         ) as mock_github_class:
             mock_github = MagicMock()
             # Return existing file with base64 content
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-file-sha",
@@ -2855,7 +2855,7 @@ dimensions:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(
                 return_value={
                     "sha": "existing-cube-sha",
@@ -3152,7 +3152,7 @@ dimensions:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
-            mock_github.get_branch = AsyncMock(return_value=None)  # branch is gone
+            mock_github.branch_exists = AsyncMock(return_value=False)  # branch is gone
             mock_github.commit_file = AsyncMock()
             mock_github_class.return_value = mock_github
 
@@ -4711,7 +4711,7 @@ class TestGitHubServiceErrorHandling:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(return_value=None)
             # Simulate a GitHub error with detailed errors array
             mock_github.commit_file = AsyncMock(
@@ -5310,7 +5310,7 @@ class TestGitSyncEdgeCases:
             "datajunction_server.api.git_sync.GitHubService",
         ) as mock_github_class:
             mock_github = MagicMock()
-            mock_github.get_branch = AsyncMock(return_value={"name": "main"})
+            mock_github.branch_exists = AsyncMock(return_value=True)
             mock_github.get_file = AsyncMock(return_value=None)
             mock_github.commit_file = AsyncMock(
                 return_value={

--- a/datajunction-server/tests/internal/git/test_github_service.py
+++ b/datajunction-server/tests/internal/git/test_github_service.py
@@ -260,6 +260,24 @@ class TestGetBranch:
             assert branch is None
 
 
+class TestBranchExists:
+    """Tests for branch_exists method."""
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_true(self, github_service):
+        """Should return True when get_branch resolves to a branch payload."""
+        github_service.get_branch = AsyncMock(return_value={"name": "main"})
+        assert await github_service.branch_exists("owner/repo", "main") is True
+        github_service.get_branch.assert_awaited_once_with("owner/repo", "main")
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_false(self, github_service):
+        """Should return False when get_branch returns None (404)."""
+        github_service.get_branch = AsyncMock(return_value=None)
+        assert await github_service.branch_exists("owner/repo", "ghost") is False
+        github_service.get_branch.assert_awaited_once_with("owner/repo", "ghost")
+
+
 class TestCreateBranch:
     """Tests for create_branch method."""
 

--- a/datajunction-server/tests/internal/git/test_yaml_export.py
+++ b/datajunction-server/tests/internal/git/test_yaml_export.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from datajunction_server.internal.git.github_service import GitHubServiceError
 from datajunction_server.internal.git.yaml_export import fetch_existing_yaml_map
 
 
@@ -72,6 +73,42 @@ async def test_fetch_existing_yaml_map_empty_archive():
             git_path=None,
         )
     assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_existing_yaml_map_download_error_best_effort():
+    """When the archive can't be fetched and raise_on_error is False (default),
+    the error is swallowed and an empty map is returned for best-effort use."""
+    with patch(
+        "datajunction_server.internal.git.yaml_export.GitHubService",
+    ) as mock_cls:
+        mock_cls.return_value.download_archive = AsyncMock(
+            side_effect=GitHubServiceError("boom"),
+        )
+        result = await fetch_existing_yaml_map(
+            github_repo_path="org/repo",
+            git_branch="main",
+            git_path=None,
+        )
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_existing_yaml_map_download_error_raises():
+    """When raise_on_error is True, the underlying GitHubServiceError propagates."""
+    with patch(
+        "datajunction_server.internal.git.yaml_export.GitHubService",
+    ) as mock_cls:
+        mock_cls.return_value.download_archive = AsyncMock(
+            side_effect=GitHubServiceError("boom"),
+        )
+        with pytest.raises(GitHubServiceError):
+            await fetch_existing_yaml_map(
+                github_repo_path="org/repo",
+                git_branch="main",
+                git_path=None,
+                raise_on_error=True,
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

A namespace's git config could be pointed at a branch that doesn't exist on the remote. Nothing caught this setting at config time, so the failure surfaced much later, causing every sync-to-git to fail deep inside `commit_file` with an opaque error. `sync_namespace_to_git` also treated an unreadable branch as empty, meaning a blind commit could clobber or mis-diff files (orphan-deletion is computed from that baseline).

This adds config-time guards to `update_namespace_git_config` when the branch is actually changing:
- Protect the default branch: a namespace pinned to its repo's default branch can't be repointed to another branch here.
- Branch must exist on the remote: reject pointing a namespace at a ghost ref. Enforced only when GitHub is configured; the repo to check is resolved from the namespace itself or inherited from its parent. Allows the update and logs a warning if the GitHub API is unreachable, so remote hiccups don't block namespace administration.

Sync-time hardening:
- `sync_node_to_git` checks `branch_exists` up front and raises a clear, actionable "branch does not exist … recreate it or update git config" message instead of an opaque ref error.
- `sync_namespace_to_git` now fetches the baseline YAML with `raise_on_error=True`.

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
