### PR TITLE
Add semantic-layer REST API exposing cubes as views

### DIFF
--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -46,6 +46,7 @@ from datajunction_server.api import (
     notifications,
     preaggregations,
     rbac,
+    semantic_layer,
     sql,
     system,
     tags,
@@ -141,6 +142,7 @@ def configure_app(app: FastAPI) -> None:
     app.include_router(basic.router)
     app.include_router(notifications.router)
     app.include_router(preaggregations.router)
+    app.include_router(semantic_layer.router)
     app.include_router(service_account.secure_router)
     app.include_router(service_account.router)
     app.include_router(system.router)

--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -1,0 +1,386 @@
+"""
+Semantic-layer REST API implementing the sl-db-engine-spec over DataJunction
+cubes (each cube = a "view").
+
+Spec: https://github.com/betodealmeida/sl-db-engine-spec/blob/main/server/SPEC.md
+
+DJ generates SQL; the client executes it. This router does NOT run queries —
+``/views/{view}/sql`` returns physical SQL + dialect for the client to run;
+``/views/list`` and ``/views/{view}`` are metadata. Mounted at ``/semantic``.
+"""
+
+import logging
+from typing import Any, Optional, Union
+
+from fastapi import Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import User
+from datajunction_server.errors import DJException
+from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.sql import generate_metrics_sql
+from datajunction_server.models.node_type import NodeType
+from datajunction_server.utils import get_current_user, get_session
+
+logger = logging.getLogger(__name__)
+
+# SecureAPIRouter (vs a plain APIRouter) attaches the DJHTTPBearer dependency,
+# which validates the JWT/cookie and populates ``request.state.user`` so that
+# ``get_current_user`` resolves — matching every other secured router
+# (cubes, nodes, …).
+router = SecureAPIRouter(prefix="/semantic", tags=["semantic-layer"])
+
+# Default row limit applied when the caller doesn't specify one, to bound result size.
+DEFAULT_ROW_LIMIT = 10000
+# An explicit limit above this is rejected (400).
+MAX_ROW_LIMIT = 100000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _problem(status_code: int, detail: str) -> JSONResponse:
+    """Build an error response matching the spec's ``{status_code, detail}`` shape."""
+    return JSONResponse(
+        status_code=status_code,
+        content={"status_code": status_code, "detail": detail},
+    )
+
+
+def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
+    """Spec ``metrics`` list. type/aggregation are coarse defaults — real types
+    come through the query-result schema; ``definition`` is display-only."""
+    return [
+        MetricInfo(
+            id=metric_name,
+            name=metric_name.split(".")[-1],
+            type="double",
+            definition=metric_name,
+            description=None,
+            aggregation="OTHER",
+        )
+        for metric_name in cube.cube_node_metrics
+    ]
+
+
+def _dimensions_payload(cube: NodeRevision) -> list["DimensionInfo"]:
+    """Spec ``dimensions`` list. type is a coarse default (real types come through
+    the query-result schema); grain detection is deferred."""
+    return [
+        DimensionInfo(
+            id=dim_ref,
+            name=dim_ref.split(".")[-1],
+            type="string",
+            definition=dim_ref,
+            description=None,
+            grain=None,
+        )
+        for dim_ref in cube.cube_node_dimensions
+    ]
+
+
+def _view_payload(cube: NodeRevision) -> "ViewDetail":
+    """Serialize a cube as a full semantic view (spec ``/views/{view}`` detail).
+
+    Reads ``cube_node_metrics``/``cube_node_dimensions`` (metric names + dimension
+    refs) off the cube's current revision — the only cube data the spec payload
+    needs. Everything else is a coarse default filled in above.
+    """
+    return ViewDetail(
+        name=cube.name,
+        uid=cube.name,
+        features=[],  # no optional spec features for now
+        dimensions=_dimensions_payload(cube),
+        metrics=_metrics_payload(cube),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filter / order translation (spec QueryPayload -> DJ build_metrics_sql args)
+# ---------------------------------------------------------------------------
+
+# Comparison operators accepted for filters; anything else (IN/LIKE/…) is rejected.
+_ALLOWED_OPERATORS = frozenset(
+    {"=", "!=", ">", "<", ">=", "<=", "IS NULL", "IS NOT NULL"},
+)
+_NULLARY_OPERATORS = frozenset({"IS NULL", "IS NOT NULL"})
+
+
+def _quote_value(value: Any) -> str:
+    """Render a scalar Python value as a SQL literal via sqlglot, which handles
+    quote-escaping and numeric/bool/NULL rendering for the scalars the client
+    sends (strings, numbers, bools, null)."""
+    # Imported lazily so the optional ``sqlglot`` extra isn't required at app
+    # import time — the rest of the codebase keeps sqlglot off the eager import
+    # path (e.g. transpilation.py imports it inside functions).
+    import sqlglot  # noqa: PLC0415
+
+    return sqlglot.exp.convert(value).sql(dialect="spark")
+
+
+def _filter_to_sql(flt: "FilterPayload") -> str:
+    """Spec FilterPayload -> ``<id> <op> <literal>``. Column is validated against
+    the cube by the caller; value is quoted. No arbitrary SQL reaches DJ."""
+    op = flt.operator.upper()
+    if op not in _ALLOWED_OPERATORS:
+        raise DJException(
+            message=f"Unsupported filter operator: {flt.operator}",
+            http_status_code=400,
+        )
+    if not flt.column:
+        raise DJException(
+            message=f"Filter with operator {flt.operator} requires a column",
+            http_status_code=400,
+        )
+    if op in _NULLARY_OPERATORS:
+        return f"{flt.column} {op}"
+    return f"{flt.column} {op} {_quote_value(flt.value)}"
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class OrderPayload(BaseModel):
+    """A single ORDER BY clause."""
+
+    by: str
+    direction: str = "ASC"
+
+
+class FilterPayload(BaseModel):
+    """A WHERE/HAVING filter."""
+
+    type: str = "WHERE"
+    column: Optional[str] = None
+    operator: str = "="
+    value: Any = None
+
+
+class QueryPayload(BaseModel):
+    """The query specification."""
+
+    metrics: list[str] = Field(default_factory=list)
+    dimensions: list[str] = Field(default_factory=list)
+    filters: list[FilterPayload] = Field(default_factory=list)
+    order: list[OrderPayload] = Field(default_factory=list)
+    limit: Optional[int] = None
+    # Accepted so we can explicitly reject it (DJ SQL generation has no offset);
+    # silently ignoring it would return page 1 for every page.
+    offset: Optional[int] = None
+
+
+class QueryRequest(BaseModel):
+    """Body for POST /views/{view_name}/sql (backs the spec's /query)."""
+
+    query: QueryPayload
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class MetricInfo(BaseModel):
+    """A metric exposed by a semantic view."""
+
+    id: str
+    name: str
+    type: str
+    definition: str
+    description: Optional[str]
+    aggregation: str
+
+
+class DimensionInfo(BaseModel):
+    """A dimension exposed by a semantic view."""
+
+    id: str
+    name: str
+    type: str
+    definition: str
+    description: Optional[str]
+    grain: Optional[str]
+
+
+class ViewSummary(BaseModel):
+    """Summary entry returned by ``/views/list`` (``{name, uid, features}``)."""
+
+    name: str
+    uid: str
+    features: list[str]
+
+
+class ViewDetail(BaseModel):
+    """Full semantic view returned by ``/views/{view}``."""
+
+    name: str
+    uid: str
+    features: list[str]
+    dimensions: list[DimensionInfo]
+    metrics: list[MetricInfo]
+
+
+class ColumnInfo(BaseModel):
+    """A single output column of the generated SQL."""
+
+    name: str
+    type: str
+
+
+class GeneratedSQLResponse(BaseModel):
+    """Physical SQL + metadata returned by ``/views/{view}/sql``."""
+
+    sql: str
+    dialect: str
+    columns: list[ColumnInfo]
+    cube_name: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/views/list", response_model=list[ViewSummary])
+async def list_views(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),  # noqa: ARG001
+) -> Union[list[ViewSummary], JSONResponse]:
+    """List the semantic views (DJ cubes) available to the caller.
+
+    The spec's ``/views/list`` returns summaries only (``{name, uid, features}``);
+    full metrics/dimensions are fetched per-view via ``/views/{view}``.
+    """
+    try:
+        cubes = await Node.find(session, node_type=NodeType.CUBE)
+    except DJException as exc:
+        return _problem(exc.http_status_code or 400, exc.message)
+    return [ViewSummary(name=cube.name, uid=cube.name, features=[]) for cube in cubes]
+
+
+@router.post("/views/{view_name}", response_model=ViewDetail)
+async def get_view(
+    view_name: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),  # noqa: ARG001
+) -> Union[ViewDetail, JSONResponse]:
+    """Describe a single semantic view: its metrics and dimensions."""
+    try:
+        cube_node = await Node.get_cube_by_name(
+            session,
+            view_name,
+            for_measures_sql=True,  # load only what we need to build the metrics
+        )
+    except DJException as exc:
+        return _problem(exc.http_status_code or 404, exc.message)
+    if cube_node is None or cube_node.current is None:
+        return _problem(404, f"View `{view_name}` does not exist.")
+    return _view_payload(cube_node.current)
+
+
+async def _generate_sql(
+    session: AsyncSession,
+    payload: QueryPayload,
+    cube_rev: NodeRevision,
+) -> GeneratedSQLResponse:
+    """Generate physical SQL pinned to this cube (``matched_cube=cube_rev``), so
+    we don't let ``find_matching_cube`` pick a different/differently-filtered
+    materialization.
+    """
+    orderby = (
+        [f"{o.by} {o.direction.upper()}" for o in payload.order]
+        if payload.order
+        else None
+    )
+    limit = payload.limit if payload.limit is not None else DEFAULT_ROW_LIMIT
+
+    request_filters = [_filter_to_sql(f) for f in payload.filters]
+
+    # Delegate to the shared metrics-SQL core (the same helper ``/sql/metrics/v3``
+    # uses). Pinning the view's cube via ``matched_cube`` makes the dialect
+    # resolve from that cube's own availability and applies its stored
+    # ``cube_filters``; ``dialect=None`` lets the helper do that resolution.
+    generated_sql = await generate_metrics_sql(
+        session,
+        metrics=payload.metrics,
+        dimensions=payload.dimensions,
+        filters=request_filters,
+        matched_cube=cube_rev,
+        orderby=orderby,
+        limit=limit,
+        use_materialized=True,
+        dialect=None,
+    )
+    # ``generated_sql.sql`` renders via ``to_sql(query, dialect)``, which already
+    # applies DJ's dialect rules and transpiles to the resolved dialect, so it is
+    # execution-ready for the caller (which runs it directly). We return the
+    # dialect so the caller knows which engine to run it on.
+    columns = generated_sql.columns or []
+    return GeneratedSQLResponse(
+        sql=generated_sql.sql,
+        dialect=generated_sql.dialect.value,
+        columns=[ColumnInfo(name=col.name, type=str(col.type)) for col in columns],
+        cube_name=generated_sql.cube_name,
+    )
+
+
+@router.post("/views/{view_name}/sql", response_model=GeneratedSQLResponse)
+async def generate_query_sql(
+    view_name: str,
+    body: QueryRequest,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),  # noqa: ARG001
+) -> Union[GeneratedSQLResponse, JSONResponse]:
+    """Generate physical SQL for a view query."""
+    payload = body.query
+    if payload.offset:
+        return _problem(
+            400,
+            "Pagination via `offset` is not supported yet.",
+        )
+    if payload.limit is not None and payload.limit < 0:
+        return _problem(400, "`limit` must be non-negative.")
+    if payload.limit is not None and payload.limit > MAX_ROW_LIMIT:
+        return _problem(
+            400,
+            f"`limit` {payload.limit} exceeds the maximum of {MAX_ROW_LIMIT}.",
+        )
+    if not payload.metrics:
+        return _problem(
+            400,
+            "A query must request at least one metric. Dimension-only queries "
+            "(distinct values) are not supported on this endpoint.",
+        )
+    try:
+        cube_node = await Node.get_cube_by_name(session, view_name)
+        if cube_node is None or cube_node.current is None:
+            return _problem(404, f"View `{view_name}` does not exist.")
+        cube_rev = cube_node.current
+        # Everything referenced must belong to this cube (full refs incl. role
+        # suffixes), else one view could compute another's metrics.
+        allowed_metrics = set(cube_rev.cube_node_metrics)
+        allowed_dims = set(cube_rev.cube_node_dimensions)
+        allowed = allowed_metrics | allowed_dims
+        bad_metrics = [m for m in payload.metrics if m not in allowed_metrics]
+        bad_dims = [d for d in payload.dimensions if d not in allowed_dims]
+        bad_filters = [
+            f.column for f in payload.filters if f.column and f.column not in allowed
+        ]
+        if bad_metrics or bad_dims or bad_filters:
+            return _problem(
+                400,
+                f"View `{view_name}` does not contain: "
+                f"metrics={bad_metrics} dimensions={bad_dims} "
+                f"filter_columns={bad_filters}",
+            )
+        result = await _generate_sql(session, payload, cube_rev)
+    except DJException as exc:
+        return _problem(exc.http_status_code or 400, exc.message)
+    return result

--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -317,6 +317,7 @@ async def _generate_sql(
         limit=limit,
         use_materialized=True,
         dialect=None,
+        endpoint="/semantic-layer/views/sql",
     )
     # ``generated_sql.sql`` renders via ``to_sql(query, dialect)``, which already
     # applies DJ's dialect rules and transpiles to the resolved dialect, so it is

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -634,9 +634,9 @@ async def get_metrics_sql_v3(
             Set to False when generating SQL for materialization refresh to avoid
             circular references.
     """
-    _t0 = time.monotonic()
     # Shared metrics-SQL core (cube pinning, cube_filters prepend, dialect
-    # auto-resolve, build_metrics_sql). Also used by the semantic-layer endpoint.
+    # auto-resolve, build_metrics_sql, and the build-latency metrics + [SQL] log).
+    # Also used by the semantic-layer endpoint.
     result = await generate_metrics_sql(
         session,
         metrics=metrics,
@@ -648,32 +648,6 @@ async def get_metrics_sql_v3(
         use_materialized=use_materialized,
         dialect=dialect,
         query_parameters=json.loads(query_params) or None,
-    )
-    elapsed_ms = (time.monotonic() - _t0) * 1000
-    _tags = {"query_type": "metrics", "query_version": "v3"}
-    get_metrics_provider().timer(
-        "dj.sql.build_latency_ms",
-        elapsed_ms,
-        _tags,
-    )
-    get_metrics_provider().counter("dj.sql.requests", tags=_tags)
-
-    _logger.info(
-        "[SQL] endpoint=%s metrics=%s dimensions=%s filters=%s elapsed_ms=%.1f",
-        "/sql/metrics/v3/",
-        metrics,
-        dimensions,
-        filters,
-        elapsed_ms,
-        extra={
-            "endpoint": "/sql/metrics/v3/",
-            "query_type": "metrics",
-            "query_version": "v3",
-            "metrics": metrics,
-            "dimensions": dimensions,
-            "filters": filters,
-            "elapsed_ms": elapsed_ms,
-        },
     )
 
     return V3TranslatedSQL(

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -14,9 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.utils import get_current_user
 from datajunction_server.construction.build_v3 import (
     build_combiner_sql,
-    build_metrics_sql,
     build_measures_sql,
-    resolve_dialect_and_engine_for_metrics,
 )
 from datajunction_server.construction.build_v3.combiners import (
     build_combiner_sql_from_preaggs,
@@ -38,6 +36,7 @@ from datajunction_server.database.user import User
 from datajunction_server.database.queryrequest import QueryBuildType
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.sql import generate_metrics_sql
 from datajunction_server.models.metric import TranslatedSQL, V3TranslatedSQL
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import V3ColumnMetadata
@@ -635,46 +634,19 @@ async def get_metrics_sql_v3(
             Set to False when generating SQL for materialization refresh to avoid
             circular references.
     """
-    merged_filters = list(filters)
-    matched_cube = None
-
-    if cube:
-        # User explicitly specified a cube — load it directly, apply its filters.
-        cube_node = await Node.get_cube_by_name(session, cube)
-        if cube_node:
-            matched_cube = cube_node.current
-            if matched_cube.cube_filters:
-                merged_filters = matched_cube.cube_filters + merged_filters
-            if not metrics:
-                metrics = matched_cube.cube_node_metrics
-                if not dimensions:
-                    dimensions = matched_cube.cube_node_dimensions
-
-    # Auto-resolve dialect if not explicitly provided
-    resolved_dialect = dialect
-    if resolved_dialect is None:  # pragma: no branch
-        execution_ctx = await resolve_dialect_and_engine_for_metrics(
-            session=session,
-            metrics=metrics,
-            dimensions=dimensions,
-            use_materialized=use_materialized,
-        )
-        resolved_dialect = execution_ctx.dialect
-        # Only reuse the resolved cube if the user didn't explicitly provide one
-        if matched_cube is None:
-            matched_cube = execution_ctx.cube
-
     _t0 = time.monotonic()
-    result = await build_metrics_sql(
-        session=session,
+    # Shared metrics-SQL core (cube pinning, cube_filters prepend, dialect
+    # auto-resolve, build_metrics_sql). Also used by the semantic-layer endpoint.
+    result = await generate_metrics_sql(
+        session,
         metrics=metrics,
         dimensions=dimensions,
-        filters=merged_filters,
+        filters=filters,
+        cube=cube,
         orderby=orderby if orderby else None,
         limit=limit,
-        dialect=resolved_dialect,
         use_materialized=use_materialized,
-        matched_cube=matched_cube,
+        dialect=dialect,
         query_parameters=json.loads(query_params) or None,
     )
     elapsed_ms = (time.monotonic() - _t0) * 1000
@@ -691,7 +663,7 @@ async def get_metrics_sql_v3(
         "/sql/metrics/v3/",
         metrics,
         dimensions,
-        merged_filters,
+        filters,
         elapsed_ms,
         extra={
             "endpoint": "/sql/metrics/v3/",
@@ -699,7 +671,7 @@ async def get_metrics_sql_v3(
             "query_version": "v3",
             "metrics": metrics,
             "dimensions": dimensions,
-            "filters": merged_filters,
+            "filters": filters,
             "elapsed_ms": elapsed_ms,
         },
     )

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -180,6 +180,7 @@ async def resolve_dialect_and_engine_for_metrics(
     engine_name: Optional[str] = None,
     engine_version: Optional[str] = None,
     dialect_override: Optional[Dialect] = None,
+    matched_cube: Optional[NodeRevision] = None,
 ) -> ResolvedExecutionContext:
     """
     Resolve dialect and engine for a metrics query in a single lookup.
@@ -206,6 +207,9 @@ async def resolve_dialect_and_engine_for_metrics(
         engine_version: Optional explicit engine version override
         dialect_override: Optional dialect to force, overrides auto-resolution for
             both SQL generation and engine selection
+        matched_cube: When provided, resolve the dialect from THIS cube's
+            availability instead of discovering one via find_matching_cube — so a
+            pinned query's dialect matches the cube it actually builds from.
 
     Returns:
         ResolvedExecutionContext with dialect, engine, catalog_name, and optional cube
@@ -221,11 +225,19 @@ async def resolve_dialect_and_engine_for_metrics(
         dialect_override is None or dialect_override == Dialect.DRUID
     )
     if use_cube:
-        cube = await find_matching_cube(
-            session,
-            metrics,
-            dimensions,
-            require_availability=True,
+        # When a cube is pinned, resolve the dialect from that specific cube's
+        # availability rather than discovering an arbitrary superset cube — this
+        # keeps the resolved dialect consistent with the cube the build actually
+        # renders from. Otherwise, discover a materialized cube as before.
+        cube = (
+            matched_cube
+            if matched_cube is not None
+            else await find_matching_cube(
+                session,
+                metrics,
+                dimensions,
+                require_availability=True,
+            )
         )
 
         if cube and cube.availability:

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -1,6 +1,11 @@
 import logging
-from typing import Any, Tuple, cast
+from typing import TYPE_CHECKING, Any, Tuple, cast
 import re
+
+if TYPE_CHECKING:
+    from datajunction_server.construction.build_v3.types import (
+        GeneratedSQL as BuildV3GeneratedSQL,
+    )
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -163,6 +168,88 @@ async def build_node_sql(
         sql=v3_result.sql,
         columns=[_v3_to_model_column(col) for col in v3_result.columns],
         dialect=engine.dialect if engine else None,
+    )
+
+
+async def generate_metrics_sql(
+    session: AsyncSession,
+    *,
+    metrics: list[str],
+    dimensions: list[str],
+    filters: list[str] | None = None,
+    cube: str | None = None,
+    matched_cube: NodeRevision | None = None,
+    orderby: list[str] | None = None,
+    limit: int | None = None,
+    use_materialized: bool = True,
+    dialect: Dialect | None = None,
+    query_parameters: dict[str, Any] | None = None,
+) -> "BuildV3GeneratedSQL":
+    """
+    Shared core for the "generate SQL for specific metrics" flow, used by both the
+    canonical ``/sql/metrics/v3`` endpoint and the semantic-layer endpoint.
+
+    Behavior:
+      - If ``cube`` (a cube node name) is given and ``matched_cube`` is not already
+        provided, load the cube directly (pins it so ``find_matching_cube`` can't
+        pick a different / differently-filtered materialization).
+      - If a cube revision is in play, prepend its stored ``cube_filters`` to the
+        request filters (and fall back to the cube's full metric/dimension set for
+        a bare cube query with no explicit metrics/dimensions).
+      - If ``dialect`` is None, auto-resolve it via
+        ``resolve_dialect_and_engine_for_metrics``; adopt that resolver's cube only
+        when no cube was otherwise provided (mirrors the canonical endpoint).
+      - Call and return the raw ``build_metrics_sql`` result; callers map it to
+        their own response models.
+    """
+    # Imported lazily (like build_node_sql's build_v3 import below) to avoid an
+    # import cycle: build_v3 pulls in modules that import this one.
+    from datajunction_server.construction.build_v3 import (  # noqa: PLC0415
+        build_metrics_sql,
+        resolve_dialect_and_engine_for_metrics,
+    )
+
+    merged_filters = list(filters or [])
+
+    if cube and matched_cube is None:
+        cube_node = await Node.get_cube_by_name(session, cube)
+        if cube_node:
+            matched_cube = cube_node.current
+
+    if matched_cube is not None:
+        if matched_cube.cube_filters:
+            merged_filters = list(matched_cube.cube_filters) + merged_filters
+        if not metrics:
+            metrics = matched_cube.cube_node_metrics
+            if not dimensions:
+                dimensions = matched_cube.cube_node_dimensions
+
+    # Auto-resolve dialect if not explicitly provided.
+    resolved_dialect = dialect
+    if resolved_dialect is None:
+        execution_ctx = await resolve_dialect_and_engine_for_metrics(
+            session=session,
+            metrics=metrics,
+            dimensions=dimensions,
+            use_materialized=use_materialized,
+            matched_cube=matched_cube,
+        )
+        resolved_dialect = execution_ctx.dialect
+        # Only reuse the resolved cube if the caller didn't provide one.
+        if matched_cube is None:
+            matched_cube = execution_ctx.cube
+
+    return await build_metrics_sql(
+        session=session,
+        metrics=metrics,
+        dimensions=dimensions,
+        filters=merged_filters,
+        orderby=orderby,
+        limit=limit,
+        dialect=resolved_dialect,
+        use_materialized=use_materialized,
+        matched_cube=matched_cube,
+        query_parameters=query_parameters,
     )
 
 

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Tuple, cast
 import re
 
@@ -40,6 +41,7 @@ from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.catalog import Catalog
 from datajunction_server.errors import DJInvalidInputException, DJException
 from datajunction_server.internal.engines import get_engine
+from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.models import access
 from datajunction_server.models.column import SemanticType
 from datajunction_server.models.cube_materialization import Aggregability
@@ -184,6 +186,7 @@ async def generate_metrics_sql(
     use_materialized: bool = True,
     dialect: Dialect | None = None,
     query_parameters: dict[str, Any] | None = None,
+    endpoint: str = "/sql/metrics/v3/",
 ) -> "BuildV3GeneratedSQL":
     """
     Shared core for the "generate SQL for specific metrics" flow, used by both the
@@ -201,6 +204,8 @@ async def generate_metrics_sql(
         when no cube was otherwise provided (mirrors the canonical endpoint).
       - Call and return the raw ``build_metrics_sql`` result; callers map it to
         their own response models.
+      - Emit the build-latency metrics and ``[SQL]`` log here (tagged with
+        ``endpoint``) so they reflect the merged, as-built values.
     """
     # Imported lazily (like build_node_sql's build_v3 import below) to avoid an
     # import cycle: build_v3 pulls in modules that import this one.
@@ -209,6 +214,7 @@ async def generate_metrics_sql(
         resolve_dialect_and_engine_for_metrics,
     )
 
+    _t0 = time.monotonic()
     merged_filters = list(filters or [])
 
     if cube and matched_cube is None:
@@ -239,7 +245,7 @@ async def generate_metrics_sql(
         if matched_cube is None:
             matched_cube = execution_ctx.cube
 
-    return await build_metrics_sql(
+    result = await build_metrics_sql(
         session=session,
         metrics=metrics,
         dimensions=dimensions,
@@ -251,6 +257,30 @@ async def generate_metrics_sql(
         matched_cube=matched_cube,
         query_parameters=query_parameters,
     )
+
+    elapsed_ms = (time.monotonic() - _t0) * 1000
+    _tags = {"query_type": "metrics", "query_version": "v3"}
+    provider = get_metrics_provider()
+    provider.timer("dj.sql.build_latency_ms", elapsed_ms, _tags)
+    provider.counter("dj.sql.requests", tags=_tags)
+    logger.info(
+        "[SQL] endpoint=%s metrics=%s dimensions=%s filters=%s elapsed_ms=%.1f",
+        endpoint,
+        metrics,
+        dimensions,
+        merged_filters,
+        elapsed_ms,
+        extra={
+            "endpoint": endpoint,
+            "query_type": "metrics",
+            "query_version": "v3",
+            "metrics": metrics,
+            "dimensions": dimensions,
+            "filters": merged_filters,
+            "elapsed_ms": elapsed_ms,
+        },
+    )
+    return result
 
 
 async def build_sql_for_multiple_metrics(

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -1,0 +1,411 @@
+"""Unit + integration tests for the semantic-layer REST API.
+
+The unit tests cover the pure logic — filter translation and value quoting —
+without a database. The DB-backed endpoint tests (list / view / sql against a
+seeded cube) use the standard ``client`` fixture over the testcontainers
+Postgres harness.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from datajunction_server.errors import DJException
+
+from datajunction_server.api.semantic_layer import (
+    FilterPayload,
+    MAX_ROW_LIMIT,
+    _filter_to_sql,
+    _quote_value,
+)
+
+
+class TestFilterToSql:
+    def test_equality_quotes_string_value(self):
+        flt = FilterPayload(column="ns.dim", operator="=", value="North")
+        assert _filter_to_sql(flt) == "ns.dim = 'North'"
+
+    def test_is_null_omits_value(self):
+        flt = FilterPayload(column="ns.dim", operator="IS NULL")
+        assert _filter_to_sql(flt) == "ns.dim IS NULL"
+
+    def test_comparison_operator_passes_through(self):
+        flt = FilterPayload(column="ns.metric", operator=">=", value=10)
+        assert _filter_to_sql(flt) == "ns.metric >= 10"
+
+    def test_unsupported_operator_rejected_400(self):
+        flt = FilterPayload(column="ns.dim", operator="LIKE", value="x%")
+        with pytest.raises(DJException) as exc:
+            _filter_to_sql(flt)
+        assert exc.value.http_status_code == 400
+
+    def test_missing_column_rejected_400(self):
+        flt = FilterPayload(column=None, operator="=", value="x")
+        with pytest.raises(DJException) as exc:
+            _filter_to_sql(flt)
+        assert exc.value.http_status_code == 400
+
+
+class TestQuoteValue:
+    def test_none_is_null(self):
+        assert _quote_value(None) == "NULL"
+
+    def test_bool_renders_sql_literal(self):
+        assert _quote_value(True) == "TRUE"
+        assert _quote_value(False) == "FALSE"
+
+    def test_number_is_bare(self):
+        assert _quote_value(42) == "42"
+
+    def test_string_escapes_single_quotes(self):
+        # DJ's parser uses Spark's grammar (BACKSLASH escaping); a doubled ''
+        # would mis-lex into two adjacent strings. So the correct literal is
+        # backslash-escaped.
+        assert _quote_value("O'Brien") == "'O\\'Brien'"
+
+
+# ---------------------------------------------------------------------------
+# DB-backed integration tests (require the testcontainers Postgres harness)
+# ---------------------------------------------------------------------------
+
+
+async def _expect(resp, *codes):
+    assert resp.status_code in codes, f"{resp.status_code}: {resp.text}"
+    return resp
+
+
+async def _setup_cube(client: AsyncClient) -> str:
+    """Build a minimal materialization-free cube and return its node name.
+
+    sem.sales (fact) --link region_id--> sem.region (dim over sem.regions);
+    metric sem.total_amount = SUM(amount); cube sem.sales_cube over
+    [sem.total_amount] x [sem.region.region_name]. Catalog ``semcat`` has only a
+    trino engine, so the cube resolves to the trino dialect deterministically.
+    """
+    await _expect(
+        await client.post("/catalogs/", json={"name": "semcat"}),
+        200,
+        201,
+        409,
+    )
+    await _expect(
+        await client.post(
+            "/engines/",
+            json={"name": "trino", "version": "451", "dialect": "trino"},
+        ),
+        200,
+        201,
+        409,
+    )
+    await _expect(
+        await client.post(
+            "/catalogs/semcat/engines/",
+            json=[{"name": "trino", "version": "451"}],
+        ),
+        200,
+        201,
+    )
+    await _expect(await client.post("/namespaces/sem"), 200, 201, 409)
+    await _expect(
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "sem.sales",
+                "display_name": "Sales",
+                "description": "",
+                "mode": "published",
+                "catalog": "semcat",
+                "schema_": "sem",
+                "table": "sales",
+                "columns": [
+                    {"name": "id", "type": "bigint"},
+                    {"name": "region_id", "type": "bigint"},
+                    {"name": "amount", "type": "double"},
+                ],
+            },
+        ),
+        200,
+        201,
+    )
+    await _expect(
+        await client.post(
+            "/nodes/source/",
+            json={
+                "name": "sem.regions",
+                "display_name": "Regions",
+                "description": "",
+                "mode": "published",
+                "catalog": "semcat",
+                "schema_": "sem",
+                "table": "regions",
+                "columns": [
+                    {"name": "region_id", "type": "bigint"},
+                    {"name": "region_name", "type": "string"},
+                ],
+            },
+        ),
+        200,
+        201,
+    )
+    await _expect(
+        await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "sem.region",
+                "display_name": "Region",
+                "description": "",
+                "mode": "published",
+                "primary_key": ["region_id"],
+                "query": "SELECT region_id, region_name FROM sem.regions",
+            },
+        ),
+        200,
+        201,
+    )
+    await _expect(
+        await client.post(
+            "/nodes/sem.sales/link/",
+            json={
+                "dimension_node": "sem.region",
+                "join_type": "inner",
+                "join_on": "sem.sales.region_id = sem.region.region_id",
+            },
+        ),
+        200,
+        201,
+    )
+    await _expect(
+        await client.post(
+            "/nodes/metric/",
+            json={
+                "name": "sem.total_amount",
+                "display_name": "Total Amount",
+                "description": "",
+                "mode": "published",
+                "query": "SELECT SUM(amount) FROM sem.sales",
+            },
+        ),
+        200,
+        201,
+    )
+    await _expect(
+        await client.post(
+            "/nodes/cube/",
+            json={
+                "name": "sem.sales_cube",
+                "display_name": "Sales Cube",
+                "description": "Sales by region",
+                "mode": "published",
+                "metrics": ["sem.total_amount"],
+                "dimensions": ["sem.region.region_name"],
+            },
+        ),
+        200,
+        201,
+    )
+    return "sem.sales_cube"
+
+
+@pytest.mark.asyncio
+async def test_semantic_endpoints_end_to_end(client: AsyncClient):
+    view = await _setup_cube(client)
+    query = {
+        "additional_configuration": {},
+        "query": {
+            "metrics": ["sem.total_amount"],
+            "dimensions": ["sem.region.region_name"],
+        },
+    }
+
+    # /views/list includes the cube.
+    resp = await _expect(
+        await client.post("/semantic/views/list", json={"runtime_configuration": {}}),
+        200,
+    )
+    assert any(v["name"] == view for v in resp.json())
+
+    # /views/{view} returns the cube's metrics and dimensions in spec shape.
+    resp = await _expect(
+        await client.post(
+            f"/semantic/views/{view}",
+            json={"additional_configuration": {}},
+        ),
+        200,
+    )
+    detail = resp.json()
+    assert {m["id"] for m in detail["metrics"]} == {"sem.total_amount"}
+    assert any(d["id"] == "sem.region.region_name" for d in detail["dimensions"])
+
+    # /sql generates physical SQL, pinned to this cube, in the trino dialect.
+    resp = await _expect(
+        await client.post(f"/semantic/views/{view}/sql", json=query),
+        200,
+    )
+    sql_body = resp.json()
+    assert sql_body["dialect"] == "trino"
+    assert "SELECT" in sql_body["sql"].upper()
+    assert sql_body["columns"]
+
+    # Unknown metric/dimension ids are rejected (400).
+    resp = await client.post(
+        f"/semantic/views/{view}/sql",
+        json={"query": {"metrics": ["sem.not_a_metric"], "dimensions": []}},
+    )
+    assert resp.status_code == 400, resp.text
+
+    # Dimension-only queries are rejected at the boundary (400).
+    resp = await client.post(
+        f"/semantic/views/{view}/sql",
+        json={"query": {"metrics": [], "dimensions": ["sem.region.region_name"]}},
+    )
+    assert resp.status_code == 400, resp.text
+
+    # Unknown view -> 404.
+    resp = await client.post(
+        "/semantic/views/sem.does_not_exist/sql",
+        json={"query": {"metrics": ["sem.total_amount"], "dimensions": []}},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# generate_query_sql request-validation rejections
+#
+# These fire before any cube lookup, so no seeded cube is required — the
+# view-name path param can be arbitrary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_sql_rejects_offset(client: AsyncClient):
+    """`offset` present -> 400 (covers the ``if payload.offset`` branch)."""
+    resp = await client.post(
+        "/semantic/views/any_view/sql",
+        json={"query": {"metrics": ["m"], "offset": 5}},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "offset" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_sql_rejects_negative_limit(client: AsyncClient):
+    """Negative `limit` -> 400 (covers the ``limit < 0`` branch)."""
+    resp = await client.post(
+        "/semantic/views/any_view/sql",
+        json={"query": {"metrics": ["m"], "limit": -1}},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "non-negative" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_generate_sql_rejects_limit_over_max(client: AsyncClient):
+    """`limit` > MAX_ROW_LIMIT -> 400 (covers the ``limit > MAX_ROW_LIMIT`` branch)."""
+    resp = await client.post(
+        "/semantic/views/any_view/sql",
+        json={"query": {"metrics": ["m"], "limit": MAX_ROW_LIMIT + 1}},
+    )
+    assert resp.status_code == 400, resp.text
+    assert str(MAX_ROW_LIMIT) in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# get_view unknown-view 404 (the ``cube_node is None`` branch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_view_unknown_returns_404(client: AsyncClient):
+    """An unknown view name on ``/views/{view}`` -> 404."""
+    resp = await client.post(
+        "/semantic/views/sem.no_such_view",
+        json={"additional_configuration": {}},
+    )
+    assert resp.status_code == 404, resp.text
+    assert "does not exist" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# DJException handlers (the ``except DJException`` branches) — forced via
+# monkeypatch so the underlying call raises a DJException with a specific
+# status code, and we assert the ``{status_code, detail}`` problem shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_views_djexception_returns_problem(
+    client: AsyncClient,
+    monkeypatch,
+):
+    """``Node.find`` raising DJException -> problem response in list_views."""
+    monkeypatch.setattr(
+        "datajunction_server.api.semantic_layer.Node.find",
+        AsyncMock(
+            side_effect=DJException(message="find blew up", http_status_code=418),
+        ),
+    )
+    resp = await client.post("/semantic/views/list", json={"runtime_configuration": {}})
+    assert resp.status_code == 418, resp.text
+    assert resp.json() == {"status_code": 418, "detail": "find blew up"}
+
+
+@pytest.mark.asyncio
+async def test_get_view_djexception_returns_problem(
+    client: AsyncClient,
+    monkeypatch,
+):
+    """``Node.get_cube_by_name`` raising DJException -> problem in get_view."""
+    monkeypatch.setattr(
+        "datajunction_server.api.semantic_layer.Node.get_cube_by_name",
+        AsyncMock(
+            side_effect=DJException(message="cube blew up", http_status_code=422),
+        ),
+    )
+    resp = await client.post(
+        "/semantic/views/some_view",
+        json={"additional_configuration": {}},
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json() == {"status_code": 422, "detail": "cube blew up"}
+
+
+@pytest.mark.asyncio
+async def test_generate_sql_djexception_returns_problem(
+    client: AsyncClient,
+    monkeypatch,
+):
+    """``generate_metrics_sql`` raising DJException -> problem in generate_query_sql.
+
+    The request passes validation and cube-membership (a fake cube exposing the
+    requested metric/dimension is returned) so execution reaches ``_generate_sql``,
+    where the patched ``generate_metrics_sql`` raises.
+    """
+    fake_cube = SimpleNamespace(
+        current=SimpleNamespace(
+            cube_node_metrics=["sem.total_amount"],
+            cube_node_dimensions=["sem.region.region_name"],
+        ),
+    )
+    monkeypatch.setattr(
+        "datajunction_server.api.semantic_layer.Node.get_cube_by_name",
+        AsyncMock(return_value=fake_cube),
+    )
+    monkeypatch.setattr(
+        "datajunction_server.api.semantic_layer.generate_metrics_sql",
+        AsyncMock(
+            side_effect=DJException(message="sql gen blew up", http_status_code=400),
+        ),
+    )
+    resp = await client.post(
+        "/semantic/views/sem.sales_cube/sql",
+        json={
+            "query": {
+                "metrics": ["sem.total_amount"],
+                "dimensions": ["sem.region.region_name"],
+            },
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json() == {"status_code": 400, "detail": "sql gen blew up"}

--- a/datajunction-server/tests/api/sql_instrumentation_test.py
+++ b/datajunction-server/tests/api/sql_instrumentation_test.py
@@ -71,7 +71,8 @@ async def test_v3_metrics_endpoint_emits_structured_log(
     caplog,
 ):
     """`/sql/metrics/v3/` should emit a structured log with extra={...}."""
-    caplog.set_level(logging.INFO, logger="datajunction_server.api.sql")
+    # Logged by generate_metrics_sql, which lives in internal.sql.
+    caplog.set_level(logging.INFO, logger="datajunction_server.internal.sql")
     response = await client_with_build_v3.get(
         "/sql/metrics/v3/",
         params={

--- a/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
@@ -2872,3 +2872,120 @@ class TestDataEndpointCubePath:
         finally:
             if get_query_service_client in client.app.dependency_overrides:
                 del client.app.dependency_overrides[get_query_service_client]
+
+
+class TestResolveDialectPinAware:
+    """
+    Tests that ``resolve_dialect_and_engine_for_metrics`` honors a pinned cube.
+
+    Reproduces the latent correctness bug where the resolver derived the dialect
+    from *any* materialized superset cube (via ``find_matching_cube``) rather than
+    from the cube the caller actually pinned. When a pinned cube A is UNmaterialized
+    but a separate materialized cube B covers the same metrics+dims, the old resolver
+    returned DRUID (from B) while the build rendered A's source SQL — an unrunnable
+    Druid-dialect query. With the fix, a pin resolves the dialect from the pinned
+    cube's own availability (falling through to the Trino-preferring fallback when the
+    pinned cube is unmaterialized).
+    """
+
+    @pytest.mark.asyncio
+    async def test_pinned_unmaterialized_cube_does_not_inherit_other_cubes_dialect(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """Pin an UNmaterialized cube A while a materialized cube B covers the same
+        metrics+dims. Discovery (no pin) picks B → DRUID; pinning A → the
+        Trino-preferring fallback (A has no availability) → TRINO."""
+        from datajunction_server.construction.build_v3.cube_matcher import (
+            resolve_dialect_and_engine_for_metrics,
+        )
+        from datajunction_server.database.node import Node
+
+        client = client_with_build_v3
+
+        metrics = ["v3.total_revenue"]
+        dimensions = ["v3.product.category"]
+
+        # Give the default catalog a Trino engine so the metric-catalog fallback
+        # has a Trino engine to prefer (BUILD_V3's default catalog ships with only
+        # spark + druid). Rolled back with the function-scoped session.
+        response = await client.post(
+            "/engines/",
+            json={"name": "trino", "version": "", "dialect": "trino"},
+        )
+        assert response.status_code in (200, 201), response.json()
+        response = await client.post(
+            "/catalogs/default/engines/",
+            json=[{"name": "trino", "version": "", "dialect": "trino"}],
+        )
+        assert response.status_code in (200, 201), response.json()
+
+        # Cube A: UNmaterialized (no availability).
+        response = await client.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.pin_cube_unmaterialized",
+                "metrics": metrics,
+                "dimensions": dimensions,
+                "mode": "published",
+                "description": "Pinned unmaterialized cube A",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        # Cube B: MATERIALIZED (availability on the default catalog, which has a
+        # druid engine) covering the same metrics+dims.
+        response = await client.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.pin_cube_materialized",
+                "metrics": metrics,
+                "dimensions": dimensions,
+                "mode": "published",
+                "description": "Materialized superset cube B",
+            },
+        )
+        assert response.status_code == 201, response.json()
+        response = await client.post(
+            "/data/v3.pin_cube_materialized/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "pin_cube_materialized",
+                "valid_through_ts": int(time.time() * 1000),
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        # Discovery path (no pin): find_matching_cube picks the materialized B, so
+        # the dialect comes from B's availability catalog → DRUID.
+        discovered = await resolve_dialect_and_engine_for_metrics(
+            session,
+            metrics=metrics,
+            dimensions=dimensions,
+        )
+        assert discovered.dialect == Dialect.DRUID
+        assert discovered.cube is not None
+        assert discovered.cube.name == "v3.pin_cube_materialized"
+
+        # Pinned path: pin the UNmaterialized cube A. Its availability is falsy, so
+        # the resolver must NOT return B's DRUID dialect; it falls through to the
+        # metric-catalog fallback which prefers Trino → TRINO. This is the assertion
+        # that proves the bug is fixed.
+        cube_a_node = await Node.get_cube_by_name(
+            session,
+            "v3.pin_cube_unmaterialized",
+        )
+        cube_a_rev = cube_a_node.current
+        assert cube_a_rev.availability is None
+
+        pinned = await resolve_dialect_and_engine_for_metrics(
+            session,
+            metrics=metrics,
+            dimensions=dimensions,
+            matched_cube=cube_a_rev,
+        )
+        assert pinned.dialect == Dialect.TRINO
+        # Fell through to the metric-catalog fallback, so no cube is returned.
+        assert pinned.cube is None

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -22,6 +22,25 @@ class TestMetricsSQLBasic:
         assert "SELECT" in result["sql"].upper()
 
     @pytest.mark.asyncio
+    async def test_explicit_dialect_is_honored(self, client_with_build_v3):
+        """
+        An explicit ``dialect`` param bypasses auto-resolution: the shared
+        ``generate_metrics_sql`` helper uses the caller-supplied dialect instead
+        of resolving one from cube availability / the metric's catalog.
+        """
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "dialect": "trino",
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["dialect"] == "trino"
+
+    @pytest.mark.asyncio
     async def test_simple_single_metric(self, client_with_build_v3):
         """
         Test metrics SQL for a single simple metric (SUM).


### PR DESCRIPTION
Implements part of the spec from https://github.com/betodealmeida/sl-db-engine-spec/blob/5f41b523975b2547ba73fb606a0b69615fc6967e/server/SPEC.md

Expose /semantic/* so external clients can browse cubes as views and get physical SQL to execute. SQL generation reuses DJ's canonical metrics-SQL path via a shared generate_metrics_sql helper; dialect resolution is now pin-aware so a pinned cube's dialect matches the cube it builds from.