### PR TITLE
[RBAC PR 1 follow-up] Fail closed for grant delegation

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_17_2359-rbacenumfix1_sync_rbac_enum_values.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_17_2359-rbacenumfix1_sync_rbac_enum_values.py
@@ -3,7 +3,7 @@
 from alembic import op
 
 revision = "rbacenumfix1"
-down_revision = "cm0001jsonbgin"
+down_revision = "pa0002external"
 branch_labels = None
 depends_on = None
 

--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_17_2359-rbacenumfix1_sync_rbac_enum_values.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_17_2359-rbacenumfix1_sync_rbac_enum_values.py
@@ -1,0 +1,17 @@
+"""Sync RBAC enum values with ORM serialization."""
+
+from alembic import op
+
+revision = "rbacenumfix1"
+down_revision = "cm0001jsonbgin"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for value in ("HIERARCHY", "ROLE", "ROLE_ASSIGNMENT", "ROLE_SCOPE"):
+        op.execute(f"ALTER TYPE entitytype ADD VALUE IF NOT EXISTS '{value}'")
+
+
+def downgrade():
+    pass

--- a/datajunction-server/datajunction_server/api/groups.py
+++ b/datajunction-server/datajunction_server/api/groups.py
@@ -35,7 +35,10 @@ async def enforce_group_administration(access_checker: AccessChecker) -> None:
     privileged, cross-cutting operation rather than a per-namespace one.
     """
     access_checker.add_scope(ResourceType.NAMESPACE, "*", ResourceAction.MANAGE)
-    await access_checker.check(on_denied=AccessDenialMode.RAISE)
+    await access_checker.check(
+        on_denied=AccessDenialMode.RAISE,
+        require_explicit_grant=True,
+    )
 
 
 @router.post("/groups/", response_model=GroupOutput, status_code=201)

--- a/datajunction-server/datajunction_server/api/rbac.py
+++ b/datajunction-server/datajunction_server/api/rbac.py
@@ -32,6 +32,7 @@ from datajunction_server.models.rbac import (
     RoleScopeInput,
     RoleScopeOutput,
     RoleUpdate,
+    ScopeValue,
 )
 from datajunction_server.utils import get_session, get_current_user
 from datajunction_server.models.user import UserOutput
@@ -448,7 +449,7 @@ async def delete_scope_from_role(
     role_name: str,
     action: ResourceAction,
     scope_type: ResourceType,
-    scope_value: str,
+    scope_value: ScopeValue,
     *,
     session: AsyncSession = Depends(get_session),
     current_user: UserOutput = Depends(get_current_user),

--- a/datajunction-server/datajunction_server/api/rbac.py
+++ b/datajunction-server/datajunction_server/api/rbac.py
@@ -64,7 +64,10 @@ async def enforce_scope_management(
             scope.scope_value,
             ResourceAction.MANAGE,
         )
-    await access_checker.check(on_denied=AccessDenialMode.RAISE)
+    await access_checker.check(
+        on_denied=AccessDenialMode.RAISE,
+        require_explicit_grant=True,
+    )
 
 
 async def log_activity(
@@ -463,8 +466,16 @@ async def delete_scope_from_role(
         include_deleted=False,
     )
 
-    access_checker.add_scope(scope_type, scope_value, ResourceAction.MANAGE)
-    await access_checker.check(on_denied=AccessDenialMode.RAISE)
+    await enforce_scope_management(
+        access_checker,
+        [
+            RoleScopeInput(
+                action=action,
+                scope_type=scope_type,
+                scope_value=scope_value,
+            ),
+        ],
+    )
 
     # Find the scope by composite key
     delete_stmt = (

--- a/datajunction-server/datajunction_server/database/rbac.py
+++ b/datajunction-server/datajunction_server/database/rbac.py
@@ -220,9 +220,18 @@ class RoleScope(Base):
         nullable=False,
     )
 
-    action: Mapped[ResourceAction] = mapped_column(Enum(ResourceAction), nullable=False)
+    action: Mapped[ResourceAction] = mapped_column(
+        Enum(
+            ResourceAction,
+            values_callable=lambda enum: [item.value for item in enum],
+        ),
+        nullable=False,
+    )
     scope_type: Mapped[ResourceType] = mapped_column(
-        Enum(ResourceType),
+        Enum(
+            ResourceType,
+            values_callable=lambda enum: [item.value for item in enum],
+        ),
         nullable=False,
     )
     scope_value: Mapped[str] = mapped_column(String(500), nullable=False)

--- a/datajunction-server/datajunction_server/internal/access/authorization/service.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/service.py
@@ -14,6 +14,7 @@ from datajunction_server.models.access import (
     ResourceAction,
     ResourceRequest,
     ResourceType,
+    parse_scope_pattern,
 )
 from datajunction_server.internal.access.authorization.context import (
     AuthContext,
@@ -327,8 +328,8 @@ class RBACAuthorizationService(AuthorizationService):
         delegated_value: str,
     ) -> bool:
         """Return whether one supported scope pattern contains another."""
-        granted_pattern = cls._parse_scope_pattern(granted_value)
-        delegated_pattern = cls._parse_scope_pattern(delegated_value)
+        granted_pattern = parse_scope_pattern(granted_value)
+        delegated_pattern = parse_scope_pattern(delegated_value)
         if granted_pattern is None or delegated_pattern is None:
             return False
 
@@ -351,24 +352,6 @@ class RBACAuthorizationService(AuthorizationService):
         return delegated_prefix == granted_prefix or delegated_prefix.startswith(
             granted_prefix + SEPARATOR,
         )
-
-    @staticmethod
-    def _parse_scope_pattern(value: str) -> tuple[str, str] | None:
-        """Parse exact, trailing-wildcard, and global scope patterns."""
-        if not value or value == "*":
-            return ("global", "")
-        if (
-            value.startswith(SEPARATOR)
-            or value.endswith(SEPARATOR)
-            or SEPARATOR * 2 in value
-        ):
-            return None
-        if "*" not in value:
-            return ("exact", value)
-        if value.count("*") != 1 or not value.endswith(f"{SEPARATOR}*"):
-            return None
-        prefix = value[: -len(f"{SEPARATOR}*")]
-        return ("subtree", prefix) if prefix else None
 
     @classmethod
     def _scope_grants_permission(

--- a/datajunction-server/datajunction_server/internal/access/authorization/service.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/service.py
@@ -64,6 +64,21 @@ class AuthorizationService(ABC):
             The same list of requests with approved=True/False set on each
         """
 
+    def authorize_explicit_grants(
+        self,
+        auth_context: AuthContext,
+        requests: list[ResourceRequest],
+    ) -> list[AccessDecision]:
+        """Deny control-plane access until a provider explicitly supports it."""
+        return [
+            AccessDecision(
+                request=request,
+                approved=False,
+                reason="explicit_grant_provider_required",
+            )
+            for request in requests
+        ]
+
 
 class RBACAuthorizationService(AuthorizationService):
     """
@@ -142,6 +157,19 @@ class RBACAuthorizationService(AuthorizationService):
             ]
         return [self._make_decision(auth_context, request) for request in requests]
 
+    def authorize_explicit_grants(
+        self,
+        auth_context: AuthContext,
+        requests: list[ResourceRequest],
+    ) -> list[AccessDecision]:
+        """Authorize from assigned roles without policy fallback."""
+        if auth_context.is_admin:
+            return self.authorize(auth_context, requests)
+        return [
+            self._make_explicit_grant_decision(auth_context, request)
+            for request in requests
+        ]
+
     def _make_decision(
         self,
         auth_context: AuthContext,
@@ -159,6 +187,33 @@ class RBACAuthorizationService(AuthorizationService):
         return AccessDecision(
             request=request,
             approved=(has_grant or settings.default_access_policy == "permissive"),
+        )
+
+    def _make_explicit_grant_decision(
+        self,
+        auth_context: AuthContext,
+        request: ResourceRequest,
+    ) -> AccessDecision:
+        """Resolve a request from assigned roles only."""
+        has_grant = (
+            self.has_scope_permission(
+                assignments=auth_context.role_assignments,
+                action=request.verb,
+                scope_type=request.access_object.resource_type,
+                scope_value=request.access_object.name,
+            )
+            if request.scope_target
+            else self.has_permission(
+                assignments=auth_context.role_assignments,
+                action=request.verb,
+                resource_type=request.access_object.resource_type,
+                resource_name=request.access_object.name,
+            )
+        )
+        return AccessDecision(
+            request=request,
+            approved=has_grant,
+            reason="explicit_grant" if has_grant else "explicit_grant_required",
         )
 
     @classmethod
@@ -236,6 +291,87 @@ class RBACAuthorizationService(AuthorizationService):
         return False
 
     @classmethod
+    def has_scope_permission(
+        cls,
+        assignments: List,
+        action: ResourceAction,
+        scope_type: ResourceType,
+        scope_value: str,
+    ) -> bool:
+        """Return whether an assigned scope contains the requested scope."""
+        for assignment in assignments:
+            if assignment.expires_at and assignment.expires_at < datetime.now(
+                timezone.utc,
+            ):
+                continue
+            for granted_scope in assignment.role.scopes:
+                granted_actions = cls.PERMISSION_HIERARCHY.get(
+                    granted_scope.action,
+                    {granted_scope.action},
+                )
+                if action in granted_actions and cls.scope_contains_scope(
+                    granted_scope.scope_type,
+                    granted_scope.scope_value,
+                    scope_type,
+                    scope_value,
+                ):
+                    return True
+        return False
+
+    @classmethod
+    def scope_contains_scope(
+        cls,
+        granted_type: ResourceType,
+        granted_value: str,
+        delegated_type: ResourceType,
+        delegated_value: str,
+    ) -> bool:
+        """Return whether one supported scope pattern contains another."""
+        granted_pattern = cls._parse_scope_pattern(granted_value)
+        delegated_pattern = cls._parse_scope_pattern(delegated_value)
+        if granted_pattern is None or delegated_pattern is None:
+            return False
+
+        if granted_type != delegated_type and not (
+            granted_type == ResourceType.NAMESPACE
+            and delegated_type == ResourceType.NODE
+            and granted_pattern[0] != "global"
+        ):
+            return False
+
+        granted_kind, granted_prefix = granted_pattern
+        delegated_kind, delegated_prefix = delegated_pattern
+        if granted_kind == "global":
+            return True
+        if delegated_kind == "global":
+            return False
+        if granted_kind == "exact":
+            return delegated_kind == "exact" and granted_prefix == delegated_prefix
+        if delegated_kind == "exact":
+            return delegated_prefix.startswith(granted_prefix + SEPARATOR)
+        return delegated_prefix == granted_prefix or delegated_prefix.startswith(
+            granted_prefix + SEPARATOR,
+        )
+
+    @staticmethod
+    def _parse_scope_pattern(value: str) -> tuple[str, str] | None:
+        """Parse exact, trailing-wildcard, and global scope patterns."""
+        if not value or value == "*":
+            return ("global", "")
+        if (
+            value.startswith(SEPARATOR)
+            or value.endswith(SEPARATOR)
+            or SEPARATOR * 2 in value
+        ):
+            return None
+        if "*" not in value:
+            return ("exact", value)
+        if value.count("*") != 1 or not value.endswith(f"{SEPARATOR}*"):
+            return None
+        prefix = value[: -len(f"{SEPARATOR}*")]
+        return ("subtree", prefix) if prefix else None
+
+    @classmethod
     def _scope_grants_permission(
         cls,
         scope,
@@ -292,6 +428,14 @@ class PassthroughAuthorizationService(AuthorizationService):
     ) -> list[AccessDecision]:
         """Approve all requests without checks (sync)."""
         return [AccessDecision(request=request, approved=True) for request in requests]
+
+    def authorize_explicit_grants(
+        self,
+        auth_context: AuthContext,
+        requests: list[ResourceRequest],
+    ) -> list[AccessDecision]:
+        """Approve control-plane checks when authorization is disabled."""
+        return self.authorize(auth_context, requests)
 
 
 @lru_cache(maxsize=None)

--- a/datajunction-server/datajunction_server/internal/access/authorization/service.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/service.py
@@ -335,7 +335,6 @@ class RBACAuthorizationService(AuthorizationService):
         if granted_type != delegated_type and not (
             granted_type == ResourceType.NAMESPACE
             and delegated_type == ResourceType.NODE
-            and granted_pattern[0] != "global"
         ):
             return False
 

--- a/datajunction-server/datajunction_server/internal/access/authorization/validator.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/validator.py
@@ -128,12 +128,14 @@ class AccessChecker:
                     name=scope_value or "*",
                     resource_type=scope_type,
                 ),
+                scope_target=True,
             ),
         )
 
     async def check(
         self,
         on_denied: AccessDenialMode = AccessDenialMode.FILTER,
+        require_explicit_grant: bool = False,
     ) -> list[AccessDecision]:
         """
         Validate all requests using AuthorizationService.
@@ -143,9 +145,14 @@ class AccessChecker:
                 - FILTER: Return only approved (default)
                 - RAISE: Raise exception if any denied
                 - RETURN_ALL: Return all with approved field set
+            require_explicit_grant: Ignore provider fallback authorization
         """
         auth_service = get_authorization_service()
-        access_decisions = auth_service.authorize(self.auth_context, self.requests)
+        access_decisions = (
+            auth_service.authorize_explicit_grants(self.auth_context, self.requests)
+            if require_explicit_grant
+            else auth_service.authorize(self.auth_context, self.requests)
+        )
 
         if on_denied == AccessDenialMode.RETURN:
             return access_decisions

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -62,16 +62,24 @@ class ResourceRequest:
     """
     Resource Requests provide the information
     that is available to grant access to a resource
+
+    ``scope_target`` marks a delegated scope pattern so authorization can
+    prove containment instead of treating it as one concrete resource.
     """
 
     verb: ResourceAction
     access_object: Resource
+    scope_target: bool = False
 
     def __hash__(self) -> int:
-        return hash((self.verb, self.access_object))
+        return hash((self.verb, self.access_object, self.scope_target))
 
     def __eq__(self, other) -> bool:
-        return self.verb == other.verb and self.access_object == other.access_object
+        return (
+            self.verb == other.verb
+            and self.access_object == other.access_object
+            and self.scope_target == other.scope_target
+        )
 
     def __str__(self) -> str:
         return (

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -4,6 +4,7 @@ Models for authorization
 
 from dataclasses import dataclass
 
+from datajunction_server.naming import SEPARATOR
 from datajunction_server.typing import StrEnum
 from datajunction_server.database.node import Node, NodeRevision
 
@@ -27,6 +28,24 @@ class ResourceAction(StrEnum):
     EXECUTE = "execute"  # Run queries against nodes
     DELETE = "delete"  # Delete resources (keep for safety/auditability)
     MANAGE = "manage"  # Grant/revoke permissions (RBAC-specific)
+
+
+def parse_scope_pattern(value: str) -> tuple[str, str] | None:
+    """Parse exact, trailing-wildcard, and global scope patterns."""
+    if not value or value == "*":
+        return ("global", "")
+    if (
+        value.startswith(SEPARATOR)
+        or value.endswith(SEPARATOR)
+        or SEPARATOR * 2 in value
+    ):
+        return None
+    if "*" not in value:
+        return ("exact", value)
+    if value.count("*") != 1 or not value.endswith(f"{SEPARATOR}*"):
+        return None
+    prefix = value[: -len(f"{SEPARATOR}*")]
+    return ("subtree", prefix) if prefix else None
 
 
 @dataclass(frozen=True)

--- a/datajunction-server/datajunction_server/models/rbac.py
+++ b/datajunction-server/datajunction_server/models/rbac.py
@@ -1,9 +1,33 @@
 """Pydantic models for RBAC."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Annotated
 
-from datajunction_server.models.access import ResourceAction, ResourceType
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, StringConstraints
+
+from datajunction_server.models.access import (
+    ResourceAction,
+    ResourceType,
+    parse_scope_pattern,
+)
 from datajunction_server.typing import UTCDatetime
+
+
+def validate_scope_value(value: str) -> str:
+    """Reject scope values outside the supported containment grammar."""
+    if not value.strip():
+        raise ValueError("scope_value cannot be blank; use '*' for a global scope")
+    if value != value.strip() or parse_scope_pattern(value) is None:
+        raise ValueError(
+            "scope_value must be '*', an exact scope, or a subtree ending in '.*'",
+        )
+    return value
+
+
+ScopeValue = Annotated[
+    str,
+    StringConstraints(max_length=500),
+    AfterValidator(validate_scope_value),
+]
 
 
 class PrincipalOutput(BaseModel):
@@ -20,7 +44,7 @@ class RoleScopeInput(BaseModel):
 
     action: ResourceAction
     scope_type: ResourceType
-    scope_value: str = Field(..., max_length=500)
+    scope_value: ScopeValue
 
 
 class RoleScopeOutput(BaseModel):

--- a/datajunction-server/tests/api/graphql/find_nodes_test.py
+++ b/datajunction-server/tests/api/graphql/find_nodes_test.py
@@ -1976,15 +1976,25 @@ async def _setup_team_ownership(client: AsyncClient) -> None:
       - default.repair_order_details.owners == ['team-analytics']  (group only)
       - default.repair_orders_fact still has 'dj' as an owner
     """
-    # Register the group and add 'dj' as a member.
-    resp = await client.post("/groups/", params={"username": "team-analytics"})
-    assert resp.status_code == 201, resp.text
-
-    resp = await client.post(
-        "/groups/team-analytics/members/",
-        params={"member_username": "dj"},
+    # Register the group and add 'dj' as a member. Group administration now
+    # requires an explicit MANAGE grant, so authorize this setup as passthrough.
+    from datajunction_server.internal.access.authorization import (
+        PassthroughAuthorizationService,
     )
-    assert resp.status_code == 201, resp.text
+
+    with mock.patch(
+        "datajunction_server.internal.access.authorization."
+        "validator.get_authorization_service",
+        return_value=PassthroughAuthorizationService(),
+    ):
+        resp = await client.post("/groups/", params={"username": "team-analytics"})
+        assert resp.status_code == 201, resp.text
+
+        resp = await client.post(
+            "/groups/team-analytics/members/",
+            params={"member_username": "dj"},
+        )
+        assert resp.status_code == 201, resp.text
 
     # Re-assign a node so the group is the sole owner (dj no longer owns it).
     resp = await client.patch(

--- a/datajunction-server/tests/api/groups_test.py
+++ b/datajunction-server/tests/api/groups_test.py
@@ -5,7 +5,11 @@ Tests for groups API endpoints.
 import pytest
 from httpx import AsyncClient
 
-from datajunction_server.internal.access.authorization import AuthorizationService
+from datajunction_server.internal.access.authorization import (
+    AuthorizationService,
+    PassthroughAuthorizationService,
+    RBACAuthorizationService,
+)
 from datajunction_server.models import access
 
 VALIDATOR_AUTH_SERVICE = (
@@ -27,6 +31,18 @@ class DenyManageAuthorizationService(AuthorizationService):
             )
             for request in requests
         ]
+
+    def authorize_explicit_grants(self, auth_context, requests):
+        return self.authorize(auth_context, requests)
+
+
+@pytest.fixture(autouse=True)
+def allow_control_plane_by_default(mocker):
+    """Keep existing endpoint tests focused on group behavior."""
+    mocker.patch(
+        VALIDATOR_AUTH_SERVICE,
+        lambda: PassthroughAuthorizationService(),
+    )
 
 
 # Group Registration Tests
@@ -366,6 +382,23 @@ async def test_group_lifecycle(
 
 
 # MANAGE Enforcement Tests
+
+
+@pytest.mark.asyncio
+async def test_permissive_policy_cannot_authorize_group_administration(
+    module__client: AsyncClient,
+    mocker,
+) -> None:
+    """Group administration requires an explicit global MANAGE grant."""
+    mocker.patch(VALIDATOR_AUTH_SERVICE, lambda: RBACAuthorizationService())
+
+    response = await module__client.post(
+        "/groups/",
+        params={"username": "permissive-blocked-team"},
+    )
+
+    assert response.status_code == 403
+    assert "Access denied" in response.json()["message"]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/rbac_test.py
+++ b/datajunction-server/tests/api/rbac_test.py
@@ -11,7 +11,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.database.history import History
 from datajunction_server.database.rbac import RoleScope, RoleAssignment
 from datajunction_server.database.user import User
-from datajunction_server.internal.access.authorization import AuthorizationService
+from datajunction_server.internal.access.authorization import (
+    AuthorizationService,
+    PassthroughAuthorizationService,
+    RBACAuthorizationService,
+)
 from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.models import access
 
@@ -35,6 +39,9 @@ class DenyManageAuthorizationService(AuthorizationService):
             for request in requests
         ]
 
+    def authorize_explicit_grants(self, auth_context, requests):
+        return self.authorize(auth_context, requests)
+
 
 class ScopedManageAuthorizationService(AuthorizationService):
     """Grants MANAGE only on a fixed set of namespace patterns."""
@@ -55,6 +62,18 @@ class ScopedManageAuthorizationService(AuthorizationService):
             )
             for request in requests
         ]
+
+    def authorize_explicit_grants(self, auth_context, requests):
+        return self.authorize(auth_context, requests)
+
+
+@pytest.fixture(autouse=True)
+def allow_control_plane_by_default(mocker):
+    """Keep existing endpoint tests focused on role behavior."""
+    mocker.patch(
+        VALIDATOR_AUTH_SERVICE,
+        lambda: PassthroughAuthorizationService(),
+    )
 
 
 @pytest.mark.asyncio
@@ -962,6 +981,34 @@ async def test_audit_logging_for_role_assignments(
 # ============================================================================
 # MANAGE Enforcement Tests
 # ============================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope_type", ["node", "namespace"])
+async def test_global_scope_requires_explicit_manage_under_permissive_policy(
+    client_with_basic: AsyncClient,
+    mocker,
+    scope_type: str,
+):
+    """Permissive policy cannot authorize global grant delegation."""
+    mocker.patch(VALIDATOR_AUTH_SERVICE, lambda: RBACAuthorizationService())
+
+    response = await client_with_basic.post(
+        "/roles/",
+        json={
+            "name": f"blocked-global-{scope_type}",
+            "scopes": [
+                {
+                    "action": "write",
+                    "scope_type": scope_type,
+                    "scope_value": "*",
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 403
+    assert "Access denied" in response.json()["message"]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/rbac_test.py
+++ b/datajunction-server/tests/api/rbac_test.py
@@ -133,6 +133,64 @@ async def test_create_role_with_scopes(client_with_basic: AsyncClient):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("scope_value", ["", " ", "\t"])
+async def test_create_role_rejects_blank_scope_value(
+    client_with_basic: AsyncClient,
+    scope_value: str,
+):
+    """Global scopes must use an explicit wildcard."""
+    response = await client_with_basic.post(
+        "/roles/",
+        json={
+            "name": "invalid-blank-scope",
+            "scopes": [
+                {
+                    "action": "read",
+                    "scope_type": "namespace",
+                    "scope_value": scope_value,
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == [
+        "body",
+        "scopes",
+        0,
+        "scope_value",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope_value",
+    ["finance*", ".*", "**", "finance.*.revenue", "finance..*", ".finance"],
+)
+async def test_create_role_rejects_malformed_scope_value(
+    client_with_basic: AsyncClient,
+    scope_value: str,
+):
+    """Malformed scope patterns fail request validation."""
+    response = await client_with_basic.post(
+        "/roles/",
+        json={
+            "name": "invalid-malformed-scope",
+            "scopes": [
+                {
+                    "action": "read",
+                    "scope_type": "namespace",
+                    "scope_value": scope_value,
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert "exact scope" in response.json()["detail"][0]["msg"]
+
+
+@pytest.mark.asyncio
 async def test_create_role_duplicate_name(client_with_basic: AsyncClient):
     """Test that creating a role with duplicate name fails."""
     # Create first role
@@ -503,6 +561,19 @@ async def test_delete_scope_not_found(client_with_basic: AsyncClient):
         f"/roles/test-role/scopes/read/namespace/{scope_value}",
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_scope_rejects_malformed_scope_value(
+    client_with_basic: AsyncClient,
+):
+    """Path scope values use the same validation as request bodies."""
+    response = await client_with_basic.delete(
+        "/roles/test-role/scopes/read/namespace/finance*",
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["path", "scope_value"]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -1,6 +1,8 @@
 """Tests for RBAC authorization logic."""
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +14,7 @@ from datajunction_server.internal.access.authorization import (
     AccessChecker,
     AccessDenialMode,
     AuthContext,
+    AuthorizationService,
     PassthroughAuthorizationService,
     RBACAuthorizationService,
     get_authorization_service,
@@ -19,6 +22,7 @@ from datajunction_server.internal.access.authorization import (
 from datajunction_server.errors import DJAuthorizationException
 from datajunction_server.internal.access.authentication.basic import get_user
 from datajunction_server.models.access import (
+    AccessDecision,
     Resource,
     ResourceAction,
     ResourceRequest,
@@ -27,6 +31,15 @@ from datajunction_server.models.access import (
 from datajunction_server.internal.access.group_membership import (
     GroupMembershipService,
 )
+
+
+class PermissiveFallbackAuthorizationService(AuthorizationService):
+    """Test provider with a permissive normal authorization path."""
+
+    name = "test_permissive_fallback"
+
+    def authorize(self, auth_context, requests):
+        return [AccessDecision(request=request, approved=True) for request in requests]
 
 
 class TestResourceMatching:
@@ -146,6 +159,202 @@ class TestResourceMatching:
 
         # It would only match if resource literally starts with "finance.*.revenue."
         # which is unlikely in practice
+
+
+class TestScopeContainment:
+    """Tests for delegated scope containment."""
+
+    @pytest.mark.parametrize(
+        "granted_type,granted_value,delegated_type,delegated_value,expected",
+        [
+            (ResourceType.NAMESPACE, "*", ResourceType.NAMESPACE, "*", True),
+            (ResourceType.NAMESPACE, "finance.*", ResourceType.NAMESPACE, "*", False),
+            (ResourceType.NODE, "*", ResourceType.NODE, "*", True),
+            (ResourceType.NODE, "finance.*", ResourceType.NODE, "*", False),
+            (
+                ResourceType.NAMESPACE,
+                "finance.*",
+                ResourceType.NAMESPACE,
+                "finance.revenue.*",
+                True,
+            ),
+            (
+                ResourceType.NAMESPACE,
+                "finance.revenue.*",
+                ResourceType.NAMESPACE,
+                "finance.*",
+                False,
+            ),
+            (
+                ResourceType.NAMESPACE,
+                "finance.*",
+                ResourceType.NODE,
+                "finance.revenue",
+                True,
+            ),
+            (ResourceType.NAMESPACE, "*", ResourceType.NODE, "*", False),
+        ],
+    )
+    def test_scope_contains_scope(
+        self,
+        granted_type,
+        granted_value,
+        delegated_type,
+        delegated_value,
+        expected,
+    ) -> None:
+        assert (
+            RBACAuthorizationService.scope_contains_scope(
+                granted_type,
+                granted_value,
+                delegated_type,
+                delegated_value,
+            )
+            is expected
+        )
+
+    @pytest.mark.parametrize(
+        "pattern",
+        ["finance*", ".*", "**", "finance.*.revenue", "finance..*"],
+    )
+    def test_global_manage_rejects_malformed_scope(self, pattern: str) -> None:
+        assert not RBACAuthorizationService.scope_contains_scope(
+            ResourceType.NAMESPACE,
+            "*",
+            ResourceType.NAMESPACE,
+            pattern,
+        )
+
+
+@pytest.mark.parametrize("scope_type", [ResourceType.NODE, ResourceType.NAMESPACE])
+def test_explicit_authorization_ignores_permissive_fallback(
+    scope_type: ResourceType,
+    mocker,
+) -> None:
+    mock_settings = mocker.patch(
+        "datajunction_server.internal.access.authorization.service.settings",
+    )
+    mock_settings.default_access_policy = "permissive"
+    context = AuthContext(1, "no-grants", "basic", [])
+    request = ResourceRequest(
+        ResourceAction.MANAGE,
+        Resource(name="*", resource_type=scope_type),
+        scope_target=True,
+    )
+    service = RBACAuthorizationService()
+
+    assert service.authorize(context, [request])[0].approved is True
+    assert service.authorize_explicit_grants(context, [request])[0].approved is False
+
+
+def test_explicit_authorization_uses_scope_containment() -> None:
+    assignment = SimpleNamespace(
+        expires_at=None,
+        role=SimpleNamespace(
+            scopes=[
+                SimpleNamespace(
+                    action=ResourceAction.MANAGE,
+                    scope_type=ResourceType.NAMESPACE,
+                    scope_value="finance.*",
+                ),
+            ],
+        ),
+    )
+    context = AuthContext(
+        1,
+        "finance-owner",
+        "basic",
+        [cast(RoleAssignment, assignment)],
+    )
+    request = ResourceRequest(
+        ResourceAction.MANAGE,
+        Resource("finance.revenue.*", ResourceType.NAMESPACE),
+        scope_target=True,
+    )
+
+    decision = RBACAuthorizationService().authorize_explicit_grants(
+        context,
+        [request],
+    )[0]
+    assert decision.approved is True
+    assert decision.reason == "explicit_grant"
+
+
+def test_custom_provider_must_opt_in_to_control_plane_authorization() -> None:
+    context = AuthContext(1, "custom-provider-user", "basic", [])
+    request = ResourceRequest(
+        ResourceAction.MANAGE,
+        Resource("*", ResourceType.NAMESPACE),
+        scope_target=True,
+    )
+    service = PermissiveFallbackAuthorizationService()
+
+    assert service.authorize(context, [request])[0].approved is True
+    assert service.authorize_explicit_grants(context, [request])[0].approved is False
+
+
+def test_admin_authorizes_explicit_grants_via_bypass() -> None:
+    context = AuthContext(1, "root", "basic", [], is_admin=True)
+    request = ResourceRequest(
+        ResourceAction.MANAGE,
+        Resource("*", ResourceType.NAMESPACE),
+        scope_target=True,
+    )
+
+    decision = RBACAuthorizationService().authorize_explicit_grants(
+        context,
+        [request],
+    )[0]
+
+    assert decision.approved is True
+    assert decision.reason == "admin"
+
+
+def _scope(action, scope_type, scope_value):
+    return SimpleNamespace(
+        action=action,
+        scope_type=scope_type,
+        scope_value=scope_value,
+    )
+
+
+def _assignment(scopes, expires_at=None):
+    return cast(
+        RoleAssignment,
+        SimpleNamespace(expires_at=expires_at, role=SimpleNamespace(scopes=scopes)),
+    )
+
+
+def test_has_scope_permission_allows_exact_grant() -> None:
+    assignments = [
+        _assignment(
+            [_scope(ResourceAction.MANAGE, ResourceType.NAMESPACE, "finance")],
+        ),
+    ]
+
+    assert RBACAuthorizationService.has_scope_permission(
+        assignments=assignments,
+        action=ResourceAction.MANAGE,
+        scope_type=ResourceType.NAMESPACE,
+        scope_value="finance",
+    )
+
+
+def test_has_scope_permission_skips_expired_and_mismatched_scopes() -> None:
+    expired = _assignment(
+        [_scope(ResourceAction.MANAGE, ResourceType.NAMESPACE, "finance.*")],
+        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    wrong_action = _assignment(
+        [_scope(ResourceAction.READ, ResourceType.NAMESPACE, "finance.*")],
+    )
+
+    assert not RBACAuthorizationService.has_scope_permission(
+        assignments=[expired, wrong_action],
+        action=ResourceAction.MANAGE,
+        scope_type=ResourceType.NAMESPACE,
+        scope_value="finance.revenue",
+    )
 
 
 @pytest.mark.asyncio
@@ -490,6 +699,9 @@ class TestAuthorizationService:
 
         assert len(result) == 2
         assert all(req.approved for req in result)
+        assert all(
+            req.approved for req in service.authorize_explicit_grants(user, requests)
+        )
 
     async def test_rbac_service_with_permissions(
         self,

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -168,6 +168,7 @@ class TestScopeContainment:
         "granted_type,granted_value,delegated_type,delegated_value,expected",
         [
             (ResourceType.NAMESPACE, "*", ResourceType.NAMESPACE, "*", True),
+            (ResourceType.NAMESPACE, "", ResourceType.NAMESPACE, "finance", True),
             (ResourceType.NAMESPACE, "finance.*", ResourceType.NAMESPACE, "*", False),
             (ResourceType.NODE, "*", ResourceType.NODE, "*", True),
             (ResourceType.NODE, "finance.*", ResourceType.NODE, "*", False),

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -192,7 +192,16 @@ class TestScopeContainment:
                 "finance.revenue",
                 True,
             ),
-            (ResourceType.NAMESPACE, "*", ResourceType.NODE, "*", False),
+            # A global namespace grant contains node scopes: managing every
+            # namespace implies managing every node within them.
+            (ResourceType.NAMESPACE, "*", ResourceType.NODE, "*", True),
+            (ResourceType.NAMESPACE, "*", ResourceType.NODE, "finance.revenue", True),
+            # A subtree namespace grant still cannot delegate all nodes.
+            (ResourceType.NAMESPACE, "finance.*", ResourceType.NODE, "*", False),
+            # Node grants never contain namespace scopes, so managing all nodes
+            # cannot be escalated into managing namespaces, groups, or roles.
+            (ResourceType.NODE, "*", ResourceType.NAMESPACE, "*", False),
+            (ResourceType.NODE, "*", ResourceType.NAMESPACE, "finance.*", False),
         ],
     )
     def test_scope_contains_scope(


### PR DESCRIPTION
Tracking: #2234 (step 1 follow-up in the RBAC enablement sequence).

DJ's default RBAC policy is permissive, and the endpoints that hand out permissions (create a role, add a scope, assign a role, manage a group) rely on that same fallback. So on a default deployment, any logged-in user can `POST /roles/` granting `node:*` (write on every node) and assign it to themselves. The permission system cannot be enforced if any user can grant themselves any permission.

**Why this was missed initially:** #2230 added the `MANAGE` checks and was verified with the policy flipped to restrictive, and its endpoint tests mocked `MANAGE` denial directly. Neither path ran the real permission logic under the normal permissive default, which is exactly where the hole is. The test database is also built from ORM metadata, so it never hit the Alembic enum mismatch that this PR also fixes.

## Background: what "grant delegation" means here

The RBAC admin endpoints are how one principal hands permissions to another. Handing out access is itself a privileged action. The rule this PR enforces: you can only give away access that you already administer. Concretely, if you hold `MANAGE` on the `finance.*` namespace, you may create or assign roles scoped inside `finance.*`, but not roles that touch `growth.*` or everything.

## What this PR changes

These rules now apply to the role and group admin endpoints only. Ordinary metadata calls (creating nodes, etc.) are unchanged.

1. **No permissive fallback for granting permissions.** Creating, updating, assigning, or revoking a role, and creating or editing a group, now require the caller to actually hold a matching `MANAGE` grant. The permissive default no longer counts as authorization for these endpoints. This is the core fix: it is what stops a normal user from self-granting `node:*`.

2. **You can only delegate what you manage (containment).** Every scope in a role you create or assign must fit inside one of your own `MANAGE` scopes. With a caller who holds `MANAGE` on `namespace:finance.*`:
   - allowed: a role granting `read` on `finance.revenue.*` (inside `finance.*`)
   - denied: a role granting `read` on `growth.*` (a namespace you do not manage)
   - denied: a role granting `write` on `node:*` or `namespace:*` (everything)

3. **Invalid scope values fail request validation.** New scopes must be a single namespace/node (`finance.revenue`), a subtree (`finance.*`), or global (`*`). Blank, whitespace-only, and malformed values such as `finance*`, `.*`, `**`, or mid-string wildcards return 422. Containment also fails closed for unsupported values already stored in the database.

4. **Admins still bypass.** The existing `is_admin` break-glass path still authorizes these endpoints, so a fresh deployment can bootstrap its first grants.

5. **Migrated-database fix (found during manual verification).** On a real Alembic-migrated database, the RBAC scope enums are stored as lowercase and the `history` entity enum was missing the RBAC labels, so creating a role returned a 500. This PR serializes the enums with the values Alembic actually created and adds a migration for the missing history labels, so the endpoints work on deployed schemas, not only on test databases.

Behavior change: on the default permissive policy, the role and group admin endpoints now return 403 instead of silently allowing a self-grant. A caller needs an explicit `MANAGE` grant (or admin). Everything outside these endpoints keeps its current behavior, and the passthrough provider still approves everything for local dev and tests.

---
Verification:

1. Started this branch in slot 1, logged in as the seeded non-admin `dj` user, and confirmed the server was healthy.

```text
./dev.sh up -d
GET http://localhost:8100/health/
-> [{"name":"database","status":"ok"}] HTTP_STATUS:200

POST /basic/login/ username=dj password=dj
-> HTTP_STATUS:200
GET /whoami/
-> {"username":"dj","is_admin":false,...} HTTP_STATUS:200
```

2. As a normal user with no grants and the default permissive policy, confirmed the self-grant hole is closed: global and group-admin requests are now denied.

```text
POST /roles/ {scope_type:"node", scope_value:"*"}
-> {"message":"Access denied to 1 resource(s): *",...} HTTP_STATUS:403

POST /groups/?username=manual-team-final
-> {"message":"Access denied to 1 resource(s): *",...} HTTP_STATUS:403
```

3. Used the admin bypass to bootstrap one manager grant (`MANAGE namespace:finance.*`) assigned to `dj`, then dropped `dj` back to a non-admin user.

```text
UPDATE users SET is_admin=true WHERE username='dj';
POST /roles/ manual-finance-manager-final [MANAGE namespace:finance.*]
-> HTTP_STATUS:201
POST /roles/manual-finance-manager-final/assign {principal_username:"dj"}
-> HTTP_STATUS:201
UPDATE users SET is_admin=false WHERE username='dj';
GET /whoami/
-> {"username":"dj","is_admin":false,...} HTTP_STATUS:200
```

4. As that non-admin manager, confirmed delegation inside `finance.*` is allowed while anything outside it is denied.

```text
POST /roles/ manual-finance-reader-final [READ namespace:finance.revenue.*]
-> HTTP_STATUS:201

POST /roles/ manual-growth-reader-final [READ namespace:growth.*]
-> {"message":"Access denied to 1 resource(s): growth.*",...} HTTP_STATUS:403

POST /roles/ manual-global-node-with-finance-final [WRITE node:*]
-> {"message":"Access denied to 1 resource(s): *",...} HTTP_STATUS:403
```