### PR TITLE
feat(instrumentation): structured event logging interface

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -52,6 +52,7 @@ from datajunction_server.construction.build_v3.utils import (
 )
 from datajunction_server.database.partition import Partition
 from datajunction_server.errors import DJError, DJInvalidInputException, ErrorCode
+from datajunction_server.instrumentation import events
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.partition import PartitionType
 from datajunction_server.sql.parsing import ast
@@ -532,6 +533,14 @@ async def build_metrics_sql(
                 dialect = Dialect.TRINO
         else:
             dialect = Dialect.TRINO
+
+    # Emit after dialect resolution (so engine is accurate) but before the heavy build.
+    events.emit(
+        "query_requested",
+        metrics=list(metrics),
+        dimensions=list(dimensions),
+        engine=dialect.name,
+    )
 
     # Setup context (loads nodes, decomposes metrics, adds dimensions from expressions)
     ctx = await setup_build_context(

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -46,6 +46,9 @@ from datajunction_server.construction.build_v3.types import (
     GrainGroupSQL,
 )
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
+from datajunction_server.construction.build_v3.filters import (
+    get_filter_column_references,
+)
 from datajunction_server.construction.build_v3.utils import (
     add_dimensions_from_filters,
     add_dimensions_from_metric_expressions,
@@ -480,6 +483,15 @@ async def build_grain_groups(
     )
 
 
+def _telemetry_filter_columns(filters: list[str] | None) -> list[str]:
+    """Unique column names referenced across all filter predicates, for
+    telemetry — never the filter literal values."""
+    columns: set[str] = set()
+    for predicate in filters or []:
+        columns.update(get_filter_column_references(predicate))
+    return sorted(columns)
+
+
 async def build_metrics_sql(
     session: AsyncSession,
     metrics: list[str],
@@ -539,6 +551,9 @@ async def build_metrics_sql(
         "query_requested",
         metrics=list(metrics),
         dimensions=list(dimensions),
+        filter_columns=_telemetry_filter_columns(filters),
+        orderby=list(orderby or []),
+        limit=limit,
         engine=dialect.name,
     )
 

--- a/datajunction-server/datajunction_server/instrumentation/events.py
+++ b/datajunction-server/datajunction_server/instrumentation/events.py
@@ -1,0 +1,113 @@
+"""
+Structured event emission.
+
+Application code calls ``events.emit(event_type, **fields)`` from anywhere. It
+is a no-op by default; a deployment installs a real publisher at startup via
+``set_publisher(fn)``. Events are enriched with the current request identity
+(caller/client/trace_id) when a deployment populates it via ``set_identity`` —
+this package never sets identity itself, so without a deployment it stays empty.
+"""
+
+import inspect
+import logging
+import time
+from contextvars import ContextVar
+from typing import Any, Callable
+
+_logger = logging.getLogger(__name__)
+
+# The failure warning is rate-limited so a broken publisher can't flood logs;
+# the counter fires on every failure regardless.
+_FAILURE_LOG_INTERVAL_S = 60.0
+_last_failure_log = 0.0
+
+_identity: ContextVar[dict[str, Any] | None] = ContextVar(
+    "dj_identity",
+    default=None,
+)
+
+
+def set_identity(identity: dict[str, Any]):
+    """Set per-request identity (caller, client, trace_id, ...). Returns a token."""
+    return _identity.set(identity)
+
+
+def reset_identity(token) -> None:
+    """Reset the identity ContextVar using the token returned by ``set_identity``."""
+    _identity.reset(token)
+
+
+def _noop_publish(event: dict[str, Any]) -> None:
+    """Default no-op publisher. Replaced via ``set_publisher`` at startup."""
+
+
+# ``Any`` (not ``None``): emit() inspects the return value to catch a
+# mis-installed async publisher returning an un-awaited coroutine.
+_publish: Callable[[dict[str, Any]], Any] = _noop_publish
+
+
+def set_publisher(fn: Callable[[dict[str, Any]], None]) -> None:
+    """Install the publisher (once, at startup). ``fn`` must be synchronous."""
+    global _publish
+    _publish = fn
+
+
+def emit(event_type: str, /, **fields: Any) -> None:
+    """Emit a structured event, carrying the current identity context.
+
+    Precedence: identity < explicit ``fields`` < system keys ``event_type`` /
+    ``ts_ms`` (which can't be clobbered). ``event_type`` is positional-only so a
+    ``fields`` dict carrying that key merges in rather than raising ``TypeError``.
+    """
+    try:
+        # Built inside the guard so a bad set_identity() value (non-mapping)
+        # can't make {**identity} raise into application code.
+        identity = _identity.get() or {}
+        event = {
+            **identity,
+            **fields,
+            "event_type": event_type,
+            "ts_ms": int(time.time() * 1000),
+        }
+        result = _publish(event)
+        if inspect.iscoroutine(result):  # async publisher: never awaited, so dropped
+            result.close()
+            _note_publish_failure(event_type)
+    except Exception:  # pylint: disable=broad-except
+        _note_publish_failure(event_type)
+
+
+def _note_publish_failure(event_type: str) -> None:
+    """Record a dropped event without ever raising.
+
+    Counter and warning are guarded independently so a broken logging handler
+    can't suppress the counter (the drop signal, so it goes first).
+    """
+    global _last_failure_log
+    try:
+        # Lazy import avoids a cycle and keeps emit()'s success path cheap.
+        from datajunction_server.instrumentation.provider import (  # pylint: disable=import-outside-toplevel
+            get_metrics_provider,
+        )
+
+        get_metrics_provider().counter(
+            "dj.events.publish_failed",
+            tags={"event_type": event_type},
+        )
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    try:
+        now = time.monotonic()
+        if now - _last_failure_log >= _FAILURE_LOG_INTERVAL_S:
+            _logger.warning(
+                "event publish failed (event_type=%s); suppressing further "
+                "warnings for %ds",
+                event_type,
+                int(_FAILURE_LOG_INTERVAL_S),
+                exc_info=True,
+            )
+            # Stamp only on success, so a failed log doesn't open the window.
+            _last_failure_log = now
+    except Exception:  # pylint: disable=broad-except
+        pass

--- a/datajunction-server/tests/construction/build_v3/builder_test.py
+++ b/datajunction-server/tests/construction/build_v3/builder_test.py
@@ -1,0 +1,22 @@
+"""Unit tests for helpers in ``construction.build_v3.builder``."""
+
+from datajunction_server.construction.build_v3 import builder
+
+
+def test_telemetry_filter_columns_none_and_empty():
+    """No filters yields no columns."""
+    assert builder._telemetry_filter_columns(None) == []
+    assert builder._telemetry_filter_columns([]) == []
+
+
+def test_telemetry_filter_columns_extracts_and_dedupes():
+    """Column references are extracted and de-duplicated across predicates,
+    and literal values are never included."""
+    columns = builder._telemetry_filter_columns(
+        [
+            "default.hard_hat.state = 'AZ'",
+            "default.hard_hat.state <> 'NY' AND default.repair_order.hard_hat_id > 5",
+        ],
+    )
+    assert columns == ["default.hard_hat.state", "default.repair_order.hard_hat_id"]
+    assert "AZ" not in columns and "NY" not in columns

--- a/datajunction-server/tests/instrumentation/events_test.py
+++ b/datajunction-server/tests/instrumentation/events_test.py
@@ -1,0 +1,302 @@
+"""
+Tests for ``datajunction_server.instrumentation.events``.
+"""
+
+import pytest
+
+from datajunction_server.instrumentation import events
+
+
+@pytest.fixture(autouse=True)
+def reset_publisher_and_identity():
+    """Restore the default no-op publisher and clear identity after every test."""
+    original_publish = events._publish  # pylint: disable=protected-access
+    yield
+    events.set_publisher(original_publish)
+    # Clear any identity a test left set so it can't bleed into the next test.
+    events._identity.set(None)  # pylint: disable=protected-access
+    # Reset the rate-limit clock so a test that opened the window can't suppress
+    # the warning in a later test (the global isn't otherwise reset).
+    events._last_failure_log = 0.0  # pylint: disable=protected-access
+
+
+def test_emit_is_noop_by_default():
+    """Default publisher is a no-op; emit must not raise."""
+    events.emit("anything", foo="bar")
+
+
+def test_set_publisher_receives_event():
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    events.emit("query_requested", metrics=["m1"], cube_hit=True)
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event["event_type"] == "query_requested"
+    assert event["metrics"] == ["m1"]
+    assert event["cube_hit"] is True
+    assert isinstance(event["ts_ms"], int)
+    assert event["ts_ms"] > 0
+
+
+def test_emit_merges_identity():
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    token = events.set_identity({"caller": "alice@nflx", "client": "ui"})
+    try:
+        events.emit("request", path="/sql")
+    finally:
+        events.reset_identity(token)
+
+    event = captured[0]
+    assert event["caller"] == "alice@nflx"
+    assert event["client"] == "ui"
+    assert event["path"] == "/sql"
+    assert event["event_type"] == "request"
+
+
+def test_emit_without_identity_has_no_caller():
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    events.emit("request", path="/sql")
+
+    event = captured[0]
+    assert "caller" not in event
+    assert event["path"] == "/sql"
+
+
+def test_identity_reset_clears_subsequent_emits():
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    token = events.set_identity({"caller": "bob@nflx"})
+    events.emit("request", path="/a")
+    events.reset_identity(token)
+    events.emit("request", path="/b")
+
+    assert captured[0]["caller"] == "bob@nflx"
+    assert "caller" not in captured[1]
+
+
+def test_field_overrides_identity_collision():
+    """Explicit fields take precedence over identity keys."""
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    token = events.set_identity({"caller": "alice@nflx", "client": "ui"})
+    try:
+        events.emit("request", client="mcp")  # override
+    finally:
+        events.reset_identity(token)
+
+    assert captured[0]["caller"] == "alice@nflx"
+    assert captured[0]["client"] == "mcp"
+
+
+def test_system_keys_win_over_fields_and_identity():
+    """``event_type``/``ts_ms`` are system-owned and cannot be clobbered.
+
+    ``event_type`` is positional so it can't even reach ``**fields`` — Python
+    rejects it. The reachable clobber vectors are an identity dict carrying
+    ``event_type``/``ts_ms`` and a ``ts_ms`` field; the system values win in
+    both cases.
+    """
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    token = events.set_identity({"event_type": "from_identity", "ts_ms": -1})
+    try:
+        events.emit("query_requested", ts_ms=0)
+    finally:
+        events.reset_identity(token)
+
+    event = captured[0]
+    assert event["event_type"] == "query_requested"
+    # ts_ms is the canonical generated timestamp, not the field/identity value.
+    assert event["ts_ms"] > 0
+
+
+def test_emit_swallows_publisher_exceptions():
+    def boom(event):
+        raise RuntimeError("publisher broke")
+
+    events.set_publisher(boom)
+
+    # Must not raise
+    events.emit("request", path="/sql")
+
+
+def test_publish_failure_increments_counter(monkeypatch):
+    """A failing publisher bumps ``dj.events.publish_failed`` and never raises."""
+    calls: list[tuple[str, dict]] = []
+
+    class _FakeCounter:
+        def counter(self, name, tags=None):
+            calls.append((name, tags or {}))
+
+    monkeypatch.setattr(
+        "datajunction_server.instrumentation.provider.get_metrics_provider",
+        lambda: _FakeCounter(),
+    )
+
+    def boom(event):
+        raise RuntimeError("publisher broke")
+
+    events.set_publisher(boom)
+    events.emit("query_requested", metrics=["m1"])
+
+    assert ("dj.events.publish_failed", {"event_type": "query_requested"}) in calls
+
+
+def test_counter_still_fires_when_failure_logger_raises(monkeypatch):
+    """If the publisher raises AND the failure-path logger raises, emit() must
+    not propagate AND the drop counter must still fire. Regression test: the
+    counter and the warning are recorded under independent guards, so a broken
+    logging handler cannot suppress the counter (they previously shared one
+    ``try`` and a raising warning skipped the counter entirely)."""
+    calls: list[tuple[str, dict]] = []
+
+    class _FakeCounter:
+        def counter(self, name, tags=None):
+            calls.append((name, tags or {}))
+
+    monkeypatch.setattr(
+        "datajunction_server.instrumentation.provider.get_metrics_provider",
+        lambda: _FakeCounter(),
+    )
+
+    def boom(event):
+        raise RuntimeError("publisher broke")
+
+    def boom_warning(*args, **kwargs):
+        raise RuntimeError("logging handler broke")
+
+    events.set_publisher(boom)
+    monkeypatch.setattr(events._logger, "warning", boom_warning)
+    events._last_failure_log = 0.0  # force the rate-limit window open
+
+    # Must not raise even though both the publisher and the logger blow up...
+    events.emit("query_requested", metrics=["m1"])
+
+    # ...and the counter still fired despite the warning handler raising.
+    assert ("dj.events.publish_failed", {"event_type": "query_requested"}) in calls
+
+
+def test_emit_never_raises_when_identity_is_not_a_mapping(monkeypatch):
+    """A deployment that misuses ``set_identity`` with a non-mapping must not
+    make emit() raise into application code: event construction (``{**identity}``,
+    which would raise ``TypeError``) happens inside the guard, and the drop is
+    counted."""
+    calls: list[tuple[str, dict]] = []
+
+    class _FakeCounter:
+        def counter(self, name, tags=None):
+            calls.append((name, tags or {}))
+
+    monkeypatch.setattr(
+        "datajunction_server.instrumentation.provider.get_metrics_provider",
+        lambda: _FakeCounter(),
+    )
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    # A non-mapping identity (a deployment bug): ``{**identity}`` raises TypeError.
+    events._identity.set(object())  # type: ignore[arg-type]
+
+    events.emit("query_requested", metrics=["m1"])  # must not raise
+
+    # Nothing was published (construction failed) but the drop was counted.
+    assert captured == []
+    assert ("dj.events.publish_failed", {"event_type": "query_requested"}) in calls
+
+
+def test_async_publisher_is_detected_not_silently_dropped(monkeypatch):
+    """An async publisher returns an un-awaited coroutine; emit() detects it and
+    counts a failure instead of dropping the event silently."""
+    calls: list[tuple[str, dict]] = []
+
+    class _FakeCounter:
+        def counter(self, name, tags=None):
+            calls.append((name, tags or {}))
+
+    monkeypatch.setattr(
+        "datajunction_server.instrumentation.provider.get_metrics_provider",
+        lambda: _FakeCounter(),
+    )
+
+    async def async_publish(event):  # pragma: no cover - never awaited
+        pass
+
+    events.set_publisher(async_publish)
+    events.emit("query_requested", metrics=["m1"])  # must not raise
+
+    assert ("dj.events.publish_failed", {"event_type": "query_requested"}) in calls
+
+
+def test_event_type_in_fields_dict_merges_harmlessly():
+    """``event_type`` is positional-only, so a fields dict carrying an
+    ``event_type`` key merges in (and the canonical value wins) instead of
+    raising TypeError."""
+    captured: list[dict] = []
+    events.set_publisher(captured.append)
+
+    events.emit("query_requested", **{"event_type": "spoofed", "ts_ms": 0})
+
+    event = captured[0]
+    assert event["event_type"] == "query_requested"
+    assert event["ts_ms"] > 0
+
+
+def test_publish_failure_warning_is_rate_limited_but_counter_always_fires(monkeypatch):
+    """The failure WARNING is rate-limited (one per ``_FAILURE_LOG_INTERVAL_S``),
+    but the ``dj.events.publish_failed`` counter fires on *every* drop — so a
+    second failure inside the window skips the log yet still bumps the counter."""
+    calls: list[tuple[str, dict]] = []
+    warnings: list = []
+
+    class _FakeCounter:
+        def counter(self, name, tags=None):
+            calls.append((name, tags or {}))
+
+    monkeypatch.setattr(
+        "datajunction_server.instrumentation.provider.get_metrics_provider",
+        lambda: _FakeCounter(),
+    )
+    monkeypatch.setattr(events._logger, "warning", lambda *a, **k: warnings.append(a))
+
+    def boom(event):
+        raise RuntimeError("publisher broke")
+
+    events.set_publisher(boom)
+    events.emit("query_requested", metrics=["m1"])  # opens the rate-limit window
+    events.emit("query_requested", metrics=["m2"])  # inside window: no warning
+
+    # The counter fires on both drops...
+    assert (
+        calls.count(("dj.events.publish_failed", {"event_type": "query_requested"}))
+        == 2
+    )
+    # ...but the WARNING is logged only once (second drop is rate-limited).
+    assert len(warnings) == 1
+
+
+def test_publish_failure_counter_failure_is_swallowed(monkeypatch):
+    """If even the failure-counter path raises, emit() still must not raise."""
+
+    def broken_provider():
+        raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(
+        "datajunction_server.instrumentation.provider.get_metrics_provider",
+        broken_provider,
+    )
+
+    def boom(event):
+        raise RuntimeError("publisher broke")
+
+    events.set_publisher(boom)
+    # Must not raise even though both the publisher and the counter fail.
+    events.emit("request", path="/sql")


### PR DESCRIPTION
Add events.emit(event_type, **fields), by default a no-op. Deployments install a publisher with set_publisher(). emit() never raises into application code. Publish failures are counted and logged with a rate-limited warning.

Emit a query_requested event from build_metrics_sql.