### PR TITLE
Fix node column resolution for role playing dimensions

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -372,15 +372,40 @@ async def create_a_cube(
 
 def get_node_column(node: Node, column_name: str) -> Column:
     """
-    Gets the specified column on a node
+    Gets the specified column on a node.
+
+    Resolution order:
+      1. Role-qualified identity: `<name>[<role>]` (i.e. name + dimension_column),
+         so a caller can target a specific role-played dimension column.
+      2. Bare name, when unambiguous (backward compatible).
+      3. Bare name that maps to multiple role-played columns -> raise, listing the
+         role-qualified options, instead of silently binding the last one.
     """
-    column_map = {column.name: column for column in node.current.columns}
-    if column_name not in column_map:
+    columns = node.current.columns
+
+    # 1. exact role-qualified match: name + dimension_column (e.g. "...dateint[epoch_date]")
+    by_role_qualified = {
+        col.name + (col.dimension_column or ""): col for col in columns
+    }
+    if column_name in by_role_qualified:
+        return by_role_qualified[column_name]
+
+    # 2/3. bare-name resolution
+    same_name = [col for col in columns if col.name == column_name]
+    if not same_name:
         raise DJDoesNotExistException(
             message=f"Column `{column_name}` does not exist on node `{node.name}`!",
         )
-    column = column_map[column_name]
-    return column
+    if len(same_name) > 1:
+        options = sorted(col.name + (col.dimension_column or "") for col in same_name)
+        raise DJInvalidInputException(
+            message=(
+                f"Column `{column_name}` on node `{node.name}` is ambiguous across "
+                f"multiple role-played dimensions. Specify the role-qualified column, "
+                f"one of: {options}"
+            ),
+        )
+    return same_name[0]
 
 
 async def validate_and_build_attribute(

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -4049,6 +4049,88 @@ class TestCubeRoleQualifiedDimensions:
         sql_column_names = [col["name"] for col in cube["sql_columns"]]
         assert len(sql_column_names) == len(set(sql_column_names))
 
+    @pytest.mark.asyncio
+    async def test_partition_targets_role_qualified_column(
+        self,
+        module__client_with_build_v3: AsyncClient,
+    ):
+        """
+        The column-scoped partition endpoints resolve a role-qualified column
+        identity, so a partition can be pinned to one role-played dimension
+        without touching the other. A bare (ambiguous) name is rejected rather
+        than silently binding the last-iterated column (Defects A and B).
+        """
+        cube_name = "v3.partition_role_cube"
+        response = await module__client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": cube_name,
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.location.country[from]",
+                    "v3.location.country[to]",
+                    "v3.product.category",
+                ],
+                "mode": "published",
+                "description": "Role-playing country dim for partition targeting",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        async def country_columns_by_role():
+            """Map role suffix -> column dict for the collided `country` columns."""
+            cube = (
+                await module__client_with_build_v3.get(f"/cubes/{cube_name}/")
+            ).json()
+            return {
+                col["dimension_column"]: col
+                for col in cube["columns"]
+                if col["name"] == "v3.location.country"
+            }
+
+        # Role-qualified POST targets exactly the [from] role column.
+        response = await module__client_with_build_v3.post(
+            f"/nodes/{cube_name}/columns/v3.location.country[from]/partition",
+            json={"type_": "categorical"},
+        )
+        assert response.status_code == 201, response.json()
+        body = response.json()
+        assert body["name"] == "v3.location.country"
+        assert body["dimension_column"] == "[from]"
+        assert body["partition"]["type_"] == "categorical"
+
+        # The [to] role column is untouched.
+        country_cols = await country_columns_by_role()
+        assert country_cols["[from]"]["partition"] is not None
+        assert country_cols["[to]"]["partition"] is None
+
+        # Bare (ambiguous) name refuses to silently pick a winner.
+        response = await module__client_with_build_v3.post(
+            f"/nodes/{cube_name}/columns/v3.location.country/partition",
+            json={"type_": "categorical"},
+        )
+        assert response.status_code == 422, response.json()
+        message = response.json()["message"]
+        assert "ambiguous" in message
+        assert "v3.location.country[from]" in message
+        assert "v3.location.country[to]" in message
+
+        # ...and the ambiguous attempt didn't set a partition on either column.
+        country_cols = await country_columns_by_role()
+        assert country_cols["[from]"]["partition"] is not None
+        assert country_cols["[to]"]["partition"] is None
+
+        # Role-qualified DELETE removes the partition from [from] only.
+        response = await module__client_with_build_v3.delete(
+            f"/nodes/{cube_name}/columns/v3.location.country[from]/partition",
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["partition"] is None
+
+        country_cols = await country_columns_by_role()
+        assert country_cols["[from]"]["partition"] is None
+        assert country_cols["[to]"]["partition"] is None
+
 
 class TestCubeDeactivateEndpoint:
     """Tests for DELETE /cubes/{name}/materialize endpoint."""

--- a/datajunction-server/tests/internal/nodes/get_node_column_test.py
+++ b/datajunction-server/tests/internal/nodes/get_node_column_test.py
@@ -1,0 +1,106 @@
+"""
+Tests for ``get_node_column``, in particular its handling of role-playing
+dimension columns that share a bare ``name`` but differ by ``dimension_column``
+(the role suffix).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from datajunction_server.database.column import Column
+from datajunction_server.errors import (
+    DJDoesNotExistException,
+    DJInvalidInputException,
+)
+from datajunction_server.internal.nodes import get_node_column
+
+
+def _make_node(name: str, columns):
+    """Lightweight stand-in exposing the attributes ``get_node_column`` reads."""
+    return SimpleNamespace(name=name, current=SimpleNamespace(columns=columns))
+
+
+def _role_playing_node():
+    """
+    A node with two columns sharing the bare name ``...dateint`` but reached via
+    two different role-played dimensions, plus a plain non-role column.
+    """
+    epoch_date = Column(
+        name="arc.content_migration.dt_date_d.dateint",
+        type="int",
+        dimension_column="[epoch_date]",
+        order=0,
+        attributes=[],
+    )
+    region_date = Column(
+        name="arc.content_migration.dt_date_d.dateint",
+        type="int",
+        dimension_column="[region_date]",
+        order=1,
+        attributes=[],
+    )
+    plain = Column(name="event_id", type="int", order=2, attributes=[])
+    node = _make_node(
+        "arc.content_migration.cade_batch_funnel",
+        [epoch_date, region_date, plain],
+    )
+    return node, epoch_date, region_date, plain
+
+
+def test_get_node_column_role_qualified_resolves_specific_role():
+    """Role-qualified identity targets the exact role-played column."""
+    node, epoch_date, region_date, _ = _role_playing_node()
+
+    assert (
+        get_node_column(
+            node,
+            "arc.content_migration.dt_date_d.dateint[epoch_date]",
+        )
+        is epoch_date
+    )
+    assert (
+        get_node_column(
+            node,
+            "arc.content_migration.dt_date_d.dateint[region_date]",
+        )
+        is region_date
+    )
+
+
+def test_get_node_column_ambiguous_bare_name_raises():
+    """
+    A bare name matching multiple role-played columns must raise (no silent
+    last-wins), listing both role-qualified options.
+    """
+    node, epoch_date, region_date, _ = _role_playing_node()
+
+    with pytest.raises(DJInvalidInputException) as exc_info:
+        result = get_node_column(
+            node,
+            "arc.content_migration.dt_date_d.dateint",
+        )
+        # It must NOT silently pick either column.
+        assert result not in (epoch_date, region_date)
+
+    message = exc_info.value.message
+    assert "ambiguous" in message
+    assert "arc.content_migration.dt_date_d.dateint[epoch_date]" in message
+    assert "arc.content_migration.dt_date_d.dateint[region_date]" in message
+
+
+def test_get_node_column_unique_bare_name_backward_compatible():
+    """A non-colliding bare name still resolves (backward compatible)."""
+    node, _, _, plain = _role_playing_node()
+    assert get_node_column(node, "event_id") is plain
+
+
+def test_get_node_column_unknown_column_raises_not_found():
+    """An unknown column raises the existing not-found exception/message."""
+    node, _, _, _ = _role_playing_node()
+    with pytest.raises(DJDoesNotExistException) as exc_info:
+        get_node_column(node, "does_not_exist")
+    assert exc_info.value.message == (
+        "Column `does_not_exist` does not exist on node "
+        "`arc.content_migration.cade_batch_funnel`!"
+    )


### PR DESCRIPTION
# Fix role-playing dimension column resolution in column-scoped endpoints

## Problem

get_node_column — the shared resolver behind the set-partition, remove-partition, and set-attributes endpoints — resolves columns strictly by bare name, with no awareness of the role suffix (dimension_column). For a node with two columns sharing a bare name but different roles (e.g. a date dim reached via two FKs), this caused two bugs:

- Silent wrong-column: a bare-name request bound the operation to whichever role sorted last in a dict comprehension — no error, silently corrupting materialization config.
- Can't target a role: a role-qualified name (…dateint[epoch_date]) matched nothing → 404, so there was no way to pin the operation to a specific role.

Surfaced on cube arc.content_migration.cade_batch_funnel, where a UI materialize intending [epoch_date] silently landed the partition on [region_date].

## Fix

Resolve by the role-qualified identity (name + dimension_column) first, fall back to bare name only when unambiguous, and raise a 422 listing the role-qualified options when a bare name is ambiguous — instead of silently picking one. Fixing the shared resolver fixes set-partition, remove-partition, and set-attributes at once. No endpoint signature or client changes.

## Tests

- Unit (get_node_column): role-qualified resolves to the right role; ambiguous bare name raises listing both options; unique bare name still works; unknown column still 404s with the original message.
- API: role-qualified POST/DELETE …/partition targets one role without touching the other; bare ambiguous POST returns 422 and sets nothing.
- Existing partition/attributes/materialize tests still pass (backward compat)
