### PR TITLE
Reconcile externally-built pre-aggregations from YAML deploys

### DIFF
--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -46,6 +46,24 @@ class ResultStatus(str, Enum):
     NOOP = "noop"
 
 
+class SpecKind(str, Enum):
+    """
+    Top-level ``kind`` discriminator on a project YAML file.
+
+    A file with no ``kind`` defaults to ``NODE`` (backwards compatible: existing
+    files carry no discriminator). Pre-aggregations live in the same tree but
+    are not nodes, so they declare ``kind: preagg`` and route to the
+    deployment's ``preaggregations`` list.
+    """
+
+    NODE = "node"
+    PREAGG = "preagg"
+
+    @classmethod
+    def default(cls) -> "SpecKind":
+        return cls.NODE
+
+
 class DeploymentService:
     """
     High-level deployment client for exporting and importing DJ namespaces.
@@ -491,26 +509,27 @@ class DeploymentService:
         project_metadata = self._read_project_yaml(base_dir)
         collected, warnings = self._collect_nodes_from_dir(base_dir)
 
-        # Every YAML file declares its ``kind``. An absent discriminator means
-        # ``node`` (backwards compatible: existing files carry no ``kind``).
-        # Pre-aggregation specs live in the same tree but are not nodes, so they
-        # are routed to the deployment's ``preaggregations`` list. The key is
-        # stripped so it never reaches the node/pre-agg payload.
-        valid_kinds = {"node", "preagg"}
+        # Every YAML file declares its ``kind`` (see SpecKind); an absent
+        # discriminator defaults to a node. Pre-aggregation specs live in the
+        # same tree but are not nodes, so they are routed to the deployment's
+        # ``preaggregations`` list. The key is stripped so it never reaches the
+        # node/pre-agg payload.
         nodes: list[dict[str, Any]] = []
         preaggregations: list[dict[str, Any]] = []
         for item in collected:
-            kind = item.pop("kind", "node")
-            if kind == "node":
-                nodes.append(item)
-            elif kind == "preagg":
+            raw_kind = item.pop("kind", SpecKind.default().value)
+            try:
+                kind = SpecKind(raw_kind)
+            except ValueError:
+                raise DJClientException(
+                    f"Unknown kind '{raw_kind}' in "
+                    f"'{item.get('name', '<unnamed>')}'; expected one of "
+                    f"{[k.value for k in SpecKind]}.",
+                )
+            if kind is SpecKind.PREAGG:
                 preaggregations.append(item)
             else:
-                raise DJClientException(
-                    f"Unknown kind '{kind}' in "
-                    f"'{item.get('name', '<unnamed>')}'; expected one of "
-                    f"{sorted(valid_kinds)}.",
-                )
+                nodes.append(item)
 
         # Deduplicate nodes by name (keep last occurrence)
         seen_names: dict[str, dict] = {}

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -491,11 +491,26 @@ class DeploymentService:
         project_metadata = self._read_project_yaml(base_dir)
         collected, warnings = self._collect_nodes_from_dir(base_dir)
 
-        # Pre-aggregation specs live in the same YAML tree but are not nodes;
-        # identify them by the ``measure_columns`` field and route them to the
-        # deployment's ``preaggregations`` list.
-        preaggregations = [item for item in collected if "measure_columns" in item]
-        nodes = [item for item in collected if "measure_columns" not in item]
+        # Every YAML file declares its ``kind``. An absent discriminator means
+        # ``node`` (backwards compatible: existing files carry no ``kind``).
+        # Pre-aggregation specs live in the same tree but are not nodes, so they
+        # are routed to the deployment's ``preaggregations`` list. The key is
+        # stripped so it never reaches the node/pre-agg payload.
+        valid_kinds = {"node", "preagg"}
+        nodes: list[dict[str, Any]] = []
+        preaggregations: list[dict[str, Any]] = []
+        for item in collected:
+            kind = item.pop("kind", "node")
+            if kind == "node":
+                nodes.append(item)
+            elif kind == "preagg":
+                preaggregations.append(item)
+            else:
+                raise DJClientException(
+                    f"Unknown kind '{kind}' in "
+                    f"'{item.get('name', '<unnamed>')}'; expected one of "
+                    f"{sorted(valid_kinds)}.",
+                )
 
         # Deduplicate nodes by name (keep last occurrence)
         seen_names: dict[str, dict] = {}

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -489,7 +489,13 @@ class DeploymentService:
             )
 
         project_metadata = self._read_project_yaml(base_dir)
-        nodes, warnings = self._collect_nodes_from_dir(base_dir)
+        collected, warnings = self._collect_nodes_from_dir(base_dir)
+
+        # Pre-aggregation specs live in the same YAML tree but are not nodes;
+        # identify them by the ``measure_columns`` field and route them to the
+        # deployment's ``preaggregations`` list.
+        preaggregations = [item for item in collected if "measure_columns" in item]
+        nodes = [item for item in collected if "measure_columns" not in item]
 
         # Deduplicate nodes by name (keep last occurrence)
         seen_names: dict[str, dict] = {}
@@ -508,6 +514,7 @@ class DeploymentService:
             or project_metadata.get("prefix", ""),
             "nodes": nodes,
             "tags": project_metadata.get("tags", []),
+            "preaggregations": preaggregations,
         }
 
         # Add deployment source if available from env vars

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -46,12 +46,13 @@ def test_pull_extracts_zip_from_server(tmp_path):
 
 
 def test_reconstruct_deployment_spec_separates_preaggregations(tmp_path):
-    """Pre-agg YAML files (identified by measure_columns) route to preaggregations."""
+    """Files with ``kind: preagg`` route to preaggregations; the rest are nodes."""
     (tmp_path / "dj.yaml").write_text("namespace: ns\n")
     (tmp_path / "revenue.yaml").write_text(
         "name: ns.revenue\nnode_type: metric\nquery: SELECT SUM(amount) FROM ns.fct\n",
     )
-    (tmp_path / "revenue_agg.preagg.yaml").write_text(
+    (tmp_path / "revenue_by_day.yaml").write_text(
+        "kind: preagg\n"
         "name: revenue_by_day\n"
         "metrics:\n  - ns.revenue\n"
         "dimensions:\n  - ns.date.day\n"
@@ -64,12 +65,24 @@ def test_reconstruct_deployment_spec_separates_preaggregations(tmp_path):
     svc = DeploymentService(MagicMock())
     spec, _ = svc._reconstruct_deployment_spec(tmp_path)
 
+    # The node file (no kind → node) stays a node.
     assert [node["name"] for node in spec["nodes"]] == ["ns.revenue"]
     assert len(spec["preaggregations"]) == 1
-    assert spec["preaggregations"][0]["name"] == "revenue_by_day"
-    assert spec["preaggregations"][0]["measure_columns"] == {
-        "ns.revenue": "revenue_sum",
-    }
+    preagg = spec["preaggregations"][0]
+    assert preagg["name"] == "revenue_by_day"
+    assert preagg["measure_columns"] == {"ns.revenue": "revenue_sum"}
+    # The discriminator is stripped before reaching the payload.
+    assert "kind" not in preagg
+
+
+def test_reconstruct_deployment_spec_rejects_unknown_kind(tmp_path):
+    """An unrecognized ``kind`` fails loudly instead of silently becoming a node."""
+    (tmp_path / "dj.yaml").write_text("namespace: ns\n")
+    (tmp_path / "mystery.yaml").write_text("kind: widget\nname: ns.mystery\n")
+
+    svc = DeploymentService(MagicMock())
+    with pytest.raises(DJClientException, match="Unknown kind 'widget'"):
+        svc._reconstruct_deployment_spec(tmp_path)
 
 
 def test_pull_uploads_existing_yaml_files(tmp_path):

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -45,6 +45,33 @@ def test_pull_extracts_zip_from_server(tmp_path):
     assert (tmp_path / "foo" / "bar" / "baz.yaml").exists()
 
 
+def test_reconstruct_deployment_spec_separates_preaggregations(tmp_path):
+    """Pre-agg YAML files (identified by measure_columns) route to preaggregations."""
+    (tmp_path / "dj.yaml").write_text("namespace: ns\n")
+    (tmp_path / "revenue.yaml").write_text(
+        "name: ns.revenue\nnode_type: metric\nquery: SELECT SUM(amount) FROM ns.fct\n",
+    )
+    (tmp_path / "revenue_agg.preagg.yaml").write_text(
+        "name: revenue_by_day\n"
+        "metrics:\n  - ns.revenue\n"
+        "dimensions:\n  - ns.date.day\n"
+        "catalog: default\n"
+        "schema: agg\n"
+        "table: revenue_agg\n"
+        "measure_columns:\n  ns.revenue: revenue_sum\n",
+    )
+
+    svc = DeploymentService(MagicMock())
+    spec, _ = svc._reconstruct_deployment_spec(tmp_path)
+
+    assert [node["name"] for node in spec["nodes"]] == ["ns.revenue"]
+    assert len(spec["preaggregations"]) == 1
+    assert spec["preaggregations"][0]["name"] == "revenue_by_day"
+    assert spec["preaggregations"][0]["measure_columns"] == {
+        "ns.revenue": "revenue_sum",
+    }
+
+
 def test_pull_uploads_existing_yaml_files(tmp_path):
     (tmp_path / "old.yaml").write_text("name: ns.old\n")
     updated_zip = _make_zip({"old.yaml": "name: ns.old\nquery: SELECT 2\n"})

--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -57,6 +57,7 @@ from datajunction_server.models.preaggregation import (
     BackfillResponse,
     BulkDeactivateWorkflowsResponse,
     DeactivatedWorkflowInfo,
+    ExternalPreAggTable,
     GrainMode,
     DEFAULT_SCHEDULE,
     PlanPreAggregationsRequest,
@@ -686,42 +687,31 @@ async def plan_preaggregations(
     )
 
 
-@router.post(
-    "/preaggs/register",
-    response_model=PlanPreAggregationsResponse,
-    status_code=HTTPStatus.CREATED,
-    name="Register External Pre-aggregations",
-)
-async def register_preaggregations(
-    data: RegisterPreAggregationsRequest,
+async def register_external_preaggregations(
+    session: AsyncSession,
+    query_service_client: QueryServiceClient,
+    request_headers: dict[str, str],
     *,
-    session: AsyncSession = Depends(get_session),
-    request: Request,
-    query_service_client: QueryServiceClient = Depends(get_query_service_client),
-) -> PlanPreAggregationsResponse:
+    name: Optional[str],
+    metrics: list[str],
+    dimensions: list[str],
+    table: ExternalPreAggTable,
+    measure_columns: dict[str, str],
+) -> list[PreAggregation]:
     """
-    Register an externally-built pre-aggregation table.
+    Core logic for adopting an externally-built pre-aggregation table.
 
-    Unlike ``/preaggs/plan`` (where DJ generates and owns the materialization),
-    this adopts a table built by an external pipeline. DJ decomposes the
-    requested metrics into component measures, binds each measure to a physical
-    column via ``measure_columns``, validates them against the table, records
-    the pre-aggregation, and — when ``valid_through_ts`` is supplied — marks it
-    available so grain resolution can route queries to it.
+    Decomposes ``metrics`` into component measures, binds each to a physical
+    column via ``measure_columns``, validates them against ``table``, and upserts
+    the pre-aggregation(s) marked ``EXTERNAL``. Flushes but does NOT commit — the
+    caller owns the transaction (the endpoint commits; the deploy orchestrator
+    commits its whole plan). Callers must ensure ``query_service_client`` is
+    configured. Returns the created/updated pre-aggregations.
     """
-    request_headers = dict(request.headers)
-    if not query_service_client:
-        raise DJConfigurationException(
-            message=(
-                "Registering external pre-aggregations requires a configured "
-                "query service for column inference."
-            ),
-        )
-
     # 1. Validate each mapped metric is a measure, and map its single component's
     #    expression hash to the declared physical column.
     measure_hash_to_column: dict[str, str] = {}
-    for metric_name, physical_column in data.measure_columns.items():
+    for metric_name, physical_column in measure_columns.items():
         node = await Node.get_by_name(
             session,
             metric_name,
@@ -754,18 +744,18 @@ async def register_preaggregations(
     # 2. Decompose the requested metrics into grain groups (no SQL is executed).
     measures_result = await build_measures_sql(
         session=session,
-        metrics=data.metrics,
-        dimensions=data.dimensions,
+        metrics=metrics,
+        dimensions=dimensions,
         dialect=Dialect.SPARK,
         use_materialized=False,
     )
 
     # 3. Introspect the external table and confirm the declared columns exist.
-    catalog = await get_catalog_by_name(session=session, name=data.table.catalog)
+    catalog = await get_catalog_by_name(session=session, name=table.catalog)
     table_columns = await query_service_client.get_columns_for_table(
         catalog.name,
-        data.table.schema_,
-        data.table.table,
+        table.schema_,
+        table.table,
         request_headers,
         catalog.engines[0] if catalog.engines else None,
     )
@@ -779,8 +769,7 @@ async def register_preaggregations(
         raise DJInvalidInputException(
             message=(
                 f"Columns {missing_columns} declared in measure_columns were not "
-                f"found in table "
-                f"{data.table.catalog}.{data.table.schema_}.{data.table.table}."
+                f"found in table {table.catalog}.{table.schema_}.{table.table}."
             ),
         )
 
@@ -794,7 +783,7 @@ async def register_preaggregations(
         node_revision_id = parent_node.current.id
         grain_columns = list(measures_result.requested_dimensions)
 
-        measures: list[PreAggMeasure] = []
+        grain_measures: list[PreAggMeasure] = []
         for component in grain_group.components:
             expr_hash = compute_expression_hash(component.expression)
             if expr_hash not in measure_hash_to_column:
@@ -805,7 +794,7 @@ async def register_preaggregations(
                         f"is_measure metric it corresponds to."
                     ),
                 )
-            measures.append(
+            grain_measures.append(
                 PreAggMeasure(
                     **{
                         **component.model_dump(),
@@ -833,47 +822,93 @@ async def register_preaggregations(
             session=session,
             node_revision_id=node_revision_id,
             grain_columns=grain_columns,
-            measure_expr_hashes={m.expr_hash for m in measures if m.expr_hash},
+            measure_expr_hashes={m.expr_hash for m in grain_measures if m.expr_hash},
         )
         if existing:
-            existing.measures = measures
+            existing.measures = grain_measures
             existing.columns = columns
             existing.sql = grain_group.sql
             existing.strategy = MaterializationStrategy.EXTERNAL
-            existing.name = data.name
+            existing.name = name
             preagg = existing
         else:
             preagg = PreAggregation(
                 node_revision_id=node_revision_id,
                 grain_columns=grain_columns,
-                measures=measures,
+                measures=grain_measures,
                 columns=columns,
                 sql=grain_group.sql,
                 grain_group_hash=grain_group_hash,
                 preagg_hash=compute_preagg_hash(
                     node_revision_id,
                     grain_columns,
-                    measures,
+                    grain_measures,
                 ),
                 strategy=MaterializationStrategy.EXTERNAL,
-                name=data.name,
+                name=name,
             )
             session.add(preagg)
         created_preaggs.append(preagg)
 
         # 5. Set availability immediately when freshness is provided; otherwise
         #    leave it pending for the availability callback to report.
-        if data.table.valid_through_ts is not None:
+        if table.valid_through_ts is not None:
             availability = AvailabilityState(
-                catalog=data.table.catalog,
-                schema_=data.table.schema_,
-                table=data.table.table,
-                valid_through_ts=data.table.valid_through_ts,
+                catalog=table.catalog,
+                schema_=table.schema_,
+                table=table.table,
+                valid_through_ts=table.valid_through_ts,
             )
             session.add(availability)
             await session.flush()
             preagg.availability_id = availability.id
 
+    await session.flush()
+    return created_preaggs
+
+
+@router.post(
+    "/preaggs/register",
+    response_model=PlanPreAggregationsResponse,
+    status_code=HTTPStatus.CREATED,
+    name="Register External Pre-aggregations",
+)
+async def register_preaggregations(
+    data: RegisterPreAggregationsRequest,
+    *,
+    session: AsyncSession = Depends(get_session),
+    request: Request,
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+) -> PlanPreAggregationsResponse:
+    """
+    Register an externally-built pre-aggregation table.
+
+    Unlike ``/preaggs/plan`` (where DJ generates and owns the materialization),
+    this adopts a table built by an external pipeline. DJ decomposes the
+    requested metrics into component measures, binds each measure to a physical
+    column via ``measure_columns``, validates them against the table, records
+    the pre-aggregation, and — when ``valid_through_ts`` is supplied — marks it
+    available so grain resolution can route queries to it.
+    """
+    request_headers = dict(request.headers)
+    if not query_service_client:
+        raise DJConfigurationException(
+            message=(
+                "Registering external pre-aggregations requires a configured "
+                "query service for column inference."
+            ),
+        )
+
+    created_preaggs = await register_external_preaggregations(
+        session,
+        query_service_client,
+        request_headers,
+        name=data.name,
+        metrics=data.metrics,
+        dimensions=data.dimensions,
+        table=data.table,
+        measure_columns=data.measure_columns,
+    )
     await session.commit()
 
     preagg_ids = [p.id for p in created_preaggs]

--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -39,8 +39,6 @@ from datajunction_server.database.preaggregation import (
     compute_expression_hash,
     compute_preagg_hash,
 )
-from datajunction_server.api.helpers import get_catalog_by_name
-from datajunction_server.sql.decompose import MetricComponentExtractor
 from datajunction_server.errors import (
     DJConfigurationException,
     DJDoesNotExistException,
@@ -48,6 +46,9 @@ from datajunction_server.errors import (
     DJQueryServiceClientException,
 )
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.preaggregations import (
+    register_external_preaggregations,
+)
 from datajunction_server.models.node_type import NodeNameVersion, NodeType
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.materialization import MaterializationStrategy
@@ -57,7 +58,6 @@ from datajunction_server.models.preaggregation import (
     BackfillResponse,
     BulkDeactivateWorkflowsResponse,
     DeactivatedWorkflowInfo,
-    ExternalPreAggTable,
     GrainMode,
     DEFAULT_SCHEDULE,
     PlanPreAggregationsRequest,
@@ -685,246 +685,6 @@ async def plan_preaggregations(
     return PlanPreAggregationsResponse(
         preaggs=[await _preagg_to_info(p, session) for p in loaded_preaggs],
     )
-
-
-def _assert_measure_column_compatible(
-    *,
-    measure_name: str,
-    physical_column: str,
-    expected_type: Optional[str],
-    actual_type: object,
-    table: "ExternalPreAggTable",
-) -> None:
-    """
-    Reject a ``measure_columns`` mapping whose physical column type is
-    incompatible with the measure's expected type (e.g. a SUM measure bound to
-    a string column).
-
-    Conservative by design: both types are re-parsed into concrete
-    ``ColumnType`` subclasses (the query service wraps physical types as a bare
-    ``ColumnType`` string, which ``is_compatible`` cannot reason about), and the
-    check is skipped whenever a type is unknown or unparseable. Only clear
-    cross-family mismatches are rejected, so int-vs-bigint never false-fails.
-    """
-    from typing import cast
-
-    from datajunction_server.sql.parsing.backends.antlr4 import parse_rule
-    from datajunction_server.sql.parsing.types import ColumnType
-
-    if expected_type is None:  # pragma: no cover - defensive
-        return
-    try:
-        expected = cast(ColumnType, parse_rule(str(expected_type), "dataType"))
-        actual = cast(ColumnType, parse_rule(str(actual_type), "dataType"))
-    except Exception:  # pragma: no cover - defensive
-        return
-    if not expected.is_compatible(actual):
-        raise DJInvalidInputException(
-            message=(
-                f"Column '{physical_column}' (type {actual}) in table "
-                f"{table.catalog}.{table.schema_}.{table.table} is not "
-                f"type-compatible with measure '{measure_name}' "
-                f"(expected {expected})."
-            ),
-        )
-
-
-async def register_external_preaggregations(
-    session: AsyncSession,
-    query_service_client: QueryServiceClient,
-    request_headers: dict[str, str],
-    *,
-    name: Optional[str],
-    metrics: list[str],
-    dimensions: list[str],
-    table: ExternalPreAggTable,
-    measure_columns: dict[str, str],
-) -> list[PreAggregation]:
-    """
-    Core logic for adopting an externally-built pre-aggregation table.
-
-    Decomposes ``metrics`` into component measures, binds each to a physical
-    column via ``measure_columns``, validates them against ``table``, and upserts
-    the pre-aggregation(s) marked ``EXTERNAL``. Flushes but does NOT commit — the
-    caller owns the transaction (the endpoint commits; the deploy orchestrator
-    commits its whole plan). Callers must ensure ``query_service_client`` is
-    configured. Returns the created/updated pre-aggregations.
-    """
-    # 1. Validate each mapped metric is a measure, and map its single component's
-    #    expression hash to the declared physical column.
-    measure_hash_to_column: dict[str, str] = {}
-    for metric_name, physical_column in measure_columns.items():
-        node = await Node.get_by_name(
-            session,
-            metric_name,
-            options=[
-                selectinload(Node.current).options(
-                    *NodeRevision.default_load_options(),
-                ),
-            ],
-            raise_if_not_exists=False,
-        )
-        if not node or node.type != NodeType.METRIC:
-            raise DJInvalidInputException(
-                message=f"'{metric_name}' in measure_columns is not a metric node.",
-            )
-        if not node.current.is_measure:
-            raise DJInvalidInputException(
-                message=(
-                    f"Metric '{metric_name}' is not a measure: its query is not a "
-                    f"single aggregation that maps 1:1 to a column. Composite "
-                    f"metrics (e.g. AVG, ratios) must be modelled as derived "
-                    f"metrics over their base measures."
-                ),
-            )
-        components, _ = await MetricComponentExtractor(node.current.id).extract(session)
-        # is_measure guarantees exactly one component.
-        measure_hash_to_column[compute_expression_hash(components[0].expression)] = (
-            physical_column
-        )
-
-    # 2. Decompose the requested metrics into grain groups (no SQL is executed).
-    measures_result = await build_measures_sql(
-        session=session,
-        metrics=metrics,
-        dimensions=dimensions,
-        dialect=Dialect.SPARK,
-        use_materialized=False,
-    )
-
-    # 3. Introspect the external table and confirm the declared columns exist.
-    catalog = await get_catalog_by_name(session=session, name=table.catalog)
-    table_columns = await query_service_client.get_columns_for_table(
-        catalog.name,
-        table.schema_,
-        table.table,
-        request_headers,
-        catalog.engines[0] if catalog.engines else None,
-    )
-    table_columns_by_name = {col.name: col.type for col in table_columns}
-    missing_columns = sorted(
-        column
-        for column in measure_hash_to_column.values()
-        if column not in table_columns_by_name
-    )
-    if missing_columns:
-        raise DJInvalidInputException(
-            message=(
-                f"Columns {missing_columns} declared in measure_columns were not "
-                f"found in table {table.catalog}.{table.schema_}.{table.table}."
-            ),
-        )
-
-    # 4. For each grain group: verify measure coverage, bind source columns,
-    #    and upsert the pre-aggregation.
-    created_preaggs: list[PreAggregation] = []
-    for grain_group in measures_result.grain_groups:
-        parent_node = measures_result.ctx.nodes.get(grain_group.parent_name)
-        if not parent_node or not parent_node.current:  # pragma: no cover
-            continue
-        node_revision_id = parent_node.current.id
-        grain_columns = list(measures_result.requested_dimensions)
-
-        # Expected measure types, keyed by measure name, for the physical-column
-        # type-compatibility check below.
-        measure_types = {
-            col.name: col.type
-            for col in grain_group.columns
-            if col.semantic_type in ("metric_component", "measure", "metric")
-        }
-
-        grain_measures: list[PreAggMeasure] = []
-        for component in grain_group.components:
-            expr_hash = compute_expression_hash(component.expression)
-            if expr_hash not in measure_hash_to_column:
-                raise DJInvalidInputException(
-                    message=(
-                        f"Measure '{component.name}' required by the requested "
-                        f"metrics is not covered by measure_columns. Add the "
-                        f"is_measure metric it corresponds to."
-                    ),
-                )
-            physical_column = measure_hash_to_column[expr_hash]
-            measure_name = grain_group.component_aliases.get(
-                component.name,
-                component.name,
-            )
-            _assert_measure_column_compatible(
-                measure_name=component.name,
-                physical_column=physical_column,
-                expected_type=measure_types.get(measure_name)
-                or measure_types.get(component.name),
-                actual_type=table_columns_by_name[physical_column],
-                table=table,
-            )
-            grain_measures.append(
-                PreAggMeasure(
-                    **{
-                        **component.model_dump(),
-                        "name": measure_name,
-                    },
-                    expr_hash=expr_hash,
-                    source_column=physical_column,
-                ),
-            )
-
-        columns = [
-            V3ColumnMetadata(
-                name=col.name,
-                type=col.type,
-                semantic_type=col.semantic_type,
-                semantic_name=col.semantic_name,
-            )
-            for col in grain_group.columns
-        ]
-        grain_group_hash = compute_grain_group_hash(node_revision_id, grain_columns)
-        existing = await PreAggregation.find_matching(
-            session=session,
-            node_revision_id=node_revision_id,
-            grain_columns=grain_columns,
-            measure_expr_hashes={m.expr_hash for m in grain_measures if m.expr_hash},
-        )
-        if existing:
-            existing.measures = grain_measures
-            existing.columns = columns
-            existing.sql = grain_group.sql
-            existing.strategy = MaterializationStrategy.EXTERNAL
-            existing.name = name
-            preagg = existing
-        else:
-            preagg = PreAggregation(
-                node_revision_id=node_revision_id,
-                grain_columns=grain_columns,
-                measures=grain_measures,
-                columns=columns,
-                sql=grain_group.sql,
-                grain_group_hash=grain_group_hash,
-                preagg_hash=compute_preagg_hash(
-                    node_revision_id,
-                    grain_columns,
-                    grain_measures,
-                ),
-                strategy=MaterializationStrategy.EXTERNAL,
-                name=name,
-            )
-            session.add(preagg)
-        created_preaggs.append(preagg)
-
-        # 5. Set availability immediately when freshness is provided; otherwise
-        #    leave it pending for the availability callback to report.
-        if table.valid_through_ts is not None:
-            availability = AvailabilityState(
-                catalog=table.catalog,
-                schema_=table.schema_,
-                table=table.table,
-                valid_through_ts=table.valid_through_ts,
-            )
-            session.add(availability)
-            await session.flush()
-            preagg.availability_id = availability.id
-
-    await session.flush()
-    return created_preaggs
 
 
 @router.post(

--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -687,6 +687,48 @@ async def plan_preaggregations(
     )
 
 
+def _assert_measure_column_compatible(
+    *,
+    measure_name: str,
+    physical_column: str,
+    expected_type: Optional[str],
+    actual_type: object,
+    table: "ExternalPreAggTable",
+) -> None:
+    """
+    Reject a ``measure_columns`` mapping whose physical column type is
+    incompatible with the measure's expected type (e.g. a SUM measure bound to
+    a string column).
+
+    Conservative by design: both types are re-parsed into concrete
+    ``ColumnType`` subclasses (the query service wraps physical types as a bare
+    ``ColumnType`` string, which ``is_compatible`` cannot reason about), and the
+    check is skipped whenever a type is unknown or unparseable. Only clear
+    cross-family mismatches are rejected, so int-vs-bigint never false-fails.
+    """
+    from typing import cast
+
+    from datajunction_server.sql.parsing.backends.antlr4 import parse_rule
+    from datajunction_server.sql.parsing.types import ColumnType
+
+    if expected_type is None:  # pragma: no cover - defensive
+        return
+    try:
+        expected = cast(ColumnType, parse_rule(str(expected_type), "dataType"))
+        actual = cast(ColumnType, parse_rule(str(actual_type), "dataType"))
+    except Exception:  # pragma: no cover - defensive
+        return
+    if not expected.is_compatible(actual):
+        raise DJInvalidInputException(
+            message=(
+                f"Column '{physical_column}' (type {actual}) in table "
+                f"{table.catalog}.{table.schema_}.{table.table} is not "
+                f"type-compatible with measure '{measure_name}' "
+                f"(expected {expected})."
+            ),
+        )
+
+
 async def register_external_preaggregations(
     session: AsyncSession,
     query_service_client: QueryServiceClient,
@@ -759,11 +801,11 @@ async def register_external_preaggregations(
         request_headers,
         catalog.engines[0] if catalog.engines else None,
     )
-    table_column_names = {col.name for col in table_columns}
+    table_columns_by_name = {col.name: col.type for col in table_columns}
     missing_columns = sorted(
         column
         for column in measure_hash_to_column.values()
-        if column not in table_column_names
+        if column not in table_columns_by_name
     )
     if missing_columns:
         raise DJInvalidInputException(
@@ -783,6 +825,14 @@ async def register_external_preaggregations(
         node_revision_id = parent_node.current.id
         grain_columns = list(measures_result.requested_dimensions)
 
+        # Expected measure types, keyed by measure name, for the physical-column
+        # type-compatibility check below.
+        measure_types = {
+            col.name: col.type
+            for col in grain_group.columns
+            if col.semantic_type in ("metric_component", "measure", "metric")
+        }
+
         grain_measures: list[PreAggMeasure] = []
         for component in grain_group.components:
             expr_hash = compute_expression_hash(component.expression)
@@ -794,17 +844,27 @@ async def register_external_preaggregations(
                         f"is_measure metric it corresponds to."
                     ),
                 )
+            physical_column = measure_hash_to_column[expr_hash]
+            measure_name = grain_group.component_aliases.get(
+                component.name,
+                component.name,
+            )
+            _assert_measure_column_compatible(
+                measure_name=component.name,
+                physical_column=physical_column,
+                expected_type=measure_types.get(measure_name)
+                or measure_types.get(component.name),
+                actual_type=table_columns_by_name[physical_column],
+                table=table,
+            )
             grain_measures.append(
                 PreAggMeasure(
                     **{
                         **component.model_dump(),
-                        "name": grain_group.component_aliases.get(
-                            component.name,
-                            component.name,
-                        ),
+                        "name": measure_name,
                     },
                     expr_hash=expr_hash,
-                    source_column=measure_hash_to_column[expr_hash],
+                    source_column=physical_column,
                 ),
             )
 

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -378,6 +378,41 @@ class PreAggregation(Base):
         return result.scalar_one_or_none()
 
     @classmethod
+    async def get_external_by_namespace(
+        cls,
+        session: AsyncSession,
+        namespace: str,
+    ) -> List["PreAggregation"]:
+        """
+        Get all EXTERNAL-strategy pre-aggregations whose node lives in the given
+        namespace. Used by deploy-time reconciliation to diff against the spec.
+        """
+        from sqlalchemy.orm import joinedload
+
+        from datajunction_server.database.node import Node
+
+        statement = (
+            select(cls)
+            .join(NodeRevision, cls.node_revision_id == NodeRevision.id)
+            .join(Node, NodeRevision.node_id == Node.id)
+            .options(
+                joinedload(cls.node_revision),
+                joinedload(cls.availability),
+            )
+            .where(
+                # The deployment namespace is a prefix: nodes live in it or in a
+                # sub-namespace (e.g. "ns" and "ns.default").
+                sa.or_(
+                    Node.namespace == namespace,
+                    Node.namespace.like(f"{namespace}.%"),
+                ),
+                cls.strategy == MaterializationStrategy.EXTERNAL,
+            )
+        )
+        result = await session.execute(statement)
+        return list(result.scalars().unique().all())
+
+    @classmethod
     async def find_matching(
         cls,
         session: AsyncSession,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1041,7 +1041,7 @@ class DeploymentOrchestrator:
         exist. Skipped during dry runs (registration introspects the external
         table and mutates state). Reuses the same core as POST /preaggs/register.
         """
-        from datajunction_server.api.preaggregations import (
+        from datajunction_server.internal.preaggregations import (
             register_external_preaggregations,
         )
         from datajunction_server.database.preaggregation import PreAggregation

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1056,10 +1056,75 @@ class DeploymentOrchestrator:
         )
         if not specs and not existing:
             return
+
+        # Never mass-deregister external pre-aggs from a deploy that declares
+        # none: they may be managed out of band (POST /preaggs/register), or the
+        # pre-agg files may simply be absent from this push. Removing them all
+        # requires an explicit ``allow_empty`` opt-in (mirrors the node wipe
+        # guard). This is the real footgun -- the fully-empty-spec case is
+        # already refused upstream because a pre-agg's parent node is deleted too.
+        if not specs and not self.deployment_spec.allow_empty:
+            self.warnings.append(
+                DJError(
+                    code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                    message=(
+                        f"{len(existing)} external pre-aggregation(s) in "
+                        f"namespace '{namespace}' were left intact because the "
+                        f"deployment declares none. Re-run with allow_empty to "
+                        f"deregister them."
+                    ),
+                ),
+            )
+            logger.info(
+                "Skipped deregistering %d external pre-agg(s) in %s "
+                "(no specs declared, allow_empty not set)",
+                len(existing),
+                namespace,
+            )
+            return
+
+        declared_names = {spec.rendered_name for spec in specs}
+        existing_ids = {preagg.id for preagg in existing}
+        existing_names = {preagg.name for preagg in existing}
+
+        # Dry run: report the planned register/delete without mutating anything
+        # (no registration, so no external-table introspection either). Delete
+        # planning is name-level here; the wet run below deletes by row identity.
         if self.dry_run:
+            for spec in specs:
+                self.deployed_results.append(
+                    DeploymentResult(
+                        name=spec.rendered_name,
+                        deploy_type=DeploymentResult.Type.PREAGG,
+                        status=DeploymentResult.Status.SUCCESS,
+                        operation=(
+                            DeploymentResult.Operation.UPDATE
+                            if spec.rendered_name in existing_names
+                            else DeploymentResult.Operation.CREATE
+                        ),
+                        message="externally-built pre-aggregation",
+                    ),
+                )
+            for preagg in existing:
+                if preagg.name not in declared_names:
+                    self.deployed_results.append(
+                        DeploymentResult(
+                            name=preagg.name or f"preaggregation:{preagg.id}",
+                            deploy_type=DeploymentResult.Type.PREAGG,
+                            status=DeploymentResult.Status.SUCCESS,
+                            operation=DeploymentResult.Operation.DELETE,
+                            message="dropped from spec",
+                        ),
+                    )
             return
 
         query_service_client = self.context.query_service_client
+        request_headers = (
+            dict(self.context.request.headers) if self.context.request else {}
+        )
+
+        errors_before = len(self.errors)
+        upserted_ids: set[int] = set()
         if specs and not query_service_client:
             self.errors.append(
                 DJError(
@@ -1070,49 +1135,76 @@ class DeploymentOrchestrator:
                     ),
                 ),
             )
-            return
-        request_headers = (
-            dict(self.context.request.headers) if self.context.request else {}
-        )
+        else:
+            # Upsert each spec; track which pre-agg rows this deploy touched.
+            for spec in specs:
+                # A non-empty spec list implies a configured query service
+                # (guarded above). The assert narrows the Optional for mypy.
+                assert query_service_client is not None
+                try:
+                    created = await register_external_preaggregations(
+                        self.session,
+                        query_service_client,
+                        request_headers,
+                        name=spec.rendered_name,
+                        metrics=spec.rendered_metrics,
+                        dimensions=spec.rendered_dimensions,
+                        table=ExternalPreAggTable(
+                            catalog=spec.catalog,
+                            schema=spec.schema_,
+                            table=spec.table,
+                            valid_through_ts=spec.valid_through_ts,
+                        ),
+                        measure_columns=spec.rendered_measure_columns,
+                    )
+                    upserted_ids.update(preagg.id for preagg in created)
+                    for preagg in created:
+                        self.deployed_results.append(
+                            DeploymentResult(
+                                name=spec.rendered_name,
+                                deploy_type=DeploymentResult.Type.PREAGG,
+                                status=DeploymentResult.Status.SUCCESS,
+                                operation=(
+                                    DeploymentResult.Operation.UPDATE
+                                    if preagg.id in existing_ids
+                                    else DeploymentResult.Operation.CREATE
+                                ),
+                                message="externally-built pre-aggregation",
+                            ),
+                        )
+                except DJException as exc:
+                    self.errors.append(
+                        DJError(
+                            code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                            message=(
+                                f"Pre-aggregation '{spec.rendered_name}': {exc.message}"
+                            ),
+                        ),
+                    )
 
-        # Upsert each spec; track which pre-agg rows this deploy touched.
-        upserted_ids: set[int] = set()
-        for spec in specs:
-            # Guaranteed by the guard above: a non-empty spec list implies a
-            # configured query service. (assert narrows the Optional for mypy.)
-            assert query_service_client is not None
-            try:
-                created = await register_external_preaggregations(
-                    self.session,
-                    query_service_client,
-                    request_headers,
-                    name=spec.rendered_name,
-                    metrics=spec.rendered_metrics,
-                    dimensions=spec.rendered_dimensions,
-                    table=ExternalPreAggTable(
-                        catalog=spec.catalog,
-                        schema=spec.schema_,
-                        table=spec.table,
-                        valid_through_ts=spec.valid_through_ts,
-                    ),
-                    measure_columns=spec.rendered_measure_columns,
-                )
-                upserted_ids.update(preagg.id for preagg in created)
-            except DJException as exc:
-                self.errors.append(
-                    DJError(
-                        code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
-                        message=f"Pre-aggregation '{spec.rendered_name}': {exc.message}",
-                    ),
-                )
+        # If any spec failed to register, abort before deleting anything: a
+        # transient failure must not deregister a still-declared pre-agg, and
+        # the error must surface (the outer SAVEPOINT rolls the deploy back).
+        if len(self.errors) > errors_before:
+            raise DJInvalidDeploymentConfig(
+                message="Failed to reconcile pre-aggregations",
+                errors=self.errors,
+                warnings=self.warnings,
+            )
 
         # Delete-on-removal: any EXTERNAL pre-agg in this namespace not (re)created
-        # by this deploy has been dropped from the spec.
-        for preagg in await PreAggregation.get_external_by_namespace(
-            self.session,
-            namespace,
-        ):
+        # by this deploy has been dropped from the spec (or is a stale grain).
+        for preagg in existing:
             if preagg.id not in upserted_ids:
+                self.deployed_results.append(
+                    DeploymentResult(
+                        name=preagg.name or f"preaggregation:{preagg.id}",
+                        deploy_type=DeploymentResult.Type.PREAGG,
+                        status=DeploymentResult.Status.SUCCESS,
+                        operation=DeploymentResult.Operation.DELETE,
+                        message="dropped from spec",
+                    ),
+                )
                 await self.session.delete(preagg)
 
         await self.session.flush()
@@ -3135,6 +3227,11 @@ class DeploymentOrchestrator:
         deleting nodes that are genuinely absent from a real spec is the expected
         sync behavior. Also fires on dry-run, so a preview surfaces the refusal
         instead of quietly listing deletions.
+
+        Note: external pre-aggregations are protected transitively -- they hang
+        off parent nodes, so a fully-empty spec that would deregister them also
+        deletes those parents and is refused here. The case where a *content-ful*
+        spec omits pre-aggs is handled in ``_reconcile_preaggregations``.
         """
         spec = self.deployment_spec
         if spec.allow_empty or spec.nodes or spec.hierarchies or spec.tags:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -35,6 +35,7 @@ from datajunction_server.database.user import User, OAuthProvider
 from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.errors import (
     DJError,
+    DJException,
     DJInvalidDeploymentConfig,
     DJInvalidInputException,
     DJWarning,
@@ -437,10 +438,24 @@ class DeploymentOrchestrator:
         self._guard_against_accidental_wipe(deployment_plan)
 
         if deployment_plan.is_empty() and not self.deployment_spec.hierarchies:
-            return DeploymentExecuteResult(
-                results=await self._handle_no_changes(),
-                downstream_impacts=[],
+            # Pre-aggregations still need reconciling on an otherwise-empty
+            # deploy: to register specs, or to delete external pre-aggs that were
+            # dropped from the spec.
+            from datajunction_server.database.preaggregation import PreAggregation
+
+            needs_preagg_reconcile = bool(
+                self.deployment_spec.preaggregations,
+            ) or bool(
+                await PreAggregation.get_external_by_namespace(
+                    self.session,
+                    self.deployment_spec.namespace,
+                ),
             )
+            if not needs_preagg_reconcile:
+                return DeploymentExecuteResult(
+                    results=await self._handle_no_changes(),
+                    downstream_impacts=[],
+                )
 
         downstream = await self._execute_deployment_plan(deployment_plan)
         return DeploymentExecuteResult(
@@ -1017,6 +1032,92 @@ class DeploymentOrchestrator:
         await self.session.flush()
         logger.info("Upserted %d hierarchies", len(valid_specs))
 
+    async def _reconcile_preaggregations(self) -> None:
+        """
+        Register externally-built pre-aggregations declared in the spec, and
+        remove EXTERNAL pre-aggs in this namespace that were dropped from it.
+
+        Runs after nodes/links/cubes so the referenced metrics and dimensions
+        exist. Skipped during dry runs (registration introspects the external
+        table and mutates state). Reuses the same core as POST /preaggs/register.
+        """
+        from datajunction_server.api.preaggregations import (
+            register_external_preaggregations,
+        )
+        from datajunction_server.database.preaggregation import PreAggregation
+        from datajunction_server.models.preaggregation import ExternalPreAggTable
+
+        specs = self.deployment_spec.preaggregations
+        namespace = self.deployment_spec.namespace
+
+        existing = await PreAggregation.get_external_by_namespace(
+            self.session,
+            namespace,
+        )
+        if not specs and not existing:
+            return
+        if self.dry_run:
+            return
+
+        query_service_client = self.context.query_service_client
+        if specs and not query_service_client:
+            self.errors.append(
+                DJError(
+                    code=ErrorCode.QUERY_SERVICE_ERROR,
+                    message=(
+                        "Registering pre-aggregations requires a configured query "
+                        "service for column inference."
+                    ),
+                ),
+            )
+            return
+        request_headers = (
+            dict(self.context.request.headers) if self.context.request else {}
+        )
+
+        # Upsert each spec; track which pre-agg rows this deploy touched.
+        upserted_ids: set[int] = set()
+        for spec in specs:
+            # Guaranteed by the guard above: a non-empty spec list implies a
+            # configured query service. (assert narrows the Optional for mypy.)
+            assert query_service_client is not None
+            try:
+                created = await register_external_preaggregations(
+                    self.session,
+                    query_service_client,
+                    request_headers,
+                    name=spec.rendered_name,
+                    metrics=spec.rendered_metrics,
+                    dimensions=spec.rendered_dimensions,
+                    table=ExternalPreAggTable(
+                        catalog=spec.catalog,
+                        schema=spec.schema_,
+                        table=spec.table,
+                        valid_through_ts=spec.valid_through_ts,
+                    ),
+                    measure_columns=spec.rendered_measure_columns,
+                )
+                upserted_ids.update(preagg.id for preagg in created)
+            except DJException as exc:
+                self.errors.append(
+                    DJError(
+                        code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                        message=f"Pre-aggregation '{spec.rendered_name}': {exc.message}",
+                    ),
+                )
+
+        # Delete-on-removal: any EXTERNAL pre-agg in this namespace not (re)created
+        # by this deploy has been dropped from the spec.
+        for preagg in await PreAggregation.get_external_by_namespace(
+            self.session,
+            namespace,
+        ):
+            if preagg.id not in upserted_ids:
+                await self.session.delete(preagg)
+
+        await self.session.flush()
+        logger.info("Reconciled %d pre-aggregation spec(s)", len(specs))
+
     async def _setup_owners(self):
         """
         Validate that all owners defined in the deployment spec exist.
@@ -1469,6 +1570,10 @@ class DeploymentOrchestrator:
         # (no node changes) are not silently dropped.
         with timer.phase("deploy hierarchies"):
             await self._setup_hierarchies()
+
+        # Register/reconcile externally-built pre-aggregations after nodes exist.
+        with timer.phase("reconcile preaggregations"):
+            await self._reconcile_preaggregations()
 
         # Run impact propagation before deletions so deleted nodes'
         # children are still reachable via NodeRelationship.

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -1,0 +1,272 @@
+"""
+Internal pre-aggregation logic shared by the API layer and the deployment
+orchestrator.
+
+The reusable core lives here (rather than in ``api/preaggregations.py``) so that
+``internal`` code -- notably the deployment orchestrator's reconcile step -- can
+call it without importing from the ``api`` layer, keeping the dependency
+direction api -> internal.
+"""
+
+from typing import Optional, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from datajunction_server.api.helpers import get_catalog_by_name
+from datajunction_server.construction.build_v3.builder import build_measures_sql
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.availabilitystate import AvailabilityState
+from datajunction_server.database.preaggregation import (
+    PreAggregation,
+    compute_expression_hash,
+    compute_grain_group_hash,
+    compute_preagg_hash,
+)
+from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.models.decompose import PreAggMeasure
+from datajunction_server.models.dialect import Dialect
+from datajunction_server.models.materialization import MaterializationStrategy
+from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.preaggregation import ExternalPreAggTable
+from datajunction_server.models.query import V3ColumnMetadata
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.sql.decompose import MetricComponentExtractor
+
+
+def assert_measure_column_compatible(
+    *,
+    measure_name: str,
+    physical_column: str,
+    expected_type: Optional[str],
+    actual_type: object,
+    table: ExternalPreAggTable,
+) -> None:
+    """
+    Reject a ``measure_columns`` mapping whose physical column type is
+    incompatible with the measure's expected type (e.g. a SUM measure bound to
+    a string column).
+
+    Conservative by design: both types are re-parsed into concrete
+    ``ColumnType`` subclasses (the query service wraps physical types as a bare
+    ``ColumnType`` string, which ``is_compatible`` cannot reason about), and the
+    check is skipped whenever a type is unknown or unparseable. Only clear
+    cross-family mismatches are rejected, so int-vs-bigint never false-fails.
+    """
+    from datajunction_server.sql.parsing.backends.antlr4 import parse_rule
+    from datajunction_server.sql.parsing.types import ColumnType
+
+    if expected_type is None:  # pragma: no cover - defensive
+        return
+    try:
+        expected = cast(ColumnType, parse_rule(str(expected_type), "dataType"))
+        actual = cast(ColumnType, parse_rule(str(actual_type), "dataType"))
+    except Exception:  # pragma: no cover - defensive
+        return
+    if not expected.is_compatible(actual):
+        raise DJInvalidInputException(
+            message=(
+                f"Column '{physical_column}' (type {actual}) in table "
+                f"{table.catalog}.{table.schema_}.{table.table} is not "
+                f"type-compatible with measure '{measure_name}' "
+                f"(expected {expected})."
+            ),
+        )
+
+
+async def register_external_preaggregations(
+    session: AsyncSession,
+    query_service_client: QueryServiceClient,
+    request_headers: dict[str, str],
+    *,
+    name: Optional[str],
+    metrics: list[str],
+    dimensions: list[str],
+    table: ExternalPreAggTable,
+    measure_columns: dict[str, str],
+) -> list[PreAggregation]:
+    """
+    Core logic for adopting an externally-built pre-aggregation table.
+
+    Decomposes ``metrics`` into component measures, binds each to a physical
+    column via ``measure_columns``, validates them against ``table``, and upserts
+    the pre-aggregation(s) marked ``EXTERNAL``. Flushes but does NOT commit — the
+    caller owns the transaction (the endpoint commits; the deploy orchestrator
+    commits its whole plan). Callers must ensure ``query_service_client`` is
+    configured. Returns the created/updated pre-aggregations.
+    """
+    # 1. Validate each mapped metric is a measure, and map its single component's
+    #    expression hash to the declared physical column.
+    measure_hash_to_column: dict[str, str] = {}
+    for metric_name, physical_column in measure_columns.items():
+        node = await Node.get_by_name(
+            session,
+            metric_name,
+            options=[
+                selectinload(Node.current).options(
+                    *NodeRevision.default_load_options(),
+                ),
+            ],
+            raise_if_not_exists=False,
+        )
+        if not node or node.type != NodeType.METRIC:
+            raise DJInvalidInputException(
+                message=f"'{metric_name}' in measure_columns is not a metric node.",
+            )
+        if not node.current.is_measure:
+            raise DJInvalidInputException(
+                message=(
+                    f"Metric '{metric_name}' is not a measure: its query is not a "
+                    f"single aggregation that maps 1:1 to a column. Composite "
+                    f"metrics (e.g. AVG, ratios) must be modelled as derived "
+                    f"metrics over their base measures."
+                ),
+            )
+        components, _ = await MetricComponentExtractor(node.current.id).extract(session)
+        # is_measure guarantees exactly one component.
+        measure_hash_to_column[compute_expression_hash(components[0].expression)] = (
+            physical_column
+        )
+
+    # 2. Decompose the requested metrics into grain groups (no SQL is executed).
+    measures_result = await build_measures_sql(
+        session=session,
+        metrics=metrics,
+        dimensions=dimensions,
+        dialect=Dialect.SPARK,
+        use_materialized=False,
+    )
+
+    # 3. Introspect the external table and confirm the declared columns exist.
+    catalog = await get_catalog_by_name(session=session, name=table.catalog)
+    table_columns = await query_service_client.get_columns_for_table(
+        catalog.name,
+        table.schema_,
+        table.table,
+        request_headers,
+        catalog.engines[0] if catalog.engines else None,
+    )
+    table_columns_by_name = {col.name: col.type for col in table_columns}
+    missing_columns = sorted(
+        column
+        for column in measure_hash_to_column.values()
+        if column not in table_columns_by_name
+    )
+    if missing_columns:
+        raise DJInvalidInputException(
+            message=(
+                f"Columns {missing_columns} declared in measure_columns were not "
+                f"found in table {table.catalog}.{table.schema_}.{table.table}."
+            ),
+        )
+
+    # 4. For each grain group: verify measure coverage, bind source columns,
+    #    and upsert the pre-aggregation.
+    created_preaggs: list[PreAggregation] = []
+    for grain_group in measures_result.grain_groups:
+        parent_node = measures_result.ctx.nodes.get(grain_group.parent_name)
+        if not parent_node or not parent_node.current:  # pragma: no cover
+            continue
+        node_revision_id = parent_node.current.id
+        grain_columns = list(measures_result.requested_dimensions)
+
+        # Expected measure types, keyed by measure name, for the physical-column
+        # type-compatibility check below.
+        measure_types = {
+            col.name: col.type
+            for col in grain_group.columns
+            if col.semantic_type in ("metric_component", "measure", "metric")
+        }
+
+        grain_measures: list[PreAggMeasure] = []
+        for component in grain_group.components:
+            expr_hash = compute_expression_hash(component.expression)
+            if expr_hash not in measure_hash_to_column:
+                raise DJInvalidInputException(
+                    message=(
+                        f"Measure '{component.name}' required by the requested "
+                        f"metrics is not covered by measure_columns. Add the "
+                        f"is_measure metric it corresponds to."
+                    ),
+                )
+            physical_column = measure_hash_to_column[expr_hash]
+            measure_name = grain_group.component_aliases.get(
+                component.name,
+                component.name,
+            )
+            assert_measure_column_compatible(
+                measure_name=component.name,
+                physical_column=physical_column,
+                expected_type=measure_types.get(measure_name)
+                or measure_types.get(component.name),
+                actual_type=table_columns_by_name[physical_column],
+                table=table,
+            )
+            grain_measures.append(
+                PreAggMeasure(
+                    **{
+                        **component.model_dump(),
+                        "name": measure_name,
+                    },
+                    expr_hash=expr_hash,
+                    source_column=physical_column,
+                ),
+            )
+
+        columns = [
+            V3ColumnMetadata(
+                name=col.name,
+                type=col.type,
+                semantic_type=col.semantic_type,
+                semantic_name=col.semantic_name,
+            )
+            for col in grain_group.columns
+        ]
+        grain_group_hash = compute_grain_group_hash(node_revision_id, grain_columns)
+        existing = await PreAggregation.find_matching(
+            session=session,
+            node_revision_id=node_revision_id,
+            grain_columns=grain_columns,
+            measure_expr_hashes={m.expr_hash for m in grain_measures if m.expr_hash},
+        )
+        if existing:
+            existing.measures = grain_measures
+            existing.columns = columns
+            existing.sql = grain_group.sql
+            existing.strategy = MaterializationStrategy.EXTERNAL
+            existing.name = name
+            preagg = existing
+        else:
+            preagg = PreAggregation(
+                node_revision_id=node_revision_id,
+                grain_columns=grain_columns,
+                measures=grain_measures,
+                columns=columns,
+                sql=grain_group.sql,
+                grain_group_hash=grain_group_hash,
+                preagg_hash=compute_preagg_hash(
+                    node_revision_id,
+                    grain_columns,
+                    grain_measures,
+                ),
+                strategy=MaterializationStrategy.EXTERNAL,
+                name=name,
+            )
+            session.add(preagg)
+        created_preaggs.append(preagg)
+
+        # 5. Set availability immediately when freshness is provided; otherwise
+        #    leave it pending for the availability callback to report.
+        if table.valid_through_ts is not None:
+            availability = AvailabilityState(
+                catalog=table.catalog,
+                schema_=table.schema_,
+                table=table.table,
+                valid_through_ts=table.valid_through_ts,
+            )
+            session.add(availability)
+            await session.flush()
+            preagg.availability_id = availability.id
+
+    await session.flush()
+    return created_preaggs

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -115,6 +115,41 @@ class HierarchySpec(NamespacedSpec):
     levels: list[HierarchyLevelSpec] = Field(default_factory=list, min_length=2)
 
 
+class PreAggSpec(NamespacedSpec):
+    """
+    Specification for an externally-built pre-aggregation table adopted at deploy
+    time (equivalent to POST /preaggs/register). ``name`` is a stable handle used
+    for reconciliation and availability callbacks. Metric/dimension references may
+    use ``${prefix}`` or be fully qualified; they are rendered against the
+    deployment namespace.
+    """
+
+    metrics: list[str] = Field(default_factory=list)
+    dimensions: list[str] = Field(default_factory=list)
+    catalog: str
+    schema_: str = Field(alias="schema")
+    table: str
+    valid_through_ts: int | None = None
+    measure_columns: dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @property
+    def rendered_metrics(self) -> list[str]:
+        return [render_prefixes(metric, self.namespace) for metric in self.metrics]
+
+    @property
+    def rendered_dimensions(self) -> list[str]:
+        return [render_prefixes(dim, self.namespace) for dim in self.dimensions]
+
+    @property
+    def rendered_measure_columns(self) -> dict[str, str]:
+        return {
+            render_prefixes(metric, self.namespace): column
+            for metric, column in self.measure_columns.items()
+        }
+
+
 class PartitionSpec(BaseModel):
     """
     Represents a partition
@@ -850,6 +885,7 @@ class DeploymentSpec(BaseModel):
     nodes: list[NodeUnion] = Field(default_factory=list)
     tags: list[TagSpec] = Field(default_factory=list)
     hierarchies: list[HierarchySpec] = Field(default_factory=list)
+    preaggregations: list[PreAggSpec] = Field(default_factory=list)
     source: DeploymentSource | None = None  # CI/CD provenance tracking
     git_config: NamespaceGitConfig | None = None  # Git branch management config
     force: bool = Field(
@@ -916,6 +952,9 @@ class DeploymentSpec(BaseModel):
         for hierarchy in self.hierarchies:
             if not hierarchy.namespace:
                 hierarchy.namespace = self.namespace
+        for preagg in self.preaggregations:
+            if not preagg.namespace:
+                preagg.namespace = self.namespace
         return self
 
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -992,6 +992,7 @@ class DeploymentResult(BaseModel):
         LINK = "link"
         TAG = "tag"
         NAMESPACE = "namespace"
+        PREAGG = "preaggregation"
         GENERAL = "general"
 
     name: str

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5436,3 +5436,291 @@ class TestCubeBareDimRoleAwareDeployment:
         response = await client.get(f"/nodes/{namespace}.orders_cube/")
         assert response.status_code == 200, response.json()
         assert response.json()["status"] == "valid"
+
+
+def _hard_hat_deploy_nodes(default_hard_hats, default_us_states, default_us_state):
+    """Fact + dimension + link + a COUNT measure metric, for pre-agg deploy tests."""
+    hard_hat_facts = TransformSpec(
+        name="default.hard_hat_facts",
+        node_type=NodeType.TRANSFORM,
+        query="SELECT hard_hat_id, state FROM ${prefix}default.hard_hats",
+        dimension_links=[
+            DimensionJoinLinkSpec(
+                dimension_node="${prefix}default.us_state",
+                join_type="inner",
+                join_on=(
+                    "${prefix}default.hard_hat_facts.state = "
+                    "${prefix}default.us_state.state_short"
+                ),
+            ),
+        ],
+        owners=["dj"],
+    )
+    count_hard_hats = MetricSpec(
+        name="default.count_hard_hats",
+        node_type=NodeType.METRIC,
+        query="SELECT COUNT(*) FROM ${prefix}default.hard_hat_facts",
+        owners=["dj"],
+    )
+    return [
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+        hard_hat_facts,
+        count_hard_hats,
+    ]
+
+
+def _override_query_service(client, columns):
+    async def _fake_columns(*args, **kwargs):
+        return [SimpleNamespace(name=name) for name in columns]
+
+    mock_qs = MagicMock()
+    mock_qs.get_columns_for_table = _fake_columns
+    client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+
+
+def _clear_query_service(client):
+    client.app.dependency_overrides.pop(get_query_service_client, None)
+
+
+def _preagg_spec(name, table, measure_columns, dimensions=None):
+    return PreAggSpec(
+        name=name,
+        metrics=["${prefix}default.count_hard_hats"],
+        dimensions=dimensions or ["${prefix}default.us_state.state_name"],
+        catalog="default",
+        schema="analytics",
+        table=table,
+        valid_through_ts=1700000000,
+        measure_columns=measure_columns,
+    )
+
+
+class TestExternalPreAggDeploy:
+    """Deploy-time reconciliation of externally-registered pre-aggregations."""
+
+    @pytest.mark.asyncio
+    async def test_deploy_preagg_invalid_metric_fails(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """A pre-agg whose measure_columns key is not a valid measure is rejected;
+        no pre-agg is created."""
+        _override_query_service(client, ["hard_hat_count", "state_name"])
+        try:
+            bad = _preagg_spec(
+                "bad_preagg",
+                "hh_bad",
+                {"${prefix}default.does_not_exist": "hard_hat_count"},
+            )
+            await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_bad",
+                    nodes=_hard_hat_deploy_nodes(
+                        default_hard_hats,
+                        default_us_states,
+                        default_us_state,
+                    ),
+                    preaggregations=[bad],
+                ),
+            )
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_bad.default.hard_hat_facts"},
+            )
+            assert listing.status_code == 200
+            assert listing.json()["items"] == []
+        finally:
+            _clear_query_service(client)
+
+    @pytest.mark.asyncio
+    async def test_deploy_preagg_without_query_service(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """Registering pre-aggs needs a query service; without one, none are created."""
+        client.app.dependency_overrides[get_query_service_client] = lambda: None
+        try:
+            spec = _preagg_spec(
+                "needs_qs",
+                "hh_qs",
+                {"${prefix}default.count_hard_hats": "hard_hat_count"},
+            )
+            await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_noqs",
+                    nodes=_hard_hat_deploy_nodes(
+                        default_hard_hats,
+                        default_us_states,
+                        default_us_state,
+                    ),
+                    preaggregations=[spec],
+                ),
+            )
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_noqs.default.hard_hat_facts"},
+            )
+            assert listing.json()["items"] == []
+        finally:
+            _clear_query_service(client)
+
+    @pytest.mark.asyncio
+    async def test_dry_run_skips_preagg_reconcile(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """A dry-run (impact preview) does not register pre-aggregations."""
+        _override_query_service(client, ["hard_hat_count", "state_name"])
+        try:
+            nodes = _hard_hat_deploy_nodes(
+                default_hard_hats,
+                default_us_states,
+                default_us_state,
+            )
+            # Real deploy of the nodes (no pre-agg) so the fact node exists.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace="preagg_dry", nodes=nodes),
+            )
+            assert data["status"] == "success", data["results"]
+            # Dry-run impact WITH a pre-agg -> reconcile is skipped.
+            spec = _preagg_spec(
+                "dry_preagg",
+                "hh_dry",
+                {"${prefix}default.count_hard_hats": "hard_hat_count"},
+            )
+            await client.post(
+                "/deployments/impact",
+                json=DeploymentSpec(
+                    namespace="preagg_dry",
+                    nodes=nodes,
+                    preaggregations=[spec],
+                ).model_dump(),
+            )
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_dry.default.hard_hat_facts"},
+            )
+            assert listing.json()["items"] == []
+        finally:
+            _clear_query_service(client)
+
+    @pytest.mark.asyncio
+    async def test_delete_on_removal_scoped_to_namespace(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """A deploy to one namespace does not remove pre-aggs in another."""
+        _override_query_service(client, ["hard_hat_count", "state_name"])
+        try:
+            nodes = _hard_hat_deploy_nodes(
+                default_hard_hats,
+                default_us_states,
+                default_us_state,
+            )
+            spec = _preagg_spec(
+                "keep_me",
+                "hh_keep",
+                {"${prefix}default.count_hard_hats": "hard_hat_count"},
+            )
+            # Namespace A gets a pre-agg.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_a",
+                    nodes=nodes,
+                    preaggregations=[spec],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+            # Namespace B deploys with no pre-aggs.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace="preagg_b", nodes=nodes),
+            )
+            assert data["status"] == "success", data["results"]
+            # A's pre-agg is untouched.
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_a.default.hard_hat_facts"},
+            )
+            assert len(listing.json()["items"]) == 1
+        finally:
+            _clear_query_service(client)
+
+    @pytest.mark.asyncio
+    async def test_deploy_updates_existing_preagg(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """Re-deploying the same pre-agg with a different table/column updates it
+        in place rather than creating a duplicate."""
+        nodes = _hard_hat_deploy_nodes(
+            default_hard_hats,
+            default_us_states,
+            default_us_state,
+        )
+        try:
+            _override_query_service(client, ["hh_count_v1", "state_name"])
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_upd",
+                    nodes=nodes,
+                    preaggregations=[
+                        _preagg_spec(
+                            "hh_agg",
+                            "hh_agg_v1",
+                            {"${prefix}default.count_hard_hats": "hh_count_v1"},
+                        ),
+                    ],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+
+            _override_query_service(client, ["hh_count_v2", "state_name"])
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_upd",
+                    nodes=nodes,
+                    preaggregations=[
+                        _preagg_spec(
+                            "hh_agg",
+                            "hh_agg_v2",
+                            {"${prefix}default.count_hard_hats": "hh_count_v2"},
+                        ),
+                    ],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_upd.default.hard_hat_facts"},
+            )
+            items = listing.json()["items"]
+            assert len(items) == 1
+            source_columns = {m["source_column"] for m in items[0]["measures"]}
+            assert source_columns == {"hh_count_v2"}
+        finally:
+            _clear_query_service(client)

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1787,10 +1787,15 @@ class TestDeployments:
                 for measure in preagg["measures"]
             )
 
-            # Re-deploy without the preaggregation -> it is reconciled away.
+            # Re-deploy without the preaggregation -> declaring none never
+            # mass-deregisters, so allow_empty is required to reconcile it away.
             data = await deploy_and_wait(
                 client,
-                DeploymentSpec(namespace="preagg_deploy", nodes=nodes),
+                DeploymentSpec(
+                    namespace="preagg_deploy",
+                    nodes=nodes,
+                    allow_empty=True,
+                ),
             )
             assert data["status"] == "success", data["results"]
             listing = await client.get("/preaggs/", params={"node_name": fact_node})
@@ -5517,8 +5522,8 @@ class TestExternalPreAggDeploy:
         default_us_states,
         default_us_state,
     ):
-        """A pre-agg whose measure_columns key is not a valid measure is rejected;
-        no pre-agg is created."""
+        """A pre-agg whose measure_columns key is not a valid measure fails the
+        whole deploy and rolls it back -- no nodes or pre-aggs are left behind."""
         _override_query_service(client, ["hard_hat_count", "state_name"])
         try:
             bad = _preagg_spec(
@@ -5526,7 +5531,7 @@ class TestExternalPreAggDeploy:
                 "hh_bad",
                 {"${prefix}default.does_not_exist": "hard_hat_count"},
             )
-            await deploy_and_wait(
+            data = await deploy_and_wait(
                 client,
                 DeploymentSpec(
                     namespace="preagg_bad",
@@ -5538,12 +5543,13 @@ class TestExternalPreAggDeploy:
                     preaggregations=[bad],
                 ),
             )
-            listing = await client.get(
-                "/preaggs/",
-                params={"node_name": "preagg_bad.default.hard_hat_facts"},
-            )
-            assert listing.status_code == 200
-            assert listing.json()["items"] == []
+            assert data["status"] == "failed"
+            message = data["results"][-1]["message"]
+            assert "Failed to reconcile pre-aggregations" in message
+            assert "is not a metric node" in message
+            # The whole deploy rolled back: the fact node was not created.
+            node_resp = await client.get("/nodes/preagg_bad.default.hard_hat_facts")
+            assert node_resp.status_code == 404
         finally:
             _clear_query_service(client)
 
@@ -5555,7 +5561,8 @@ class TestExternalPreAggDeploy:
         default_us_states,
         default_us_state,
     ):
-        """Registering pre-aggs needs a query service; without one, none are created."""
+        """Registering pre-aggs needs a query service; without one the deploy
+        fails and rolls back rather than silently skipping."""
         client.app.dependency_overrides[get_query_service_client] = lambda: None
         try:
             spec = _preagg_spec(
@@ -5563,7 +5570,7 @@ class TestExternalPreAggDeploy:
                 "hh_qs",
                 {"${prefix}default.count_hard_hats": "hard_hat_count"},
             )
-            await deploy_and_wait(
+            data = await deploy_and_wait(
                 client,
                 DeploymentSpec(
                     namespace="preagg_noqs",
@@ -5575,23 +5582,25 @@ class TestExternalPreAggDeploy:
                     preaggregations=[spec],
                 ),
             )
-            listing = await client.get(
-                "/preaggs/",
-                params={"node_name": "preagg_noqs.default.hard_hat_facts"},
+            assert data["status"] == "failed"
+            assert (
+                "requires a configured query service" in data["results"][-1]["message"]
             )
-            assert listing.json()["items"] == []
+            # The whole deploy rolled back: the fact node was not created.
+            node_resp = await client.get("/nodes/preagg_noqs.default.hard_hat_facts")
+            assert node_resp.status_code == 404
         finally:
             _clear_query_service(client)
 
     @pytest.mark.asyncio
-    async def test_dry_run_skips_preagg_reconcile(
+    async def test_dry_run_reports_preagg_reconcile(
         self,
         client,
         default_hard_hats,
         default_us_states,
         default_us_state,
     ):
-        """A dry-run (impact preview) does not register pre-aggregations."""
+        """A dry-run reports the planned pre-agg register without persisting it."""
         _override_query_service(client, ["hard_hat_count", "state_name"])
         try:
             nodes = _hard_hat_deploy_nodes(
@@ -5605,25 +5614,64 @@ class TestExternalPreAggDeploy:
                 DeploymentSpec(namespace="preagg_dry", nodes=nodes),
             )
             assert data["status"] == "success", data["results"]
-            # Dry-run impact WITH a pre-agg -> reconcile is skipped.
+
             spec = _preagg_spec(
                 "dry_preagg",
                 "hh_dry",
                 {"${prefix}default.count_hard_hats": "hard_hat_count"},
             )
-            await client.post(
-                "/deployments/impact",
-                json=DeploymentSpec(
-                    namespace="preagg_dry",
-                    nodes=nodes,
-                    preaggregations=[spec],
-                ).model_dump(),
-            )
+
+            async def _impact_preagg_results(preaggs, allow_empty=False):
+                impact = await client.post(
+                    "/deployments/impact",
+                    json=DeploymentSpec(
+                        namespace="preagg_dry",
+                        nodes=nodes,
+                        preaggregations=preaggs,
+                        allow_empty=allow_empty,
+                    ).model_dump(),
+                )
+                return [
+                    r
+                    for r in impact.json()["results"]
+                    if r["deploy_type"] == "preaggregation"
+                ]
+
+            # Not yet registered -> planned CREATE, nothing persisted.
+            results = await _impact_preagg_results([spec])
+            assert len(results) == 1
+            assert results[0]["name"] == "preagg_dry.dry_preagg"
+            assert results[0]["operation"] == "create"
             listing = await client.get(
                 "/preaggs/",
                 params={"node_name": "preagg_dry.default.hard_hat_facts"},
             )
             assert listing.json()["items"] == []
+
+            # Actually register it, then dry-run again.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_dry",
+                    nodes=nodes,
+                    preaggregations=[spec],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+
+            # Re-declaring it -> planned UPDATE.
+            results = await _impact_preagg_results([spec])
+            assert [r["operation"] for r in results] == ["update"]
+
+            # Dropping it (allow_empty) -> planned DELETE, still there afterward.
+            results = await _impact_preagg_results([], allow_empty=True)
+            assert len(results) == 1
+            assert results[0]["operation"] == "delete"
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_dry.default.hard_hat_facts"},
+            )
+            assert len(listing.json()["items"]) == 1
         finally:
             _clear_query_service(client)
 
@@ -5731,5 +5779,64 @@ class TestExternalPreAggDeploy:
             assert len(items) == 1
             source_columns = {m["source_column"] for m in items[0]["measures"]}
             assert source_columns == {"hh_count_v2"}
+        finally:
+            _clear_query_service(client)
+
+    @pytest.mark.asyncio
+    async def test_preagg_kept_when_none_declared(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """A content-ful deploy that declares no pre-aggs leaves existing
+        external pre-aggs intact; allow_empty is required to deregister them."""
+        _override_query_service(client, ["hard_hat_count", "state_name"])
+        try:
+            nodes = _hard_hat_deploy_nodes(
+                default_hard_hats,
+                default_us_states,
+                default_us_state,
+            )
+            fact_node = "preagg_keep.default.hard_hat_facts"
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_keep",
+                    nodes=nodes,
+                    preaggregations=[
+                        _preagg_spec(
+                            "keep_me2",
+                            "hh_keep2",
+                            {"${prefix}default.count_hard_hats": "hard_hat_count"},
+                        ),
+                    ],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+
+            # Re-deploy the same nodes with NO pre-aggs -> the pre-agg is kept,
+            # not silently deregistered.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace="preagg_keep", nodes=nodes),
+            )
+            assert data["status"] == "success", data["results"]
+            listing = await client.get("/preaggs/", params={"node_name": fact_node})
+            assert len(listing.json()["items"]) == 1
+
+            # allow_empty opts into the deregistration.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_keep",
+                    nodes=nodes,
+                    allow_empty=True,
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+            listing = await client.get("/preaggs/", params={"node_name": fact_node})
+            assert listing.json()["items"] == []
         finally:
             _clear_query_service(client)

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -3,6 +3,7 @@ import json
 from unittest import mock
 import uuid
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from datajunction_server.models.deployment import (
@@ -18,7 +19,9 @@ from datajunction_server.models.deployment import (
     DimensionJoinLinkSpec,
     GitDeploymentSource,
     LocalDeploymentSource,
+    PreAggSpec,
 )
+from datajunction_server.utils import get_query_service_client
 from datajunction_server.internal.git.github_service import GitHubServiceError
 from datajunction_server.api.deployments import (
     InProcessExecutor,
@@ -1695,6 +1698,105 @@ class TestDeployments:
             "${prefix}default.us_state.state_name",
             "${prefix}default.us_state.state_region",
         ]
+
+    @pytest.mark.asyncio
+    async def test_deploy_reconciles_external_preaggregation(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        An externally-built pre-aggregation declared in the deployment spec is
+        registered at deploy time and reconciled away when dropped from the spec.
+        """
+        hard_hat_facts = TransformSpec(
+            name="default.hard_hat_facts",
+            node_type=NodeType.TRANSFORM,
+            query="SELECT hard_hat_id, state FROM ${prefix}default.hard_hats",
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="${prefix}default.us_state",
+                    join_type="inner",
+                    join_on=(
+                        "${prefix}default.hard_hat_facts.state = "
+                        "${prefix}default.us_state.state_short"
+                    ),
+                ),
+            ],
+            owners=["dj"],
+        )
+        count_hard_hats = MetricSpec(
+            name="default.count_hard_hats",
+            node_type=NodeType.METRIC,
+            query="SELECT COUNT(*) FROM ${prefix}default.hard_hat_facts",
+            owners=["dj"],
+        )
+        nodes = [
+            default_hard_hats,
+            default_us_states,
+            default_us_state,
+            hard_hat_facts,
+            count_hard_hats,
+        ]
+
+        async def _fake_columns(*args, **kwargs):
+            return [
+                SimpleNamespace(name="hard_hat_count"),
+                SimpleNamespace(name="state_name"),
+            ]
+
+        mock_qs = MagicMock()
+        mock_qs.get_columns_for_table = _fake_columns
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        fact_node = "preagg_deploy.default.hard_hat_facts"
+        try:
+            preagg_spec = PreAggSpec(
+                name="hard_hats_by_state",
+                metrics=["${prefix}default.count_hard_hats"],
+                dimensions=["${prefix}default.us_state.state_name"],
+                catalog="default",
+                schema="analytics",
+                table="hard_hats_agg",
+                valid_through_ts=1700000000,
+                measure_columns={
+                    "${prefix}default.count_hard_hats": "hard_hat_count",
+                },
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_deploy",
+                    nodes=nodes,
+                    preaggregations=[preagg_spec],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+
+            # The external pre-agg was registered against the fact node.
+            listing = await client.get("/preaggs/", params={"node_name": fact_node})
+            assert listing.status_code == 200, listing.text
+            items = listing.json()["items"]
+            assert len(items) == 1
+            preagg = items[0]
+            assert preagg["name"] == "preagg_deploy.hard_hats_by_state"
+            assert preagg["strategy"] == "external"
+            assert any(
+                measure["source_column"] == "hard_hat_count"
+                for measure in preagg["measures"]
+            )
+
+            # Re-deploy without the preaggregation -> it is reconciled away.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace="preagg_deploy", nodes=nodes),
+            )
+            assert data["status"] == "success", data["results"]
+            listing = await client.get("/preaggs/", params={"node_name": fact_node})
+            assert listing.json()["items"] == []
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
 
     @pytest.mark.asyncio
     async def test_deploy_dimension_with_update(

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1743,8 +1743,8 @@ class TestDeployments:
 
         async def _fake_columns(*args, **kwargs):
             return [
-                SimpleNamespace(name="hard_hat_count"),
-                SimpleNamespace(name="state_name"),
+                SimpleNamespace(name="hard_hat_count", type="bigint"),
+                SimpleNamespace(name="state_name", type="string"),
             ]
 
         mock_qs = MagicMock()
@@ -5472,8 +5472,17 @@ def _hard_hat_deploy_nodes(default_hard_hats, default_us_states, default_us_stat
 
 
 def _override_query_service(client, columns):
+    items = (
+        columns.items()
+        if isinstance(columns, dict)
+        else [(name, "bigint") for name in columns]
+    )
+    table_columns = [
+        SimpleNamespace(name=name, type=type_str) for name, type_str in items
+    ]
+
     async def _fake_columns(*args, **kwargs):
-        return [SimpleNamespace(name=name) for name in columns]
+        return table_columns
 
     mock_qs = MagicMock()
     mock_qs.get_columns_for_table = _fake_columns

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -2340,12 +2340,27 @@ class TestIncrementalTimeMaterialization:
         assert temporal_partition.granularity == "day"
 
 
-def _mock_query_service(client_with_build_v3, columns: list[str]):
-    """Override the query service so get_columns_for_table returns ``columns``."""
+def _mock_query_service(client_with_build_v3, columns):
+    """
+    Override the query service so get_columns_for_table returns ``columns``.
+
+    ``columns`` may be a list of column names (each defaulting to a numeric
+    type) or a mapping of column name -> SQL type string, for exercising the
+    measure/column type-compatibility check.
+    """
     from types import SimpleNamespace
 
+    items = (
+        columns.items()
+        if isinstance(columns, dict)
+        else [(name, "double") for name in columns]
+    )
+    table_columns = [
+        SimpleNamespace(name=name, type=type_str) for name, type_str in items
+    ]
+
     async def _fake_get_columns(*args, **kwargs):
-        return [SimpleNamespace(name=name) for name in columns]
+        return table_columns
 
     mock_client = MagicMock()
     mock_client.get_columns_for_table = _fake_get_columns
@@ -2444,6 +2459,45 @@ class TestRegisterPreAggregations:
             )
             assert response.status_code == 422
             assert "not found in table" in response.text
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_register_rejects_incompatible_column_type(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """A numeric measure bound to a non-numeric column is rejected."""
+        _mock_query_service(
+            client_with_build_v3,
+            {
+                "revenue_total": "string",  # incompatible: measure is numeric
+                "order_cnt": "double",
+                "category": "string",
+            },
+        )
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "bad_types_agg",
+                    },
+                    "measure_columns": {
+                        "v3.total_revenue": "revenue_total",
+                        "v3.order_count": "order_cnt",
+                    },
+                },
+            )
+            assert response.status_code == 422
+            message = response.json()["message"]
+            assert "'revenue_total' (type string)" in message
+            assert "default.analytics.bad_types_agg" in message
+            assert "is not type-compatible" in message
         finally:
             del client_with_build_v3.app.dependency_overrides[get_query_service_client]
 

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -2502,6 +2502,47 @@ class TestRegisterPreAggregations:
             del client_with_build_v3.app.dependency_overrides[get_query_service_client]
 
     @pytest.mark.asyncio
+    async def test_register_accepts_compatible_but_different_type(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """Type checking is category-level: a numeric measure binds to a numeric
+        column even when the exact type differs (e.g. bigint vs the inferred
+        double), so int/bigint/decimal never false-reject a valid registration."""
+        _mock_query_service(
+            client_with_build_v3,
+            {
+                "revenue_total": "bigint",  # compatible with the numeric measure
+                "order_cnt": "int",
+                "category": "string",
+            },
+        )
+        try:
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.avg_order_value"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "compatible_types_agg",
+                    },
+                    "measure_columns": {
+                        "v3.total_revenue": "revenue_total",
+                        "v3.order_count": "order_cnt",
+                    },
+                },
+            )
+            assert response.status_code == 201, response.text
+            source_columns = {
+                m["source_column"] for m in response.json()["preaggs"][0]["measures"]
+            }
+            assert source_columns == {"revenue_total", "order_cnt"}
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
     async def test_register_without_valid_through_ts_is_pending(
         self,
         client_with_build_v3: AsyncClient,

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -101,18 +101,49 @@ class TestExternalPreAggRouting:
             measure_columns={"v3.total_revenue": "revenue_sum"},
             table_columns=["status", "revenue_sum"],
         )
-        response = await client_with_build_v3.get(
+        # Measures SQL: reads the external table, applying SUM over the
+        # user-supplied physical column (revenue_sum) aliased to the measure.
+        measures_response = await client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.total_revenue"],
                 "dimensions": ["v3.order_details.status"],
             },
         )
-        assert response.status_code == 200
-        sql = get_first_grain_group(response.json())["sql"]
-        # Routed to the external table, reading the mapped physical column.
-        assert "default.analytics.revenue_by_status" in sql
-        assert "revenue_sum" in sql
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT status, SUM(revenue_sum) revenue_sum
+            FROM default.analytics.revenue_by_status
+            GROUP BY status
+            """,
+        )
+
+        # Metrics SQL: wraps the pre-agg read in a CTE and applies the combiner.
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, SUM(revenue_sum) revenue_sum
+                FROM default.analytics.revenue_by_status
+                GROUP BY status
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.revenue_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
 
     @pytest.mark.asyncio
     async def test_external_preagg_rolls_up_additive(self, client_with_build_v3):
@@ -130,15 +161,38 @@ class TestExternalPreAggRouting:
             measure_columns={"v3.total_revenue": "revenue_sum"},
             table_columns=["status", "revenue_sum"],
         )
-        # Query at a coarser grain (no dimensions) -> roll up the additive sum.
-        response = await client_with_build_v3.get(
+        # Query at a coarser grain (no dimensions) -> roll up the additive sum
+        # straight off the external table.
+        measures_response = await client_with_build_v3.get(
             "/sql/measures/v3/",
             params={"metrics": ["v3.total_revenue"]},
         )
-        assert response.status_code == 200
-        sql = get_first_grain_group(response.json())["sql"]
-        assert "default.analytics.revenue_by_status" in sql
-        assert "revenue_sum" in sql
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT SUM(revenue_sum) revenue_sum
+            FROM default.analytics.revenue_by_status
+            """,
+        )
+
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={"metrics": ["v3.total_revenue"]},
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT SUM(revenue_sum) revenue_sum
+                FROM default.analytics.revenue_by_status
+            )
+            SELECT SUM(order_details_0.revenue_sum) AS total_revenue
+            FROM order_details_0
+            """,
+        )
 
     @pytest.mark.asyncio
     async def test_external_non_additive_not_rolled_up(self, client_with_build_v3):
@@ -192,6 +246,232 @@ class TestExternalPreAggRouting:
         assert response.status_code == 200
         sql = get_first_grain_group(response.json())["sql"]
         assert "default.analytics.revenue_pending" not in sql
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_multiple_measures_covered(
+        self,
+        client_with_build_v3,
+    ):
+        """Two additive measures registered on one external table are both read
+        from it at the exact grain."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue", "v3.total_quantity"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_qty_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={
+                "v3.total_revenue": "revenue_sum",
+                "v3.total_quantity": "qty_sum",
+            },
+            table_columns=["status", "revenue_sum", "qty_sum"],
+        )
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue", "v3.total_quantity"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT status,
+                   SUM(revenue_sum) revenue_sum,
+                   SUM(qty_sum) qty_sum
+            FROM default.analytics.revenue_qty_by_status
+            GROUP BY status
+            """,
+        )
+
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue", "v3.total_quantity"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status,
+                       SUM(revenue_sum) revenue_sum,
+                       SUM(qty_sum) qty_sum
+                FROM default.analytics.revenue_qty_by_status
+                GROUP BY status
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.revenue_sum) AS total_revenue,
+                   SUM(order_details_0.qty_sum) AS total_quantity
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_partial_metric_coverage_falls_back(
+        self,
+        client_with_build_v3,
+    ):
+        """Pre-agg substitution is all-or-nothing per grain group: if the table
+        covers only some of the requested measures at that grain, the whole
+        group is computed from source (here total_unit_price is uncovered, so
+        even the covered total_revenue/total_quantity come from source)."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue", "v3.total_quantity"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_qty_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={
+                "v3.total_revenue": "revenue_sum",
+                "v3.total_quantity": "qty_sum",
+            },
+            table_columns=["status", "revenue_sum", "qty_sum"],
+        )
+        # total_unit_price is NOT covered by the pre-agg.
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [
+                    "v3.total_revenue",
+                    "v3.total_quantity",
+                    "v3.total_unit_price",
+                ],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert measures_response.status_code == 200
+        grain_groups = measures_response.json()["grain_groups"]
+        # All three FULL-additive measures share one grain group, computed from
+        # source -- the pre-agg is not referenced.
+        assert len(grain_groups) == 1
+        measures_sql = grain_groups[0]["sql"]
+        assert "default.analytics.revenue_qty_by_status" not in measures_sql
+        assert_sql_equal(
+            measures_sql,
+            """
+            WITH v3_order_details AS (
+                SELECT o.status,
+                       oi.quantity,
+                       oi.unit_price,
+                       oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t1.status,
+                   SUM(t1.line_total) line_total_sum_e1f61696,
+                   SUM(t1.quantity) quantity_sum_06b64d2e,
+                   SUM(t1.unit_price) unit_price_sum_55cff00f
+            FROM v3_order_details t1
+            GROUP BY t1.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_rollup_over_covered_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """A pre-agg at [status, product_id] answers a coarser [status] query by
+        rolling the additive measure up over the dropped dimension."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.order_details.status",
+                "v3.order_details.product_id",
+            ],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status_product",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["status", "product_id", "revenue_sum"],
+        )
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT status, SUM(revenue_sum) revenue_sum
+            FROM default.analytics.revenue_by_status_product
+            GROUP BY status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_extra_dimension_falls_back(
+        self,
+        client_with_build_v3,
+    ):
+        """A query needing a dimension the pre-agg lacks cannot use it (a rollup
+        cannot add a grain), so it computes from source."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["status", "revenue_sum"],
+        )
+        # product_id is not in the pre-agg grain -> cannot be served by it.
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.order_details.status",
+                    "v3.order_details.product_id",
+                ],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert "default.analytics.revenue_by_status" not in measures_sql
+        assert_sql_equal(
+            measures_sql,
+            """
+            WITH v3_order_details AS (
+                SELECT o.status,
+                       oi.product_id,
+                       oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t1.status,
+                   t1.product_id,
+                   SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.status, t1.product_id
+            """,
+        )
 
 
 class TestMetricsSQLWithPreAggregation:

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -54,8 +54,14 @@ async def _register_external_preagg(
     Returns the created pre-agg payloads.
     """
 
+    items = (
+        table_columns.items()
+        if isinstance(table_columns, dict)
+        else [(name, "double") for name in table_columns]
+    )
+
     async def _fake_columns(*args, **kwargs):
-        return [SimpleNamespace(name=name) for name in table_columns]
+        return [SimpleNamespace(name=name, type=type_str) for name, type_str in items]
 
     mock_qs = MagicMock()
     mock_qs.get_columns_for_table = _fake_columns

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -31,8 +31,161 @@ from datajunction_server.models.decompose import (
     MetricComponent,
     PreAggMeasure,
 )
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.utils import get_query_service_client
 from . import assert_sql_equal, get_first_grain_group
+
+
+async def _register_external_preagg(
+    client,
+    *,
+    metrics,
+    dimensions,
+    table_ref,
+    measure_columns,
+    table_columns,
+):
+    """
+    Register an externally-built pre-aggregation via /preaggs/register with a
+    mocked query service that reports ``table_columns`` for the external table.
+    Returns the created pre-agg payloads.
+    """
+
+    async def _fake_columns(*args, **kwargs):
+        return [SimpleNamespace(name=name) for name in table_columns]
+
+    mock_qs = MagicMock()
+    mock_qs.get_columns_for_table = _fake_columns
+    client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+    try:
+        response = await client.post(
+            "/preaggs/register",
+            json={
+                "metrics": metrics,
+                "dimensions": dimensions,
+                "table": table_ref,
+                "measure_columns": measure_columns,
+            },
+        )
+        assert response.status_code == 201, response.text
+        return response.json()["preaggs"]
+    finally:
+        del client.app.dependency_overrides[get_query_service_client]
+
+
+class TestExternalPreAggRouting:
+    """Queries route to externally-registered pre-agg tables via source_column."""
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_used_at_exact_grain(self, client_with_build_v3):
+        """An exact-grain query reads the external table's physical source column."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["status", "revenue_sum"],
+        )
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert response.status_code == 200
+        sql = get_first_grain_group(response.json())["sql"]
+        # Routed to the external table, reading the mapped physical column.
+        assert "default.analytics.revenue_by_status" in sql
+        assert "revenue_sum" in sql
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_rolls_up_additive(self, client_with_build_v3):
+        """An additive measure rolls up from an external pre-agg at a coarser grain."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["status", "revenue_sum"],
+        )
+        # Query at a coarser grain (no dimensions) -> roll up the additive sum.
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={"metrics": ["v3.total_revenue"]},
+        )
+        assert response.status_code == 200
+        sql = get_first_grain_group(response.json())["sql"]
+        assert "default.analytics.revenue_by_status" in sql
+        assert "revenue_sum" in sql
+
+    @pytest.mark.asyncio
+    async def test_external_non_additive_not_rolled_up(self, client_with_build_v3):
+        """A non-additive measure (COUNT DISTINCT) does not roll up to a coarser
+        grain; the query falls back to raw sources."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.order_count"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "orders_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.order_count": "order_cnt"},
+            table_columns=["status", "order_cnt"],
+        )
+        # Coarser grain than the pre-agg -> a distinct count cannot be summed.
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={"metrics": ["v3.order_count"]},
+        )
+        assert response.status_code == 200
+        sql = get_first_grain_group(response.json())["sql"]
+        assert "default.analytics.orders_by_status" not in sql
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_pending_not_used(self, client_with_build_v3):
+        """A registered pre-agg with no availability (no valid_through_ts) is not
+        used to answer queries."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_pending",
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["status", "revenue_sum"],
+        )
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert response.status_code == 200
+        sql = get_first_grain_group(response.json())["sql"]
+        assert "default.analytics.revenue_pending" not in sql
 
 
 class TestMetricsSQLWithPreAggregation:

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -473,6 +473,186 @@ class TestExternalPreAggRouting:
             """,
         )
 
+    @pytest.mark.asyncio
+    async def test_external_preagg_filter_on_covered_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """A filter on a dimension in the pre-agg grain is pushed onto the
+        pre-agg read."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["status", "revenue_sum"],
+        )
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "filters": ["v3.order_details.status = 'completed'"],
+            },
+        )
+        assert measures_response.status_code == 200
+        # The grain-group read stays a clean pre-agg scan (no filter inlined).
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT status, SUM(revenue_sum) revenue_sum
+            FROM default.analytics.revenue_by_status
+            GROUP BY status
+            """,
+        )
+        # Since status is in the grain, the filter is correctly applied at the
+        # metrics layer over the pre-agg-derived CTE (post-aggregation is
+        # equivalent to pre-aggregation for a grain column).
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "filters": ["v3.order_details.status = 'completed'"],
+            },
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, SUM(revenue_sum) revenue_sum
+                FROM default.analytics.revenue_by_status
+                GROUP BY status
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.revenue_sum) AS total_revenue
+            FROM order_details_0
+            WHERE order_details_0.status = 'completed'
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_filter_on_uncovered_column(
+        self,
+        client_with_build_v3,
+    ):
+        """A filter on a column absent from the pre-agg grain forces a fallback
+        to source (the pre-agg has already aggregated that column away)."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["status", "revenue_sum"],
+        )
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+                "filters": ["v3.order_details.product_id = 5"],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert "default.analytics.revenue_by_status" not in measures_sql
+        # product_id must be filtered before aggregation, so it is inlined into
+        # the source CTE rather than applied over the pre-agg.
+        assert_sql_equal(
+            measures_sql,
+            """
+            WITH v3_order_details AS (
+                SELECT o.status,
+                       oi.product_id,
+                       oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+                WHERE oi.product_id = 5
+            )
+            SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_cross_fact_partial_substitution(
+        self,
+        client_with_build_v3,
+    ):
+        """Substitution is per grain group: for a cross-fact metric, the fact
+        with an external pre-agg reads it while the other fact computes from
+        source, then the two are FULL OUTER JOINed on the shared dimension.
+
+        revenue_per_visitor = total_revenue (order_details) / visitor_count
+        (page_views_enriched); only total_revenue is pre-aggregated.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.customer.customer_id"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_customer",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns=["customer_id", "revenue_sum"],
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.revenue_per_visitor"],
+                "dimensions": ["v3.customer.customer_id"],
+            },
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH
+            v3_page_views_enriched AS (
+                SELECT customer_id
+                FROM default.v3.page_views
+            ),
+            order_details_0 AS (
+                SELECT customer_id, SUM(revenue_sum) revenue_sum
+                FROM default.analytics.revenue_by_customer
+                GROUP BY customer_id
+            ),
+            page_views_enriched_0 AS (
+                SELECT t1.customer_id
+                FROM v3_page_views_enriched t1
+                GROUP BY t1.customer_id
+            )
+            SELECT COALESCE(order_details_0.customer_id,
+                            page_views_enriched_0.customer_id) AS customer_id,
+                   SUM(order_details_0.revenue_sum)
+                   / NULLIF(COUNT(DISTINCT page_views_enriched_0.customer_id), 0)
+                   AS revenue_per_visitor
+            FROM order_details_0
+            FULL OUTER JOIN page_views_enriched_0
+                ON order_details_0.customer_id = page_views_enriched_0.customer_id
+            GROUP BY 1
+            """,
+        )
+
 
 class TestMetricsSQLWithPreAggregation:
     """

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -13,6 +13,7 @@ from datajunction_server.models.deployment import (
     TransformSpec,
     ColumnSpec,
     PartitionSpec,
+    PreAggSpec,
     Granularity,
     PartitionType,
     eq_columns,
@@ -598,3 +599,32 @@ def test_deployment_results_property_getter():
     assert len(results) == 1
     assert results[0].name == "test_node"
     assert results[0].status == DeploymentResult.Status.SUCCESS
+
+
+def test_deployment_spec_preserves_explicit_preagg_namespace():
+    """
+    set_namespaces propagates the deployment namespace onto pre-agg specs that
+    don't have one, but leaves an already-namespaced pre-agg spec untouched.
+    """
+    spec = DeploymentSpec(
+        namespace="ns",
+        preaggregations=[
+            PreAggSpec(
+                name="already_scoped",
+                namespace="explicit",
+                catalog="c",
+                schema="s",
+                table="t",
+                measure_columns={},
+            ),
+            PreAggSpec(
+                name="unscoped",
+                catalog="c",
+                schema="s",
+                table="t",
+                measure_columns={},
+            ),
+        ],
+    )
+    assert spec.preaggregations[0].namespace == "explicit"
+    assert spec.preaggregations[1].namespace == "ns"

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -243,6 +243,7 @@ def test_deployment_spec():
         ],
         "tags": [],
         "hierarchies": [],
+        "preaggregations": [],
         "source": None,
         "auto_register_sources": True,
         "force": False,


### PR DESCRIPTION
### Summary

This change lets users register an externally-built pre-aggregated table so DJ routes matching metric queries to it, and manage those registrations declaratively via `dj push`. It builds on the register endpoint (#2338) and `EXTERNAL` strategy (#2342).

A pre-aggregation is its own file, distinguished by a top-level `kind: preagg`. Everything else defaults to `kind: node`, so existing projects are unaffected (no migration needed).
```yaml
  # views_by_page.yaml
  kind: preagg
  name: views_by_page
  # is_measure metrics only (single SUM/COUNT/MIN/MAX/COUNT DISTINCT);
  # AVG/ratios must be modelled as derived metrics over base measures.
  metrics:
    - ${prefix}view_seconds
    - ${prefix}session_count
  dimensions:                       # the grain the table is aggregated to
    - ${prefix}page_dim.page_id
    - ${prefix}page_dim.country
  catalog: warehouse                # the externally-built table (DJ never writes it)
  schema: analytics
  table: views_by_page_daily
  valid_through_ts: 1700000000      # optional freshness; else stays pending
  measure_columns:                  # bind each measure to its physical column
    ${prefix}view_seconds: view_secs_sum
    ${prefix}session_count: session_cnt
```
`dj push` reconciles it with the server. A one-off `POST /preaggs/register` accepts the same fields.

#### Behavior

  - Validation (endpoint + push) rejects unknown/non-metric keys, non-measures (AVG/ratio), missing physical columns, uncovered measures, and type-incompatible bindings (e.g. SUM bound to a string).
  - Errors fail the deploy and roll it back so that there are no silently swallowed failures.
  - Dry-run reports planned create/update/delete without mutating.
  - No accidental mass-deregistration: a deploy declaring zero pre-aggs warns and skips rather than removing existing ones and `allow_empty` opts in.
  - Deregister a pre-aggregation by removing the file and re-pushing (needs allow_empty if it's the last one).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
