### PR TITLE
Enable role-aware cube dimensions

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -445,17 +445,52 @@ async def resolve_downstream_references(
     return newly_valid_nodes
 
 
-def map_dimensions_to_roles(dimensions: List[str]) -> Dict[str, str]:
+def dimension_roles_in_order(dimensions: List[str]) -> List[Optional[str]]:
     """
-    Returns a mapping between dimension attributes and their roles.
-    For example, ["default.users.user_id[user]"] would turn into
-    {"default.users.user_id": "[user]"}
+    The `[role]` suffix (or None) for each dimension reference, in order.
+
+    One entry per reference (keyed by position, not column name), so two roles on
+    the same column are not collapsed. E.g.
+    `["a.x[start]", "a.x[end]", "b.y"]` -> `["[start]", "[end]", None]`.
     """
-    dimension_attrs = [FullColumnName(dim) for dim in dimensions]
-    return {
-        attr.node_name + SEPARATOR + attr.column_name: attr.role  # type: ignore
-        for attr in dimension_attrs
-    }
+    roles: List[Optional[str]] = []
+    for dim in dimensions:
+        attr = FullColumnName(dim)
+        roles.append(f"[{attr.role}]" if attr.role else None)
+    return roles
+
+
+def cube_element_roles(
+    num_metrics: int,
+    dimension_refs: List[str],
+) -> List[Optional[str]]:
+    """
+    Role suffix (or None) for each cube element, aligned to the cube's
+    node_columns.
+
+    A cube's node_columns are built metrics-first, then dimensions, so the result
+    is `num_metrics` Nones (metrics carry no role) followed by one `[role]`-or-None
+    per dimension reference. Callers index this by each node_column's position.
+    """
+    metric_roles: List[Optional[str]] = [None] * num_metrics
+    return metric_roles + dimension_roles_in_order(dimension_refs)
+
+
+def dedupe_cube_elements(columns: List[Column]) -> List[Column]:
+    """
+    Dedupe cube element columns by column id.
+
+    `cube_elements` is the many-to-many between a cube revision and the columns
+    it references (its metric columns and dimension attributes), keyed by
+    `(cube_id, column.id)`. A dimension attribute referenced under multiple roles
+    resolves to the same Column object, so appending it once per role would
+    violate `pk_cube`. Roles live on the cube's node_columns, so deduping here is
+    lossless.
+    """
+    deduped: Dict = {}
+    for col in columns:
+        deduped.setdefault(col.id if col.id is not None else id(col), col)
+    return list(deduped.values())
 
 
 async def validate_cube(

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -14,7 +14,8 @@ from datajunction_server.api.helpers import (
     get_node_namespace,
     COLUMN_NAME_REGEX,
     _resolve_required_dimensions,
-    map_dimensions_to_roles,
+    cube_element_roles,
+    dedupe_cube_elements,
 )
 from datajunction_server.construction.build_v2 import FullColumnName
 from datajunction_server.database import Node, NodeRevision
@@ -2631,7 +2632,9 @@ class DeploymentOrchestrator:
         # Build the "columns" for this node based on the cube elements
         node_columns = []
 
-        dimension_to_roles_mapping = map_dimensions_to_roles(
+        # Role suffix per cube element, aligned to metric_columns + dimension_columns.
+        element_roles = cube_element_roles(
+            len(validation_data.metric_columns),
             cube_spec.rendered_dimensions or [],
         )
 
@@ -2670,10 +2673,8 @@ class DeploymentOrchestrator:
                 ],
                 order=idx,
             )
-            if full_element_name in dimension_to_roles_mapping:
-                node_column.dimension_column = dimension_to_roles_mapping[
-                    full_element_name
-                ]
+            if element_roles[idx]:
+                node_column.dimension_column = element_roles[idx]
 
             # Apply partition from column spec if specified
             if full_element_name in column_spec_map:
@@ -2695,8 +2696,9 @@ class DeploymentOrchestrator:
             type=NodeType.CUBE,
             query="",
             columns=node_columns,
-            cube_elements=validation_data.metric_columns
-            + validation_data.dimension_columns,
+            cube_elements=dedupe_cube_elements(
+                validation_data.metric_columns + validation_data.dimension_columns,
+            ),
             parents=list(
                 set(validation_data.dimension_nodes + validation_data.metric_nodes),
             ),

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -812,21 +812,16 @@ async def _cube_project_config(
         namespace_requested=namespace_requested,
     )
     cube_revision = await get_single_cube_revision_metadata(session, node.name)
-    metrics = []
-    dimensions = []
-    for element in cube_revision.cube_elements:
-        if element.type == NodeType.METRIC:
-            metrics.append(element.node_name)
-        else:
-            dimensions.append(f"{element.node_name}.{element.name}")
     return {
         "filename": filename,
         "directory": directory,
         "build_name": build_name,
         "display_name": cube_revision.display_name,
         "description": cube_revision.description,
-        "metrics": metrics,
-        "dimensions": dimensions,
+        # cube_node_metrics/cube_node_dimensions read the cube's node_columns and
+        # are already role-aware, so no manual role reconstruction is needed.
+        "metrics": cube_revision.cube_node_metrics,
+        "dimensions": cube_revision.cube_node_dimensions,
         "columns": [
             {
                 "name": column.name,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -21,12 +21,13 @@ from datajunction_server.internal.caching.interface import Cache
 from datajunction_server.models.deployment import DeploymentResult
 from datajunction_server.models.query import QueryCreate
 from datajunction_server.api.helpers import (
+    cube_element_roles,
+    dedupe_cube_elements,
     get_attribute_type,
     get_catalog_by_name,
     get_column,
     get_node_by_name,
     get_node_namespace,
-    map_dimensions_to_roles,
     raise_if_node_exists,
     resolve_downstream_references,
     validate_cube,
@@ -637,7 +638,8 @@ async def create_cube_node_revision(
     # Build the "columns" for this node based on the cube elements. These are used
     # for marking partition columns when the cube gets materialized.
     node_columns = []
-    dimension_to_roles_mapping = map_dimensions_to_roles(data.dimensions or [])
+    # Role suffix per cube element, aligned to metric_columns + dimension_columns.
+    element_roles = cube_element_roles(len(metric_columns), data.dimensions or [])
     for idx, col in enumerate(metric_columns + dimension_columns):
         await session.refresh(col, ["node_revision"])
         referenced_node = col.node_revision
@@ -659,13 +661,8 @@ async def create_cube_node_revision(
             ],
             order=idx,
         )
-        if (
-            full_element_name in dimension_to_roles_mapping
-            and dimension_to_roles_mapping[full_element_name]
-        ):
-            node_column.dimension_column = (
-                "[" + dimension_to_roles_mapping[full_element_name] + "]"
-            )
+        if element_roles[idx]:
+            node_column.dimension_column = element_roles[idx]
 
         node_columns.append(node_column)
 
@@ -676,7 +673,7 @@ async def create_cube_node_revision(
         type=NodeType.CUBE,
         query="",
         columns=node_columns,
-        cube_elements=metric_columns + dimension_columns,
+        cube_elements=dedupe_cube_elements(metric_columns + dimension_columns),
         parents=list(set(dimension_nodes + metric_nodes)),
         status=status,
         catalog=catalog,

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -72,13 +72,14 @@ class CubeElementMetadata(BaseModel):
         """
         Derives the column name in the generated Cube SQL based on the CubeElement
         """
-        query_column_name = (
-            self.name
-            if self.type == "metric"
-            else amenable_name(
-                f"{self.node_name}{SEPARATOR}{self.name}",
-            )
-        )
+        if self.type == "metric":
+            query_column_name = self.name
+        else:
+            full_name = f"{self.node_name}{SEPARATOR}{self.name}"
+            # Include the role so two roles on one column get distinct names.
+            if self.role:
+                full_name = f"{full_name}[{self.role}]"
+            query_column_name = amenable_name(full_name)
         return ColumnOutput(
             name=query_column_name,
             display_name=self.display_name,
@@ -131,30 +132,32 @@ class CubeRevisionMetadata(BaseModel):
             key=lambda elem: element_ordering.get(from_amenable_name(elem.name), 0),
         )
 
-        # Cube columns hold the role suffix in `dimension_column` for any
-        # element selected via a named role. Build a lookup keyed by the same
-        # full dotted name we'll reconstruct for each dimension element below.
-        roles_by_full_name: dict[str, str] = {
-            col.name: col.dimension_column
-            for col in cube.columns
-            if col.dimension_column
-        }
-
         # Parse the database object into a pydantic object
         cube_metadata = cls.model_validate(cube)
 
-        # Attach role to each dimension element by matching its reconstructed
-        # full name (`<node_name>.<element_name>`) against the cube columns.
-        for elem_meta, raw_elem in zip(
-            cube_metadata.cube_elements,
-            cube.cube_elements,
-        ):
-            if elem_meta.type == "metric":
+        # node_columns are the role-aware source of truth (one per role); the
+        # cube_elements many-to-many holds each referenced column only once. Expand
+        # each dimension element into one entry per role so both survive on load.
+        metric_names = {metric.name for metric in cube.cube_metrics()}
+        roles_by_full_name: dict[str, List[Optional[str]]] = {}
+        for col in sorted(cube.columns, key=lambda c: c.order):
+            if col.name in metric_names:
                 continue
-            full_name = f"{raw_elem.node_revision.name}.{raw_elem.name}"
-            role_suffix = roles_by_full_name.get(full_name)
-            if role_suffix:
-                elem_meta.role = role_suffix.strip("[]")
+            role = col.dimension_column.strip("[]") if col.dimension_column else None
+            roles_by_full_name.setdefault(col.name, []).append(role)
+
+        expanded_elements: List[CubeElementMetadata] = []
+        for elem_meta in cube_metadata.cube_elements:
+            if elem_meta.type == "metric":
+                expanded_elements.append(elem_meta)
+                continue
+            full_name = f"{elem_meta.node_name}{SEPARATOR}{elem_meta.name}"
+            roles = roles_by_full_name.get(full_name, [None])
+            for position, role in enumerate(roles):
+                element = elem_meta if position == 0 else elem_meta.model_copy()
+                element.role = role
+                expanded_elements.append(element)
+        cube_metadata.cube_elements = expanded_elements
 
         # Populate metric measures
         cube_metadata.measures = []

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2948,6 +2948,25 @@ async def test_derive_sql_column():
     assert sql_column.display_name == expected_sql_column.display_name
     assert sql_column.type == expected_sql_column.type
 
+    # Role-qualified dimensions include the role, so two roles on the same
+    # column produce distinct SQL column names.
+    from_col = CubeElementMetadata(
+        name="dateint",
+        display_name="Date",
+        node_name="foo.dates",
+        type="dimension",
+        role="start",
+    ).derive_sql_column()
+    to_col = CubeElementMetadata(
+        name="dateint",
+        display_name="Date",
+        node_name="foo.dates",
+        type="dimension",
+        role="end",
+    ).derive_sql_column()
+    assert from_col.name != to_col.name
+    assert "start" in from_col.name and "end" in to_col.name
+
 
 @pytest.mark.asyncio
 async def test_cube_materialization_metadata(
@@ -3969,6 +3988,66 @@ class TestCubeMaterializeV2Endpoint:
         )
         assert response.status_code == 404
         assert "not found" in response.json()["message"].lower()
+
+
+class TestCubeRoleQualifiedDimensions:
+    """A cube may reference the same dimension attribute under two roles (e.g.
+    `v3.location.country[from]` and `[to]`) — regression for pk_cube."""
+
+    @pytest.mark.asyncio
+    async def test_create_cube_same_column_two_roles(
+        self,
+        module__client_with_build_v3: AsyncClient,
+    ):
+        """One column under two roles must not raise pk_cube; both survive on load."""
+        response = await module__client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.two_role_country_cube",
+                "metrics": ["v3.total_revenue"],
+                # Same column under two roles, plus a plain (roleless) dimension.
+                "dimensions": [
+                    "v3.location.country[from]",
+                    "v3.location.country[to]",
+                    "v3.product.category",
+                ],
+                "mode": "published",
+                "description": "Same location.country column under from/to roles",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        response = await module__client_with_build_v3.get(
+            "/cubes/v3.two_role_country_cube/",
+        )
+        assert response.status_code == 200, response.json()
+        cube = response.json()
+
+        # Both role-qualified dimensions survive — not collapsed to one — and the
+        # plain dimension is unaffected.
+        assert cube["cube_node_dimensions"] == [
+            "v3.location.country[from]",
+            "v3.location.country[to]",
+            "v3.product.category",
+        ]
+
+        # cube_node_dimensions above is the authoritative ordered list; cube_elements
+        # is a secondary view whose ordering across distinct source columns is
+        # pre-existing, so assert its contents as a set.
+        dimension_elements = {
+            (elem["node_name"], elem["name"], elem["role"])
+            for elem in cube["cube_elements"]
+            if elem["type"] == "dimension"
+        }
+        assert dimension_elements == {
+            ("v3.location", "country", "from"),
+            ("v3.location", "country", "to"),
+            ("v3.product", "category", None),
+        }
+
+        # SQL column names stay distinct (would collide if role were dropped).
+        sql_column_names = [col["name"] for col in cube["sql_columns"]]
+        assert len(sql_column_names) == len(set(sql_column_names))
 
 
 class TestCubeDeactivateEndpoint:

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -4951,3 +4951,113 @@ async def test_validate_reference_dimension_link_good_attribute():
 
     # Should not raise
     await validate_reference_dimension_link(link, node, dim_node)
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestCubeRoleCollisionDeployment:
+    """pk_cube role-collision repro via the push path: a fact links one dimension
+    twice under two roles and a cube references the same column under both. The
+    real push previously crashed with a pk_cube UniqueViolation."""
+
+    @pytest.mark.asyncio
+    async def test_deploy_cube_same_column_two_roles(self, client):
+        namespace = "pk_cube_role"
+        nodes = [
+            SourceSpec(
+                name="orders_raw",
+                description="Raw orders",
+                catalog="default",
+                schema="roads",
+                table="orders_raw",
+                columns=[
+                    ColumnSpec(name="order_dateint", type="int"),
+                    ColumnSpec(name="ship_dateint", type="int"),
+                ],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            SourceSpec(
+                name="dates_raw",
+                description="Raw dates",
+                catalog="default",
+                schema="roads",
+                table="dates_raw",
+                columns=[
+                    ColumnSpec(name="dateint", type="int"),
+                    ColumnSpec(name="monthint", type="int"),
+                ],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            DimensionSpec(
+                name="dates_d",
+                description="Date dimension",
+                query="SELECT dateint, monthint FROM ${prefix}dates_raw",
+                primary_key=["dateint"],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            TransformSpec(
+                name="orders_f",
+                description="Orders fact linked to dates twice (order/ship)",
+                query="SELECT order_dateint, ship_dateint FROM ${prefix}orders_raw",
+                dimension_links=[
+                    DimensionJoinLinkSpec(
+                        dimension_node="${prefix}dates_d",
+                        join_type="left",
+                        join_on="${prefix}orders_f.order_dateint = ${prefix}dates_d.dateint",
+                        role="order_date",
+                    ),
+                    DimensionJoinLinkSpec(
+                        dimension_node="${prefix}dates_d",
+                        join_type="left",
+                        join_on="${prefix}orders_f.ship_dateint = ${prefix}dates_d.dateint",
+                        role="ship_date",
+                    ),
+                ],
+                owners=["dj"],
+            ),
+            MetricSpec(
+                name="order_count",
+                description="Order count",
+                query="SELECT COUNT(*) FROM ${prefix}orders_f",
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            CubeSpec(
+                name="orders_cube",
+                display_name="Orders Cube",
+                description="Cube referencing dates_d.monthint under both roles",
+                metrics=["${prefix}order_count"],
+                dimensions=[
+                    "${prefix}dates_d.monthint[order_date]",
+                    "${prefix}dates_d.monthint[ship_date]",
+                ],
+                owners=["dj"],
+            ),
+        ]
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        # The real push must succeed — previously it raised a pk_cube UniqueViolation.
+        assert data["status"] == DeploymentStatus.SUCCESS.value, data
+
+        # Both role-qualified dimensions survive on the deployed cube.
+        response = await client.get(f"/cubes/{namespace}.orders_cube/")
+        assert response.status_code == 200, response.json()
+        cube = response.json()
+        assert cube["cube_node_dimensions"] == [
+            f"{namespace}.dates_d.monthint[order_date]",
+            f"{namespace}.dates_d.monthint[ship_date]",
+        ]
+        dimension_elements = [
+            (elem["node_name"], elem["name"], elem["role"])
+            for elem in cube["cube_elements"]
+            if elem["type"] == "dimension"
+        ]
+        assert dimension_elements == [
+            (f"{namespace}.dates_d", "monthint", "order_date"),
+            (f"{namespace}.dates_d", "monthint", "ship_date"),
+        ]

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -11,13 +11,49 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from datajunction_server.api import helpers
-from datajunction_server.api.helpers import find_required_dimensions
+from datajunction_server.api.helpers import (
+    dedupe_cube_elements,
+    dimension_roles_in_order,
+    find_required_dimensions,
+)
+from datajunction_server.database.column import Column
 from datajunction_server.internal import sql
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import DJDoesNotExistException, DJException
 from datajunction_server.internal.nodes import propagate_valid_status
 from datajunction_server.models.node import NodeStatus
+from datajunction_server.sql.parsing.types import IntegerType
+
+
+def test_dimension_roles_in_order():
+    """One [role] suffix (or None) per reference — two roles on the same column
+    are NOT collapsed."""
+    assert dimension_roles_in_order(
+        [
+            "v3.location.country[from]",
+            "v3.location.country[to]",
+            "v3.product.category",
+        ],
+    ) == ["[from]", "[to]", None]
+
+
+def test_dedupe_cube_elements_same_object():
+    """The same Column appended twice (two roles on one column) is deduped."""
+    col_a = Column(name="a", type=IntegerType())
+    col_b = Column(name="b", type=IntegerType())
+    assert dedupe_cube_elements([col_a, col_a, col_b]) == [col_a, col_b]
+
+
+def test_dedupe_cube_elements_by_column_id():
+    """Distinct Column objects that share a persisted id (the pk_cube key) dedupe."""
+    col1 = Column(name="dateint", type=IntegerType())
+    col1.id = 5
+    col2 = Column(name="dateint", type=IntegerType())
+    col2.id = 5
+    col3 = Column(name="other", type=IntegerType())
+    col3.id = 6
+    assert dedupe_cube_elements([col1, col2, col3]) == [col1, col3]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -832,7 +832,7 @@ async def test_export_namespaces(client_with_roads: AsyncClient):
             },
         ],
         "description": "An example cube so that the export path is tested",
-        "dimensions": ["default.hard_hat.hire_date", "default.hard_hat.city"],
+        "dimensions": ["default.hard_hat.city", "default.hard_hat.hire_date"],
         "directory": "",
         "display_name": "Example Cube",
         "filename": "example_cube.cube.yaml",


### PR DESCRIPTION
### Summary

A cube should be able to reference the same dimension attribute under two different roles -- e.g. a windowed cube including `date.dateint[window_start_date]` and `date.dateint[window_end_date]`. Today that's broken end-to-end:
1. **Storage Violation**: `cube_elements` is the many-to-many relationship between a cube revision and the columns it references, keyed by `(cube_id, column.id)`. Both cube building paths append the same `Column` twice (a dimension attribute under two roles resolves to one Column still), so persisting the cube inserts two rows with the same key, resulting in a Postgres `pk_cube` UniqueViolation.
2. **Write Collapse**: Role assignment went through a name-keyed dict that dropped all but the last role for a shared attribute, so the distinction between roles was lost before storage. The deployment path also stored the role without its `[...]`.
3. **Read Collapse**:`from_cube_revision` keyed roles by column name and built its element list from the deduped many-to-many, surfacing at most one role on load.

The fix is to leverage the fact that a cube's `node_columns` are already storing the role (role held in `Column.dimension_column`), and the SQL/materialization path reads them via `cube_node_dimensions`. So this makes `node_columns` authoritative and keeps `cube_elements` as the deduped set of referenced columns.

### Test Plan

Added unit tests for `dimension_roles_in_order` and `dedupe_cube_elements`. Added two integration tests, one for creating a cube via the normal path, and another via the deployment push path. In both cases, the cube referenced one dimension attribute under two roles.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
