### PR TITLE
Make sqlglot a required dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
 
           # Install dependencies (each package has different extras)
           if [ "${{ matrix.library }}" = "server" ]; then
-            uv sync --group test --extra transpilation --python ${{ matrix.python-version }}
+            uv sync --group test --python ${{ matrix.python-version }}
           elif [ "${{ matrix.library }}" = "client" ]; then
             uv sync --group test --extra mcp --python ${{ matrix.python-version }}
           else

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,7 +12,7 @@ DataJunction (DJ) is currently supported in Python 3.8, 3.9, and 3.10. It's reco
     $ pyenv virtualenv 3.8 dj  # or 3.9/3.10
 
 Then you can pick any of the components you want to develop on, say ``cd datajunction-server`` or ``cd datajunction-clients/python``,
-install required dependencies with ``pdm install`` and call ``make test`` to run all the unit tests for that component.
+install required dependencies with ``make setup`` (which runs ``uv sync``) and call ``make test`` to run all the unit tests for that component.
 
 DJ relies heavily on these libraries:
 
@@ -242,7 +242,7 @@ A few `fixtures <https://docs.pytest.org/en/7.1.x/explanation/fixtures.html#abou
 Adding new dependencies
 =======================
 
-When a PR introduces a new dependency, add them to ``setup.cfg`` under ``install_requires``. If the dependency version is less than ``1.0`` and you expect it to change often it's better to pin the dependency, eg:
+When a PR introduces a new dependency, add it to ``pyproject.toml`` under ``[project]`` ``dependencies`` (or the appropriate optional-dependencies extra) and refresh the lock with ``uv lock``. If the dependency version is less than ``1.0`` and you expect it to change often it's better to pin the dependency, eg:
 
 .. code-block:: config
 

--- a/datajunction-server/Dockerfile
+++ b/datajunction-server/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /code
 COPY . /code
 
 # Install dependencies using uv (faster than pip)
-RUN uv sync --extra uvicorn --extra transpilation --no-dev
+RUN uv sync --extra uvicorn --no-dev
 
 CMD ["sh", "-c", "uv run opentelemetry-instrument uvicorn datajunction_server.api.main:app --host 0.0.0.0 --port 8000 $RELOAD"]
 EXPOSE 8000

--- a/datajunction-server/Makefile
+++ b/datajunction-server/Makefile
@@ -1,5 +1,5 @@
 setup:
-	uv sync --group test --extra transpilation
+	uv sync --group test
 
 docker-build:
 	docker build .

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -1,8 +1,9 @@
 """SQL transpilation plugins manager."""
 
-import importlib
 from typing import Optional
 import logging
+
+import sqlglot
 
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.dialect import DialectRegistry, dialect_plugin
@@ -17,30 +18,14 @@ class SQLTranspilationPlugin:
     """
     SQL transpilation plugin base class. To add support for a new SQL transpilation library,
     implement this class with a custom `transpile_sql` method that works for the library. The
-    base implementation here will handle checking that the package exists before loading and
-    using it, or skipping transpilation if the package cannot be loaded.
+    base implementation here is a no-op that returns the query unchanged.
+
+    ``package_name`` identifies the plugin and is matched against
+    ``settings.transpilation_plugins`` to decide whether the plugin is registered
+    (see ``register_dialect_plugin``).
     """
 
     package_name: Optional[str] = "default"
-
-    def __init__(self):
-        """
-        Load the package
-        """
-        self.check_package()
-
-    def check_package(self):
-        """
-        Check that the selected SQL transpilation package is installed and loads it.
-        """
-        if self.package_name:  # pragma: no cover
-            try:
-                importlib.import_module(self.package_name)
-            except ImportError:
-                logger.warning(
-                    "The SQL transpilation package is not installed: %s",
-                    self.package_name,
-                )
 
     def transpile_sql(
         self,
@@ -80,8 +65,6 @@ class SQLGlotTranspilationPlugin(SQLTranspilationPlugin):
         """
         Transpile a given SQL query using the specific library.
         """
-        import sqlglot
-
         # Check to make sure that the output dialect is supported by sqlglot before transpiling
         if (
             input_dialect

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -59,6 +59,10 @@ dependencies = [
     # Query parsing
     "antlr4-python3-runtime==4.13.1",
 
+    # SQL transpilation — required: DJ transpiles generated SQL per dialect and
+    # has no fallback (see datajunction_server/transpilation.py).
+    "sqlglot>=18.0.1",
+
     # Model Context Protocol (powers /mcp endpoint)
     "mcp>=1.0.0",
     # Terminal-friendly charts for the MCP visualize_metrics tool
@@ -104,9 +108,6 @@ classifiers = [
 uvicorn = [
     "uvicorn[standard]>=0.21.1",
 ]
-transpilation = [
-    "sqlglot>=18.0.1",
-]
 
 # Query client dependencies for different data warehouse vendors
 snowflake = [
@@ -115,7 +116,6 @@ snowflake = [
 
 bigquery = [
     "google-cloud-bigquery>=3.0.0",
-    "sqlglot>=18.0.1",
 ]
 
 all = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - ./datajunction-server:/code
       - /code/.venv  # Isolate container venv from local
-    command: /bin/sh -c "uv sync --extra uvicorn --extra transpilation --no-dev && uv run opentelemetry-instrument uvicorn datajunction_server.api.main:app --host 0.0.0.0 --port 8000 --reload"
+    command: /bin/sh -c "uv sync --extra uvicorn --no-dev && uv run opentelemetry-instrument uvicorn datajunction_server.api.main:app --host 0.0.0.0 --port 8000 --reload"
     ports:
       - "${DJ_PORT:-8000}:8000"
     depends_on:

--- a/uv.lock
+++ b/uv.lock
@@ -870,6 +870,7 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-utils" },
+    { name = "sqlglot" },
     { name = "sse-starlette" },
     { name = "strawberry-graphql" },
     { name = "types-cachetools" },
@@ -884,13 +885,9 @@ all = [
 ]
 bigquery = [
     { name = "google-cloud-bigquery" },
-    { name = "sqlglot" },
 ]
 snowflake = [
     { name = "snowflake-connector-python" },
-]
-transpilation = [
-    { name = "sqlglot" },
 ]
 uvicorn = [
     { name = "uvicorn", extra = ["standard"] },
@@ -959,8 +956,7 @@ requires-dist = [
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "sqlalchemy-utils", specifier = ">=0.40.0,<1.0.0" },
-    { name = "sqlglot", marker = "extra == 'bigquery'", specifier = ">=18.0.1" },
-    { name = "sqlglot", marker = "extra == 'transpilation'", specifier = ">=18.0.1" },
+    { name = "sqlglot", specifier = ">=18.0.1" },
     { name = "sse-starlette", specifier = ">=1.6.0,<=2.0.0" },
     { name = "strawberry-graphql", specifier = ">=0.235.0" },
     { name = "types-cachetools", specifier = ">=5.3.0.6" },
@@ -968,7 +964,7 @@ requires-dist = [
     { name = "yamlfix", specifier = ">=1.16.0" },
     { name = "yarl", specifier = ">=1.8.2,<2.0.0" },
 ]
-provides-extras = ["all", "bigquery", "snowflake", "transpilation", "uvicorn"]
+provides-extras = ["all", "bigquery", "snowflake", "uvicorn"]
 
 [package.metadata.requires-dev]
 test = [


### PR DESCRIPTION
DJ transpiles generated SQL per dialect via sqlglot and has no realistic fallback, yet sqlglot was only an optional extra (`transpilation`, and duplicated in `bigquery`).

Promote sqlglot to a core dependency and drop the now-redundant optional plumbing:

- pyproject.toml: add `sqlglot>=18.0.1` to core dependencies; remove the `transpilation` extra and the duplicate entry in the `bigquery` extra.
- transpilation.py: import sqlglot at module top level matched against settings.transpilation_plugins.
- Makefile / CI: drop `--extra transpilation` from `uv sync`.
- requirements/docker.txt: update the documented export command
- uv.lock: sqlglot moves from the extras to the core dependency set.

