### PR TITLE
Fix required dimensions from linked dimensions across namespaces

### DIFF
--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -178,7 +178,7 @@ class Column(Base):  # type: ignore
         """
         Full column name that includes the node it belongs to, i.e., default.hard_hat.first_name
         """
-        return f"{self.node_revision.name}.{self.name}"  # type: ignore  # pragma: no cover
+        return f"{self.node_revision.name}.{self.name}"  # type: ignore
 
     def copy(self) -> "Column":
         """

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -618,10 +618,25 @@ class Node(Base):
                 legacy_from_md,
             )
 
+            # A required dimension that is a direct column on a parent node is
+            # exported as its bare column name (portable as-is). One that lives on
+            # a node elsewhere on the graph (e.g. a linked dimension) is exported
+            # as its fully-qualified `node.column` path, so a re-deploy into a
+            # different namespace can still find it — the bare name would fail to
+            # resolve against the parents. Prefix parameterization (`${prefix}`) is
+            # applied later, in get_node_specs_for_export, and only for in-deploy
+            # nodes. Only touch ``parents`` when there are required dims to classify.
+            required_dimensions_spec: list[str] = []
+            if self.current.required_dimensions:
+                parent_names = {parent.name for parent in self.current.parents}
+                required_dimensions_spec = sorted(
+                    col.name
+                    if col.node_revision.name in parent_names
+                    else col.full_name()
+                    for col in self.current.required_dimensions
+                )
             extra_kwargs.update(
-                required_dimensions=sorted(
-                    col.name for col in self.current.required_dimensions
-                ),
+                required_dimensions=required_dimensions_spec,
                 direction=self.current.metric_metadata.direction
                 if self.current.metric_metadata
                 else None,
@@ -1727,7 +1742,11 @@ class NodeRevision(
                 ),
                 joinedload(DimensionLink.node_revision),
             ),
-            selectinload(NodeRevision.required_dimensions),
+            selectinload(NodeRevision.required_dimensions).options(
+                # to_spec reads col.full_name() -> col.node_revision.name for
+                # off-graph required dimensions; preload it to avoid MissingGreenlet.
+                joinedload(Column.node_revision).load_only(NodeRevision.name),
+            ),
             selectinload(NodeRevision.cube_elements)
             .selectinload(Column.node_revision)
             .options(

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import joinedload, selectinload, defer, load_only, noload
 from datajunction_server.api.helpers import (
     get_node_namespace,
     COLUMN_NAME_REGEX,
+    _resolve_required_dimensions,
     map_dimensions_to_roles,
 )
 from datajunction_server.construction.build_v2 import FullColumnName
@@ -1577,8 +1578,26 @@ class DeploymentOrchestrator:
 
         deployed_results, deployed_nodes = [], {}
 
+        # Deploy-ordering graph: augment the dependency graph with each metric's
+        # required-dimension nodes, so a dimension referenced only via
+        # required_dimensions (not a query parent) still deploys before the metric
+        # that needs it. Kept separate from plan.node_graph so it never leaks into
+        # parent classification — these are ordering edges, not parents.
+        ordering_graph = {name: list(deps) for name, deps in plan.node_graph.items()}
+        for node_spec in plan.to_deploy:
+            if isinstance(node_spec, MetricSpec) and node_spec.required_dimensions:
+                for required_dim in node_spec.rendered_required_dimensions:
+                    if SEPARATOR not in required_dim:
+                        continue
+                    dim_node = required_dim.rsplit(SEPARATOR, 1)[0]
+                    if dim_node == node_spec.rendered_name:  # pragma: no cover
+                        continue
+                    deps = ordering_graph.setdefault(node_spec.rendered_name, [])
+                    if dim_node not in deps:
+                        deps.append(dim_node)
+
         # Order nodes topologically based on dependencies
-        levels = topological_levels(plan.node_graph, ascending=False)
+        levels = topological_levels(ordering_graph, ascending=False)
         logger.info(
             "Deploying nodes in topological order with %d levels",
             len(levels),
@@ -3775,17 +3794,29 @@ class DeploymentOrchestrator:
                     min_decimal_exponent=metric_spec.min_decimal_exponent,
                 )
 
-            # Assign required dimensions if specified and present in columns
+            # Bind required dimensions. A required dim is either a bare column on a
+            # parent, or a fully-qualified `node.column` path pointing at a node
+            # elsewhere on the graph (e.g. a dimension linked to a parent). Resolve
+            # both against the accumulated in-flight node map (dependency_nodes) —
+            # the same context validation uses. `${prefix}` is rendered to the target
+            # namespace so cross-namespace deploys bind to the right node.
+            #
+            # The referenced dim node is guaranteed to already be in dependency_nodes
+            # because the deploy-ordering graph adds it as an ordering dependency, so
+            # it deploys in an earlier topological level than this metric.
             if metric_spec.required_dimensions:
-                required_dimensions = []
-                origin_node = new_revision.parents[0].current
-                columns_mapping = {col.name: col for col in origin_node.columns}
-                for dim in metric_spec.required_dimensions:
-                    if dim in columns_mapping:
-                        required_dimensions.append(
-                            columns_mapping[dim],
-                        )  # pragma: no cover
-                new_revision.required_dimensions = required_dimensions
+                parent_columns = [
+                    col
+                    for parent in new_revision.parents
+                    if parent.current
+                    for col in parent.current.columns
+                ]
+                _, matched_columns = _resolve_required_dimensions(
+                    metric_spec.rendered_required_dimensions,
+                    parent_columns,
+                    dependency_nodes,
+                )
+                new_revision.required_dimensions = matched_columns
         return new_revision
 
     def _resolve_metric_unit(

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -601,7 +601,9 @@ class NodeSpecBulkValidator:
         """
         req_dim_node_names: set[str] = set()
         for spec in specs:
-            for req_dim in getattr(spec, "required_dimensions", None) or []:
+            # Use rendered (${prefix}-resolved) paths so the dim node names match
+            # the deployed/target namespace, not the parameterized export form.
+            for req_dim in getattr(spec, "rendered_required_dimensions", None) or []:
                 if SEPARATOR in req_dim:
                     dim_node_name = req_dim.rsplit(SEPARATOR, 1)[0]
                     req_dim_node_names.add(dim_node_name)
@@ -685,7 +687,9 @@ class NodeSpecBulkValidator:
         pre-populated in a single batch query by _prefetch_required_dimension_nodes
         rather than per-node.
         """
-        required_dimensions = getattr(spec, "required_dimensions", None) or []
+        # Rendered (${prefix}-resolved) paths so full-path required dims resolve
+        # against the deployed namespace's nodes rather than the export form.
+        required_dimensions = getattr(spec, "rendered_required_dimensions", None) or []
         if not required_dimensions:
             return None
 

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -37,6 +37,7 @@ from datajunction_server.models.deployment import (
     DeploymentSourceType,
     GitDeploymentSource,
     LocalDeploymentSource,
+    MetricSpec,
     NamespaceSourcesResponse,
     NodeSpec,
 )
@@ -1164,6 +1165,24 @@ async def get_node_specs_for_export(
             NodeType.METRIC,
         ):
             node_spec.query = inject_prefixes(node_spec.query, namespace)
+        if node_spec.node_type == NodeType.METRIC:
+            metric_spec = cast(MetricSpec, node_spec)
+            if metric_spec.required_dimensions:
+                # Required dims that are full `node.column` paths get the same
+                # in-deploy-vs-external treatment as cube refs: parameterized to
+                # ${prefix} when the node is part of this deployment, left as the
+                # raw full path when it's external. Bare column names (direct parent
+                # columns) contain no namespace prefix, so they pass through
+                # unchanged.
+                metric_spec.required_dimensions = [
+                    _inject_prefix_for_cube_ref(
+                        required_dim,
+                        namespace,
+                        parent_namespace,
+                        namespace_suffixes,
+                    )
+                    for required_dim in metric_spec.required_dimensions
+                ]
         if node_spec.node_type in (
             NodeType.SOURCE,
             NodeType.TRANSFORM,

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -581,6 +581,22 @@ class MetricSpec(NodeSpec):
             return None
         return self.unit_enum.value.name.lower()
 
+    @property
+    def rendered_required_dimensions(self) -> list[str]:
+        """
+        Required dimensions with `${prefix}` resolved to this spec's namespace.
+
+        Full `node.column` paths that were parameterized on export (in-deploy
+        nodes) map back to the target namespace here; bare column names and raw
+        external paths contain no `${prefix}` and pass through unchanged.
+        """
+        return [
+            render_prefixes(required_dim, self.namespace)
+            if "${prefix}" in required_dim
+            else required_dim
+            for required_dim in (self.required_dimensions or [])
+        ]
+
     def model_dump(self, **kwargs):  # pragma: no cover
         base = super().model_dump(**kwargs)
         base["unit"] = self.unit

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1599,6 +1599,94 @@ class TestDeployments:
         )
 
     @pytest.mark.asyncio
+    async def test_required_dimension_from_linked_dimension_roundtrips(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        A metric whose required dimension lives on a dimension linked to its
+        upstream transform must survive a pull-from-A / push-to-B round trip.
+
+        Regression test for the bug where such a required dimension exported as
+        its bare column name, which then failed to resolve against the metric's
+        parents in the target namespace ("references to columns as required
+        dimensions that are not on parent nodes").
+        """
+        # A transform that carries a dimension link to us_state, and a metric on
+        # that transform whose required dimension is a *us_state* column — i.e. a
+        # dimension elsewhere on the graph, not a direct column of the parent.
+        hard_hat_facts = TransformSpec(
+            name="default.hard_hat_facts",
+            node_type=NodeType.TRANSFORM,
+            query="SELECT hard_hat_id, state FROM ${prefix}default.hard_hats",
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="${prefix}default.us_state",
+                    join_type="inner",
+                    join_on=(
+                        "${prefix}default.hard_hat_facts.state = "
+                        "${prefix}default.us_state.state_short"
+                    ),
+                ),
+            ],
+            owners=["dj"],
+        )
+        num_hard_hats = MetricSpec(
+            name="default.num_hard_hats",
+            node_type=NodeType.METRIC,
+            query="SELECT COUNT(*) FROM ${prefix}default.hard_hat_facts",
+            required_dimensions=["${prefix}default.us_state.state_name"],
+            owners=["dj"],
+        )
+        nodes = [
+            default_hard_hats,
+            default_us_states,
+            default_us_state,
+            hard_hat_facts,
+            num_hard_hats,
+        ]
+
+        # Deploy to namespace A.
+        data_a = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace="rt_a", nodes=nodes),
+        )
+        assert data_a["status"] == "success", data_a["results"]
+
+        # Export A: the required dimension is on a linked dimension (not a parent
+        # column), so it must export as a ${prefix}-parameterized full path.
+        export_a = (await client.get("/namespaces/rt_a/export/spec")).json()["nodes"]
+        metric_a = next(
+            spec
+            for spec in export_a
+            if spec["name"] == "${prefix}default.num_hard_hats"
+        )
+        assert metric_a["required_dimensions"] == [
+            "${prefix}default.us_state.state_name",
+        ]
+
+        # Push the exported specs to namespace B — this is what failed before.
+        deployment_b = DeploymentSpec.model_validate(
+            {"namespace": "rt_b", "nodes": export_a},
+        )
+        data_b = await deploy_and_wait(client, deployment_b)
+        assert data_b["status"] == "success", data_b["results"]
+
+        # The required dimension survived the round trip and re-bound in B.
+        export_b = (await client.get("/namespaces/rt_b/export/spec")).json()["nodes"]
+        metric_b = next(
+            spec
+            for spec in export_b
+            if spec["name"] == "${prefix}default.num_hard_hats"
+        )
+        assert metric_b["required_dimensions"] == [
+            "${prefix}default.us_state.state_name",
+        ]
+
+    @pytest.mark.asyncio
     async def test_deploy_dimension_with_update(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1634,11 +1634,16 @@ class TestDeployments:
             ],
             owners=["dj"],
         )
+        # Two required dims on the SAME linked dimension node — exercises the
+        # dedup when adding deploy-ordering edges (the node is only added once).
         num_hard_hats = MetricSpec(
             name="default.num_hard_hats",
             node_type=NodeType.METRIC,
             query="SELECT COUNT(*) FROM ${prefix}default.hard_hat_facts",
-            required_dimensions=["${prefix}default.us_state.state_name"],
+            required_dimensions=[
+                "${prefix}default.us_state.state_name",
+                "${prefix}default.us_state.state_region",
+            ],
             owners=["dj"],
         )
         nodes = [
@@ -1666,6 +1671,7 @@ class TestDeployments:
         )
         assert metric_a["required_dimensions"] == [
             "${prefix}default.us_state.state_name",
+            "${prefix}default.us_state.state_region",
         ]
 
         # Push the exported specs to namespace B — this is what failed before.
@@ -1684,6 +1690,7 @@ class TestDeployments:
         )
         assert metric_b["required_dimensions"] == [
             "${prefix}default.us_state.state_name",
+            "${prefix}default.us_state.state_region",
         ]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

A metric whose required dimension lives on a dimension linked to its upstream transform (rather than a direct column of a parent) could not be round-tripped across namespaces via `dj pull` from namespace A and `dj push` to namespace B. The push failed metric creation with:
```
[invalid] Node definition contains references to columns as required dimensions that are not on parent nodes.
```

This is because the required dimensions on metric nodes were exported as bare column names (e.g., `country_id`). A bare name only resolves against the metric's direct parent columns, so a dimension elsewhere on the graph (e.g. `us_state.state_name` linked to the parent transform) couldn't be found in the target namespace. Two further gaps meant even a fully-qualified path may not have worked: the export never `${prefix}`-parameterized `required_dimensions`, and the deploy-time binding matched bare names against the first parent only.

This PR makes the export carry enough information to relocate the reference, and makes the deployment orchestrator resolve it:
- Export (`database/node.py`): `to_spec` emits the bare column name when the required dim is a direct parent column (portable as-is), and the fully-qualified `node.column` or `${prefix}node.column` path when it lives elsewhere on the graph.
- Parameterize (`internal/namespaces.py`): `get_node_specs_for_export` runs each required dim through `_inject_prefix_for_cube_ref` so that `${prefix}` is injected for nodes within this deployment, leaving the raw full path for external nodes.
- Render on deploy (`models/deployment.py`): new `MetricSpec.rendered_required_dimensions` resolves `${prefix}` to the target namespace.
- Order + bind (`internal/deployment/orchestrator.py`): a required-dimension node is added as a deploy-ordering dependency (separate from parent classification) so it deploys before the metric, and binding now uses `_resolve_required_dimensions` which handles both bare-columns and full-paths.
- Validate on deploy (`internal/deployment/validation.py`): required-dimension validation now uses the rendered paths so full paths resolve against the deployed namespace's nodes.

### Test Plan

Added a new regression test `test_required_dimension_from_linked_dimension_roundtrips`, which deploys a metric with a required dimension sourced from a linked dimension into namespace A, exports it, re-deploys the exported specs to namespace B, and asserts that the required dimension is preserved and re-bound in B.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
