### PR TITLE
Add lifecycle node field

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0000-b3c4d5e6f7a8_add_lifecycle_to_noderevision.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0000-b3c4d5e6f7a8_add_lifecycle_to_noderevision.py
@@ -1,0 +1,47 @@
+"""
+Add lifecycle column to noderevision
+
+Revision ID: b3c4d5e6f7a8
+Revises: 3c7a9f1b2e4d
+Create Date: 2026-07-12 00:00:00.000000+00:00
+
+Adds `lifecycle` (dev/experimental/stable/deprecated/retired) and backfills it
+from the existing `mode`: draft -> dev, published -> stable. `mode` is retained
+and derived from `lifecycle` on write.
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b3c4d5e6f7a8"
+down_revision = "3c7a9f1b2e4d"
+branch_labels = None
+depends_on = None
+
+lifecycle_enum = sa.Enum(
+    "DEV",
+    "EXPERIMENTAL",
+    "STABLE",
+    "DEPRECATED",
+    "RETIRED",
+    name="lifecyclestate",
+)
+
+
+def upgrade():
+    lifecycle_enum.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "noderevision",
+        sa.Column("lifecycle", lifecycle_enum, nullable=True),
+    )
+    op.execute(
+        "UPDATE noderevision SET lifecycle = "
+        "(CASE mode WHEN 'DRAFT' THEN 'DEV' ELSE 'STABLE' END)::lifecyclestate",
+    )
+    op.alter_column("noderevision", "lifecycle", nullable=False)
+
+
+def downgrade():
+    op.drop_column("noderevision", "lifecycle")
+    lifecycle_enum.drop(op.get_bind(), checkfirst=True)

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -68,6 +68,7 @@ from datajunction_server.models.deployment import (
 from datajunction_server.models.node import (
     DEFAULT_DRAFT_VERSION,
     BuildCriteria,
+    LifecycleState,
     MetricUnit,
     NodeCursor,
     NodeMode,
@@ -1490,6 +1491,12 @@ class NodeRevision(
     mode: Mapped[NodeMode] = mapped_column(
         Enum(NodeMode),
         default=NodeMode.PUBLISHED,
+    )
+    lifecycle: Mapped[LifecycleState] = mapped_column(
+        Enum(LifecycleState),
+        default=LifecycleState.STABLE,
+        server_default=LifecycleState.STABLE.name,
+        nullable=False,
     )
 
     version: Mapped[Optional[str]] = mapped_column(

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -88,6 +88,7 @@ from datajunction_server.models.node import (
     NodeMode,
     NodeStatus,
     NodeType,
+    resolve_lifecycle,
 )
 from datajunction_server.models.unit import (
     AtomicUnit,
@@ -2555,6 +2556,10 @@ class DeploymentOrchestrator:
                         namespace=namespace,
                     )
 
+                    _, cube_mode = resolve_lifecycle(
+                        cube_spec.mode,
+                        cube_spec.lifecycle,
+                    )
                     new_node = Node(
                         name=cube_spec.rendered_name,
                         namespace=namespace,
@@ -2562,7 +2567,7 @@ class DeploymentOrchestrator:
                         display_name=cube_spec.display_name,
                         current_version=(
                             str(DEFAULT_DRAFT_VERSION)
-                            if cube_spec.mode == NodeMode.DRAFT
+                            if cube_mode == NodeMode.DRAFT
                             else str(DEFAULT_PUBLISHED_VERSION)
                         ),
                         tags=[
@@ -2696,6 +2701,10 @@ class DeploymentOrchestrator:
 
             node_columns.append(node_column)
 
+        cube_lifecycle, cube_mode = resolve_lifecycle(
+            cube_spec.mode,
+            cube_spec.lifecycle,
+        )
         node_revision = NodeRevision(
             name=cube_spec.rendered_name,
             display_name=cube_spec.display_name
@@ -2715,7 +2724,8 @@ class DeploymentOrchestrator:
             created_by_id=self.context.current_user.id,
             node=new_node,
             version=new_node.current_version,
-            mode=cube_spec.mode,
+            mode=cube_mode,
+            lifecycle=cube_lifecycle,
             cube_filters=cube_spec.rendered_filters or [],
             custom_metadata=cube_spec.custom_metadata,
             # Initialize to empty so dimension_links can be appended without
@@ -3605,6 +3615,7 @@ class DeploymentOrchestrator:
         existing: Node | None,
     ) -> Node:
         """Create or update a Node object based on the spec and existing node"""
+        _, node_mode = resolve_lifecycle(node_spec.mode, node_spec.lifecycle)
         new_node = (
             Node(
                 name=node_spec.rendered_name,
@@ -3613,7 +3624,7 @@ class DeploymentOrchestrator:
                 namespace=".".join(node_spec.rendered_name.split(".")[:-1]),
                 current_version=(
                     str(DEFAULT_DRAFT_VERSION)
-                    if node_spec.mode == NodeMode.DRAFT
+                    if node_mode == NodeMode.DRAFT
                     else str(DEFAULT_PUBLISHED_VERSION)
                 ),
                 tags=[self.registry.tags[tag_name] for tag_name in node_spec.tags],
@@ -3703,12 +3714,17 @@ class DeploymentOrchestrator:
         else:
             catalog = self.registry.catalogs.get(result.spec.catalog)
 
+        node_lifecycle, node_mode = resolve_lifecycle(
+            result.spec.mode,
+            result.spec.lifecycle,
+        )
         new_revision = NodeRevision(
             name=result.spec.rendered_name,
             display_name=result.spec.display_name,
             type=result.spec.node_type,
             description=result.spec.description,
-            mode=result.spec.mode,
+            mode=node_mode,
+            lifecycle=node_lifecycle,
             version=new_node.current_version,
             node=new_node,
             catalog=catalog,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -92,6 +92,7 @@ from datajunction_server.models.node import (
     CreateCubeNode,
     CreateNode,
     CreateSourceNode,
+    LifecycleState,
     LineageColumn,
     NodeMode,
     NodeOutput,
@@ -189,6 +190,7 @@ async def create_a_source_node(
         )
         for idx, column_data in enumerate(data.columns)
     ]
+    lifecycle, mode = resolve_lifecycle(data.mode, data.lifecycle)
     node_revision = NodeRevision(
         name=data.name,
         display_name=data.display_name or f"{catalog.name}.{data.schema_}.{data.table}",
@@ -202,6 +204,8 @@ async def create_a_source_node(
         parents=[],
         created_by_id=current_user.id,
         query=data.query,
+        mode=mode,
+        lifecycle=lifecycle,
     )
     node.display_name = node_revision.display_name
 
@@ -210,7 +214,7 @@ async def create_a_source_node(
         session,
         node_revision,
         node,
-        data.mode,
+        mode,
         current_user=current_user,
         save_history=save_history,
     )
@@ -497,6 +501,30 @@ async def set_node_column_attributes(
     return [column]
 
 
+def resolve_updated_lifecycle(
+    old_lifecycle: LifecycleState,
+    old_mode: NodeMode,
+    new_mode: NodeMode,
+    lifecycle: Optional[LifecycleState],
+) -> "tuple[LifecycleState, NodeMode]":
+    """Resolve the (lifecycle, mode) pair for a revision derived from a prior
+    one (update/copy-forward paths).
+
+    An explicit ``lifecycle`` always wins (mode is re-derived from it), same
+    as ``resolve_lifecycle``. Absent an explicit lifecycle: if the mode being
+    applied hasn't changed from the prior revision, the prior lifecycle is
+    preserved as-is (so an update that doesn't touch mode/lifecycle can't
+    silently reset e.g. `experimental` back to `dev`); if the mode *has*
+    changed (legacy `mode`-only input), lifecycle is derived fresh from the
+    new mode, matching `resolve_lifecycle`'s back-compat behavior.
+    """
+    if lifecycle is not None:
+        return resolve_lifecycle(new_mode, lifecycle)
+    if new_mode == old_mode:
+        return old_lifecycle, new_mode
+    return resolve_lifecycle(new_mode, None)
+
+
 async def create_node_revision(
     data: CreateNode,
     node_type: NodeType,
@@ -669,6 +697,7 @@ async def create_cube_node_revision(
 
         node_columns.append(node_column)
 
+    cube_lifecycle, cube_mode = resolve_lifecycle(data.mode, data.lifecycle)
     node_revision = NodeRevision(
         name=data.name,
         display_name=data.display_name or labelize(data.name.split(SEPARATOR)[-1]),
@@ -681,7 +710,8 @@ async def create_cube_node_revision(
         status=status,
         catalog=catalog,
         created_by_id=current_user.id,
-        mode=data.mode,
+        mode=cube_mode,
+        lifecycle=cube_lifecycle,
         cube_filters=data.filters or None,
         custom_metadata=data.custom_metadata,
     )
@@ -987,6 +1017,7 @@ async def copy_to_new_node(
         description=old_revision.description,
         query=old_revision.query,
         mode=old_revision.mode,
+        lifecycle=old_revision.lifecycle,
         version=old_revision.version,
         node=new_node,
         catalog=old_revision.catalog,
@@ -1441,6 +1472,11 @@ def has_minor_changes(
         or (data and data.mode and old_revision.mode != data.mode)
         or (
             data
+            and data.lifecycle is not None
+            and old_revision.lifecycle != data.lifecycle
+        )
+        or (
+            data
             and data.display_name
             and old_revision.display_name != data.display_name
         )
@@ -1497,13 +1533,21 @@ async def update_cube_node(
     major_changes = (data.metrics and data.metrics != old_metrics) or (
         data.dimensions and data.dimensions != old_dimensions
     )
+    cube_new_mode = data.mode or node_revision.mode
+    cube_lifecycle, cube_mode = resolve_updated_lifecycle(
+        node_revision.lifecycle,
+        node_revision.mode,
+        cube_new_mode,
+        data.lifecycle,
+    )
     create_cube = CreateCubeNode(
         name=node_revision.name,
         display_name=data.display_name or node_revision.display_name,
         description=data.description or node_revision.description,
         metrics=data.metrics or old_metrics,
         dimensions=data.dimensions or old_dimensions,
-        mode=data.mode or node_revision.mode,
+        mode=cube_mode,
+        lifecycle=cube_lifecycle,
         filters=data.filters
         if data.filters is not None
         else (node_revision.cube_filters or []),
@@ -1807,6 +1851,7 @@ def copy_existing_node_revision(old_revision: NodeRevision, current_user: User):
         table=old_revision.table,
         parents=old_revision.parents,
         mode=old_revision.mode,
+        lifecycle=old_revision.lifecycle,
         materializations=old_revision.materializations,
         status=old_revision.status,
         required_dimensions=list(old_revision.required_dimensions),
@@ -1870,6 +1915,7 @@ async def create_node_from_inactive(
                 display_name=data.display_name,
                 description=data.description,
                 mode=data.mode,
+                lifecycle=data.lifecycle,
             )
             if isinstance(data, CreateSourceNode):
                 update_node.catalog = data.catalog
@@ -1987,6 +2033,11 @@ async def create_new_revision_from_existing(
         or (data and data.mode and old_revision.mode != data.mode)
         or (
             data
+            and data.lifecycle is not None
+            and old_revision.lifecycle != data.lifecycle
+        )
+        or (
+            data
             and data.display_name
             and old_revision.display_name != data.display_name
         )
@@ -2037,6 +2088,12 @@ async def create_new_revision_from_existing(
 
     old_version = Version.parse(node.current_version)
     new_mode = data.mode if data and data.mode else old_revision.mode
+    new_lifecycle, new_mode = resolve_updated_lifecycle(
+        old_revision.lifecycle,
+        old_revision.mode,
+        new_mode,
+        data.lifecycle if data else None,
+    )
     new_revision = NodeRevision(
         name=old_revision.name,
         node_id=node.id,
@@ -2071,6 +2128,7 @@ async def create_new_revision_from_existing(
         table=old_revision.table,
         parents=[],
         mode=new_mode,
+        lifecycle=new_lifecycle,
         materializations=[],
         status=old_revision.status,
         metric_metadata=(
@@ -3855,6 +3913,7 @@ async def refresh_source(
         display_name=current_revision.display_name,
         description=current_revision.description,
         mode=current_revision.mode,
+        lifecycle=current_revision.lifecycle,
         catalog_id=current_revision.catalog_id,
         schema_=current_revision.schema_,
         table=current_revision.table,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -97,6 +97,7 @@ from datajunction_server.models.node import (
     NodeOutput,
     NodeStatus,
     UpdateNode,
+    resolve_lifecycle,
 )
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate
@@ -505,6 +506,7 @@ async def create_node_revision(
     """
     Create a non-source node revision.
     """
+    lifecycle, mode = resolve_lifecycle(data.mode, data.lifecycle)
     node_revision = NodeRevision(
         name=data.name,
         display_name=(
@@ -516,7 +518,8 @@ async def create_node_revision(
         type=node_type,
         status=NodeStatus.VALID,
         query=data.query,
-        mode=data.mode,
+        mode=mode,
+        lifecycle=lifecycle,
         required_dimensions=data.required_dimensions or [],
         created_by_id=current_user.id,
         custom_metadata=data.custom_metadata,

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -22,6 +22,7 @@ from datajunction_server.models.dimensionlink import (
 )
 from datajunction_server.models.impact import DownstreamImpact
 from datajunction_server.models.node import (
+    LifecycleState,
     MetricDirection,
     MetricUnit,
     NodeMode,
@@ -302,6 +303,7 @@ class NodeSpec(NamespacedSpec):
     description: str | None = None
     tags: list[str] = Field(default_factory=list)
     mode: NodeMode = NodeMode.PUBLISHED
+    lifecycle: LifecycleState | None = None
     custom_metadata: dict | None = None
 
     _query_ast: Any | None = PrivateAttr(default=None)

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -100,7 +100,7 @@ class LifecycleState(StrEnum):
 
 
 # States that permit saving an invalid node (mode=draft equivalent).
-_LENIENT_LIFECYCLES = {LifecycleState.DEV, LifecycleState.EXPERIMENTAL}
+_LENIENT_LIFECYCLES = frozenset({LifecycleState.DEV, LifecycleState.EXPERIMENTAL})
 
 
 def resolve_lifecycle(

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -734,6 +734,7 @@ class MutableNodeFields(BaseModel):
     display_name: str | None = None
     description: str | None = None
     mode: NodeMode = NodeMode.PUBLISHED
+    lifecycle: LifecycleState | None = None
     primary_key: list[str] | None = None
     custom_metadata: dict | None = None
     owners: list[str] | None = None
@@ -1085,6 +1086,7 @@ class NodeOutput(GenericNodeOutputModel):
     version: str
     status: NodeStatus
     mode: NodeMode
+    lifecycle: LifecycleState
     catalog: CatalogInfo | None = None
     schema_: str | None = None
     table: str | None = None

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -74,6 +74,50 @@ class NodeMode(StrEnum):
     DRAFT = "draft"
 
 
+class LifecycleState(StrEnum):
+    """
+    Node lifecycle state. Ordered least-to-most mature until deprecation:
+    dev -> experimental -> stable -> deprecated -> retired.
+
+    `mode` is derived from this: dev/experimental are lenient (mode=draft,
+    may be saved invalid); stable and beyond are strict (mode=published).
+    """
+
+    DEV = "dev"
+    EXPERIMENTAL = "experimental"
+    STABLE = "stable"
+    DEPRECATED = "deprecated"
+    RETIRED = "retired"
+
+    def to_mode(self) -> "NodeMode":
+        """Derive the legacy `mode` from this lifecycle state."""
+        return NodeMode.DRAFT if self in _LENIENT_LIFECYCLES else NodeMode.PUBLISHED
+
+    @classmethod
+    def from_mode(cls, mode: "NodeMode") -> "LifecycleState":
+        """Derive a lifecycle state from a legacy `mode` (back-compat)."""
+        return cls.DEV if mode == NodeMode.DRAFT else cls.STABLE
+
+
+# States that permit saving an invalid node (mode=draft equivalent).
+_LENIENT_LIFECYCLES = {LifecycleState.DEV, LifecycleState.EXPERIMENTAL}
+
+
+def resolve_lifecycle(
+    mode: "NodeMode",
+    lifecycle: "LifecycleState | None",
+) -> "tuple[LifecycleState, NodeMode]":
+    """Reconcile the two fields into a consistent (lifecycle, mode) pair.
+
+    When `lifecycle` is supplied it wins and `mode` is derived from it. When it
+    is absent (legacy callers), `lifecycle` is derived from `mode` and `mode` is
+    kept as-is.
+    """
+    if lifecycle is not None:
+        return lifecycle, lifecycle.to_mode()
+    return LifecycleState.from_mode(mode), mode
+
+
 class NodeStatus(StrEnum):
     """
     Node status.

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5194,3 +5194,41 @@ class TestCubeBareDimRoleAwareDeployment:
         response = await client.get(f"/nodes/{namespace}.orders_cube/")
         assert response.status_code == 200, response.json()
         assert response.json()["status"] == "valid"
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestDeploymentLifecycle:
+    @pytest.mark.asyncio
+    async def test_deploy_with_lifecycle_derives_mode(self, client):
+        namespace = "lifecycle_deploy"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace=namespace,
+                nodes=[
+                    SourceSpec(
+                        name="src",
+                        description="s",
+                        catalog="default",
+                        schema="roads",
+                        table="src",
+                        columns=[ColumnSpec(name="a", type="int")],
+                        dimension_links=[],
+                        owners=["dj"],
+                    ),
+                    TransformSpec(
+                        name="xf",
+                        description="t",
+                        query="SELECT a FROM ${prefix}src",
+                        dimension_links=[],
+                        owners=["dj"],
+                        lifecycle="experimental",
+                    ),
+                ],
+            ),
+        )
+        assert data["status"] == DeploymentStatus.SUCCESS.value
+        node = await client.get(f"/nodes/{namespace}.xf/")
+        body = node.json()
+        assert body["lifecycle"] == "experimental"
+        assert body["mode"] == "draft"

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -7537,6 +7537,34 @@ class TestNodeLifecycle:
         assert data["mode"] == "draft"
         assert data["lifecycle"] == "dev"
 
+    @pytest.mark.asyncio
+    async def test_patch_conflicting_mode_and_lifecycle_lifecycle_wins(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """PATCHing both `mode` and `lifecycle` at once with a conflicting
+        pair (mode=draft, lifecycle=stable) must resolve in favor of the
+        explicit `lifecycle`, not the explicit `mode`."""
+        create_response = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.lc_patch_conflict",
+                "description": "x",
+                "query": "SELECT 1 AS one",
+                "lifecycle": "experimental",
+            },
+        )
+        assert create_response.status_code == 201
+
+        patch_response = await client.patch(
+            "/nodes/default.lc_patch_conflict/",
+            json={"mode": "draft", "lifecycle": "stable"},
+        )
+        assert patch_response.status_code == 200
+        data = patch_response.json()
+        assert data["lifecycle"] == "stable"
+        assert data["mode"] == "published"
+
 
 class TestCopyNode:
     """Tests for the copy node API endpoint"""

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -7432,6 +7432,30 @@ class TestNodeLifecycle:
         assert data["mode"] == "draft"
 
     @pytest.mark.asyncio
+    async def test_create_source_node_mode_only_backfills_lifecycle(
+        self,
+        client_with_basic: AsyncClient,
+    ) -> None:
+        """A source node created with only mode=draft (no lifecycle)
+        persists mode=draft and derives lifecycle=dev."""
+        response = await client_with_basic.post(
+            "/nodes/source/",
+            json={
+                "name": "basic.source.mode_only_draft",
+                "description": "Mode-only draft source",
+                "columns": [{"name": "id", "type": "int"}],
+                "mode": "draft",
+                "catalog": "public",
+                "schema_": "basic",
+                "table": "mode_only_draft",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert data["mode"] == "draft"
+        assert data["lifecycle"] == "dev"
+
+    @pytest.mark.asyncio
     async def test_patch_node_lifecycle_derives_mode(
         self,
         client: AsyncClient,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -7328,6 +7328,86 @@ ON s.state_region = r.us_region_id""",
     ]
 
 
+class TestNodeLifecycle:
+    """Tests for the `lifecycle` field on node create and its effect on the
+    derived `mode` and the validity-enforcement threshold."""
+
+    @pytest.mark.asyncio
+    async def test_create_node_with_lifecycle_derives_mode(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """lifecycle=experimental persists mode=draft; stable persists published."""
+        for lifecycle, expected_mode in [
+            ("experimental", "draft"),
+            ("stable", "published"),
+        ]:
+            response = await client.post(
+                "/nodes/transform/",
+                json={
+                    "name": f"default.lc_{lifecycle}",
+                    "description": "x",
+                    "query": "SELECT 1 AS one",
+                    "lifecycle": lifecycle,
+                },
+            )
+            data = response.json()
+            assert response.status_code == 201
+            assert data["lifecycle"] == lifecycle
+            assert data["mode"] == expected_mode
+
+    @pytest.mark.asyncio
+    async def test_create_node_mode_only_backfills_lifecycle(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Legacy caller sending only mode gets lifecycle derived (back-compat)."""
+        response = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.lc_mode_only",
+                "description": "x",
+                "query": "SELECT 1 AS one",
+                "mode": "draft",
+            },
+        )
+        data = response.json()
+        assert response.status_code == 201
+        assert data["mode"] == "draft"
+        assert data["lifecycle"] == "dev"
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_gates_validity_enforcement(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """experimental may be saved invalid; stable may not."""
+        bad_query = "SELECT 1 AS one FROM default.does_not_exist"
+
+        ok = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.lc_invalid_ok",
+                "description": "x",
+                "query": bad_query,
+                "lifecycle": "experimental",
+            },
+        )
+        assert ok.status_code == 201
+        assert ok.json()["status"] == "invalid"
+
+        strict = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.lc_invalid_reject",
+                "description": "x",
+                "query": bad_query,
+                "lifecycle": "stable",
+            },
+        )
+        assert strict.status_code == 422
+
+
 class TestCopyNode:
     """Tests for the copy node API endpoint"""
 

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -7407,6 +7407,112 @@ class TestNodeLifecycle:
         )
         assert strict.status_code == 422
 
+    @pytest.mark.asyncio
+    async def test_create_source_node_with_lifecycle_derives_mode(
+        self,
+        client_with_basic: AsyncClient,
+    ) -> None:
+        """A source node created with lifecycle=experimental persists
+        mode=draft, matching the non-source create path."""
+        response = await client_with_basic.post(
+            "/nodes/source/",
+            json={
+                "name": "basic.source.lc_experimental",
+                "description": "Experimental source",
+                "columns": [{"name": "id", "type": "int"}],
+                "lifecycle": "experimental",
+                "catalog": "public",
+                "schema_": "basic",
+                "table": "lc_experimental",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert data["lifecycle"] == "experimental"
+        assert data["mode"] == "draft"
+
+    @pytest.mark.asyncio
+    async def test_patch_node_lifecycle_derives_mode(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """PATCHing lifecycle=deprecated on a node sets mode=published on the
+        new revision, mirroring the create path's lifecycle->mode derivation."""
+        create_response = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.lc_patch_target",
+                "description": "x",
+                "query": "SELECT 1 AS one",
+                "lifecycle": "experimental",
+            },
+        )
+        assert create_response.status_code == 201
+
+        patch_response = await client.patch(
+            "/nodes/default.lc_patch_target/",
+            json={"lifecycle": "deprecated"},
+        )
+        assert patch_response.status_code == 200
+        data = patch_response.json()
+        assert data["lifecycle"] == "deprecated"
+        assert data["mode"] == "published"
+
+    @pytest.mark.asyncio
+    async def test_patch_unrelated_field_preserves_lifecycle(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """PATCHing only `description` on an experimental node must not reset
+        its lifecycle/mode back to the stable/published defaults."""
+        create_response = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.lc_patch_preserve",
+                "description": "x",
+                "query": "SELECT 1 AS one",
+                "lifecycle": "experimental",
+            },
+        )
+        assert create_response.status_code == 201
+
+        patch_response = await client.patch(
+            "/nodes/default.lc_patch_preserve/",
+            json={"description": "new description"},
+        )
+        assert patch_response.status_code == 200
+        data = patch_response.json()
+        assert data["description"] == "new description"
+        assert data["lifecycle"] == "experimental"
+        assert data["mode"] == "draft"
+
+    @pytest.mark.asyncio
+    async def test_patch_mode_only_backfills_lifecycle(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Legacy caller PATCHing only `mode` still gets lifecycle derived
+        from the new mode (back-compat), on a node that starts out stable."""
+        create_response = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": "default.lc_patch_mode_only",
+                "description": "x",
+                "query": "SELECT 1 AS one",
+                "lifecycle": "stable",
+            },
+        )
+        assert create_response.status_code == 201
+
+        patch_response = await client.patch(
+            "/nodes/default.lc_patch_mode_only/",
+            json={"mode": "draft"},
+        )
+        assert patch_response.status_code == 200
+        data = patch_response.json()
+        assert data["mode"] == "draft"
+        assert data["lifecycle"] == "dev"
+
 
 class TestCopyNode:
     """Tests for the copy node API endpoint"""

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -230,6 +230,7 @@ def test_deployment_spec():
                 "description": None,
                 "dimension_links": [],
                 "display_name": None,
+                "lifecycle": None,
                 "mode": NodeMode.PUBLISHED,
                 "name": "test_node",
                 "node_type": NodeType.SOURCE,

--- a/datajunction-server/tests/models/test_lifecycle.py
+++ b/datajunction-server/tests/models/test_lifecycle.py
@@ -1,0 +1,54 @@
+"""Unit tests for LifecycleState and resolve_lifecycle (pure, no DB)."""
+
+import pytest
+
+from datajunction_server.models.node import (
+    LifecycleState,
+    NodeMode,
+    resolve_lifecycle,
+)
+
+
+@pytest.mark.parametrize(
+    "state, expected_mode",
+    [
+        (LifecycleState.DEV, NodeMode.DRAFT),
+        (LifecycleState.EXPERIMENTAL, NodeMode.DRAFT),
+        (LifecycleState.STABLE, NodeMode.PUBLISHED),
+        (LifecycleState.DEPRECATED, NodeMode.PUBLISHED),
+        (LifecycleState.RETIRED, NodeMode.PUBLISHED),
+    ],
+)
+def test_to_mode(state, expected_mode):
+    assert state.to_mode() == expected_mode
+
+
+@pytest.mark.parametrize(
+    "mode, expected_state",
+    [
+        (NodeMode.DRAFT, LifecycleState.DEV),
+        (NodeMode.PUBLISHED, LifecycleState.STABLE),
+    ],
+)
+def test_from_mode(mode, expected_state):
+    assert LifecycleState.from_mode(mode) == expected_state
+
+
+def test_resolve_prefers_explicit_lifecycle():
+    # lifecycle given → it wins and mode is derived from it
+    assert resolve_lifecycle(NodeMode.PUBLISHED, LifecycleState.EXPERIMENTAL) == (
+        LifecycleState.EXPERIMENTAL,
+        NodeMode.DRAFT,
+    )
+
+
+def test_resolve_derives_lifecycle_from_mode_when_absent():
+    # back-compat: only mode given → lifecycle derived, mode unchanged
+    assert resolve_lifecycle(NodeMode.DRAFT, None) == (
+        LifecycleState.DEV,
+        NodeMode.DRAFT,
+    )
+    assert resolve_lifecycle(NodeMode.PUBLISHED, None) == (
+        LifecycleState.STABLE,
+        NodeMode.PUBLISHED,
+    )


### PR DESCRIPTION
### Summary

Adds a first-class lifecycle field (`dev` / `experimental` / `stable` / `deprecated` / `retired`) to nodes and derives the existing mode (`draft`/`published`) from it. We'll keep `mode` as a stored column, but it is now computed from lifecycle on write, so all existing mode behavior and readers keep working. Clients/specs that send only mode are fully backwards-compatible (`lifecycle` is derived from `mode`).

- Added a `LifecycleState` enum + `resolve_lifecycle(mode, lifecycle)` where an explicit `lifecycle` setting wins, but if it's absent, it gets derived from `mode`.
- Added `lifecycle` column on `noderevision` + Alembic migration backfilling from `mode` (`draft` to `dev`, `published` to `stable`).
- `mode` is derived from `lifecycle` on every write path: API create, source-create, update, reactivate, copy-forward, and deployment specs. The validity gate (lenient below stable, strict at/above) reads the derived mode unchanged.

This also  corrects a latent bug where source-create previously ignored input mode and persisted published with a draft version number; it now honors mode/lifecycle like every other path.

#### Deferred (follow-up PRs)

Response warnings, discovery filtering, dependency guards, change events, configurable vocabulary, and migrating readers off `mode`.

### Test Plan

Added new unit + API + deployment tests (lifecycle to mode derivation, mode-only back-compat, validity threshold, conflict resolution, lifecycle preservation across revisions).

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
