### PR TITLE
Add `POST /preaggs/register` for external tables

### DIFF
--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -39,7 +39,10 @@ from datajunction_server.database.preaggregation import (
     compute_expression_hash,
     compute_preagg_hash,
 )
+from datajunction_server.api.helpers import get_catalog_by_name
+from datajunction_server.sql.decompose import MetricComponentExtractor
 from datajunction_server.errors import (
+    DJConfigurationException,
     DJDoesNotExistException,
     DJInvalidInputException,
     DJQueryServiceClientException,
@@ -61,6 +64,7 @@ from datajunction_server.models.preaggregation import (
     PreAggregationInfo,
     PreAggregationListResponse,
     PreAggMaterializationInput,
+    RegisterPreAggregationsRequest,
     UpdatePreAggregationAvailabilityRequest,
     WorkflowResponse,
     WorkflowStatus,
@@ -182,6 +186,7 @@ async def _preagg_to_info(
                 used_by_metrics=sorted(measure_metrics, key=lambda m: m.name)
                 if measure_metrics
                 else None,
+                source_column=measure.source_column,
             ),
         )
 
@@ -677,6 +682,208 @@ async def plan_preaggregations(
 
     return PlanPreAggregationsResponse(
         preaggs=[await _preagg_to_info(p, session) for p in loaded_preaggs],
+    )
+
+
+@router.post(
+    "/preaggs/register",
+    response_model=PlanPreAggregationsResponse,
+    status_code=HTTPStatus.CREATED,
+    name="Register External Pre-aggregations",
+)
+async def register_preaggregations(
+    data: RegisterPreAggregationsRequest,
+    *,
+    session: AsyncSession = Depends(get_session),
+    request: Request,
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+) -> PlanPreAggregationsResponse:
+    """
+    Register an externally-built pre-aggregation table.
+
+    Unlike ``/preaggs/plan`` (where DJ generates and owns the materialization),
+    this adopts a table built by an external pipeline. DJ decomposes the
+    requested metrics into component measures, binds each measure to a physical
+    column via ``measure_columns``, validates them against the table, records
+    the pre-aggregation, and — when ``valid_through_ts`` is supplied — marks it
+    available so grain resolution can route queries to it.
+    """
+    request_headers = dict(request.headers)
+    if not query_service_client:
+        raise DJConfigurationException(
+            message=(
+                "Registering external pre-aggregations requires a configured "
+                "query service for column inference."
+            ),
+        )
+
+    # 1. Validate each mapped metric is a measure, and map its single component's
+    #    expression hash to the declared physical column.
+    measure_hash_to_column: dict[str, str] = {}
+    for metric_name, physical_column in data.measure_columns.items():
+        node = await Node.get_by_name(
+            session,
+            metric_name,
+            options=[
+                selectinload(Node.current).options(
+                    *NodeRevision.default_load_options(),
+                ),
+            ],
+            raise_if_not_exists=False,
+        )
+        if not node or node.type != NodeType.METRIC:
+            raise DJInvalidInputException(
+                message=f"'{metric_name}' in measure_columns is not a metric node.",
+            )
+        if not node.current.is_measure:
+            raise DJInvalidInputException(
+                message=(
+                    f"Metric '{metric_name}' is not a measure: its query is not a "
+                    f"single aggregation that maps 1:1 to a column. Composite "
+                    f"metrics (e.g. AVG, ratios) must be modelled as derived "
+                    f"metrics over their base measures."
+                ),
+            )
+        components, _ = await MetricComponentExtractor(node.current.id).extract(session)
+        # is_measure guarantees exactly one component.
+        measure_hash_to_column[compute_expression_hash(components[0].expression)] = (
+            physical_column
+        )
+
+    # 2. Decompose the requested metrics into grain groups (no SQL is executed).
+    measures_result = await build_measures_sql(
+        session=session,
+        metrics=data.metrics,
+        dimensions=data.dimensions,
+        dialect=Dialect.SPARK,
+        use_materialized=False,
+    )
+
+    # 3. Introspect the external table and confirm the declared columns exist.
+    catalog = await get_catalog_by_name(session=session, name=data.table.catalog)
+    table_columns = await query_service_client.get_columns_for_table(
+        catalog.name,
+        data.table.schema_,
+        data.table.table,
+        request_headers,
+        catalog.engines[0] if catalog.engines else None,
+    )
+    table_column_names = {col.name for col in table_columns}
+    missing_columns = sorted(
+        column
+        for column in measure_hash_to_column.values()
+        if column not in table_column_names
+    )
+    if missing_columns:
+        raise DJInvalidInputException(
+            message=(
+                f"Columns {missing_columns} declared in measure_columns were not "
+                f"found in table "
+                f"{data.table.catalog}.{data.table.schema_}.{data.table.table}."
+            ),
+        )
+
+    # 4. For each grain group: verify measure coverage, bind source columns,
+    #    and upsert the pre-aggregation.
+    created_preaggs: list[PreAggregation] = []
+    for grain_group in measures_result.grain_groups:
+        parent_node = measures_result.ctx.nodes.get(grain_group.parent_name)
+        if not parent_node or not parent_node.current:  # pragma: no cover
+            continue
+        node_revision_id = parent_node.current.id
+        grain_columns = list(measures_result.requested_dimensions)
+
+        measures: list[PreAggMeasure] = []
+        for component in grain_group.components:
+            expr_hash = compute_expression_hash(component.expression)
+            if expr_hash not in measure_hash_to_column:
+                raise DJInvalidInputException(
+                    message=(
+                        f"Measure '{component.name}' required by the requested "
+                        f"metrics is not covered by measure_columns. Add the "
+                        f"is_measure metric it corresponds to."
+                    ),
+                )
+            measures.append(
+                PreAggMeasure(
+                    **{
+                        **component.model_dump(),
+                        "name": grain_group.component_aliases.get(
+                            component.name,
+                            component.name,
+                        ),
+                    },
+                    expr_hash=expr_hash,
+                    source_column=measure_hash_to_column[expr_hash],
+                ),
+            )
+
+        columns = [
+            V3ColumnMetadata(
+                name=col.name,
+                type=col.type,
+                semantic_type=col.semantic_type,
+                semantic_name=col.semantic_name,
+            )
+            for col in grain_group.columns
+        ]
+        grain_group_hash = compute_grain_group_hash(node_revision_id, grain_columns)
+        existing = await PreAggregation.find_matching(
+            session=session,
+            node_revision_id=node_revision_id,
+            grain_columns=grain_columns,
+            measure_expr_hashes={m.expr_hash for m in measures if m.expr_hash},
+        )
+        if existing:
+            existing.measures = measures
+            existing.columns = columns
+            existing.sql = grain_group.sql
+            preagg = existing
+        else:
+            preagg = PreAggregation(
+                node_revision_id=node_revision_id,
+                grain_columns=grain_columns,
+                measures=measures,
+                columns=columns,
+                sql=grain_group.sql,
+                grain_group_hash=grain_group_hash,
+                preagg_hash=compute_preagg_hash(
+                    node_revision_id,
+                    grain_columns,
+                    measures,
+                ),
+            )
+            session.add(preagg)
+        created_preaggs.append(preagg)
+
+        # 5. Set availability immediately when freshness is provided; otherwise
+        #    leave it pending for the availability callback to report.
+        if data.table.valid_through_ts is not None:
+            availability = AvailabilityState(
+                catalog=data.table.catalog,
+                schema_=data.table.schema_,
+                table=data.table.table,
+                valid_through_ts=data.table.valid_through_ts,
+            )
+            session.add(availability)
+            await session.flush()
+            preagg.availability_id = availability.id
+
+    await session.commit()
+
+    preagg_ids = [p.id for p in created_preaggs]
+    stmt = (
+        select(PreAggregation)
+        .options(
+            joinedload(PreAggregation.node_revision),
+            joinedload(PreAggregation.availability),
+        )
+        .where(PreAggregation.id.in_(preagg_ids))
+    )
+    result = await session.execute(stmt)
+    loaded = list(result.scalars().unique().all())
+    return PlanPreAggregationsResponse(
+        preaggs=[await _preagg_to_info(p, session) for p in loaded],
     )
 
 

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -174,7 +174,9 @@ def get_preagg_measure_column(
 
     for measure in preagg.measures:
         if measure.expr_hash == target_hash:
-            return measure.name
+            # Externally-registered pre-aggs bind the measure to a physical
+            # column name that may differ from the DJ component name.
+            return measure.source_column or measure.name
 
     return None
 

--- a/datajunction-server/datajunction_server/models/decompose.py
+++ b/datajunction-server/datajunction_server/models/decompose.py
@@ -111,6 +111,9 @@ class PreAggMeasure(MetricComponent):
 
     expr_hash: str | None = None  # Hash of expression for identity matching
     used_by_metrics: list[MetricRef] | None = None  # Metrics that use this measure
+    # Physical column holding this measure in an externally-registered pre-agg
+    # table. None for DJ-managed pre-aggs (the component name IS the column).
+    source_column: str | None = None
 
 
 class DecomposedMetric(BaseModel):

--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -85,6 +85,57 @@ class PlanPreAggregationsResponse(BaseModel):
     preaggs: List["PreAggregationInfo"]
 
 
+class ExternalPreAggTable(BaseModel):
+    """An externally-built table backing a registered pre-aggregation."""
+
+    catalog: str = Field(description="Catalog where the external table exists")
+    schema_: Optional[str] = Field(
+        default=None,
+        alias="schema",
+        description="Schema where the external table exists",
+    )
+    table: str = Field(description="Name of the external table")
+    valid_through_ts: Optional[int] = Field(
+        default=None,
+        description=(
+            "Timestamp (epoch) through which the external data is valid. When "
+            "provided, availability is set immediately; otherwise the pre-agg is "
+            "registered as pending until reported via the availability endpoint."
+        ),
+    )
+
+    class Config:
+        populate_by_name = True
+
+
+class RegisterPreAggregationsRequest(BaseModel):
+    """
+    Request model for registering an externally-built pre-aggregation table.
+
+    Unlike /preaggs/plan (where DJ generates and owns the materialization), this
+    adopts a table already built by an external pipeline. DJ decomposes the
+    metrics to determine the required measures, binds each to a physical column
+    via ``measure_columns``, validates them against the table, and records the
+    pre-aggregation so grain resolution can route queries to it.
+    """
+
+    metrics: List[str] = Field(
+        description="Metric node names the external table should serve",
+    )
+    dimensions: List[str] = Field(
+        description="Dimension references defining the table's grain",
+    )
+    table: ExternalPreAggTable = Field(description="The externally-built table")
+    measure_columns: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Maps each is_measure metric name to the physical column in the "
+            "external table holding its pre-aggregated value. Every component "
+            "measure of the requested metrics must be covered."
+        ),
+    )
+
+
 class UpdatePreAggregationAvailabilityRequest(BaseModel):
     """Request model for updating pre-aggregation availability."""
 

--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -89,8 +89,7 @@ class ExternalPreAggTable(BaseModel):
     """An externally-built table backing a registered pre-aggregation."""
 
     catalog: str = Field(description="Catalog where the external table exists")
-    schema_: Optional[str] = Field(
-        default=None,
+    schema_: str = Field(
         alias="schema",
         description="Schema where the external table exists",
     )

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -687,6 +687,7 @@ class TestGetPreaggregationById:
                 "grain_alias": None,
                 "merge": "SUM",
                 "name": "line_total_sum_e1f61696",
+                "source_column": None,
                 "rule": {
                     "level": None,
                     "type": "full",
@@ -753,6 +754,7 @@ class TestGetPreaggregationById:
                 "grain_alias": None,
                 "merge": "SUM",
                 "name": "quantity_sum_06b64d2e",
+                "source_column": None,
                 "rule": {
                     "level": None,
                     "type": "full",
@@ -2392,7 +2394,8 @@ class TestRegisterPreAggregations:
 
     @pytest.mark.asyncio
     async def test_register_rejects_non_measure(
-        self, client_with_build_v3: AsyncClient
+        self,
+        client_with_build_v3: AsyncClient,
     ):
         """A derived/ratio metric cannot be used as a measure_columns key."""
         _mock_query_service(client_with_build_v3, ["some_col"])
@@ -2441,5 +2444,142 @@ class TestRegisterPreAggregations:
             )
             assert response.status_code == 422
             assert "not found in table" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_without_valid_through_ts_is_pending(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """Without a valid_through_ts, the pre-agg is registered but pending."""
+        _mock_query_service(client_with_build_v3, ["revenue_total", "order_cnt"])
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "agg_pending",
+                    },
+                    "measure_columns": {
+                        "v3.total_revenue": "revenue_total",
+                        "v3.order_count": "order_cnt",
+                    },
+                },
+            )
+            assert response.status_code == 201, response.text
+            assert response.json()["preaggs"][0]["status"] == "pending"
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_is_idempotent(self, client_with_build_v3: AsyncClient):
+        """Registering the same table twice updates the existing pre-agg."""
+        _mock_query_service(client_with_build_v3, ["revenue_total", "order_cnt"])
+        payload = {
+            "metrics": ["v3.avg_order_value"],
+            "dimensions": ["v3.product.category"],
+            "table": {
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "agg_idem",
+                "valid_through_ts": 1700000000,
+            },
+            "measure_columns": {
+                "v3.total_revenue": "revenue_total",
+                "v3.order_count": "order_cnt",
+            },
+        }
+        try:
+            first = await client_with_build_v3.post("/preaggs/register", json=payload)
+            assert first.status_code == 201, first.text
+            second = await client_with_build_v3.post("/preaggs/register", json=payload)
+            assert second.status_code == 201, second.text
+            assert first.json()["preaggs"][0]["id"] == second.json()["preaggs"][0]["id"]
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_rejects_uncovered_measure(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """Every component measure of the requested metrics must be covered."""
+        _mock_query_service(client_with_build_v3, ["revenue_total"])
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "agg_partial",
+                    },
+                    # order_count's measure is missing.
+                    "measure_columns": {"v3.total_revenue": "revenue_total"},
+                },
+            )
+            assert response.status_code == 422
+            assert "not covered by measure_columns" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_rejects_unknown_metric(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """A measure_columns key that is not a metric node is rejected."""
+        _mock_query_service(client_with_build_v3, ["c"])
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "t",
+                    },
+                    "measure_columns": {"v3.does_not_exist": "c"},
+                },
+            )
+            assert response.status_code == 422
+            assert "not a metric node" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_requires_query_service(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """Registration requires a configured query service for column inference."""
+        client_with_build_v3.app.dependency_overrides[get_query_service_client] = (
+            lambda: None
+        )
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "t",
+                    },
+                    "measure_columns": {"v3.total_revenue": "revenue_total"},
+                },
+            )
+            assert response.status_code != 201
+            assert "query service" in response.text
         finally:
             del client_with_build_v3.app.dependency_overrides[get_query_service_client]

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -2336,3 +2336,110 @@ class TestIncrementalTimeMaterialization:
         assert temporal_partition.column_name is not None
         assert temporal_partition.format == "yyyyMMdd"
         assert temporal_partition.granularity == "day"
+
+
+def _mock_query_service(client_with_build_v3, columns: list[str]):
+    """Override the query service so get_columns_for_table returns ``columns``."""
+    from types import SimpleNamespace
+
+    async def _fake_get_columns(*args, **kwargs):
+        return [SimpleNamespace(name=name) for name in columns]
+
+    mock_client = MagicMock()
+    mock_client.get_columns_for_table = _fake_get_columns
+    client_with_build_v3.app.dependency_overrides[get_query_service_client] = (
+        lambda: mock_client
+    )
+
+
+class TestRegisterPreAggregations:
+    """Tests for POST /preaggs/register (externally-built tables)."""
+
+    @pytest.mark.asyncio
+    async def test_register_external_preagg(self, client_with_build_v3: AsyncClient):
+        """A derived metric is registered by mapping its base measures to columns."""
+        _mock_query_service(
+            client_with_build_v3,
+            ["revenue_total", "order_cnt", "category"],
+        )
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "avg_order_value_agg",
+                        "valid_through_ts": 1700000000,
+                    },
+                    "measure_columns": {
+                        "v3.total_revenue": "revenue_total",
+                        "v3.order_count": "order_cnt",
+                    },
+                },
+            )
+            assert response.status_code == 201, response.text
+            preagg = response.json()["preaggs"][0]
+            # Every measure is bound to its declared physical column.
+            source_columns = {m["source_column"] for m in preagg["measures"]}
+            assert source_columns == {"revenue_total", "order_cnt"}
+            # valid_through_ts was provided, so it is immediately available.
+            assert preagg["status"] == "active"
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_rejects_non_measure(
+        self, client_with_build_v3: AsyncClient
+    ):
+        """A derived/ratio metric cannot be used as a measure_columns key."""
+        _mock_query_service(client_with_build_v3, ["some_col"])
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "bad_agg",
+                    },
+                    "measure_columns": {"v3.avg_order_value": "some_col"},
+                },
+            )
+            assert response.status_code == 422
+            assert "not a measure" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_rejects_missing_column(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """Declared physical columns must exist in the external table."""
+        _mock_query_service(client_with_build_v3, ["only_this_column"])
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "avg_agg",
+                    },
+                    "measure_columns": {
+                        "v3.total_revenue": "revenue_total",
+                        "v3.order_count": "order_cnt",
+                    },
+                },
+            )
+            assert response.status_code == 422
+            assert "not found in table" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -791,6 +791,47 @@ class TestGetPreaggMeasureColumn:
         assert result == "total_revenue"
 
     @pytest.mark.asyncio
+    async def test_prefers_source_column(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """Externally-registered measures resolve to their physical source_column."""
+        avail = AvailabilityState(
+            catalog="test",
+            schema_="test",
+            table="preagg",
+            valid_through_ts=9999999999,
+        )
+        session.add(avail)
+        await session.flush()
+
+        measure = PreAggMeasure(
+            name="total_revenue",
+            expression="price * quantity",
+            aggregation="SUM",
+            merge="SUM",
+            rule=AggregationRule(type=Aggregability.FULL),
+            expr_hash=compute_expression_hash("price * quantity"),
+            source_column="revenue_physical",
+        )
+        preagg = PreAggregation(
+            node_revision_id=parent_node.current.id,
+            grain_columns=["dim1"],
+            measures=[measure],
+            sql="SELECT ...",
+            grain_group_hash="hash_sc",
+            preagg_hash="srccol1",
+            availability_id=avail.id,
+        )
+        session.add(preagg)
+        await session.flush()
+
+        component = make_component("sum_revenue", "price * quantity")
+
+        assert get_preagg_measure_column(preagg, component) == "revenue_physical"
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_no_match(
         self,
         session: AsyncSession,


### PR DESCRIPTION
### Summary

Adds a `source_column` field to `PreAggMeasure` and a `/preaggs/register` endpoint that adopts an externally-built pre-aggregation table (one DJ did not generate or run). DJ decomposes the requested metrics into component measures, binds each to a physical column via `measure_columns`, validates them against the table (every `measure_columns` key is an `is_measure` metric), records the `PreAggregation`, and when a `valid_through_ts` is supplied, sets availability so grain resolution can route queries to it.

The query builder (`get_preagg_measure_column`) now prefers a measure's `source_column`, so registered external columns are used at query time.

Advances #2118.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
