### PR TITLE
Make deploy-time cube dimension validation role-aware

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
+++ b/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
@@ -17,24 +17,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.build_v3.loaders import find_join_paths_batch
 
-# Sentinel for the `role` argument meaning "any role" (node-level check,
-# role-agnostic). Distinct from `None`, which means a *bare* (role-less)
-# reference that must match only a role-less join path.
-_ANY_ROLE = object()
-
 
 class DimensionReachability:
     """Batched dimension reachability — one BFS query, in-memory lookups.
 
-    Reachability is tracked at two granularities:
-
-    - Node-level (role-agnostic): "is dimension node X reachable at all?"
-      Used by impact propagation.
-    - Role-aware: "is dimension node X reachable under role R (or bare)?"
-      Used by cube deploy-time validation, which must match the role-aware
-      availability check that revalidation performs — a *bare* dimension
-      reference must only be considered reachable when a *role-less* join path
-      exists, not when the sole path carries a role.
+    Tracks reachability node-level (role-agnostic, for impact propagation) and
+    role-aware (for cube deploy validation). See `is_reachable_under_role` for
+    the bare-vs-role matching rule.
     """
 
     def __init__(
@@ -43,27 +32,22 @@ class DimensionReachability:
         local_names: dict[int, str] | None = None,
     ):
         self._paths = paths
-        # Fast lookup: source_rev_id → set of reachable dimension node names
-        self._reachable: dict[int, set[str]] = {}
-        # Role-aware lookup: source_rev_id → set of (dim_node_name, role_path).
-        # role_path is the "->" joined chain of link roles ("" for a role-less
-        # path), exactly as produced by find_join_paths_batch and as suffixed
-        # onto dimension attribute names by get_dimensions.
+        # Reachable (dimension, role) pairs for each source node; role is "" for
+        # a role-less path. Keying on role — not just the dimension — is what
+        # rejects a bare reference that's only reachable under a role.
         self._reachable_roles: dict[int, set[tuple[str, str]]] = {}
         for (src_id, dim_name, role_path), _links in paths.items():
-            self._reachable.setdefault(src_id, set()).add(dim_name)
             self._reachable_roles.setdefault(src_id, set()).add(
                 (dim_name, role_path),
             )
-        # Local dimensions: a node can always reach itself (its own columns
-        # are "local dimensions" that don't need a join path). Local dimensions
-        # carry no role (role-less).
-        if local_names:
-            for rev_id, node_name in local_names.items():
-                self._reachable.setdefault(rev_id, set()).add(node_name)
-                self._reachable_roles.setdefault(rev_id, set()).add(
-                    (node_name, ""),
-                )
+        # A node always reaches its own columns ("local dimensions"), role-less.
+        for rev_id, node_name in (local_names or {}).items():
+            self._reachable_roles.setdefault(rev_id, set()).add((node_name, ""))
+        # Node-level (role-agnostic) view, derived once for O(1) lookups.
+        self._reachable: dict[int, set[str]] = {
+            sid: {name for name, _role in roles}
+            for sid, roles in self._reachable_roles.items()
+        }
 
     @classmethod
     async def build(
@@ -90,27 +74,21 @@ class DimensionReachability:
         )
         return cls(paths, local_names)
 
-    def is_reachable(
+    def is_reachable(self, source_rev_id: int, dim_name: str) -> bool:
+        """Node-level (role-agnostic) check: is the dimension reachable at all?"""
+        return dim_name in self._reachable.get(source_rev_id, set())
+
+    def is_reachable_under_role(
         self,
         source_rev_id: int,
         dim_name: str,
-        role: object = _ANY_ROLE,
+        role: str | None,
     ) -> bool:
-        """Check if a dimension is reachable from a source node.
-
-        Args:
-            source_rev_id: Revision ID of the source node.
-            dim_name: Dimension node name.
-            role: If left as the default (`_ANY_ROLE`), performs a role-agnostic
-                node-level check. Pass `None` for a *bare* reference (matches
-                only a role-less join path) or a role string (e.g.
-                ``"order_date"`` / ``"a->b"`` for multi-hop) to match only that
-                exact role path.
+        """Role-aware check. A bare reference (role=None) matches only a
+        role-less join path; a role string matches only that exact role path
+        (e.g. "order_date", or "a->b" for multi-hop).
         """
-        if role is _ANY_ROLE:
-            return dim_name in self._reachable.get(source_rev_id, set())
-        role_path = role or ""
-        return (dim_name, role_path) in self._reachable_roles.get(
+        return (dim_name, role or "") in self._reachable_roles.get(
             source_rev_id,
             set(),
         )
@@ -151,25 +129,17 @@ class DimensionReachability:
         source_rev_ids: set[int],
         requested: set[tuple[str, str | None]],
     ) -> dict[tuple[str, str | None], set[int]]:
-        """Role-aware variant of :meth:`unreachable_dimensions`.
-
-        Args:
-            source_rev_ids: Source node revision IDs.
-            requested: Set of ``(dim_node_name, role)`` pairs, where ``role`` is
-                ``None`` for a bare reference or a role string. A bare reference
-                is unreachable unless a role-less join path exists; a role-played
-                reference is unreachable unless a path with that exact role
-                exists.
-
-        Returns a dict mapping ``(dim_node_name, role)`` → set of source_rev_ids
-        that lack a matching path. Empty dict means all are reachable.
+        """Role-aware variant of unreachable_dimensions. `requested` is a set of
+        (dim_node_name, role) pairs (role=None for bare); see
+        is_reachable_under_role for matching. Returns {(dim, role): set of source
+        rev ids that lack a path}.
         """
         missing: dict[tuple[str, str | None], set[int]] = {}
         for dim_name, role in requested:
             unreachable_from = {
                 sid
                 for sid in source_rev_ids
-                if not self.is_reachable(sid, dim_name, role)
+                if not self.is_reachable_under_role(sid, dim_name, role)
             }
             if unreachable_from:
                 missing[(dim_name, role)] = unreachable_from

--- a/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
+++ b/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
@@ -17,9 +17,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.build_v3.loaders import find_join_paths_batch
 
+# Sentinel for the `role` argument meaning "any role" (node-level check,
+# role-agnostic). Distinct from `None`, which means a *bare* (role-less)
+# reference that must match only a role-less join path.
+_ANY_ROLE = object()
+
 
 class DimensionReachability:
-    """Batched dimension reachability — one BFS query, in-memory lookups."""
+    """Batched dimension reachability — one BFS query, in-memory lookups.
+
+    Reachability is tracked at two granularities:
+
+    - Node-level (role-agnostic): "is dimension node X reachable at all?"
+      Used by impact propagation.
+    - Role-aware: "is dimension node X reachable under role R (or bare)?"
+      Used by cube deploy-time validation, which must match the role-aware
+      availability check that revalidation performs — a *bare* dimension
+      reference must only be considered reachable when a *role-less* join path
+      exists, not when the sole path carries a role.
+    """
 
     def __init__(
         self,
@@ -29,13 +45,25 @@ class DimensionReachability:
         self._paths = paths
         # Fast lookup: source_rev_id → set of reachable dimension node names
         self._reachable: dict[int, set[str]] = {}
-        for (src_id, dim_name, _role), _links in paths.items():
+        # Role-aware lookup: source_rev_id → set of (dim_node_name, role_path).
+        # role_path is the "->" joined chain of link roles ("" for a role-less
+        # path), exactly as produced by find_join_paths_batch and as suffixed
+        # onto dimension attribute names by get_dimensions.
+        self._reachable_roles: dict[int, set[tuple[str, str]]] = {}
+        for (src_id, dim_name, role_path), _links in paths.items():
             self._reachable.setdefault(src_id, set()).add(dim_name)
+            self._reachable_roles.setdefault(src_id, set()).add(
+                (dim_name, role_path),
+            )
         # Local dimensions: a node can always reach itself (its own columns
-        # are "local dimensions" that don't need a join path).
+        # are "local dimensions" that don't need a join path). Local dimensions
+        # carry no role (role-less).
         if local_names:
             for rev_id, node_name in local_names.items():
                 self._reachable.setdefault(rev_id, set()).add(node_name)
+                self._reachable_roles.setdefault(rev_id, set()).add(
+                    (node_name, ""),
+                )
 
     @classmethod
     async def build(
@@ -62,9 +90,30 @@ class DimensionReachability:
         )
         return cls(paths, local_names)
 
-    def is_reachable(self, source_rev_id: int, dim_name: str) -> bool:
-        """Check if a dimension is reachable from a source node."""
-        return dim_name in self._reachable.get(source_rev_id, set())
+    def is_reachable(
+        self,
+        source_rev_id: int,
+        dim_name: str,
+        role: object = _ANY_ROLE,
+    ) -> bool:
+        """Check if a dimension is reachable from a source node.
+
+        Args:
+            source_rev_id: Revision ID of the source node.
+            dim_name: Dimension node name.
+            role: If left as the default (`_ANY_ROLE`), performs a role-agnostic
+                node-level check. Pass `None` for a *bare* reference (matches
+                only a role-less join path) or a role string (e.g.
+                ``"order_date"`` / ``"a->b"`` for multi-hop) to match only that
+                exact role path.
+        """
+        if role is _ANY_ROLE:
+            return dim_name in self._reachable.get(source_rev_id, set())
+        role_path = role or ""
+        return (dim_name, role_path) in self._reachable_roles.get(
+            source_rev_id,
+            set(),
+        )
 
     def reachable_from(self, source_rev_id: int) -> set[str]:
         """All dimension names reachable from a source node."""
@@ -95,4 +144,33 @@ class DimensionReachability:
             }
             if unreachable_from:
                 missing[dim] = unreachable_from
+        return missing
+
+    def unreachable_dimension_roles(
+        self,
+        source_rev_ids: set[int],
+        requested: set[tuple[str, str | None]],
+    ) -> dict[tuple[str, str | None], set[int]]:
+        """Role-aware variant of :meth:`unreachable_dimensions`.
+
+        Args:
+            source_rev_ids: Source node revision IDs.
+            requested: Set of ``(dim_node_name, role)`` pairs, where ``role`` is
+                ``None`` for a bare reference or a role string. A bare reference
+                is unreachable unless a role-less join path exists; a role-played
+                reference is unreachable unless a path with that exact role
+                exists.
+
+        Returns a dict mapping ``(dim_node_name, role)`` → set of source_rev_ids
+        that lack a matching path. Empty dict means all are reachable.
+        """
+        missing: dict[tuple[str, str | None], set[int]] = {}
+        for dim_name, role in requested:
+            unreachable_from = {
+                sid
+                for sid in source_rev_ids
+                if not self.is_reachable(sid, dim_name, role)
+            }
+            if unreachable_from:
+                missing[(dim_name, role)] = unreachable_from
         return missing

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2296,25 +2296,35 @@ class DeploymentOrchestrator:
             if p.current
         }
 
-        # Check dimension reachability using the pre-computed batched BFS
+        # Check dimension reachability using the pre-computed batched BFS.
+        # This is role-aware: a bare reference (no `[role]` suffix) is only
+        # reachable under a role-less join path, while a role-played reference
+        # must match a path carrying that exact role. This mirrors the
+        # role-aware availability check performed on revalidation, so a cube
+        # that would compute INVALID on revalidation is rejected here at deploy.
         dim_compat_errors: list[DJError] = []
         if cube_spec.rendered_dimensions:  # pragma: no branch
-            requested_dim_nodes = {
-                dim.rsplit(SEPARATOR, 1)[0] for dim in cube_spec.rendered_dimensions
+            requested_dim_roles = {
+                (
+                    FullColumnName(dim).node_name,
+                    FullColumnName(dim).role,
+                )
+                for dim in cube_spec.rendered_dimensions
             }
-            unreachable = reachability.unreachable_dimensions(
+            unreachable = reachability.unreachable_dimension_roles(
                 cube_parent_rev_ids,
-                requested_dim_nodes,
+                requested_dim_roles,
             )
-            for dim_name, missing_from_ids in unreachable.items():
+            for (dim_name, role), missing_from_ids in unreachable.items():
                 parent_names = sorted(
                     rev_id_to_parent.get(rid, str(rid)) for rid in missing_from_ids
                 )
+                dim_label = dim_name + (f"[{role}]" if role else "")
                 dim_compat_errors.append(
                     DJError(
                         code=ErrorCode.INVALID_DIMENSION,
                         message=(
-                            f"The dimension attribute `{dim_name}` is not "
+                            f"The dimension attribute `{dim_label}` is not "
                             f"reachable from parent node(s): {', '.join(parent_names)}. "
                             f"Add a dimension link to make it available."
                         ),

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2296,20 +2296,15 @@ class DeploymentOrchestrator:
             if p.current
         }
 
-        # Check dimension reachability using the pre-computed batched BFS.
-        # This is role-aware: a bare reference (no `[role]` suffix) is only
-        # reachable under a role-less join path, while a role-played reference
-        # must match a path carrying that exact role. This mirrors the
-        # role-aware availability check performed on revalidation, so a cube
-        # that would compute INVALID on revalidation is rejected here at deploy.
+        # Role-aware reachability (see DimensionReachability): mirrors the
+        # revalidation availability check so a cube that would revalidate
+        # INVALID is rejected here at deploy.
         dim_compat_errors: list[DJError] = []
         if cube_spec.rendered_dimensions:  # pragma: no branch
             requested_dim_roles = {
-                (
-                    FullColumnName(dim).node_name,
-                    FullColumnName(dim).role,
-                )
+                (fcn.node_name, fcn.role)
                 for dim in cube_spec.rendered_dimensions
+                for fcn in (FullColumnName(dim),)
             }
             unreachable = reachability.unreachable_dimension_roles(
                 cube_parent_rev_ids,
@@ -2333,6 +2328,9 @@ class DeploymentOrchestrator:
 
         # Validate that dimensions referenced in filters are reachable
         # and that the specific columns exist on those dimension nodes.
+        # TODO: filter reachability is still role-agnostic; a bare filter dim
+        # reachable only under a role can deploy green and flip on revalidation,
+        # the same gap just closed above for cube dimensions.
         if cube_spec.rendered_filters and cube_parent_rev_ids:
             filter_refs = _extract_dimension_refs_from_filters(
                 cube_spec.rendered_filters,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5061,3 +5061,136 @@ class TestCubeRoleCollisionDeployment:
             (f"{namespace}.dates_d", "monthint", "order_date"),
             (f"{namespace}.dates_d", "monthint", "ship_date"),
         ]
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestCubeBareDimRoleAwareDeployment:
+    """Deploy-time cube validation must be role-aware.
+
+    A cube that references a dimension attribute BARE (no role) while the
+    parent's ONLY link to that dimension is role-played must be rejected at
+    deploy time (the bare attribute is not available on every metric), matching
+    what a subsequent revalidation would compute. Previously the deploy path
+    used a role-agnostic reachability check and accepted the bare reference,
+    deploying green and then flipping to INVALID on revalidation.
+    """
+
+    def _nodes(self, bare: bool):
+        """Fact links dates_d ONLY under role `order_date`; cube references
+        dates_d.monthint bare (bare=True) or role-qualified (bare=False)."""
+        dim_ref = (
+            "${prefix}dates_d.monthint"
+            if bare
+            else "${prefix}dates_d.monthint[order_date]"
+        )
+        return [
+            SourceSpec(
+                name="orders_raw",
+                description="Raw orders",
+                catalog="default",
+                schema="roads",
+                table="orders_raw",
+                columns=[
+                    ColumnSpec(name="order_dateint", type="int"),
+                ],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            SourceSpec(
+                name="dates_raw",
+                description="Raw dates",
+                catalog="default",
+                schema="roads",
+                table="dates_raw",
+                columns=[
+                    ColumnSpec(name="dateint", type="int"),
+                    ColumnSpec(name="monthint", type="int"),
+                ],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            DimensionSpec(
+                name="dates_d",
+                description="Date dimension",
+                query="SELECT dateint, monthint FROM ${prefix}dates_raw",
+                primary_key=["dateint"],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            TransformSpec(
+                name="orders_f",
+                description="Orders fact linked to dates ONLY under role order_date",
+                query="SELECT order_dateint FROM ${prefix}orders_raw",
+                dimension_links=[
+                    DimensionJoinLinkSpec(
+                        dimension_node="${prefix}dates_d",
+                        join_type="left",
+                        join_on=(
+                            "${prefix}orders_f.order_dateint = ${prefix}dates_d.dateint"
+                        ),
+                        role="order_date",
+                    ),
+                ],
+                owners=["dj"],
+            ),
+            MetricSpec(
+                name="order_count",
+                description="Order count",
+                query="SELECT COUNT(*) FROM ${prefix}orders_f",
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            CubeSpec(
+                name="orders_cube",
+                display_name="Orders Cube",
+                description="Cube referencing dates_d.monthint",
+                metrics=["${prefix}order_count"],
+                dimensions=[dim_ref],
+                owners=["dj"],
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_deploy_bare_dim_only_reachable_under_role_is_rejected(
+        self,
+        client,
+    ):
+        """Repro: bare `dates_d.monthint` where the only link carries a role
+        must be rejected at deploy time (INVALID_DIMENSION)."""
+        namespace = "cube_bare_role_reject"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=self._nodes(bare=True)),
+        )
+        cube_result = next(
+            r for r in data["results"] if r["name"] == f"{namespace}.orders_cube"
+        )
+        assert cube_result["status"] in ("invalid", "failed"), cube_result
+        assert f"{namespace}.dates_d" in cube_result["message"], cube_result
+        assert (
+            "not reachable" in cube_result["message"]
+            or "not available on every metric" in cube_result["message"]
+        ), cube_result
+
+        # The deploy-time status must match what revalidation would compute.
+        response = await client.get(f"/nodes/{namespace}.orders_cube/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["status"] == "invalid"
+
+    @pytest.mark.asyncio
+    async def test_deploy_role_qualified_dim_passes(self, client):
+        """The role-qualified version passes push and revalidates valid."""
+        namespace = "cube_role_qualified_ok"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=self._nodes(bare=False)),
+        )
+        assert data["status"] == DeploymentStatus.SUCCESS.value, data
+        cube_result = next(
+            r for r in data["results"] if r["name"] == f"{namespace}.orders_cube"
+        )
+        assert cube_result["status"] not in ("invalid", "failed"), cube_result
+
+        response = await client.get(f"/nodes/{namespace}.orders_cube/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["status"] == "valid"

--- a/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
+++ b/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
@@ -88,14 +88,14 @@ class TestDimensionReachabilityInMemory:
         }
         r = DimensionReachability(paths)
         # Bare request: matches only the role-less path.
-        assert r.is_reachable(10, "dim.date", role=None)
+        assert r.is_reachable_under_role(10, "dim.date", None)
         # Role request: matches only that exact role.
-        assert r.is_reachable(10, "dim.date", role="order")
-        assert not r.is_reachable(10, "dim.date", role="ship")
+        assert r.is_reachable_under_role(10, "dim.date", "order")
+        assert not r.is_reachable_under_role(10, "dim.date", "ship")
         # dim.geo is only reachable under the `signup` role, not bare.
-        assert not r.is_reachable(10, "dim.geo", role=None)
-        assert r.is_reachable(10, "dim.geo", role="signup")
-        # Default (no role arg) stays role-agnostic / node-level.
+        assert not r.is_reachable_under_role(10, "dim.geo", None)
+        assert r.is_reachable_under_role(10, "dim.geo", "signup")
+        # The node-level check stays role-agnostic.
         assert r.is_reachable(10, "dim.geo")
 
     def test_unreachable_dimension_roles(self):
@@ -117,8 +117,8 @@ class TestDimensionReachabilityInMemory:
     def test_local_names_are_role_less(self):
         """Local dimensions are role-less (bare) reachable."""
         r = DimensionReachability({}, local_names={10: "node.fact"})
-        assert r.is_reachable(10, "node.fact", role=None)
-        assert not r.is_reachable(10, "node.fact", role="x")
+        assert r.is_reachable_under_role(10, "node.fact", None)
+        assert not r.is_reachable_under_role(10, "node.fact", "x")
 
     def test_local_names(self):
         """Local names make each source reachable from itself."""

--- a/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
+++ b/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
@@ -78,6 +78,48 @@ class TestDimensionReachabilityInMemory:
         # dim.date is reachable (role doesn't affect node-level reachability)
         assert r.is_reachable(10, "dim.date")
 
+    def test_role_aware_reachability(self):
+        """Role-aware check: bare matches only role-less paths; a role matches
+        only that exact role path."""
+        paths = {
+            (10, "dim.date", ""): [100],
+            (10, "dim.date", "order"): [101],
+            (10, "dim.geo", "signup"): [102],
+        }
+        r = DimensionReachability(paths)
+        # Bare request: matches only the role-less path.
+        assert r.is_reachable(10, "dim.date", role=None)
+        # Role request: matches only that exact role.
+        assert r.is_reachable(10, "dim.date", role="order")
+        assert not r.is_reachable(10, "dim.date", role="ship")
+        # dim.geo is only reachable under the `signup` role, not bare.
+        assert not r.is_reachable(10, "dim.geo", role=None)
+        assert r.is_reachable(10, "dim.geo", role="signup")
+        # Default (no role arg) stays role-agnostic / node-level.
+        assert r.is_reachable(10, "dim.geo")
+
+    def test_unreachable_dimension_roles(self):
+        """Bare reference to a role-only-linked dim is reported unreachable,
+        while the role-qualified reference is reachable."""
+        paths = {
+            (10, "dim.geo", "signup"): [100],
+            (20, "dim.geo", "signup"): [200],
+        }
+        r = DimensionReachability(paths)
+        # Bare request is unreachable from both sources.
+        assert r.unreachable_dimension_roles(
+            {10, 20},
+            {("dim.geo", None)},
+        ) == {("dim.geo", None): {10, 20}}
+        # Role-qualified request is reachable from both.
+        assert r.unreachable_dimension_roles({10, 20}, {("dim.geo", "signup")}) == {}
+
+    def test_local_names_are_role_less(self):
+        """Local dimensions are role-less (bare) reachable."""
+        r = DimensionReachability({}, local_names={10: "node.fact"})
+        assert r.is_reachable(10, "node.fact", role=None)
+        assert not r.is_reachable(10, "node.fact", role="x")
+
     def test_local_names(self):
         """Local names make each source reachable from itself."""
         paths = {(10, "dim.country", ""): [100]}


### PR DESCRIPTION
### Summary

Deploy-time validation doesn't account for a dimension's role in cubes. It accepts a bare dimension reference even when that dimension is only reachable under a role, whereas revalidation (role-aware) then rejects it, leading to inconsistency between deploy-time validation and later validation.

This wasn't always a gap, as deploy validation originally reused the same role-aware `validate_shared_dimensions` that revalidation uses, but that per-cube call was slow (many redundant `get_dimensions` DB calls). #2000 replaced it with a batched BFS (DimensionReachability) for speed, and that BFS keyed reachability on the dimension node name only, dropping the role. Furthermore, cube dimensions role-awareness was only recently added in #2320. The role-blindness coupled with role-awareness in the recent PRs introduced the divergence.

The fix is to make the fast batched BFS role-complete, keeping the #2000 perf win.

**Follow-ups (not in this PR)**

- Unify both deploy-time and revalidation onto the BFS. In order to do this, we need to extend it to validate attribute-level availability + per-metric "shared" semantics, prove parity, then switch `validate_shared_dimensions` (and the query-build path) to consume it.
- Cube filter reachability is still role-agnostic, so the same bug class survives for filters.

### Test Plan

Added a repro test in `TestCubeBareDimRoleAwareDeployment`, where a dim reachable only under a role is rejected at deploy if it doesn't have one specified; the role-qualified version passes and revalidates valid.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
