### PR TITLE
Independent sibling parent dropped from parent columns map on revalidation

### DIFF
--- a/datajunction-server/datajunction_server/internal/impact.py
+++ b/datajunction-server/datajunction_server/internal/impact.py
@@ -764,9 +764,7 @@ def _build_parent_columns_map(
         if parent.name in failed_names:
             continue
         parent_node = (
-            loaded_nodes.get(parent.name)
-            or nodes_by_name.get(parent.name)
-            or parent
+            loaded_nodes.get(parent.name) or nodes_by_name.get(parent.name) or parent
         )
         if parent_node and parent_node.current and parent_node.current.columns:
             parent_map[parent.name] = {

--- a/datajunction-server/datajunction_server/internal/impact.py
+++ b/datajunction-server/datajunction_server/internal/impact.py
@@ -750,12 +750,24 @@ def _build_parent_columns_map(
     Looks up parents from the loaded nodes first, then falls back to
     the broader visited nodes index.  Parents that failed revalidation
     are excluded so that their children fail naturally.
+
+    A node's parents that are *not* part of the current impact set (e.g. an
+    independent sibling parent, unaffected by the change that triggered this
+    revalidation) appear in neither index.  For those we fall back to the
+    parent object already attached to ``node.current.parents``, whose columns
+    were eager-loaded in ``_batch_load_nodes_for_revalidation``.  Without this
+    fallback the sibling silently drops out of the map and the child fails
+    revalidation with "Table <sibling> not found in parent columns map".
     """
     parent_map: dict[str, dict[str, ColumnType]] = {}
     for parent in node.current.parents or []:
         if parent.name in failed_names:
             continue
-        parent_node = loaded_nodes.get(parent.name) or nodes_by_name.get(parent.name)
+        parent_node = (
+            loaded_nodes.get(parent.name)
+            or nodes_by_name.get(parent.name)
+            or parent
+        )
         if parent_node and parent_node.current and parent_node.current.columns:
             parent_map[parent.name] = {
                 col.name: col.type for col in parent_node.current.columns

--- a/datajunction-server/tests/internal/impact_test.py
+++ b/datajunction-server/tests/internal/impact_test.py
@@ -1013,6 +1013,80 @@ async def test_multiple_roots_same_downstream(session, current_user: User):
 
 
 @pytest.mark.asyncio
+async def test_revalidation_independent_sibling_parent_not_dropped(
+    session,
+    current_user: User,
+):
+    """Only one of a child's two parents changes — the untouched sibling parent
+    must still be resolvable during revalidation.
+
+    Regression test: ``ns.source_b`` is not downstream of the changed node, so
+    it never appears in the impact BFS and is absent from both node indexes.
+    ``_build_parent_columns_map`` must fall back to the parent object attached
+    to the child (columns eager-loaded during the batch load); otherwise the
+    sibling silently drops out of the map and the child fails revalidation with
+    "Table `ns.source_b` not found in parent columns map".
+    """
+    session.add(NodeNamespace(namespace="ns"))
+
+    # source_a's id column has changed type (INT -> BIGINT). It is the only
+    # node in the changed set.
+    parent_a, parent_a_rev = _make_node(
+        "ns.source_a",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("id", BigIntType())],
+    )
+    # source_b is independent of source_a and is never edited — it exists only
+    # as a second parent of the child.
+    parent_b, parent_b_rev = _make_node(
+        "ns.source_b",
+        NodeType.SOURCE,
+        NodeStatus.VALID,
+        current_user.id,
+        columns=[("id", BigIntType()), ("name", StringType())],
+    )
+    child, child_rev = _make_node(
+        "ns.transform",
+        NodeType.TRANSFORM,
+        NodeStatus.VALID,
+        current_user.id,
+        query="SELECT a.id, b.name FROM ns.source_a a JOIN ns.source_b b ON a.id = b.id",
+        columns=[("id", IntegerType()), ("name", StringType())],
+    )
+    await _persist(
+        session,
+        parent_a,
+        parent_a_rev,
+        parent_b,
+        parent_b_rev,
+        child,
+        child_rev,
+    )
+    await _persist(
+        session,
+        _link(parent_a, child_rev),
+        _link(parent_b, child_rev),
+    )
+
+    result = await propagate_impact(session, "ns", {"ns.source_a"})
+
+    by_name = {r.name: r for r in result}
+    assert "ns.transform" in by_name
+    impact = by_name["ns.transform"]
+    # The child revalidates cleanly: source_a's type change flows through and
+    # the untouched sibling source_b still resolves — not WILL_INVALIDATE.
+    assert impact.impact_type == ImpactType.MAY_AFFECT
+    assert "Column types changed" in impact.impact_reason
+    assert "not found in parent columns map" not in impact.impact_reason
+    # The child's id column picked up the new BIGINT type from source_a.
+    col_types = {col.name: col.type for col in child_rev.columns}
+    assert isinstance(col_types["id"], BigIntType)
+    assert child_rev.status == NodeStatus.VALID
+
+
+@pytest.mark.asyncio
 async def test_propagate_impact_dimension_link_stub(session, current_user: User):
     """Passing changed_link_node_names exercises the dimension link stub."""
     session.add(NodeNamespace(namespace="ns"))


### PR DESCRIPTION
### Summary

When a child node joins two parents and only one parent changes, downstream impact propagation revalidates the child. The BFS only discovers descendants of the changed node, so an independent sibling parent (not downstream of the change) is absent from both `loaded_nodes` and `nodes_by_name`.

`_build_parent_columns_map` silently skipped any parent missing from those two indexes, so the sibling dropped out of the map and the child failed revalidation with "Table `<sibling>` not found in parent columns map", even though the child's query never changed.

This falls back to the parent object already attached to `node.current.parents`, whose columns are eager-loaded during the batch load, so unchanged sibling parents remain resolvable.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
