### PR TITLE
[RBAC PR 2 follow-up] Verify break-glass readiness

### DIFF
--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -55,6 +55,9 @@ from datajunction_server.api import (
 
 from datajunction_server.api.access.authentication import basic, whoami, service_account
 from datajunction_server.api.attributes import default_attribute_types
+from datajunction_server.internal.access.authorization.readiness import (
+    verify_rbac_admins,
+)
 from datajunction_server.internal.seed import seed_default_catalogs
 from datajunction_server.api.graphql.main import graphql_app, schema as graphql_schema  # noqa: F401
 from datajunction_server.constants import AUTH_COOKIE, LOGGED_IN_FLAG_COOKIE
@@ -84,6 +87,7 @@ async def lifespan(app: FastAPI):  # pragma: no cover
     async with session_factory() as session:
         await default_attribute_types(session)
         await seed_default_catalogs(session)
+        await verify_rbac_admins(session, settings)
 
     yield
 

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -213,6 +213,12 @@ class Settings(BaseSettings):  # pragma: no cover
     # - "restrictive": Deny by default
     default_access_policy: str = "permissive"  # or "restrictive"
 
+    # Require configured break-glass admins before serving requests.
+    # Restrictive default access also enables this check automatically.
+    # RBAC_ADMIN_USERS uses JSON list syntax, for example ["admin-user"].
+    rbac_require_admin: bool = False
+    rbac_admin_users: List[str] = Field(default_factory=list)
+
     # Interval in seconds with which to expire caching of any indexes
     index_cache_expire: int = 60
 

--- a/datajunction-server/datajunction_server/internal/access/authorization/readiness.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/readiness.py
@@ -1,0 +1,63 @@
+"""RBAC activation readiness checks."""
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.config import Settings
+from datajunction_server.database.user import PrincipalKind, User
+
+logger = logging.getLogger(__name__)
+
+
+async def verify_rbac_admins(
+    session: AsyncSession,
+    settings: Settings,
+) -> None:
+    """Verify the configured human break-glass admins before enforcement."""
+    admin_required = settings.authorization_provider == "rbac" and (
+        settings.rbac_require_admin or settings.default_access_policy == "restrictive"
+    )
+    if not admin_required:
+        return
+
+    expected_usernames = list(dict.fromkeys(settings.rbac_admin_users))
+    if not expected_usernames:
+        raise RuntimeError(
+            "RBAC enforcement requires RBAC_ADMIN_USERS to name at least one "
+            "seeded break-glass admin",
+        )
+
+    users = await User.get_by_usernames(
+        session,
+        expected_usernames,
+        raise_if_not_exists=False,
+        options=[],
+    )
+    users_by_name = {user.username: user for user in users}
+    missing = [
+        username for username in expected_usernames if username not in users_by_name
+    ]
+    wrong_kind = [user.username for user in users if user.kind != PrincipalKind.USER]
+    not_admin = [
+        user.username
+        for user in users
+        if user.kind == PrincipalKind.USER and not user.is_admin
+    ]
+
+    problems = []
+    if missing:
+        problems.append(f"missing users: {', '.join(missing)}")
+    if wrong_kind:
+        problems.append(f"non-user principals: {', '.join(wrong_kind)}")
+    if not_admin:
+        problems.append(f"users without is_admin: {', '.join(not_admin)}")
+    if problems:
+        raise RuntimeError(
+            "RBAC break-glass admin verification failed: " + "; ".join(problems),
+        )
+
+    logger.info(
+        "rbac_admin_readiness_verified admins=%s",
+        ",".join(expected_usernames),
+    )

--- a/datajunction-server/datajunction_server/internal/access/authorization/service.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/service.py
@@ -24,6 +24,7 @@ from datajunction_server.utils import (
 )
 
 logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("datajunction.audit.rbac")
 
 settings = get_settings()
 
@@ -124,20 +125,23 @@ class RBACAuthorizationService(AuthorizationService):
         Returns:
             Same list of requests with approved=True/False set
         """
-        # Break-glass: admins bypass all RBAC checks. Kept as a single explicit
-        # check (and logged for audit) so the bypass is easy to find and, if
-        # ever needed, to scope down to "admin bypasses grants but still
-        # respects X".
         if auth_context.is_admin:
-            logger.info(
-                "Admin access bypass: user=%s (id=%s) approved %d request(s): %s",
+            logged_requests = requests[:20]
+            audit_logger.warning(
+                "event=rbac_admin_bypass reason=admin_bypass actor=%s actor_id=%s "
+                "request_count=%d requests=%s truncated=%s",
                 auth_context.username,
                 auth_context.user_id,
                 len(requests),
-                ", ".join(str(request) for request in requests),
+                ",".join(str(request) for request in logged_requests),
+                len(requests) > len(logged_requests),
             )
             return [
-                AccessDecision(request=request, approved=True, reason="admin")
+                AccessDecision(
+                    request=request,
+                    approved=True,
+                    reason="admin_bypass",
+                )
                 for request in requests
             ]
         return [self._make_decision(auth_context, request) for request in requests]

--- a/datajunction-server/tests/internal/access/authorization_readiness_test.py
+++ b/datajunction-server/tests/internal/access/authorization_readiness_test.py
@@ -1,0 +1,112 @@
+"""Tests for RBAC activation readiness."""
+
+import logging
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.config import Settings
+from datajunction_server.database.user import OAuthProvider, PrincipalKind, User
+from datajunction_server.internal.access.authorization.readiness import (
+    verify_rbac_admins,
+)
+
+
+@pytest.mark.asyncio
+async def test_permissive_rbac_does_not_require_admins(
+    clean_session: AsyncSession,
+) -> None:
+    settings = Settings(
+        authorization_provider="rbac",
+        default_access_policy="permissive",
+        rbac_require_admin=False,
+        rbac_admin_users=[],
+    )
+
+    await verify_rbac_admins(clean_session, settings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("policy", "require_admin"),
+    [("restrictive", False), ("permissive", True)],
+)
+async def test_enforcement_requires_admin_usernames(
+    clean_session: AsyncSession,
+    policy: str,
+    require_admin: bool,
+) -> None:
+    settings = Settings(
+        authorization_provider="rbac",
+        default_access_policy=policy,
+        rbac_require_admin=require_admin,
+        rbac_admin_users=[],
+    )
+
+    with pytest.raises(RuntimeError, match="RBAC_ADMIN_USERS"):
+        await verify_rbac_admins(clean_session, settings)
+
+
+@pytest.mark.asyncio
+async def test_admin_verification_reports_invalid_principals(
+    clean_session: AsyncSession,
+) -> None:
+    clean_session.add_all(
+        [
+            User(
+                username="ordinary-user",
+                oauth_provider=OAuthProvider.BASIC,
+                kind=PrincipalKind.USER,
+                is_admin=False,
+            ),
+            User(
+                username="admin-group",
+                oauth_provider=OAuthProvider.BASIC,
+                kind=PrincipalKind.GROUP,
+                is_admin=True,
+            ),
+        ],
+    )
+    await clean_session.commit()
+    settings = Settings(
+        authorization_provider="rbac",
+        rbac_require_admin=True,
+        rbac_admin_users=["missing", "ordinary-user", "admin-group"],
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await verify_rbac_admins(clean_session, settings)
+
+    message = str(exc_info.value)
+    assert "missing users: missing" in message
+    assert "non-user principals: admin-group" in message
+    assert "users without is_admin: ordinary-user" in message
+
+
+@pytest.mark.asyncio
+async def test_admin_verification_accepts_seeded_admin(
+    clean_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    clean_session.add(
+        User(
+            username="break-glass",
+            oauth_provider=OAuthProvider.BASIC,
+            kind=PrincipalKind.USER,
+            is_admin=True,
+        ),
+    )
+    await clean_session.commit()
+    settings = Settings(
+        authorization_provider="rbac",
+        rbac_require_admin=True,
+        rbac_admin_users=["break-glass"],
+    )
+
+    with caplog.at_level(
+        logging.INFO,
+        logger="datajunction_server.internal.access.authorization.readiness",
+    ):
+        await verify_rbac_admins(clean_session, settings)
+
+    assert "rbac_admin_readiness_verified admins=break-glass" in caplog.messages

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -1,5 +1,6 @@
 """Tests for RBAC authorization logic."""
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -588,7 +589,7 @@ class TestAuthorizationService:
 class TestAdminBypass:
     """Tests for the admin break-glass bypass in RBACAuthorizationService."""
 
-    async def test_admin_bypasses_restrictive_policy(self, mocker):
+    async def test_admin_bypasses_restrictive_policy(self, mocker, caplog):
         """An admin is approved for everything, even under restrictive policy."""
         mock_settings = mocker.patch(
             "datajunction_server.internal.access.authorization.service.settings",
@@ -619,9 +620,18 @@ class TestAdminBypass:
                 ),
             ),
         ]
-        decisions = service.authorize(auth_context, requests)
+        with caplog.at_level(
+            logging.WARNING,
+            logger="datajunction.audit.rbac",
+        ):
+            decisions = service.authorize(auth_context, requests)
+
         assert all(decision.approved for decision in decisions)
-        assert all(decision.reason == "admin" for decision in decisions)
+        assert all(decision.reason == "admin_bypass" for decision in decisions)
+        assert len(caplog.messages) == 1
+        assert caplog.messages[0].startswith(
+            "event=rbac_admin_bypass reason=admin_bypass actor=root actor_id=1",
+        )
 
     async def test_non_admin_denied_under_restrictive(self, mocker):
         """A non-admin with no grants is denied under restrictive policy."""

--- a/db-init/create-dj-user.sql
+++ b/db-init/create-dj-user.sql
@@ -1,5 +1,5 @@
 INSERT INTO users (username, password, oauth_provider, is_admin, kind)
 VALUES
-    ('dj', '$2b$12$K5oXl1Qs/UiNzvysOckn2uJjJmGHrhnk97hFRlMboP4NbvNbtoQ4a', 'BASIC', false, 'USER')
+    ('dj', '$2b$12$K5oXl1Qs/UiNzvysOckn2uJjJmGHrhnk97hFRlMboP4NbvNbtoQ4a', 'BASIC', true, 'USER')
 ON CONFLICT (username)
-DO NOTHING;
+DO UPDATE SET is_admin = EXCLUDED.is_admin;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       # Allow the slot's UI origin through CORS. The default whitelist only
       # permits :3000 so slots running on other ports are blocked without this.
       - CORS_ORIGIN_WHITELIST=["http://localhost:${DJ_UI_PORT:-3000}"]
+      # Verify the local break-glass account without changing the access policy.
+      - RBAC_REQUIRE_ADMIN=${RBAC_REQUIRE_ADMIN:-true}
+      - RBAC_ADMIN_USERS=${RBAC_ADMIN_USERS:-["dj"]}
     build:
       context: ./datajunction-server
       args:
@@ -30,8 +33,12 @@ services:
     ports:
       - "${DJ_PORT:-8000}:8000"
     depends_on:
-      - db-migration
-      - postgres_metadata
+      db-migration:
+        condition: service_completed_successfully
+      db-seed:
+        condition: service_completed_successfully
+      postgres_metadata:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:


### PR DESCRIPTION
Tracking: #2234 (step 2 follow-up in the RBAC enablement sequence).

Restrictive RBAC depends on an admin recovery path, but the server can start while the configured user has `is_admin=false`. That can lock every operator out, while bypass use is difficult to identify in ordinary authorization logs.

**Why this was missed initially:** #2232 manually promoted `dj` before testing the bypass, so it proved recovery only after a valid admin already existed. It did not exercise cold startup with a missing or invalid admin, or check for a machine-distinct audit event.

This PR makes the recovery path an activation prerequisite:

- **Startup verification**: restrictive RBAC, or `RBAC_REQUIRE_ADMIN=true`, requires every configured `RBAC_ADMIN_USERS` entry to exist as a human user with `is_admin=true`.
- **Local admin seed**: the Compose path seeds `dj` as an admin, updates existing local rows idempotently, and waits for `db-seed` before starting the server.
- **Distinct audit event**: admin bypasses emit one bounded WARNING event on `datajunction.audit.rbac` with `event=rbac_admin_bypass`, actor fields, request count, and `reason=admin_bypass`.

Permissive deployments remain unchanged when admin readiness is disabled. Restrictive deployments fail before serving requests when the configured admin set is missing or invalid. Admin promotion remains an operations and seed concern; this adds no public promotion API.

---
Verification:

1. Started this branch from a fresh slot 2 database. Compose ran `db-seed` before the server, the seeded `dj` row was an admin, and startup verified the configured admin.

```text
./dev.sh up -d
SELECT username, is_admin FROM users WHERE username='dj';
-> dj | t

server log:
rbac_admin_readiness_verified admins=dj

GET http://localhost:8200/health/
-> [{"name":"database","status":"ok"}] HTTP_STATUS:200
POST /basic/login/ username=dj password=dj
-> HTTP_STATUS:200
GET /whoami/
-> {"username":"dj","is_admin":true,...} HTTP_STATUS:200
```

2. Created a namespace and source node through the admin bypass, then checked the dedicated audit event.

```text
POST /namespaces/manual_admin_bypass
-> HTTP_STATUS:201

POST /nodes/source/ {name:"manual_admin_bypass.orders_admin", catalog:"default", schema_:"public", table:"orders_admin", columns:[{name:"id",type:"int"}]}
-> HTTP_STATUS:200

server log:
WARNING datajunction.audit.rbac:
event=rbac_admin_bypass reason=admin_bypass actor=dj actor_id=1 request_count=1 requests=write:namespace/manual_admin_bypass truncated=False
```

3. Removed the configured user's admin flag and restarted only the server. The application refused to start and the health request could not connect.

```text
UPDATE users SET is_admin=false WHERE username='dj';
docker restart dj-s2
GET http://localhost:8200/health/
-> connection reset, HTTP_STATUS:000

server log:
RuntimeError: RBAC break-glass admin verification failed: users without is_admin: dj
ERROR: Application startup failed. Exiting.
```

4. Restored the admin flag and restarted the server. Readiness passed and traffic resumed.

```text
UPDATE users SET is_admin=true WHERE username='dj';
docker restart dj-s2
GET http://localhost:8200/health/
-> [{"name":"database","status":"ok"}] HTTP_STATUS:200
```