### PR TITLE
Git-backed namespace management

### DIFF
--- a/datajunction-server/datajunction_server/api/deployments.py
+++ b/datajunction-server/datajunction_server/api/deployments.py
@@ -97,12 +97,18 @@ async def _verify_git_deployment(
         deployment_spec.namespace,
     )
 
-    # Verify commit exists in the configured repository
+    # Verify commit exists in the configured repository. A namespace can be
+    # git_only without a github_repo_path (e.g. auto-locked on first git deploy,
+    # or a flat namespace locked via PATCH). There's no repo to verify the
+    # commit against, so skip verification rather than hard-failing the deploy —
+    # the lock is about blocking UI edits, and this deploy is already git-sourced.
     if not github_repo_path:
-        raise DJInvalidInputException(  # pragma: no cover
-            message=f"Namespace '{deployment_spec.namespace}' is git-only but has no "
-            "github_repo_path configured. Cannot verify commit.",
+        logger.info(
+            "Namespace %s is git-only with no github_repo_path; "
+            "skipping commit verification.",
+            deployment_spec.namespace,
         )
+        return
 
     try:
         github = GitHubService()
@@ -127,6 +133,69 @@ async def _verify_git_deployment(
         deployment_spec.source.commit_sha[:8],
         namespace_obj.github_repo_path if namespace_obj else github_repo_path,
     )
+
+
+def _normalize_repo_path(repository: str) -> str:
+    """
+    Normalize a deployment source repository to the ``owner/repo`` form stored in
+    ``NodeNamespace.github_repo_path``. Accepts ``github.com/org/repo``,
+    ``https://github.netflix.net/corp/repo.git``, ``git@host:corp/repo``, or an
+    already-normalized ``corp/repo`` — and returns the trailing ``owner/repo``.
+    """
+    repo = repository.strip()
+    for prefix in ("https://", "http://", "ssh://", "git@"):
+        if repo.startswith(prefix):
+            repo = repo[len(prefix) :]
+    repo = repo.replace(":", "/")
+    if repo.endswith(".git"):
+        repo = repo[: -len(".git")]
+    parts = [segment for segment in repo.split("/") if segment]
+    return "/".join(parts[-2:]) if len(parts) >= 2 else repo
+
+
+async def _maybe_autolock_git_namespace(deployment_spec: DeploymentSpec) -> None:
+    """
+    Default-on-git-push: when a namespace is deployed from git, record the repo it
+    tracks (``github_repo_path`` + ``git_branch``) so it becomes a *repo owner* and
+    is UI-locked via ``is_repo_owner`` — the single "git-managed ⇒ read-only"
+    signal. No ``git_only`` write, so unlock is a config change (detach the repo).
+
+    Guards:
+    - Only a git deploy carrying a ``commit_sha`` — a reproducible, CI-driven
+      deployment. Looser branch-only git deploys are left editable.
+    - Only a non-branch namespace (no ``parent_namespace``) — branch namespaces
+      are meant to be git-deployed *and* editable (edit, sync back).
+    - Only when ``github_repo_path`` is unset — never clobber an intentional
+      config on later deploys.
+    - ``git_branch`` is set to the deployed branch (non-null) so the namespace is
+      a *flat* repo owner, not mistaken for a child-spawning git root.
+
+    Called only after a successful deploy, so the namespace already exists.
+    """
+    src = deployment_spec.source
+    if (
+        not src
+        or src.type != DeploymentSourceType.GIT
+        or not getattr(src, "commit_sha", None)
+        or not getattr(src, "repository", None)
+    ):
+        return
+    async with session_context() as session:
+        ns = await NodeNamespace.get(
+            session,
+            deployment_spec.namespace,
+            raise_if_not_exists=False,
+        )
+        if (
+            ns is None
+            or ns.parent_namespace is not None
+            or ns.github_repo_path is not None
+        ):
+            return
+        ns.github_repo_path = _normalize_repo_path(src.repository)
+        ns.git_branch = getattr(src, "branch", None) or ns.git_branch
+        session.add(ns)
+        await session.commit()
 
 
 class DeploymentExecutor(ABC):
@@ -222,6 +291,8 @@ class InProcessExecutor(DeploymentExecutor):
                     results,
                     downstream_impacts=execute_result.downstream_impacts,
                 )
+                if final_status == DeploymentStatus.SUCCESS:
+                    await _maybe_autolock_git_namespace(deployment_spec)
         except Exception as exc:
             logger.error("Deployment %s failed: %s", deployment_id, exc, exc_info=True)
             await InProcessExecutor.update_status(
@@ -274,18 +345,21 @@ async def create_deployment(
     )
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
 
-    # Check git_only enforcement
+    # Git-managed namespaces (explicitly git_only, or a repo owner) require a
+    # verified git deployment. A repo owner is any namespace that directly owns
+    # a repo (github_repo_path set, no parent) — covers both git roots and flat
+    # git-backed namespaces.
     namespace_obj = await NodeNamespace.get(
         session,
         deployment_spec.namespace,
         raise_if_not_exists=False,
     )
-    is_git_root = (
+    is_repo_owner = (
         namespace_obj is not None
         and namespace_obj.github_repo_path is not None
-        and namespace_obj.git_branch is None
+        and namespace_obj.parent_namespace is None
     )
-    if namespace_obj and (namespace_obj.git_only or is_git_root):
+    if namespace_obj and (namespace_obj.git_only or is_repo_owner):
         await _verify_git_deployment(session, deployment_spec, namespace_obj)
 
     _t0 = time.monotonic()
@@ -305,6 +379,7 @@ async def create_deployment(
             cache=cache,
         ),
     )
+
     deployment = await session.get(Deployment, deployment_id)
     status = deployment.status.value if deployment else "unknown"
     get_metrics_provider().timer(

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -133,9 +133,7 @@ async def check_namespace_not_git_only(
     for ns in sorted(matches, key=lambda n: len(n.namespace), reverse=True):
         is_self = ns.namespace == namespace
         is_repo_owner = (
-            is_self
-            and ns.github_repo_path is not None
-            and ns.parent_namespace is None
+            is_self and ns.github_repo_path is not None and ns.parent_namespace is None
         )
         if ns.git_only or is_repo_owner:
             scope_msg = (

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -102,11 +102,13 @@ async def check_namespace_not_git_only(
 
     Blocks mutations when any ancestor (or the namespace itself):
     - Has ``git_only=True`` (explicitly locked), OR
-    - Is a git root (``github_repo_path`` set and ``git_branch`` null).
+    - Is a repo owner (``github_repo_path`` set and no ``parent_namespace``).
 
-    Branch namespaces (children of a git root with a non-null ``git_branch``)
-    are intentionally allowed — edits there are valid and get synced back to
-    the git repo, so they don't trip this check.
+    A repo owner covers both a git root (spawns ``<ns>.<branch>`` children) and
+    a flat git-backed namespace (tracks a branch directly). Branch namespaces
+    (children with a ``parent_namespace``) are intentionally allowed — edits
+    there are valid and get synced back to the git repo, so they don't trip
+    this check.
 
     Implementation: namespace names contain their parent path (``a.b.c``),
     so we materialize every prefix and fire a single ``IN`` query. One round
@@ -125,15 +127,17 @@ async def check_namespace_not_git_only(
     )
 
     # Walk deepest-first so the most specific locked ancestor (the one the
-    # user can most usefully act on) wins the error message. ``is_git_root``
+    # user can most usefully act on) wins the error message. ``is_repo_owner``
     # only applies to the namespace itself — its branch children are
     # intentionally editable — so don't propagate that flag up the chain.
     for ns in sorted(matches, key=lambda n: len(n.namespace), reverse=True):
         is_self = ns.namespace == namespace
-        is_git_root = (
-            is_self and ns.github_repo_path is not None and ns.git_branch is None
+        is_repo_owner = (
+            is_self
+            and ns.github_repo_path is not None
+            and ns.parent_namespace is None
         )
-        if ns.git_only or is_git_root:
+        if ns.git_only or is_repo_owner:
             scope_msg = (
                 f"'{namespace}'"
                 if is_self

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -796,9 +796,6 @@ async def update_namespace_git_config(
         if config.parent_namespace is not None
         else node_namespace.parent_namespace
     )
-    new_git_only = (
-        config.git_only if config.git_only is not None else node_namespace.git_only
-    )
 
     # Early validations (independent of parent relationship)
     validate_git_path(new_path)
@@ -821,21 +818,13 @@ async def update_namespace_git_config(
                 "Remove parent_namespace if you want to configure this as a git root.",
             )
 
-    # Validate git_only - only meaningful for branch namespaces.
-    # Git root namespaces (those with github_repo_path) are auto-locked and do not
-    # need git_only to be set explicitly.
-    if new_git_only:
-        is_branch_namespace = new_parent and new_branch
-
-        if not is_branch_namespace:
-            raise DJInvalidInputException(
-                message=(
-                    "git_only is only applicable to branch namespaces that have "
-                    "parent_namespace and git_branch configured. "
-                    "Git root namespaces are automatically locked when "
-                    "github_repo_path is set."
-                ),
-            )
+    # git_only is a per-namespace lock and is valid on ANY namespace — flat,
+    # git root, or branch. Git roots are still auto-locked via is_git_root, but
+    # a flat git-backed namespace (one that does not follow the
+    # <namespace>.<branch> structure) can now be locked explicitly instead of
+    # silently staying UI-editable. Enforcement lives in
+    # check_namespace_not_git_only, which already honors the flag on any
+    # namespace and cascades to descendants.
 
     # Validate parent_namespace if provided
     if new_parent:

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -4639,6 +4639,58 @@ class TestGitOnlyNamespaceDeployments:
 
         assert data["status"] == DeploymentStatus.SUCCESS.value
 
+    @pytest.mark.asyncio
+    async def test_git_deploy_persists_repo_and_locks(self, client):
+        """A CI git deploy (with commit_sha) to a flat namespace persists the repo
+        it tracks, making it a repo owner that is UI-locked via is_repo_owner.
+        Unlock is a config change (detach the repo), not a git_only toggle."""
+        namespace = "git_autolock_flat"
+
+        source_spec = SourceSpec(
+            name="s1",
+            description="Test source",
+            catalog="default",
+            schema="test",
+            table="t1",
+            columns=[ColumnSpec(name="id", type="int")],
+        )
+
+        # First git deploy — namespace doesn't exist yet and has no repo, so
+        # commit verification is skipped and the deploy succeeds. The repo path
+        # gets normalized (github.com/corp/repo -> corp/repo) and persisted.
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace=namespace,
+                nodes=[source_spec],
+                source=GitDeploymentSource(
+                    repository="github.com/corp/repo",
+                    branch="main",
+                    commit_sha="abc123",
+                ),
+            ),
+        )
+        assert data["status"] == DeploymentStatus.SUCCESS.value
+
+        # Repo + branch persisted → a flat repo owner. No git_only write.
+        cfg = (await client.get(f"/namespaces/{namespace}/git")).json()
+        assert cfg["github_repo_path"] == "corp/repo"
+        assert cfg["git_branch"] == "main"
+        assert not cfg["git_only"]
+
+        # Locked via is_repo_owner: a UI node mutation is blocked.
+        blocked = await client.delete(f"/nodes/{namespace}.s1/")
+        assert blocked.status_code == 422
+        assert "git-managed" in blocked.json()["message"]
+
+        # Unlock = detach the repo (config change), not a git_only toggle.
+        detach = await client.delete(f"/namespaces/{namespace}/git")
+        assert detach.status_code in (200, 204)
+
+        # Now editable again.
+        ok = await client.delete(f"/nodes/{namespace}.s1/")
+        assert ok.status_code in (200, 201)
+
 
 @pytest.mark.xdist_group(name="deployments")
 class TestDeploymentStatusUpdate:

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -20,7 +20,10 @@ from datajunction_server.models.deployment import (
     LocalDeploymentSource,
 )
 from datajunction_server.internal.git.github_service import GitHubServiceError
-from datajunction_server.api.deployments import InProcessExecutor
+from datajunction_server.api.deployments import (
+    InProcessExecutor,
+    _normalize_repo_path,
+)
 from datajunction_server.models.dimensionlink import JoinType
 from datajunction_server.database.node import Node, NodeRelationship
 from datajunction_server.database.tag import Tag
@@ -4690,6 +4693,91 @@ class TestGitOnlyNamespaceDeployments:
         # Now editable again.
         ok = await client.delete(f"/nodes/{namespace}.s1/")
         assert ok.status_code in (200, 201)
+
+    @pytest.mark.parametrize(
+        "repository, expected",
+        [
+            # Already normalized.
+            ("corp/repo", "corp/repo"),
+            # Bare host-prefixed form (no scheme).
+            ("github.com/corp/repo", "corp/repo"),
+            # https:// scheme prefix + .git suffix stripped.
+            ("https://github.netflix.net/corp/repo.git", "corp/repo"),
+            # http:// scheme prefix.
+            ("http://github.com/org/repo", "org/repo"),
+            # ssh:// scheme prefix.
+            ("ssh://git@host/corp/repo.git", "corp/repo"),
+            # scp-style git@host:owner/repo (colon normalized to slash).
+            ("git@github.netflix.net:corp/repo", "corp/repo"),
+            # Single segment (no owner) — returned as-is.
+            ("repo", "repo"),
+        ],
+    )
+    def test_normalize_repo_path(self, repository, expected):
+        """_normalize_repo_path reduces any repo URL form to owner/repo.
+
+        Covers the scheme-prefix strip (https/http/ssh/git@), the ``.git``
+        suffix strip, colon->slash for scp-style URLs, and the single-segment
+        fallthrough.
+        """
+        assert _normalize_repo_path(repository) == expected
+
+    @pytest.mark.asyncio
+    async def test_git_only_namespace_no_repo_skips_verification(self, client):
+        """A git_only namespace with NO github_repo_path skips commit verification.
+
+        A namespace can be locked (git_only=True) without ever recording a repo
+        (e.g. a flat namespace locked via PATCH before its first git deploy).
+        There is no repo to verify the commit against, so _verify_git_deployment
+        must skip verification and let the git-sourced deploy proceed rather than
+        hard-failing.
+        """
+        namespace = "git_only_no_repo"
+
+        # Lock the namespace WITHOUT configuring a github_repo_path.
+        await client.post(f"/namespaces/{namespace}")
+        patched = await client.patch(
+            f"/namespaces/{namespace}/git",
+            json={"git_only": True},
+        )
+        assert patched.status_code == 200
+        cfg = (await client.get(f"/namespaces/{namespace}/git")).json()
+        assert cfg["git_only"] is True
+        assert cfg["github_repo_path"] is None
+
+        source_spec = SourceSpec(
+            name="s1",
+            description="Test source",
+            catalog="default",
+            schema="test",
+            table="t1",
+            columns=[ColumnSpec(name="id", type="int")],
+        )
+
+        # GitHubService should never be constructed since verification is skipped.
+        with patch(
+            "datajunction_server.api.deployments.GitHubService",
+        ) as mock_github_class:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace=namespace,
+                    nodes=[source_spec],
+                    source=GitDeploymentSource(
+                        repository="myorg/myrepo",
+                        branch="main",
+                        commit_sha="abc123def456",
+                    ),
+                ),
+            )
+            assert data["status"] == DeploymentStatus.SUCCESS.value
+            mock_github_class.assert_not_called()
+
+        # Still git_only-locked (repo never attached, git_only stays set), so a
+        # direct UI node mutation remains blocked.
+        blocked = await client.delete(f"/nodes/{namespace}.s1/")
+        assert blocked.status_code == 422
+        assert "git-managed" in blocked.json()["message"]
 
 
 @pytest.mark.xdist_group(name="deployments")

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -1830,15 +1830,13 @@ class TestBranchManagement:
         from datajunction_server.internal.git.github_service import GitHubServiceError
 
         await client_with_service_setup.post("/namespaces/ns_cleanup.main")
-        await client_with_service_setup.patch(
-            "/namespaces/ns_cleanup.main/git",
-            json={
-                "github_repo_path": "myorg/myrepo",
-                "git_branch": "main",
-            },
-        )
 
-        # Create some nodes in parent namespace that will be copied
+        # Create some nodes in the parent namespace that will be copied into the
+        # branch. They must be authored BEFORE configuring git — once the
+        # namespace is a git repo owner, direct node creates are rejected. These
+        # nodes get copied into the branch namespace, so when the branch-create
+        # rollback fires, _cleanup_namespace_and_nodes has >=1 node to delete
+        # (exercising the delete-loop body).
         await client_with_service_setup.post(
             "/nodes/source/",
             json={
@@ -1857,6 +1855,14 @@ class TestBranchManagement:
                 "schema_": "test",
                 "table": "bar",
                 "columns": [{"name": "id", "type": "int"}],
+            },
+        )
+
+        await client_with_service_setup.patch(
+            "/namespaces/ns_cleanup.main/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
             },
         )
 

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -2518,15 +2518,11 @@ class TestGitSync:
         """
         client = client_with_service_setup
 
-        # Create a namespace with a transform node
+        # Create a namespace with a transform node. Nodes are authored via the
+        # node API BEFORE configuring the namespace as a git repo owner —
+        # once github_repo_path is set (with no parent_namespace) the namespace
+        # becomes a read-only git root and direct node creates are rejected.
         await client.post("/namespaces/sync_test")
-        await client.patch(
-            "/namespaces/sync_test/git",
-            json={
-                "github_repo_path": "myorg/myrepo",
-                "git_branch": "main",
-            },
-        )
 
         # Create source for the transform to reference
         await client.post(
@@ -2551,6 +2547,15 @@ class TestGitSync:
                 "name": "sync_test.orders_fact",
                 "description": "Orders fact transform",
                 "query": "SELECT order_id, amount FROM sync_test.orders_source",
+            },
+        )
+
+        # Now configure git — this makes sync_test a git repo owner.
+        await client.patch(
+            "/namespaces/sync_test/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
             },
         )
 
@@ -2644,14 +2649,9 @@ columns:
         client = client_with_service_setup
 
         await client.post("/namespaces/orphan_test")
-        await client.patch(
-            "/namespaces/orphan_test/git",
-            json={
-                "github_repo_path": "myorg/myrepo",
-                "git_branch": "main",
-            },
-        )
 
+        # Author the node before configuring git — a git repo owner rejects
+        # direct node creates (they must be deployed from git).
         await client.post(
             "/nodes/source/",
             json={
@@ -2661,6 +2661,14 @@ columns:
                 "schema_": "public",
                 "table": "kept",
                 "columns": [{"name": "id", "type": "int"}],
+            },
+        )
+
+        await client.patch(
+            "/namespaces/orphan_test/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
             },
         )
 
@@ -3580,18 +3588,10 @@ class TestPullRequest:
         client_with_service_setup: AsyncClient,
     ):
         """Test finding nodes with git_info via both REST and GraphQL."""
-        # Create namespace with git config
+        # Create namespace and author the node BEFORE configuring git —
+        # once configured as a git repo owner the namespace is read-only for
+        # direct node creates.
         await client_with_service_setup.post("/namespaces/gql_test.main")
-        await client_with_service_setup.patch(
-            "/namespaces/gql_test.main/git",
-            json={
-                "github_repo_path": "myorg/metrics-repo",
-                "git_branch": "main",
-                "default_branch": "main",
-                "git_path": "definitions/",
-                "git_only": False,
-            },
-        )
 
         # Create a transform node in this namespace
         await client_with_service_setup.post(
@@ -3601,6 +3601,17 @@ class TestPullRequest:
                 "description": "Revenue metric",
                 "query": "SELECT SUM(amount) as revenue FROM sales",
                 "mode": "draft",
+            },
+        )
+
+        await client_with_service_setup.patch(
+            "/namespaces/gql_test.main/git",
+            json={
+                "github_repo_path": "myorg/metrics-repo",
+                "git_branch": "main",
+                "default_branch": "main",
+                "git_path": "definitions/",
+                "git_only": False,
             },
         )
 
@@ -4323,15 +4334,10 @@ class TestCopyNodesToNamespace:
         client_with_service_setup: AsyncClient,
     ):
         """Test that creating a branch copies nodes from parent namespace."""
-        # Create parent namespace with git config
+        # Create parent namespace and author its nodes BEFORE configuring git.
+        # Once the parent is a git repo owner, direct node creates are rejected,
+        # so seed the parent's nodes first, then configure git.
         await client_with_service_setup.post("/namespaces/copy_test.main")
-        await client_with_service_setup.patch(
-            "/namespaces/copy_test.main/git",
-            json={
-                "github_repo_path": "myorg/myrepo",
-                "git_branch": "main",
-            },
-        )
 
         # Create some nodes in the parent namespace
         response = await client_with_service_setup.post(
@@ -4359,6 +4365,14 @@ class TestCopyNodesToNamespace:
             },
         )
         assert response.status_code <= HTTPStatus.CREATED
+
+        await client_with_service_setup.patch(
+            "/namespaces/copy_test.main/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+            },
+        )
 
         # Create a branch - this should trigger copy_nodes_to_namespace
         with patch(
@@ -4437,12 +4451,10 @@ async def test_branch_copy_preserves_invalid_source_status(
     parent = "status_copy.main"
     branch_full = "status_copy.feature_copy"
 
-    # Set up parent namespace with git config and one transform.
+    # Set up parent namespace with one transform, THEN configure git.
+    # Direct node creates are rejected once the namespace is a git repo owner,
+    # so author the nodes before configuring git.
     await client.post(f"/namespaces/{parent}")
-    await client.patch(
-        f"/namespaces/{parent}/git",
-        json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
-    )
     response = await client.post(
         "/nodes/source/",
         json={
@@ -4462,6 +4474,10 @@ async def test_branch_copy_preserves_invalid_source_status(
         },
     )
     assert response.status_code <= HTTPStatus.CREATED
+    await client.patch(
+        f"/namespaces/{parent}/git",
+        json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+    )
 
     # Mark the transform as INVALID directly. Going through the API to
     # reliably produce an INVALID node is fragile (validators tend to
@@ -5373,15 +5389,9 @@ class TestGitSyncEdgeCases:
         client_with_service_setup: AsyncClient,
     ):
         """Test syncing a node whose name doesn't start with namespace prefix."""
-        # Create a namespace
+        # Create a namespace and author the node BEFORE configuring git — a git
+        # repo owner rejects direct node creates.
         await client_with_service_setup.post("/namespaces/edge_test")
-        await client_with_service_setup.patch(
-            "/namespaces/edge_test/git",
-            json={
-                "github_repo_path": "myorg/myrepo",
-                "git_branch": "main",
-            },
-        )
 
         # Create a source node that has a short name matching namespace
         # (edge case where node_name doesn't start with "namespace.")
@@ -5397,6 +5407,14 @@ class TestGitSyncEdgeCases:
             },
         )
         assert response.status_code <= HTTPStatus.CREATED
+
+        await client_with_service_setup.patch(
+            "/namespaces/edge_test/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+            },
+        )
 
         with patch(
             "datajunction_server.api.git_sync.GitHubService",

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -3014,28 +3014,36 @@ async def test_validate_git_path_allows_valid_relative_paths(
 
 
 @pytest.mark.asyncio
-async def test_validate_git_only_blocked_without_git_config(
+async def test_git_only_allowed_on_flat_namespace(
     module__client_with_all_examples: AsyncClient,
 ) -> None:
-    """Test that git_only=true is blocked when not a branch namespace."""
+    """git_only is a per-namespace lock, valid on a flat namespace with no
+    parent_namespace/git_branch (i.e. not following the <ns>.<branch> pattern)."""
     await module__client_with_all_examples.post("/namespaces/gitonly.test1/")
 
-    # Try to enable git_only without parent_namespace and git_branch
-    git_config = {
-        "git_only": True,
-        # Missing parent_namespace and git_branch (required for branch namespace)
-    }
+    # Enable git_only without parent_namespace or git_branch — previously
+    # rejected, now allowed on any namespace.
     response = await module__client_with_all_examples.patch(
         "/namespaces/gitonly.test1/git",
-        json=git_config,
+        json={"git_only": True},
     )
-    assert response.status_code == 422
-    assert response.json()["message"] == (
-        "git_only is only applicable to branch namespaces that have "
-        "parent_namespace and git_branch configured. "
-        "Git root namespaces are automatically locked when "
-        "github_repo_path is set."
+    assert response.status_code == 200
+    assert response.json()["git_only"] is True
+
+    # It persists on the namespace's git config.
+    fetched = await module__client_with_all_examples.get(
+        "/namespaces/gitonly.test1/git",
     )
+    assert fetched.status_code == 200
+    assert fetched.json()["git_only"] is True
+
+    # The lock can be toggled back off (the escape hatch).
+    reopened = await module__client_with_all_examples.patch(
+        "/namespaces/gitonly.test1/git",
+        json={"git_only": False},
+    )
+    assert reopened.status_code == 200
+    assert reopened.json()["git_only"] is False
 
 
 @pytest.mark.asyncio

--- a/datajunction-ui/src/app/components/GitMenu.jsx
+++ b/datajunction-ui/src/app/components/GitMenu.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { secondaryButtonStyle } from './buttonStyles';
+
+const itemStyle = {
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  padding: '10px 16px',
+  border: 'none',
+  background: '#ffffff',
+  color: '#1e293b',
+  fontSize: '13px',
+  fontFamily: 'inherit',
+  textTransform: 'none',
+  cursor: 'pointer',
+  textDecoration: 'none',
+  boxSizing: 'border-box',
+};
+
+const onItemOver = e => {
+  e.currentTarget.style.background = '#f3eeff';
+};
+const onItemOut = e => {
+  e.currentTarget.style.background = '#ffffff';
+};
+
+/**
+ * Low-frequency git actions for a namespace, in a hover dropdown. Renders only
+ * the items whose handlers/urls are provided, so read-only and editable callers
+ * pass exactly the valid set. Reuses the shared `.dropdown` hover CSS.
+ */
+export default function GitMenu({
+  repoPath,
+  branch,
+  viewInGitUrl,
+  onOpenSettings,
+  onNewBranch,
+  onDelete,
+}) {
+  return (
+    <div className="dropdown" data-testid="git-menu">
+      <button type="button" style={secondaryButtonStyle} aria-label="Git menu">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="6" y1="3" x2="6" y2="15" />
+          <circle cx="18" cy="6" r="3" />
+          <circle cx="6" cy="18" r="3" />
+          <path d="M18 9a9 9 0 0 1-9 9" />
+        </svg>
+        Git ▾
+      </button>
+      <div
+        className="dropdown-content add-node-dropdown-content"
+        role="menu"
+        // marginTop:0 removes the shared 6px gap between trigger and menu; the
+        // gap is a hover dead zone that closes the menu before the cursor
+        // reaches it. Flush menu keeps the :hover area continuous.
+        style={{ textTransform: 'none', marginTop: 0 }}
+      >
+        {repoPath && (
+          <div
+            style={{
+              padding: '10px 16px',
+              fontSize: '12px',
+              color: '#64748b',
+              borderBottom: '1px solid #e2e8f0',
+              background: '#ffffff',
+            }}
+          >
+            <code style={{ fontSize: '11px' }}>{repoPath}</code>
+            {branch && (
+              <>
+                {' '}
+                @ <code style={{ fontSize: '11px' }}>{branch}</code>
+              </>
+            )}
+          </div>
+        )}
+        {onNewBranch && (
+          <button
+            type="button"
+            style={itemStyle}
+            onClick={onNewBranch}
+            onMouseOver={onItemOver}
+            onMouseOut={onItemOut}
+          >
+            + New Branch
+          </button>
+        )}
+        {viewInGitUrl && (
+          <a
+            style={itemStyle}
+            href={viewInGitUrl}
+            target="_blank"
+            rel="noreferrer"
+            onMouseOver={onItemOver}
+            onMouseOut={onItemOut}
+          >
+            View in git
+          </a>
+        )}
+        {onOpenSettings && (
+          <button
+            type="button"
+            style={itemStyle}
+            onClick={onOpenSettings}
+            onMouseOver={onItemOver}
+            onMouseOut={onItemOut}
+          >
+            Git settings
+          </button>
+        )}
+        {onDelete && (
+          <button
+            type="button"
+            style={{ ...itemStyle, color: '#dc2626' }}
+            onClick={onDelete}
+            onMouseOver={onItemOver}
+            onMouseOut={onItemOut}
+          >
+            Delete branch
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -296,9 +296,12 @@ export default function NamespaceHeader({
   const isBranch = gitShape === 'branch';
   const gitConfigOwnerNamespace = isBranch ? gitRootNamespace : namespace;
   const gitConfigOwnerConfig = isBranch ? parentGitConfig : gitConfig;
+  // Report the read-only verdict only once it's actually known (git config +
+  // sources loaded). Firing a premature `false` on mount makes consumers flash
+  // editable UI (e.g. the node edit form) before the real verdict arrives.
   useEffect(() => {
-    if (onReadOnlyChange) onReadOnlyChange(!!isGitManaged);
-  }, [isGitManaged, onReadOnlyChange]);
+    if (onReadOnlyChange && !gitConfigLoading) onReadOnlyChange(!!isGitManaged);
+  }, [isGitManaged, gitConfigLoading, onReadOnlyChange]);
 
   const viewInGitUrl = () => {
     const repo = gitConfig?.github_repo_path;

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -4,15 +4,11 @@ import {
   topLevelNamespaces,
 } from '../pages/NamespacePage/namespaceOptions';
 import DJClientContext from '../providers/djclient';
-import Tooltip from './Tooltip';
 import {
   secondaryButtonStyle as buttonStyle,
   primaryButtonStyle,
-  dangerButtonStyle,
   onSecondaryHover,
   onSecondaryOut,
-  onDangerHover,
-  onDangerOut,
 } from './buttonStyles';
 import {
   GitSettingsModal,
@@ -21,11 +17,14 @@ import {
   CreatePRModal,
   DeleteBranchModal,
 } from './git';
+import { detectShape } from './git/gitShape';
+import GitMenu from './GitMenu';
 
 export default function NamespaceHeader({
   namespace,
   children,
   onGitConfigLoaded,
+  onReadOnlyChange,
   namespaceOptions,
   currentNamespace,
 }) {
@@ -185,12 +184,6 @@ export default function NamespaceHeader({
 
   const namespaceParts = namespace ? namespace.split('.') : [];
 
-  // Git config is valid if:
-  // - Git root: has github_repo_path
-  // - Branch namespace: has parent_namespace and git_branch (inherits repo from parent)
-  const hasGitConfig =
-    gitConfig?.github_repo_path ||
-    (gitConfig?.parent_namespace && gitConfig?.git_branch);
   // ``branch_namespace`` is the branch this namespace belongs to (equals the
   // namespace when called against the branch itself, the ancestor branch when
   // called against a descendant).
@@ -206,16 +199,29 @@ export default function NamespaceHeader({
 
   // Handlers for git operations
   const handleSaveGitConfig = async config => {
-    const result = await djClient.updateNamespaceGitConfig(namespace, config);
+    const result = await djClient.updateNamespaceGitConfig(
+      gitConfigOwnerNamespace,
+      config,
+    );
     if (!result?._error) {
-      setGitConfig(result);
+      if (isBranch) setParentGitConfig(prev => ({ ...prev, ...result }));
+      else setGitConfig(result);
     }
     return result;
   };
   const handleRemoveGitConfig = async () => {
-    const result = await djClient.deleteNamespaceGitConfig(namespace);
+    if (
+      !window.confirm(
+        'Remove this git config binding? If this namespace is still being deployed from git by CI, it will remain read-only. This does not delete any nodes or repo files.',
+      )
+    )
+      return;
+    const result = await djClient.deleteNamespaceGitConfig(
+      gitConfigOwnerNamespace,
+    );
     if (!result?._error) {
-      setGitConfig(null);
+      if (isBranch) setParentGitConfig(null);
+      else setGitConfig(null);
     }
   };
 
@@ -223,6 +229,7 @@ export default function NamespaceHeader({
   // branch — whether we're viewing the root itself or one of its branches (on a
   // branch page the root is carried by git_root_namespace / parentGitConfig).
   const gitRootNamespace = gitConfig?.git_root_namespace || namespace;
+
   const rootDefaultBranch = isGitRoot
     ? gitConfig?.default_branch
     : parentGitConfig?.default_branch;
@@ -271,6 +278,36 @@ export default function NamespaceHeader({
       namespace,
       deleteGitBranch,
     );
+  };
+
+  // Git state derivations
+  const gitShape = detectShape(gitConfig || {});
+  const isReadOnly =
+    !!gitConfig?.git_only || gitShape === 'flat' || gitShape === 'root';
+  const isGitDeployed =
+    !!sources &&
+    sources.total_deployments > 0 &&
+    sources.primary_source?.type === 'git';
+  const isGitManaged = isGitDeployed || isReadOnly;
+  // Repo config is owned by the git root. On a branch, edits target the root
+  // (its config is parentGitConfig — branches sit one level below the root); a
+  // flat or plain namespace owns its own config. This keeps flat namespaces
+  // (e.g. magnesium.tech, no parent) editing themselves.
+  const isBranch = gitShape === 'branch';
+  const gitConfigOwnerNamespace = isBranch ? gitRootNamespace : namespace;
+  const gitConfigOwnerConfig = isBranch ? parentGitConfig : gitConfig;
+  useEffect(() => {
+    if (onReadOnlyChange) onReadOnlyChange(!!isGitManaged);
+  }, [isGitManaged, onReadOnlyChange]);
+
+  const viewInGitUrl = () => {
+    const repo = gitConfig?.github_repo_path;
+    if (!repo) return null;
+    const branch = gitConfig?.git_branch || gitConfig?.default_branch || 'main';
+    const path = gitConfig?.git_path
+      ? `/${gitConfig.git_path.replace(/^\/|\/$/g, '')}`
+      : '';
+    return `https://github.netflix.net/${repo}/tree/${branch}${path}`;
   };
 
   return (
@@ -695,7 +732,7 @@ export default function NamespaceHeader({
           )}
 
           {/* Git-only (read-only) indicator */}
-          {gitConfig?.git_only && (
+          {isGitManaged && (
             <span
               style={{
                 display: 'flex',
@@ -728,52 +765,34 @@ export default function NamespaceHeader({
             </span>
           )}
 
-          {/* Deployment badge + dropdown (existing functionality) */}
-          {sources && sources.total_deployments > 0 && (
-            <div
-              style={{ position: 'relative', marginLeft: '8px' }}
-              ref={dropdownRef}
-            >
-              <button
-                onClick={() =>
-                  setDeploymentsDropdownOpen(!deploymentsDropdownOpen)
-                }
-                style={{
-                  height: '32px',
-                  padding: '0 12px',
-                  fontSize: '12px',
-                  border: 'none',
-                  borderRadius: '4px',
-                  backgroundColor: '#ffffff',
-                  color: '#0b3d91',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                  whiteSpace: 'nowrap',
-                }}
+          {/* Local deployment badge + dropdown (non-git deploys only;
+              git deployments are surfaced in the status strip below) */}
+          {sources &&
+            sources.total_deployments > 0 &&
+            sources.primary_source?.type !== 'git' && (
+              <div
+                style={{ position: 'relative', marginLeft: '8px' }}
+                ref={dropdownRef}
               >
-                {sources.primary_source?.type === 'git' ? (
-                  <>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="12"
-                      height="12"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <line x1="6" y1="3" x2="6" y2="15"></line>
-                      <circle cx="18" cy="6" r="3"></circle>
-                      <circle cx="6" cy="18" r="3"></circle>
-                      <path d="M18 9a9 9 0 0 1-9 9"></path>
-                    </svg>
-                    Deployed from Git
-                  </>
-                ) : (
+                <button
+                  onClick={() =>
+                    setDeploymentsDropdownOpen(!deploymentsDropdownOpen)
+                  }
+                  style={{
+                    height: '32px',
+                    padding: '0 12px',
+                    fontSize: '12px',
+                    border: 'none',
+                    borderRadius: '4px',
+                    backgroundColor: '#ffffff',
+                    color: '#0b3d91',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '4px',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
                   <>
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -791,67 +810,27 @@ export default function NamespaceHeader({
                     </svg>
                     Local Deploy
                   </>
-                )}
-                <span style={{ fontSize: '8px' }}>
-                  {deploymentsDropdownOpen ? '▲' : '▼'}
-                </span>
-              </button>
+                  <span style={{ fontSize: '8px' }}>
+                    {deploymentsDropdownOpen ? '▲' : '▼'}
+                  </span>
+                </button>
 
-              {deploymentsDropdownOpen && (
-                <div
-                  style={{
-                    position: 'absolute',
-                    top: '100%',
-                    left: 0,
-                    marginTop: '4px',
-                    padding: '12px',
-                    backgroundColor: 'white',
-                    border: '1px solid #ddd',
-                    borderRadius: '8px',
-                    boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                    zIndex: 1000,
-                    minWidth: 'max-content',
-                  }}
-                >
-                  {sources.primary_source?.type === 'git' ? (
-                    <a
-                      href={
-                        sources.primary_source.repository?.startsWith('http')
-                          ? sources.primary_source.repository
-                          : `https://${sources.primary_source.repository}`
-                      }
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                        fontSize: '13px',
-                        fontWeight: 400,
-                        textDecoration: 'none',
-                        marginBottom: '12px',
-                      }}
-                    >
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <line x1="6" y1="3" x2="6" y2="15" />
-                        <circle cx="18" cy="6" r="3" />
-                        <circle cx="6" cy="18" r="3" />
-                        <path d="M18 9a9 9 0 0 1-9 9" />
-                      </svg>
-                      {sources.primary_source.repository}
-                      {sources.primary_source.branch &&
-                        ` (${sources.primary_source.branch})`}
-                    </a>
-                  ) : (
+                {deploymentsDropdownOpen && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: '100%',
+                      left: 0,
+                      marginTop: '4px',
+                      padding: '12px',
+                      backgroundColor: 'white',
+                      border: '1px solid #ddd',
+                      borderRadius: '8px',
+                      boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                      zIndex: 1000,
+                      minWidth: 'max-content',
+                    }}
+                  >
                     <div
                       style={{
                         display: 'flex',
@@ -880,166 +859,167 @@ export default function NamespaceHeader({
                         ? `Local deploys by ${recentDeployments[0].created_by}`
                         : 'Local/adhoc deployments'}
                     </div>
-                  )}
 
-                  {/* Separator */}
-                  <div
-                    style={{
-                      height: '1px',
-                      backgroundColor: '#e2e8f0',
-                      marginBottom: '8px',
-                    }}
-                  />
+                    {/* Separator */}
+                    <div
+                      style={{
+                        height: '1px',
+                        backgroundColor: '#e2e8f0',
+                        marginBottom: '8px',
+                      }}
+                    />
 
-                  {/* Recent deployments list */}
-                  {recentDeployments?.length > 0 ? (
-                    recentDeployments.map((d, idx) => {
-                      const isGit = d.source?.type === 'git';
-                      const statusColor =
-                        d.status === 'success'
-                          ? '#22c55e'
-                          : d.status === 'failed'
-                          ? '#ef4444'
-                          : '#94a3b8';
+                    {/* Recent deployments list */}
+                    {recentDeployments?.length > 0 ? (
+                      recentDeployments.map((d, idx) => {
+                        const isGit = d.source?.type === 'git';
+                        const statusColor =
+                          d.status === 'success'
+                            ? '#22c55e'
+                            : d.status === 'failed'
+                            ? '#ef4444'
+                            : '#94a3b8';
 
-                      const commitUrl =
-                        isGit && d.source?.repository && d.source?.commit_sha
-                          ? `${
-                              d.source.repository.startsWith('http')
-                                ? d.source.repository
-                                : `https://${d.source.repository}`
-                            }/commit/${d.source.commit_sha}`
-                          : null;
+                        const commitUrl =
+                          isGit && d.source?.repository && d.source?.commit_sha
+                            ? `${
+                                d.source.repository.startsWith('http')
+                                  ? d.source.repository
+                                  : `https://${d.source.repository}`
+                              }/commit/${d.source.commit_sha}`
+                            : null;
 
-                      const detail = isGit
-                        ? d.source?.branch || 'main'
-                        : d.source?.reason || d.source?.hostname || 'adhoc';
+                        const detail = isGit
+                          ? d.source?.branch || 'main'
+                          : d.source?.reason || d.source?.hostname || 'adhoc';
 
-                      const shortSha = d.source?.commit_sha?.slice(0, 7);
+                        const shortSha = d.source?.commit_sha?.slice(0, 7);
 
-                      return (
-                        <div
-                          key={`${d.uuid}-${idx}`}
-                          style={{
-                            display: 'grid',
-                            gridTemplateColumns: '18px 1fr auto',
-                            alignItems: 'center',
-                            gap: '8px',
-                            padding: '6px 0',
-                            borderBottom:
-                              idx === recentDeployments.length - 1
-                                ? 'none'
-                                : '1px solid #f1f5f9',
-                            fontSize: '12px',
-                          }}
-                        >
-                          {/* Status dot */}
+                        return (
                           <div
+                            key={`${d.uuid}-${idx}`}
                             style={{
-                              width: '8px',
-                              height: '8px',
-                              borderRadius: '50%',
-                              backgroundColor: statusColor,
-                            }}
-                            title={d.status}
-                          />
-
-                          {/* User + detail */}
-                          <div
-                            style={{
-                              display: 'flex',
+                              display: 'grid',
+                              gridTemplateColumns: '18px 1fr auto',
                               alignItems: 'center',
-                              gap: '6px',
-                              minWidth: 0,
+                              gap: '8px',
+                              padding: '6px 0',
+                              borderBottom:
+                                idx === recentDeployments.length - 1
+                                  ? 'none'
+                                  : '1px solid #f1f5f9',
+                              fontSize: '12px',
                             }}
                           >
-                            <span
+                            {/* Status dot */}
+                            <div
                               style={{
-                                fontWeight: 500,
-                                color: '#0f172a',
-                                whiteSpace: 'nowrap',
+                                width: '8px',
+                                height: '8px',
+                                borderRadius: '50%',
+                                backgroundColor: statusColor,
+                              }}
+                              title={d.status}
+                            />
+
+                            {/* User + detail */}
+                            <div
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '6px',
+                                minWidth: 0,
                               }}
                             >
-                              {d.created_by || 'unknown'}
-                            </span>
-                            <span style={{ color: '#cbd5e1' }}>—</span>
-                            {isGit ? (
-                              <>
+                              <span
+                                style={{
+                                  fontWeight: 500,
+                                  color: '#0f172a',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {d.created_by || 'unknown'}
+                              </span>
+                              <span style={{ color: '#cbd5e1' }}>—</span>
+                              {isGit ? (
+                                <>
+                                  <span
+                                    style={{
+                                      color: '#64748b',
+                                      whiteSpace: 'nowrap',
+                                    }}
+                                  >
+                                    {detail}
+                                  </span>
+                                  {shortSha && (
+                                    <>
+                                      <span style={{ color: '#cbd5e1' }}>
+                                        @
+                                      </span>
+                                      {commitUrl ? (
+                                        <a
+                                          href={commitUrl}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          style={{
+                                            fontFamily: 'monospace',
+                                            fontSize: '11px',
+                                            color: '#3b82f6',
+                                            textDecoration: 'none',
+                                          }}
+                                        >
+                                          {shortSha}
+                                        </a>
+                                      ) : (
+                                        <span
+                                          style={{
+                                            fontFamily: 'monospace',
+                                            fontSize: '11px',
+                                            color: '#64748b',
+                                          }}
+                                        >
+                                          {shortSha}
+                                        </span>
+                                      )}
+                                    </>
+                                  )}
+                                </>
+                              ) : (
                                 <span
                                   style={{
                                     color: '#64748b',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
                                     whiteSpace: 'nowrap',
                                   }}
                                 >
                                   {detail}
                                 </span>
-                                {shortSha && (
-                                  <>
-                                    <span style={{ color: '#cbd5e1' }}>@</span>
-                                    {commitUrl ? (
-                                      <a
-                                        href={commitUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        style={{
-                                          fontFamily: 'monospace',
-                                          fontSize: '11px',
-                                          color: '#3b82f6',
-                                          textDecoration: 'none',
-                                        }}
-                                      >
-                                        {shortSha}
-                                      </a>
-                                    ) : (
-                                      <span
-                                        style={{
-                                          fontFamily: 'monospace',
-                                          fontSize: '11px',
-                                          color: '#64748b',
-                                        }}
-                                      >
-                                        {shortSha}
-                                      </span>
-                                    )}
-                                  </>
-                                )}
-                              </>
-                            ) : (
-                              <span
-                                style={{
-                                  color: '#64748b',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                }}
-                              >
-                                {detail}
-                              </span>
-                            )}
-                          </div>
+                              )}
+                            </div>
 
-                          {/* Timestamp */}
-                          <span
-                            style={{
-                              color: '#94a3b8',
-                              fontSize: '11px',
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {new Date(d.created_at).toLocaleDateString()}
-                          </span>
-                        </div>
-                      );
-                    })
-                  ) : (
-                    <div style={{ color: '#94a3b8', fontSize: '12px' }}>
-                      No recent deployments
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
+                            {/* Timestamp */}
+                            <span
+                              style={{
+                                color: '#94a3b8',
+                                fontSize: '11px',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {new Date(d.created_at).toLocaleDateString()}
+                            </span>
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <div style={{ color: '#94a3b8', fontSize: '12px' }}>
+                        No recent deployments
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
         </div>
 
         {/* Right side: git actions + children */}
@@ -1056,38 +1036,177 @@ export default function NamespaceHeader({
             marginLeft: 'auto',
           }}
         >
-          {/* Git controls for namespaces not inside a branch (git roots,
-              orphan namespaces). Subnamespaces under a branch fall through
-              to the branch-scoped block below so we don't render two sets
-              of buttons. */}
-          {namespace && !isInBranch && !gitConfigLoading && (
-            <>
-              <button
-                style={buttonStyle}
-                onClick={() => setShowGitSettings(true)}
-                onMouseOver={onSecondaryHover}
-                onMouseOut={onSecondaryOut}
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <circle cx="12" cy="12" r="3" />
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                </svg>
-                Git Settings
-              </button>
-              {canCreateBranch ? (
+          {/* Git controls — one primary action per state + a Git ▾ menu for the
+              rest. isGitManaged (read-only) is the master switch and overrides
+              structural gitShape. */}
+          {!gitConfigLoading &&
+            namespace &&
+            (() => {
+              const repoBranch =
+                gitConfig?.git_branch || gitConfig?.default_branch;
+              const editableBranch = gitShape === 'branch' && !isGitManaged;
+              const gitUrl = viewInGitUrl();
+
+              // Read-only: fork to propose a change; everything else in the menu.
+              if (isGitManaged) {
+                return (
+                  <>
+                    {canCreateBranch && (
+                      <button
+                        style={primaryButtonStyle}
+                        onClick={() => setShowCreateBranch(true)}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <line x1="12" y1="5" x2="12" y2="19" />
+                          <line x1="5" y1="12" x2="19" y2="12" />
+                        </svg>
+                        New Branch
+                      </button>
+                    )}
+                    <GitMenu
+                      repoPath={gitConfig?.github_repo_path}
+                      branch={repoBranch}
+                      viewInGitUrl={gitUrl}
+                      onOpenSettings={() => setShowGitSettings(true)}
+                    />
+                  </>
+                );
+              }
+
+              // Editable working branch: the edit -> ship loop inline.
+              if (editableBranch) {
+                return (
+                  <>
+                    <button
+                      style={buttonStyle}
+                      onClick={() => setShowSyncToGit(true)}
+                      onMouseOver={onSecondaryHover}
+                      onMouseOut={onSecondaryOut}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M21 12a9 9 0 0 1-9 9m9-9a9 9 0 0 0-9-9m9 9H3m9 9a9 9 0 0 1-9-9m9 9c1.66 0 3-4.03 3-9s-1.34-9-3-9m0 18c-1.66 0-3-4.03-3-9s1.34-9 3-9m-9 9a9 9 0 0 1 9-9" />
+                      </svg>
+                      Sync to Git
+                    </button>
+                    {prLoading ? (
+                      <button
+                        style={{
+                          ...buttonStyle,
+                          cursor: 'default',
+                          opacity: 0.6,
+                        }}
+                        disabled
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          style={{ animation: 'spin 1s linear infinite' }}
+                        >
+                          <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                        </svg>
+                        Checking PR...
+                      </button>
+                    ) : existingPR ? (
+                      <a
+                        href={existingPR.pr_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          ...primaryButtonStyle,
+                          textDecoration: 'none',
+                          backgroundColor: '#16a34a',
+                          borderColor: '#16a34a',
+                        }}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <circle cx="18" cy="18" r="3" />
+                          <circle cx="6" cy="6" r="3" />
+                          <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+                          <line x1="6" y1="9" x2="6" y2="21" />
+                        </svg>
+                        View PR #{existingPR.pr_number}
+                      </a>
+                    ) : (
+                      <button
+                        style={primaryButtonStyle}
+                        onClick={() => setShowCreatePR(true)}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <circle cx="18" cy="18" r="3" />
+                          <circle cx="6" cy="6" r="3" />
+                          <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+                          <line x1="6" y1="9" x2="6" y2="21" />
+                        </svg>
+                        Create PR
+                      </button>
+                    )}
+                    <GitMenu
+                      repoPath={gitConfig?.github_repo_path}
+                      branch={repoBranch}
+                      viewInGitUrl={gitUrl}
+                      onNewBranch={
+                        canCreateBranch && (() => setShowCreateBranch(true))
+                      }
+                      onDelete={() => setShowDeleteBranch(true)}
+                    />
+                  </>
+                );
+              }
+
+              // Plain (not-git): a single entry to adopt git.
+              return (
                 <button
-                  style={primaryButtonStyle}
-                  onClick={() => setShowCreateBranch(true)}
+                  style={buttonStyle}
+                  onClick={() => setShowGitSettings(true)}
+                  onMouseOver={onSecondaryHover}
+                  onMouseOut={onSecondaryOut}
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -1100,202 +1219,15 @@ export default function NamespaceHeader({
                     strokeLinecap="round"
                     strokeLinejoin="round"
                   >
-                    <line x1="12" y1="5" x2="12" y2="19" />
-                    <line x1="5" y1="12" x2="19" y2="12" />
+                    <line x1="6" y1="3" x2="6" y2="15" />
+                    <circle cx="18" cy="6" r="3" />
+                    <circle cx="6" cy="18" r="3" />
+                    <path d="M18 9a9 9 0 0 1-9 9" />
                   </svg>
-                  New Branch
+                  Connect to Git
                 </button>
-              ) : (
-                <></>
-              )}
-            </>
-          )}
-
-          {/* Git controls for branch namespaces (and subnamespaces under them) */}
-          {isInBranch && hasGitConfig && (
-            <>
-              <button
-                style={buttonStyle}
-                onClick={() => setShowGitSettings(true)}
-                onMouseOver={onSecondaryHover}
-                onMouseOut={onSecondaryOut}
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <circle cx="12" cy="12" r="3" />
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                </svg>
-                Git Settings
-              </button>
-
-              {/* New branch off the git root — always available, even on
-                  read-only (git_only) branches, since it forks the root. */}
-              {canCreateBranch && (
-                <button
-                  style={primaryButtonStyle}
-                  onClick={() => setShowCreateBranch(true)}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <line x1="12" y1="5" x2="12" y2="19" />
-                    <line x1="5" y1="12" x2="19" y2="12" />
-                  </svg>
-                  New Branch
-                </button>
-              )}
-
-              {/* Sync to Git and Create PR only for editable branches (git_only = false) */}
-              {!gitConfig?.git_only && (
-                <>
-                  <button
-                    style={buttonStyle}
-                    onClick={() => setShowSyncToGit(true)}
-                    onMouseOver={onSecondaryHover}
-                    onMouseOut={onSecondaryOut}
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="14"
-                      height="14"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M21 12a9 9 0 0 1-9 9m9-9a9 9 0 0 0-9-9m9 9H3m9 9a9 9 0 0 1-9-9m9 9c1.66 0 3-4.03 3-9s-1.34-9-3-9m0 18c-1.66 0-3-4.03-3-9s1.34-9 3-9m-9 9a9 9 0 0 1 9-9" />
-                    </svg>
-                    Sync to Git
-                  </button>
-                  {prLoading ? (
-                    <button
-                      style={{
-                        ...buttonStyle,
-                        cursor: 'default',
-                        opacity: 0.6,
-                      }}
-                      disabled
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        style={{ animation: 'spin 1s linear infinite' }}
-                      >
-                        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                      </svg>
-                      Checking PR...
-                    </button>
-                  ) : existingPR ? (
-                    <a
-                      href={existingPR.pr_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{
-                        ...primaryButtonStyle,
-                        textDecoration: 'none',
-                        backgroundColor: '#16a34a',
-                        borderColor: '#16a34a',
-                      }}
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <circle cx="18" cy="18" r="3" />
-                        <circle cx="6" cy="6" r="3" />
-                        <path d="M13 6h3a2 2 0 0 1 2 2v7" />
-                        <line x1="6" y1="9" x2="6" y2="21" />
-                      </svg>
-                      View PR #{existingPR.pr_number}
-                    </a>
-                  ) : (
-                    <button
-                      style={primaryButtonStyle}
-                      onClick={() => setShowCreatePR(true)}
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <circle cx="18" cy="18" r="3" />
-                        <circle cx="6" cy="6" r="3" />
-                        <path d="M13 6h3a2 2 0 0 1 2 2v7" />
-                        <line x1="6" y1="9" x2="6" y2="21" />
-                      </svg>
-                      Create PR
-                    </button>
-                  )}
-
-                  {/* Delete Branch - only for editable branches */}
-                  <Tooltip content="Delete this branch">
-                    <button
-                      style={dangerButtonStyle}
-                      onClick={() => setShowDeleteBranch(true)}
-                      onMouseOver={onDangerHover}
-                      onMouseOut={onDangerOut}
-                      aria-label="Delete branch"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M3 6h18" />
-                        <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-                        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-                      </svg>
-                    </button>
-                  </Tooltip>
-                </>
-              )}
-            </>
-          )}
+              );
+            })()}
 
           {/* Additional actions passed as children */}
           {children}
@@ -1307,8 +1239,9 @@ export default function NamespaceHeader({
           onClose={() => setShowGitSettings(false)}
           onSave={handleSaveGitConfig}
           onRemove={handleRemoveGitConfig}
-          currentConfig={gitConfig}
-          namespace={namespace}
+          currentConfig={gitConfigOwnerConfig}
+          namespace={gitConfigOwnerNamespace}
+          nodeCount={0} // TODO: wire real node count
         />
 
         <CreateBranchModal

--- a/datajunction-ui/src/app/components/SplitFilter.jsx
+++ b/datajunction-ui/src/app/components/SplitFilter.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+/**
+ * A compact pill segmented control: a rounded pill split into option halves with
+ * a hairline divider and a light-blue active tint. Shared so the same styling is
+ * used by the namespace filters and the Git Configuration modal.
+ *
+ * Clicking the active option calls `onChange('')` (deselect). Callers that must
+ * always keep a selection should ignore the empty value, e.g.
+ * `onChange={v => v && setValue(v)}`.
+ */
+export default function SplitFilter({ label, options, value, onChange }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '2px',
+        flex: '0 0 auto',
+      }}
+    >
+      <label
+        style={{
+          fontSize: '10px',
+          fontWeight: '600',
+          color: '#666',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+        }}
+      >
+        {label}
+      </label>
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          height: '32px',
+          border: '1px solid #cbd5e1',
+          borderRadius: '999px',
+          backgroundColor: '#ffffff',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {options.map((option, index) => {
+          const active = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onChange(active ? '' : option.value)}
+              style={{
+                height: '30px',
+                margin: 0,
+                padding: '0 13px',
+                border: 'none',
+                borderLeft: index === 0 ? 'none' : '1px solid #e2e8f0',
+                borderRadius: 0,
+                backgroundColor: active ? '#e3f2fd' : 'transparent',
+                color: active ? '#1976d2' : '#475569',
+                fontFamily: 'inherit',
+                fontSize: '12px',
+                fontWeight: active ? '600' : '500',
+                textTransform: 'none',
+                cursor: 'pointer',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/datajunction-ui/src/app/components/__tests__/GitMenu.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/GitMenu.test.jsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GitMenu from '../GitMenu';
+
+describe('<GitMenu />', () => {
+  it('renders the repo @ branch identity header', () => {
+    render(
+      <GitMenu
+        repoPath="corp/ads-dj"
+        branch="main"
+        viewInGitUrl="https://git/x"
+        onOpenSettings={() => {}}
+      />,
+    );
+    expect(screen.getByText('corp/ads-dj')).toBeInTheDocument();
+    expect(screen.getByText('main')).toBeInTheDocument();
+  });
+
+  it('renders only the items whose handlers/urls are provided', () => {
+    render(
+      <GitMenu repoPath="corp/ads-dj" branch="main" viewInGitUrl={null} />,
+    );
+    expect(screen.queryByText('Git settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('View in git')).not.toBeInTheDocument();
+    expect(screen.queryByText('+ New Branch')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete branch')).not.toBeInTheDocument();
+  });
+
+  it('renders Git settings only when onOpenSettings is provided', () => {
+    const onOpenSettings = vi.fn();
+    render(
+      <GitMenu
+        repoPath="corp/ads-dj"
+        branch="main"
+        viewInGitUrl={null}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+    fireEvent.click(screen.getByText('Git settings'));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders New Branch, View in git and Delete when provided and fires handlers', () => {
+    const onNewBranch = vi.fn();
+    const onDelete = vi.fn();
+    const onOpenSettings = vi.fn();
+    render(
+      <GitMenu
+        repoPath="corp/ads-dj"
+        branch="feature"
+        viewInGitUrl="https://git/x"
+        onOpenSettings={onOpenSettings}
+        onNewBranch={onNewBranch}
+        onDelete={onDelete}
+      />,
+    );
+    expect(screen.getByText('View in git')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('+ New Branch'));
+    fireEvent.click(screen.getByText('Delete branch'));
+    fireEvent.click(screen.getByText('Git settings'));
+    expect(onNewBranch).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/datajunction-ui/src/app/components/__tests__/GitModals.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/GitModals.test.jsx
@@ -741,23 +741,14 @@ describe('<GitSettingsModal />', () => {
     isOpen: true,
     onClose: vi.fn(),
     onSave: vi.fn(),
+    onRemove: vi.fn(),
     currentConfig: null,
     namespace: 'analytics.prod',
+    nodeCount: 0,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock fetch for parent config fetching
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            github_repo_path: 'test/repo',
-            git_path: 'nodes/',
-          }),
-      }),
-    );
   });
 
   it('should not render when isOpen is false', () => {
@@ -765,113 +756,151 @@ describe('<GitSettingsModal />', () => {
     expect(screen.queryByText('Git Configuration')).not.toBeInTheDocument();
   });
 
-  it('should render the modal with git root form fields', () => {
+  it('should render the modal heading and source toggle', () => {
     render(<GitSettingsModal {...defaultProps} />);
 
-    expect(screen.getByText('Git Configuration')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Git Configuration' }),
+    ).toBeInTheDocument();
+    // Source of definitions toggle is always visible
+    expect(screen.getByText('Edited in DataJunction')).toBeInTheDocument();
+    expect(screen.getByText('Git repo')).toBeInTheDocument();
+    // By default, source is "dj" so git-specific fields are hidden
+    expect(screen.queryByLabelText(/Repository/)).not.toBeInTheDocument();
+  });
+
+  it('should show Repository and Branch fields when Git repo is selected', async () => {
+    render(<GitSettingsModal {...defaultProps} />);
+
+    await userEvent.click(screen.getByText('Git repo'));
+
     expect(screen.getByLabelText(/Repository/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Path/)).toBeInTheDocument();
-    // Branch field (from branch mode) should NOT be present in git root mode
-    expect(screen.queryByLabelText(/^Branch \*/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/^Branch$/)).toBeInTheDocument();
+    // No checkbox — intent-based modal has no git_only toggle
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
-  it('should pre-fill form with git root config', () => {
-    const config = {
-      github_repo_path: 'myorg/repo',
-      git_path: 'definitions/',
-    };
+  it('should show Default branch field in root (Feature branches + PRs) mode', async () => {
+    render(<GitSettingsModal {...defaultProps} />);
 
-    render(<GitSettingsModal {...defaultProps} currentConfig={config} />);
+    await userEvent.click(screen.getByText('Git repo'));
+    await userEvent.click(screen.getByText('Feature branches + PRs'));
 
-    expect(screen.getByLabelText(/Repository/)).toHaveValue('myorg/repo');
-    expect(screen.getByLabelText(/Path/)).toHaveValue('definitions/');
-    // Branch field (from branch mode) should NOT be present in git root mode
-    expect(screen.queryByLabelText(/^Branch \*/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Default branch/)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Branch$/)).not.toBeInTheDocument();
   });
 
-  it('should pre-fill git_only checkbox from branch namespace config', () => {
-    const config = {
-      parent_namespace: 'analytics',
-      git_branch: 'feature',
-      git_only: false,
-    };
+  it('should preselect flat mode from an existing flat (branch-tracking) config', () => {
+    render(
+      <GitSettingsModal
+        {...defaultProps}
+        currentConfig={{
+          github_repo_path: 'myorg/repo',
+          git_branch: 'develop',
+        }}
+      />,
+    );
+
+    // Source should default to "git", flat mode active
+    expect(screen.getByDisplayValue('myorg/repo')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('develop')).toBeInTheDocument();
+    expect(screen.getByText('Tracks a branch')).toBeInTheDocument();
+  });
+
+  it('should preselect root mode from an existing root config', () => {
+    render(
+      <GitSettingsModal
+        {...defaultProps}
+        currentConfig={{
+          github_repo_path: 'myorg/repo',
+          default_branch: 'main',
+        }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('myorg/repo')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('main')).toBeInTheDocument();
+    expect(screen.getByText('Feature branches + PRs')).toBeInTheDocument();
+  });
+
+  it('should call onSave with flat payload when Tracks a branch form is submitted', async () => {
+    defaultProps.onSave.mockResolvedValue({});
+
+    render(<GitSettingsModal {...defaultProps} />);
+
+    await userEvent.click(screen.getByText('Git repo'));
+    await userEvent.type(screen.getByLabelText(/Repository/), 'corp/defs');
+    await userEvent.clear(screen.getByLabelText(/^Branch$/));
+    await userEvent.type(screen.getByLabelText(/^Branch$/), 'develop');
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith({
+        github_repo_path: 'corp/defs',
+        git_branch: 'develop',
+      });
+    });
+  });
+
+  it('should call onSave with root payload when Feature branches + PRs is selected', async () => {
+    defaultProps.onSave.mockResolvedValue({});
+
+    render(<GitSettingsModal {...defaultProps} />);
+
+    await userEvent.click(screen.getByText('Git repo'));
+    await userEvent.click(screen.getByText('Feature branches + PRs'));
+    await userEvent.type(screen.getByLabelText(/Repository/), 'corp/defs');
+    await userEvent.clear(screen.getByLabelText(/Default branch/));
+    await userEvent.type(screen.getByLabelText(/Default branch/), 'trunk');
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith({
+        github_repo_path: 'corp/defs',
+        default_branch: 'trunk',
+      });
+    });
+  });
+
+  it('should call onRemove (not onSave) when Edited in DataJunction is selected', async () => {
+    defaultProps.onSave.mockResolvedValue({});
+    defaultProps.onRemove.mockResolvedValue({});
 
     render(
       <GitSettingsModal
         {...defaultProps}
-        namespace="analytics.feature"
-        currentConfig={config}
+        currentConfig={{ github_repo_path: 'myorg/repo', git_branch: 'main' }}
       />,
     );
 
-    const checkbox = screen.getByRole('checkbox');
-    expect(checkbox).not.toBeChecked();
-  });
-
-  it('should default path to nodes/ for new config', () => {
-    render(<GitSettingsModal {...defaultProps} />);
-    expect(screen.getByLabelText(/Path/)).toHaveValue('nodes/');
-  });
-
-  it('should not show git_only checkbox in git root mode for new config', () => {
-    render(<GitSettingsModal {...defaultProps} />);
-    // Git root mode has no checkbox
-    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
-  });
-
-  it('should call onSave when git root form is submitted', async () => {
-    defaultProps.onSave.mockResolvedValue({ success: true });
-
-    render(<GitSettingsModal {...defaultProps} />);
-
-    await userEvent.type(screen.getByLabelText(/Repository/), 'myorg/repo');
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
+    // Source is already "git" from currentConfig; switch back to dj
+    await userEvent.click(screen.getByText('Edited in DataJunction'));
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
     await waitFor(() => {
-      expect(defaultProps.onSave).toHaveBeenCalledWith({
-        default_branch: 'main',
-        github_repo_path: 'myorg/repo',
-        git_path: 'nodes/',
-      });
+      expect(defaultProps.onRemove).toHaveBeenCalled();
     });
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
   });
 
-  it('should call onSave with git_only when branch namespace form is submitted', async () => {
-    defaultProps.onSave.mockResolvedValue({ success: true });
+  it('should show an error when Repository is empty and Git repo is selected', async () => {
+    render(<GitSettingsModal {...defaultProps} />);
 
-    render(
-      <GitSettingsModal {...defaultProps} namespace="analytics.feature" />,
-    );
+    await userEvent.click(screen.getByText('Git repo'));
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
-    // Switch to branch mode
-    await userEvent.click(screen.getByText('Branch Namespace'));
-
-    await userEvent.type(screen.getByLabelText(/Branch/), 'feature-x');
-    await userEvent.click(screen.getByRole('checkbox')); // Uncheck git_only
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
-
-    await waitFor(() => {
-      expect(defaultProps.onSave).toHaveBeenCalledWith({
-        git_branch: 'feature-x',
-        parent_namespace: 'analytics',
-        git_only: false,
-      });
-    });
+    expect(screen.getByText('Repository is required')).toBeInTheDocument();
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
   });
 
   it('should show success message after save', async () => {
-    defaultProps.onSave.mockResolvedValue({ success: true });
+    defaultProps.onSave.mockResolvedValue({});
 
     render(<GitSettingsModal {...defaultProps} />);
 
+    await userEvent.click(screen.getByText('Git repo'));
     await userEvent.type(screen.getByLabelText(/Repository/), 'myorg/repo');
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
     await waitFor(() => {
       expect(
@@ -880,7 +909,7 @@ describe('<GitSettingsModal />', () => {
     });
   });
 
-  it('should show error when save fails', async () => {
+  it('should show error when onSave returns _error response', async () => {
     defaultProps.onSave.mockResolvedValue({
       _error: true,
       message: 'Invalid repository',
@@ -888,10 +917,9 @@ describe('<GitSettingsModal />', () => {
 
     render(<GitSettingsModal {...defaultProps} />);
 
+    await userEvent.click(screen.getByText('Git repo'));
     await userEvent.type(screen.getByLabelText(/Repository/), 'invalid');
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
     await waitFor(() => {
       expect(screen.getByText('Invalid repository')).toBeInTheDocument();
@@ -903,25 +931,23 @@ describe('<GitSettingsModal />', () => {
 
     render(<GitSettingsModal {...defaultProps} />);
 
+    await userEvent.click(screen.getByText('Git repo'));
     await userEvent.type(screen.getByLabelText(/Repository/), 'myorg/repo');
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument();
     });
   });
 
-  it('should show default error when onSave throws without message', async () => {
+  it('should show default error message when onSave throws without message', async () => {
     defaultProps.onSave.mockRejectedValue({});
 
     render(<GitSettingsModal {...defaultProps} />);
 
+    await userEvent.click(screen.getByText('Git repo'));
     await userEvent.type(screen.getByLabelText(/Repository/), 'myorg/repo');
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
     await waitFor(() => {
       expect(
@@ -930,26 +956,16 @@ describe('<GitSettingsModal />', () => {
     });
   });
 
-  it('should not show git-only checkbox in git root mode', async () => {
-    render(<GitSettingsModal {...defaultProps} />);
-
-    // Git root mode should not have git_only checkbox
-    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
-  });
-
-  it('should toggle git-only checkbox in branch mode', async () => {
+  it('should warn when switching a namespace with existing nodes to git', async () => {
     render(
-      <GitSettingsModal {...defaultProps} namespace="analytics.feature" />,
+      <GitSettingsModal {...defaultProps} currentConfig={null} nodeCount={3} />,
     );
 
-    // Switch to branch mode
-    await userEvent.click(screen.getByText('Branch Namespace'));
+    await userEvent.click(screen.getByText('Git repo'));
 
-    const checkbox = screen.getByRole('checkbox');
-    expect(checkbox).toBeChecked(); // Default is true
-
-    await userEvent.click(checkbox);
-    expect(checkbox).not.toBeChecked();
+    expect(
+      screen.getByText(/3 nodes here aren't in the repo/),
+    ).toBeInTheDocument();
   });
 
   it('should call onClose when Cancel is clicked', async () => {
@@ -974,7 +990,7 @@ describe('<GitSettingsModal />', () => {
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
-  it('should show Saving... button text while saving', async () => {
+  it('should show Saving... and disable the button while saving', async () => {
     let resolveSave;
     defaultProps.onSave.mockImplementation(
       () =>
@@ -985,27 +1001,24 @@ describe('<GitSettingsModal />', () => {
 
     render(<GitSettingsModal {...defaultProps} />);
 
+    await userEvent.click(screen.getByText('Git repo'));
     await userEvent.type(screen.getByLabelText(/Repository/), 'myorg/repo');
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
     expect(screen.getByText('Saving...')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled();
 
-    // Resolve to complete the test
-    resolveSave({ success: true });
+    resolveSave({});
   });
 
-  it('should clear error and success when closed', async () => {
-    defaultProps.onSave.mockResolvedValue({ success: true });
+  it('should show Close button after success and call onClose when clicked', async () => {
+    defaultProps.onSave.mockResolvedValue({});
 
     render(<GitSettingsModal {...defaultProps} />);
 
+    await userEvent.click(screen.getByText('Git repo'));
     await userEvent.type(screen.getByLabelText(/Repository/), 'myorg/repo');
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save Settings' }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/ }));
 
     await waitFor(() => {
       expect(
@@ -1013,19 +1026,10 @@ describe('<GitSettingsModal />', () => {
       ).toBeInTheDocument();
     });
 
-    // After success, button changes from "Cancel" to "Close"
-    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+    // Button changes from "Cancel" to "Close" after success
+    const closeBtn = screen.getByRole('button', { name: 'Close' });
+    await userEvent.click(closeBtn);
     expect(defaultProps.onClose).toHaveBeenCalled();
-  });
-
-  it('should update path field', async () => {
-    render(<GitSettingsModal {...defaultProps} />);
-
-    const pathInput = screen.getByLabelText(/Path/);
-    await userEvent.clear(pathInput);
-    await userEvent.type(pathInput, 'definitions/');
-
-    expect(pathInput).toHaveValue('definitions/');
   });
 });
 

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -1,18 +1,87 @@
 import * as React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { createRenderer } from 'react-test-renderer/shallow';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 
 import NamespaceHeader from '../NamespaceHeader';
 import DJClientContext from '../../providers/djclient';
 
-const renderer = createRenderer();
+// Helper: render NamespaceHeader with a minimal mock DJ client.
+// Options:
+//   namespace  - namespace string (default 'test.namespace')
+//   gitConfig  - value returned by getNamespaceGitConfig (default: rejects)
+const renderHeader = ({ namespace = 'test.namespace', gitConfig } = {}) => {
+  const mockDjClient = {
+    namespaceSources: vi.fn().mockResolvedValue({
+      total_deployments: 0,
+      primary_source: null,
+    }),
+    listDeployments: vi.fn().mockResolvedValue([]),
+    getNamespaceGitConfig:
+      gitConfig !== undefined
+        ? vi.fn().mockResolvedValue(gitConfig)
+        : vi.fn().mockRejectedValue(new Error('no config')),
+    getNamespaceBranches: vi.fn().mockResolvedValue([]),
+    deleteNamespaceGitConfig: vi.fn().mockResolvedValue({ success: true }),
+    updateNamespaceGitConfig: vi.fn().mockResolvedValue(gitConfig || {}),
+  };
+  return render(
+    <MemoryRouter>
+      <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+        <NamespaceHeader namespace={namespace} />
+      </DJClientContext.Provider>
+    </MemoryRouter>,
+  );
+};
+
+// Render with explicit git config + deployment sources so we can exercise the
+// three toolbar states. getPullRequest is mocked because branch namespaces
+// fetch an existing PR on mount.
+const renderHeaderState = ({ namespace, gitConfig, sources }) => {
+  const mockDjClient = {
+    namespaceSources: vi
+      .fn()
+      .mockResolvedValue(
+        sources || { total_deployments: 0, primary_source: null },
+      ),
+    listDeployments: vi.fn().mockResolvedValue([]),
+    getNamespaceGitConfig: vi.fn().mockResolvedValue(gitConfig),
+    getNamespaceBranches: vi.fn().mockResolvedValue([]),
+    getPullRequest: vi.fn().mockResolvedValue(null),
+    deleteNamespaceGitConfig: vi.fn().mockResolvedValue({ success: true }),
+    updateNamespaceGitConfig: vi.fn().mockResolvedValue(gitConfig || {}),
+  };
+  return render(
+    <MemoryRouter>
+      <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+        <NamespaceHeader namespace={namespace} />
+      </DJClientContext.Provider>
+    </MemoryRouter>,
+  );
+};
 
 describe('<NamespaceHeader />', () => {
-  it('should render and match the snapshot', () => {
-    renderer.render(<NamespaceHeader namespace="shared.dimensions.accounts" />);
-    const renderedOutput = renderer.getRenderOutput();
-    expect(renderedOutput).toMatchSnapshot();
+  it('should render and match the snapshot', async () => {
+    const mockDjClient = {
+      namespaceSources: vi
+        .fn()
+        .mockResolvedValue({ total_deployments: 0, primary_source: null }),
+      listDeployments: vi.fn().mockResolvedValue([]),
+      getPullRequest: vi.fn().mockResolvedValue(null),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
+      getNamespaceGitConfig: vi.fn().mockResolvedValue({}),
+    };
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/namespaces/shared.dimensions.accounts']}>
+        <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+          <NamespaceHeader namespace="shared.dimensions.accounts" />
+        </DJClientContext.Provider>
+      </MemoryRouter>,
+    );
+    // Let git config resolve so the snapshot is the settled state.
+    await waitFor(() =>
+      expect(mockDjClient.getNamespaceGitConfig).toHaveBeenCalled(),
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render git source badge when source type is git with branch', async () => {
@@ -42,8 +111,11 @@ describe('<NamespaceHeader />', () => {
       );
     });
 
-    // Should render Deployed from Git badge for git source
-    expect(screen.getByText(/Deployed from Git/)).toBeInTheDocument();
+    // Git-deployed namespaces are read-only; the strip was removed, but the
+    // Read-only badge in the breadcrumb area still shows for isGitManaged.
+    expect(screen.getByText('Read-only')).toBeInTheDocument();
+    // No "Deployed from Git" text (strip removed) and no local-deploy badge
+    expect(screen.queryByText(/Local Deploy/)).not.toBeInTheDocument();
   });
 
   it('should render git source badge when source type is git without branch', async () => {
@@ -73,8 +145,9 @@ describe('<NamespaceHeader />', () => {
       );
     });
 
-    // Should render Deployed from Git badge for git source even without branch
-    expect(screen.getByText(/Deployed from Git/)).toBeInTheDocument();
+    // Git-deployed namespaces show the Read-only badge (strip removed).
+    expect(screen.getByText('Read-only')).toBeInTheDocument();
+    expect(screen.queryByText(/Local Deploy/)).not.toBeInTheDocument();
   });
 
   it('should render local source badge when source type is local', async () => {
@@ -161,7 +234,7 @@ describe('<NamespaceHeader />', () => {
     expect(screen.queryByText(/Deployed from Git/)).not.toBeInTheDocument();
   });
 
-  it('should open dropdown when clicking the git managed button', async () => {
+  it('should show read-only controls (not a dropdown) for git-deployed namespace', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
         total_deployments: 5,
@@ -194,17 +267,26 @@ describe('<NamespaceHeader />', () => {
       </MemoryRouter>,
     );
 
+    // Git-deployed namespace shows the Read-only badge in the breadcrumb area.
     await waitFor(() => {
-      expect(screen.getByText(/Deployed from Git/)).toBeInTheDocument();
+      expect(screen.getByText('Read-only')).toBeInTheDocument();
     });
 
-    // Click the dropdown button
-    fireEvent.click(screen.getByText(/Deployed from Git/));
+    // Should NOT show "Edited in DataJunction" or "Connect to Git"
+    expect(
+      screen.queryByText(/Edited in DataJunction/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /connect to git/i }),
+    ).not.toBeInTheDocument();
 
-    // Should show repository link in dropdown
-    await waitFor(() => {
-      expect(screen.getByText(/github.com\/test\/repo/)).toBeInTheDocument();
-    });
+    // Status strip is removed; no .git-status-strip element
+    expect(document.querySelector('.git-status-strip')).toBeNull();
+
+    // Git settings is available via the Git menu
+    expect(
+      screen.getAllByRole('button', { name: /git settings/i }).length,
+    ).toBeGreaterThanOrEqual(1);
   });
 
   it('should open dropdown when clicking local deploy button', async () => {
@@ -296,19 +378,13 @@ describe('<NamespaceHeader />', () => {
       </MemoryRouter>,
     );
 
+    // Git-deployed namespaces show the Read-only badge (strip removed).
     await waitFor(() => {
-      expect(screen.getByText(/Deployed from Git/)).toBeInTheDocument();
+      expect(screen.getByText('Read-only')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText(/Deployed from Git/));
-
-    // Should show branch names in deployment list
-    await waitFor(() => {
-      expect(screen.getByText(/feature-branch/)).toBeInTheDocument();
-    });
-
-    // Should show short commit SHA
-    expect(screen.getByText(/abc1234/)).toBeInTheDocument();
+    // Git deployments are not shown in a dropdown; no local-deploy-style list.
+    expect(screen.queryByText(/feature-branch/)).not.toBeInTheDocument();
   });
 
   it('should show local deployments with reason', async () => {
@@ -353,17 +429,24 @@ describe('<NamespaceHeader />', () => {
     });
   });
 
-  it('should close dropdown when clicking outside', async () => {
+  it('should close local deploy dropdown when clicking outside', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 5,
+        total_deployments: 2,
         primary_source: {
-          type: 'git',
-          repository: 'github.com/test/repo',
-          branch: 'main',
+          type: 'local',
+          hostname: 'localhost',
         },
       }),
-      listDeployments: vi.fn().mockResolvedValue([]),
+      listDeployments: vi.fn().mockResolvedValue([
+        {
+          uuid: 'deploy-1',
+          status: 'success',
+          created_at: '2024-01-15T10:00:00Z',
+          created_by: 'testuser',
+          source: { type: 'local', hostname: 'localhost', reason: 'testing' },
+        },
+      ]),
     };
 
     render(
@@ -375,35 +458,34 @@ describe('<NamespaceHeader />', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Deployed from Git/)).toBeInTheDocument();
+      expect(screen.getByText(/Local Deploy/)).toBeInTheDocument();
     });
 
     // Open dropdown
-    fireEvent.click(screen.getByText(/Deployed from Git/));
+    fireEvent.click(screen.getByText(/Local Deploy/));
 
     await waitFor(() => {
-      expect(screen.getByText(/github.com\/test\/repo/)).toBeInTheDocument();
+      expect(screen.getByText(/Local deploys by testuser/)).toBeInTheDocument();
     });
 
-    // Click outside (on the breadcrumb)
+    // Click outside
     fireEvent.mouseDown(document.body);
 
     // Dropdown should close
     await waitFor(() => {
       expect(
-        screen.queryByText(/github.com\/test\/repo.*\(main\)/),
+        screen.queryByText(/Local deploys by testuser/),
       ).not.toBeInTheDocument();
     });
   });
 
-  it('should toggle dropdown arrow indicator', async () => {
+  it('should toggle local deploy dropdown arrow indicator', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 5,
+        total_deployments: 2,
         primary_source: {
-          type: 'git',
-          repository: 'github.com/test/repo',
-          branch: 'main',
+          type: 'local',
+          hostname: 'localhost',
         },
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
@@ -418,14 +500,14 @@ describe('<NamespaceHeader />', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Deployed from Git/)).toBeInTheDocument();
+      expect(screen.getByText(/Local Deploy/)).toBeInTheDocument();
     });
 
     // Initially shows down arrow
     expect(screen.getByText('▼')).toBeInTheDocument();
 
     // Click to open
-    fireEvent.click(screen.getByText(/Deployed from Git/));
+    fireEvent.click(screen.getByText(/Local Deploy/));
 
     // Should show up arrow when open
     await waitFor(() => {
@@ -433,7 +515,7 @@ describe('<NamespaceHeader />', () => {
     });
   });
 
-  it('should handle git repository URL with https prefix', async () => {
+  it('should show read-only controls even with https-prefixed repo in sources', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
         total_deployments: 1,
@@ -454,19 +536,18 @@ describe('<NamespaceHeader />', () => {
       </MemoryRouter>,
     );
 
+    // Git-deployed namespaces show the Read-only badge (strip removed).
     await waitFor(() => {
-      expect(screen.getByText(/Deployed from Git/)).toBeInTheDocument();
+      expect(screen.getByText('Read-only')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText(/Deployed from Git/));
-
-    await waitFor(() => {
-      // Find link by its text content (repository URL)
-      const link = screen.getByRole('link', {
-        name: /github\.com\/test\/repo/,
-      });
-      expect(link).toHaveAttribute('href', 'https://github.com/test/repo');
-    });
+    // Should NOT show "Connect to Git" or "Edited in DataJunction"
+    expect(
+      screen.queryByText(/Edited in DataJunction/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /connect to git/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('should render adhoc deployment label when no created_by', async () => {
@@ -509,7 +590,7 @@ describe('<NamespaceHeader />', () => {
     });
   });
 
-  it('should show Git Settings button and open modal', async () => {
+  it('should show Connect to Git button and open git settings modal', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
         total_deployments: 0,
@@ -527,11 +608,12 @@ describe('<NamespaceHeader />', () => {
       </MemoryRouter>,
     );
 
+    // Plain (not-git) state shows a "Connect to Git" button that opens the modal.
     await waitFor(() => {
-      expect(screen.getByText('Git Settings')).toBeInTheDocument();
+      expect(screen.getByText('Connect to Git')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText('Git Settings'));
+    fireEvent.click(screen.getByText('Connect to Git'));
 
     await waitFor(() => {
       expect(screen.getByText('Git Configuration')).toBeInTheDocument();
@@ -575,12 +657,9 @@ describe('<NamespaceHeader />', () => {
   it('should show Create PR and Delete Branch for branch namespaces', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi
@@ -598,6 +677,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
     };
 
@@ -657,15 +737,12 @@ describe('<NamespaceHeader />', () => {
   });
 
   it('should open Sync to Git modal when button is clicked', async () => {
-    // Sync to Git only shows for branch namespaces
+    // Sync to Git only shows for editable branch namespaces (no git deployments).
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi
@@ -683,6 +760,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
     };
 
@@ -715,8 +793,7 @@ describe('<NamespaceHeader />', () => {
       getNamespaceGitConfig: vi.fn().mockResolvedValue(null),
       updateNamespaceGitConfig: vi.fn().mockResolvedValue({
         github_repo_path: 'myorg/repo',
-        git_path: 'nodes/',
-        // git_branch and git_only not present in git root config
+        git_branch: 'main',
       }),
     };
 
@@ -728,22 +805,37 @@ describe('<NamespaceHeader />', () => {
       </MemoryRouter>,
     );
 
+    // Plain (not-git) state shows Connect to Git which opens the git settings modal.
     await waitFor(() => {
-      expect(screen.getByText('Git Settings')).toBeInTheDocument();
+      expect(screen.getByText('Connect to Git')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText('Git Settings'));
+    fireEvent.click(screen.getByText('Connect to Git'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/Repository/)).toBeInTheDocument();
+      expect(screen.getByText('Git Configuration')).toBeInTheDocument();
     });
 
+    // Q1: choose "Git repo" (modal opens with 'dj' selected since config is null)
+    fireEvent.click(screen.getByRole('button', { name: 'Git repo' }));
+
+    // Q2: choose "Tracks a branch" (flat model)
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Tracks a branch' }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Tracks a branch' }));
+
+    // Fill Repository and Branch fields
     fireEvent.change(screen.getByLabelText(/Repository/), {
       target: { value: 'myorg/repo' },
     });
-    // Branch field is not present in git root mode
+    fireEvent.change(screen.getByLabelText(/Branch/), {
+      target: { value: 'main' },
+    });
 
-    fireEvent.click(screen.getByText('Save Settings'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(mockDjClient.updateNamespaceGitConfig).toHaveBeenCalledWith(
@@ -880,7 +972,12 @@ describe('<NamespaceHeader />', () => {
     await waitFor(() => {
       expect(screen.getByText('New Branch')).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText('feature'));
+    // Click the branch-crumb button (not the <code> in the git strip).
+    fireEvent.click(
+      screen
+        .getAllByText('feature')
+        .find(el => el.closest('button') && el.tagName !== 'CODE'),
+    );
     expect(await screen.findByText('New branch')).toBeInTheDocument();
 
     // Drive creation via the toolbar button.
@@ -902,15 +999,12 @@ describe('<NamespaceHeader />', () => {
   });
 
   it('should call syncNamespaceToGit when syncing', async () => {
-    // Sync to Git only shows for branch namespaces
+    // Sync to Git only shows for editable branch namespaces (no git deployments).
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi
@@ -928,6 +1022,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
       syncNamespaceToGit: vi.fn().mockResolvedValue({
         files_synced: 5,
@@ -971,12 +1066,9 @@ describe('<NamespaceHeader />', () => {
   it('should show View PR button when PR exists', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi.fn().mockResolvedValue({
@@ -987,6 +1079,7 @@ describe('<NamespaceHeader />', () => {
         parent_namespace: 'test.main',
         branch_namespace: 'test.feature',
       }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue({
         pr_number: 42,
         pr_url: 'https://github.com/test/repo/pull/42',
@@ -1009,12 +1102,9 @@ describe('<NamespaceHeader />', () => {
   it('should call createPullRequest when creating a PR', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi
@@ -1032,6 +1122,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
       syncNamespaceToGit: vi.fn().mockResolvedValue({
         files_synced: 3,
@@ -1097,12 +1188,9 @@ describe('<NamespaceHeader />', () => {
   it('should call deleteBranch when deleting a branch', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi
@@ -1120,6 +1208,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
       deleteBranch: vi.fn().mockResolvedValue({ success: true }),
     };
@@ -1189,6 +1278,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
     };
 
@@ -1241,6 +1331,7 @@ describe('<NamespaceHeader />', () => {
           branch_namespace: 'test.feature',
         })
         .mockRejectedValueOnce(new Error('Parent not found')),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
     };
 
@@ -1265,12 +1356,9 @@ describe('<NamespaceHeader />', () => {
   it('should handle error fetching PR gracefully', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi
@@ -1288,6 +1376,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockRejectedValue(new Error('API Error')),
     };
 
@@ -1368,9 +1457,7 @@ describe('<NamespaceHeader />', () => {
   });
 
   it('should call deleteNamespaceGitConfig when removing git settings', async () => {
-    // Mock window.confirm for this test
-    global.confirm = vi.fn(() => true);
-
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
         total_deployments: 0,
@@ -1394,39 +1481,39 @@ describe('<NamespaceHeader />', () => {
       </MemoryRouter>,
     );
 
+    // Flat (read-only) state: Git settings is accessible via the Git menu.
     await waitFor(() => {
-      expect(screen.getByText('Git Settings')).toBeInTheDocument();
+      expect(screen.getByText('Git settings')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText('Git Settings'));
+    fireEvent.click(screen.getByText('Git settings'));
 
     await waitFor(() => {
       expect(screen.getByText('Git Configuration')).toBeInTheDocument();
     });
 
-    // Click reset button in the modal (button text is "Reset")
-    const removeButton = screen.getByText('Reset');
-    fireEvent.click(removeButton);
+    // The config has git_branch so detectShape returns 'flat' → modal opens with
+    // source='git'. Switch to "Edited in DataJunction" then Save to trigger onRemove
+    // which calls deleteNamespaceGitConfig.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Edited in DataJunction' }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(mockDjClient.deleteNamespaceGitConfig).toHaveBeenCalledWith(
         'test.namespace',
       );
     });
-
-    // Clean up mock
-    vi.restoreAllMocks();
   });
 
   it('should handle sync error in handleCreatePR', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 1,
-        primary_source: {
-          type: 'git',
-          repository: 'test/repo',
-          branch: 'feature',
-        },
+        // No git deployments so isGitManaged stays false and editable-branch controls show.
+        total_deployments: 0,
+        primary_source: null,
       }),
       listDeployments: vi.fn().mockResolvedValue([]),
       getNamespaceGitConfig: vi
@@ -1444,6 +1531,7 @@ describe('<NamespaceHeader />', () => {
           git_branch: 'main',
           git_path: 'nodes/',
         }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
       getPullRequest: vi.fn().mockResolvedValue(null),
       syncNamespaceToGit: vi.fn().mockResolvedValue({
         _error: true,
@@ -1490,6 +1578,417 @@ describe('<NamespaceHeader />', () => {
       expect(
         screen.getByText(/Sync failed: merge conflict/),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('git toolbar (formerly git strip)', () => {
+    it('renders read-only toolbar (no Unlink, no strip) for a flat namespace', async () => {
+      renderHeader({
+        namespace: 'magnesium.tech',
+        gitConfig: {
+          github_repo_path: 'corp/tech-realtime-guardrails',
+          git_branch: 'main',
+        },
+      });
+      // Status strip removed; verify the Git menu is present instead.
+      await waitFor(() => {
+        expect(screen.getByTestId('git-menu')).toBeInTheDocument();
+      });
+      // No .git-status-strip element
+      expect(document.querySelector('.git-status-strip')).toBeNull();
+      // Repo info shown in Git menu header
+      expect(
+        screen.getByText(/corp\/tech-realtime-guardrails/),
+      ).toBeInTheDocument();
+      // Git settings button present via the Git menu
+      expect(
+        screen.getAllByRole('button', { name: /git settings/i }).length,
+      ).toBeGreaterThanOrEqual(1);
+      // Unlink button NOT present
+      expect(
+        screen.queryByRole('button', { name: /unlink/i }),
+      ).not.toBeInTheDocument();
+      // "Edited in DataJunction" NOT present
+      expect(
+        screen.queryByText(/Edited in DataJunction/),
+      ).not.toBeInTheDocument();
+      // "Connect to Git" NOT present
+      expect(
+        screen.queryByRole('button', { name: /connect to git/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders read-only controls when sources signal git deployment (empty gitConfig)', async () => {
+      // isGitDeployed should trigger even without a gitConfig
+      const mockDjClient = {
+        namespaceSources: vi.fn().mockResolvedValue({
+          total_deployments: 3,
+          primary_source: {
+            type: 'git',
+            repository: 'corp/repo',
+            branch: 'main',
+          },
+        }),
+        listDeployments: vi.fn().mockResolvedValue([]),
+        getNamespaceGitConfig: vi
+          .fn()
+          .mockRejectedValue(new Error('no config')),
+        deleteNamespaceGitConfig: vi.fn().mockResolvedValue({ success: true }),
+        updateNamespaceGitConfig: vi.fn().mockResolvedValue({}),
+      };
+      render(
+        <MemoryRouter>
+          <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+            <NamespaceHeader namespace="corp.deployed" />
+          </DJClientContext.Provider>
+        </MemoryRouter>,
+      );
+      // isGitDeployed → isGitManaged → read-only badge shown
+      await waitFor(() => {
+        expect(screen.getByText('Read-only')).toBeInTheDocument();
+      });
+      // Status strip removed
+      expect(document.querySelector('.git-status-strip')).toBeNull();
+      expect(
+        screen.queryByText(/Edited in DataJunction/),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /connect to git/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /unlink/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders Connect to Git button for a non-git namespace (no strip, no "Edited in DJ" text)', async () => {
+      renderHeader({ namespace: 'some.sandbox', gitConfig: {} });
+      // Plain (not-git) state: single Connect to Git button, no strip text.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /connect to git/i }),
+        ).toBeInTheDocument();
+      });
+      expect(document.querySelector('.git-status-strip')).toBeNull();
+      // "Edited in DataJunction" was strip text — no longer rendered.
+      expect(
+        screen.queryByText(/Edited in DataJunction/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows read-only Git menu for flat namespace even when git_only is false', async () => {
+      // detectShape returns 'flat' when github_repo_path + git_branch present.
+      // isReadOnly is true → isGitManaged is true → read-only toolbar (GitMenu, no strip).
+      renderHeader({
+        namespace: 'flat.ns',
+        gitConfig: {
+          github_repo_path: 'corp/some-repo',
+          git_branch: 'main',
+          git_only: false,
+        },
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('git-menu')).toBeInTheDocument();
+      });
+      // Status strip is removed.
+      expect(document.querySelector('.git-status-strip')).toBeNull();
+    });
+  });
+
+  describe('handleRemoveGitConfig confirm guard', () => {
+    it('Unlink button is NOT rendered on the page (only accessible via modal)', async () => {
+      // handleRemoveGitConfig still exists for modal use, but is not exposed
+      // as a standalone page button. The status strip (which previously had it)
+      // has been removed entirely.
+      renderHeader({
+        namespace: 'flat.ns',
+        gitConfig: {
+          github_repo_path: 'corp/some-repo',
+          git_branch: 'main',
+          git_only: false,
+        },
+      });
+
+      // Wait for the Git menu to appear (flat namespace → isGitManaged → GitMenu).
+      await waitFor(() => {
+        expect(screen.getByTestId('git-menu')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole('button', { name: /unlink/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('git toolbar states', () => {
+    it('read-only namespace shows New Branch + Git menu, no edit actions, no strip', async () => {
+      // shape "root": github_repo_path + default_branch, no git_branch, no parent
+      renderHeaderState({
+        namespace: 'ads',
+        gitConfig: {
+          github_repo_path: 'corp/ads-dj',
+          default_branch: 'main',
+          git_root_namespace: 'ads',
+        },
+      });
+      expect(await screen.findByText('New Branch')).toBeInTheDocument();
+      expect(screen.getByText('Git settings')).toBeInTheDocument();
+      expect(screen.queryByText('Sync to Git')).not.toBeInTheDocument();
+      expect(screen.queryByText('Create PR')).not.toBeInTheDocument();
+      expect(screen.queryByText('Delete branch')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Deployed from Git/)).not.toBeInTheDocument();
+      expect(document.querySelector('.git-status-strip')).toBeNull();
+      // exactly one "Git settings" entry point
+      expect(screen.getAllByText('Git settings')).toHaveLength(1);
+    });
+
+    it('editable branch shows Sync to Git + Create PR inline and a Git menu', async () => {
+      // shape "branch": has parent_namespace; not git-deployed => editable
+      renderHeaderState({
+        namespace: 'ads.feature',
+        gitConfig: {
+          github_repo_path: 'corp/ads-dj',
+          git_branch: 'feature',
+          parent_namespace: 'ads',
+          branch_namespace: 'ads.feature',
+          git_root_namespace: 'ads',
+        },
+        sources: { total_deployments: 0, primary_source: null },
+      });
+      expect(await screen.findByText('Sync to Git')).toBeInTheDocument();
+      expect(screen.getByText('Create PR')).toBeInTheDocument();
+      expect(screen.getByText('Delete branch')).toBeInTheDocument();
+      expect(screen.queryByText('Git settings')).not.toBeInTheDocument();
+      expect(document.querySelector('.git-status-strip')).toBeNull();
+    });
+
+    it('plain (not-git) namespace shows a single Connect to Git control', async () => {
+      renderHeaderState({ namespace: 'plain.ns', gitConfig: {} });
+      expect(await screen.findByText('Connect to Git')).toBeInTheDocument();
+      expect(screen.queryByTestId('git-menu')).toBeNull();
+      expect(screen.queryByText('Sync to Git')).not.toBeInTheDocument();
+    });
+
+    it('fires onReadOnlyChange(true) for a git-managed namespace', async () => {
+      const onReadOnlyChange = vi.fn();
+      const mockDjClient = {
+        namespaceSources: vi
+          .fn()
+          .mockResolvedValue({ total_deployments: 0, primary_source: null }),
+        listDeployments: vi.fn().mockResolvedValue([]),
+        getNamespaceGitConfig: vi.fn().mockResolvedValue({
+          github_repo_path: 'corp/ads-dj',
+          default_branch: 'main',
+          git_root_namespace: 'ads',
+        }),
+        getPullRequest: vi.fn().mockResolvedValue(null),
+      };
+      render(
+        <MemoryRouter>
+          <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+            <NamespaceHeader
+              namespace="ads"
+              onReadOnlyChange={onReadOnlyChange}
+            />
+          </DJClientContext.Provider>
+        </MemoryRouter>,
+      );
+      await waitFor(() => expect(onReadOnlyChange).toHaveBeenCalledWith(true));
+    });
+
+    it('fires onReadOnlyChange(false) for a plain namespace', async () => {
+      const onReadOnlyChange = vi.fn();
+      const mockDjClient = {
+        namespaceSources: vi
+          .fn()
+          .mockResolvedValue({ total_deployments: 0, primary_source: null }),
+        listDeployments: vi.fn().mockResolvedValue([]),
+        getNamespaceGitConfig: vi.fn().mockResolvedValue({}),
+        getPullRequest: vi.fn().mockResolvedValue(null),
+      };
+      render(
+        <MemoryRouter>
+          <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+            <NamespaceHeader
+              namespace="plain.ns"
+              onReadOnlyChange={onReadOnlyChange}
+            />
+          </DJClientContext.Provider>
+        </MemoryRouter>,
+      );
+      await waitFor(() => expect(onReadOnlyChange).toHaveBeenCalledWith(false));
+    });
+  });
+
+  describe('manage git from the branch (option B)', () => {
+    const LocationDisplay = () => (
+      <div data-testid="loc">
+        {useLocation().pathname}
+        {useLocation().search}
+      </div>
+    );
+
+    // Read-only default branch: deployed from git, has a parent (the root).
+    const deployedBranchClient = updateSpy => ({
+      namespaceSources: vi.fn().mockResolvedValue({
+        total_deployments: 1,
+        primary_source: {
+          type: 'git',
+          repository: 'corp/ads-dj',
+          branch: 'main',
+        },
+      }),
+      listDeployments: vi.fn().mockResolvedValue([]),
+      getPullRequest: vi.fn().mockResolvedValue(null),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
+      getNamespaceGitConfig: vi.fn().mockImplementation(ns =>
+        Promise.resolve(
+          ns === 'ads'
+            ? {
+                github_repo_path: 'corp/ads-dj',
+                default_branch: 'main',
+                git_root_namespace: 'ads',
+              }
+            : {
+                github_repo_path: 'corp/ads-dj',
+                git_branch: 'main',
+                parent_namespace: 'ads',
+                branch_namespace: 'ads.main',
+                git_root_namespace: 'ads',
+              },
+        ),
+      ),
+      updateNamespaceGitConfig:
+        updateSpy ||
+        vi.fn().mockResolvedValue({ github_repo_path: 'corp/ads-dj' }),
+    });
+
+    it('read-only default branch: Git settings edits the ROOT in place', async () => {
+      const updateSpy = vi
+        .fn()
+        .mockResolvedValue({ github_repo_path: 'corp/ads-dj' });
+      render(
+        <MemoryRouter initialEntries={['/namespaces/ads.main']}>
+          <DJClientContext.Provider
+            value={{ DataJunctionAPI: deployedBranchClient(updateSpy) }}
+          >
+            <LocationDisplay />
+            <NamespaceHeader namespace="ads.main" />
+          </DJClientContext.Provider>
+        </MemoryRouter>,
+      );
+      fireEvent.click(await screen.findByText('Git settings'));
+      // Modal opens in place (no navigation).
+      expect(await screen.findByText('Git Configuration')).toBeInTheDocument();
+      expect(screen.getByTestId('loc').textContent).toBe(
+        '/namespaces/ads.main',
+      );
+      // Wait for the modal to preselect from the ROOT's config (async fetch)
+      // before saving — otherwise it defaults to "not-git" and Save would remove.
+      await screen.findByDisplayValue('corp/ads-dj');
+      // Saving targets the ROOT namespace, not the branch.
+      fireEvent.click(screen.getByText('Save'));
+      await waitFor(() =>
+        expect(updateSpy).toHaveBeenCalledWith('ads', expect.anything()),
+      );
+    });
+
+    it('editable working branch: NO Git settings item', async () => {
+      const client = {
+        namespaceSources: vi
+          .fn()
+          .mockResolvedValue({ total_deployments: 0, primary_source: null }),
+        listDeployments: vi.fn().mockResolvedValue([]),
+        getPullRequest: vi.fn().mockResolvedValue(null),
+        getNamespaceBranches: vi.fn().mockResolvedValue([]),
+        getNamespaceGitConfig: vi.fn().mockResolvedValue({
+          github_repo_path: 'corp/ads-dj',
+          git_branch: 'random_branch',
+          parent_namespace: 'ads',
+          branch_namespace: 'ads.random_branch',
+          git_root_namespace: 'ads',
+        }),
+      };
+      render(
+        <MemoryRouter initialEntries={['/namespaces/ads.random_branch']}>
+          <DJClientContext.Provider value={{ DataJunctionAPI: client }}>
+            <NamespaceHeader namespace="ads.random_branch" />
+          </DJClientContext.Provider>
+        </MemoryRouter>,
+      );
+      // The edit->ship loop is present...
+      expect(await screen.findByText('Sync to Git')).toBeInTheDocument();
+      expect(screen.getByText('Create PR')).toBeInTheDocument();
+      // ...but no repo-binding management here.
+      expect(screen.queryByText('Git settings')).not.toBeInTheDocument();
+    });
+
+    it('read-only default branch: New Branch survives a branch-side save with thin PATCH response', async () => {
+      // Regression guard for the merge-vs-replace bug: when a save returns a
+      // PATCH response that omits `default_branch`, parentGitConfig must be
+      // MERGED (not replaced) so rootDefaultBranch stays set and canCreateBranch
+      // remains true — keeping the "+ New Branch" control visible.
+      const updateSpy = vi
+        .fn()
+        .mockResolvedValue({ github_repo_path: 'corp/ads-dj' }); // NO default_branch
+      render(
+        <MemoryRouter initialEntries={['/namespaces/ads.main']}>
+          <DJClientContext.Provider
+            value={{ DataJunctionAPI: deployedBranchClient(updateSpy) }}
+          >
+            <NamespaceHeader namespace="ads.main" />
+          </DJClientContext.Provider>
+        </MemoryRouter>,
+      );
+      // "New Branch" must be present before any save.
+      expect(await screen.findByText('New Branch')).toBeInTheDocument();
+      // Open Git settings modal.
+      fireEvent.click(screen.getByText('Git settings'));
+      // Wait for modal to pre-populate from the ROOT's config.
+      await screen.findByDisplayValue('corp/ads-dj');
+      // Save — returns the thin PATCH response (no default_branch).
+      fireEvent.click(screen.getByText('Save'));
+      await waitFor(() =>
+        expect(updateSpy).toHaveBeenCalledWith('ads', expect.anything()),
+      );
+      // "New Branch" must still be present after the save.
+      expect(screen.getByText('New Branch')).toBeInTheDocument();
+    });
+
+    it('flat namespace: Git settings edits ITSELF', async () => {
+      const updateSpy = vi.fn().mockResolvedValue({
+        github_repo_path: 'corp/tech-realtime-guardrails',
+      });
+      const client = {
+        namespaceSources: vi
+          .fn()
+          .mockResolvedValue({ total_deployments: 0, primary_source: null }),
+        listDeployments: vi.fn().mockResolvedValue([]),
+        getPullRequest: vi.fn().mockResolvedValue(null),
+        getNamespaceBranches: vi.fn().mockResolvedValue([]),
+        getNamespaceGitConfig: vi.fn().mockResolvedValue({
+          github_repo_path: 'corp/tech-realtime-guardrails',
+          git_branch: 'main',
+          git_root_namespace: 'magnesium.tech',
+        }),
+        updateNamespaceGitConfig: updateSpy,
+      };
+      render(
+        <MemoryRouter initialEntries={['/namespaces/magnesium.tech']}>
+          <DJClientContext.Provider value={{ DataJunctionAPI: client }}>
+            <NamespaceHeader namespace="magnesium.tech" />
+          </DJClientContext.Provider>
+        </MemoryRouter>,
+      );
+      fireEvent.click(await screen.findByText('Git settings'));
+      // Wait for the modal to preselect from its OWN config before saving.
+      await screen.findByDisplayValue('corp/tech-realtime-guardrails');
+      fireEvent.click(screen.getByText('Save'));
+      await waitFor(() =>
+        expect(updateSpy).toHaveBeenCalledWith(
+          'magnesium.tech',
+          expect.anything(),
+        ),
+      );
     });
   });
 });

--- a/datajunction-ui/src/app/components/__tests__/__snapshots__/NamespaceHeader.test.jsx.snap
+++ b/datajunction-ui/src/app/components/__tests__/__snapshots__/NamespaceHeader.test.jsx.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<NamespaceHeader /> > should render and match the snapshot 1`] = `
-<React.Fragment>
+<DocumentFragment>
   <style>
     
           @keyframes spin {
@@ -11,38 +11,14 @@ exports[`<NamespaceHeader /> > should render and match the snapshot 1`] = `
         
   </style>
   <div
-    style={
-      {
-        "alignItems": "center",
-        "background": "#ffffff",
-        "borderBottom": "1px solid #e2e8f0",
-        "borderTop": "1px solid #e2e8f0",
-        "display": "flex",
-        "flexWrap": "wrap",
-        "gap": "8px",
-        "justifyContent": "space-between",
-        "marginBottom": "16px",
-        "padding": "12px 12px 12px 20px",
-      }
-    }
+    style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px; padding: 12px 12px 12px 20px; margin-bottom: 16px; border-top: 1px solid rgb(226, 232, 240); border-bottom: 1px solid rgb(226, 232, 240); background: rgb(255, 255, 255);"
   >
     <div
-      style={
-        {
-          "alignItems": "center",
-          "display": "flex",
-          "gap": "8px",
-        }
-      }
+      style="display: flex; align-items: center; gap: 8px;"
     >
       <a
         href="/"
-        style={
-          {
-            "alignItems": "center",
-            "display": "flex",
-          }
-        }
+        style="display: flex; align-items: center;"
       >
         <svg
           fill="currentColor"
@@ -65,27 +41,15 @@ exports[`<NamespaceHeader /> > should render and match the snapshot 1`] = `
       >
         <path
           d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"
-          fillRule="evenodd"
+          fill-rule="evenodd"
         />
       </svg>
       <span
-        style={
-          {
-            "alignItems": "center",
-            "display": "flex",
-            "gap": "8px",
-          }
-        }
+        style="display: flex; align-items: center; gap: 8px;"
       >
         <a
           href="/namespaces/shared"
-          style={
-            {
-              "color": "#1e293b",
-              "fontWeight": "400",
-              "textDecoration": "none",
-            }
-          }
+          style="font-weight: 400; color: rgb(30, 41, 59); text-decoration: none;"
         >
           shared
         </a>
@@ -98,28 +62,16 @@ exports[`<NamespaceHeader /> > should render and match the snapshot 1`] = `
         >
           <path
             d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"
-            fillRule="evenodd"
+            fill-rule="evenodd"
           />
         </svg>
       </span>
       <span
-        style={
-          {
-            "alignItems": "center",
-            "display": "flex",
-            "gap": "8px",
-          }
-        }
+        style="display: flex; align-items: center; gap: 8px;"
       >
         <a
           href="/namespaces/shared.dimensions"
-          style={
-            {
-              "color": "#1e293b",
-              "fontWeight": "400",
-              "textDecoration": "none",
-            }
-          }
+          style="font-weight: 400; color: rgb(30, 41, 59); text-decoration: none;"
         >
           dimensions
         </a>
@@ -132,78 +84,61 @@ exports[`<NamespaceHeader /> > should render and match the snapshot 1`] = `
         >
           <path
             d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"
-            fillRule="evenodd"
+            fill-rule="evenodd"
           />
         </svg>
       </span>
       <span
-        style={
-          {
-            "alignItems": "center",
-            "display": "flex",
-            "gap": "8px",
-          }
-        }
+        style="display: flex; align-items: center; gap: 8px;"
       >
         <a
           href="/namespaces/shared.dimensions.accounts"
-          style={
-            {
-              "color": "#1e293b",
-              "fontWeight": "400",
-              "textDecoration": "none",
-            }
-          }
+          style="font-weight: 400; color: rgb(30, 41, 59); text-decoration: none;"
         >
           accounts
         </a>
       </span>
     </div>
     <div
-      style={
-        {
-          "alignItems": "center",
-          "display": "flex",
-          "flexWrap": "wrap",
-          "gap": "8px",
-          "justifyContent": "flex-end",
-          "marginLeft": "auto",
-        }
-      }
-    />
-    <GitSettingsModal
-      currentConfig={null}
-      isOpen={false}
-      namespace="shared.dimensions.accounts"
-      onClose={[Function]}
-      onRemove={[Function]}
-      onSave={[Function]}
-    />
-    <CreateBranchModal
-      isGitRoot={true}
-      isOpen={false}
-      namespace="shared.dimensions.accounts"
-      onClose={[Function]}
-      onCreate={[Function]}
-    />
-    <SyncToGitModal
-      isOpen={false}
-      namespace="shared.dimensions.accounts"
-      onClose={[Function]}
-      onSync={[Function]}
-    />
-    <CreatePRModal
-      isOpen={false}
-      namespace="shared.dimensions.accounts"
-      onClose={[Function]}
-      onCreate={[Function]}
-    />
-    <DeleteBranchModal
-      isOpen={false}
-      namespace="shared.dimensions.accounts"
-      onClose={[Function]}
-      onDelete={[Function]}
-    />
+      style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; margin-left: auto;"
+    >
+      <button
+        style="height: 28px; padding: 0px 10px; font-size: 12px; font-weight: 500; border-width: 1px; border-style: solid; border-color: rgb(226, 232, 240); border-radius: 4px; background-color: rgb(255, 255, 255); color: rgb(71, 85, 105); cursor: pointer; display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; transition: all 0.15s ease;"
+      >
+        <svg
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <line
+            x1="6"
+            x2="6"
+            y1="3"
+            y2="15"
+          />
+          <circle
+            cx="18"
+            cy="6"
+            r="3"
+          />
+          <circle
+            cx="6"
+            cy="18"
+            r="3"
+          />
+          <path
+            d="M18 9a9 9 0 0 1-9 9"
+          />
+        </svg>
+        Connect to Git
+      </button>
+    </div>
   </div>
-</React.Fragment>
+</DocumentFragment>
 `;

--- a/datajunction-ui/src/app/components/git/GitSettingsModal.jsx
+++ b/datajunction-ui/src/app/components/git/GitSettingsModal.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { detectShape, buildGitConfigPayload } from './gitShape';
+import SplitFilter from '../SplitFilter';
 
 /**
  * Modal for configuring git settings for a namespace.
- * Supports two modes:
- * - Git Root: Configure repository and path only (no branch, no git_only flag)
- * - Branch Namespace: Auto-calculates parent from namespace name, user sets branch and git_only
- *   (e.g., "demo.main" automatically has parent "demo")
- *   git_only determines if the branch is read-only (deployed from git) or editable (UI changes allowed)
+ * Intent-based: user picks "Edited in DataJunction" or "Git repo",
+ * then (if git) picks "Tracks a branch" (flat) or "Feature branches + PRs" (root).
+ * No git_only checkbox — git-backed namespaces are always read-only here.
  */
 export function GitSettingsModal({
   isOpen,
@@ -15,110 +15,49 @@ export function GitSettingsModal({
   onRemove,
   currentConfig,
   namespace,
+  nodeCount = 0,
 }) {
-  const [mode, setMode] = useState('root'); // 'root' or 'branch'
-  const [repoPath, setRepoPath] = useState('');
-  const [branch, setBranch] = useState('');
-  const [path, setPath] = useState('');
+  const [source, setSource] = useState('dj'); // 'dj' | 'git'
+  const [model, setModel] = useState('flat'); // 'flat' | 'root'
+  const [repository, setRepository] = useState('');
+  const [branch, setBranch] = useState('main');
   const [defaultBranch, setDefaultBranch] = useState('main');
-  const [gitOnly, setGitOnly] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [removing, setRemoving] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
-  const [wasRemoved, setWasRemoved] = useState(false);
-  const [parentConfig, setParentConfig] = useState(null);
-
-  // Auto-calculate parent namespace from current namespace
-  // e.g., "demo.main" -> "demo", "demo.metrics.feature1" -> "demo.metrics"
-  const parentNamespace = namespace?.includes('.')
-    ? namespace.substring(0, namespace.lastIndexOf('.'))
-    : '';
 
   useEffect(() => {
-    if (currentConfig) {
-      // Determine mode based on whether parent_namespace is set
-      const isBranchMode = !!currentConfig.parent_namespace;
-      setMode(isBranchMode ? 'branch' : 'root');
-
-      setRepoPath(currentConfig.github_repo_path || '');
-      setBranch(currentConfig.git_branch || '');
-      setPath(currentConfig.git_path || 'nodes/');
-      setDefaultBranch(currentConfig.default_branch || 'main');
-
-      // git_only is only relevant for branch namespaces
-      // Default to true (read-only) for new branch configs, use existing value if set
-      if (isBranchMode) {
-        setGitOnly(
-          currentConfig.git_only !== undefined ? currentConfig.git_only : true,
-        );
-      }
-    } else {
-      // New configuration - default to git root mode and nodes/ path
-      setMode('root');
-      setPath('nodes/');
-      // Default git_only to true for when user switches to branch mode
-      setGitOnly(true);
-    }
-    // Don't reset success here - it gets reset when modal closes
-    // Otherwise the success banner disappears when currentConfig updates after save
+    if (!isOpen) return;
+    const shape = detectShape(currentConfig || {});
+    setSource(shape === 'not-git' ? 'dj' : 'git');
+    setModel(shape === 'root' ? 'root' : 'flat');
+    setRepository(currentConfig?.github_repo_path || '');
+    setBranch(currentConfig?.git_branch || 'main');
+    setDefaultBranch(currentConfig?.default_branch || 'main');
     setError(null);
-    setWasRemoved(false);
-    setParentConfig(null);
-  }, [currentConfig]);
+  }, [currentConfig, isOpen]);
 
   const handleSubmit = async e => {
     e.preventDefault();
     setError(null);
     setSuccess(false);
-    setWasRemoved(false);
-
-    // Client-side validation
-    if (mode === 'branch') {
-      if (!parentNamespace) {
-        setError(
-          'Cannot configure as branch namespace: namespace has no parent (no dots in name)',
-        );
-        return;
-      }
-      if (!branch.trim()) {
-        setError('Git branch is required for branch mode');
-        return;
-      }
-    } else {
-      // Git root mode
-      if (!repoPath.trim()) {
-        setError('Repository is required');
-        return;
-      }
+    if (source === 'git' && !repository.trim()) {
+      setError('Repository is required');
+      return;
     }
-
     setSaving(true);
-
     try {
-      const config =
-        mode === 'branch'
-          ? {
-              // Branch mode: only send branch, parent, and git_only
-              git_branch: branch.trim() || null,
-              parent_namespace: parentNamespace || null,
-              git_only: gitOnly,
-            }
-          : {
-              // Git root mode: only send repo, path, and default_branch (no git_branch, no git_only)
-              github_repo_path: repoPath.trim() || null,
-              git_path: path.trim() || null,
-              default_branch: defaultBranch.trim() || null,
-            };
-
-      const result = await onSave(config);
-      if (result?._error) {
-        setError(result.message);
-      } else {
-        setSuccess(true);
-        // Keep modal open so user can see success message
-        // User can close manually via Close button or X
-      }
+      const payload = buildGitConfigPayload({
+        source,
+        model,
+        repository,
+        branch,
+        defaultBranch,
+      });
+      const result =
+        payload === null ? await onRemove() : await onSave(payload);
+      if (result?._error) setError(result.message);
+      else setSuccess(true);
     } catch (err) {
       setError(err.message || 'Failed to save git settings');
     } finally {
@@ -126,63 +65,9 @@ export function GitSettingsModal({
     }
   };
 
-  // Fetch parent config when parent namespace changes (only if modal is open)
-  useEffect(() => {
-    if (isOpen && mode === 'branch' && parentNamespace) {
-      // Fetch parent's git config to show inherited values
-      fetch(`/api/namespaces/${parentNamespace}/git`)
-        .then(res => (res.ok ? res.json() : null))
-        .then(data => setParentConfig(data))
-        .catch(() => setParentConfig(null));
-    } else {
-      setParentConfig(null);
-    }
-  }, [isOpen, mode, parentNamespace]);
-
-  const handleRemove = async () => {
-    if (
-      !window.confirm(
-        'Remove git configuration? This will disconnect this namespace from git but will not delete any files.',
-      )
-    ) {
-      return;
-    }
-
-    setError(null);
-    setSuccess(false);
-    setWasRemoved(false);
-    setRemoving(true);
-
-    try {
-      const config = {
-        github_repo_path: null,
-        git_branch: null,
-        git_path: null,
-        git_only: false,
-      };
-
-      const result = await onRemove(config);
-      if (result?._error) {
-        setError(result.message);
-      } else {
-        setSuccess(true);
-        setWasRemoved(true);
-        // Close modal after successful removal
-        setTimeout(() => {
-          onClose();
-        }, 1500);
-      }
-    } catch (err) {
-      setError(err.message || 'Failed to remove git settings');
-    } finally {
-      setRemoving(false);
-    }
-  };
-
   const handleClose = () => {
     setError(null);
     setSuccess(false);
-    setWasRemoved(false);
     onClose();
   };
 
@@ -203,7 +88,14 @@ export function GitSettingsModal({
         </div>
 
         <form onSubmit={handleSubmit}>
-          <div className="modal-body">
+          <div
+            className="modal-body"
+            style={{
+              fontFamily:
+                'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+              textTransform: 'none',
+            }}
+          >
             <p
               style={{
                 color: '#64748b',
@@ -211,8 +103,7 @@ export function GitSettingsModal({
                 marginBottom: '16px',
               }}
             >
-              Configure git integration for <strong>{namespace}</strong> to
-              enable branch management and sync changes to GitHub.
+              Configure git integration for <strong>{namespace}</strong>.
             </p>
 
             {error && (
@@ -231,304 +122,97 @@ export function GitSettingsModal({
               </div>
             )}
 
-            {/* Mode Toggle */}
-            <div style={{ marginBottom: '20px' }}>
-              <div
-                style={{
-                  display: 'flex',
-                  gap: '12px',
-                  padding: '4px',
-                  backgroundColor: '#f1f5f9',
-                  borderRadius: '8px',
-                }}
-              >
-                <button
-                  type="button"
-                  onClick={() => setMode('root')}
-                  disabled={saving}
-                  style={{
-                    flex: 1,
-                    padding: '10px 16px',
-                    fontSize: '13px',
-                    fontWeight: 500,
-                    border: 'none',
-                    borderRadius: '6px',
-                    backgroundColor:
-                      mode === 'root' ? '#ffffff' : 'transparent',
-                    color: mode === 'root' ? '#0f172a' : '#64748b',
-                    cursor: saving ? 'not-allowed' : 'pointer',
-                    boxShadow:
-                      mode === 'root' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
-                    transition: 'all 0.15s',
-                  }}
-                >
-                  Git Root
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setMode('branch')}
-                  disabled={saving}
-                  style={{
-                    flex: 1,
-                    padding: '10px 16px',
-                    fontSize: '13px',
-                    fontWeight: 500,
-                    border: 'none',
-                    borderRadius: '6px',
-                    backgroundColor:
-                      mode === 'branch' ? '#ffffff' : 'transparent',
-                    color: mode === 'branch' ? '#0f172a' : '#64748b',
-                    cursor: saving ? 'not-allowed' : 'pointer',
-                    boxShadow:
-                      mode === 'branch' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
-                    transition: 'all 0.15s',
-                  }}
-                >
-                  Branch Namespace
-                </button>
-              </div>
-              <span
-                style={{
-                  display: 'block',
-                  marginTop: '8px',
-                  fontSize: '12px',
-                  color: '#64748b',
-                }}
-              >
-                {mode === 'root'
-                  ? 'Configure repository for this namespace (recommended for most users)'
-                  : `Link to parent "${
-                      parentNamespace || '(none)'
-                    }" and inherit repository configuration`}
-              </span>
+            {/* Q1: Source of definitions */}
+            <div
+              style={{
+                display: 'flex',
+                textTransform: 'none',
+                marginBottom: '16px',
+              }}
+            >
+              <SplitFilter
+                label="Source of definitions"
+                value={source}
+                onChange={v => v && setSource(v)}
+                options={[
+                  { value: 'dj', label: 'Edited in DataJunction' },
+                  { value: 'git', label: 'Git repo' },
+                ]}
+              />
             </div>
 
-            {/* Conditional Fields based on Mode */}
-            {mode === 'root' ? (
+            {source === 'git' && (
               <>
-                {/* Git Root Mode - Repository and Path only */}
+                {detectShape(currentConfig || {}) === 'not-git' &&
+                  nodeCount > 0 && (
+                    <div className="git-repo-wins-warning" role="alert">
+                      ⚠️ {nodeCount} nodes here aren't in the repo and will be
+                      replaced by the repo's contents on the next deploy. Git
+                      becomes the source of truth for this namespace.
+                    </div>
+                  )}
+
+                {/* Q2: Git model */}
+                <div
+                  style={{
+                    display: 'flex',
+                    textTransform: 'none',
+                    marginBottom: '16px',
+                  }}
+                >
+                  <SplitFilter
+                    label="Git model"
+                    value={model}
+                    onChange={v => v && setModel(v)}
+                    options={[
+                      { value: 'flat', label: 'Tracks a branch' },
+                      { value: 'root', label: 'Feature branches + PRs' },
+                    ]}
+                  />
+                </div>
+
                 <div className="form-group">
-                  <label htmlFor="git-repo-path">Repository *</label>
+                  <label htmlFor="git-repo-path">Repository</label>
                   <input
                     id="git-repo-path"
                     type="text"
                     placeholder="owner/repo"
-                    value={repoPath}
-                    onChange={e => setRepoPath(e.target.value)}
+                    value={repository}
+                    onChange={e => setRepository(e.target.value)}
                     disabled={saving}
-                    required
                   />
-                  <span className="form-hint">
-                    GitHub repository path (e.g., "myorg/dj-definitions")
-                  </span>
                 </div>
 
-                <div className="form-group">
-                  <label htmlFor="git-path">Path</label>
-                  <input
-                    id="git-path"
-                    type="text"
-                    placeholder="nodes/"
-                    value={path}
-                    onChange={e => setPath(e.target.value)}
-                    disabled={saving}
-                  />
-                  <span className="form-hint">
-                    Subdirectory within the repo for node YAML files
-                  </span>
-                </div>
-
-                <div className="form-group">
-                  <label htmlFor="default-branch">Default Branch</label>
-                  <input
-                    id="default-branch"
-                    type="text"
-                    placeholder="main"
-                    value={defaultBranch}
-                    onChange={e => setDefaultBranch(e.target.value)}
-                    disabled={saving}
-                  />
-                  <span className="form-hint">
-                    Default branch to use when creating new branches (e.g.,
-                    "main")
-                  </span>
-                </div>
-              </>
-            ) : (
-              <>
-                {/* Branch Mode - Show parent and branch field */}
-                {!parentNamespace ? (
-                  <div
-                    style={{
-                      marginBottom: '16px',
-                      padding: '12px',
-                      backgroundColor: '#fef2f2',
-                      borderRadius: '6px',
-                      border: '1px solid #fecaca',
-                      color: '#dc2626',
-                      fontSize: '13px',
-                    }}
-                  >
-                    Cannot configure as branch namespace: namespace "{namespace}
-                    " has no parent. Branch namespaces must have a dot in their
-                    name (e.g., "demo.main").
+                {model === 'flat' ? (
+                  <div className="form-group">
+                    <label htmlFor="git-branch">Branch</label>
+                    <input
+                      id="git-branch"
+                      type="text"
+                      placeholder="main"
+                      value={branch}
+                      onChange={e => setBranch(e.target.value)}
+                      disabled={saving}
+                    />
                   </div>
                 ) : (
-                  <>
-                    {/* Display parent namespace as read-only info */}
-                    <div
-                      style={{
-                        marginBottom: '16px',
-                        padding: '12px',
-                        backgroundColor: '#f8fafc',
-                        borderRadius: '6px',
-                        border: '1px solid #e2e8f0',
-                      }}
-                    >
-                      <div
-                        style={{
-                          fontSize: '12px',
-                          fontWeight: 600,
-                          color: '#475569',
-                          marginBottom: '8px',
-                        }}
-                      >
-                        Parent Namespace
-                      </div>
-                      <div
-                        style={{
-                          fontSize: '14px',
-                          fontWeight: 500,
-                          color: '#0f172a',
-                          fontFamily: 'monospace',
-                        }}
-                      >
-                        {parentNamespace}
-                      </div>
-                      <div
-                        style={{
-                          fontSize: '12px',
-                          color: '#64748b',
-                          marginTop: '6px',
-                        }}
-                      >
-                        Repository configuration will be inherited from this
-                        parent
-                      </div>
-                    </div>
-
-                    {/* Show inherited config from parent */}
-                    {parentConfig && (
-                      <div
-                        style={{
-                          marginBottom: '16px',
-                          padding: '12px',
-                          backgroundColor: '#f0f9ff',
-                          borderRadius: '6px',
-                          border: '1px solid #bae6fd',
-                        }}
-                      >
-                        <div
-                          style={{
-                            fontSize: '12px',
-                            fontWeight: 600,
-                            color: '#0369a1',
-                            marginBottom: '8px',
-                          }}
-                        >
-                          Inherited Configuration
-                        </div>
-                        <div style={{ fontSize: '12px', color: '#64748b' }}>
-                          <div style={{ marginBottom: '4px' }}>
-                            <strong>Repository:</strong>{' '}
-                            {parentConfig.github_repo_path ||
-                              '(not configured)'}
-                          </div>
-                          <div>
-                            <strong>Path:</strong>{' '}
-                            {parentConfig.git_path || '(root)'}
-                          </div>
-                        </div>
-                      </div>
-                    )}
-                  </>
+                  <div className="form-group">
+                    <label htmlFor="git-default-branch">Default branch</label>
+                    <input
+                      id="git-default-branch"
+                      type="text"
+                      placeholder="main"
+                      value={defaultBranch}
+                      onChange={e => setDefaultBranch(e.target.value)}
+                      disabled={saving}
+                    />
+                  </div>
                 )}
 
-                <div className="form-group">
-                  <label htmlFor="git-branch">Branch *</label>
-                  <input
-                    id="git-branch"
-                    type="text"
-                    placeholder="feature-x, dev, etc."
-                    value={branch}
-                    onChange={e => setBranch(e.target.value)}
-                    disabled={saving}
-                    required
-                  />
-                  <span className="form-hint">
-                    Git branch name for this namespace
-                  </span>
-                </div>
-
-                {/* Git-only checkbox - only for branch namespaces */}
-                <div
-                  style={{
-                    marginTop: '16px',
-                    padding: '12px',
-                    backgroundColor: gitOnly ? '#fef3c7' : '#f0fdf4',
-                    borderRadius: '6px',
-                    border: `1px solid ${gitOnly ? '#fcd34d' : '#86efac'}`,
-                  }}
-                >
-                  <label
-                    style={{
-                      display: 'flex',
-                      alignItems: 'flex-start',
-                      gap: '10px',
-                      cursor: 'pointer',
-                      margin: 0,
-                      textTransform: 'none',
-                      letterSpacing: 'normal',
-                      fontSize: '14px',
-                      fontWeight: 'normal',
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={gitOnly}
-                      onChange={e => setGitOnly(e.target.checked)}
-                      disabled={saving}
-                      style={{ marginTop: '3px' }}
-                    />
-                    <span>
-                      <span
-                        style={{
-                          fontWeight: 600,
-                          color: gitOnly ? '#92400e' : '#166534',
-                          textTransform: 'none',
-                        }}
-                      >
-                        {gitOnly
-                          ? 'Read-only (Git is source of truth)'
-                          : 'Editable (UI edits allowed)'}
-                      </span>
-                      <span
-                        style={{
-                          display: 'block',
-                          marginTop: '4px',
-                          fontSize: '12px',
-                          color: '#64748b',
-                          fontWeight: 'normal',
-                          textTransform: 'none',
-                        }}
-                      >
-                        {gitOnly
-                          ? 'Changes must be made via git and deployed through CI/CD. UI editing is disabled.'
-                          : 'Users can edit nodes in the UI. Changes can be synced to git.'}
-                      </span>
-                    </span>
-                  </label>
-                </div>
+                <p className="git-readonly-note">
+                  🔒 Git-backed namespaces are read-only here; edit via git +
+                  CI.
+                </p>
               </>
             )}
 
@@ -561,74 +245,41 @@ export function GitSettingsModal({
                   <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
                   <polyline points="22 4 12 14.01 9 11.01" />
                 </svg>
-                {wasRemoved
-                  ? 'Git configuration removed successfully!'
-                  : 'Git configuration saved successfully!'}
+                Git configuration saved successfully!
               </div>
             )}
           </div>
 
           <div
             className="modal-actions"
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
+            style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}
           >
-            {/* Left side: Remove button (only show if git is configured) */}
-            <div>
-              {currentConfig?.github_repo_path && !success && (
-                <button
-                  type="button"
-                  onClick={handleRemove}
-                  disabled={saving || removing}
-                  style={{
-                    padding: '8px 16px',
-                    fontSize: '13px',
-                    fontWeight: 500,
-                    border: '1px solid #fca5a5',
-                    borderRadius: '6px',
-                    backgroundColor: removing ? '#fee2e2' : '#ffffff',
-                    color: removing ? '#991b1b' : '#dc2626',
-                    cursor: saving || removing ? 'not-allowed' : 'pointer',
-                    opacity: saving || removing ? 0.6 : 1,
-                  }}
-                >
-                  {removing ? 'Removing...' : 'Reset'}
-                </button>
-              )}
-            </div>
-
-            {/* Right side: Save/Cancel buttons */}
-            <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={handleClose}
+              disabled={saving}
+            >
+              {success ? 'Close' : 'Cancel'}
+            </button>
+            {!success && (
               <button
-                type="button"
-                className="btn-secondary"
-                onClick={handleClose}
-                disabled={saving || removing}
+                type="submit"
+                className="btn-primary"
+                disabled={saving}
+                style={
+                  saving
+                    ? {
+                        opacity: 0.7,
+                        cursor: 'wait',
+                        backgroundColor: '#9ca3af',
+                      }
+                    : {}
+                }
               >
-                {success ? 'Close' : 'Cancel'}
+                {saving ? 'Saving...' : 'Save'}
               </button>
-              {!success && (
-                <button
-                  type="submit"
-                  className="btn-primary"
-                  disabled={saving || removing}
-                  style={
-                    saving
-                      ? {
-                          opacity: 0.7,
-                          cursor: 'wait',
-                          backgroundColor: '#9ca3af',
-                        }
-                      : {}
-                  }
-                >
-                  {saving ? 'Saving...' : 'Save Settings'}
-                </button>
-              )}
-            </div>
+            )}
           </div>
         </form>
       </div>

--- a/datajunction-ui/src/app/components/git/__tests__/GitSettingsModal.test.jsx
+++ b/datajunction-ui/src/app/components/git/__tests__/GitSettingsModal.test.jsx
@@ -1,489 +1,77 @@
-import * as React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import GitSettingsModal from '../GitSettingsModal';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GitSettingsModal } from '../GitSettingsModal';
 
-describe('<GitSettingsModal />', () => {
-  const mockOnClose = vi.fn();
-  const mockOnSave = vi.fn();
-  const mockOnRemove = vi.fn();
+const open = props =>
+  render(
+    <GitSettingsModal
+      isOpen
+      namespace="magnesium.tech"
+      onClose={vi.fn()}
+      onSave={vi.fn().mockResolvedValue({})}
+      onRemove={vi.fn().mockResolvedValue({})}
+      currentConfig={null}
+      {...props}
+    />,
+  );
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    // Mock window.confirm
-    global.confirm = vi.fn(() => true);
-    // Mock fetch for parent config fetching
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            github_repo_path: 'test/repo',
-            git_path: 'nodes/',
-          }),
-      }),
-    );
+it('has no read-only / git_only checkbox', () => {
+  open();
+  expect(
+    screen.queryByText(/editable \(ui edits allowed\)/i),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText(/git is source of truth/i)).not.toBeInTheDocument();
+});
+
+it('shows repo + branch fields for "tracks a branch" and saves a flat payload', async () => {
+  const onSave = vi.fn().mockResolvedValue({});
+  open({ onSave });
+  fireEvent.click(screen.getByText(/git repo/i));
+  fireEvent.click(screen.getByText(/tracks a branch/i));
+  fireEvent.change(screen.getByLabelText(/repository/i), {
+    target: { value: 'corp/tech-realtime-guardrails' },
   });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+  fireEvent.change(screen.getByLabelText(/^branch$/i), {
+    target: { value: 'main' },
   });
-
-  it('should render with existing git root config', () => {
-    const currentConfig = {
-      github_repo_path: 'test/repo',
-      git_path: 'nodes/',
-      default_branch: 'main',
-    };
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.namespace"
-      />,
-    );
-
-    expect(screen.getByDisplayValue('test/repo')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('nodes/')).toBeInTheDocument();
-    // Default branch field should be present in git root mode
-    expect(screen.getByLabelText(/Default Branch/)).toBeInTheDocument();
-    expect(screen.getByDisplayValue('main')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  await screen.findByText(/success|saved/i).catch(() => {});
+  expect(onSave).toHaveBeenCalledWith({
+    github_repo_path: 'corp/tech-realtime-guardrails',
+    git_branch: 'main',
   });
+});
 
-  it('should render with existing branch namespace config', () => {
-    const currentConfig = {
-      parent_namespace: 'test',
-      git_branch: 'main',
-      git_only: false,
-    };
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.feature"
-      />,
-    );
-
-    expect(screen.getByDisplayValue('main')).toBeInTheDocument();
-    expect(screen.getByText('test')).toBeInTheDocument(); // Parent shown as read-only
-    // git_only is false, so checkbox should not be checked
-    const checkbox = screen.getByRole('checkbox');
-    expect(checkbox).not.toBeChecked();
+it('preselects flat mode from an existing flat config', () => {
+  open({
+    currentConfig: { github_repo_path: 'corp/repo', git_branch: 'main' },
   });
+  expect(screen.getByDisplayValue('corp/repo')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('main')).toBeInTheDocument();
+});
 
-  it('should call onRemove when Reset button is clicked and confirmed', async () => {
-    const currentConfig = {
-      github_repo_path: 'test/repo',
-      git_path: 'nodes/',
-    };
+it('warns before connecting a namespace that already has nodes', () => {
+  render(
+    <GitSettingsModal isOpen namespace="some.sandbox" nodeCount={4}
+      onClose={vi.fn()} onSave={vi.fn().mockResolvedValue({})}
+      onRemove={vi.fn()} currentConfig={null} />,
+  );
+  fireEvent.click(screen.getByText(/git repo/i));
+  expect(screen.getByText(/4 nodes here aren't in the repo/i)).toBeInTheDocument();
+  expect(screen.getByText(/replaced by the repo/i)).toBeInTheDocument();
+});
 
-    mockOnRemove.mockResolvedValue({ success: true });
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.namespace"
-      />,
-    );
-
-    const removeButton = screen.getByText('Reset');
-    fireEvent.click(removeButton);
-
-    // Verify confirmation dialog was shown
-    expect(global.confirm).toHaveBeenCalledWith(
-      expect.stringContaining('Remove git configuration?'),
-    );
-
-    await waitFor(() => {
-      expect(mockOnRemove).toHaveBeenCalledWith({
-        github_repo_path: null,
-        git_branch: null,
-        git_path: null,
-        git_only: false,
-      });
-    });
+it('selecting "Edited in DataJunction" saves via onRemove, not onSave', async () => {
+  const onSave = vi.fn().mockResolvedValue({});
+  const onRemove = vi.fn().mockResolvedValue({});
+  open({
+    onSave,
+    onRemove,
+    currentConfig: { github_repo_path: 'corp/repo', git_branch: 'main' },
   });
-
-  it('should not call onRemove when user cancels confirmation', async () => {
-    global.confirm = vi.fn(() => false);
-
-    const currentConfig = {
-      github_repo_path: 'test/repo',
-      git_path: 'nodes/',
-    };
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.namespace"
-      />,
-    );
-
-    const removeButton = screen.getByText('Reset');
-    fireEvent.click(removeButton);
-
-    expect(global.confirm).toHaveBeenCalled();
-    expect(mockOnRemove).not.toHaveBeenCalled();
-  });
-
-  it('should show error message when remove fails', async () => {
-    const currentConfig = {
-      github_repo_path: 'test/repo',
-      git_path: 'nodes/',
-    };
-
-    mockOnRemove.mockResolvedValue({
-      _error: true,
-      message: 'Failed to remove git configuration',
-    });
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.namespace"
-      />,
-    );
-
-    const removeButton = screen.getByText('Reset');
-    fireEvent.click(removeButton);
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Failed to remove git configuration/),
-      ).toBeInTheDocument();
-    });
-
-    // Modal should stay open on error
-    expect(mockOnClose).not.toHaveBeenCalled();
-  });
-
-  it('should show success message and close modal after successful removal', async () => {
-    const currentConfig = {
-      github_repo_path: 'test/repo',
-      git_path: 'nodes/',
-    };
-
-    mockOnRemove.mockResolvedValue({ success: true });
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.namespace"
-      />,
-    );
-
-    const removeButton = screen.getByText('Reset');
-    fireEvent.click(removeButton);
-
-    await waitFor(() => {
-      expect(mockOnRemove).toHaveBeenCalled();
-    });
-
-    // Success message should appear
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Git configuration removed successfully/),
-      ).toBeInTheDocument();
-    });
-
-    // Wait for the timeout-driven modal close (real-timer wait).
-    await waitFor(
-      () => {
-        expect(mockOnClose).toHaveBeenCalled();
-      },
-      { timeout: 3000 },
-    );
-  });
-
-  it('should handle exception during remove', async () => {
-    const currentConfig = {
-      github_repo_path: 'test/repo',
-      git_path: 'nodes/',
-    };
-
-    mockOnRemove.mockRejectedValue(new Error('Network error'));
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.namespace"
-      />,
-    );
-
-    const removeButton = screen.getByText('Reset');
-    fireEvent.click(removeButton);
-
-    await waitFor(() => {
-      expect(screen.getByText(/Network error/)).toBeInTheDocument();
-    });
-  });
-
-  it('should show removing state while operation is in progress', async () => {
-    const currentConfig = {
-      github_repo_path: 'test/repo',
-      git_path: 'nodes/',
-    };
-
-    // Create a promise that we can control
-    let resolveRemove;
-    const removePromise = new Promise(resolve => {
-      resolveRemove = resolve;
-    });
-    mockOnRemove.mockReturnValue(removePromise);
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={currentConfig}
-        namespace="test.namespace"
-      />,
-    );
-
-    const removeButton = screen.getByText('Reset');
-    fireEvent.click(removeButton);
-
-    // Button text should change to "Removing..." and be disabled
-    await waitFor(() => {
-      expect(screen.getByText('Removing...')).toBeInTheDocument();
-      expect(screen.getByText('Removing...')).toBeDisabled();
-    });
-
-    // Resolve the promise
-    resolveRemove({ success: true });
-
-    // Button should disappear after success (replaced by success message)
-    await waitFor(() => {
-      expect(screen.queryByText('Reset')).not.toBeInTheDocument();
-      expect(screen.queryByText('Removing...')).not.toBeInTheDocument();
-    });
-  });
-
-  it('should call onSave when Save Settings is clicked in git root mode', async () => {
-    mockOnSave.mockResolvedValue({ success: true });
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={null}
-        namespace="test.namespace"
-      />,
-    );
-
-    // Default mode is git root
-    fireEvent.change(screen.getByLabelText(/Repository/), {
-      target: { value: 'myorg/repo' },
-    });
-
-    fireEvent.click(screen.getByText('Save Settings'));
-
-    await waitFor(() => {
-      expect(mockOnSave).toHaveBeenCalledWith({
-        github_repo_path: 'myorg/repo',
-        git_path: 'nodes/', // Default value
-        default_branch: 'main', // Default value for git roots
-      });
-    });
-  });
-
-  it('should call onSave when Save Settings is clicked in branch mode', async () => {
-    mockOnSave.mockResolvedValue({ success: true });
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={null}
-        namespace="test.feature"
-      />,
-    );
-
-    // Switch to branch mode
-    fireEvent.click(screen.getByText('Branch Namespace'));
-
-    // Fill in branch name
-    fireEvent.change(screen.getByLabelText(/Branch/), {
-      target: { value: 'feature-x' },
-    });
-
-    fireEvent.click(screen.getByText('Save Settings'));
-
-    await waitFor(() => {
-      expect(mockOnSave).toHaveBeenCalledWith({
-        git_branch: 'feature-x',
-        parent_namespace: 'test',
-        git_only: true, // Default for branch mode
-      });
-    });
-  });
-
-  it('should show error when branch name is empty in branch mode', async () => {
-    const { container } = render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={null}
-        namespace="test.feature"
-      />,
-    );
-
-    // Switch to branch mode
-    fireEvent.click(screen.getByText('Branch Namespace'));
-
-    // Try to save without entering a branch name. The Save Settings button
-    // is type="submit" inside a <form>; React 18 batches the click→submit
-    // synthetic events differently, so submit the form directly.
-    fireEvent.submit(container.querySelector('form'));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Git branch is required for branch mode'),
-      ).toBeInTheDocument();
-    });
-
-    expect(mockOnSave).not.toHaveBeenCalled();
-  });
-
-  it('should show error when namespace has no parent in branch mode', async () => {
-    const { container } = render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={null}
-        namespace="toplevel"
-      />,
-    );
-
-    // Switch to branch mode (should fail because namespace has no parent)
-    fireEvent.click(screen.getByText('Branch Namespace'));
-
-    fireEvent.submit(container.querySelector('form'));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /Cannot configure as branch namespace: namespace has no parent/,
-        ),
-      ).toBeInTheDocument();
-    });
-
-    expect(mockOnSave).not.toHaveBeenCalled();
-  });
-
-  it('should show error when repository is empty in git root mode', async () => {
-    const { container } = render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={null}
-        namespace="test.namespace"
-      />,
-    );
-
-    // Default is git root mode
-    // Clear the repository field if it has any default value
-    const repoInput = screen.getByLabelText(/Repository/);
-    fireEvent.change(repoInput, { target: { value: '' } });
-
-    fireEvent.submit(container.querySelector('form'));
-
-    await waitFor(() => {
-      expect(screen.getByText('Repository is required')).toBeInTheDocument();
-    });
-
-    expect(mockOnSave).not.toHaveBeenCalled();
-  });
-
-  it('should handle parent config fetch failure gracefully', async () => {
-    // Mock fetch to fail
-    global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
-
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={{
-          parent_namespace: 'test',
-          git_branch: 'main',
-        }}
-        namespace="test.feature"
-      />,
-    );
-
-    // Wait for the component to attempt fetching parent config
-    await waitFor(() => {
-      // Should still render even if parent config fetch fails
-      expect(screen.getByDisplayValue('main')).toBeInTheDocument();
-    });
-
-    // Parent config should not be shown (fetch failed)
-    expect(screen.queryByText('test/repo')).not.toBeInTheDocument();
-  });
-
-  it('should allow switching from branch mode to root mode', async () => {
-    render(
-      <GitSettingsModal
-        isOpen={true}
-        onClose={mockOnClose}
-        onSave={mockOnSave}
-        onRemove={mockOnRemove}
-        currentConfig={null}
-        namespace="test.feature"
-      />,
-    );
-
-    // Start in branch mode
-    fireEvent.click(screen.getByText('Branch Namespace'));
-    expect(screen.getByLabelText('Branch *')).toBeInTheDocument();
-
-    // Switch to root mode
-    fireEvent.click(screen.getByText('Git Root'));
-
-    // Should show repository and default branch fields instead of branch field
-    expect(screen.getByLabelText(/Repository/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Default Branch/)).toBeInTheDocument();
-    expect(screen.queryByLabelText('Branch *')).not.toBeInTheDocument();
-  });
+  fireEvent.click(screen.getByText(/edited in datajunction/i));
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  await screen.findByText(/success|saved/i).catch(() => {});
+  expect(onRemove).toHaveBeenCalled();
+  expect(onSave).not.toHaveBeenCalled();
 });

--- a/datajunction-ui/src/app/components/git/__tests__/GitSettingsModal.test.jsx
+++ b/datajunction-ui/src/app/components/git/__tests__/GitSettingsModal.test.jsx
@@ -52,12 +52,20 @@ it('preselects flat mode from an existing flat config', () => {
 
 it('warns before connecting a namespace that already has nodes', () => {
   render(
-    <GitSettingsModal isOpen namespace="some.sandbox" nodeCount={4}
-      onClose={vi.fn()} onSave={vi.fn().mockResolvedValue({})}
-      onRemove={vi.fn()} currentConfig={null} />,
+    <GitSettingsModal
+      isOpen
+      namespace="some.sandbox"
+      nodeCount={4}
+      onClose={vi.fn()}
+      onSave={vi.fn().mockResolvedValue({})}
+      onRemove={vi.fn()}
+      currentConfig={null}
+    />,
   );
   fireEvent.click(screen.getByText(/git repo/i));
-  expect(screen.getByText(/4 nodes here aren't in the repo/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(/4 nodes here aren't in the repo/i),
+  ).toBeInTheDocument();
   expect(screen.getByText(/replaced by the repo/i)).toBeInTheDocument();
 });
 

--- a/datajunction-ui/src/app/components/git/__tests__/gitShape.test.js
+++ b/datajunction-ui/src/app/components/git/__tests__/gitShape.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { detectShape, buildGitConfigPayload } from '../gitShape';
+
+describe('detectShape', () => {
+  it('returns not-git when nothing is set', () => {
+    expect(detectShape({})).toBe('not-git');
+    expect(detectShape({ github_repo_path: null, git_branch: null })).toBe(
+      'not-git',
+    );
+  });
+  it('returns branch when parent_namespace is set', () => {
+    expect(
+      detectShape({
+        parent_namespace: 'growth.metrics',
+        git_branch: 'feature-x',
+      }),
+    ).toBe('branch');
+  });
+  it('returns flat when repo + git_branch, no parent', () => {
+    expect(
+      detectShape({ github_repo_path: 'corp/repo', git_branch: 'main' }),
+    ).toBe('flat');
+  });
+  it('returns root when repo but no git_branch, no parent', () => {
+    expect(
+      detectShape({
+        github_repo_path: 'corp/repo',
+        git_branch: null,
+        default_branch: 'main',
+      }),
+    ).toBe('root');
+  });
+});
+
+describe('buildGitConfigPayload', () => {
+  it('flat sends repo + git_branch only', () => {
+    expect(
+      buildGitConfigPayload({
+        source: 'git',
+        model: 'flat',
+        repository: 'corp/repo',
+        branch: 'main',
+      }),
+    ).toEqual({ github_repo_path: 'corp/repo', git_branch: 'main' });
+  });
+  it('root sends repo + default_branch only', () => {
+    expect(
+      buildGitConfigPayload({
+        source: 'git',
+        model: 'root',
+        repository: 'corp/repo',
+        defaultBranch: 'main',
+      }),
+    ).toEqual({ github_repo_path: 'corp/repo', default_branch: 'main' });
+  });
+  it('dj source clears git config', () => {
+    expect(buildGitConfigPayload({ source: 'dj' })).toBeNull();
+  });
+});

--- a/datajunction-ui/src/app/components/git/gitShape.js
+++ b/datajunction-ui/src/app/components/git/gitShape.js
@@ -1,0 +1,32 @@
+// Classify a namespace's git config (from GET /namespaces/{ns}/git) into one of
+// four shapes. Order matters: a branch (has a parent) is checked before repo
+// ownership, since a branch inherits repo fields.
+export function detectShape(config = {}) {
+  if (config.parent_namespace) return 'branch';
+  if (config.github_repo_path) {
+    return config.git_branch ? 'flat' : 'root';
+  }
+  return 'not-git';
+}
+
+// Build the PATCH /namespaces/{ns}/git body from the modal form. Returns null
+// to signal "clear git config" (the caller issues DELETE instead of PATCH).
+export function buildGitConfigPayload({
+  source,
+  model,
+  repository,
+  branch,
+  defaultBranch,
+}) {
+  if (source !== 'git') return null;
+  if (model === 'flat') {
+    return {
+      github_repo_path: repository?.trim() || null,
+      git_branch: branch?.trim() || null,
+    };
+  }
+  return {
+    github_repo_path: repository?.trim() || null,
+    default_branch: defaultBranch?.trim() || null,
+  };
+}

--- a/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/__tests__/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { screen, waitFor } from '@testing-library/react';
 import { render } from '../../../../setupTests';
 import fetchMock from 'mocks/fetchMock';
@@ -207,6 +207,48 @@ describe('AddEditNodePage', () => {
       expect(screen.getByText('(repair_order_id)')).toBeInTheDocument();
     });
   });
+
+  it('redirects the edit route to the node view for a read-only (git-backed) node', async () => {
+    const mockDjClient = initializeMockDJClient();
+    mockDjClient.DataJunctionAPI.namespaceSources = vi
+      .fn()
+      .mockResolvedValue(null);
+    mockDjClient.DataJunctionAPI.listDeployments = vi
+      .fn()
+      .mockResolvedValue([]);
+    // magnesium.tech is a flat git-backed namespace → read-only via shape.
+    mockDjClient.DataJunctionAPI.getNamespaceGitConfig = vi
+      .fn()
+      .mockResolvedValue({
+        github_repo_path: 'corp/tech-realtime-guardrails',
+        git_branch: 'main',
+        git_root_namespace: 'magnesium.tech',
+      });
+
+    const LocationDisplay = () => (
+      <div data-testid="loc">{useLocation().pathname}</div>
+    );
+    render(
+      <MemoryRouter
+        initialEntries={['/nodes/magnesium.tech.withinapp_ttr_log/edit']}
+      >
+        <LocationDisplay />
+        <Routes>
+          <Route path="nodes/:name/edit" element={testElement(mockDjClient)} />
+          <Route path="nodes/:name" element={<div>node view</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Redirected away from the edit route to the node view...
+    await waitFor(() =>
+      expect(screen.getByTestId('loc').textContent).toBe(
+        '/nodes/magnesium.tech.withinapp_ttr_log',
+      ),
+    );
+    // ...and the editor form ("Edit" heading) never rendered.
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+  }, 60000);
 
   it('Verify edit page node not found', async () => {
     const mockDjClient = initializeMockDJClient();

--- a/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/index.jsx
@@ -44,6 +44,22 @@ export function AddEditNodePage({ extensions = {} }) {
   let { nodeType, initialNamespace, name } = useParams();
   const action = name !== undefined ? Action.Edit : Action.Add;
 
+  // A read-only (git-managed) node can't be edited in the UI. If someone hits
+  // the edit route directly, send them back to the node view once the
+  // namespace's read-only verdict (from NamespaceHeader) is known.
+  const [isReadOnly, setIsReadOnly] = useState(undefined);
+  useEffect(() => {
+    if (action === Action.Edit && isReadOnly === true) {
+      navigate(`/nodes/${name}`, { replace: true });
+    }
+  }, [action, isReadOnly, name, navigate]);
+
+  const headerNamespace = initialNamespace
+    ? initialNamespace
+    : name
+    ? name.substring(0, name.lastIndexOf('.'))
+    : '';
+
   const initialValues = {
     name: action === Action.Edit ? name : '',
     namespace: action === Action.Add ? initialNamespace : '',
@@ -414,16 +430,26 @@ export function AddEditNodePage({ extensions = {} }) {
     }
   };
 
+  // Editing a node we can't yet confirm is editable (verdict still loading) or
+  // one that is read-only: render just the header (which resolves the verdict
+  // and triggers the redirect above) — never the editor form. Avoids flashing
+  // the editor before redirecting a read-only node.
+  if (action === Action.Edit && isReadOnly !== false) {
+    return (
+      <div className="mid">
+        <NamespaceHeader
+          namespace={headerNamespace}
+          onReadOnlyChange={setIsReadOnly}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="mid">
       <NamespaceHeader
-        namespace={
-          initialNamespace
-            ? initialNamespace
-            : name
-            ? name.substring(0, name.lastIndexOf('.'))
-            : ''
-        }
+        namespace={headerNamespace}
+        onReadOnlyChange={setIsReadOnly}
       />
       <div className="node-builder">
         <div className="node-builder-main">

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
@@ -545,7 +545,7 @@ describe('NamespacePage', () => {
   describe('Git-root namespace (branch landing page)', () => {
     const gitRootConfig = {
       github_repo_path: 'org/repo',
-      git_branch: 'main',
+      git_branch: null,
       default_branch: 'main',
       parent_namespace: null,
       git_only: false,
@@ -636,8 +636,8 @@ describe('NamespacePage', () => {
         },
         { timeout: 3000 },
       );
-      // ...where the branch-creation entry point is still present.
-      expect(await screen.findByText('New Branch')).toBeInTheDocument();
+      // ...where the branch-creation entry point is still present (inside the Git menu).
+      expect(await screen.findByText('+ New Branch')).toBeInTheDocument();
     });
   });
 
@@ -773,5 +773,137 @@ describe('NamespacePage', () => {
       },
       { timeout: 1000 },
     );
+  });
+
+  describe('Read-only git states', () => {
+    it('shows the node table but no add/edit controls for a flat (read-only) namespace', async () => {
+      // A flat namespace: has a repo path AND its own git_branch, no parent_namespace.
+      // detectShape returns 'flat' → read-only; edit controls must be hidden.
+      const flatConfig = {
+        github_repo_path: 'corp/repo',
+        git_branch: 'main',
+        default_branch: null,
+        parent_namespace: null,
+        git_only: false,
+        git_root_namespace: 'magnesium.tech',
+      };
+      mockDjClient.getNamespaceGitConfig.mockResolvedValue(flatConfig);
+      mockDjClient.listNamespacesWithGit.mockResolvedValue([
+        { namespace: 'magnesium.tech', numNodes: 1, git: null },
+      ]);
+      mockDjClient.listNodesForLanding.mockResolvedValue({
+        data: {
+          findNodesPaginated: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
+              hasPrevPage: false,
+              startCursor: null,
+            },
+            edges: [
+              {
+                node: {
+                  name: 'magnesium.tech.some_metric',
+                  type: 'METRIC',
+                  currentVersion: 'v1.0',
+                  tags: [],
+                  editedBy: [],
+                  current: {
+                    displayName: 'Some Metric',
+                    status: 'VALID',
+                    mode: 'PUBLISHED',
+                    updatedAt: '2024-10-18T15:15:33.532949+00:00',
+                  },
+                  createdBy: { username: 'dj' },
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      renderWithProviders(<NamespacePage />, {
+        route: '/namespaces/magnesium.tech',
+      });
+
+      // The node name should appear in the table.
+      expect(await screen.findByText('some_metric')).toBeInTheDocument();
+
+      // No add/edit controls for a read-only (flat) namespace.
+      expect(screen.queryByText(/\+ Add Node/i)).not.toBeInTheDocument();
+    });
+
+    it('never shows Add Node on a git-deployed branch namespace (no flash)', async () => {
+      // Regression guard: a branch namespace (gitShape === 'branch') that is
+      // git-deployed is read-only. NamespaceHeader fires onReadOnlyChange(true)
+      // via a useEffect — one render after showEditControls first becomes true.
+      // The guard must be `headerReadOnly === false` (not `!headerReadOnly`) so
+      // Add Node stays hidden during the intermediate render where headerReadOnly
+      // is still `undefined`.
+      const branchConfig = {
+        github_repo_path: 'org/repo',
+        git_branch: 'main',
+        git_path: 'nodes/',
+        git_only: false,
+        parent_namespace: 'ads',
+        branch_namespace: 'ads.main',
+        git_root_namespace: 'ads',
+      };
+      mockDjClient.getNamespaceGitConfig.mockResolvedValue(branchConfig);
+      mockDjClient.namespaceSources.mockResolvedValue({
+        total_deployments: 1,
+        primary_source: { type: 'git', repository: 'org/repo', branch: 'main' },
+      });
+      mockDjClient.listNamespacesWithGit.mockResolvedValue([
+        { namespace: 'ads', numNodes: 0, git: null },
+        { namespace: 'ads.main', numNodes: 3, git: null },
+      ]);
+      mockDjClient.listNodesForLanding.mockResolvedValue({
+        data: {
+          findNodesPaginated: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
+              hasPrevPage: false,
+              startCursor: null,
+            },
+            edges: [
+              {
+                node: {
+                  name: 'ads.main.revenue',
+                  type: 'METRIC',
+                  currentVersion: 'v1.0',
+                  tags: [],
+                  editedBy: [],
+                  current: {
+                    displayName: 'Revenue',
+                    status: 'VALID',
+                    mode: 'PUBLISHED',
+                    updatedAt: '2024-10-18T15:15:33.532949+00:00',
+                  },
+                  createdBy: { username: 'dj' },
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      renderWithProviders(<NamespacePage />, {
+        route: '/namespaces/ads.main',
+      });
+
+      // Wait for the node table to settle (proves the component rendered fully,
+      // including all effects — onReadOnlyChange has fired by this point).
+      expect(await screen.findByText('revenue')).toBeInTheDocument();
+
+      // Add Node must never appear at any point. Because headerReadOnly starts
+      // as `undefined` (fixed) vs `false` (buggy), the old guard `!headerReadOnly`
+      // would render Add Node on the first pass when gitConfig resolves but before
+      // the namespaceSources effect fires onReadOnlyChange. The new guard
+      // `headerReadOnly === false` keeps it hidden until explicitly known editable.
+      // After all effects settle, Add Node must still be absent (git-deployed = read-only).
+      expect(screen.queryByText('+ Add Node')).not.toBeInTheDocument();
+    });
   });
 });

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -12,6 +12,7 @@ import { useCurrentUser } from '../../providers/UserProvider';
 import AddNodeDropdown from '../../components/AddNodeDropdown';
 import NodeListActions from '../../components/NodeListActions';
 import NamespaceHeader from '../../components/NamespaceHeader';
+import SplitFilter from '../../components/SplitFilter';
 import Tooltip from '../../components/Tooltip';
 import {
   secondaryButtonStyle,
@@ -24,6 +25,7 @@ import NamespaceNav from './NamespaceNav';
 import { isHiddenNamespace } from './namespaceOptions';
 import { NODE_TYPE_ORDER, NODE_TYPE_COLORS } from './nodeTypes';
 import { getDJUrl } from '../../services/DJService';
+import { detectShape } from '../../components/git/gitShape';
 
 import 'styles/node-list.css';
 import 'styles/sorted-table.css';
@@ -144,68 +146,6 @@ function relativeDate(value) {
     }
   }
   return 'just now';
-}
-
-function SplitFilter({ label, options, value, onChange }) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '2px',
-        flex: '0 0 auto',
-      }}
-    >
-      <label
-        style={{
-          fontSize: '10px',
-          fontWeight: '600',
-          color: '#666',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-        }}
-      >
-        {label}
-      </label>
-      <div
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          height: '32px',
-          border: '1px solid #cbd5e1',
-          borderRadius: '999px',
-          backgroundColor: '#ffffff',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {options.map((option, index) => {
-          const active = value === option.value;
-          return (
-            <button
-              key={option.value}
-              type="button"
-              onClick={() => onChange(active ? '' : option.value)}
-              style={{
-                height: '30px',
-                padding: '0 13px',
-                border: 'none',
-                borderLeft: index === 0 ? 'none' : '1px solid #e2e8f0',
-                backgroundColor: active ? '#e3f2fd' : 'transparent',
-                color: active ? '#1976d2' : '#475569',
-                fontSize: '12px',
-                fontWeight: active ? '600' : '500',
-                cursor: 'pointer',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {option.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
 }
 
 export function NamespacePage() {
@@ -432,6 +372,8 @@ export function NamespacePage() {
   }, [debouncedSearch]);
 
   const [typeCounts, setTypeCounts] = useState(null);
+  // undefined until NamespaceHeader reports the read-only verdict, so Add Node stays hidden until known
+  const [headerReadOnly, setHeaderReadOnly] = useState(undefined);
 
   // Only show edit/add controls once git config has loaded and namespace is not git-only
   const gitConfigLoaded = gitConfig !== undefined;
@@ -441,8 +383,12 @@ export function NamespacePage() {
     gitConfigLoaded &&
     !!gitConfig?.github_repo_path &&
     gitConfig?.git_root_namespace === namespace;
+  // Edit controls are only shown for editable shapes: plain (not-git) namespaces
+  // and branch namespaces. Flat and root git-backed namespaces are read-only in
+  // the UI — their nodes are managed via git.
+  const gitShape = gitConfigLoaded ? detectShape(gitConfig || {}) : null;
   const showEditControls =
-    gitConfigLoaded && !gitConfig?.git_only && !isGitRoot;
+    gitConfigLoaded && (gitShape === 'not-git' || gitShape === 'branch');
   // Sub-namespaces can be created from the rail only for plain (non-git-backed)
   // namespaces; git-backed ones are managed via git, not the UI. The git config
   // endpoint returns an object with null fields (not null) for non-git
@@ -465,24 +411,32 @@ export function NamespacePage() {
       message: response.json?.message || 'Failed to create namespace',
     };
   };
-  // A git root has no nodes of its own — they live on its default branch. The node
-  // table (and its filters/keyword search) therefore browse `<root>.<default_branch>`,
-  // so a git root shows the same browsable table as any other namespace.
+  // Distinguish a *child-spawning* git root (owns the repo, has no branch of its
+  // own — its nodes live on `<root>.<default_branch>`) from a *flat* git-backed
+  // namespace (has its own `git_branch`, e.g. tracks `main` directly, with no
+  // `<ns>.<branch>` children). Only the former is browsed via / redirected to its
+  // default branch; a flat namespace is its own branch and must stay put.
+  const isChildSpawningRoot = isGitRoot && !gitConfig?.git_branch;
+
+  // A child-spawning root has no nodes of its own — they live on its default
+  // branch — so the node table browses `<root>.<default_branch>`. A flat
+  // namespace browses itself.
   const tableNamespace =
-    isGitRoot && gitConfig?.default_branch
+    isChildSpawningRoot && gitConfig?.default_branch
       ? `${namespace}.${gitConfig.default_branch}`
       : namespace;
 
-  // A git root has no nodes of its own and isn't a browsable branch — redirect to
-  // its default branch so the URL is the branch (giving the breadcrumb its branch
-  // switcher) and everything is scoped consistently.
+  // A child-spawning root isn't a browsable branch — redirect to its default
+  // branch so the URL is the branch (giving the breadcrumb its branch switcher)
+  // and everything is scoped consistently. A flat git-backed namespace is NOT
+  // redirected: it *is* the branch, and `<ns>.<default_branch>` doesn't exist.
   useEffect(() => {
-    if (isGitRoot && gitConfig?.default_branch) {
+    if (isChildSpawningRoot && gitConfig?.default_branch) {
       navigate(`/namespaces/${namespace}.${gitConfig.default_branch}`, {
         replace: true,
       });
     }
-  }, [isGitRoot, gitConfig, namespace, navigate]);
+  }, [isChildSpawningRoot, gitConfig, namespace, navigate]);
 
   // Per-type node counts (recursive) for the current namespace, shown inline in
   // the TYPE filter options (e.g. "Metric (342)").
@@ -1302,6 +1256,7 @@ export function NamespacePage() {
           <NamespaceHeader
             namespace={namespace}
             onGitConfigLoaded={setGitConfig}
+            onReadOnlyChange={setHeaderReadOnly}
             namespaceOptions={rawNamespaces}
             currentNamespace={namespace}
           >
@@ -1353,7 +1308,9 @@ export function NamespacePage() {
                 </button>
               </Tooltip>
             )}
-            {showEditControls && <AddNodeDropdown namespace={namespace} />}
+            {showEditControls && headerReadOnly === false && (
+              <AddNodeDropdown namespace={namespace} />
+            )}
           </NamespaceHeader>
 
           <div className="table-responsive">

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
@@ -409,6 +409,44 @@ describe('<NodePage />', () => {
     expect(container.getElementsByClassName('language-sql')).toMatchSnapshot();
   }, 60000);
 
+  it('hides Edit and shows the read-only badge for a node in a read-only (flat git) namespace', async () => {
+    const djClient = mockDJClient();
+    djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    djClient.DataJunctionAPI.getMetric.mockResolvedValue(
+      mocks.mockMetricNodeJson,
+    );
+    // magnesium.tech is a flat git-backed namespace (github_repo_path +
+    // git_branch, no parent) → read-only via shape, even though git_only is
+    // not set. Regression guard: node pages must honor shape-based read-only,
+    // not just the git_only flag.
+    djClient.DataJunctionAPI.getNamespaceGitConfig.mockResolvedValue({
+      github_repo_path: 'corp/tech-realtime-guardrails',
+      git_branch: 'main',
+      git_root_namespace: 'magnesium.tech',
+    });
+    const element = (
+      <DJClientContext.Provider value={djClient}>
+        <NodePage {...defaultProps} />
+      </DJClientContext.Provider>
+    );
+    render(
+      <MemoryRouter
+        initialEntries={['/nodes/magnesium.tech.withinapp_ttr_log/info']}
+      >
+        <Routes>
+          <Route path="nodes/:name/:tab" element={element} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // The read-only badge appears once the namespace git config resolves...
+    expect(await screen.findByLabelText('ReadOnly')).toBeInTheDocument();
+    // ...and the Edit button is not offered.
+    expect(
+      screen.queryByRole('button', { name: 'Edit' }),
+    ).not.toBeInTheDocument();
+  }, 60000);
+
   it('renders the NodeInfo tab correctly for cube nodes', async () => {
     const djClient = mockDJClient();
     djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockCubeNode);

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -34,8 +34,9 @@ export function NodePage() {
   });
 
   const [node, setNode] = useState(null);
-  // Use undefined to indicate "not yet loaded", null means "loaded but no config"
-  const [gitConfig, setGitConfig] = useState(undefined);
+  // undefined = not yet known; NamespaceHeader reports the read-only verdict
+  // (git_only, flat/root shape, or git-deployed) once its config + sources load.
+  const [isReadOnly, setIsReadOnly] = useState(undefined);
 
   const onClickTab = id => () => {
     // Preview tab redirects to Query Planner instead of showing content
@@ -140,7 +141,7 @@ export function NodePage() {
         <NodeColumnTab
           node={node}
           djClient={djClient}
-          readOnly={!!gitConfig?.git_only}
+          readOnly={!!isReadOnly}
         />
       );
       break;
@@ -177,8 +178,6 @@ export function NodePage() {
       tabToDisplay = <NodeInfoTab node={node} />;
   }
 
-  const isGitOnly = gitConfig?.git_only;
-
   const buttonStyle = {
     height: '28px',
     padding: '0 10px',
@@ -194,13 +193,10 @@ export function NodePage() {
     whiteSpace: 'nowrap',
   };
 
-  // Don't show buttons until git config has loaded (undefined = not loaded yet)
-  const gitConfigLoaded = gitConfig !== undefined;
-
   const NodeButtons = () => {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-        {gitConfigLoaded && !isGitOnly && (
+        {isReadOnly === false && (
           <button
             style={buttonStyle}
             onClick={() => navigate(`/nodes/${node?.name}/edit`)}
@@ -224,7 +220,7 @@ export function NodePage() {
     <div className="node__header">
       <NamespaceHeader
         namespace={name.split('.').slice(0, -1).join('.')}
-        onGitConfigLoaded={setGitConfig}
+        onReadOnlyChange={setIsReadOnly}
       />
       <div className="card">
         {node === undefined ? (
@@ -259,7 +255,7 @@ export function NodePage() {
                   >
                     {node?.type}
                   </span>
-                  {gitConfigLoaded && isGitOnly && (
+                  {isReadOnly === true && (
                     <span
                       style={{
                         display: 'inline-flex',


### PR DESCRIPTION
### Summary

Makes git-backed DJ namespaces coherent to manage in the UI, and generalizes the backend that gates them. A namespace can be one of the following:
- a git root (owns a repo, spawns branches)
- a flat git namespace (tracks a branch directly)
- an editable working branch
- or a plain DJ namespace.

Each now presents a clean, single-line toolbar with one obvious way to view/manage/edit, along with consistent read-only enforcement across the namespace page, node pages, and the edit route.

#### Backend

- Generalize the git-managed/read-only signal from `is_git_root` to `is_repo_owner` (`github_repo_path` set and no `parent_namespace`), which covers both git roots and flat namespaces.
- `git_only` is now valid on any namespace (not just branches); enforcement (check_namespace_not_git_only) honors it uniformly.
- On first git deploy, a namespace that tracks a repo is auto-locked as a repo owner (UI read-only) without a `git_only` write, so unlinking is just a config change.
- Persist/normalize `github_repo_path` on deploy.

#### UI

- One Git ▾ dropdown for low-frequency git actions that renders only the items valid for the current state.
- `NamespaceHeader` is rewritten to a state-driven, single-line toolbar.
- `GitSettingsModal` rewritten from a git-only checkbox / path form into an intent-based form:
<img width="470" height="605" alt="Screenshot 2026-07-12 at 9 05 36 AM" src="https://github.com/user-attachments/assets/7ea8f1c8-4223-4ac7-af6b-a7d6792afd6d" />

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
