### PR TITLE
Add computed is_measure flag on metric nodes

### DIFF
--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -550,11 +550,12 @@ def load_node_revision_options(node_revision_fields, is_current: bool = True):
         defer(DBNodeRevision.query_ast),
         defer(DBNodeRevision.lineage),
     ]
-    # query is also used by metric_metadata and extracted_measures resolvers
+    # query is also used by metric_metadata, extracted_measures and is_measure
     needs_query = (
         "query" in node_revision_fields
         or "metric_metadata" in node_revision_fields
         or "extracted_measures" in node_revision_fields
+        or "is_measure" in node_revision_fields
     )
     if not needs_query:
         options.append(defer(DBNodeRevision.query))
@@ -628,8 +629,8 @@ def load_node_revision_options(node_revision_fields, is_current: bool = True):
     else:
         options.append(noload(DBNodeRevision.catalog))
 
-    # Handle parents
-    if "parents" in node_revision_fields:
+    # Handle parents (is_measure inspects parents to exclude derived metrics)
+    if "parents" in node_revision_fields or "is_measure" in node_revision_fields:
         options.append(selectinload(DBNodeRevision.parents))
     else:
         options.append(noload(DBNodeRevision.parents))

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -472,6 +472,18 @@ class NodeRevision:
         return root.is_derived_metric
 
     @strawberry.field
+    def is_measure(self, root: "DBNodeRevision") -> bool:
+        """
+        Returns True if this metric is a "measure": a single top-level aggregation
+        call (e.g. SUM(x), COUNT(x), AVG(x)) with no cross-measure arithmetic that
+        does not reference other metrics. Only measures map 1:1 to a column in an
+        externally-built pre-aggregation table.
+        """
+        if root.type != NodeType_.METRIC:
+            return False
+        return root.is_measure
+
+    @strawberry.field
     async def extracted_measures(
         self,
         root: "DBNodeRevision",

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -382,6 +382,7 @@ type NodeRevision {
   primaryKey: [String!]!
   metricMetadata: MetricMetadata
   isDerivedMetric: Boolean!
+  isMeasure: Boolean!
   extractedMeasures: DecomposedMetric
   cubeMetrics: [NodeRevision!]!
   cubeFilters: [String!]!

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -1811,6 +1811,48 @@ class NodeRevision(
         return any(parent.type == NodeType.METRIC for parent in self.parents)
 
     @property
+    def is_measure(self) -> bool:
+        """
+        Whether this metric is a "measure": its query is a single aggregation
+        that decomposes into exactly one storable, re-aggregatable component
+        (e.g. ``SUM(x)``, ``COUNT(x)``, ``MIN(x)``, ``COUNT(DISTINCT x)``), and
+        it does not reference other metrics.
+
+        Aggregations that decompose into multiple components are NOT measures:
+        ``AVG(x)`` is stored as separate ``SUM`` and ``COUNT`` components (and
+        recombined as ``SUM(sum)/SUM(count)``), so it cannot map to a single
+        column — it must be modelled as a derived metric over its own ``SUM``
+        and ``COUNT`` measures. Cross-measure arithmetic (``SUM(x)/COUNT(y)``,
+        ``1.5 * SUM(x)``) and non-decomposable aggregations (``MAX_BY``) are not
+        measures either.
+
+        Only measures can be mapped 1:1 to a column in an externally-built
+        pre-aggregation table.
+        """
+        if self.type != NodeType.METRIC:
+            return False
+        if self.is_derived_metric:
+            return False
+        from datajunction_server.sql.decompose import get_decomposition
+        from datajunction_server.sql.parsing import ast
+        from datajunction_server.sql.parsing.backends.antlr4 import parse
+
+        projections = parse(self.query).select.projection
+        if len(projections) != 1:
+            return False
+        # Strip a trailing ``AS name`` alias to reach the underlying expression.
+        projection = projections[0]
+        expression = (
+            projection.child if isinstance(projection, ast.Alias) else projection
+        )
+        if not (isinstance(expression, ast.Function) and expression.is_aggregation()):
+            return False
+        # A measure maps 1:1 to a single stored column, so its aggregation must
+        # decompose into exactly one component (SUM/COUNT/MIN/MAX/COUNT DISTINCT).
+        decomposition = get_decomposition(expression.function())
+        return decomposition is not None and len(decomposition.components) == 1
+
+    @property
     def metric_parents(self) -> List["Node"]:
         """
         Get the list of parent nodes that are metrics.

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -50,6 +50,11 @@ class Metric(BaseModel):
     unit: Optional[Dict] = None
     required_dimensions: List[str]
 
+    # Whether the metric is a single aggregation call (a "measure") that can map
+    # 1:1 to a column in an externally-built pre-aggregation table. Derived/ratio
+    # metrics are not measures. Computed on the fly from the metric's expression.
+    is_measure: bool
+
     incompatible_druid_functions: List[str]
 
     measures: List[MetricComponent]
@@ -98,6 +103,7 @@ class Metric(BaseModel):
                 node.current.columns[0].unit if node.current.columns else None,
             ),
             required_dimensions=[dim.name for dim in node.current.required_dimensions],
+            is_measure=node.current.is_measure,
             incompatible_druid_functions=incompatible_druid_functions,
             measures=measures,
             derived_query=str(derived_sql).strip(),

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -2733,6 +2733,48 @@ async def test_is_derived_metric_field(
 
 
 @pytest.mark.asyncio
+async def test_is_measure_field(
+    client_example_loader,
+) -> None:
+    """
+    Test the isMeasure field on NodeRevision.
+    - Non-metric nodes are not measures.
+    - A single-aggregation base metric (SELECT SUM(...)) is a measure.
+    - A derived/ratio metric is not a measure.
+    """
+    client = await client_example_loader(["BUILD_V3"])
+
+    # isMeasure is requested standalone (no parents/query co-selected): the
+    # loader must eager-load the query column and parents on its behalf.
+    query = """
+    {
+        findNodes(names: ["v3.order_details", "v3.total_revenue", "v3.avg_order_value"]) {
+            name
+            type
+            current {
+                isMeasure
+            }
+        }
+    }
+    """
+    response = await client.post("/graphql", json={"query": query})
+    assert response.status_code == 200
+    nodes = {n["name"]: n for n in response.json()["data"]["findNodes"]}
+
+    # Transform node - not a measure
+    assert nodes["v3.order_details"]["type"] == "TRANSFORM"
+    assert nodes["v3.order_details"]["current"]["isMeasure"] is False
+
+    # Base metric "SELECT SUM(line_total) FROM v3.order_details" - a measure
+    assert nodes["v3.total_revenue"]["type"] == "METRIC"
+    assert nodes["v3.total_revenue"]["current"]["isMeasure"] is True
+
+    # Derived ratio metric - not a measure
+    assert nodes["v3.avg_order_value"]["type"] == "METRIC"
+    assert nodes["v3.avg_order_value"]["current"]["isMeasure"] is False
+
+
+@pytest.mark.asyncio
 async def test_find_cubes_scalar_only_with_tag_filter(
     client_with_roads: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -451,11 +451,13 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
     assert data["upstream_node"] == "default.repair_orders_fact"
     assert data["expression"] == "count(repair_order_id)"
     assert data["custom_metadata"] == {"foo": "bar"}
+    assert data["is_measure"] is True  # single COUNT aggregation
 
     response = await module__client_with_roads.get(
         "/metrics/default.discounted_orders_rate",
     )
     data = response.json()
+    assert data["is_measure"] is False  # ratio: sum(...) / count(*)
     assert data["incompatible_druid_functions"] == ["IF"]
     assert data["measures"] == [
         {

--- a/datajunction-server/tests/models/node_test.py
+++ b/datajunction-server/tests/models/node_test.py
@@ -16,6 +16,71 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.typing import UTCDatetime
 
 
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("SELECT SUM(x) FROM a", True),
+        ("SELECT COUNT(x) FROM a", True),
+        ("SELECT COUNT(DISTINCT x) FROM a", True),
+        ("SELECT MAX(x) FROM a", True),
+        ("SELECT SUM(x * price) FROM a", True),
+        ("SELECT SUM(x) AS total FROM a", True),  # aliased projection
+        # AVG decomposes into SUM + COUNT (two components), so it is NOT a
+        # 1:1-mappable measure — model it as a derived metric over its own
+        # SUM and COUNT measures instead.
+        ("SELECT AVG(x) FROM a", False),
+        ("SELECT AVG(x) AS avg_x FROM a", False),  # aliased AVG
+        ("SELECT SUM(x) / COUNT(y) AS ratio FROM a", False),  # aliased ratio
+        ("SELECT SUM(x) / COUNT(y) FROM a", False),
+        ("SELECT 1.5 * SUM(x) FROM a", False),
+        ("SELECT SUM(x) + SUM(y) FROM a", False),
+        ("SELECT SUM(x), COUNT(y) FROM a", False),  # more than one projection
+        ("SELECT MAX_BY(x, y) FROM a", False),  # single agg, but non-decomposable
+    ],
+)
+def test_is_measure(query: str, expected: bool) -> None:
+    """
+    A metric is a measure iff its query is a single top-level aggregation call
+    (no cross-measure arithmetic).
+    """
+    revision = NodeRevision(
+        name="m",
+        type=NodeType.METRIC,
+        version="1",
+        query=query,
+        parents=[],
+    )
+    assert revision.is_measure is expected
+
+
+def test_is_measure_false_for_non_metric() -> None:
+    """Only metric nodes can be measures."""
+    revision = NodeRevision(
+        name="t",
+        type=NodeType.TRANSFORM,
+        version="1",
+        query="SELECT SUM(x) FROM a",
+        parents=[],
+    )
+    assert revision.is_measure is False
+
+
+def test_is_measure_false_for_derived_metric() -> None:
+    """
+    A metric that references another metric is derived, not a measure, even if
+    its top-level expression looks like a single aggregation.
+    """
+    base = Node(name="base", type=NodeType.METRIC, current_version="1")
+    revision = NodeRevision(
+        name="m",
+        type=NodeType.METRIC,
+        version="1",
+        query="SELECT SUM(base) FROM base",
+        parents=[base],
+    )
+    assert revision.is_measure is False
+
+
 def test_node_relationship(session: AsyncSession) -> None:
     """
     Test the n:n self-referential relationships.


### PR DESCRIPTION
### Summary

A metric is a "measure" when its query is a single top-level aggregation call (e.g., `SUM(x)`, `COUNT(x)`) with no cross-measure arithmetic and it does not reference other metrics. Computed on the fly from the metric's expression.

Exposed on the REST metric response (`is_measure`) and the GraphQL NodeRevision type (`isMeasure`). The `findNodes` loader eager-loads the query column and parents when `isMeasure` is requested so the field resolves standalone.

Only measures can map 1:1 to a column in an externally-built pre-aggregation table (prerequisite for #2118).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
