### PR TITLE
Mark registered pre-aggs EXTERNAL and guard against DJ materialization

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_18_0000-pa0002external_add_external_strategy_and_name.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_18_0000-pa0002external_add_external_strategy_and_name.py
@@ -1,0 +1,34 @@
+"""add EXTERNAL strategy value and name column to pre_aggregation
+
+Revision ID: pa0002external
+Revises: cm0001jsonbgin
+Create Date: 2026-07-18 00:00:00.000000+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pa0002external"
+down_revision = "cm0001jsonbgin"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Stable handle for externally-registered pre-aggs (YAML reconcile / callbacks).
+    op.add_column(
+        "pre_aggregation",
+        sa.Column("name", sa.String(), nullable=True),
+    )
+    # Marks pre-aggs adopted from external tables (never DJ-materialized). The enum
+    # values are stored as the enum member names (uppercase), matching the existing
+    # materializationstrategy values.
+    op.execute("ALTER TYPE materializationstrategy ADD VALUE IF NOT EXISTS 'EXTERNAL'")
+
+
+def downgrade():
+    op.drop_column("pre_aggregation", "name")
+    # Postgres does not support removing a value from an enum type, so the
+    # 'EXTERNAL' value is intentionally left in place on downgrade.

--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -201,6 +201,7 @@ async def _preagg_to_info(
         sql=preagg.sql,
         grain_group_hash=preagg.grain_group_hash,
         preagg_hash=preagg.preagg_hash,
+        name=preagg.name,
         strategy=preagg.strategy,
         schedule=preagg.schedule,
         lookback_window=preagg.lookback_window,
@@ -838,6 +839,8 @@ async def register_preaggregations(
             existing.measures = measures
             existing.columns = columns
             existing.sql = grain_group.sql
+            existing.strategy = MaterializationStrategy.EXTERNAL
+            existing.name = data.name
             preagg = existing
         else:
             preagg = PreAggregation(
@@ -852,6 +855,8 @@ async def register_preaggregations(
                     grain_columns,
                     measures,
                 ),
+                strategy=MaterializationStrategy.EXTERNAL,
+                name=data.name,
             )
             session.add(preagg)
         created_preaggs.append(preagg)
@@ -938,6 +943,12 @@ async def materialize_preaggregation(
 
     if not preagg:
         raise DJDoesNotExistException(f"Pre-aggregation with ID {preagg_id} not found")
+
+    if preagg.strategy == MaterializationStrategy.EXTERNAL:
+        raise DJInvalidInputException(
+            message="Cannot materialize an externally-registered pre-aggregation; "
+            "its table is built and maintained by an external pipeline.",
+        )
 
     # Validate strategy is set
     if not preagg.strategy:
@@ -1443,6 +1454,12 @@ async def run_preagg_backfill(
 
     if not preagg:
         raise DJDoesNotExistException(f"Pre-aggregation with ID {preagg_id} not found")
+
+    if preagg.strategy == MaterializationStrategy.EXTERNAL:
+        raise DJInvalidInputException(
+            "Cannot backfill an externally-registered pre-aggregation; its table "
+            "is built and maintained by an external pipeline.",
+        )
 
     # Validate: workflow must exist
     if not preagg.workflow_urls:

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -243,6 +243,10 @@ class PreAggregation(Base):
         unique=True,
     )
 
+    # Optional stable, human-supplied handle for externally-registered pre-aggs.
+    # Used by YAML deploy reconciliation and availability-by-name callbacks.
+    name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
     # === Materialization Config ===
     strategy: Mapped[Optional[MaterializationStrategy]] = mapped_column(
         Enum(MaterializationStrategy),

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -86,6 +86,11 @@ class MaterializationStrategy(StrEnum):
     # -> Availability state: single view
     VIEW = "view"
 
+    # An externally-built pre-aggregation table adopted via /preaggs/register.
+    # DJ does not generate, run, or refresh it; it only routes queries to it.
+    # -> Availability state: single table, reported by the external pipeline
+    EXTERNAL = "external"
+
 
 class GenericMaterializationInput(BaseModel):
     """

--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -118,6 +118,13 @@ class RegisterPreAggregationsRequest(BaseModel):
     pre-aggregation so grain resolution can route queries to it.
     """
 
+    name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional stable handle for the pre-aggregation, used by YAML deploy "
+            "reconciliation and availability-by-name callbacks."
+        ),
+    )
     metrics: List[str] = Field(
         description="Metric node names the external table should serve",
     )
@@ -208,6 +215,7 @@ class PreAggregationInfo(BaseModel):
     sql: str  # The generated SQL for materializing this pre-agg
     grain_group_hash: str
     preagg_hash: str  # Unique hash including measures (used for table/workflow naming)
+    name: Optional[str] = None  # Stable handle for externally-registered pre-aggs
 
     # Materialization config
     strategy: Optional[MaterializationStrategy] = None

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -181,6 +181,7 @@ async def test_materialization_info(module__client: AsyncClient) -> None:
             {"label": "Snapshot Partition", "name": "snapshot_partition"},
             {"label": "Incremental Time", "name": "incremental_time"},
             {"label": "View", "name": "view"},
+            {"label": "External", "name": "external"},
         ],
     }
 

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -2583,3 +2583,93 @@ class TestRegisterPreAggregations:
             assert "query service" in response.text
         finally:
             del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_sets_external_strategy_and_name(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """A registered pre-agg is marked EXTERNAL and keeps its handle."""
+        _mock_query_service(client_with_build_v3, ["revenue_total", "order_cnt"])
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "name": "aov_by_category",
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "aov_agg",
+                        "valid_through_ts": 1700000000,
+                    },
+                    "measure_columns": {
+                        "v3.total_revenue": "revenue_total",
+                        "v3.order_count": "order_cnt",
+                    },
+                },
+            )
+            assert response.status_code == 201, response.text
+            preagg = response.json()["preaggs"][0]
+            assert preagg["strategy"] == "external"
+            assert preagg["name"] == "aov_by_category"
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    async def _register_external(self, client, table_name):
+        """Register a simple external pre-agg and return its id."""
+        response = await client.post(
+            "/preaggs/register",
+            json={
+                "metrics": ["v3.avg_order_value"],
+                "dimensions": ["v3.product.category"],
+                "table": {
+                    "catalog": "default",
+                    "schema": "analytics",
+                    "table": table_name,
+                    "valid_through_ts": 1700000000,
+                },
+                "measure_columns": {
+                    "v3.total_revenue": "revenue_total",
+                    "v3.order_count": "order_cnt",
+                },
+            },
+        )
+        assert response.status_code == 201, response.text
+        return response.json()["preaggs"][0]["id"]
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_cannot_be_materialized(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """DJ must not materialize (overwrite) an externally-built table."""
+        _mock_query_service(client_with_build_v3, ["revenue_total", "order_cnt"])
+        try:
+            preagg_id = await self._register_external(client_with_build_v3, "aov_mat")
+            response = await client_with_build_v3.post(
+                f"/preaggs/{preagg_id}/materialize",
+            )
+            assert response.status_code == 422
+            assert "externally-registered" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_cannot_be_backfilled(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """DJ must not backfill an externally-built table."""
+        _mock_query_service(client_with_build_v3, ["revenue_total", "order_cnt"])
+        try:
+            preagg_id = await self._register_external(client_with_build_v3, "aov_bf")
+            response = await client_with_build_v3.post(
+                f"/preaggs/{preagg_id}/backfill",
+                json={"start_date": "2026-01-01"},
+            )
+            assert response.status_code == 422
+            assert "externally-registered" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]


### PR DESCRIPTION
### Summary

Adds an `EXTERNAL` MaterializationStrategy value and a nullable `name` column to `pre_aggregation`.

With this change, `/preaggs/{id}/materialize` and `/preaggs/{id}/backfill` now reject `EXTERNAL` pre-aggs, since DJ should never overwrite or backfill a table built and maintained by an external pipeline. `EXTERNAL` stays out of `VALID_PREAGG_STRATEGIES` so `/preaggs/plan` keeps rejecting it too.

Advances #2118.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
