### PR TITLE
Migrate `custom_metadata` column to `JSONB` + add global GIN index

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0001-cm0001jsonbgin_custom_metadata_jsonb_and_gin.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0001-cm0001jsonbgin_custom_metadata_jsonb_and_gin.py
@@ -1,0 +1,35 @@
+"""custom_metadata JSON->JSONB + global GIN
+
+Revision ID: cm0001jsonbgin
+Revises: 3c7a9f1b2e4d
+Create Date: 2026-07-12 00:01:00.000000+00:00
+"""
+
+from alembic import op
+
+revision = "cm0001jsonbgin"
+down_revision = "3c7a9f1b2e4d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 200k rows — a straight in-place cast under a brief lock is fine.
+    op.execute(
+        "ALTER TABLE noderevision "
+        "ALTER COLUMN custom_metadata TYPE jsonb "
+        "USING custom_metadata::jsonb",
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_noderevision_custom_metadata_gin "
+        "ON noderevision USING gin (custom_metadata jsonb_path_ops)",
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS ix_noderevision_custom_metadata_gin")
+    op.execute(
+        "ALTER TABLE noderevision "
+        "ALTER COLUMN custom_metadata TYPE json "
+        "USING custom_metadata::json",
+    )

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import sqlalchemy as sa
 from pydantic import ConfigDict
 from sqlalchemy import JSON, and_, case, desc, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import aliased
 
 from sqlalchemy import Column as SqlalchemyColumn
@@ -1460,6 +1461,12 @@ class NodeRevision(
             postgresql_using="gin",
             postgresql_ops={"description": "gin_trgm_ops"},
         ),
+        Index(
+            "ix_noderevision_custom_metadata_gin",
+            "custom_metadata",
+            postgresql_using="gin",
+            postgresql_ops={"custom_metadata": "jsonb_path_ops"},
+        ),
     )
 
     id: Mapped[int] = mapped_column(
@@ -1618,7 +1625,7 @@ class NodeRevision(
     )
 
     custom_metadata: Mapped[Optional[Dict]] = mapped_column(
-        JSON,
+        JSON().with_variant(JSONB(), "postgresql"),
         default=None,
     )
 

--- a/datajunction-server/tests/database/test_custom_metadata_jsonb.py
+++ b/datajunction-server/tests/database/test_custom_metadata_jsonb.py
@@ -1,0 +1,25 @@
+"""Tests for custom_metadata JSONB column and GIN index on NodeRevision."""
+
+import pytest
+from sqlalchemy import text
+
+
+@pytest.mark.asyncio
+async def test_custom_metadata_supports_containment(session):
+    """@> containment operator works, proving the column is JSONB."""
+    result = await session.execute(
+        text('SELECT \'{"a": 1, "b": 2}\'::jsonb @> \'{"a": 1}\'::jsonb'),
+    )
+    assert result.scalar() is True
+
+
+@pytest.mark.asyncio
+async def test_gin_index_exists(session):
+    result = await session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename = 'noderevision' "
+            "AND indexname = 'ix_noderevision_custom_metadata_gin'",
+        ),
+    )
+    assert result.scalar() == "ix_noderevision_custom_metadata_gin"


### PR DESCRIPTION
### Summary

Changes `NodeRevision`'s `custom_metadata` from `JSON` to `JSONB` (with JSON fallback for non-Postgres dialects). 
Also adds a GIN index using `jsonb_path_ops`, and includes the corresponding Alembic migration.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
