### PR TITLE
Refuse empty-spec deployments that would wipe a namespace

### DIFF
--- a/datajunction-clients/python/datajunction/cli.py
+++ b/datajunction-clients/python/datajunction/cli.py
@@ -46,6 +46,7 @@ class DJCLI:
         namespace: str | None = None,
         verbose: bool = False,
         force: bool = False,
+        allow_empty: bool = False,
     ):
         """
         Alias for deploy without dryrun.
@@ -55,6 +56,7 @@ class DJCLI:
             namespace=namespace,
             verbose=verbose,
             force=force,
+            allow_empty=allow_empty,
         )
 
     def dryrun(
@@ -892,6 +894,15 @@ class DJCLI:
             help="Force update all nodes even if they are unchanged",
         )
         push_parser.add_argument(
+            "--allow-empty",
+            action="store_true",
+            help=(
+                "Allow a push with no node files to soft-delete all nodes in the "
+                "target namespace (otherwise refused, to guard against an "
+                "accidental empty or mistyped directory)"
+            ),
+        )
+        push_parser.add_argument(
             "--format",
             type=str,
             default="text",
@@ -1502,6 +1513,7 @@ class DJCLI:
                     namespace=args.namespace,
                     verbose=args.verbose,
                     force=args.force,
+                    allow_empty=args.allow_empty,
                 )
             except DJDeploymentFailure:
                 # Errors already displayed in the deployment panel

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -107,6 +107,7 @@ class DeploymentService:
         console: Console | None = None,
         verbose: bool = False,
         force: bool = False,
+        allow_empty: bool = False,
     ):
         """
         Push a local project to a namespace.
@@ -159,6 +160,8 @@ class DeploymentService:
                 )
         if force:
             deployment_spec["force"] = True
+        if allow_empty:
+            deployment_spec["allow_empty"] = True
         deployment_data = self.client.deploy(deployment_spec)
         deployment_uuid = deployment_data["uuid"]
 
@@ -475,6 +478,16 @@ class DeploymentService:
         Reads exported YAML files and reconstructs a DeploymentSpec-compatible dict.
         Returns (deployment_spec, warnings).
         """
+        # A non-existent directory silently yields zero node files, which the
+        # server would interpret as "delete every node in the namespace". Fail
+        # fast with a clear error instead of forming an empty spec (issue #2301).
+        if not Path(base_dir).is_dir():
+            raise DJClientException(
+                f"Directory not found: {base_dir}. Refusing to push an empty "
+                f"deployment -- an empty node set would soft-delete the nodes in "
+                f"the target namespace. Check the path.",
+            )
+
         project_metadata = self._read_project_yaml(base_dir)
         nodes, warnings = self._collect_nodes_from_dir(base_dir)
 

--- a/datajunction-clients/python/tests/test_cli.py
+++ b/datajunction-clients/python/tests/test_cli.py
@@ -1457,6 +1457,37 @@ class TestImpactAnalysis:
         _, kwargs = mock_push.call_args
         assert kwargs.get("force") is False
 
+    def test_push_allow_empty_flag_passed_to_service(self, tmp_path):
+        """--allow-empty on `dj push` must propagate allow_empty=True (issue #2301)."""
+        from datajunction.cli import DJCLI
+
+        cli = DJCLI(builder_client=mock.MagicMock())
+        with patch.object(cli.deployment_service, "push") as mock_push:
+            mock_push.return_value = None
+            with patch.object(
+                sys,
+                "argv",
+                ["dj", "push", str(tmp_path), "--allow-empty"],
+            ):
+                cli.run()
+
+        mock_push.assert_called_once()
+        _, kwargs = mock_push.call_args
+        assert kwargs.get("allow_empty") is True
+
+    def test_push_without_allow_empty_defaults_false(self, tmp_path):
+        """Omitting --allow-empty on `dj push` must pass allow_empty=False."""
+        from datajunction.cli import DJCLI
+
+        cli = DJCLI(builder_client=mock.MagicMock())
+        with patch.object(cli.deployment_service, "push") as mock_push:
+            mock_push.return_value = None
+            with patch.object(sys, "argv", ["dj", "push", str(tmp_path)]):
+                cli.run()
+
+        _, kwargs = mock_push.call_args
+        assert kwargs.get("allow_empty") is False
+
 
 class TestDJCLIClientCreation:
     """Tests for DJCLI client creation from environment variables."""

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -601,6 +601,66 @@ def test_reconstruct_deployment_spec(tmp_path):
     assert spec["nodes"][0]["name"] == "foo.bar"
 
 
+def test_reconstruct_deployment_spec_missing_dir_raises(tmp_path):
+    """A non-existent directory must fail fast rather than form an empty spec.
+
+    Regression for issue #2301: an empty node set would otherwise be sent to
+    the server and interpreted as "delete every node in the namespace".
+    """
+    svc = DeploymentService(MagicMock())
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(DJClientException, match="Directory not found"):
+        svc._reconstruct_deployment_spec(missing)
+
+
+def _write_min_project(tmp_path):
+    """Write a minimal valid project (dj.yaml + one node) under tmp_path."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    node_dir = tmp_path / "foo"
+    node_dir.mkdir()
+    (node_dir / "bar.yaml").write_text(
+        yaml.safe_dump({"name": "foo.bar", "query": "SELECT 1"}),
+    )
+
+
+def test_push_threads_allow_empty(tmp_path):
+    """push(allow_empty=True) must set allow_empty on the deployment spec."""
+    _write_min_project(tmp_path)
+    svc = DeploymentService(MagicMock())
+
+    captured = {}
+
+    def fake_deploy(spec):
+        captured["spec"] = spec
+        # Short-circuit before the poll/print machinery -- we only care that
+        # the spec handed to the server carries the flag.
+        raise DJClientException("stop")
+
+    svc.client.deploy = MagicMock(side_effect=fake_deploy)
+
+    with pytest.raises(DJClientException, match="stop"):
+        svc.push(tmp_path, namespace="foo", allow_empty=True)
+    assert captured["spec"]["allow_empty"] is True
+
+
+def test_push_omits_allow_empty_by_default(tmp_path):
+    """Without allow_empty, the flag must not appear on the deployment spec."""
+    _write_min_project(tmp_path)
+    svc = DeploymentService(MagicMock())
+
+    captured = {}
+
+    def fake_deploy(spec):
+        captured["spec"] = spec
+        raise DJClientException("stop")
+
+    svc.client.deploy = MagicMock(side_effect=fake_deploy)
+
+    with pytest.raises(DJClientException, match="stop"):
+        svc.push(tmp_path, namespace="foo")
+    assert "allow_empty" not in captured["spec"]
+
+
 def test_system_seed_matches_server_deployment_spec():
     """
     The bundled system-node seed is deployed at bootstrap by

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -433,6 +433,8 @@ class DeploymentOrchestrator:
                 )
             self.deployed_results.extend(pre_results)
 
+        self._guard_against_accidental_wipe(deployment_plan)
+
         if deployment_plan.is_empty() and not self.deployment_spec.hierarchies:
             return DeploymentExecuteResult(
                 results=await self._handle_no_changes(),
@@ -3003,6 +3005,40 @@ class DeploymentOrchestrator:
         ]
 
         return to_create + to_update, to_skip, to_delete
+
+    def _guard_against_accidental_wipe(self, plan: "DeploymentPlan") -> None:
+        """Refuse to delete a populated namespace from an empty spec.
+
+        A deployment spec with zero nodes almost always means an accidental
+        empty push -- e.g. a mistyped ``directory`` argument on ``dj push``
+        that resolved to no node files. Interpreting that as "delete every
+        node in the namespace" is a silent data-loss footgun (issue #2301).
+        Require an explicit ``allow_empty`` opt-in for the rare intentional
+        teardown.
+
+        Note: this fires for dry-run as well, so a dry-run that *would* wipe a
+        namespace surfaces the refusal loudly rather than quietly listing the
+        deletions in its preview.
+        """
+        if self.deployment_spec.allow_empty or self.deployment_spec.nodes:
+            # Either the caller opted in, or the spec has nodes and the
+            # deletions are a genuine diff (e.g. removing a few of many).
+            return
+        if not plan.to_delete:
+            return  # empty spec, nothing to delete -- harmless
+
+        names = sorted(node.rendered_name for node in plan.to_delete)
+        preview = ", ".join(names[:5]) + (", …" if len(names) > 5 else "")
+        raise DJInvalidDeploymentConfig(
+            message=(
+                f"Refusing to deploy to namespace "
+                f"`{self.deployment_spec.namespace}`: the deployment spec "
+                f"contains no nodes, but this would soft-delete "
+                f"{len(plan.to_delete)} existing node(s) ({preview}). This "
+                f"usually means an empty or mistyped source directory. If you "
+                f"really intend to remove all nodes, re-run with `allow_empty`."
+            ),
+        )
 
     async def check_external_deps(
         self,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -3007,18 +3007,12 @@ class DeploymentOrchestrator:
         return to_create + to_update, to_skip, to_delete
 
     def _guard_against_accidental_wipe(self, plan: "DeploymentPlan") -> None:
-        """Refuse to delete a populated namespace from an empty spec.
+        """Refuse to wipe a populated namespace from an empty spec.
 
-        A deployment spec with zero nodes almost always means an accidental
-        empty push -- e.g. a mistyped ``directory`` argument on ``dj push``
-        that resolved to no node files. Interpreting that as "delete every
-        node in the namespace" is a silent data-loss footgun (issue #2301).
-        Require an explicit ``allow_empty`` opt-in for the rare intentional
-        teardown.
-
-        Note: this fires for dry-run as well, so a dry-run that *would* wipe a
-        namespace surfaces the refusal loudly rather than quietly listing the
-        deletions in its preview.
+        A zero-node spec usually means an accidental empty push (e.g. a mistyped
+        ``directory``), so treating it as "delete everything" is a data-loss
+        footgun. Require an explicit ``allow_empty`` opt-in. Also fires on dry-run,
+        so a preview surfaces the refusal instead of quietly listing deletions.
         """
         if self.deployment_spec.allow_empty or self.deployment_spec.nodes:
             # Either the caller opted in, or the spec has nodes and the

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -3007,16 +3007,24 @@ class DeploymentOrchestrator:
         return to_create + to_update, to_skip, to_delete
 
     def _guard_against_accidental_wipe(self, plan: "DeploymentPlan") -> None:
-        """Refuse to wipe a populated namespace from an empty spec.
+        """Refuse to wipe a populated namespace from a *fully empty* spec.
 
-        A zero-node spec usually means an accidental empty push (e.g. a mistyped
-        ``directory``), so treating it as "delete everything" is a data-loss
-        footgun. Require an explicit ``allow_empty`` opt-in. Also fires on dry-run,
-        so a preview surfaces the refusal instead of quietly listing deletions.
+        A deployment that carries no content at all -- no nodes, hierarchies, or
+        tags -- is the signature of an accidental empty push (e.g. a mistyped or
+        empty ``directory`` that yielded nothing). Treating that as "delete
+        everything" is a data-loss footgun, so it's refused unless the caller
+        explicitly opts in with ``allow_empty``.
+
+        A spec that carries *any* content (even just a hierarchy or a tag, as a
+        ``sync-from-git`` push may) is an intentional diff and is never guarded --
+        deleting nodes that are genuinely absent from a real spec is the expected
+        sync behavior. Also fires on dry-run, so a preview surfaces the refusal
+        instead of quietly listing deletions.
         """
-        if self.deployment_spec.allow_empty or self.deployment_spec.nodes:
-            # Either the caller opted in, or the spec has nodes and the
-            # deletions are a genuine diff (e.g. removing a few of many).
+        spec = self.deployment_spec
+        if spec.allow_empty or spec.nodes or spec.hierarchies or spec.tags:
+            # Opted in, or the spec carries content -> the deletions are a
+            # genuine diff, not an accidental wipe.
             return
         if not plan.to_delete:
             return  # empty spec, nothing to delete -- harmless

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -860,6 +860,16 @@ class DeploymentSpec(BaseModel):
             "re-deployment (e.g., after infrastructure changes)."
         ),
     )
+    allow_empty: bool = Field(
+        default=False,
+        description=(
+            "If True, permit a deployment whose spec contains zero nodes to "
+            "soft-delete the existing nodes in the target namespace. Guards "
+            "against an accidental empty push (e.g. a mistyped `directory` "
+            "argument that resolves to no node files) silently wiping a "
+            "namespace. See issue #2301."
+        ),
+    )
     auto_register_sources: bool = Field(
         default=True,
         description=(

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -867,7 +867,7 @@ class DeploymentSpec(BaseModel):
             "soft-delete the existing nodes in the target namespace. Guards "
             "against an accidental empty push (e.g. a mistyped `directory` "
             "argument that resolves to no node files) silently wiping a "
-            "namespace. See issue #2301."
+            "namespace."
         ),
     )
     auto_register_sources: bool = Field(

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2421,9 +2421,11 @@ class TestDeployments:
             ),
         )
         assert data["status"] == "success"
+        # Deleting every node via an empty spec is intentional here, so opt in
+        # with allow_empty (the accidental-wipe guard otherwise refuses it).
         data = await deploy_and_wait(
             client,
-            DeploymentSpec(namespace=namespace, nodes=[]),
+            DeploymentSpec(namespace=namespace, nodes=[], allow_empty=True),
         )
         deletes = {
             (r["deploy_type"], r["name"]): r

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -3,6 +3,7 @@ Unit tests for DeploymentOrchestrator
 """
 
 import pytest
+from types import SimpleNamespace
 from sqlalchemy import select
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 
@@ -157,6 +158,76 @@ def mock_registry():
     )
 
     return registry
+
+
+class TestGuardAgainstAccidentalWipe:
+    """Regression for issue #2301: an empty deployment spec must not silently
+    soft-delete an entire namespace.
+
+    A ``dj push`` against a non-existent/mistyped directory resolves to zero
+    node files, which the diff would otherwise interpret as "delete every node
+    in the namespace". The guard refuses that unless ``allow_empty`` is set.
+    """
+
+    @staticmethod
+    def _make_orchestrator(session, current_user, *, nodes, allow_empty=False):
+        spec = DeploymentSpec(namespace="test", nodes=nodes, allow_empty=allow_empty)
+        mock_context = MagicMock(spec=DeploymentContext)
+        mock_context.current_user = current_user
+        return DeploymentOrchestrator(
+            deployment_spec=spec,
+            deployment_id="test-wipe-guard",
+            session=session,
+            context=mock_context,
+        )
+
+    @staticmethod
+    def _plan_deleting(count):
+        """A stand-in plan that would delete ``count`` nodes."""
+        return SimpleNamespace(
+            to_delete=[
+                SimpleNamespace(rendered_name=f"test.node_{i}") for i in range(count)
+            ],
+        )
+
+    def test_allow_empty_bypasses_guard(self, session, current_user):
+        """allow_empty=True opts into deleting a namespace from an empty spec."""
+        orchestrator = self._make_orchestrator(
+            session,
+            current_user,
+            nodes=[],
+            allow_empty=True,
+        )
+        # Would delete 3 nodes, but the caller opted in -> no raise.
+        orchestrator._guard_against_accidental_wipe(self._plan_deleting(3))
+
+    def test_non_empty_spec_bypasses_guard(self, orchestrator):
+        """A spec with nodes -> deletions are a genuine diff, never guarded."""
+        orchestrator._guard_against_accidental_wipe(self._plan_deleting(3))
+
+    def test_empty_spec_no_deletions_is_ok(self, session, current_user):
+        """An empty spec that deletes nothing is harmless."""
+        orchestrator = self._make_orchestrator(session, current_user, nodes=[])
+        orchestrator._guard_against_accidental_wipe(self._plan_deleting(0))
+
+    def test_empty_spec_refuses_wipe(self, session, current_user):
+        """Empty spec + pending deletions -> refused, with a listing preview."""
+        orchestrator = self._make_orchestrator(session, current_user, nodes=[])
+        with pytest.raises(
+            DJInvalidDeploymentConfig,
+            match=r"contains no nodes.*soft-delete 2 existing node\(s\)",
+        ) as exc:
+            orchestrator._guard_against_accidental_wipe(self._plan_deleting(2))
+        # 2 <= 5 deletions -> no truncation ellipsis
+        assert "…" not in exc.value.message
+
+    def test_empty_spec_refuses_wipe_truncates_preview(self, session, current_user):
+        """More than 5 pending deletions -> preview is truncated with an ellipsis."""
+        orchestrator = self._make_orchestrator(session, current_user, nodes=[])
+        with pytest.raises(DJInvalidDeploymentConfig) as exc:
+            orchestrator._guard_against_accidental_wipe(self._plan_deleting(7))
+        assert "soft-delete 7 existing node(s)" in exc.value.message
+        assert "…" in exc.value.message
 
 
 class TestResourceSetup:

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -32,6 +32,8 @@ from datajunction_server.internal.deployment.validation import (
 from datajunction_server.models.deployment import (
     ColumnSpec,
     DeploymentSpec,
+    HierarchySpec,
+    HierarchyLevelSpec,
     PartitionType,
     PartitionSpec,
     TagSpec,
@@ -170,8 +172,22 @@ class TestGuardAgainstAccidentalWipe:
     """
 
     @staticmethod
-    def _make_orchestrator(session, current_user, *, nodes, allow_empty=False):
-        spec = DeploymentSpec(namespace="test", nodes=nodes, allow_empty=allow_empty)
+    def _make_orchestrator(
+        session,
+        current_user,
+        *,
+        nodes,
+        hierarchies=None,
+        tags=None,
+        allow_empty=False,
+    ):
+        spec = DeploymentSpec(
+            namespace="test",
+            nodes=nodes,
+            hierarchies=hierarchies or [],
+            tags=tags or [],
+            allow_empty=allow_empty,
+        )
         mock_context = MagicMock(spec=DeploymentContext)
         mock_context.current_user = current_user
         return DeploymentOrchestrator(
@@ -203,6 +219,37 @@ class TestGuardAgainstAccidentalWipe:
 
     def test_non_empty_spec_bypasses_guard(self, orchestrator):
         """A spec with nodes -> deletions are a genuine diff, never guarded."""
+        orchestrator._guard_against_accidental_wipe(self._plan_deleting(3))
+
+    def test_hierarchy_only_spec_bypasses_guard(self, session, current_user):
+        """A spec carrying a hierarchy (but no nodes) is intentional content,
+        not an accidental empty push -- e.g. a sync-from-git push of a hierarchy.
+        It must not be guarded even though it would delete nodes.
+        """
+        orchestrator = self._make_orchestrator(
+            session,
+            current_user,
+            nodes=[],
+            hierarchies=[
+                HierarchySpec(
+                    name="h",
+                    levels=[
+                        HierarchyLevelSpec(name="l1", dimension_node="test.d"),
+                        HierarchyLevelSpec(name="l2", dimension_node="test.d"),
+                    ],
+                ),
+            ],
+        )
+        orchestrator._guard_against_accidental_wipe(self._plan_deleting(3))
+
+    def test_tag_only_spec_bypasses_guard(self, session, current_user):
+        """A spec carrying only tags (no nodes) is intentional content too."""
+        orchestrator = self._make_orchestrator(
+            session,
+            current_user,
+            nodes=[],
+            tags=[TagSpec(name="t", display_name="T")],
+        )
         orchestrator._guard_against_accidental_wipe(self._plan_deleting(3))
 
     def test_empty_spec_no_deletions_is_ok(self, session, current_user):

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -246,6 +246,7 @@ def test_deployment_spec():
         "source": None,
         "auto_register_sources": True,
         "force": False,
+        "allow_empty": False,
         "default_catalog": None,
     }
 


### PR DESCRIPTION
### Summary

Fixes #2301.

The problem is that `dj push <directory>` with a non-existent or mistyped directory silently resolves to zero node files, and the deployment diff interprets an empty incoming spec as "delete everything not present". This results in a silent, typo-triggered data-loss.

This PR adds a few guardrails, both server-side and client-side.

**Server Guards**

The server refuses to carry out a deployment with an empty node list when that namespace currently has nodes. Normally, deploying a set of nodes means "make the namespace match this set", so anything not in the set gets removed. The danger is that an empty set reads as "remove everything."

The guard makes it so that if the incoming deployment is empty and it would end up deleting existing nodes, the server stops and returns an error explaining that an empty deployment would wipe the namespace. If someone genuinely wants to empty a namespace, they say so explicitly with an opt-in (`--allow-empty`), and then it proceeds.

**Client Guards**

1. Directory check. Before it does anything, `dj push` confirms the directory pointed at actually exists. Today, a mistyped or missing path just finds no files and produces an empty deployment, which is exactly what triggers the wipe. Now it stops immediately with a "that directory doesn't exist" error, so the empty deployment never even gets built or sent.
2. The opt-in flag. For the rare case where you really do intend to clear out a namespace, the client exposes an `--allow-empty` option that passes the explicit go-ahead through to the server's guard.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
