### PR TITLE
fix: don't drop a derived metric's dimension-sourced base metric

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/decomposition.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/decomposition.py
@@ -249,7 +249,8 @@ def get_base_metrics_for_derived(ctx: BuildContext, metric_node: Node) -> list[N
     """
     For a derived metric, get all the base metrics it depends on.
 
-    Returns list of base metric nodes (metrics that SELECT FROM a fact/transform, not other metrics).
+    Returns list of base metric nodes (metrics that SELECT FROM a fact/transform
+    or a dimension source, not other metrics).
     """
     base_metrics = []
     visited = set()
@@ -259,24 +260,22 @@ def get_base_metrics_for_derived(ctx: BuildContext, metric_node: Node) -> list[N
             return
         visited.add(node.name)
 
-        parent_names = ctx.parent_map.get(node.name, [])
-        for parent_name in parent_names:
+        # Recurse through metric parents. A node with any metric parent is itself
+        # derived; a node with no metric parent is a base metric -- regardless of
+        # whether its data source is a fact/transform or a dimension node (a base
+        # metric can be defined directly on a dimension node). Classifying by
+        # "has a metric parent" avoids mistaking a dimension-sourced base metric
+        # for a bare required-dimension reference, which would drop its grain group.
+        has_metric_parent = False
+        for parent_name in ctx.parent_map.get(node.name, []):
             parent = ctx.nodes.get(parent_name)
             if not parent:  # pragma: no cover
                 continue
-
             if parent.type == NodeType.METRIC:
-                # Parent is also a metric - recurse
+                has_metric_parent = True
                 collect_bases(parent)
-            elif parent.type == NodeType.DIMENSION:
-                # Skip dimension nodes - they're for required dimensions (e.g., in window
-                # functions), not the actual data source. Don't treat the derived metric
-                # as a base metric just because it references a dimension.
-                continue  # pragma: no cover
-            else:
-                # Parent is a fact/transform - this is a base metric
-                base_metrics.append(node)
-                break  # Found the base, don't check other parents
+        if not has_metric_parent:
+            base_metrics.append(node)
 
     collect_bases(metric_node)
     return base_metrics

--- a/datajunction-server/tests/construction/build_v3/decomposition_test.py
+++ b/datajunction-server/tests/construction/build_v3/decomposition_test.py
@@ -17,14 +17,13 @@ class TestGetBaseMetricsForDerived:
 
     def test_skips_dimension_parents(self):
         """
-        Test that get_base_metrics_for_derived skips dimension node parents.
-
-        This covers line 270: continue when parent.type == NodeType.DIMENSION
+        Test that a required-dimension link on the derived metric doesn't derail
+        base-metric detection.
 
         When a derived metric has a dimension as a parent (e.g., for required_dimensions
-        in window functions), that dimension should be skipped and not cause the metric
-        to be treated as a base metric. It should continue to find the actual metric
-        or fact/transform parent.
+        in window functions), that dimension link should be ignored: it is not a metric
+        (so it isn't recursed into) and it must not cause the derived metric itself to be
+        treated as a base metric. Only the real metric parent's base is collected.
         """
         # Create mock nodes
         dimension_node = MagicMock()
@@ -99,6 +98,65 @@ class TestGetBaseMetricsForDerived:
         # Should find the metric as a base metric (via fact parent)
         assert len(result) == 1
         assert result[0].name == "v3.some_metric"
+
+    def test_collects_base_metric_defined_on_dimension_source(self):
+        """
+        A derived ratio whose two base metrics have DIFFERENT parents -- one on a
+        fact/transform, the other defined directly on a dimension node -- must
+        collect BOTH base metrics.
+
+        Regression for the cross-parent ratio bug: a base metric whose data source
+        is a dimension node was mistaken for a bare required-dimension reference and
+        dropped, so its grain group was never built and the generated SQL referenced
+        an aggregate column that no CTE computed.
+        """
+        fact_node = MagicMock()
+        fact_node.name = "v3.visits_fact"
+        fact_node.type = NodeType.TRANSFORM
+
+        dim_source = MagicMock()
+        dim_source.name = "v3.accounts_dim"
+        dim_source.type = NodeType.DIMENSION
+
+        date_dim = MagicMock()
+        date_dim.name = "v3.date"
+        date_dim.type = NodeType.DIMENSION
+
+        numerator = MagicMock()
+        numerator.name = "v3.visited_accounts"
+        numerator.type = NodeType.METRIC
+
+        denominator = MagicMock()
+        denominator.name = "v3.eligible_accounts"
+        denominator.type = NodeType.METRIC
+
+        derived = MagicMock()
+        derived.name = "v3.visit_rate"
+        derived.type = NodeType.METRIC
+
+        ctx = MagicMock(spec=BuildContext)
+        ctx.nodes = {
+            n.name: n
+            for n in [fact_node, dim_source, date_dim, numerator, denominator, derived]
+        }
+        # date is a required-dimension link on each metric; the numerator's data
+        # source is a fact, the denominator's data source is a dimension node.
+        ctx.parent_map = {
+            "v3.visit_rate": [
+                "v3.visited_accounts",
+                "v3.eligible_accounts",
+                "v3.date",
+            ],
+            "v3.visited_accounts": ["v3.visits_fact", "v3.date"],
+            "v3.eligible_accounts": ["v3.accounts_dim", "v3.date"],
+        }
+
+        result = get_base_metrics_for_derived(ctx, derived)
+
+        assert {n.name for n in result} == {
+            "v3.visited_accounts",
+            "v3.eligible_accounts",
+        }
 
 
 class TestIsDerivedMetric:
@@ -176,7 +234,8 @@ async def test_decomposition_with_dimension_parent_integration(
     - required_dimensions: ["v3.date.date_id[order]"] - creates dimension parent
     - References v3.total_revenue - creates metric parent
 
-    This exercises line 270 (skip dimension) in a real scenario.
+    This exercises the required-dimension-link path in a real scenario: the
+    dimension parent must not be mistaken for a data source.
     """
     client = module__client_with_build_v3
 

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -6279,3 +6279,90 @@ class TestMetricsSQLEdgeCases:
             GROUP BY  page_views_enriched_0.category
             """,
         )
+
+
+class TestCrossParentDerivedRatio:
+    @pytest.mark.asyncio
+    async def test_derived_ratio_with_dimension_sourced_base_metric(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        A derived ratio whose two base metrics have different parents -- the
+        numerator on a fact/transform, the denominator defined directly on a
+        dimension node -- must build BOTH grain groups and FULL OUTER JOIN them.
+
+        Regression: the dimension-sourced denominator was dropped, so the final
+        SELECT referenced an aggregate that no CTE computed (invalid SQL).
+        """
+        # Denominator base metric defined ON the v3.product dimension node.
+        resp = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.catalog_price_total",
+                "description": "Total catalog price (defined on the product dimension)",
+                "query": "SELECT SUM(price) FROM v3.product",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        # Cross-parent derived ratio: fact-sourced numerator / dimension-sourced denominator.
+        resp = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.revenue_per_catalog_dollar",
+                "description": "Revenue per catalog dollar (cross-parent ratio)",
+                "query": "SELECT v3.total_revenue / NULLIF(v3.catalog_price_total, 0)",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.revenue_per_catalog_dollar"],
+                "dimensions": ["v3.product.category"],
+                "dialect": "trino",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+
+        # Both grain groups are built (order_details_0 for the fact-sourced
+        # numerator, product_0 for the dimension-sourced denominator) and joined
+        # with FULL OUTER JOIN, so the denominator aggregate (price_sum_*) is
+        # actually computed rather than referenced out of thin air.
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_order_details AS (
+              SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+              FROM default.v3.orders o
+              JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_product AS (
+              SELECT product_id, category FROM default.v3.products
+            ),
+            order_details_0 AS (
+              SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
+              FROM v3_order_details t1
+              LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+              GROUP BY t2.category
+            ),
+            product_0 AS (
+              SELECT t1.category, SUM(t1.price) price_sum_78363aa6
+              FROM v3_product t1
+              GROUP BY t1.category
+            )
+            SELECT
+              COALESCE(order_details_0.category, product_0.category) AS category,
+              SUM(order_details_0.line_total_sum_e1f61696)
+                / NULLIF(SUM(product_0.price_sum_78363aa6), 0) AS revenue_per_catalog_dollar
+            FROM order_details_0
+            FULL OUTER JOIN product_0 ON order_details_0.category = product_0.category
+            GROUP BY 1
+            """,
+        )


### PR DESCRIPTION
### Summary

A derived metric whose two base metrics have different parents (e.g., one on a transform, the other defined on a dimension node) compiled to invalid SQL. The planner built only the transform grain group and dropped the dimension-sourced one, so the final `SELECT` referenced an aggregate that no CTE computed. The metric is marked valid at push time, so this only surfaced at SQL generation.

The root cause is that `get_base_metrics_for_derived` classified a node as a base metric only when it found a transform parent, and continued past dimension parents, assuming a dimension parent is always a required-dimension link. But a base metric can be defined directly on a dimension node, so its denominator was silently skipped and its grain group never built.

The fix is to classify by "has no metric parent" instead of "has a transform parent" when recursing through metric parents. A node with no metric parent is a base metric regardless of whether its source is a transform or a dimension node. This routes cross-parent derived metrics through the existing multi-grain-group `FULL OUTER JOIN` path.

### Test Plan

Added a unit test on the collector (both base metrics returned) and an end-to-end SQL test asserting both grain-group CTEs are built and joined (fails on the pre-fix code).

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
