### PR TITLE
Require exact grain match for non-additive pre-agg measures

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -16,7 +16,7 @@ from datajunction_server.database.preaggregation import (
     get_measure_expr_hashes,
     compute_expression_hash,
 )
-from datajunction_server.models.decompose import MetricComponent
+from datajunction_server.models.decompose import Aggregability, MetricComponent
 from datajunction_server.models.preaggregation import TemporalPartitionColumn
 from datajunction_server.naming import SEPARATOR
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
@@ -90,6 +90,16 @@ def find_matching_preagg(
     # Normalize requested grain to a set for comparison
     requested_grain_set = set(requested_grain)
 
+    # Non-additive measures (e.g. COUNT(DISTINCT ...), raw AVG components) cannot
+    # be rolled up to a coarser grain without producing wrong results. When any
+    # required component is not fully additive, a pre-agg can only satisfy the
+    # query if its grain EXACTLY matches the requested grain (no roll-up). Fully
+    # additive measures may still be rolled up via a superset (subset) match.
+    requires_exact_grain = any(
+        component.rule.type != Aggregability.FULL
+        for _, component in grain_group.components
+    )
+
     # Find a matching pre-agg
     best_match: PreAggregation | None = None
     best_grain_size = float("inf")
@@ -97,9 +107,18 @@ def find_matching_preagg(
     for preagg in available:
         preagg_grain_set = set(preagg.grain_columns or [])
 
-        # Check grain compatibility: requested grain must be a subset of pre-agg grain
-        # This means pre-agg is at same or finer grain (can roll up)
-        if not requested_grain_set.issubset(preagg_grain_set):
+        # Check grain compatibility. For additive measures the pre-agg may be at
+        # the same or a finer grain (roll-up allowed → subset match). For
+        # non-additive measures the pre-agg grain must exactly match the request.
+        if requires_exact_grain:
+            if requested_grain_set != preagg_grain_set:
+                logger.debug(
+                    f"[BuildV3] Pre-agg {preagg.id} grain {preagg_grain_set} "
+                    f"must exactly match requested grain {requested_grain_set} "
+                    f"because the grain group has non-additive measures",
+                )
+                continue
+        elif not requested_grain_set.issubset(preagg_grain_set):
             logger.debug(
                 f"[BuildV3] Pre-agg {preagg.id} grain {preagg_grain_set} "
                 f"doesn't cover requested grain {requested_grain_set}",

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -650,7 +650,9 @@ class TestFindMatchingPreagg:
             grain_columns=["dim1", "dim2"],
             measures=[
                 make_preagg_measure(
-                    "num_users", "DISTINCT user_id", aggregation="COUNT"
+                    "num_users",
+                    "DISTINCT user_id",
+                    aggregation="COUNT",
                 ),
             ],
             sql="SELECT ...",
@@ -706,7 +708,9 @@ class TestFindMatchingPreagg:
             grain_columns=["dim1", "dim2"],
             measures=[
                 make_preagg_measure(
-                    "num_users", "DISTINCT user_id", aggregation="COUNT"
+                    "num_users",
+                    "DISTINCT user_id",
+                    aggregation="COUNT",
                 ),
             ],
             sql="SELECT ...",

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -626,6 +626,125 @@ class TestFindMatchingPreagg:
         assert result is not None
         assert result.id == preagg.id
 
+    @pytest.mark.asyncio
+    async def test_non_additive_measure_requires_exact_grain(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+    ):
+        """A non-additive (LIMITED) measure must NOT be rolled up to a coarser
+        grain: a finer-grain pre-agg cannot satisfy a coarser-grain query
+        because re-aggregating a distinct count double-counts."""
+        avail = AvailabilityState(
+            catalog="test",
+            schema_="test",
+            table="preagg",
+            valid_through_ts=9999999999,
+        )
+        session.add(avail)
+        await session.flush()
+
+        preagg = PreAggregation(
+            node_revision_id=parent_node.current.id,
+            grain_columns=["dim1", "dim2"],
+            measures=[
+                make_preagg_measure(
+                    "num_users", "DISTINCT user_id", aggregation="COUNT"
+                ),
+            ],
+            sql="SELECT ...",
+            grain_group_hash="hash_na1",
+            preagg_hash="naex1",
+            availability_id=avail.id,
+        )
+        session.add(preagg)
+        await session.flush()
+
+        ctx = BuildContext(
+            session=session,
+            metrics=["test.metric"],
+            dimensions=["test.dim"],
+            use_materialized=True,
+            available_preaggs={parent_node.current.id: [preagg]},
+        )
+
+        component = MetricComponent(
+            name="num_users",
+            expression="DISTINCT user_id",
+            aggregation="COUNT",
+            merge="SUM",
+            rule=AggregationRule(type=Aggregability.LIMITED, level=["user_id"]),
+        )
+        grain_group = make_grain_group(parent_node, [(metric_node, component)])
+
+        # Requesting a coarser grain than the pre-agg: must NOT match.
+        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_non_additive_measure_matches_exact_grain(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+    ):
+        """A non-additive measure still matches when the pre-agg grain is exactly
+        the requested grain (no roll-up needed, so the value is correct)."""
+        avail = AvailabilityState(
+            catalog="test",
+            schema_="test",
+            table="preagg",
+            valid_through_ts=9999999999,
+        )
+        session.add(avail)
+        await session.flush()
+
+        preagg = PreAggregation(
+            node_revision_id=parent_node.current.id,
+            grain_columns=["dim1", "dim2"],
+            measures=[
+                make_preagg_measure(
+                    "num_users", "DISTINCT user_id", aggregation="COUNT"
+                ),
+            ],
+            sql="SELECT ...",
+            grain_group_hash="hash_na2",
+            preagg_hash="naex2",
+            availability_id=avail.id,
+        )
+        session.add(preagg)
+        await session.flush()
+
+        ctx = BuildContext(
+            session=session,
+            metrics=["test.metric"],
+            dimensions=["test.dim"],
+            use_materialized=True,
+            available_preaggs={parent_node.current.id: [preagg]},
+        )
+
+        component = MetricComponent(
+            name="num_users",
+            expression="DISTINCT user_id",
+            aggregation="COUNT",
+            merge="SUM",
+            rule=AggregationRule(type=Aggregability.LIMITED, level=["user_id"]),
+        )
+        grain_group = make_grain_group(parent_node, [(metric_node, component)])
+
+        # Requesting exactly the pre-agg grain: no roll-up, so this is valid.
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            ["dim1", "dim2"],
+            grain_group,
+        )
+
+        assert result is not None
+        assert result.id == preagg.id
+
 
 class TestGetPreaggMeasureColumn:
     """Tests for get_preagg_measure_column function."""


### PR DESCRIPTION
### Summary

`find_matching_preagg` allowed a finer-grain pre-aggregation to satisfy a coarser-grain query via subset matching, and never inspected component aggregability. Rolling up a non-additive measure (e.g., `COUNT(DISTINCT ...)`) to a coarser grain double-counts and returns wrong results.

When any required component's aggregability is not `FULL`, we should require the pre-agg grain to exactly match the requested grain. Fully additive measures still roll up via subset match.

This is a prerequisite for external pre-aggregation registration (#2118).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
